### PR TITLE
Remove dd extension from required extensions in composer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running phpcs
-          command: ((git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3-) | xargs -r composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml) || true
+          command: (git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3-) | xargs -r composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml
       - <<: *STEP_STORE_TEST_RESULTS
       - <<: *STEP_STORE_ARTIFACTS
   "Static Analysis":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running phpcs
-          command: (git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3-) | xargs -r composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml
+          command: (git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3- || true) | xargs -r composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml
       - <<: *STEP_STORE_TEST_RESULTS
       - <<: *STEP_STORE_ARTIFACTS
   "Static Analysis":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running phpcs
-          command: (git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3-) | xargs composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml
+          command: ((git diff --name-status origin/master...HEAD | egrep "^[ACMR].*\.php$" | cut -c 3-) | xargs -r composer lint-5.4 -- --report=junit | tee test-results/phpcs/results.xml) || true
       - <<: *STEP_STORE_TEST_RESULTS
       - <<: *STEP_STORE_ARTIFACTS
   "Static Analysis":

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-curl": "*",
-        "ext-ddtrace": "*",
         "opentracing/opentracing": "1.0.0-beta5@dev",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0.0",


### PR DESCRIPTION
Makes using code instrumented with DD library a bit nicer to work on workstations where this extension is not installed.