### PR TITLE
Removes BCMath dependency from circle-ci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
     working_directory: ~/datadog
     steps:
       - checkout
-      - run:
-          name: Install php-bcmath
-          command: sudo docker-php-ext-install bcmath
       - run: composer install -n
       - run:
           name: Run lint
@@ -36,9 +33,6 @@ jobs:
     working_directory: ~/datadog
     steps:
       - checkout
-      - run:
-          name: Install php-bcmath
-          command: sudo docker-php-ext-install bcmath
       - run: composer install
       - run:
           name: Run lint
@@ -60,9 +54,6 @@ jobs:
     working_directory: ~/datadog
     steps:
       - checkout
-      - run:
-          name: Install php-bcmath
-          command: sudo docker-php-ext-install bcmath
       - run: composer install
       - run:
           name: Run lint
@@ -84,9 +75,6 @@ jobs:
     working_directory: ~/datadog
     steps:
       - checkout
-      - run:
-          name: Install php-bcmath
-          command: sudo docker-php-ext-install bcmath
       - run: composer install
       - run:
           name: Run lint


### PR DESCRIPTION
We got rid of `bcmath` some time ago. We should remove it from circle ci.

Ping @vlad-mh @palazzem @kevinlebrun 