### PR TITLE
Add timeouts to Curl Http client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
           command: composer test-integration -- --log-junit test-results/php-integration/results.xml
       - run:
           name: Run << parameters.integration_testsuite >> integration test
-          command: composer << parameters.integration_testsuite >>
+          command: DD_TRACE_AGENT_TIMEOUT=2000 composer << parameters.integration_testsuite >>
       - <<: *STEP_PERSIST_TO_WORKSPACE
       - <<: *STEP_STORE_TEST_RESULTS
 
@@ -552,7 +552,7 @@ workflows:
           requires: [ 'Code Checkout' ]
           name: "PHP 56 Web integration tests"
           integration_testsuite: "test-web-56"
-          # docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debu
+          # docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debug
           docker_image: "datadog/docker-library:ddtrace_php_5_6"
       - integration_tests:
           requires: [ 'Code Checkout' ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Tracer limited mode, stopping span creation when memory use raises to 80% of current PHP memory limit #437
+- Configurable Curl timeouts `DD_TRACE_AGENT_TIMEOUT` and `DD_TRACE_AGENT_CONNECT_TIMEOUT` when communicating with the agent #150
 
 ### Fixed
 - Generation of `E_WARNING` in certain contexts of PHP 5 installs when the `date.timezone` INI setting is not set #435

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -20,12 +20,16 @@ final class Http implements Transport
     // https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/api.go#L31
     const AGENT_REQUEST_BODY_LIMIT = 10485760; // 10 * 1024 * 1024 => 10MB
     const TRACE_AGENT_PORT_ENV = 'DD_TRACE_AGENT_PORT';
+    const AGENT_TIMEOUT_ENV = 'DD_AGENT_TIMEOUT';
+    const AGENT_CONNECT_TIMEOUT_ENV = 'DD_AGENT_CONNECT_TIMEOUT';
 
     // Default values for trace agent configuration
     const DEFAULT_AGENT_HOST = 'localhost';
     const DEFAULT_TRACE_AGENT_PORT = '8126';
     const DEFAULT_TRACE_AGENT_PATH = '/v0.3/traces';
     const PRIORITY_SAMPLING_TRACE_AGENT_PATH = '/v0.4/traces';
+    const DEFAULT_AGENT_CONNECT_TIMEOUT = 100;
+    const DEFAULT_AGENT_TIMEOUT = 500;
 
     /**
      * @var Encoder
@@ -68,6 +72,8 @@ final class Http implements Transport
 
         $this->config = array_merge([
             'endpoint' => $endpoint,
+            'connect_timeout' => getenv(self::AGENT_CONNECT_TIMEOUT_ENV) ?: self::DEFAULT_AGENT_CONNECT_TIMEOUT,
+            'timeout' => getenv(self::AGENT_TIMEOUT_ENV) ?: self::DEFAULT_AGENT_TIMEOUT,
         ], $config);
     }
 
@@ -115,8 +121,8 @@ final class Http implements Transport
         curl_setopt($handle, CURLOPT_POST, true);
         curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handle, CURLOPT_TIMEOUT_MS, 500);
-        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, 100);
+        curl_setopt($handle, CURLOPT_TIMEOUT_MS, $this->config['timeout']);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, $this->config['connect_timeout']);
 
         $curlHeaders = [
             'Content-Type: ' . $this->encoder->getContentType(),

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -20,8 +20,8 @@ final class Http implements Transport
     // https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/api.go#L31
     const AGENT_REQUEST_BODY_LIMIT = 10485760; // 10 * 1024 * 1024 => 10MB
     const TRACE_AGENT_PORT_ENV = 'DD_TRACE_AGENT_PORT';
-    const AGENT_TIMEOUT_ENV = 'DD_AGENT_TIMEOUT';
-    const AGENT_CONNECT_TIMEOUT_ENV = 'DD_AGENT_CONNECT_TIMEOUT';
+    const AGENT_TIMEOUT_ENV = 'DD_TRACE_AGENT_TIMEOUT';
+    const AGENT_CONNECT_TIMEOUT_ENV = 'DD_TRACE_AGENT_CONNECT_TIMEOUT';
 
     // Default values for trace agent configuration
     const DEFAULT_AGENT_HOST = 'localhost';

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -115,6 +115,8 @@ final class Http implements Transport
         curl_setopt($handle, CURLOPT_POST, true);
         curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_TIMEOUT_MS, 500);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, 100);
 
         $curlHeaders = [
             'Content-Type: ' . $this->encoder->getContentType(),


### PR DESCRIPTION
Fail fast if there are problems connecting to the agent.