### PR TITLE
Fix GitHub PR template link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@ Any description you feel is relevant and gives more background to this PR, if ne
 -->
 
 ### Readiness checklist
-- [ ] [docs/changelog.md](Changelog entry) added, if necessary
+- [ ] [Changelog entry](docs/changelog.md) added, if necessary
 - [ ] Tests added for this feature/bug


### PR DESCRIPTION
### Description

The markdown url used incorrect format 

### Readiness checklist
- [x] ~[docs/changelog.md](Changelog entry) added, if necessary~
- [x] ~Tests added for this feature/bug~
