### PR TITLE
Fix PHP 5.6 ZTS builds

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -105,25 +105,25 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     return SUCCESS;
 }
 
-static int datadog_info_print(const char *str) { return php_output_write(str, strlen(str)); }
+static int datadog_info_print(const char *str TSRMLS_DC) { return php_output_write(str, strlen(str) TSRMLS_CC); }
 
 static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
     php_info_print_box_start(0);
-    datadog_info_print("Datadog PHP tracer extension");
+    datadog_info_print("Datadog PHP tracer extension" TSRMLS_CC);
     if (!sapi_module.phpinfo_as_text) {
-        datadog_info_print("<br><strong>For help, check out ");
+        datadog_info_print("<br><strong>For help, check out " TSRMLS_CC);
         datadog_info_print(
             "<a href=\"https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started\" "
-            "style=\"background:transparent;\">the documentation</a>.</strong>");
+            "style=\"background:transparent;\">the documentation</a>.</strong>" TSRMLS_CC);
     } else {
         datadog_info_print(
             "\nFor help, check out the documentation at "
-            "https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started");
+            "https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started" TSRMLS_CC);
     }
-    datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
-    datadog_info_print("(c) Datadog 2018\n");
+    datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n" TSRMLS_CC);
+    datadog_info_print("(c) Datadog 2018\n" TSRMLS_CC);
     php_info_print_box_end();
 
     php_info_print_table_start();


### PR DESCRIPTION
This should fix the ZTS builds in 5.6. We don't need any `#if`'s for PHP 7 since all the `TSRMLS_*` macros exist in PHP 7 for BC. :)