### PR TITLE
Set $logger for the Encoder class, and log errors encoding JSON

### DIFF
--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -4,9 +4,13 @@ namespace DDTrace\Encoders;
 
 use DDTrace\Encoder;
 use DDTrace\Span;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
 final class Json implements Encoder
 {
+    use LoggerAwareTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -35,6 +39,7 @@ final class Json implements Encoder
     {
         $json = json_encode($this->spanToArray($span));
         if (false === $json) {
+            $this->logger->debug("Failed to json-encode span: " . json_last_error_msg());
             return "";
         }
 

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -4,12 +4,20 @@ namespace DDTrace\Encoders;
 
 use DDTrace\Encoder;
 use DDTrace\Span;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class Json implements Encoder
 {
-    use LoggerAwareTrait;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?: new NullLogger();
+    }
 
     /**
      * {@inheritdoc}

--- a/src/DDTrace/Encoders/Noop.php
+++ b/src/DDTrace/Encoders/Noop.php
@@ -3,9 +3,13 @@
 namespace DDTrace\Encoders;
 
 use DDTrace\Encoder;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
 final class Noop implements Encoder
 {
+    use LoggerAwareTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/DDTrace/Encoders/Noop.php
+++ b/src/DDTrace/Encoders/Noop.php
@@ -3,13 +3,9 @@
 namespace DDTrace\Encoders;
 
 use DDTrace\Encoder;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 
 final class Noop implements Encoder
 {
-    use LoggerAwareTrait;
-
     /**
      * {@inheritdoc}
      */

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -90,7 +90,6 @@ final class Http implements Transport
             $this->logger->debug(
                 sprintf('Reporting of spans failed, status code %d', $statusCode)
             );
-
             return;
         }
     }

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -54,8 +54,7 @@ JSON;
             )
             ->shouldBeCalled();
 
-        $jsonEncoder = new Json();
-        $jsonEncoder->setLogger($logger->reveal());
+        $jsonEncoder = new Json($logger->reveal());
         $encodedTrace = $jsonEncoder->encodeTraces([[$span, $span]]);
         $this->assertEquals($expectedPayload, $encodedTrace);
     }

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -6,6 +6,7 @@ use DDTrace\Encoders\Json;
 use DDTrace\Span;
 use DDTrace\SpanContext;
 use PHPUnit\Framework;
+use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 
 final class JsonTest extends Framework\TestCase
@@ -27,7 +28,11 @@ JSON;
             'test_resource',
             1518038421211969
         );
-        $jsonEncoder = new Json();
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger->debug(Argument::any())->shouldNotBeCalled();
+
+        $jsonEncoder = new Json($logger->reveal());
         $encodedTrace = $jsonEncoder->encodeTraces([[$span]]);
         $this->assertEquals($expectedPayload, $encodedTrace);
     }

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -6,6 +6,7 @@ use DDTrace\Encoders\Json;
 use DDTrace\Span;
 use DDTrace\SpanContext;
 use PHPUnit\Framework;
+use Psr\Log\LoggerInterface;
 
 final class JsonTest extends Framework\TestCase
 {
@@ -46,7 +47,15 @@ JSON;
         // this will generate a malformed UTF-8 string
         $span->setTag('invalid', hex2bin('37f2bef0ab085308'));
 
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger
+            ->debug(
+                'Failed to json-encode span: Malformed UTF-8 characters, possibly incorrectly encoded'
+            )
+            ->shouldBeCalled();
+
         $jsonEncoder = new Json();
+        $jsonEncoder->setLogger($logger->reveal());
         $encodedTrace = $jsonEncoder->encodeTraces([[$span, $span]]);
         $this->assertEquals($expectedPayload, $encodedTrace);
     }


### PR DESCRIPTION
Follow-up to #17 - pass the $logger to the Encoder, and if there's an error encoding JSON, log it at a debug level. If others like the LoggerAwareTrait pattern we could switch the Transport to use it as well. I'm not 100% happy with this since if you call Encoder methods yourself you aren't guaranteed to have a Logger, though. But passing $logger directly to the encodeTraces() method, while expedient, is almost certainly wrong.