### PR TITLE
Fixed inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $transport = new Http(
     new Json(),
     $logger,
     [
-        'endpoint_url' => 'http://localhost:8126/v0.3/traces', // Agent endpoint
+        'endpoint' => 'http://localhost:8126/v0.3/traces', // Agent endpoint
     ]
 );
 ```


### PR DESCRIPTION
In the Transport\Http it is using 'endpoint' while in readme it is still 'endpoint_url'