### PR TITLE
Update opentracing provides version, and specify that the dep is beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-curl": "*",
-        "opentracing/opentracing": "1.0.0-beta5",
+        "opentracing/opentracing": "1.0.0-beta5@dev",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0.0",
         "symfony/polyfill-php70": "^1.8.0"
     },
     "provide": {
-        "opentracing/opentracing": "1.0.0-beta4"
+        "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.19",


### PR DESCRIPTION
Trying to fix problems installing without having to override minimum-stability.