### PR TITLE
Laravel: Prevent traces not sent when app name is empty

### DIFF
--- a/src/DDTrace/Integrations/LaravelProvider.php
+++ b/src/DDTrace/Integrations/LaravelProvider.php
@@ -135,12 +135,14 @@ class LaravelProvider extends ServiceProvider
 
     private function getAppName()
     {
+        $name = null;
+
         if (isset($_ENV['ddtrace_app_name'])) {
-            return $_ENV['ddtrace_app_name'];
+            $name = $_ENV['ddtrace_app_name'];
         } elseif (is_callable('config')) {
-            return config('app.name');
-        } else {
-            return 'laravel';
+            $name = config('app.name');
         }
+
+        return empty($name) ? 'laravel' : $name;
     }
 }


### PR DESCRIPTION
After a lot of head scratching and not reading the logs... (I know)

I noticed that when you leave the `config('app.name')` value empty in your app no traces are being sent since it needs to have a non-empty value. So I made sure the app name does return a non-empty value so traces won't be stopped by that :)