### PR TITLE
Fix JSON encoding for malformed strings

### DIFF
--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -12,14 +12,10 @@ final class Json implements Encoder
      */
     public function encodeTraces(array $traces)
     {
-        $notEmpty = function ($value) {
-            return !empty($value);
-        };
-
-        return '[' . implode(',', array_map(function ($trace) use ($notEmpty) {
+        return '[' . implode(',', array_map(function ($trace) {
             return '[' . implode(',', array_filter(array_map(function ($span) {
                 return $this->encodeSpan($span);
-            }, $trace), $notEmpty)) . ']';
+            }, $trace))) . ']';
         }, $traces))  . ']';
     }
 

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -12,10 +12,14 @@ final class Json implements Encoder
      */
     public function encodeTraces(array $traces)
     {
-        return '[' . implode(',', array_map(function ($trace) {
-            return '[' . implode(',', array_map(function ($span) {
+        $notEmpty = function ($value) {
+            return !empty($value);
+        };
+
+        return '[' . implode(',', array_map(function ($trace) use ($notEmpty) {
+            return '[' . implode(',', array_filter(array_map(function ($span) {
                 return $this->encodeSpan($span);
-            }, $trace)) . ']';
+            }, $trace), $notEmpty)) . ']';
         }, $traces))  . ']';
     }
 
@@ -33,6 +37,11 @@ final class Json implements Encoder
      */
     private function encodeSpan(Span $span)
     {
+        $json = json_encode($this->spanToArray($span));
+        if (false === $json) {
+            return "";
+        }
+
         return str_replace([
             '"start_micro":"-"',
             '"duration_micro":"-"',
@@ -45,7 +54,7 @@ final class Json implements Encoder
             '"trace_id":' . $this->hex2dec($span->getTraceId()),
             '"span_id":' . $this->hex2dec($span->getSpanId()),
             '"parent_id":' . $this->hex2dec($span->getParentId()),
-        ], json_encode($this->spanToArray($span)));
+        ], $json);
     }
 
     /**

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -30,4 +30,24 @@ JSON;
         $encodedTrace = $jsonEncoder->encodeTraces([[$span]]);
         $this->assertEquals($expectedPayload, $encodedTrace);
     }
+
+    public function testEncodeIgnoreSpanWhenEncodingFails()
+    {
+        $expectedPayload = '[[]]';
+
+        $context = new SpanContext('160e7072ff7bd5f1', '160e7072ff7bd5f2');
+        $span = new Span(
+            'test_name',
+            $context,
+            'test_service',
+            'test_resource',
+            1518038421211969
+        );
+        // this will generate a malformed UTF-8 string
+        $span->setTag('invalid', hex2bin('37f2bef0ab085308'));
+
+        $jsonEncoder = new Json();
+        $encodedTrace = $jsonEncoder->encodeTraces([[$span, $span]]);
+        $this->assertEquals($expectedPayload, $encodedTrace);
+    }
 }


### PR DESCRIPTION
If for some reason the `json_encode` step fails, the encoder will build an invalid JSON output. As a fix I ignored all invalid spans from the JSON output.

It is something we want to log to inform the developer I think. It happened to me when I tried to send as tags all my SQL bindings. It turns out that my primary keys are binary encoded GUID.

ping @vlad-mh @palazzem