### PR TITLE
[core] Remove Span::setResource() which is not part of OpenTracing\Span interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,9 +210,7 @@ jobs:
       - checkout
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
-      - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_INSTALL
-      - <<: *STEP_COMPOSER_CACHE_SAVE
       - run:
           name: Installing phpstan
           command: composer require --dev phpstan/phpstan:~0.10.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,9 @@ jobs:
       - checkout
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
+      - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_INSTALL
+      - <<: *STEP_COMPOSER_CACHE_SAVE
       - run:
           name: Installing phpstan
           command: composer require --dev phpstan/phpstan:~0.10.3

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -148,7 +148,7 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
     // we can access object data via $this, and also execute 
     // the original method the same way 
-    $span->setResource($this->workToDo);
+    $span->setTag(Tags\RESOURCE_NAME, $this->workToDo);
     
     try {
         $result = $this->doWork(...$args);

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -25,7 +25,7 @@ class EloquentIntegration
             $scope = GlobalTracer::get()->startActiveSpan('eloquent.get');
             $span = $scope->getSpan();
             $sql = $this->getQuery()->toSql();
-            $span->setResource($sql);
+            $span->setTag(Tags\RESOURCE_NAME, $sql);
             $span->setTag(Tags\DB_STATEMENT, $sql);
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
 
@@ -46,7 +46,7 @@ class EloquentIntegration
             $scope = GlobalTracer::get()->startActiveSpan('eloquent.insert');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
-            $span->setResource($sql);
+            $span->setTag(Tags\RESOURCE_NAME, $sql);
             $span->setTag(Tags\DB_STATEMENT, $sql);
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
 
@@ -68,7 +68,7 @@ class EloquentIntegration
             $scope = GlobalTracer::get()->startActiveSpan('eloquent.update');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
-            $span->setResource($sql);
+            $span->setTag(Tags\RESOURCE_NAME, $sql);
             $span->setTag(Tags\DB_STATEMENT, $sql);
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
 

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -74,7 +74,7 @@ class LaravelProvider extends ServiceProvider
             list($route, $request) = $args;
             $span = $scope->getSpan();
 
-            $span->setResource($route->getActionName() . ' ' . Route::currentRouteName());
+            $span->setTag(Tags\RESOURCE_NAME, $route->getActionName() . ' ' . Route::currentRouteName());
             $span->setTag('laravel.route.name', $route->getName());
             $span->setTag('laravel.route.action', $route->getActionName());
             $span->setTag(Tags\HTTP_METHOD, $request->method());
@@ -166,10 +166,7 @@ class LaravelProvider extends ServiceProvider
         $span = $scope->getSpan();
         $span->setTag(Tags\SPAN_TYPE, Types\WEB_SERVLET);
         $span->setTag(Tags\SERVICE_NAME, self::getAppName());
-
-        if ($span instanceof Span) {
-            $span->setResource($resource);
-        }
+        $span->setTag(Tags\RESOURCE_NAME, $resource);
 
         return $scope;
     }

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -128,7 +128,10 @@ class LaravelProvider extends ServiceProvider
         // Name the scope when the route matches
         $this->app['events']->listen(RouteMatched::class, function (RouteMatched $event) use ($scope) {
             $span = $scope->getSpan();
-            $span->setTag(Tags\RESOURCE_NAME, $event->route->getActionName() . ' ' . (Route::currentRouteName() ?: 'unnamed_route'));
+            $span->setTag(
+                Tags\RESOURCE_NAME,
+                $event->route->getActionName() . ' ' . (Route::currentRouteName() ?: 'unnamed_route')
+            );
             $span->setTag('laravel.route.name', Route::currentRouteName());
             $span->setTag('laravel.route.action', $event->route->getActionName());
             $span->setTag('http.method', $event->request->method());

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -88,7 +88,7 @@ class LaravelProvider extends ServiceProvider
                         $args = func_get_args();
                         $scope = GlobalTracer::get()->startActiveSpan('laravel.middleware');
                         $span = $scope->getSpan();
-                        $span->setResource(get_class($this));
+                        $span->setTag(Tags\RESOURCE_NAME, get_class($this));
 
                         try {
                             return call_user_func_array([$this, 'handle'], $args);
@@ -128,7 +128,7 @@ class LaravelProvider extends ServiceProvider
         // Name the scope when the route matches
         $this->app['events']->listen(RouteMatched::class, function (RouteMatched $event) use ($scope) {
             $span = $scope->getSpan();
-            $span->setResource($event->route->getActionName() . ' ' . (Route::currentRouteName() ?: 'unnamed_route'));
+            $span->setTag(Tags\RESOURCE_NAME, $event->route->getActionName() . ' ' . (Route::currentRouteName() ?: 'unnamed_route'));
             $span->setTag('laravel.route.name', Route::currentRouteName());
             $span->setTag('laravel.route.action', $event->route->getActionName());
             $span->setTag('http.method', $event->request->method());

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -209,7 +209,7 @@ class MemcachedIntegration
             self::setServerTagsByKey($span, $memcached, $args[0]);
         }
         $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[0]));
-        $span->setTag(Tags\RESOURCE_NAME,$command);
+        $span->setTag(Tags\RESOURCE_NAME, $command);
 
         try {
             return $memcached->$command(...$args);
@@ -232,7 +232,7 @@ class MemcachedIntegration
         self::setServerTagsByKey($span, $memcached, $args[0]);
 
         $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[1]));
-        $span->setTag(Tags\RESOURCE_NAME,$command);
+        $span->setTag(Tags\RESOURCE_NAME, $command);
 
         try {
             return $memcached->$command(...$args);
@@ -255,7 +255,7 @@ class MemcachedIntegration
 
         self::setServerTagsByKey($span, $memcached, $args[1]);
         $span->setTag('memcached.query', 'cas ?');
-        $span->setTag(Tags\RESOURCE_NAME,'cas');
+        $span->setTag(Tags\RESOURCE_NAME, 'cas');
 
         try {
             return $memcached->cas(...$args);
@@ -279,7 +279,7 @@ class MemcachedIntegration
         $serverKey = $args[1];
         $span->setTag('memcached.server_key', $serverKey);
         $span->setTag('memcached.query', 'casByKey ?');
-        $span->setTag(Tags\RESOURCE_NAME,'casByKey');
+        $span->setTag(Tags\RESOURCE_NAME, 'casByKey');
         self::setServerTagsByKey($span, $memcached, $serverKey);
 
         try {
@@ -302,7 +302,7 @@ class MemcachedIntegration
 
         $query = "$command " . Obfuscation::toObfuscatedString($args[0], ',');
         $span->setTag('memcached.query', $query);
-        $span->setTag(Tags\RESOURCE_NAME,$command);
+        $span->setTag(Tags\RESOURCE_NAME, $command);
 
         try {
             return $memcached->$command(...$args);
@@ -326,7 +326,7 @@ class MemcachedIntegration
 
         $query = "$command " . Obfuscation::toObfuscatedString($args[1], ',');
         $span->setTag('memcached.query', $query);
-        $span->setTag(Tags\RESOURCE_NAME,$command);
+        $span->setTag(Tags\RESOURCE_NAME, $command);
 
         try {
             return $memcached->$command(...$args);

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -102,7 +102,7 @@ class MemcachedIntegration
             $span->setTag(Tags\SPAN_TYPE, Types\MEMCACHED);
             $span->setTag(Tags\SERVICE_NAME, 'memcached');
             $span->setTag('memcached.command', 'flush');
-            $span->setResource('flush');
+            $span->setTag(Tags\RESOURCE_NAME, 'flush');
 
             try {
                 return $this->flush(...$args);
@@ -209,7 +209,7 @@ class MemcachedIntegration
             self::setServerTagsByKey($span, $memcached, $args[0]);
         }
         $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[0]));
-        $span->setResource($command);
+        $span->setTag(Tags\RESOURCE_NAME,$command);
 
         try {
             return $memcached->$command(...$args);
@@ -232,7 +232,7 @@ class MemcachedIntegration
         self::setServerTagsByKey($span, $memcached, $args[0]);
 
         $span->setTag('memcached.query', "$command " . Obfuscation::toObfuscatedString($args[1]));
-        $span->setResource($command);
+        $span->setTag(Tags\RESOURCE_NAME,$command);
 
         try {
             return $memcached->$command(...$args);
@@ -255,7 +255,7 @@ class MemcachedIntegration
 
         self::setServerTagsByKey($span, $memcached, $args[1]);
         $span->setTag('memcached.query', 'cas ?');
-        $span->setResource('cas');
+        $span->setTag(Tags\RESOURCE_NAME,'cas');
 
         try {
             return $memcached->cas(...$args);
@@ -279,7 +279,7 @@ class MemcachedIntegration
         $serverKey = $args[1];
         $span->setTag('memcached.server_key', $serverKey);
         $span->setTag('memcached.query', 'casByKey ?');
-        $span->setResource('casByKey');
+        $span->setTag(Tags\RESOURCE_NAME,'casByKey');
         self::setServerTagsByKey($span, $memcached, $serverKey);
 
         try {
@@ -302,7 +302,7 @@ class MemcachedIntegration
 
         $query = "$command " . Obfuscation::toObfuscatedString($args[0], ',');
         $span->setTag('memcached.query', $query);
-        $span->setResource($command);
+        $span->setTag(Tags\RESOURCE_NAME,$command);
 
         try {
             return $memcached->$command(...$args);
@@ -326,7 +326,7 @@ class MemcachedIntegration
 
         $query = "$command " . Obfuscation::toObfuscatedString($args[1], ',');
         $span->setTag('memcached.query', $query);
-        $span->setResource($command);
+        $span->setTag(Tags\RESOURCE_NAME,$command);
 
         try {
             return $memcached->$command(...$args);

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -379,7 +379,7 @@ class MysqliIntegration
         $span = $scope->getSpan();
         $span->setTag(Tags\SPAN_TYPE, Types\SQL);
         $span->setTag(Tags\SERVICE_NAME, 'mysqli');
-        $span->setResource($resource);
+        $span->setTag(Tags\RESOURCE_NAME, $resource);
         return $scope;
     }
 

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -39,7 +39,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setResource('PDO.__construct');
+            $span->setTag(Tags\RESOURCE_NAME,'PDO.__construct');
 
             try {
                 $this->__construct(...$args);
@@ -60,7 +60,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setResource($statement);
+            $span->setTag(Tags\RESOURCE_NAME,$statement);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -87,7 +87,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setResource($args[0]);
+            $span->setTag(Tags\RESOURCE_NAME,$args[0]);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -134,7 +134,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setResource($args[0]);
+            $span->setTag(Tags\RESOURCE_NAME,$args[0]);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -156,7 +156,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setResource($this->queryString);
+            $span->setTag(Tags\RESOURCE_NAME,$this->queryString);
             PDOIntegration::setStatementTags($this, $span);
 
             try {

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -39,7 +39,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setTag(Tags\RESOURCE_NAME,'PDO.__construct');
+            $span->setTag(Tags\RESOURCE_NAME, 'PDO.__construct');
 
             try {
                 $this->__construct(...$args);
@@ -60,7 +60,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setTag(Tags\RESOURCE_NAME,$statement);
+            $span->setTag(Tags\RESOURCE_NAME, $statement);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -87,7 +87,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setTag(Tags\RESOURCE_NAME,$args[0]);
+            $span->setTag(Tags\RESOURCE_NAME, $args[0]);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -134,7 +134,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setTag(Tags\RESOURCE_NAME,$args[0]);
+            $span->setTag(Tags\RESOURCE_NAME, $args[0]);
             PDOIntegration::setConnectionTags($this, $span);
 
             try {
@@ -156,7 +156,7 @@ class PDOIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\SQL);
             $span->setTag(Tags\SERVICE_NAME, 'PDO');
-            $span->setTag(Tags\RESOURCE_NAME,$this->queryString);
+            $span->setTag(Tags\RESOURCE_NAME, $this->queryString);
             PDOIntegration::setStatementTags($this, $span);
 
             try {

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -40,7 +40,7 @@ class PredisIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\CACHE);
             $span->setTag(Tags\SERVICE_NAME, 'redis');
-            $span->setResource('Predis.Client.__construct');
+            $span->setTag(Tags\RESOURCE_NAME,'Predis.Client.__construct');
             try {
                 call_user_func_array([$this, '__construct'], $args);
                 PredisIntegration::storeConnectionParams($this, $args);
@@ -60,7 +60,7 @@ class PredisIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\CACHE);
             $span->setTag(Tags\SERVICE_NAME, 'redis');
-            $span->setResource('Predis.Client.connect');
+            $span->setTag(Tags\RESOURCE_NAME,'Predis.Client.connect');
             PredisIntegration::setConnectionTags($this, $span);
 
             try {
@@ -85,7 +85,7 @@ class PredisIntegration
             $span->setTag(Tags\SERVICE_NAME, 'redis');
             $span->setTag('redis.raw_command', $query);
             $span->setTag('redis.args_length', count($arguments));
-            $span->setResource($query);
+            $span->setTag(Tags\RESOURCE_NAME,$query);
             PredisIntegration::setConnectionTags($this, $span);
 
             try {
@@ -110,7 +110,7 @@ class PredisIntegration
                 $span->setTag(Tags\SERVICE_NAME, 'redis');
                 $span->setTag('redis.raw_command', $query);
                 $span->setTag('redis.args_length', count($arguments));
-                $span->setResource($query);
+                $span->setTag(Tags\RESOURCE_NAME,$query);
                 PredisIntegration::setConnectionTags($this, $span);
 
                 try {

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -40,7 +40,7 @@ class PredisIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\CACHE);
             $span->setTag(Tags\SERVICE_NAME, 'redis');
-            $span->setTag(Tags\RESOURCE_NAME,'Predis.Client.__construct');
+            $span->setTag(Tags\RESOURCE_NAME, 'Predis.Client.__construct');
             try {
                 call_user_func_array([$this, '__construct'], $args);
                 PredisIntegration::storeConnectionParams($this, $args);
@@ -60,7 +60,7 @@ class PredisIntegration
             $span = $scope->getSpan();
             $span->setTag(Tags\SPAN_TYPE, Types\CACHE);
             $span->setTag(Tags\SERVICE_NAME, 'redis');
-            $span->setTag(Tags\RESOURCE_NAME,'Predis.Client.connect');
+            $span->setTag(Tags\RESOURCE_NAME, 'Predis.Client.connect');
             PredisIntegration::setConnectionTags($this, $span);
 
             try {
@@ -85,7 +85,7 @@ class PredisIntegration
             $span->setTag(Tags\SERVICE_NAME, 'redis');
             $span->setTag('redis.raw_command', $query);
             $span->setTag('redis.args_length', count($arguments));
-            $span->setTag(Tags\RESOURCE_NAME,$query);
+            $span->setTag(Tags\RESOURCE_NAME, $query);
             PredisIntegration::setConnectionTags($this, $span);
 
             try {
@@ -110,7 +110,7 @@ class PredisIntegration
                 $span->setTag(Tags\SERVICE_NAME, 'redis');
                 $span->setTag('redis.raw_command', $query);
                 $span->setTag('redis.args_length', count($arguments));
-                $span->setTag(Tags\RESOURCE_NAME,$query);
+                $span->setTag(Tags\RESOURCE_NAME, $query);
                 PredisIntegration::setConnectionTags($this, $span);
 
                 try {

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -73,7 +73,7 @@ class SymfonyBundle extends Bundle
                     $route = $request->get('_route');
 
                     if ($symfonyRequestSpan !== null && $route !== null) {
-                        $symfonyRequestSpan->setResource($route);
+                        $symfonyRequestSpan->setTag(Tags\RESOURCE_NAME, $route);
                     }
                     $scope->close();
                 }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -229,7 +229,7 @@ final class Span implements OpenTracingSpan
 
     /**
      * @deprecated
-     * @param $resource
+     * @param string $resource
      */
     public function setResource($resource)
     {

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -6,8 +6,8 @@ use DDTrace\Exceptions\InvalidSpanArgument;
 use Exception;
 use InvalidArgumentException;
 use OpenTracing\Span as OpenTracingSpan;
-use OpenTracing\SpanContext as OpenTracingContext;
 use Throwable;
+
 
 final class Span implements OpenTracingSpan
 {
@@ -194,7 +194,7 @@ final class Span implements OpenTracingSpan
         }
 
         if ($key === Tags\RESOURCE_NAME) {
-            $this->resource = $value;
+            $this->resource = (string)$value;
             return;
         }
 
@@ -227,9 +227,15 @@ final class Span implements OpenTracingSpan
         return $this->tags;
     }
 
+    /**
+     * @deprecated You should use DDTrace\Span::setTag(Tags\RESOURCE_NAME, $value)
+     * @param $resource
+     */
     public function setResource($resource)
     {
-        $this->resource = (string)$resource;
+        error_log('DEPRECATED: Method "DDTrace\Span\setResource" will be removed soon, '
+            . 'you should use DDTrace\Span::setTag(Tags\RESOURCE_NAME, $value) instead.');
+        $this->setTag(Tags\RESOURCE_NAME, $resource);
     }
 
     /**

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -228,7 +228,7 @@ final class Span implements OpenTracingSpan
     }
 
     /**
-     * @deprecated You should use DDTrace\Span::setTag(Tags\RESOURCE_NAME, $value)
+     * @deprecated
      * @param $resource
      */
     public function setResource($resource)


### PR DESCRIPTION
The problem is that in specific conditions we may not have a `DDTrace\Span` and in place of it we get an `OpentTracing\NoopSpan` which just implement the interface `OpenTracing\Span` => exception.