### PR TITLE
Fix: Remove unnecessary continue statement

### DIFF
--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -41,8 +41,6 @@ final class TextMap implements Propagator
             } elseif (strpos($key, self::DEFAULT_BAGGAGE_HEADER_PREFIX) === 0) {
                 $baggageItems[substr($key, strlen(self::DEFAULT_BAGGAGE_HEADER_PREFIX))] = $value;
             }
-
-            continue;
         }
 
         if ($traceId === null || $spanId === null) {


### PR DESCRIPTION
This PR

* [x] removes an unnecessary `continue` statement