### PR TITLE
Prevent curl to print the response in STDOUT

### DIFF
--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -62,12 +62,13 @@ final class Http implements Transport
         $handle = curl_init($url);
         curl_setopt($handle, CURLOPT_POST, 1);
         curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($handle, CURLOPT_HTTPHEADER, array_merge($headers, [
             'Content-Type: ' . $this->encoder->getContentType(),
             'Content-Length: ' . strlen($body),
         ]));
 
-        if (curl_exec($handle) !== true) {
+        if (curl_exec($handle) === false) {
             $this->logger->debug(sprintf(
                 'Reporting of spans failed: %s, error code %s',
                 curl_error($handle),


### PR DESCRIPTION
When flushing traces, if everything work as expected, a "OK" can be present in the response; even in a `terminate` method for Laravel. In case of an API this will prevent the client to correctly parse the output.