### PR TITLE
Rename withTracer test method to isolateTracer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,14 +258,17 @@ jobs:
           name: Test installing packages on target systems
           command: make -f dockerfiles/verify_packages/Makefile
 
+
 workflows:
   version: 2
   build_packages:
     jobs:
-      - "hold":
-          type: approval
       - "7.0 20151012": &BUILD_PACKAGE_FORKFLOW
-          requires: [ "hold" ]
+          filters:
+            tags:
+              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            branches:
+              ignore: /.*/
       - "7.1 20160303": *BUILD_PACKAGE_FORKFLOW
       - "7.2 20170718": *BUILD_PACKAGE_FORKFLOW
       - "7.0 zts 20151012-zts": *BUILD_PACKAGE_FORKFLOW

--- a/tests/Integration/Common/IntegrationTestCase.php
+++ b/tests/Integration/Common/IntegrationTestCase.php
@@ -28,7 +28,7 @@ abstract class IntegrationTestCase extends TestCase
      * @param $fn
      * @return Span[][]
      */
-    public function withTracer($fn)
+    public function isolateTracer($fn)
     {
         $transport = new DebugTransport();
         $tracer = new Tracer($transport);
@@ -47,7 +47,7 @@ abstract class IntegrationTestCase extends TestCase
      */
     public function inTestScope($name, $fn)
     {
-        return $this->withTracer(function ($tracer) use ($fn, $name) {
+        return $this->isolateTracer(function ($tracer) use ($fn, $name) {
             $scope = $tracer->startActiveSpan($name);
             $fn($tracer);
             $scope->close();

--- a/tests/Integration/Integrations/MemcachedTest.php
+++ b/tests/Integration/Integrations/MemcachedTest.php
@@ -37,7 +37,7 @@ final class MemcachedTest extends IntegrationTestCase
 
         $this->client = new \Memcached();
         $this->client->addServer(MEMCACHED_HOST, MEMCACHED_PORT);
-        $this->withTracer(function () {
+        $this->isolateTracer(function () {
             // Cleaning up existing data from previous tests
             $this->client->flush();
         });
@@ -45,7 +45,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testAdd()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 'value');
         });
         $this->assertSpans($traces, [
@@ -59,7 +59,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testAddByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 'value');
         });
         $this->assertSpans($traces, [
@@ -75,7 +75,7 @@ final class MemcachedTest extends IntegrationTestCase
     /** Should fail because memcached is compressed by default */
     public function testAppendCompressed()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             try {
                 $this->client->append('key', 'value');
                 $this->fail('An exception should be raised because client is compressed');
@@ -96,7 +96,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testAppendUncompressed()
     {
         $this->client->setOption(\Memcached::OPT_COMPRESSION, false);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->append('key', 'value');
         });
         $this->assertSpans($traces, [
@@ -111,7 +111,7 @@ final class MemcachedTest extends IntegrationTestCase
     /** Should fail because memcached is compressed by default */
     public function testAppendByKeyCompressed()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             try {
                 $this->client->appendByKey('my_server', 'key', 'value');
                 $this->fail('An exception should be raised because client is compressed');
@@ -134,7 +134,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testAppendByKey()
     {
         $this->client->setOption(\Memcached::OPT_COMPRESSION, false);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->appendByKey('my_server', 'key', 'value');
         });
         $this->assertSpans($traces, [
@@ -149,7 +149,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testDelete()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 'value');
 
             $this->assertSame('value', $this->client->get('key'));
@@ -172,7 +172,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testDeleteByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 'value');
 
             $this->assertSame('value', $this->client->getByKey('my_server', 'key'));
@@ -196,7 +196,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testDeleteMulti()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key1', 'value1');
             $this->client->add('key2', 'value2');
 
@@ -230,7 +230,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testDeleteMultiByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key1', 'value1');
             $this->client->addByKey('my_server', 'key2', 'value2');
 
@@ -261,7 +261,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testDecrementBinaryProtocol()
     {
         $this->client->setOption(\Memcached::OPT_BINARY_PROTOCOL, true);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->decrement('key', 2, 100);
 
             // Note that the default value is set as 'string' instead of int. This is not a side effect
@@ -293,7 +293,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testDecrementNonBinaryProtocol()
     {
         $this->client->setOption(\Memcached::OPT_BINARY_PROTOCOL, false);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 100);
 
             $this->client->decrement('key', 2);
@@ -315,7 +315,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testDecrementByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 100);
 
             $this->client->decrementByKey('my_server', 'key', 2);
@@ -339,7 +339,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testIncrementBinaryProtocol()
     {
         $this->client->setOption(\Memcached::OPT_BINARY_PROTOCOL, true);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->increment('key', 2, 100);
 
             // Note that the default value is set as 'string' instead of int. This is not a side effect
@@ -369,7 +369,7 @@ final class MemcachedTest extends IntegrationTestCase
     public function testIncrementNonBinaryProtocol()
     {
         $this->client->setOption(\Memcached::OPT_BINARY_PROTOCOL, false);
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 0);
             $this->client->increment('key', 2);
 
@@ -390,7 +390,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testIncrementByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 100);
             $this->client->incrementByKey('my_server', 'key', 2);
 
@@ -412,7 +412,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testFlush()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 'value');
 
             $this->assertSame('value', $this->client->get('key'));
@@ -434,7 +434,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testGet()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 'value');
 
             $this->assertSame('value', $this->client->get('key'));
@@ -451,7 +451,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testGetMulti()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key1', 'value1');
             $this->client->add('key2', 'value2');
 
@@ -470,7 +470,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testGetByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 'value');
 
             $this->assertSame('value', $this->client->getByKey('my_server', 'key'));
@@ -488,7 +488,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testGetMultiByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key1', 'value1');
             $this->client->addByKey('my_server', 'key2', 'value2');
 
@@ -511,7 +511,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testReplace()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->add('key', 'value');
             $this->client->replace('key', 'replaced');
 
@@ -530,7 +530,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testReplaceByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->addByKey('my_server', 'key', 'value');
             $this->client->replaceByKey('my_server', 'key', 'replaced');
 
@@ -550,7 +550,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testSet()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->set('key', 'value');
         });
         $this->assertSpans($traces, [
@@ -564,7 +564,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testSetByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->setByKey('my_server', 'key', 'value');
         });
         $this->assertSpans($traces, [
@@ -579,7 +579,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testSetMulti()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->setMulti(['key1' => 'value1', 'key2' => 'value2']);
 
             $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $this->client->getMulti(['key1', 'key2']));
@@ -596,7 +596,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testSetMultiByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->setMultiByKey('my_server', ['key1' => 'value1', 'key2' => 'value2']);
 
             $this->assertEquals(
@@ -617,7 +617,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testTouch()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->touch('key');
         });
         $this->assertSpans($traces, [
@@ -631,7 +631,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public function testTouchByKey()
     {
-        $traces = $this->withTracer(function () {
+        $traces = $this->isolateTracer(function () {
             $this->client->touchByKey('my_server', 'key');
         });
         $this->assertSpans($traces, [

--- a/tests/Integration/Integrations/MemcachedTest.php
+++ b/tests/Integration/Integrations/MemcachedTest.php
@@ -6,14 +6,6 @@ use DDTrace\Integrations;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 
-const MEMCACHED_HOST = 'memcached_integration';
-const MEMCACHED_PORT = '11211';
-
-const BASE_TAGS = [
-    'out.host' => MEMCACHED_HOST,
-    'out.port' => MEMCACHED_PORT,
-];
-
 
 final class MemcachedTest extends IntegrationTestCase
 {
@@ -21,6 +13,9 @@ final class MemcachedTest extends IntegrationTestCase
      * @var \Memcached
      */
     private $client;
+
+    private static $host = 'memcached_integration';
+    private static $port = '11211';
 
     public static function setUpBeforeClass()
     {
@@ -36,7 +31,7 @@ final class MemcachedTest extends IntegrationTestCase
         }
 
         $this->client = new \Memcached();
-        $this->client->addServer(MEMCACHED_HOST, MEMCACHED_PORT);
+        $this->client->addServer(self::$host, self::$port);
         $this->isolateTracer(function () {
             // Cleaning up existing data from previous tests
             $this->client->flush();
@@ -50,7 +45,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.add', 'memcached', 'memcached', 'add')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'add key',
                     'memcached.command' => 'add',
                 ])),
@@ -64,7 +59,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.addByKey', 'memcached', 'memcached', 'addByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'addByKey key',
                     'memcached.command' => 'addByKey',
                     'memcached.server_key' => 'my_server',
@@ -85,7 +80,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
                 ->setError()
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'append key',
                     'memcached.command' => 'append',
                 ]))
@@ -101,7 +96,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'append key',
                     'memcached.command' => 'append',
                 ])),
@@ -121,7 +116,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
                 ->setError()
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'appendByKey key',
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
@@ -139,7 +134,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'appendByKey key',
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
@@ -162,7 +157,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.delete', 'memcached', 'memcached', 'delete')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'delete key',
                     'memcached.command' => 'delete',
                 ])),
@@ -185,7 +180,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteByKey', 'memcached', 'memcached', 'deleteByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'deleteByKey key',
                     'memcached.command' => 'deleteByKey',
                     'memcached.server_key' => 'my_server',
@@ -248,7 +243,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteMultiByKey', 'memcached', 'memcached', 'deleteMultiByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'deleteMultiByKey key1,key2',
                     'memcached.command' => 'deleteMultiByKey',
                     'memcached.server_key' => 'my_server',
@@ -276,13 +271,13 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'decrement key',
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'decrement key',
                     'memcached.command' => 'decrement',
                 ])),
@@ -305,7 +300,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'decrement key',
                     'memcached.command' => 'decrement',
                 ])),
@@ -327,7 +322,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.decrementByKey', 'memcached', 'memcached', 'decrementByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'decrementByKey key',
                     'memcached.command' => 'decrementByKey',
                     'memcached.server_key' => 'my_server',
@@ -352,13 +347,13 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'increment key',
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'increment key',
                     'memcached.command' => 'increment',
                 ])),
@@ -380,7 +375,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'increment key',
                     'memcached.command' => 'increment',
                 ])),
@@ -401,7 +396,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.incrementByKey', 'memcached', 'memcached', 'incrementByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'incrementByKey key',
                     'memcached.command' => 'incrementByKey',
                     'memcached.server_key' => 'my_server',
@@ -442,7 +437,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.get', 'memcached', 'memcached', 'get')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'get key',
                     'memcached.command' => 'get',
                 ])),
@@ -478,7 +473,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getByKey', 'memcached', 'memcached', 'getByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'getByKey key',
                     'memcached.command' => 'getByKey',
                     'memcached.server_key' => 'my_server',
@@ -501,7 +496,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getMultiByKey', 'memcached', 'memcached', 'getMultiByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'getMultiByKey key1,key2',
                     'memcached.command' => 'getMultiByKey',
                     'memcached.server_key' => 'my_server',
@@ -520,7 +515,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.replace', 'memcached', 'memcached', 'replace')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'replace key',
                     'memcached.command' => 'replace',
                 ])),
@@ -539,7 +534,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.replaceByKey', 'memcached', 'memcached', 'replaceByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'replaceByKey key',
                     'memcached.command' => 'replaceByKey',
                     'memcached.server_key' => 'my_server',
@@ -555,7 +550,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.set', 'memcached', 'memcached', 'set')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'set key',
                     'memcached.command' => 'set',
                 ])),
@@ -569,7 +564,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setByKey', 'memcached', 'memcached', 'setByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'setByKey key',
                     'memcached.command' => 'setByKey',
                     'memcached.server_key' => 'my_server',
@@ -606,7 +601,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setMultiByKey', 'memcached', 'memcached', 'setMultiByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'setMultiByKey key1,key2',
                     'memcached.command' => 'setMultiByKey',
                     'memcached.server_key' => 'my_server',
@@ -622,7 +617,7 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touch', 'memcached', 'memcached', 'touch')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'touch key',
                     'memcached.command' => 'touch',
                 ])),
@@ -636,11 +631,19 @@ final class MemcachedTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touchByKey', 'memcached', 'memcached', 'touchByKey')
-                ->withExactTags(array_merge(BASE_TAGS, [
+                ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'touchByKey key',
                     'memcached.command' => 'touchByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
         ]);
+    }
+
+    private static function baseTags()
+    {
+        return [
+            'out.host' => self::$host,
+            'out.port' => self::$port,
+        ];
     }
 }

--- a/tests/Integration/Integrations/PredisTest.php
+++ b/tests/Integration/Integrations/PredisTest.php
@@ -40,7 +40,7 @@ final class PredisTest extends IntegrationTestCase
     {
         $client = new \Predis\Client([ "host" => $this->redisHostname() ]);
 
-        $traces = $this->withTracer(function () use ($client) {
+        $traces = $this->isolateTracer(function () use ($client) {
             $client->set('foo', 'value');
         });
         $this->assertCount(1, $traces);


### PR DESCRIPTION
**Blocked by #102**
This PR just rename the integration tests base method `withTracer` to `isolateTracer` to make naming more expressive. At the same time, after rebasing on master, we also adapted a few lines of code to be compatible with php 5.4.