### PR TITLE
Report all errors for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file - [docs/changelog.md](read more).
 
 ## [Unreleased]
+### Fixed
+- "Undefined offset: 0" errors in ElasticSearch integration #165
 
 ## [0.6.0] - 2018-12-03
 ### Added

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutResourceUsageDuringSmallTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
-    bootstrap="vendor/autoload.php"
+    bootstrap="tests/bootstrap.php"
     colors="true"
     columns="max"
     verbose="true"

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -176,7 +176,10 @@ class ElasticSearchIntegration
 
         dd_trace($class, $name, function () use ($name) {
             $args = func_get_args();
-            list($params) = $args;
+            $params = [];
+            if (isset($args[0])) {
+                list($params) = $args;
+            }
             $tracer = GlobalTracer::get();
             $scope = $tracer->startActiveSpan("Elasticsearch.Client.$name");
             $span = $scope->getSpan();
@@ -271,7 +274,10 @@ class ElasticSearchIntegration
 
         dd_trace($class, $name, function () use ($namespace, $name) {
             $args = func_get_args();
-            list($params) = $args;
+            $params = [];
+            if (isset($args[0])) {
+                list($params) = $args;
+            }
             $tracer = GlobalTracer::get();
             $scope = $tracer->startActiveSpan("Elasticsearch.$namespace.$name");
             $span = $scope->getSpan();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+error_reporting(E_ALL);
+
+require __DIR__.'/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,4 @@
 
 error_reporting(E_ALL);
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
### Description

Quite embarrassingly I [pushed up a feature](https://github.com/DataDog/dd-trace-php/pull/161/files#diff-309a34982b1553d403e515fb7c6fc696R35) that generated errors in `E_STRICT` mode. The tests passed because `E_STRICT` errors were ignored by default. This PR ensures all errors are reported so future PR's don't introduce these types of bugs.

Also, this PR fixes all the `Undefined offset: 0` errors that were being generated by the `ElasticSearch` integration. :)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
