### PR TITLE
[Fix] Memory leak with closures in PHP 7

### DIFF
--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -21,7 +21,10 @@ zend_function *ddtrace_function_get(const HashTable *table, zend_string *name) {
     return ptr;
 }
 
-void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) { zend_string_release(dispatch->function); }
+void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
+    zend_string_release(dispatch->function);
+    zval_dtor(&dispatch->callable);
+}
 
 void ddtrace_class_lookup_free(zval *zv) {
     ddtrace_dispatch_t *dispatch = Z_PTR_P(zv);


### PR DESCRIPTION
The closures in PHP 7 aren't being freed. When running the following snippet of PHP:

```php
# foo.php
dd_trace('strlen', function (...$args) {
    // Do stuff
});
```

In debug mode, PHP generates the following warning:

```
[Tue Nov 20 08:34:45 2018]  Script:  '%s/foo.php'
%s/Zend/zend_closures.c(451) :  Freeing 0x%d (%d bytes), script=%s/foo.php
=== Total 1 memory leaks detected ===
```

This PR fixes this particular memory leak. This also might be tangentially related to issue #119, but that's just a guess. :)