### PR TITLE
Remove unused namespace import

### DIFF
--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -6,7 +6,6 @@ use DDTrace\Exceptions\InvalidSpanArgument;
 use Exception;
 use InvalidArgumentException;
 use OpenTracing\Span as OpenTracingSpan;
-use OpenTracing\SpanContext as OpenTracingContext;
 use Throwable;
 
 final class Span implements OpenTracingSpan


### PR DESCRIPTION
The `OpenTracing\SpanContext` is not referenced in this file. :)