### PR TITLE
Report Tests and Linting using JUnit reporter so that CircleCI can better help pinpointing failed tests/lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,94 +1,96 @@
 version: 2.0
 
+aliases:
+  - &docker_agent datadog/docker-dd-agent
+  - agent_env: &agent_env
+    - DD_APM_ENABLED=true
+    - DD_BIND_HOST=0.0.0.0
+    - DD_API_KEY=invalid_key_but_this_is_fine
+  - &load_composer_deps
+    key: 'betav1-composer-deps-{{ checksum "composer.json" }}'
+  - &composer_install_deps
+    name: Composer installing dependencies
+    command: composer install -n
+  - &save_composer_deps
+    key: 'betav1-composer-deps-{{ checksum "composer.json" }}'
+    paths:
+      - vendor/
+  - &test_results_path
+    path: test-results
+  - &test_php_defaults
+    working_directory: ~/datadog
+    steps:
+      - checkout
+      - restore_cache: *load_composer_deps
+      - run: *composer_install_deps
+      - save_cache: *save_composer_deps
+      - run:
+          name: 'Waiting for Dockerized agent'
+          command: dockerize -wait tcp://127.0.0.1:8126 -timeout 1m
+      - run:
+          name: Run unit tests
+          command: composer test-unit -- --log-junit test-results/php-unit/results.xml
+      - run:
+          name: Run integration tests
+          command: composer test-integration -- --log-junit test-results/php-integration/results.xml
+      - store_test_results: *test_results_path
+      - store_artifacts: *test_results_path
+
 jobs:
+  "Lint files":
+    docker:
+      - image: circleci/php:7-cli-node-browsers
+    steps:
+      - checkout
+      - restore_cache: *load_composer_deps
+      - run: *composer_install_deps
+      - save_cache: *save_composer_deps
+      - restore_cache: &lint_deps_cache
+          key: 'betav1-lint-deps-{{ checksum "composer.json" }}'
+      - run: npm install eclint --no-package-lock --no-save
+      - save_cache:
+          <<: *lint_deps_cache
+          paths:
+            - node_modules/
+      - run: mkdir -p test-results/phpcs
+      - run: node_modules/.bin/eclint check '**/*' '!vendor/**/*' '!LICENSE'
+      - run: composer lint -- --report=junit | tee test-results/phpcs/results.xml
+      - store_test_results: *test_results_path
+      - store_artifacts: *test_results_path
+
   "php-5.6":
+    <<: *test_php_defaults
     docker:
       - image: circleci/php:5.6
       - image: datadog/docker-dd-agent
-        environment:
-        - DD_APM_ENABLED=true
-        - DD_BIND_HOST=0.0.0.0
-        - DD_API_KEY=invalid_key_but_this_is_fine
-    working_directory: ~/datadog
-    steps:
-      - checkout
-      - run: composer install -n
-      - run:
-          name: Run lint
-          command: composer lint
-      - run:
-          command: dockerize -wait tcp://127.0.0.1:8126 -timeout 1m
-      - run:
-          name: Run tests
-          command: composer test
+        environment: *agent_env
 
   "php-7.0":
+    <<: *test_php_defaults
     docker:
       - image: circleci/php:7.0
       - image: datadog/docker-dd-agent
-        environment:
-        - DD_APM_ENABLED=true
-        - DD_BIND_HOST=0.0.0.0
-        - DD_API_KEY=invalid_key_but_this_is_fine
-    working_directory: ~/datadog
-    steps:
-      - checkout
-      - run: composer install
-      - run:
-          name: Run lint
-          command: composer lint
-      - run:
-          command: dockerize -wait tcp://127.0.0.1:8126 -timeout 1m
-      - run:
-          name: Run tests
-          command: composer test
+        environment: *agent_env
 
   "php-7.1":
+    <<: *test_php_defaults
     docker:
       - image: circleci/php:7.1
       - image: datadog/docker-dd-agent
-        environment:
-        - DD_APM_ENABLED=true
-        - DD_BIND_HOST=0.0.0.0
-        - DD_API_KEY=invalid_key_but_this_is_fine
-    working_directory: ~/datadog
-    steps:
-      - checkout
-      - run: composer install
-      - run:
-          name: Run lint
-          command: composer lint
-      - run:
-          command: dockerize -wait tcp://127.0.0.1:8126 -timeout 1m
-      - run:
-          name: Run tests
-          command: composer test
+        environment: *agent_env
 
   "php-7.2":
+    <<: *test_php_defaults
     docker:
       - image: circleci/php:7.2
       - image: datadog/docker-dd-agent
-        environment:
-        - DD_APM_ENABLED=true
-        - DD_BIND_HOST=0.0.0.0
-        - DD_API_KEY=invalid_key_but_this_is_fine
-    working_directory: ~/datadog
-    steps:
-      - checkout
-      - run: composer install
-      - run:
-          name: Run lint
-          command: composer lint
-      - run:
-          command: dockerize -wait tcp://127.0.0.1:8126 -timeout 1m
-      - run:
-          name: Run tests
-          command: composer test
+        environment: *agent_env
 
 workflows:
   version: 2
   build:
     jobs:
+      - "Lint files"
       - "php-5.6"
       - "php-7.0"
       - "php-7.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
       - vendor/
   - &test_results_path
     path: test-results
-  - &test_php_defaults
+  - &php_test_defaults
     working_directory: ~/datadog
     steps:
       - checkout
@@ -59,28 +59,28 @@ jobs:
       - store_artifacts: *test_results_path
 
   "php-5.6":
-    <<: *test_php_defaults
+    <<: *php_test_defaults
     docker:
       - image: circleci/php:5.6
       - image: datadog/docker-dd-agent
         environment: *agent_env
 
   "php-7.0":
-    <<: *test_php_defaults
+    <<: *php_test_defaults
     docker:
       - image: circleci/php:7.0
       - image: datadog/docker-dd-agent
         environment: *agent_env
 
   "php-7.1":
-    <<: *test_php_defaults
+    <<: *php_test_defaults
     docker:
       - image: circleci/php:7.1
       - image: datadog/docker-dd-agent
         environment: *agent_env
 
   "php-7.2":
-    <<: *test_php_defaults
+    <<: *php_test_defaults
     docker:
       - image: circleci/php:7.2
       - image: datadog/docker-dd-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ aliases:
     - DD_BIND_HOST=0.0.0.0
     - DD_API_KEY=invalid_key_but_this_is_fine
   - &load_composer_deps
-    key: 'betav1-composer-deps-{{ checksum "composer.json" }}'
+    key: 'betav1-composer-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
   - &composer_install_deps
     name: Composer installing dependencies
     command: composer install -n
   - &save_composer_deps
-    key: 'betav1-composer-deps-{{ checksum "composer.json" }}'
+    key: 'betav1-composer-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
     paths:
       - vendor/
   - &test_results_path

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,12 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[*.php]
+block_comment_start = /*
+block_comment = *
+block_comment_end = */

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -12,4 +12,5 @@
         <severity>0</severity>
     </rule>
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ $tracer = new Tracer(
 - [Starting a root span](https://github.com/opentracing/opentracing-php#starting-an-empty-trace-by-creating-a-root-span)
 - [Starting a span for a given request](https://github.com/opentracing/opentracing-php#creating-a-span-given-an-existing-request)
 - [Active span and scope manager](https://github.com/opentracing/opentracing-php#active-spans-and-scope-manager)
-	- [Creating a child span assigning parent manually](https://github.com/opentracing/opentracing-php#creating-a-child-span-assigning-parent-manually)
-	- [Creating a child span using automatic active span management](https://github.com/opentracing/opentracing-php#creating-a-child-span-using-automatic-active-span-management)
+  - [Creating a child span assigning parent manually](https://github.com/opentracing/opentracing-php#creating-a-child-span-assigning-parent-manually)
+  - [Creating a child span using automatic active span management](https://github.com/opentracing/opentracing-php#creating-a-child-span-using-automatic-active-span-management)
 - [Using span options](https://github.com/opentracing/opentracing-php#using-span-options)
 
 ### Propagation of context


### PR DESCRIPTION
CircleCI is able to process JUnit reports to aggregate time spent on each test case as well as improve the presentation of errors in tests and lints 

This PR:
- moves linting as a separate step. As there is no need to duplicate it for different PHP versions or stop testing because small linting problem happened
- adds EditorConfig linting to make sure all files are properly indented
- Uses JUnit formatter for tests, and both EC and PHP lints.
- cleans up circleci configuration to reduce duplication and introduce caching
