### PR TITLE
SymfonyBundle: Use getenv() to get env variable

### DIFF
--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -136,7 +136,7 @@ class SymfonyBundle extends Bundle
 
     private function getAppName()
     {
-        if (!empty(getenv('ddtrace_app_name'))) {
+        if ($appName = getenv('ddtrace_app_name')) {
             return getenv('ddtrace_app_name');
         } else {
             return 'symfony';

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -137,7 +137,7 @@ class SymfonyBundle extends Bundle
     private function getAppName()
     {
         if ($appName = getenv('ddtrace_app_name')) {
-            return getenv('ddtrace_app_name');
+            return $appName;
         } else {
             return 'symfony';
         }

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -136,8 +136,8 @@ class SymfonyBundle extends Bundle
 
     private function getAppName()
     {
-        if (isset($_ENV['ddtrace_app_name'])) {
-            return $_ENV['ddtrace_app_name'];
+        if (!empty(getenv('ddtrace_app_name'))) {
+            return getenv('ddtrace_app_name');
         } else {
             return 'symfony';
         }


### PR DESCRIPTION
It is common on servers to not populate $_ENV, so `getenv()` is a more
reliable way to check an env var.

See: https://stackoverflow.com/questions/3780866/why-is-my-env-empty/27077452#27077452