### PR TITLE
Add lighter downloads when installing from composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+tests               export-ignore
+.editorconfig       export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.phpcs.xml          export-ignore
+CONTRIBUTING.md     export-ignore
+phpunit.xml         export-ignore
+RELEASING.md        export-ignore
+
+# ext/ddtrace
+.circleci           export-ignore
+src/ext             export-ignore
+.clang-format       export-ignore
+config.m4           export-ignore


### PR DESCRIPTION
When you install `dd-trace-php` with composer, all the files in the repo (including the tests and c files) are copied into the `vendor/` directory.

![screen shot 2018-10-04 at 10 18 09 am](https://user-images.githubusercontent.com/578780/46481312-1df4d400-c7c1-11e8-9cc3-9913484ce753.png)

This PR introduces a `.gitattributes` file to "blacklist" files that should not be downloaded when installing `dd-trace-php` with composer. This makes for a much lighter download.

![screen shot 2018-10-04 at 10 30 36 am](https://user-images.githubusercontent.com/578780/46481438-67ddba00-c7c1-11e8-8ccd-b26f3ce3ee55.png)

One caveat that we'd need to discuss is that this change also impacts `git archive`:

```bash
git archive --format zip --output ../export.zip [branch-name]
```

In this example, `export.zip` would also not contain any of the blacklisted files. This also applies to downloading a zip of the repo from GitHub. So the only way to get the `ddtrace` extension that was just added in #55, would be to do a `git clone` which I'm not sure is the desired outcome.

For this reason, I'd love to get your thoughts on moving the `ddtrace` extension to its own separate repo if possible. :)