### PR TITLE
Fix laravel service name

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -149,7 +149,8 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
 It is possible to configure the agent connections parameters by means of env variables.
 
-| Env variable          | Default     | Note                        |
-|-----------------------|-------------|-----------------------------|
-| `DD_AGENT_HOST`       | `localhost` | The agent host name         |
-| `DD_TRACE_AGENT_PORT` | `8126`      | The trace agent port number |
+| Env variable          | Default            | Note                                    |
+|-----------------------|--------------------|-----------------------------------------|
+| `DD_AGENT_HOST`       | `localhost`        | The agent host name                     |
+| `DD_TRACE_AGENT_PORT` | `8126`             | The trace agent port number             |
+| `ddtrace_app_name`    | `framework's name` | The service name (Laravel and Symphony) |

--- a/src/DDTrace/Integrations/LaravelProvider.php
+++ b/src/DDTrace/Integrations/LaravelProvider.php
@@ -137,8 +137,8 @@ class LaravelProvider extends ServiceProvider
     {
         $name = null;
 
-        if (isset($_ENV['ddtrace_app_name'])) {
-            $name = $_ENV['ddtrace_app_name'];
+        if (getenv('ddtrace_app_name')) {
+            $name = getenv('ddtrace_app_name');
         } elseif (is_callable('config')) {
             $name = config('app.name');
         }


### PR DESCRIPTION
Using `$_ENV` does not seem to work, using `getenv` works better.

Signed-off-by: Patrik Cyvoct <pcyvoct@assessfirst.com>