### PR TITLE
Change register to boot for laravel integration

### DIFF
--- a/src/DDTrace/Integrations/LaravelProvider.php
+++ b/src/DDTrace/Integrations/LaravelProvider.php
@@ -34,7 +34,7 @@ use function DDTrace\Time\fromMicrotime;
  */
 class LaravelProvider extends ServiceProvider
 {
-    public function register()
+    public function boot()
     {
         if (!extension_loaded('ddtrace')) {
             trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);


### PR DESCRIPTION
I'm having some issue when using register instead of boot ([something like this](https://stackoverflow.com/questions/33851821/laravel-5-1-class-cache-does-not-exist)). I've tested it, seems to run as before.

Signed-off-by: Patrik Cyvoct <pcyvoct@assessfirst.com>