### PR TITLE
Fix: Composer resolves binaries itself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,16 +50,16 @@
             "@test-unit",
             "@test-integration"
         ],
-        "test-unit": "./vendor/bin/phpunit ./tests/Unit",
+        "test-unit": "phpunit ./tests/Unit",
         "test-integration":[
             "echo \"Integration tests require the agent up and running. Use composer run-agent.\"",
-            "./vendor/bin/phpunit ./tests/Integration"
+            "phpunit ./tests/Integration"
         ],
         "run-agent": [
             "docker run -p 8126:8126 -e \"DD_APM_ENABLED=true\" -e \"DD_BIND_HOST=0.0.0.0\" -e \"DD_API_KEY=invalid_key_but_this_is_fine\" --rm datadog/docker-dd-agent",
             "while ! echo exit | nc localhost 8126; do sleep 1; done"
         ],
-        "lint": "./vendor/bin/phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "fix-lint": "./vendor/bin/phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./"
+        "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
+        "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./"
     }
 }


### PR DESCRIPTION
This PR

* [x] removes unnecessary prefixes to vendor binaries in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands:

>**Note**: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the `phpunit` binary is actually in `vendor/bin/phpunit` or `bin/phpunit` it will be found and executed.