### PR TITLE
Fix: Keep imports sorted

### DIFF
--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -5,9 +5,9 @@ namespace DDTrace;
 use DDTrace\Exceptions\InvalidSpanArgument;
 use Exception;
 use InvalidArgumentException;
+use OpenTracing\Span as OpenTracingSpan;
 use OpenTracing\SpanContext as OpenTracingContext;
 use Throwable;
-use OpenTracing\Span as OpenTracingSpan;
 
 final class Span implements OpenTracingSpan
 {

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -8,12 +8,12 @@ use DDTrace\Propagators\TextMap;
 use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
+use OpenTracing\Formats;
 use OpenTracing\NoopSpan;
 use OpenTracing\Reference;
 use OpenTracing\SpanContext as OpenTracingContext;
 use OpenTracing\StartSpanOptions;
 use OpenTracing\Tracer as OpenTracingTracer;
-use OpenTracing\Formats;
 
 final class Tracer implements OpenTracingTracer
 {

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -3,9 +3,9 @@
 namespace DDTrace\Tests\Unit;
 
 use DDTrace\Exceptions\InvalidSpanArgument;
+use DDTrace\Span;
 use DDTrace\SpanContext;
 use DDTrace\Tags;
-use DDTrace\Span;
 use Exception;
 use PHPUnit\Framework;
 

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -4,13 +4,13 @@ namespace DDTrace\Tests\Unit;
 
 use DDTrace\Propagator;
 use DDTrace\SpanContext;
+use DDTrace\Time;
 use DDTrace\Tracer;
 use DDTrace\Transport;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\NoopSpan;
 use PHPUnit\Framework;
-use DDTrace\Time;
 
 final class TracerTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] keeps imports sorted

💁‍♂️ I ran

```
$ composer global require friendsofphp/php-cs-fixer
```

and then

```
$ php-cs-fixer fix src --rules=ordered_imports
$ php-cs-fixer fix tests --rules=ordered_imports
```