### PR TITLE
Allow exporting files needed to build the extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,4 @@ RELEASING.md        export-ignore
 
 # ext/ddtrace
 .circleci           export-ignore
-src/ext             export-ignore
 .clang-format       export-ignore
-config.m4           export-ignore


### PR DESCRIPTION
We've disabled including C extension files in exported ZIP to make Composer vendored files less verbose.

But at this moment - without infra to build custom deb/rpms with the extension - using ZIP exported repositories is good way to ensure consistency with build instructions and avoid the need to clone the whole repository.