### PR TITLE
[ext/ddtrace] Add branding on PHP info output

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -1,13 +1,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <SAPI.h>
 #include <Zend/zend.h>
 #include <Zend/zend_exceptions.h>
 #include <php.h>
 #include <php_ini.h>
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
-#include <SAPI.h>
 
 #include "compat_zend_string.h"
 #include "ddtrace.h"
@@ -105,10 +105,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     return SUCCESS;
 }
 
-static int datadog_info_print(const char *str)
-{
-    return php_output_write(str, strlen(str));
-}
+static int datadog_info_print(const char *str) { return php_output_write(str, strlen(str)); }
 
 static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
@@ -117,9 +114,13 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     datadog_info_print("Datadog PHP tracer extension (experimental)");
     if (!sapi_module.phpinfo_as_text) {
         datadog_info_print("<br><strong>For help, check out ");
-        datadog_info_print("<a href=\"https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started\" style=\"background:transparent;\">the documentation</a>.</strong>");
+        datadog_info_print(
+            "<a href=\"https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started\" "
+            "style=\"background:transparent;\">the documentation</a>.</strong>");
     } else {
-        datadog_info_print("\nFor help, check out the documentation at https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started");
+        datadog_info_print(
+            "\nFor help, check out the documentation at "
+            "https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
     datadog_info_print("(c) Datadog 2018\n");

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -114,15 +114,12 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
     php_info_print_box_start(0);
-    if (!sapi_module.phpinfo_as_text) {
-        datadog_info_print("<a href=\"https://www.datadoghq.com/\"><img style=\"height:70px; width:auto; border:none;\" src=\"");
-        datadog_info_print(DATADOG_LOGO_DATA_URI "\" alt=\"Datadog logo 'Bits'\" /></a>\n");
-    }
     datadog_info_print("Datadog PHP tracer extension (experimental)");
     if (!sapi_module.phpinfo_as_text) {
-        datadog_info_print("<br><strong>Start your <a href=\"https://www.datadoghq.com/\" style=\"background:transparent;\">free trial</a>.</strong>");
+        datadog_info_print("<br><strong>For help, check out ");
+        datadog_info_print("<a href=\"https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started\" style=\"background:transparent;\">the documentation</a>.</strong>");
     } else {
-        datadog_info_print("\nStart your free trial at https://www.datadoghq.com/");
+        datadog_info_print("\nFor help, check out the documentation at https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
     datadog_info_print("(c) Datadog 2018\n");

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -111,7 +111,7 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
     php_info_print_box_start(0);
-    datadog_info_print("Datadog PHP tracer extension (experimental)");
+    datadog_info_print("Datadog PHP tracer extension");
     if (!sapi_module.phpinfo_as_text) {
         datadog_info_print("<br><strong>For help, check out ");
         datadog_info_print(

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -7,6 +7,7 @@
 #include <php_ini.h>
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
+#include <SAPI.h>
 
 #include "compat_zend_string.h"
 #include "ddtrace.h"
@@ -104,11 +105,31 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     return SUCCESS;
 }
 
+static int datadog_info_print(const char *str)
+{
+    return php_output_write(str, strlen(str));
+}
+
 static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
+    php_info_print_box_start(0);
+    if (!sapi_module.phpinfo_as_text) {
+        datadog_info_print("<a href=\"https://www.datadoghq.com/\"><img style=\"height:70px; width:auto; border:none;\" src=\"");
+        datadog_info_print(DATADOG_LOGO_DATA_URI "\" alt=\"Datadog logo 'Bits'\" /></a>\n");
+    }
+    datadog_info_print("Datadog PHP tracer extension (experimental)");
+    if (!sapi_module.phpinfo_as_text) {
+        datadog_info_print("<br><strong>Start your <a href=\"https://www.datadoghq.com/\" style=\"background:transparent;\">free trial</a>.</strong>");
+    } else {
+        datadog_info_print("\nStart your free trial at https://www.datadoghq.com/");
+    }
+    datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
+    datadog_info_print("(c) Datadog 2018\n");
+    php_info_print_box_end();
+
     php_info_print_table_start();
-    php_info_print_table_header(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
+    php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
     php_info_print_table_end();
 }

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -19,4 +19,5 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
 #ifndef PHP_DDTRACE_VERSION
 #define PHP_DDTRACE_VERSION "0.0.0-unknown"
 #endif
+
 #endif  // DDTRACE_H


### PR DESCRIPTION
This PR changes the existing `phpinfo()` output from the default...

<img width="962" alt="Default phpinfo() display" src="https://user-images.githubusercontent.com/578780/46573447-d73ae180-c95a-11e8-98b4-6ba71918d9db.png">

...to a branded version with links to start a free trail:

<img width="968" alt="Branded phpinfo() display" src="https://user-images.githubusercontent.com/578780/46573448-ed48a200-c95a-11e8-90e3-49c5741a1f27.png">

This also affects the display of `php -i`:

<img width="577" alt="PHP info from the CLI" src="https://user-images.githubusercontent.com/578780/46573458-3d276900-c95b-11e8-87cc-c836209e2085.png">

Gotta get that branding on! :D I just wanted to confirm that this display conforms to the [logo style guide](https://www.datadoghq.com/about/press/resources/) or if we need to use the white logo instead in this context.

Also - I don't know why the default behavior from the template extension uses `php_info_print_table_header()` to display the extension-enabled status, but other extensions use `php_info_print_table_row()`. So this PR also changes that display to conform to the same style as other extensions. :)