### PR TITLE
Add key obfuscation to Memcached integration

### DIFF
--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -4,6 +4,7 @@ namespace DDTrace\Integrations\Memcached;
 
 use DDTrace\Tags;
 use DDTrace\Types;
+use DDTrace\Obfuscation;
 use OpenTracing\GlobalTracer;
 
 /**
@@ -207,7 +208,7 @@ class MemcachedIntegration
         if (!is_array($args[0])) {
             self::setServerTagsByKey($span, $memcached, $args[0]);
         }
-        $span->setTag('memcached.query', "$command " . self::obfuscateKeys($args[0]));
+        $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[0]));
         $span->setResource($command);
 
         try {
@@ -230,7 +231,7 @@ class MemcachedIntegration
         $span->setTag('memcached.server_key', $args[0]);
         self::setServerTagsByKey($span, $memcached, $args[0]);
 
-        $span->setTag('memcached.query', "$command " . self::obfuscateKeys($args[1]));
+        $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[1]));
         $span->setResource($command);
 
         try {
@@ -299,7 +300,7 @@ class MemcachedIntegration
         $span->setTag(Tags\SERVICE_NAME, 'memcached');
         $span->setTag('memcached.command', $command);
 
-        $query = "$command " . self::obfuscateKeys($args[0], ',');
+        $query = "$command " . Obfuscation::toObfuscatedString($args[0], ',');
         $span->setTag('memcached.query', $query);
         $span->setResource($command);
 
@@ -323,7 +324,7 @@ class MemcachedIntegration
         $span->setTag('memcached.server_key', $args[0]);
         self::setServerTagsByKey($span, $memcached, $args[0]);
 
-        $query = "$command " . self::obfuscateKeys($args[1], ',');
+        $query = "$command " . Obfuscation::toObfuscatedString($args[1], ',');
         $span->setTag('memcached.query', $query);
         $span->setResource($command);
 
@@ -351,21 +352,5 @@ class MemcachedIntegration
         $server = $memcached->getServerByKey($key);
         $span->setTag(Tags\TARGET_HOST, $server['host']);
         $span->setTag(Tags\TARGET_PORT, $server['port']);
-    }
-
-    /**
-     * Given a callback arg, it extract the keys depending on scalar vs associative array.
-     *
-     * @param mixed $keys
-     * @param string $glue
-     * @return string
-     */
-    private static function obfuscateKeys($keys, $glue = ' ')
-    {
-        if (!is_array($keys)) {
-            return '?';
-        }
-        $obfuscatedKeys = str_repeat('?' . $glue, count($keys));
-        return rtrim($obfuscatedKeys, $glue);
     }
 }

--- a/src/DDTrace/Obfuscation.php
+++ b/src/DDTrace/Obfuscation.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DDTrace;
+
+class Obfuscation
+{
+    const REPLACEMENT = '?';
+    const DEFAULT_GLUE = ' ';
+
+    /**
+     * Obfuscate secrets with a replacement
+     *
+     * @param mixed $keys
+     * @param string $glue
+     * @return string
+     */
+    public static function toObfuscatedString($keys, $glue = self::DEFAULT_GLUE)
+    {
+        if (!is_array($keys)) {
+            return self::REPLACEMENT;
+        }
+        $obfuscatedKeys = str_repeat(self::REPLACEMENT . $glue, count($keys));
+        return rtrim($obfuscatedKeys, $glue);
+    }
+}

--- a/src/DDTrace/Obfuscation.php
+++ b/src/DDTrace/Obfuscation.php
@@ -2,7 +2,7 @@
 
 namespace DDTrace;
 
-class Obfuscation
+final class Obfuscation
 {
     const REPLACEMENT = '?';
     const DEFAULT_GLUE = ' ';
@@ -10,7 +10,7 @@ class Obfuscation
     /**
      * Obfuscate secrets with a replacement
      *
-     * @param mixed $keys
+     * @param string|array $keys
      * @param string $glue
      * @return string
      */

--- a/tests/Integration/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integration/Integrations/Memcached/MemcachedTest.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Integration\Integrations\Memcached;
 
+use DDTrace\Obfuscation;
 use DDTrace\Integrations;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
@@ -42,7 +43,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.add', 'memcached', 'memcached', 'add')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'add ?',
+                    'memcached.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'add',
                 ])),
         ]);
@@ -56,7 +57,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.addByKey', 'memcached', 'memcached', 'addByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'addByKey ?',
+                    'memcached.query' => 'addByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'addByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -77,7 +78,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
                 ->setError()
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'append ?',
+                    'memcached.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'append',
                 ]))
                 ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
@@ -93,7 +94,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'append ?',
+                    'memcached.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'append',
                 ])),
         ]);
@@ -113,7 +114,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
                 ->setError()
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'appendByKey ?',
+                    'memcached.query' => 'appendByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ]))
@@ -131,7 +132,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'appendByKey ?',
+                    'memcached.query' => 'appendByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -154,7 +155,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.delete', 'memcached', 'memcached', 'delete')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'delete ?',
+                    'memcached.query' => 'delete ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'delete',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -177,7 +178,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteByKey', 'memcached', 'memcached', 'deleteByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'deleteByKey ?',
+                    'memcached.query' => 'deleteByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'deleteByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -211,7 +212,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.deleteMulti', 'memcached', 'memcached', 'deleteMulti')
                 ->withExactTags([
-                    'memcached.query' => 'deleteMulti ?,?',
+                    'memcached.query' => 'deleteMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'deleteMulti',
                 ]),
             SpanAssertion::exists('Memcached.get'),
@@ -240,7 +241,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteMultiByKey', 'memcached', 'memcached', 'deleteMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'deleteMultiByKey ?,?',
+                    'memcached.query' => 'deleteMultiByKey ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'deleteMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -268,13 +269,13 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement ?',
+                    'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement ?',
+                    'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -297,7 +298,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement ?',
+                    'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -319,7 +320,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.decrementByKey', 'memcached', 'memcached', 'decrementByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrementByKey ?',
+                    'memcached.query' => 'decrementByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrementByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -344,13 +345,13 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment ?',
+                    'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment ?',
+                    'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -372,7 +373,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment ?',
+                    'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -393,7 +394,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.incrementByKey', 'memcached', 'memcached', 'incrementByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'incrementByKey ?',
+                    'memcached.query' => 'incrementByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'incrementByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -434,7 +435,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.get', 'memcached', 'memcached', 'get')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'get ?',
+                    'memcached.query' => 'get ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'get',
                 ])),
         ]);
@@ -453,7 +454,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.getMulti', 'memcached', 'memcached', 'getMulti')
                 ->withExactTags([
-                    'memcached.query' => 'getMulti ?,?',
+                    'memcached.query' => 'getMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'getMulti',
                 ]),
         ]);
@@ -470,7 +471,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getByKey', 'memcached', 'memcached', 'getByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'getByKey ?',
+                    'memcached.query' => 'getByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'getByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -493,7 +494,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getMultiByKey', 'memcached', 'memcached', 'getMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'getMultiByKey ?,?',
+                    'memcached.query' => 'getMultiByKey ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'getMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -512,7 +513,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.replace', 'memcached', 'memcached', 'replace')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'replace ?',
+                    'memcached.query' => 'replace ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'replace',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -531,7 +532,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.replaceByKey', 'memcached', 'memcached', 'replaceByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'replaceByKey ?',
+                    'memcached.query' => 'replaceByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'replaceByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -547,7 +548,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.set', 'memcached', 'memcached', 'set')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'set ?',
+                    'memcached.query' => 'set ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'set',
                 ])),
         ]);
@@ -561,7 +562,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setByKey', 'memcached', 'memcached', 'setByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'setByKey ?',
+                    'memcached.query' => 'setByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'setByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -578,7 +579,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setMulti', 'memcached', 'memcached', 'setMulti')
                 ->withExactTags([
-                    'memcached.query' => 'setMulti ?,?',
+                    'memcached.query' => 'setMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'setMulti',
                 ]),
             SpanAssertion::exists('Memcached.getMulti'),
@@ -598,7 +599,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setMultiByKey', 'memcached', 'memcached', 'setMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'setMultiByKey ?,?',
+                    'memcached.query' => 'setMultiByKey ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'setMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -614,7 +615,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touch', 'memcached', 'memcached', 'touch')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'touch ?',
+                    'memcached.query' => 'touch ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'touch',
                 ])),
         ]);
@@ -628,7 +629,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touchByKey', 'memcached', 'memcached', 'touchByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'touchByKey ?',
+                    'memcached.query' => 'touchByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'touchByKey',
                     'memcached.server_key' => 'my_server',
                 ])),

--- a/tests/Integration/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integration/Integrations/Memcached/MemcachedTest.php
@@ -42,7 +42,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.add', 'memcached', 'memcached', 'add')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'add key',
+                    'memcached.query' => 'add ?',
                     'memcached.command' => 'add',
                 ])),
         ]);
@@ -56,7 +56,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.addByKey', 'memcached', 'memcached', 'addByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'addByKey key',
+                    'memcached.query' => 'addByKey ?',
                     'memcached.command' => 'addByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -77,7 +77,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
                 ->setError()
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'append key',
+                    'memcached.query' => 'append ?',
                     'memcached.command' => 'append',
                 ]))
                 ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
@@ -93,7 +93,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.append', 'memcached', 'memcached', 'append')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'append key',
+                    'memcached.query' => 'append ?',
                     'memcached.command' => 'append',
                 ])),
         ]);
@@ -113,7 +113,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
                 ->setError()
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'appendByKey key',
+                    'memcached.query' => 'appendByKey ?',
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ]))
@@ -131,7 +131,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.appendByKey', 'memcached', 'memcached', 'appendByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'appendByKey key',
+                    'memcached.query' => 'appendByKey ?',
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -154,7 +154,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.delete', 'memcached', 'memcached', 'delete')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'delete key',
+                    'memcached.query' => 'delete ?',
                     'memcached.command' => 'delete',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -177,7 +177,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteByKey', 'memcached', 'memcached', 'deleteByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'deleteByKey key',
+                    'memcached.query' => 'deleteByKey ?',
                     'memcached.command' => 'deleteByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -211,7 +211,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.deleteMulti', 'memcached', 'memcached', 'deleteMulti')
                 ->withExactTags([
-                    'memcached.query' => 'deleteMulti key1,key2',
+                    'memcached.query' => 'deleteMulti ?,?',
                     'memcached.command' => 'deleteMulti',
                 ]),
             SpanAssertion::exists('Memcached.get'),
@@ -240,7 +240,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::build('Memcached.deleteMultiByKey', 'memcached', 'memcached', 'deleteMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'deleteMultiByKey key1,key2',
+                    'memcached.query' => 'deleteMultiByKey ?,?',
                     'memcached.command' => 'deleteMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -268,13 +268,13 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement key',
+                    'memcached.query' => 'decrement ?',
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement key',
+                    'memcached.query' => 'decrement ?',
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -297,7 +297,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrement key',
+                    'memcached.query' => 'decrement ?',
                     'memcached.command' => 'decrement',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -319,7 +319,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.decrementByKey', 'memcached', 'memcached', 'decrementByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'decrementByKey key',
+                    'memcached.query' => 'decrementByKey ?',
                     'memcached.command' => 'decrementByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -344,13 +344,13 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment key',
+                    'memcached.query' => 'increment ?',
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment key',
+                    'memcached.query' => 'increment ?',
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -372,7 +372,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'increment key',
+                    'memcached.query' => 'increment ?',
                     'memcached.command' => 'increment',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -393,7 +393,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.incrementByKey', 'memcached', 'memcached', 'incrementByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'incrementByKey key',
+                    'memcached.query' => 'incrementByKey ?',
                     'memcached.command' => 'incrementByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -434,7 +434,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.get', 'memcached', 'memcached', 'get')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'get key',
+                    'memcached.query' => 'get ?',
                     'memcached.command' => 'get',
                 ])),
         ]);
@@ -453,7 +453,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.getMulti', 'memcached', 'memcached', 'getMulti')
                 ->withExactTags([
-                    'memcached.query' => 'getMulti key1,key2',
+                    'memcached.query' => 'getMulti ?,?',
                     'memcached.command' => 'getMulti',
                 ]),
         ]);
@@ -470,7 +470,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getByKey', 'memcached', 'memcached', 'getByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'getByKey key',
+                    'memcached.query' => 'getByKey ?',
                     'memcached.command' => 'getByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -493,7 +493,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.getMultiByKey', 'memcached', 'memcached', 'getMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'getMultiByKey key1,key2',
+                    'memcached.query' => 'getMultiByKey ?,?',
                     'memcached.command' => 'getMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -512,7 +512,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.add'),
             SpanAssertion::build('Memcached.replace', 'memcached', 'memcached', 'replace')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'replace key',
+                    'memcached.query' => 'replace ?',
                     'memcached.command' => 'replace',
                 ])),
             SpanAssertion::exists('Memcached.get'),
@@ -531,7 +531,7 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::exists('Memcached.addByKey'),
             SpanAssertion::build('Memcached.replaceByKey', 'memcached', 'memcached', 'replaceByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'replaceByKey key',
+                    'memcached.query' => 'replaceByKey ?',
                     'memcached.command' => 'replaceByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -547,7 +547,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.set', 'memcached', 'memcached', 'set')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'set key',
+                    'memcached.query' => 'set ?',
                     'memcached.command' => 'set',
                 ])),
         ]);
@@ -561,7 +561,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setByKey', 'memcached', 'memcached', 'setByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'setByKey key',
+                    'memcached.query' => 'setByKey ?',
                     'memcached.command' => 'setByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -578,7 +578,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setMulti', 'memcached', 'memcached', 'setMulti')
                 ->withExactTags([
-                    'memcached.query' => 'setMulti key1,key2',
+                    'memcached.query' => 'setMulti ?,?',
                     'memcached.command' => 'setMulti',
                 ]),
             SpanAssertion::exists('Memcached.getMulti'),
@@ -598,7 +598,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.setMultiByKey', 'memcached', 'memcached', 'setMultiByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'setMultiByKey key1,key2',
+                    'memcached.query' => 'setMultiByKey ?,?',
                     'memcached.command' => 'setMultiByKey',
                     'memcached.server_key' => 'my_server',
                 ])),
@@ -614,7 +614,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touch', 'memcached', 'memcached', 'touch')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'touch key',
+                    'memcached.query' => 'touch ?',
                     'memcached.command' => 'touch',
                 ])),
         ]);
@@ -628,7 +628,7 @@ final class MemcachedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('Memcached.touchByKey', 'memcached', 'memcached', 'touchByKey')
                 ->withExactTags(array_merge(self::baseTags(), [
-                    'memcached.query' => 'touchByKey key',
+                    'memcached.query' => 'touchByKey ?',
                     'memcached.command' => 'touchByKey',
                     'memcached.server_key' => 'my_server',
                 ])),

--- a/tests/Unit/ObfuscationTest.php
+++ b/tests/Unit/ObfuscationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DDTrace\Tests\Unit;
+
+use PHPUnit\Framework;
+use DDTrace\Obfuscation;
+
+final class ObfuscationTest extends Framework\TestCase
+{
+    public function testAStringWillBeObfuscated()
+    {
+        $obfuscated = Obfuscation::toObfuscatedString('foo-secret');
+        $this->assertSame(Obfuscation::REPLACEMENT, $obfuscated);
+    }
+
+    public function testAnArrayWillBeObfuscatedWithDefaultGlue()
+    {
+        $obfuscated = Obfuscation::toObfuscatedString([
+            'foo-secret-one',
+            'foo-secret-two',
+        ]);
+        $this->assertSame(
+            Obfuscation::REPLACEMENT . Obfuscation::DEFAULT_GLUE . Obfuscation::REPLACEMENT,
+            $obfuscated
+        );
+    }
+
+    public function testObfuscatedArraysCanHaveACustomGlue()
+    {
+        $obfuscated = Obfuscation::toObfuscatedString([
+            'foo-secret-one',
+            'foo-secret-two',
+        ], '|');
+        $this->assertSame(
+            Obfuscation::REPLACEMENT . '|' . Obfuscation::REPLACEMENT,
+            $obfuscated
+        );
+    }
+}


### PR DESCRIPTION
Since Memcached keys can contain secrets and the keys aren't obfuscated by the dd-agent, this will obfuscate the keys before hitting the dd-agent. :)