### PR TITLE
Labbati/elastic search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "opentracing/opentracing": "1.0.0-beta5"
     },
     "require-dev": {
+        "elasticsearch/elasticsearch": "1.2.*",
         "guzzlehttp/guzzle": "^5.0",
         "mockery/mockery": "*",
         "phpcompatibility/php-compatibility": "^9.0",
@@ -41,6 +42,7 @@
         "phpcompatibility/phpcompatibility-symfony": "*",
         "phpstan/phpstan": "^0.10.5",
         "phpunit/phpunit": "^5.7.19",
+        "pimple/pimple": "~2.0",
         "predis/predis": "^1.1",
         "squizlabs/php_codesniffer": "^3.3.0",
         "symfony/process": "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,10 @@ x-aliases:
         - .:/home/circleci/app
       tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec' ]
       depends_on:
+        - ddagent_integration
+        - elasticsearch2_integration
         - redis_integration
         - mysql_integration
-        - ddagent_integration
         - memcached_integration
       environment:
         - REDIS_HOSTNAME=redis_integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-aliases:
       depends_on:
         - ddagent_integration
         - elasticsearch2_integration
+        - httpbin_integration
         - redis_integration
         - mysql_integration
         - memcached_integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
       - MYSQL_USER=test
       - MYSQL_DATABASE=test
 
+  elasticsearch2_integration:
+    image: "elasticsearch:2"
+
   redis_integration:
     image: "circleci/redis:4.0-alpine"
 

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -1,13 +1,15 @@
 <?php
 
-namespace DDTrace\Integrations\ElasticSearch;
+namespace DDTrace\Integrations\ElasticSearch\V1;
 
 use DDTrace\Span;
 use DDTrace\Tags;
 use DDTrace\Types;
 use OpenTracing\GlobalTracer;
 
-
+/**
+ * ElasticSearch driver v1 Integration
+ */
 class ElasticSearchIntegration
 {
     const DEFAULT_SERVICE_NAME = 'elasticsearch';
@@ -27,13 +29,21 @@ class ElasticSearchIntegration
         self::traceClientMethod('__construct');
         self::traceClientMethod('count');
         self::traceClientMethod('delete');
-        self::traceClientMethod('exist');
+        self::traceClientMethod('exists');
         self::traceClientMethod('explain');
         self::traceClientMethod('get');
         self::traceClientMethod('index');
         self::traceClientMethod('scroll');
         self::traceClientMethod('search');
         self::traceClientMethod('update');
+
+        // Serializers
+        self::traceMethod('Elasticsearch\Serializers\ArrayToJSONSerializer', 'serialize');
+        self::traceMethod('Elasticsearch\Serializers\ArrayToJSONSerializer', 'deserialize');
+        self::traceMethod('Elasticsearch\Serializers\EverythingToJSONSerializer', 'serialize');
+        self::traceMethod('Elasticsearch\Serializers\EverythingToJSONSerializer', 'deserialize');
+        self::traceMethod('Elasticsearch\Serializers\SmartSerializer', 'serialize');
+        self::traceMethod('Elasticsearch\Serializers\SmartSerializer', 'deserialize');
 
         // IndicesNamespace operations
         self::traceNamespaceMethod('IndicesNamespace', 'analyze');
@@ -99,7 +109,6 @@ class ElasticSearchIntegration
         self::traceNamespaceMethod('SnapshotNamespace', 'status');
 
         // ClusterNamespace operations
-        self::traceNamespaceMethod('ClusterNamespace', 'get');
         self::traceNamespaceMethod('ClusterNamespace', 'getSettings');
         self::traceNamespaceMethod('ClusterNamespace', 'health');
         self::traceNamespaceMethod('ClusterNamespace', 'pendingTasks');
@@ -113,6 +122,37 @@ class ElasticSearchIntegration
         self::traceNamespaceMethod('NodesNamespace', 'info');
         self::traceNamespaceMethod('NodesNamespace', 'shutdown');
         self::traceNamespaceMethod('NodesNamespace', 'stats');
+
+        // Endpoints
+        dd_trace('Elasticsearch\Endpoints\AbstractEndpoint', 'performRequest', function () {
+            $args = func_get_args();
+            $tracer = GlobalTracer::get();
+            $scope = $tracer->startActiveSpan("Elasticsearch.Endpoint.performRequest");
+            $span = $scope->getSpan();
+
+            $span->setTag(Tags\SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
+            $span->setTag(Tags\SPAN_TYPE, Types\ELASTICSEARCH);
+            $span->setTag(Tags\RESOURCE_NAME, $this->getUri());
+            $span->setTag(Tags\HTTP_METHOD, $this->getMethod());
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = call_user_func_array([$this, 'performRequest'], $args);
+            } catch (\Exception $ex) {
+                $thrown = $ex;
+                if ($span instanceof Span) {
+                    $span->setError($ex);
+                }
+            }
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
     }
 
     /**
@@ -120,7 +160,7 @@ class ElasticSearchIntegration
      */
     public static function traceClientMethod($name)
     {
-        $class = '\Elasticsearch\Client';
+        $class = 'Elasticsearch\Client';
         if (!method_exists($class, $name)) {
             return;
         }
@@ -157,12 +197,65 @@ class ElasticSearchIntegration
     }
 
     /**
+     * @param string $class
+     * @param array $methods
+     */
+    public static function traceSimpleMethodsCall($class, array $methods)
+    {
+        foreach ($methods as $method) {
+            ElasticSearchIntegration::traceMethod($class, $method);
+        }
+    }
+
+    /**
+     * @param string $class
+     * @param string $name
+     */
+    public static function traceMethod($class, $name)
+    {
+        if (!method_exists($class, $name)) {
+            return;
+        }
+
+        dd_trace($class, $name, function () use ($class, $name) {
+            $args = func_get_args();
+
+            $tracer = GlobalTracer::get();
+            $operationName = str_replace('\\', '.', "$class.$name");
+            $scope = $tracer->startActiveSpan($operationName);
+            $span = $scope->getSpan();
+
+            $span->setTag(Tags\SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
+            $span->setTag(Tags\SPAN_TYPE, Types\ELASTICSEARCH);
+            $span->setTag(Tags\RESOURCE_NAME, $operationName);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = call_user_func_array([$this, $name], $args);
+            } catch (\Exception $ex) {
+                $thrown = $ex;
+                if ($span instanceof Span) {
+                    $span->setError($ex);
+                }
+            }
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+    }
+
+    /**
      * @param string $namespace
      * @param string $name
      */
     public static function traceNamespaceMethod($namespace, $name)
     {
-        $class = '\Elasticsearch\Namespace' . $namespace;
+        $class = 'Elasticsearch\Namespaces\\' . $namespace;
         if (!method_exists($class, $name)) {
             return;
         }
@@ -203,7 +296,7 @@ class ElasticSearchIntegration
      * @param array|null $params
      * @return string
      */
-    private static function buildResourceName($methodName, $params)
+    public static function buildResourceName($methodName, $params)
     {
         if (!is_array($params)) {
             return $methodName;

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -20,7 +20,6 @@ class ElasticSearchIntegration
         }
 
         if (!class_exists('Elasticsearch\Client')) {
-            trigger_error('Elasticsearch\Client class is missing and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace DDTrace\Integrations\ElasticSearch;
+
+use DDTrace\Span;
+use DDTrace\Tags;
+use DDTrace\Types;
+use OpenTracing\GlobalTracer;
+
+
+class ElasticSearchIntegration
+{
+    const DEFAULT_SERVICE_NAME = 'elasticsearch';
+
+    public static function load()
+    {
+        if (!extension_loaded('ddtrace')) {
+            trigger_error('The ddtrace extension is required to instrument Eloquent', E_USER_WARNING);
+            return;
+        }
+
+        if (!class_exists('Elasticsearch\Client')) {
+            trigger_error('Elasticsearch\Client class is missing and cannot be instrumented', E_USER_WARNING);
+            return;
+        }
+
+        // Client operations
+        self::traceClientMethod('__construct');
+        self::traceClientMethod('count');
+        self::traceClientMethod('delete');
+        self::traceClientMethod('exist');
+        self::traceClientMethod('explain');
+        self::traceClientMethod('get');
+        self::traceClientMethod('index');
+        self::traceClientMethod('scroll');
+        self::traceClientMethod('search');
+        self::traceClientMethod('update');
+
+        // IndicesNamespace operations
+        self::traceNamespaceMethod('IndicesNamespace', 'analyze');
+        self::traceNamespaceMethod('IndicesNamespace', 'clearCache');
+        self::traceNamespaceMethod('IndicesNamespace', 'close');
+        self::traceNamespaceMethod('IndicesNamespace', 'create');
+        self::traceNamespaceMethod('IndicesNamespace', 'delete');
+        self::traceNamespaceMethod('IndicesNamespace', 'deleteAlias');
+        self::traceNamespaceMethod('IndicesNamespace', 'deleteMapping');
+        self::traceNamespaceMethod('IndicesNamespace', 'deleteTemplate');
+        self::traceNamespaceMethod('IndicesNamespace', 'deleteWarmer');
+        self::traceNamespaceMethod('IndicesNamespace', 'exists');
+        self::traceNamespaceMethod('IndicesNamespace', 'existsAlias');
+        self::traceNamespaceMethod('IndicesNamespace', 'existsTemplate');
+        self::traceNamespaceMethod('IndicesNamespace', 'existsType');
+        self::traceNamespaceMethod('IndicesNamespace', 'flush');
+        self::traceNamespaceMethod('IndicesNamespace', 'getAlias');
+        self::traceNamespaceMethod('IndicesNamespace', 'getAliases');
+        self::traceNamespaceMethod('IndicesNamespace', 'getFieldMapping');
+        self::traceNamespaceMethod('IndicesNamespace', 'getMapping');
+        self::traceNamespaceMethod('IndicesNamespace', 'getSettings');
+        self::traceNamespaceMethod('IndicesNamespace', 'getTemplate');
+        self::traceNamespaceMethod('IndicesNamespace', 'getWarmer');
+        self::traceNamespaceMethod('IndicesNamespace', 'open');
+        self::traceNamespaceMethod('IndicesNamespace', 'optimize');
+        self::traceNamespaceMethod('IndicesNamespace', 'putAlias');
+        self::traceNamespaceMethod('IndicesNamespace', 'putMapping');
+        self::traceNamespaceMethod('IndicesNamespace', 'putSettings');
+        self::traceNamespaceMethod('IndicesNamespace', 'putTemplate');
+        self::traceNamespaceMethod('IndicesNamespace', 'putWarmer');
+        self::traceNamespaceMethod('IndicesNamespace', 'recovery');
+        self::traceNamespaceMethod('IndicesNamespace', 'refresh');
+        self::traceNamespaceMethod('IndicesNamespace', 'segments');
+        self::traceNamespaceMethod('IndicesNamespace', 'snapshotIndex');
+        self::traceNamespaceMethod('IndicesNamespace', 'stats');
+        self::traceNamespaceMethod('IndicesNamespace', 'status');
+        self::traceNamespaceMethod('IndicesNamespace', 'updateAliases');
+        self::traceNamespaceMethod('IndicesNamespace', 'validateQuery');
+
+        // CatNamespace operations
+        self::traceNamespaceMethod('CatNamespace', 'aliases');
+        self::traceNamespaceMethod('CatNamespace', 'allocation');
+        self::traceNamespaceMethod('CatNamespace', 'count');
+        self::traceNamespaceMethod('CatNamespace', 'fielddata');
+        self::traceNamespaceMethod('CatNamespace', 'health');
+        self::traceNamespaceMethod('CatNamespace', 'help');
+        self::traceNamespaceMethod('CatNamespace', 'indices');
+        self::traceNamespaceMethod('CatNamespace', 'master');
+        self::traceNamespaceMethod('CatNamespace', 'nodes');
+        self::traceNamespaceMethod('CatNamespace', 'pendingTasks');
+        self::traceNamespaceMethod('CatNamespace', 'recovery');
+        self::traceNamespaceMethod('CatNamespace', 'shards');
+        self::traceNamespaceMethod('CatNamespace', 'threadPool');
+
+        // SnapshotNamespace operations
+        self::traceNamespaceMethod('SnapshotNamespace', 'create');
+        self::traceNamespaceMethod('SnapshotNamespace', 'createRepository');
+        self::traceNamespaceMethod('SnapshotNamespace', 'delete');
+        self::traceNamespaceMethod('SnapshotNamespace', 'deleteRepository');
+        self::traceNamespaceMethod('SnapshotNamespace', 'get');
+        self::traceNamespaceMethod('SnapshotNamespace', 'getRepository');
+        self::traceNamespaceMethod('SnapshotNamespace', 'restore');
+        self::traceNamespaceMethod('SnapshotNamespace', 'status');
+
+        // ClusterNamespace operations
+        self::traceNamespaceMethod('ClusterNamespace', 'get');
+        self::traceNamespaceMethod('ClusterNamespace', 'getSettings');
+        self::traceNamespaceMethod('ClusterNamespace', 'health');
+        self::traceNamespaceMethod('ClusterNamespace', 'pendingTasks');
+        self::traceNamespaceMethod('ClusterNamespace', 'putSettings');
+        self::traceNamespaceMethod('ClusterNamespace', 'reroute');
+        self::traceNamespaceMethod('ClusterNamespace', 'state');
+        self::traceNamespaceMethod('ClusterNamespace', 'stats');
+
+        // NodesNamespace operations
+        self::traceNamespaceMethod('NodesNamespace', 'hotThreads');
+        self::traceNamespaceMethod('NodesNamespace', 'info');
+        self::traceNamespaceMethod('NodesNamespace', 'shutdown');
+        self::traceNamespaceMethod('NodesNamespace', 'stats');
+    }
+
+    /**
+     * @param string $name
+     */
+    public static function traceClientMethod($name)
+    {
+        $class = '\Elasticsearch\Client';
+        if (!method_exists($class, $name)) {
+            return;
+        }
+
+        dd_trace($class, $name, function () use ($name) {
+            $args = func_get_args();
+            list($params) = extract($args);
+            $tracer = GlobalTracer::get();
+            $scope = $tracer->startActiveSpan("Elasticsearch.Client.$name");
+            $span = $scope->getSpan();
+
+            $span->setTag(Tags\SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
+            $span->setTag(Tags\SPAN_TYPE, Types\ELASTICSEARCH);
+            $span->setTag(Tags\RESOURCE_NAME, ElasticSearchIntegration::buildResourceName($name, $params));
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = call_user_func_array([$this, $name], $args);
+            } catch (\Exception $ex) {
+                $thrown = $ex;
+                if ($span instanceof Span) {
+                    $span->setError($ex);
+                }
+            }
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     */
+    public static function traceNamespaceMethod($namespace, $name)
+    {
+        $class = '\Elasticsearch\Namespace' . $namespace;
+        if (!method_exists($class, $name)) {
+            return;
+        }
+
+        dd_trace($class, $name, function () use ($name) {
+            $args = func_get_args();
+            list($params) = extract($args);
+            $tracer = GlobalTracer::get();
+            $scope = $tracer->startActiveSpan("Elasticsearch.Client.$name");
+            $span = $scope->getSpan();
+
+            $span->setTag(Tags\SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
+            $span->setTag(Tags\SPAN_TYPE, Types\ELASTICSEARCH);
+            $span->setTag(Tags\RESOURCE_NAME, ElasticSearchIntegration::buildResourceName($name, $params));
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = call_user_func_array([$this, $name], $args);
+            } catch (\Exception $ex) {
+                $thrown = $ex;
+                if ($span instanceof Span) {
+                    $span->setError($ex);
+                }
+            }
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+    }
+
+    /**
+     * @param $methodName
+     * @param array|null $params
+     * @return string
+     */
+    private static function buildResourceName($methodName, $params)
+    {
+        if (!is_array($params)) {
+            return $methodName;
+        }
+
+        $resourceFragments = [$methodName];
+        $relevantParamNames = ['index', 'type'];
+
+        foreach ($relevantParamNames as $relevantParamName) {
+            if (empty($params[$relevantParamName])) {
+                continue;
+            }
+            $resourceFragments[] = $relevantParamName . ':' . $params[$relevantParamName];
+        }
+
+        return implode(' ', $resourceFragments);
+    }
+}

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -168,11 +168,11 @@ class ElasticSearchIntegration
             return;
         }
 
-        dd_trace($class, $name, function () use ($name) {
+        dd_trace($class, $name, function () use ($namespace, $name) {
             $args = func_get_args();
             list($params) = extract($args);
             $tracer = GlobalTracer::get();
-            $scope = $tracer->startActiveSpan("Elasticsearch.Client.$name");
+            $scope = $tracer->startActiveSpan("Elasticsearch.$namespace.$name");
             $span = $scope->getSpan();
 
             $span->setTag(Tags\SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);

--- a/src/DDTrace/Tags.php
+++ b/src/DDTrace/Tags.php
@@ -23,3 +23,9 @@ const LOG_STACK = 'stack';
 const TARGET_HOST = 'out.host';
 const TARGET_PORT = 'out.port';
 const BYTES_OUT = 'net.out.bytes';
+
+// Elasticsearch
+const ELASTICSEARCH_BODY = 'elasticsearch.body';
+const ELASTICSEARCH_METHOD = 'elasticsearch.method';
+const ELASTICSEARCH_PARAMS = 'elasticsearch.params';
+const ELASTICSEARCH_URL = 'elasticsearch.url';

--- a/src/DDTrace/Types.php
+++ b/src/DDTrace/Types.php
@@ -8,6 +8,7 @@ const WEB_SERVLET = 'web';
 const SQL = 'sql';
 
 const CASSANDRA = 'cassandra';
+const ELASTICSEARCH = 'elasticsearch';
 const MEMCACHED = 'memcached';
 const MONGO = 'mongodb';
 const REDIS = 'redis';

--- a/tests/DebugTransport.php
+++ b/tests/DebugTransport.php
@@ -14,7 +14,6 @@ class DebugTransport implements Transport
      */
     private $traces = array();
 
-
     /***
      * Holds set headers
      *

--- a/tests/Integration/Common/IntegrationTestCase.php
+++ b/tests/Integration/Common/IntegrationTestCase.php
@@ -33,4 +33,15 @@ abstract class IntegrationTestCase extends TestCase
     {
         $this->assertExpectedSpans($this, $traces, $expectedSpans);
     }
+
+    /**
+     * Checks that the provide span exists in the provided traces and matches expectations.
+     *
+     * @param $traces
+     * @param SpanAssertion $expectedSpan
+     */
+    public function assertOneSpan($traces, SpanAssertion $expectedSpan)
+    {
+        $this->assertOneExpectedSpan($this, $traces, $expectedSpan);
+    }
 }

--- a/tests/Integration/Common/SpanAssertionTrait.php
+++ b/tests/Integration/Common/SpanAssertionTrait.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Integration\Common;
 
+use DDTrace\Span;
 
 trait SpanAssertionTrait
 {
@@ -15,5 +16,28 @@ trait SpanAssertionTrait
     public function assertExpectedSpans($testCase, $traces, $expectedSpans)
     {
         (new SpanChecker($testCase))->assertSpans($traces, $expectedSpans);
+    }
+
+    /**
+     * Checks that the provide span exists in the provided traces and matches expectations.
+     *
+     * @param TestCase $testCase
+     * @param $traces
+     * @param SpanAssertion $expectedSpan
+     */
+    public function assertOneExpectedSpan($testCase, $traces, SpanAssertion $expectedSpan)
+    {
+        $spanChecker = new SpanChecker($testCase);
+
+        $found = array_filter($spanChecker->flattenTraces($traces), function (Span $span) use ($expectedSpan) {
+            return $span->getOperationName() === $expectedSpan->getOperationName();
+        });
+
+        if (empty($found)) {
+            $testCase->fail('Span not found in traces: ' . $expectedSpan->getOperationName());
+        } else {
+            $spanChecker->assertSpan($found[0], $expectedSpan);
+        }
+
     }
 }

--- a/tests/Integration/Common/SpanAssertionTrait.php
+++ b/tests/Integration/Common/SpanAssertionTrait.php
@@ -38,6 +38,5 @@ trait SpanAssertionTrait
         } else {
             $spanChecker->assertSpan($found[0], $expectedSpan);
         }
-
     }
 }

--- a/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace DDTrace\Tests\Integration\Integrations\Curl;
+
+use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
+use DDTrace\Tests\Integration\Common\IntegrationTestCase;
+use DDTrace\Tests\Integration\Common\SpanAssertion;
+use Elasticsearch\Client;
+
+/**
+ * Tests for Elasticsearch Client. We test specifically only most commonly used tests, for the other tests we just make
+ * sure that if a non existing method is provided, that for example does not exists for the used client version
+ * the integration does not throw an exception.
+ */
+final class ElasticSearchIntegrationTest extends IntegrationTestCase
+{
+    const HOST = 'elasticsearch2_integration';
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        ElasticSearchIntegration::load();
+    }
+
+    public function testNamespaceMethodNotExistsDoesNotCrashApps()
+    {
+        ElasticSearchIntegration::traceNamespaceMethod('\Wrong\Namespace', 'wrong_method');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testMethodNotExistsDoesNotCrashApps()
+    {
+        ElasticSearchIntegration::traceMethod('\Wrong\Class', 'wrong_method');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testConstructor()
+    {
+        $traces = $this->isolateTracer(function() {
+            $this->client();
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.__construct',
+                'elasticsearch',
+                'elasticsearch',
+                '__construct'
+            ),
+        ]);
+    }
+
+    public function testCount()
+    {
+        $client = $this->client();
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertArrayHasKey('count', $client->count());
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.count',
+                'elasticsearch',
+                'elasticsearch',
+                'count'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testDelete()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertTrue(is_array($client->delete([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+            ])));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.delete',
+                'elasticsearch',
+                'elasticsearch',
+                'delete'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testExists()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertTrue($client->exists([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+            ]));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.exists',
+                'elasticsearch',
+                'elasticsearch',
+                'exists'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testExplain()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertArrayHasKey('explanation', $client->explain([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+                'body' => [
+                    'query' => [
+                        'match' => [ 'my' => 'elasticsearch' ],
+                    ],
+                ],
+            ]));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.explain',
+                'elasticsearch',
+                'elasticsearch',
+                'explain'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.serialize'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testGet()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertArrayHasKey('found', $client->get([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+            ]));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.get',
+                'elasticsearch',
+                'elasticsearch',
+                'get'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testIndex()
+    {
+        $client = $this->client();
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertArrayHasKey('created', $client->index([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+                'body' => ['my' => 'body'],
+            ]));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.index',
+                'elasticsearch',
+                'elasticsearch',
+                'index'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.serialize'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testScroll()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $docs = $client->search([
+            'search_type' => 'scan',
+            'scroll' => '1s',
+            'size' => 1,
+            'index' => 'my_index',
+            'body' => array(
+                'query' => array(
+                    'match_all' => array()
+                )
+            )
+        ]);
+        $traces = $this->isolateTracer(function() use ($client, $docs) {
+            // Now we loop until the scroll "cursors" are exhausted
+            $scroll_id = $docs['_scroll_id'];
+            while (\true) {
+                // Execute a Scroll request
+                $response = $client->scroll(
+                    array(
+                        "scroll_id" => $scroll_id,
+                        "scroll" => "1s"
+                    )
+                );
+
+                // Check to see if we got any search hits from the scroll
+                if (count($response['hits']['hits']) > 0) {
+                    // If yes, Do Work Here
+
+                    // Get new scroll_id
+                    // Must always refresh your _scroll_id!  It can change sometimes
+                    $scroll_id = $response['_scroll_id'];
+                } else {
+                    // No results, scroll cursor is empty.  You've exported all the data
+                    break;
+                }
+            }
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.scroll',
+                'elasticsearch',
+                'elasticsearch',
+                'scroll'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+            SpanAssertion::build(
+                'Elasticsearch.Client.scroll',
+                'elasticsearch',
+                'elasticsearch',
+                'scroll'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+            SpanAssertion::build(
+                'Elasticsearch.Client.scroll',
+                'elasticsearch',
+                'elasticsearch',
+                'scroll'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testSearch()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $client->search([
+                'index' => 'my_index',
+                'body' => array(
+                    'query' => array(
+                        'match_all' => array()
+                    )
+                )
+            ]);
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.search',
+                'elasticsearch',
+                'elasticsearch',
+                'search'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.serialize'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    public function testUpdate()
+    {
+        $client = $this->client();
+        $client->index([
+            'id' => 1,
+            'index' => 'my_index',
+            'type' => 'my_type',
+            'body' => ['my' => 'body'],
+        ]);
+        $traces = $this->isolateTracer(function() use ($client) {
+            $this->assertArrayHasKey('_type', $client->update([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+                'body' => ['doc' => ['my' => 'body']],
+            ]));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'Elasticsearch.Client.update',
+                'elasticsearch',
+                'elasticsearch',
+                'update'
+            ),
+            SpanAssertion::exists('Elasticsearch.Endpoint.performRequest'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.serialize'),
+            SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
+        ]);
+    }
+
+    /**
+     * @dataProvider namespacesDataProvider
+     * @param string $namespace
+     * @param string $method
+     */
+    public function testNamespaces($namespace, $method)
+    {
+        $client = $this->client();
+
+        $traces = $this->isolateTracer(function() use ($client, $namespace, $method) {
+            try {
+                $client->$namespace()->$method([]);
+            } catch (\Exception $ex) {}
+        });
+
+        $fragment = ucfirst($namespace);
+        $this->assertOneSpan($traces, SpanAssertion::exists("Elasticsearch.${fragment}Namespace.$method"));
+    }
+
+    public function namespacesDataProvider()
+    {
+        return [
+            // indices operations
+            ['indices', 'analyze'],
+            ['indices', 'analyze'],
+            ['indices', 'clearCache'],
+            ['indices', 'close'],
+            ['indices', 'create'],
+            ['indices', 'delete'],
+            ['indices', 'deleteAlias'],
+            ['indices', 'deleteMapping'],
+            ['indices', 'deleteTemplate'],
+            ['indices', 'deleteWarmer'],
+            ['indices', 'exists'],
+            ['indices', 'existsAlias'],
+            ['indices', 'existsTemplate'],
+            ['indices', 'existsType'],
+            ['indices', 'flush'],
+            ['indices', 'getAlias'],
+            ['indices', 'getAliases'],
+            ['indices', 'getFieldMapping'],
+            ['indices', 'getMapping'],
+            ['indices', 'getSettings'],
+            ['indices', 'getTemplate'],
+            ['indices', 'getWarmer'],
+            ['indices', 'open'],
+            ['indices', 'optimize'],
+            ['indices', 'putAlias'],
+            ['indices', 'putMapping'],
+            ['indices', 'putSettings'],
+            ['indices', 'putTemplate'],
+            ['indices', 'putWarmer'],
+            ['indices', 'recovery'],
+            ['indices', 'refresh'],
+            ['indices', 'segments'],
+            ['indices', 'snapshotIndex'],
+            ['indices', 'stats'],
+            ['indices', 'status'],
+            ['indices', 'updateAliases'],
+            ['indices', 'validateQuery'],
+
+            // cat operations
+            ['cat', 'aliases'],
+            ['cat', 'allocation'],
+            ['cat', 'count'],
+            ['cat', 'fielddata'],
+            ['cat', 'health'],
+            ['cat', 'help'],
+            ['cat', 'indices'],
+            ['cat', 'master'],
+            ['cat', 'nodes'],
+            ['cat', 'pendingTasks'],
+            ['cat', 'recovery'],
+            ['cat', 'shards'],
+            ['cat', 'threadPool'],
+
+            // snapshot operations
+            ['snapshot', 'create'],
+            ['snapshot', 'createRepository'],
+            ['snapshot', 'delete'],
+            ['snapshot', 'deleteRepository'],
+            ['snapshot', 'get'],
+            ['snapshot', 'getRepository'],
+            ['snapshot', 'restore'],
+            ['snapshot', 'status'],
+
+            // cluster operations
+            ['cluster', 'getSettings'],
+            ['cluster', 'health'],
+            ['cluster', 'pendingTasks'],
+            ['cluster', 'putSettings'],
+            ['cluster', 'reroute'],
+            ['cluster', 'state'],
+            ['cluster', 'stats'],
+
+            // nodes operations
+            ['nodes', 'hotThreads'],
+            ['nodes', 'info'],
+            ['nodes', 'shutdown'],
+            ['nodes', 'stats'],
+        ];
+    }
+
+    /**
+     * @return Client
+     */
+    private function client()
+    {
+        return new Client([
+            'hosts' => [
+                'elasticsearch2_integration',
+            ],
+        ]);
+    }
+}

--- a/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -345,13 +345,17 @@ final class ElasticSearchIntegrationTest extends IntegrationTestCase
 
         $this->assertSpans($traces, [
             SpanAssertion::exists('Elasticsearch.Client.search'),
-            SpanAssertion::build('Elasticsearch.Endpoint.performRequest', 'elasticsearch', 'elasticsearch', 'performRequest')
-                ->withExactTags([
-                    'elasticsearch.url' => '/my_index/_search',
-                    'elasticsearch.method' => 'GET',
-                    'elasticsearch.params' => '[]',
-                    'elasticsearch.body' => '{"query":{"match_all":[]}}'
-                ]),
+            SpanAssertion::build(
+                'Elasticsearch.Endpoint.performRequest',
+                'elasticsearch',
+                'elasticsearch',
+                'performRequest'
+            )->withExactTags([
+                'elasticsearch.url' => '/my_index/_search',
+                'elasticsearch.method' => 'GET',
+                'elasticsearch.params' => '[]',
+                'elasticsearch.body' => '{"query":{"match_all":[]}}'
+            ]),
             SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.serialize'),
             SpanAssertion::exists('Elasticsearch.Serializers.SmartSerializer.deserialize'),
         ]);


### PR DESCRIPTION
### Description

Added Elasticsearch v1.x integration. Al public methods from the client and the various name spaces are traced. In addition to that, http requests to the elastic search cluster are also tracked.

### Readiness checklist
- [ ] [docs/changelog.md](Changelog entry) added, if necessary
- [ x ] Tests added for this feature/bug
