### PR TITLE
Fix: Remove dependency on guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "guzzlehttp/psr7": "^1.4.0",
+        "ext-curl": "*",
         "opentracing/opentracing": "1.0.0-beta5",
+        "psr/http-message": "^1.0",
         "psr/log": "^1.0.0",
         "symfony/polyfill-php70": "^1.8.0"
     },

--- a/src/DDTrace/Transport.php
+++ b/src/DDTrace/Transport.php
@@ -2,13 +2,10 @@
 
 namespace DDTrace;
 
-use Psr\Http\Message\ResponseInterface;
-
 interface Transport
 {
     /**
      * @param Span[][] $traces
-     * @return ResponseInterface
      */
     public function send(array $traces);
 

--- a/src/DDTrace/Transport/Noop.php
+++ b/src/DDTrace/Transport/Noop.php
@@ -3,13 +3,11 @@
 namespace DDTrace\Transport;
 
 use DDTrace\Transport;
-use GuzzleHttp\Psr7\Response;
 
 final class Noop implements Transport
 {
     public function send(array $traces)
     {
-        return new Response();
     }
 
     public function setHeader($key, $value)


### PR DESCRIPTION
This PR

* [x] removes the dependency on `guzzlehttp/psr7` and replaces it with `psr/http-message`