### PR TITLE
Configure agent's connection parameters through env variables

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,3 +144,12 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
     }
 });
 ```
+
+## Configuration
+
+It is possible to configure the agent connections parameters by means of env variables.
+
+| Env variable          | Default     | Note                        |
+|-----------------------|-------------|-----------------------------|
+| `DD_AGENT_HOST`       | `localhost` | The agent host name         |
+| `DD_TRACE_AGENT_PORT` | `8126`      | The trace agent port number |

--- a/tests/Unit/CleanEnvTrait.php
+++ b/tests/Unit/CleanEnvTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DDTrace\Tests\Unit;
+
+
+/**
+ * This trait provides to work in a clean environment for specific env variables. Env variables provided in the method
+ * `getCleanEnvs()` are cleaned during setup and restored to their original value during tearDown.
+ */
+trait CleanEnvTrait
+{
+    /**
+     * @var array
+     */
+    private $envsValuesBeforeTest;
+
+    /**
+     * @return string[] The array of envs that will be cleared before and restore to the original value after test.
+     */
+    protected function getCleanEnvs()
+    {
+        return [];
+    }
+
+    /** @inheritdoc */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Cleaning up envs that MUST be null
+        foreach ($this->getCleanEnvs() as $env) {
+            $this->envsValuesBeforeTest[$env] = getenv($env);
+            putenv($env);
+        }
+    }
+
+    /** @inheritdoc */
+    protected function tearDown()
+    {
+        // Restoring envs to their previous value
+        foreach ($this->getCleanEnvs() as $env) {
+            $originalValue = $this->envsValuesBeforeTest[$env];
+            if ($originalValue === false) {
+                putenv($env);
+            } else {
+                putenv($env . '=' . $originalValue);
+            }
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -3,13 +3,19 @@
 namespace DDTrace\Tests\Unit\Transport;
 
 use DDTrace\Encoders\Json;
+use DDTrace\Tests\Unit\CleanEnvTrait;
 use DDTrace\Transport\Http;
 use PHPUnit\Framework;
 use Psr\Log\NullLogger;
 
 final class HttpTest extends Framework\TestCase
 {
-    const ENDPOINT = 'http://myserver:8126/v0.3/traces';
+    use CleanEnvTrait;
+
+    public function getCleanEnvs()
+    {
+        return ['DD_AGENT_HOST', 'DD_TRACE_AGENT_PORT'];
+    }
 
     public function testConfigWithDefaultValues()
     {
@@ -19,7 +25,22 @@ final class HttpTest extends Framework\TestCase
 
     public function testConfig()
     {
-        $httpTransport = new Http(new Json(), new NullLogger(), ['endpoint' => self::ENDPOINT]);
-        $this->assertEquals(self::ENDPOINT, $httpTransport->getConfig()['endpoint']);
+        $endpoint = '__end_point___';
+        $httpTransport = new Http(new Json(), new NullLogger(), ['endpoint' => $endpoint]);
+        $this->assertEquals($endpoint, $httpTransport->getConfig()['endpoint']);
+    }
+
+    public function testConfigPortFromEnv()
+    {
+        putenv('DD_TRACE_AGENT_PORT=8888');
+        $httpTransport = new Http(new Json(), new NullLogger());
+        $this->assertEquals('http://localhost:8888/v0.3/traces', $httpTransport->getConfig()['endpoint']);
+    }
+
+    public function testConfigHostFromEnv()
+    {
+        putenv('DD_AGENT_HOST=other_host');
+        $httpTransport = new Http(new Json(), new NullLogger());
+        $this->assertEquals('http://other_host:8126/v0.3/traces', $httpTransport->getConfig()['endpoint']);
     }
 }


### PR DESCRIPTION
This PR adds the possibility of configuring the trace agent connection parameters by means of env variables.

| Env variable          | Default     | Note                        |
|-----------------------|-------------|-----------------------------|
| `DD_AGENT_HOST`       | `localhost` | The agent host name         |
| `DD_TRACE_AGENT_PORT` | `8126`      | The trace agent port number |

