### PR TITLE
Fix ScopeManager fail to manage multiple scopes

### DIFF
--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -42,7 +42,7 @@ final class ScopeManager implements OpenTracingScopeManager
 
         for ($i = 0; $i < $scopeLength; $i++) {
             if ($scope === $this->scopes[$i]) {
-                unset($this->scopes[$i]);
+                array_splice($this->scopes, $i, 1);
             }
         }
     }

--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -43,6 +43,7 @@ final class ScopeManager implements OpenTracingScopeManager
         for ($i = 0; $i < $scopeLength; $i++) {
             if ($scope === $this->scopes[$i]) {
                 array_splice($this->scopes, $i, 1);
+                break;
             }
         }
     }

--- a/tests/Unit/ScopeManagerTest.php
+++ b/tests/Unit/ScopeManagerTest.php
@@ -50,4 +50,19 @@ final class ScopeManagerTest extends PHPUnit_Framework_TestCase
         $scopeManager->deactivate($scope);
         $this->assertNull($scopeManager->getActive());
     }
+
+    public function testCanManageMultipleScopes()
+    {
+        $tracer = new Tracer(new NoopTransport);
+        $scopeManager = new ScopeManager();
+
+        $scope = $scopeManager->activate($tracer->startSpan(self::OPERATION_NAME), false);
+        $scopeManager->deactivate($scope);
+
+        $scope = $scopeManager->activate($tracer->startSpan(self::OPERATION_NAME), false);
+        $scopeManager->deactivate($scope);
+
+
+        $this->assertNull($scopeManager->getActive());
+    }
 }


### PR DESCRIPTION
In its state the scope manager cannot manage more than one scope because `unset` will preserve the keys. I replaced `unset` by `array_splice` which does the same thing but recompute the array keys.

ping @vlad-mh @palazzem 