### PR TITLE
Fix: Prefer stable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         }
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
         "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "guzzlehttp/psr7": "^1.4@dev",
+        "guzzlehttp/psr7": "^1.4.0",
         "opentracing/opentracing": "1.0.0-beta5",
-        "psr/log": "^1.0@dev",
+        "psr/log": "^1.0.0",
         "symfony/polyfill-php70": "^1.8.0"
     },
     "provide": {


### PR DESCRIPTION
This PR

* [x] configures a setting in `composer.json` to prefer stable dependencies
* [x] requires stable dependencies (where possible)

💁‍♂️ For reference, see https://getcomposer.org/doc/04-schema.md#prefer-stable.