### PR TITLE
Tracer returning DDTrace\NoopSpan when in noop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file - [docs/chan
 - Curl integration #147
 - Ignore Closure in laravel #125 - thanks @Sh4d1
 
+### Fixed
+- `DDTrace\Tracer` returning a `DDTrace\NoopSpan` in place of `OpenTracing\NooSpan` when disabled #155
+
 ## [0.4.2] - 2018-11-21
 ### Added
 - Laravel 4.2 and 5.7 tests coverage : #139

--- a/src/DDTrace/NoopSpan.php
+++ b/src/DDTrace/NoopSpan.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace DDTrace;
+
+use OpenTracing\NoopSpanContext;
+
+/**
+ * A NoopSpan that provides methods defined in DDSpan
+ */
+final class NoopSpan implements SpanInterface
+{
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperationName()
+    {
+        return 'noop_span';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext()
+    {
+        return NoopSpanContext::create();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finish($finishTime = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function overwriteOperationName($newOperationName)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTag($key, $value)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log(array $fields = [], $timestamp = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addBaggageItem($key, $value)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaggageItem($key)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setError($error)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRawError($message, $type)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasError()
+    {
+        return false;
+    }
+}

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -5,11 +5,10 @@ namespace DDTrace;
 use DDTrace\Exceptions\InvalidSpanArgument;
 use Exception;
 use InvalidArgumentException;
-use OpenTracing\Span as OpenTracingSpan;
 use Throwable;
 
 
-final class Span implements OpenTracingSpan
+final class Span implements SpanInterface
 {
     /**
      * Operation Name is the name of the operation being measured. Some examples

--- a/src/DDTrace/SpanInterface.php
+++ b/src/DDTrace/SpanInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DDTrace;
+
+use OpenTracing\Span as OpenTracingSpan;
+
+/**
+ * An interface that defines the public operations of a Datadog Span, which enhances the OpenTracing Span api.
+ */
+interface SpanInterface extends OpenTracingSpan
+{
+    /**
+     * Stores a Throwable object within the span tags. The error status is
+     * updated and the error.Error() string is included with a default tag key.
+     * If the Span has been finished, it will not be modified by this method.
+     *
+     * @param \Throwable|\Exception|bool|string|null $error
+     * @throws \InvalidArgumentException
+     */
+    public function setError($error);
+
+    /**
+     * Stores an error message and type in the Span.
+     *
+     * @param string $message
+     * @param string $type
+     */
+    public function setRawError($message, $type);
+
+    /**
+     * Tells whether or not this Span contains errors.
+     *
+     * @return bool
+     */
+    public function hasError();
+}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -10,7 +10,6 @@ use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\Formats;
-use OpenTracing\NoopSpan;
 use OpenTracing\Reference;
 use OpenTracing\SpanContext as OpenTracingContext;
 use OpenTracing\StartSpanOptions;

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -2,15 +2,16 @@
 
 namespace DDTrace\Tests\Unit;
 
+use DDTrace\Encoders\Json;
 use DDTrace\Propagator;
 use DDTrace\SpanContext;
 use DDTrace\Tags;
 use DDTrace\Time;
 use DDTrace\Tracer;
 use DDTrace\Transport;
+use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
-use OpenTracing\NoopSpan;
 use PHPUnit\Framework;
 
 final class TracerTest extends Framework\TestCase
@@ -25,7 +26,7 @@ final class TracerTest extends Framework\TestCase
     {
         $tracer = Tracer::noop();
         $span = $tracer->startSpan(self::OPERATION_NAME);
-        $this->assertInstanceOf(NoopSpan::class, $span);
+        $this->assertInstanceOf('\DDTrace\NoopSpan', $span);
     }
 
     public function testCreateSpanSuccessWithExpectedValues()

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -2,14 +2,12 @@
 
 namespace DDTrace\Tests\Unit;
 
-use DDTrace\Encoders\Json;
 use DDTrace\Propagator;
 use DDTrace\SpanContext;
 use DDTrace\Tags;
 use DDTrace\Time;
 use DDTrace\Tracer;
 use DDTrace\Transport;
-use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use PHPUnit\Framework;


### PR DESCRIPTION
### Description

*Problem*

`DDTrace\Span` implements `OpenTracing\Span` interface and adds methods which are not part of the interface, e.g. `setError()`, `setRawError()` and until a few days ago `setResource()` (which has been recently removed). Such methods are used in our integrations.

`DDTrace\Tracer` when should return a `NoopSpan` returned the one from `OpenTracing` which misses such methods, causing ddtrace code to crash in integrations where such additional methods are used.

*Solution*

While the final solution will involve a refactor of the way we support `OpenTracing` and how we access our tracer, for now we just make sure that when the `DDTracer\Tracer` is not enabled it will return a `DDTrace\NoopSpan` (which exposes the all the required methods) in place of a `OpenTracing\NoopSpan`.

### Readiness checklist
- [x] [docs/changelog.md](Changelog entry) added, if necessary
- [x] Tests added for this feature/bug
