### PR TITLE
Bugfixes for PHP 5.6

### DIFF
--- a/DDMakefile
+++ b/DDMakefile
@@ -13,7 +13,7 @@ src/ext/version.h:
 	@echo "Creating [src/ext/version.h]\n"
 	@echo -n "PHP: "
 	@cat src/DDTrace/Version.php | grep VERSION
-	@(echo -n '#ifndef PHP_DDTRACE_VERSION\n#define PHP_DDTRACE_VERSION "$(VERSION)"\n#endif\n' ) > $@
+	@(echo '#ifndef PHP_DDTRACE_VERSION\n#define PHP_DDTRACE_VERSION "$(VERSION)"\n#endif' ) > $@
 	@echo "C: "
 	@cat $@ #| grep '#define'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,32 @@
 version: '3.6'
 
+x-aliases:
+  - &base_php_service
+      ulimits:
+        core: 99999999999
+      working_dir: '/home/circleci/app'
+      stdin_open: true
+      tty: true
+      volumes: [ '.:/home/circleci/app' ]
+      tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec' ]
+      depends_on:
+        - redis_integration
+        - mysql_integration
+        - ddagent_integration
+      environment:
+        - REDIS_HOSTNAME=redis_integration
+        - DDAGENT_HOSTNAME=ddagent_integration
+
 services:
+  '5.6': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_5_6' }
+  '5.6-debug': { <<: *base_php_service, build: 'dockerfiles/debug_php-5.6' }
 
-  '7.2': &base
-    image: "datadog/docker-library:ddtrace_php_7_2"
-    ulimits:
-      core: 99999999999
-    working_dir: '/home/circleci/app'
-    stdin_open: true
-    tty: true
-    volumes: [ '.:/home/circleci/app' ]
-    tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec' ]
-    depends_on:
-      - memcached_integration
-      - redis_integration
-      - ddagent_integration
-    environment:
-      - REDIS_HOSTNAME=redis_integration
-      - DDAGENT_HOSTNAME=ddagent_integration
+  '7.0': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_0' }
+  '7.1': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_1' }
+  '7.2': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_2' }
+  '7.2-debug': { <<: *base_php_service, build: 'dockerfiles/debug_php-7.2' }
 
-  '5.6': { <<: *base, image: 'datadog/docker-library:ddtrace_php_5_6' }
-
-  '7.0': { <<: *base, image: 'datadog/docker-library:ddtrace_php_7_0' }
-
-  '7.1': { <<: *base, image: 'datadog/docker-library:ddtrace_php_7_1' }
+  'fpm': { <<: *base_php_service, image: 'circleci/ruby:2.5', depends_on: [] }
 
   mysql_integration:
     image: mysql:5.6
@@ -32,8 +35,6 @@ services:
       - MYSQL_PASSWORD=test
       - MYSQL_USER=test
       - MYSQL_DATABASE=test
-
-  'fpm': { <<: *base, image: 'circleci/ruby:2.5', depends_on: [] }
 
   redis_integration:
     image: "circleci/redis:4.0-alpine"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-aliases:
         - redis_integration
         - mysql_integration
         - ddagent_integration
+        - memcached_integration
       environment:
         - REDIS_HOSTNAME=redis_integration
         - DDAGENT_HOSTNAME=ddagent_integration

--- a/dockerfiles/debug_php-5.6/Dockerfile
+++ b/dockerfiles/debug_php-5.6/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get install -y libgmp-dev libmcrypt-dev && ln -s /usr/include/x86_64-lin
 
 RUN ./configure --help
 
-
 RUN ./configure \
     --enable-mbstring \
     --enable-zip \
@@ -68,32 +67,11 @@ RUN ./configure \
     --disable-nls \
     --enable-debug
 
-# RUN ./configure  --enable-debug --help
-
-
 RUN make -j 4
 
 RUN make install
-# RUN apk --update add wget \
-# 	curl \
-# 	git \
-# 	grep \
-# 	gmp-dev \
-# 	libmcrypt-dev \
-# 	freetype-dev \
-# 	libxpm-dev \
-# 	libwebp-dev \
-# 	libjpeg-turbo-dev \
-# 	libjpeg \
-# 	bzip2-dev \
-# 	openssl-dev \
-# 	krb5-dev \
-# 	libxml2-dev \
-# 	build-base \
-# 	tar \
-# 	make \
-# 	autoconf
 
+RUN apt-get install -y valgrind
 
 CMD ["bash"]
 

--- a/dockerfiles/debug_php-5.6/Dockerfile
+++ b/dockerfiles/debug_php-5.6/Dockerfile
@@ -30,10 +30,9 @@ WORKDIR /src/php
 RUN ./buildconf --force
 
 RUN apt-get install -y libgmp-dev libmcrypt-dev && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+RUN apt-get install -y valgrind vim
 
-RUN ./configure --help
-
-RUN ./configure \
+RUN ./configure  \
     --enable-mbstring \
     --enable-zip \
     --enable-bcmath \
@@ -45,6 +44,9 @@ RUN ./configure \
     --enable-sysvsem \
     --enable-sysvshm \
     --enable-wddx \
+    --with-mysqli --with-mysql --with-pdo-mysql --enable-opcache --enable-mysqlnd \
+    --with-config-file-scan-dir=/usr/local/etc/php/conf.d \
+    --with-config-file-path=/usr/local/etc/php \
     --with-curl \
     --with-mcrypt \
     --with-t1lib=/usr \
@@ -67,11 +69,16 @@ RUN ./configure \
     --disable-nls \
     --enable-debug
 
-RUN make -j 4
+RUN make -j 2
 
 RUN make install
 
-RUN apt-get install -y valgrind
+RUN mkdir -p /usr/local/etc/php/conf.d
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('sha384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"\
+  && php composer-setup.php && php -r "unlink('composer-setup.php');"\
+  && mv composer.phar /usr/local/bin/composer
 
 CMD ["bash"]
 

--- a/src/ext/debug.h
+++ b/src/ext/debug.h
@@ -1,14 +1,15 @@
 #ifndef DD_DEBUG_H
 #define DD_DEBUG_H
 
-#ifdef DEBUG
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define DD_PRINTF(fmt, ...)                                                                          \
+#define __DD_FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __DD_PRINTF(fmt, ...)                                                                          \
     do {                                                                                             \
-        fprintf(stderr, "%s:%d #%s " fmt "\n", __FILENAME__, __LINE__, __FUNCTION__, ##__VA_ARGS__); \
+        fprintf(stderr, "%s:%d #%s " fmt "\n", __DD_FILENAME__, __LINE__, __FUNCTION__, ##__VA_ARGS__); \
         fflush(stderr);                                                                              \
     } while (0)
 
+#ifdef DEBUG
+#define DD_PRINTF(fmt, ...) __DD_PRINTF(fmt, ...)
 #define DD_PRINT_HASH(ht)                                                              \
     do {                                                                               \
         Bucket *p;                                                                     \

--- a/src/ext/debug.h
+++ b/src/ext/debug.h
@@ -2,10 +2,10 @@
 #define DD_DEBUG_H
 
 #define __DD_FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define __DD_PRINTF(fmt, ...)                                                                          \
-    do {                                                                                             \
+#define __DD_PRINTF(fmt, ...)                                                                           \
+    do {                                                                                                \
         fprintf(stderr, "%s:%d #%s " fmt "\n", __DD_FILENAME__, __LINE__, __FUNCTION__, ##__VA_ARGS__); \
-        fflush(stderr);                                                                              \
+        fflush(stderr);                                                                                 \
     } while (0)
 
 #ifdef DEBUG

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -115,6 +115,9 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
         if (!return_value_ptr) {
             zval_dtor(&rv);
         }
+        #if PHP_VERSION_ID < 70000
+        zend_vm_stack_clear_multiple(0 TSRMLS_CC);
+        #endif
     }
 
 #if PHP_VERSION_ID < 70000

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -115,9 +115,6 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
         if (!return_value_ptr) {
             zval_dtor(&rv);
         }
-        #if PHP_VERSION_ID < 70000
-        zend_vm_stack_clear_multiple(0 TSRMLS_CC);
-        #endif
     }
 
 #if PHP_VERSION_ID < 70000
@@ -275,9 +272,8 @@ static zend_always_inline zend_bool get_wrappable_function(zend_execute_data *ex
 
 static int update_opcode_leave(zend_execute_data *execute_data) {
 #if PHP_VERSION_ID < 70000
-    if (EG(exception)) {
-        zend_vm_stack_pop();  // clear param data if FN has thrown an exception
-    }
+    zend_vm_stack_clear_multiple(0 TSRMLS_CC);
+    EX(call)--;
 #else
     EX(call) = EX(call)->prev_execute_data;
 #endif

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -77,7 +77,10 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
     zend_function *func;
 #if PHP_VERSION_ID < 70000
     func = datadog_current_function(execute_data);
-    this = datadog_this(func, execute_data);
+
+    if (dispatch->clazz) {
+        this = datadog_this(func, execute_data);
+    }
 
     zend_function *callable = (zend_function *)zend_get_closure_method_def(&dispatch->callable TSRMLS_CC);
 

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -51,7 +51,9 @@ static zend_always_inline void setup_fcal_name(zend_execute_data *execute_data, 
     if (EX(call)->num_additional_args) {
         vm_stack_push_args(fci->param_count TSRMLS_CC);
     } else {
-        EX(function_state).arguments = zend_vm_stack_top(TSRMLS_C);
+        if (fci->param_count) {
+            EX(function_state).arguments = zend_vm_stack_top(TSRMLS_C);
+        }
         zend_vm_stack_push((void *)(zend_uintptr_t)fci->param_count TSRMLS_CC);
     }
 

--- a/tests/Integration/Integrations/MemcachedTest.php
+++ b/tests/Integration/Integrations/MemcachedTest.php
@@ -26,10 +26,6 @@ final class MemcachedTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Memcached integration with php 5.6 has a known bug. Work in Progress to fix it.');
-        }
-
         $this->client = new \Memcached();
         $this->client->addServer(self::$host, self::$port);
         $this->isolateTracer(function () {

--- a/tests/Integration/Integrations/PDOTest.php
+++ b/tests/Integration/Integrations/PDOTest.php
@@ -22,11 +22,6 @@ final class PDOTest extends IntegrationTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('PDO integration with php 5.6 has a known bug. Work in Progress to fix it.');
-        }
-
         $this->setUpDatabase();
     }
 

--- a/tests/Integration/Integrations/PredisTest.php
+++ b/tests/Integration/Integrations/PredisTest.php
@@ -21,10 +21,6 @@ final class PredisTest extends IntegrationTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Predis integration with php 5.6 has a known bug. Work in Progress to fix it.');
-        }
     }
 
     public function testPredisIntegrationCreatesSpans()


### PR DESCRIPTION
Fix 5.6 instrumentation dispatch bugs. 
+ reenable tests disabled for php 5.6
+ add dockerfiles that build debug version of PHP - extremely useful for tracing