### PR TITLE
Make PHPStan available to contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ aliases:
   - &STEP_COMPOSER_INSTALL
     run:
       name: Installing dependencies with composer
-      command: composer install --no-interaction --ignore-platform-reqs
+      command: composer install --no-interaction --ignore-platform-reqs --no-plugins
 
 
   - &STEP_PREPARE_TEST_RESULTS_DIR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,11 +218,8 @@ jobs:
       - <<: *STEP_COMPOSER_INSTALL
       - <<: *STEP_COMPOSER_CACHE_SAVE
       - run:
-          name: Installing phpstan
-          command: composer require --dev phpstan/phpstan:~0.10.3
-      - run:
           name: Running phpstan
-          command: vendor/bin/phpstan analyse --level=2 src
+          command: composer static-analyze
 
   "php-5.6":
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,6 @@ aliases:
     store_test_results:
       path: test-results
 
-
 jobs:
 
   "Lint files": &lint_files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,15 @@ aliases:
       paths:
         - vendor/
 
+  - &STEP_COMPOSER_INSTALL_LEGACY
+    run:
+      name: Installing composer dependencies without PHPStan
+      command: composer remove phpstan/phpstan --no-interaction --no-plugins --dev
+
   - &STEP_COMPOSER_INSTALL
     run:
       name: Installing dependencies with composer
-      command: composer install --no-interaction --ignore-platform-reqs --no-plugins
+      command: composer install --no-interaction
 
 
   - &STEP_PREPARE_TEST_RESULTS_DIR
@@ -195,7 +200,7 @@ jobs:
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_CACHE_RESTORE
-      - <<: *STEP_COMPOSER_INSTALL
+      - <<: *STEP_COMPOSER_INSTALL_LEGACY
       - <<: *STEP_COMPOSER_CACHE_SAVE
       - run:
           name: Creating directory for phpcs results
@@ -235,7 +240,7 @@ jobs:
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_CACHE_RESTORE
-      - <<: *STEP_COMPOSER_INSTALL
+      - <<: *STEP_COMPOSER_INSTALL_LEGACY
       - <<: *STEP_COMPOSER_CACHE_SAVE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
@@ -265,7 +270,7 @@ jobs:
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_CACHE_RESTORE
-      - <<: *STEP_COMPOSER_INSTALL
+      - <<: *STEP_COMPOSER_INSTALL_LEGACY
       - <<: *STEP_COMPOSER_CACHE_SAVE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ aliases:
   - &STEP_COMPOSER_INSTALL
     run:
       name: Installing dependencies with composer
-      command: composer install -n
+      command: composer install --no-interaction --ignore-platform-reqs
 
 
   - &STEP_PREPARE_TEST_RESULTS_DIR

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ In order to run tests for the php extension:
 composer fix-lint
 ```
 
+### Static Analyzer
+
+The [PHPStan static analyzer](https://github.com/phpstan/phpstan) is part of the build checks when submitting a PR. To ensure your contribution passes the static analyzer, run the following:
+
+    $ composer static-analyze
+
 ## Releasing
 
 See [RELEASING](RELEASING.md) for more information on releasing new versions.

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "phpcompatibility/php-compatibility": "^9.0",
         "phpcompatibility/phpcompatibility-passwordcompat": "^1.0",
         "phpcompatibility/phpcompatibility-symfony": "*",
+        "phpstan/phpstan": "^0.10.5",
         "phpunit/phpunit": "^5.7.19",
         "predis/predis": "^1.1",
         "squizlabs/php_codesniffer": "^3.3.0",
@@ -68,6 +69,7 @@
         "fix-lint": "phpcbf",
         "lint": "phpcs -s",
         "lint-5.4": "phpcs -s --runtime-set testVersion 5.4-7.3",
+        "static-analyze": "phpstan analyse --level=2 src",
         "run-agent": [
             "docker run -p 8126:8126 -e \"DD_APM_ENABLED=true\" -e \"DD_BIND_HOST=0.0.0.0\" -e \"DD_API_KEY=invalid_key_but_this_is_fine\" --rm datadog/docker-dd-agent",
             "while ! echo exit | nc localhost 8126; do sleep 1; done"


### PR DESCRIPTION
Part of the build checks include static analysis but there's no way to run the analyzer locally before pushing up a PR without manually installing PHPStan globally and running it with the settings from CircleCI.

This PR includes PHPStan in the dev dependencies and adds a custom Composer command to run it with the same settings as CircleCI:

    $ composer static-analyze

As a side note - it might be worth revamping the CONTRIBUTING.md docs as bit. We could move all the testing/linting/container setup docs from the main README so that the README is less cluttered and easier for non-contributors to get dd-trace-php installed in their project. Does that sound reasonable? :)