### PR TITLE
Enhancement: Use forward compatibility layer of phpunit/phpunit

### DIFF
--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -6,11 +6,11 @@ use DDTrace\Encoders\Json;
 use DDTrace\Tracer;
 use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 
-final class HttpTest extends PHPUnit_Framework_TestCase
+final class HttpTest extends Framework\TestCase
 {
     public function testSpanReportingFailsOnUnavailableAgent()
     {

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -5,9 +5,9 @@ namespace DDTrace\Tests\Unit\Encoders;
 use DDTrace\Encoders\Json;
 use DDTrace\Span;
 use DDTrace\SpanContext;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class JsonTest extends PHPUnit_Framework_TestCase
+final class JsonTest extends Framework\TestCase
 {
     public function testEncodeTracesSuccess()
     {

--- a/tests/Unit/Propagators/TextMapTest.php
+++ b/tests/Unit/Propagators/TextMapTest.php
@@ -4,9 +4,9 @@ namespace DDTrace\Tests\Unit\Propagators;
 
 use DDTrace\Propagators\TextMap;
 use DDTrace\SpanContext;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class TextMapTest extends PHPUnit_Framework_TestCase
+final class TextMapTest extends Framework\TestCase
 {
     const BAGGAGE_ITEM_KEY = 'test_key';
     const BAGGAGE_ITEM_VALUE = 'test_value';

--- a/tests/Unit/ScopeManagerTest.php
+++ b/tests/Unit/ScopeManagerTest.php
@@ -5,9 +5,9 @@ namespace DDTrace\Tests\Unit;
 use DDTrace\ScopeManager;
 use DDTrace\Tracer;
 use DDTrace\Transport\Noop as NoopTransport;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class ScopeManagerTest extends PHPUnit_Framework_TestCase
+final class ScopeManagerTest extends Framework\TestCase
 {
     const OPERATION_NAME = 'test_name';
 

--- a/tests/Unit/ScopeTest.php
+++ b/tests/Unit/ScopeTest.php
@@ -5,9 +5,9 @@ namespace DDTrace\Tests\Unit;
 use DDTrace\Scope;
 use DDTrace\ScopeManager;
 use OpenTracing\Span;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class ScopeTest extends PHPUnit_Framework_TestCase
+final class ScopeTest extends Framework\TestCase
 {
     public function testScopeFinishesSpanOnClose()
     {

--- a/tests/Unit/SpanContextTest.php
+++ b/tests/Unit/SpanContextTest.php
@@ -3,9 +3,9 @@
 namespace DDTrace\Tests\Unit;
 
 use DDTrace\SpanContext;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class SpanContextTest extends PHPUnit_Framework_TestCase
+final class SpanContextTest extends Framework\TestCase
 {
     const BAGGAGE_ITEM_KEY = 'key';
     const BAGGAGE_ITEM_VALUE = 'value';

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -7,9 +7,9 @@ use DDTrace\SpanContext;
 use DDTrace\Tags;
 use DDTrace\Span;
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 
-final class SpanTest extends PHPUnit_Framework_TestCase
+final class SpanTest extends Framework\TestCase
 {
     const OPERATION_NAME = 'test_span';
     const SERVICE = 'test_service';

--- a/tests/Unit/TimeTest.php
+++ b/tests/Unit/TimeTest.php
@@ -3,8 +3,9 @@
 namespace DDTrace\Tests;
 
 use DDTrace\Time;
+use PHPUnit\Framework;
 
-final class TimeTest extends \PHPUnit_Framework_TestCase
+final class TimeTest extends Framework\TestCase
 {
     public function testNowHasTheExpectedLength()
     {

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -9,10 +9,10 @@ use DDTrace\Transport;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\NoopSpan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 use DDTrace\Time;
 
-final class TracerTest extends PHPUnit_Framework_TestCase
+final class TracerTest extends Framework\TestCase
 {
     const OPERATION_NAME = 'test_span';
     const ANOTHER_OPERATION_NAME = 'test_span2';

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -4,9 +4,10 @@ namespace DDTrace\Tests\Unit\Transport;
 
 use DDTrace\Encoders\Json;
 use DDTrace\Transport\Http;
+use PHPUnit\Framework;
 use Psr\Log\NullLogger;
 
-final class HttpTest extends \PHPUnit_Framework_TestCase
+final class HttpTest extends Framework\TestCase
 {
     const ENDPOINT = 'http://myserver:8126/v0.3/traces';
 


### PR DESCRIPTION
This PR

* [x] uses the forward compatibility layer of `phpunit/phpunit`

💁‍♂️ This will make upgrading to newer versions of `phpunit/phpunit` (perhaps if support for PHP 5.6 is dropped) easier.