### PR TITLE
[docs] add CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing to dd-trace-php
+
+As an open source project we welcome contributions of many forms, but due to the experimental pre-beta nature
+of this repository, you should reach out before starting work on any major code changes.
+This will ensure we avoid duplicating work, or that your code can't be merged due to a rapidly changing
+base. If you have any questions, create a [GitHub issue][1] and reach us!
+
+[1]: https://github.com/DataDog/dd-trace-php/issues

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![OpenTracing Badge](https://img.shields.io/badge/OpenTracing-enabled-blue.svg)](http://opentracing.io)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)](https://php.net/)
 
-DataDog APM client that implements an [OpenTracing](http://opentracing.io) Tracer.
+Experimental PHP Tracer!
+
+This project is experimental and under active development. Use it at your own risk.
 
 ## Installation
 
@@ -94,6 +96,8 @@ $tracer = new Tracer(
 - [Propagation formats](https://github.com/opentracing/opentracing-php#propagation-formats)
 
 ## Contributing
+
+Before contributing to this open source project, read our [CONTRIBUTING.md](https://github.com/DataDog/dd-trace-php/blob/master/CONTRIBUTING.md).
 
 ### Run tests
 


### PR DESCRIPTION
### Overview

Makes explicit the Work In-Progress state of the repository. Added `CONTRIBUTING.md` so that it's clear that discussions must be opened before implementing new functionalities.