### PR TITLE
Laravel 5 publishable config file

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -99,7 +99,7 @@ To enable Laravel integration we need to configure a new Provider in `config/app
 ```php
     'providers' => [
 # .....
-      'DDTrace\Integrations\Laravel\V5\LaravelProvider',
+      \DDTrace\Integrations\Laravel\V5\LaravelProvider::class,
 ```
 
 Copy the package config to your local config with the publish command:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -92,14 +92,20 @@ composer update
 
 ### Enabling tracing
 
-#### Laravel integration
+#### Laravel 5 integration
 
 To enable Laravel integration we need to configure a new Provider in `config/app.php`
 
 ```php
     'providers' => [
 # .....
-      'DDTrace\Integrations\LaravelProvider',
+      'DDTrace\Integrations\Laravel\V5\LaravelProvider',
+```
+
+Copy the package config to your local config with the publish command:
+
+```
+php artisan vendor:publish --provider="DDTrace\Integrations\Laravel\V5\LaravelProvider"
 ```
 
 Now your Laravel application should start sending traces to the Datadog agent running on localhost (in default configuration). The Datadog agent must have APM enabled; see https://docs.datadoghq.com/tracing/setup/ for instructions on installing and configuring the agent.

--- a/src/DDTrace/Integrations/Laravel/V5/ConfigRegistry.php
+++ b/src/DDTrace/Integrations/Laravel/V5/ConfigRegistry.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DDTrace\Integrations\Laravel\V5;
+
+use DDTrace\Configuration;
+use Illuminate\Config\Repository;
+
+/**
+ * Registry that holds configuration properties and that is able to recover
+ * configuration values from environment variables.
+ */
+class ConfigRegistry extends Configuration
+{
+    /** @var \Illuminate\Config\Repository */
+    private $repository;
+
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boolValue($key, $default)
+    {
+        return (bool) $this->getValueFromRepository($key, $default);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function inArray($key, $name)
+    {
+        $value = $this->getValueFromRepository($key);
+
+        if (is_string($value)) {
+            $value = explode(',', $value);
+            $value = array_map(function ($entry) {
+                return trim(strtolower($entry));
+            }, $value);
+            $this->setValueInRepository($key, $value);
+        } elseif (!is_array($value)) {
+            $value = [];
+        }
+
+        return in_array(strtolower($name), $value);
+    }
+
+    /**
+     * Get value from the repository.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return string
+     */
+    private function getValueFromRepository($key, $default = null)
+    {
+        return $this->repository->get($this->convertKeyToRepositoryKey($key), $default);
+    }
+
+    /**
+     * Set value in the repository.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return string
+     */
+    private function setValueInRepository($key, $value)
+    {
+        return $this->repository->set($this->convertKeyToRepositoryKey($key), $value);
+    }
+
+    /**
+     * Converts dot-separated tracer configuration key to the corresponding
+     * config repository key.
+     *
+     * @param string $key
+     * @return string
+     */
+    private function convertKeyToRepositoryKey($key)
+    {
+        return 'ddtrace.' . trim(str_replace('.', '_', $key));
+    }
+}

--- a/src/DDTrace/Integrations/Laravel/config/ddtrace.php
+++ b/src/DDTrace/Integrations/Laravel/config/ddtrace.php
@@ -1,0 +1,70 @@
+<?php
+
+return [
+
+    /*
+     |--------------------------------------------------------------------------
+     | DDTrace Settings
+     |--------------------------------------------------------------------------
+     |
+     | Service name used for instrumentation and toggle that defines if the tracer
+     | is enabled or not. If set to false the code could be still instrumented
+     | because of other settings, but no spans are sent to the local trace agent.
+     |
+     */
+
+    'service_name' => env('DD_SERVICE_NAME', PHP_SAPI),
+    'trace_enabled' => env('DD_TRACE_ENABLED', true),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Distributed Tracing
+     |--------------------------------------------------------------------------
+     |
+     | Distributed tracing allows traces to be propagated across multiple instrumented
+     | applications, so that a request can be presented as a single trace, rather
+     | than a separate trace per service.
+     |
+     */
+
+    'distributed_tracing' => env('DD_DISTRIBUTED_TRACING', true),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Priority Sampling
+     |--------------------------------------------------------------------------
+     |
+     | Priority sampling consists in deciding if a trace will be kept by using a
+     | priority attribute that will be propagated for distributed traces. Its value
+     | gives indication to the Agent and to the backend on how important the trace is.
+     |
+     */
+    'priority_sampling' => env('DD_PRIORITY_SAMPLING', true),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Disabled Integrations
+     |--------------------------------------------------------------------------
+     |
+     | A comma-separated list of integrations that should be disabled.
+     |
+     */
+
+    'integrations_disabled' => env(
+        'DD_INTEGRATIONS_DISABLED',
+        !extension_loaded('ddtrace') ? 'laravel' : null
+    ),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Global Tags
+     |--------------------------------------------------------------------------
+     |
+     | Global tags set at the tracer level. These tags will be appended to each
+     | span created by the tracer. Keys and values must be strings.
+     |
+     */
+
+    'global_tags' => [],
+
+];

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -229,6 +229,14 @@ final class Tracer implements OpenTracingTracer
     }
 
     /**
+     * @param array $tags
+     */
+    public function setTags(array $tags)
+    {
+        $this->config['global_tags'] = array_merge($this->config['global_tags'], $tags);
+    }
+
+    /**
      * @return null|Span
      */
     public function getActiveSpan()


### PR DESCRIPTION
## Laravel 5 updates
- added publishable config
- bound tracer class as singleton in service container to allow tracer to be customized by integration

## General updates
- added `setTags()` method to tracer