### PR TITLE
[Integration] Add basic Guzzle v6 integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^6.3",
         "phpcompatibility/php-compatibility": "^9.0",
         "phpcompatibility/phpcompatibility-passwordcompat": "^1.0",
         "phpcompatibility/phpcompatibility-symfony": "*",

--- a/src/DDTrace/Integrations/Guzzle/v6/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/v6/GuzzleIntegration.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DDTrace\Integrations\Guzzle\v6;
+
+class GuzzleIntegration
+{
+    public static function load()
+    {
+        if (!extension_loaded('ddtrace')) {
+            trigger_error('The ddtrace extension is required to instrument Guzzle tracing', E_USER_WARNING);
+            return;
+        }
+        if (!class_exists('GuzzleHttp\Client')) {
+            trigger_error('GuzzleHttp\Client is not loaded and cannot be instrumented', E_USER_WARNING);
+            return;
+        }
+
+        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::request ( string $method [, string $uri, array $options ] )
+        dd_trace('GuzzleHttp\Client', 'request', function (...$args) {
+            $tracer = new GuzzleTracer($this, 'request', $args);
+            $tracer->setTag('http.method', strtoupper($args[0]));
+            return $tracer->trace();
+        });
+
+        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::send ( Psr\Http\Message\RequestInterface $request [, array $options ] )
+        dd_trace('GuzzleHttp\Client', 'send', function (...$args) {
+            $tracer = new GuzzleTracer($this, 'send', $args);
+            $tracer->setTag('http.method', $args[0]->getMethod());
+            return $tracer->trace();
+        });
+    }
+}

--- a/src/DDTrace/Integrations/Guzzle/v6/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/v6/GuzzleIntegration.php
@@ -15,14 +15,16 @@ class GuzzleIntegration
             return;
         }
 
-        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::request ( string $method [, string $uri, array $options ] )
+        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::request
+        //   ( string $method [, string $uri, array $options ] )
         dd_trace('GuzzleHttp\Client', 'request', function (...$args) {
             $tracer = new GuzzleTracer($this, 'request', $args);
             $tracer->setTag('http.method', strtoupper($args[0]));
             return $tracer->trace();
         });
 
-        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::send ( Psr\Http\Message\RequestInterface $request [, array $options ] )
+        // Psr\Http\Message\ResponseInterface GuzzleHttp\Client::send
+        //   ( Psr\Http\Message\RequestInterface $request [, array $options ] )
         dd_trace('GuzzleHttp\Client', 'send', function (...$args) {
             $tracer = new GuzzleTracer($this, 'send', $args);
             $tracer->setTag('http.method', $args[0]->getMethod());

--- a/src/DDTrace/Integrations/Guzzle/v6/GuzzleTracer.php
+++ b/src/DDTrace/Integrations/Guzzle/v6/GuzzleTracer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DDTrace\Integrations\Guzzle\v6;
+
+use DDTrace\Tags;
+use DDTrace\Types;
+use GuzzleHttp\Client;
+use OpenTracing\GlobalTracer;
+
+class GuzzleTracer
+{
+    private $client;
+    private $command;
+    private $args;
+
+    private $scope;
+    private $span;
+
+    public function __construct(Client $client, $command, array $args)
+    {
+        $this->client = $client;
+        $this->command = $command;
+        $this->args = $args;
+
+        $this->scope = GlobalTracer::get()->startActiveSpan("GuzzleHttp\Client.$command");
+        $this->span = $this->scope->getSpan();
+        $this->span->setTag(Tags\SPAN_TYPE, Types\GUZZLE);
+        $this->span->setTag(Tags\SERVICE_NAME, 'guzzle');
+        $this->span->setTag('guzzle.command', $command);
+        $this->span->setResource($command);
+    }
+
+    public function setTag($key, $value)
+    {
+        $this->span->setTag($key, $value);
+    }
+
+    public function trace()
+    {
+        try {
+            return $this->client->{$this->command}(...$this->args);
+        } catch (\Exception $e) {
+            $this->span->setError($e);
+            throw $e;
+        } finally {
+            $this->scope->close();
+        }
+    }
+}

--- a/src/DDTrace/Types.php
+++ b/src/DDTrace/Types.php
@@ -8,6 +8,7 @@ const WEB_SERVLET = 'web';
 const SQL = 'sql';
 
 const CASSANDRA = 'cassandra';
+const GUZZLE = 'guzzle';
 const MEMCACHED = 'memcached';
 const MONGO = 'mongodb';
 const REDIS = 'redis';

--- a/tests/Integration/Integrations/Guzzle/v6/GuzzleTest.php
+++ b/tests/Integration/Integrations/Guzzle/v6/GuzzleTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace DDTrace\Tests\Integration\Integrations\Guzzle\v6;
+
+use GuzzleHttp\Client;
+use DDTrace\Integrations;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use DDTrace\Tests\Integration\Common\SpanAssertion;
+use DDTrace\Tests\Integration\Common\IntegrationTestCase;
+
+final class GuzzleTest extends IntegrationTestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public static function setUpBeforeClass()
+    {
+        Integrations\Guzzle\v6\GuzzleIntegration::load();
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $mock = new MockHandler([
+            new Response(200),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $this->client = new Client(['handler' => $handler]);
+    }
+
+    /**
+     * @dataProvider providerHttpMethods
+     */
+    public function testMagicMethods($method)
+    {
+        $traces = $this->isolateTracer(function () use ($method) {
+            $this->client->$method('http://example.com');
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::build('GuzzleHttp\Client.request', 'guzzle', 'guzzle', 'request')
+                ->withExactTags([
+                    'http.method' => strtoupper($method),
+                    'guzzle.command' => 'request',
+                ]),
+        ]);
+    }
+
+    public function providerHttpMethods()
+    {
+        return [
+            ['get'],
+            ['delete'],
+            ['head'],
+            ['options'],
+            ['patch'],
+            ['post'],
+            ['put'],
+        ];
+    }
+
+    public function testRequest()
+    {
+        $traces = $this->isolateTracer(function () {
+            $this->client->request('get', 'http://example.com');
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::build('GuzzleHttp\Client.request', 'guzzle', 'guzzle', 'request')
+                ->withExactTags([
+                    'http.method' => 'GET',
+                    'guzzle.command' => 'request',
+                ]),
+        ]);
+    }
+
+    public function testSend()
+    {
+        $traces = $this->isolateTracer(function () {
+            $request = new Request('put', 'http://example.com');
+            $this->client->send($request);
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::build('GuzzleHttp\Client.send', 'guzzle', 'guzzle', 'send')
+                ->withExactTags([
+                    'http.method' => 'PUT',
+                    'guzzle.command' => 'send',
+                ]),
+        ]);
+    }
+}


### PR DESCRIPTION
This is still a work in progress, but I wanted to post the progress so far to make sure we're all on the same page.

There are a few specific things I'd like to point out:

1. When we're testing 3rd-party packages like this, do we want to add those to the main `composer.json` as a dev dependency? I'm thinking this will be an issue when we want to add a Guzzle v5 integration for example. So not really sure what we want to do there.
2. What are your thoughts on extracting the main tracing boilerplate into `GuzzleTracer.php`? I figured it could help reduce duplication and boilerplate.
3. Do we want to trace the other methods within the package or just the ones making HTTP calls? And if we're tracing other methods, which ones should we target?

Currently this only supports sync methods. So next up is to tackle the async methods. :)