### PR TITLE
Use the HttpFoundation method to get the status code

### DIFF
--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -137,7 +137,7 @@ class LaravelProvider extends ServiceProvider
 
         $this->app['events']->listen(RequestHandled::class, function (RequestHandled $event) use ($scope) {
             $span = $scope->getSpan();
-            $span->setTag('http.status_code', $event->response->status());
+            $span->setTag('http.status_code', $event->response->getStatusCode());
             try {
                 $user = auth()->user()->id;
                 $span->setTag('laravel.user', strlen($user) ? $user : '-');


### PR DESCRIPTION
The response in the event is not guaranteed to be an instance of `Illuminate\Http\Response` so it shouldn't use the status method. If using any of the Symfony responses this generates an error.
```
Symfony\Component\HttpFoundation\BinaryFileResponse
Symfony\Component\HttpFoundation\JsonResponse
Symfony\Component\HttpFoundation\RedirectResponse
Symfony\Component\HttpFoundation\StreamedResponse
```