### PR TITLE
Fix tiny misconfiguration of phpcs, and add defaults in .phpcs.xml file

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="DD">
-	<description>Generally-applicable sniffs for Datadog Tracing</description>
+<ruleset name="DD Trace PHP">
+    <description>Sniffs for DD Trace PHP</description>
 
-	<file>./</file>
+    <file>./</file>
 
-	<rule ref="PSR12" >
-	</rule>
+    <rule ref="PSR12"/>
 
-	<rule ref="Generic.Commenting.Todo"/>
-	<rule ref="Generic.Commenting.Fixme"/>
+    <rule ref="Generic.Commenting.Todo"/>
+    <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.Commenting.DocComment.MissingShort">
-	    <severity>0</severity>
-	</rule>
-
-	<exclude-pattern>*/vendor/*</exclude-pattern>
+        <severity>0</severity>
+    </rule>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="DD">
+	<description>Generally-applicable sniffs for Datadog Tracing</description>
+
+	<file>./</file>
+
+	<rule ref="PSR12" >
+	</rule>
+
+	<rule ref="Generic.Commenting.Todo"/>
+	<rule ref="Generic.Commenting.Fixme"/>
+    <rule ref="Generic.Commenting.DocComment.MissingShort">
+	    <severity>0</severity>
+	</rule>
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
+        "fix-lint": "phpcbf",
+        "lint": "phpcs",
         "run-agent": [
             "docker run -p 8126:8126 -e \"DD_APM_ENABLED=true\" -e \"DD_BIND_HOST=0.0.0.0\" -e \"DD_API_KEY=invalid_key_but_this_is_fine\" --rm datadog/docker-dd-agent",
             "while ! echo exit | nc localhost 8126; do sleep 1; done"

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -72,14 +72,17 @@ final class Tracer implements OpenTracingTracer
         $this->config = array_merge($this->config, $config);
     }
 
+    /**
+     * @return Tracer
+     */
     public static function noop()
     {
         return new self(
-            new NoopTransport,
+            new NoopTransport(),
             [
-                Formats\BINARY => new NoopPropagator,
-                Formats\TEXT_MAP => new NoopPropagator,
-                Formats\HTTP_HEADERS => new NoopPropagator,
+                Formats\BINARY => new NoopPropagator(),
+                Formats\TEXT_MAP => new NoopPropagator(),
+                Formats\HTTP_HEADERS => new NoopPropagator(),
             ],
             ['enabled' => false]
         );

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -14,7 +14,7 @@ final class HttpTest extends Framework\TestCase
 {
     public function testSpanReportingFailsOnUnavailableAgent()
     {
-        $tracer = new Tracer(new Noop);
+        $tracer = new Tracer(new Noop());
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger
@@ -23,7 +23,7 @@ final class HttpTest extends Framework\TestCase
             )
             ->shouldBeCalled();
 
-        $httpTransport = new Http(new Json, $logger->reveal(), [
+        $httpTransport = new Http(new Json(), $logger->reveal(), [
             'endpoint' => 'http://0.0.0.0:8127/v0.3/traces'
         ]);
 
@@ -44,12 +44,12 @@ final class HttpTest extends Framework\TestCase
 
     public function testSpanReportingSuccess()
     {
-        $tracer = new Tracer(new Noop);
+        $tracer = new Tracer(new Noop());
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->debug(Argument::any())->shouldNotBeCalled();
 
-        $httpTransport = new Http(new Json, $logger->reveal(), [
+        $httpTransport = new Http(new Json(), $logger->reveal(), [
             'endpoint' => 'http://0.0.0.0:8126/v0.3/traces'
         ]);
 
@@ -79,12 +79,12 @@ final class HttpTest extends Framework\TestCase
 
     public function testSilentlySendTraces()
     {
-        $tracer = new Tracer(new Noop);
+        $tracer = new Tracer(new Noop());
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->debug(Argument::any())->shouldNotBeCalled();
 
-        $httpTransport = new Http(new Json, $logger->reveal(), [
+        $httpTransport = new Http(new Json(), $logger->reveal(), [
             'endpoint' => 'http://0.0.0.0:8126/v0.3/traces'
         ]);
 

--- a/tests/Unit/ScopeManagerTest.php
+++ b/tests/Unit/ScopeManagerTest.php
@@ -19,7 +19,7 @@ final class ScopeManagerTest extends Framework\TestCase
 
     public function testActivateSuccess()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $span = $tracer->startSpan(self::OPERATION_NAME);
         $scopeManager = new ScopeManager();
         $scopeManager->activate($span, false);
@@ -28,14 +28,14 @@ final class ScopeManagerTest extends Framework\TestCase
 
     public function testGetScopeReturnsNull()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $tracer->startSpan(self::OPERATION_NAME);
         $this->assertNull($tracer->getScopeManager()->getActive());
     }
 
     public function testGetScopeSuccess()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $span = $tracer->startSpan(self::OPERATION_NAME);
         $scope = $tracer->getScopeManager()->activate($span, false);
         $this->assertSame($scope, $tracer->getScopeManager()->getActive());
@@ -43,7 +43,7 @@ final class ScopeManagerTest extends Framework\TestCase
 
     public function testDeactivateSuccess()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $span = $tracer->startSpan(self::OPERATION_NAME);
         $scopeManager = new ScopeManager();
         $scope = $scopeManager->activate($span, false);
@@ -53,7 +53,7 @@ final class ScopeManagerTest extends Framework\TestCase
 
     public function testCanManageMultipleScopes()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $scopeManager = new ScopeManager();
 
         $scope = $scopeManager->activate($tracer->startSpan(self::OPERATION_NAME), false);

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -29,7 +29,7 @@ final class TracerTest extends Framework\TestCase
 
     public function testCreateSpanSuccessWithExpectedValues()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $startTime = Time\now();
         $span = $tracer->startSpan(self::OPERATION_NAME, [
             'tags' => [
@@ -46,7 +46,7 @@ final class TracerTest extends Framework\TestCase
     public function testStartSpanAsChild()
     {
         $context = SpanContext::createAsRoot();
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $span = $tracer->startSpan(self::OPERATION_NAME, [
             'child_of' => $context,
         ]);
@@ -55,14 +55,14 @@ final class TracerTest extends Framework\TestCase
 
     public function testStartActiveSpan()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $scope = $tracer->startActiveSpan(self::OPERATION_NAME);
         $this->assertEquals($scope, $tracer->getScopeManager()->getActive());
     }
 
     public function testStartActiveSpanAsChild()
     {
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $parentScope = $tracer->startActiveSpan(self::OPERATION_NAME);
         $childScope = $tracer->startActiveSpan(self::ANOTHER_OPERATION_NAME);
         $this->assertEquals($childScope, $tracer->getScopeManager()->getActive());
@@ -75,7 +75,7 @@ final class TracerTest extends Framework\TestCase
         $context = SpanContext::createAsRoot();
         $carrier = [];
 
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $tracer->inject($context, self::FORMAT, $carrier);
     }
 
@@ -86,7 +86,7 @@ final class TracerTest extends Framework\TestCase
 
         $propagator = $this->prophesize(Propagator::class);
         $propagator->inject($context, $carrier)->shouldBeCalled();
-        $tracer = new Tracer(new NoopTransport, [self::FORMAT => $propagator->reveal()]);
+        $tracer = new Tracer(new NoopTransport(), [self::FORMAT => $propagator->reveal()]);
         $tracer->inject($context, self::FORMAT, $carrier);
     }
 
@@ -94,7 +94,7 @@ final class TracerTest extends Framework\TestCase
     {
         $this->expectException(UnsupportedFormat::class);
         $carrier = [];
-        $tracer = new Tracer(new NoopTransport);
+        $tracer = new Tracer(new NoopTransport());
         $tracer->extract(self::FORMAT, $carrier);
     }
 
@@ -105,7 +105,7 @@ final class TracerTest extends Framework\TestCase
 
         $propagator = $this->prophesize(Propagator::class);
         $propagator->extract($carrier)->shouldBeCalled()->willReturn($expectedContext);
-        $tracer = new Tracer(new NoopTransport, [self::FORMAT => $propagator->reveal()]);
+        $tracer = new Tracer(new NoopTransport(), [self::FORMAT => $propagator->reveal()]);
         $actualContext = $tracer->extract(self::FORMAT, $carrier);
         $this->assertEquals($expectedContext, $actualContext);
     }

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -13,13 +13,13 @@ final class HttpTest extends Framework\TestCase
 
     public function testConfigWithDefaultValues()
     {
-        $httpTransport = new Http(new Json, new NullLogger);
+        $httpTransport = new Http(new Json(), new NullLogger());
         $this->assertEquals('http://localhost:8126/v0.3/traces', $httpTransport->getConfig()['endpoint']);
     }
 
     public function testConfig()
     {
-        $httpTransport = new Http(new Json, new NullLogger, ['endpoint' => self::ENDPOINT]);
+        $httpTransport = new Http(new Json(), new NullLogger(), ['endpoint' => self::ENDPOINT]);
         $this->assertEquals(self::ENDPOINT, $httpTransport->getConfig()['endpoint']);
     }
 }


### PR DESCRIPTION
`phpcs` was used with both `Zend` and `PSR2` however only PSR2 was effectively used.

This PR instead uses PSR12 (a newer PSR2 with changes that are still compatible with our codebase).

In addition it adds my personal Favorites of disallowing `Todo` and `Fixme` comments.

With `.phpcs.xml` linting now also correctly works with VS Code extension PHP linter.