### PR TITLE
Fix: Use caret operator where applicable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         "guzzlehttp/psr7": "^1.4@dev",
         "opentracing/opentracing": "1.0.0-beta5",
         "psr/log": "^1.0@dev",
-        "symfony/polyfill-php70": "~1.8.0"
+        "symfony/polyfill-php70": "^1.8.0"
     },
     "provide": {
         "opentracing/opentracing": "1.0.0-beta4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.19",
-        "squizlabs/php_codesniffer": "3.*"
+        "phpunit/phpunit": "^5.7.19",
+        "squizlabs/php_codesniffer": "^3.3.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This PR

* [x] uses the `^` operator instead of `~` and `*` for version constraints where applicable

💁‍♂️ For reference, see https://getcomposer.org/doc/articles/versions.md.