### PR TITLE
Tiny test to verify that tracing __construct works

### DIFF
--- a/tests/ext/overriding_construct.phpt
+++ b/tests/ext/overriding_construct.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check if we can override method from a parent class in a descendant class
+--FILE--
+<?php
+class Test {
+    public function __construct() {
+        echo "METHOD" . PHP_EOL;
+    }
+}
+
+$no = 1;
+dd_trace("Test", "__construct", function () use ($no) {
+    $this->__construct();
+    echo "HOOK " . $no . PHP_EOL;
+    return $this;
+});
+
+$a = new Test();
+
+?>
+--EXPECT--
+METHOD
+HOOK 1


### PR DESCRIPTION
(it does. just needed to verify on 5.6 and figured it's a good thing to include)