### PR TITLE
Small changelog link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ All notable changes to this project will be documented in this file - [docs/chan
 - OpenTracing compliance tha can be used for manual instrumentation
 
 [Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.5.1...HEAD
-[0.5.0]: https://github.com/DataDog/dd-trace-php/compare/0.5.0...0.5.1
+[0.5.1]: https://github.com/DataDog/dd-trace-php/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/DataDog/dd-trace-php/compare/0.4.2...0.5.0
 [0.4.2]: https://github.com/DataDog/dd-trace-php/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/DataDog/dd-trace-php/compare/0.4.0...0.4.1


### PR DESCRIPTION
### Description
Link to version 0.5.1 was not active
<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
