### PR TITLE
Fix: Replace the OpenSSL CSPRNG with a fork-safe CSPRNG

### DIFF
--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -111,6 +111,6 @@ final class SpanContext implements OpenTracingSpanContext
 
     private static function nextId()
     {
-        return bin2hex(openssl_random_pseudo_bytes(8));
+        return bin2hex(random_bytes(8));
     }
 }


### PR DESCRIPTION
The OpenSSL CSPRNG is [not fork safe](https://wiki.openssl.org/index.php/Random_fork-safety) and was the [reason behind the duplicate-UUID's issue](https://benramsey.com/blog/2016/04/ramsey-uuid/#when-uuids-collide) in [`ramsey/uuid`](https://github.com/ramsey/uuid). This PR replaces the OpenSSL CSPRNG's with the [fork-safe CSPRNG in PHP 7](http://php.net/csprng). This is also backwards compatible with PHP 5.6 since this lib includes the `paragonie/random_compat` CSPRNG polyfill via `symfony/polyfill-php70`. :)