### PR TITLE
Enhancement: Update to latest version of composer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
   - &STEP_COMPOSER_SELF_UPDATE
     run:
       name: Updating composer itself
-      command: sudo composer self-update 1.6.5
+      command: sudo composer self-update
 
   - &STEP_COMPOSER_CACHE_RESTORE
     restore_cache:


### PR DESCRIPTION
This PR

* [x] removes the version constraint to ensure we update to the latest version of `composer` itself on CircleCi

💁‍♂️ For reference, see https://github.com/composer/composer/compare/1.7.1...1.7.2.