### PR TITLE
Remove symfony/polyfill from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": "^5.6 || ^7.0",
         "guzzlehttp/psr7": "^1.4@dev",
         "opentracing/opentracing": "1.0.0-beta5",
-        "psr/log": "^1.0@dev"
+        "psr/log": "^1.0@dev",
+        "symfony/polyfill-php70": "~1.8.0"
     },
     "provide": {
         "opentracing/opentracing": "1.0.0-beta4"

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "php": "^5.6 || ^7.0",
         "guzzlehttp/psr7": "^1.4@dev",
         "opentracing/opentracing": "1.0.0-beta5",
-        "psr/log": "^1.0@dev",
-        "symfony/polyfill": "~1.7.0"
+        "psr/log": "^1.0@dev"
     },
     "provide": {
         "opentracing/opentracing": "1.0.0-beta4"


### PR DESCRIPTION
https://github.com/symfony/polyfill notes that "When using Composer to manage
your dependencies, you should not require the symfony/polyfill package, but the
standalone ones"; also see https://github.com/DataDog/dd-trace-php/issues/19