### PR TITLE
Let autoload all integrations and disable specific ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file - [docs/chan
 ### Added
 - Possibility to enable/disable distributed tracing and priority sampling #160
 - Injecting distributed tracing headers in guzzle and curl requests #167
+- Possibility to autoload all integrations and to disable specific ones #168
 
 ### Fixed
 - "Undefined offset: 0" errors in ElasticSearch integration #165

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -167,7 +167,9 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
 It is possible to configure the agent connections parameters by means of env variables.
 
-| Env variable          | Default     | Note                        |
-|-----------------------|-------------|-----------------------------|
-| `DD_AGENT_HOST`       | `localhost` | The agent host name         |
-| `DD_TRACE_AGENT_PORT` | `8126`      | The trace agent port number |
+| Env variable               | Default     | Note                                                |
+|----------------------------|-------------|-----------------------------------------------------|
+| `DD_TRACE_ENABLED`         | `true`      | Globally enables the tracer                         |
+| `DD_INTEGRATIONS_DISABLED` |             | CSV list of disabled extensions, e.g. `curl,mysqli` |
+| `DD_AGENT_HOST`            | `localhost` | The agent host name                                 |
+| `DD_TRACE_AGENT_PORT`      | `8126`      | The trace agent port number                         |

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -10,6 +10,16 @@ use DDTrace\Configuration\AbstractConfiguration;
 class Configuration extends AbstractConfiguration
 {
     /**
+     * Whether or not tracing is enabled.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->boolValue('trace.enabled', true);
+    }
+
+    /**
      * Whether or not distributed tracing is enabled globally.
      *
      * @return bool
@@ -28,5 +38,16 @@ class Configuration extends AbstractConfiguration
     {
         return $this->isDistributedTracingEnabled()
             && $this->boolValue('priority.sampling', true);
+    }
+
+    /**
+     * Whether or not a specific integration is enabled.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function isIntegrationEnabled($name)
+    {
+        return !$this->inArray('integrations.disabled', $name);
     }
 }

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -48,6 +48,6 @@ class Configuration extends AbstractConfiguration
      */
     public function isIntegrationEnabled($name)
     {
-        return !$this->inArray('integrations.disabled', $name);
+        return $this->isEnabled() && !$this->inArray('integrations.disabled', $name);
     }
 }

--- a/src/DDTrace/Configuration/AbstractConfiguration.php
+++ b/src/DDTrace/Configuration/AbstractConfiguration.php
@@ -23,13 +23,23 @@ abstract class AbstractConfiguration implements Registry
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      *
      * Allows users to access configuration properties by name instead of calling explicit methods.
      */
     public function boolValue($key, $default)
     {
         return $this->registry->boolValue($key, $default);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Allows users to access configuration properties by name instead of calling explicit methods.
+     */
+    public function inArray($key, $name)
+    {
+        return $this->registry->inArray($key, $name);
     }
 
     /**

--- a/src/DDTrace/Configuration/AbstractConfiguration.php
+++ b/src/DDTrace/Configuration/AbstractConfiguration.php
@@ -23,6 +23,20 @@ abstract class AbstractConfiguration implements Registry
     }
 
     /**
+     * Returns the singleton configuration instance.
+     *
+     * @return static
+     */
+    public static function get()
+    {
+        if (self::$instance === null) {
+            self::$instance = new static();
+        }
+
+        return self::$instance;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * Allows users to access configuration properties by name instead of calling explicit methods.
@@ -40,20 +54,6 @@ abstract class AbstractConfiguration implements Registry
     public function inArray($key, $name)
     {
         return $this->registry->inArray($key, $name);
-    }
-
-    /**
-     * Returns the singleton configuration instance.
-     *
-     * @return static
-     */
-    public static function instance()
-    {
-        if (self::$instance === null) {
-            self::$instance = new static();
-        }
-
-        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -55,7 +55,7 @@ class EnvVariableRegistry implements Registry
             }
         }
 
-        return array_key_exists(strtolower($name), $this->registry[$key]);
+        return in_array(strtolower($name), $this->registry[$key]);
     }
 
     /**

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -19,11 +19,7 @@ class EnvVariableRegistry implements Registry
     }
 
     /**
-     * Extract a boolean configuration value, fallback to the corresponding env variable to read the value.
-     *
-     * @param string $key
-     * @param bool $default
-     * @return bool
+     * {@inheritdoc}
      */
     public function boolValue($key, $default)
     {
@@ -40,6 +36,26 @@ class EnvVariableRegistry implements Registry
         }
 
         return $this->registry[$key];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function inArray($key, $name)
+    {
+        if (!isset($this->registry[$key])) {
+            $value = getenv($this->convertKeyToEnvVariableName($key));
+            if (is_string($value)) {
+                $disabledIntegrations = explode(',', $value);
+                $this->registry[$key] = array_map(function ($entry) {
+                    return trim(strtolower($entry));
+                }, $disabledIntegrations);
+            } else {
+                $this->registry[$key] = [];
+            }
+        }
+
+        return array_key_exists(strtolower($name), $this->registry[$key]);
     }
 
     /**

--- a/src/DDTrace/Configuration/Registry.php
+++ b/src/DDTrace/Configuration/Registry.php
@@ -15,4 +15,14 @@ interface Registry
      * @return bool
      */
     public function boolValue($key, $default);
+
+
+    /**
+     * Returns whether or not a given case-insensitive name is contained in a configuration property.
+     *
+     * @param string $key
+     * @param string $name
+     * @return bool
+     */
+    public function inArray($key, $name);
 }

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -28,7 +28,7 @@ class CurlIntegration
             return;
         }
 
-        $globalConfig = Configuration::instance();
+        $globalConfig = Configuration::get();
 
         dd_trace('curl_exec', function ($ch) {
             $tracer = GlobalTracer::get();
@@ -92,7 +92,7 @@ class CurlIntegration
      */
     public static function injectDistributedTracingHeaders($ch)
     {
-        if (!Configuration::instance()->isDistributedTracingEnabled()) {
+        if (!Configuration::get()->isDistributedTracingEnabled()) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -17,20 +17,18 @@ use OpenTracing\GlobalTracer;
  */
 class CurlIntegration
 {
+    const NAME = 'curl';
+
     /**
      * Loads the integration.
      */
     public static function load()
     {
-        $globalConfig = Configuration::instance();
-
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument curl', E_USER_WARNING);
-            return;
-        }
         if (!function_exists('curl_exec')) {
             return;
         }
+
+        $globalConfig = Configuration::instance();
 
         dd_trace('curl_exec', function ($ch) {
             $tracer = GlobalTracer::get();

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -12,15 +12,11 @@ use OpenTracing\GlobalTracer;
  */
 class ElasticSearchIntegration
 {
+    const NAME = 'elasticsearch';
     const DEFAULT_SERVICE_NAME = 'elasticsearch';
 
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument ElasticSearch', E_USER_WARNING);
-            return;
-        }
-
         if (!class_exists('Elasticsearch\Client')) {
             return;
         }

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -9,14 +9,11 @@ use OpenTracing\GlobalTracer;
 
 class EloquentIntegration
 {
+    const NAME = 'eloquent';
+
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument Eloquent', E_USER_WARNING);
-            return;
-        }
         if (!class_exists('Illuminate\Database\Eloquent\Builder')) {
-            trigger_error('Eloquent is not loaded and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/Guzzle/V5/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/V5/GuzzleIntegration.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Message\ResponseInterface;
 
 class GuzzleIntegration extends Integration
 {
+    const NAME = 'guzzle';
     const CLASS_NAME = 'GuzzleHttp\Client';
 
     protected static function loadIntegration()

--- a/src/DDTrace/Integrations/Guzzle/V5/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/V5/GuzzleIntegration.php
@@ -45,7 +45,7 @@ class GuzzleIntegration extends Integration
      */
     public static function injectDistributedTracingHeaders($request, $span)
     {
-        if (!Configuration::instance()->isDistributedTracingEnabled()) {
+        if (!Configuration::get()->isDistributedTracingEnabled()) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -12,16 +12,11 @@ abstract class Integration
 
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to trace ' . static::CLASS_NAME, E_USER_WARNING);
-            return false;
-        }
         if (!class_exists(static::CLASS_NAME)) {
-            return false;
+            return;
         }
         // See comment on the commented out abstract function definition.
         static::loadIntegration();
-        return true;
     }
 
     /**

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -21,7 +21,7 @@ class IntegrationsLoader
         CurlIntegration::NAME => '\DDTrace\Integrations\Curl\CurlIntegration',
         ElasticSearchIntegration::NAME => '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
         EloquentIntegration::NAME => '\DDTrace\Integrations\Eloquent\EloquentIntegration',
-        GuzzleIntegration::NAME => '\DDTrace\Integrations\Guzzle\GuzzleIntegration',
+        GuzzleIntegration::NAME => '\DDTrace\Integrations\Guzzle\V5\GuzzleIntegration',
         MemcachedIntegration::NAME => '\DDTrace\Integrations\Memcached\MemcachedIntegration',
         MysqliIntegration::NAME => '\DDTrace\Integrations\Mysqli\MysqliIntegration',
         PDOIntegration::NAME => '\DDTrace\Integrations\PDO\PDOIntegration',

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DDTrace\Integrations;
+
+use DDTrace\Configuration;
+use DDTrace\Integrations\Curl\CurlIntegration;
+use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
+use DDTrace\Integrations\Eloquent\EloquentIntegration;
+use DDTrace\Integrations\Guzzle\V5\GuzzleIntegration;
+use DDTrace\Integrations\Memcached\MemcachedIntegration;
+use DDTrace\Integrations\Mysqli\MysqliIntegration;
+use DDTrace\Integrations\PDO\PDOIntegration;
+use DDTrace\Integrations\Predis\PredisIntegration;
+
+/**
+ * Loader for all integrations currently enabled.
+ */
+class IntegrationsLoader
+{
+    const LIBRARIES = [
+        CurlIntegration::NAME => '\DDTrace\Integrations\Curl\CurlIntegration',
+        ElasticSearchIntegration::NAME => '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
+        EloquentIntegration::NAME => '\DDTrace\Integrations\Eloquent\EloquentIntegration',
+        GuzzleIntegration::NAME => '\DDTrace\Integrations\Guzzle\GuzzleIntegration',
+        MemcachedIntegration::NAME => '\DDTrace\Integrations\Memcached\MemcachedIntegration',
+        MysqliIntegration::NAME => '\DDTrace\Integrations\Mysqli\MysqliIntegration',
+        PDOIntegration::NAME => '\DDTrace\Integrations\PDO\PDOIntegration',
+        PredisIntegration::NAME => '\DDTrace\Integrations\Predis\PredisIntegration',
+    ];
+
+    /**
+     * Loads all the enabled library integrations.
+     */
+    public static function load()
+    {
+        $globalConfig = Configuration::instance();
+
+        if (!$globalConfig->isEnabled()) {
+            return;
+        }
+
+        if (!extension_loaded('ddtrace')) {
+            error_log('Missing ddtrace extension. To disable tracing set env variable DD_TRACE_ENABLED=false');
+            return;
+        }
+
+        foreach (self::LIBRARIES as $name => $class) {
+            if ($globalConfig->isIntegrationEnabled($name)) {
+                call_user_func([$class, 'load']);
+            }
+        }
+    }
+}

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -40,7 +40,10 @@ class IntegrationsLoader
         }
 
         if (!extension_loaded('ddtrace')) {
-            error_log('Missing ddtrace extension. To disable tracing set env variable DD_TRACE_ENABLED=false');
+            trigger_error(
+                'Missing ddtrace extension. To disable tracing set env variable DD_TRACE_ENABLED=false',
+                E_USER_WARNING
+            );
             return;
         }
 

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -33,7 +33,7 @@ class IntegrationsLoader
      */
     public static function load()
     {
-        $globalConfig = Configuration::instance();
+        $globalConfig = Configuration::get();
 
         if (!$globalConfig->isEnabled()) {
             return;

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -4,13 +4,7 @@ namespace DDTrace\Integrations\Laravel\V4;
 
 use DDTrace;
 use DDTrace\Encoders\Json;
-use DDTrace\Integrations\Curl\CurlIntegration;
-use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
-use DDTrace\Integrations\Eloquent\EloquentIntegration;
-use DDTrace\Integrations\Guzzle\V5\GuzzleIntegration;
-use DDTrace\Integrations\Memcached\MemcachedIntegration;
-use DDTrace\Integrations\PDO\PDOIntegration;
-use DDTrace\Integrations\Predis\PredisIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\StartSpanOptionsFactory;
 use DDTrace\Tags;
 use DDTrace\Tracer;
@@ -89,20 +83,8 @@ class LaravelProvider extends ServiceProvider
             $span->setTag(Tags\HTTP_URL, $request->url());
         });
 
-        // Enable extension integrations
-        CurlIntegration::load();
-        EloquentIntegration::load();
-        if (class_exists('Memcached')) {
-            MemcachedIntegration::load();
-        }
-        GuzzleIntegration::load();
-
-        PDOIntegration::load();
-        ElasticSearchIntegration::load();
-
-        if (class_exists('Predis\Client')) {
-            PredisIntegration::load();
-        }
+        // Enable other integrations
+        IntegrationsLoader::load();
 
         // Flushes traces to agent.
         register_shutdown_function(function () use ($scope) {

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -36,7 +36,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function register()
     {
-        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return;
         }
 
@@ -61,7 +61,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function boot()
     {
-        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations\Laravel\V4;
 
 use DDTrace;
+use DDTrace\Configuration;
 use DDTrace\Encoders\Json;
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\StartSpanOptionsFactory;
@@ -30,9 +31,15 @@ use OpenTracing\GlobalTracer;
  */
 class LaravelProvider extends ServiceProvider
 {
+    const NAME = 'laravel';
+
     /** @inheritdoc */
     public function register()
     {
+        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+            return;
+        }
+
         if (!extension_loaded('ddtrace')) {
             trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
             return;
@@ -54,6 +61,10 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function boot()
     {
+        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+            return;
+        }
+
         $tracer = GlobalTracer::get();
 
         $startSpanOptions = StartSpanOptionsFactory::createForWebRequest(

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations\Laravel\V5;
 
 use DDTrace;
+use DDTrace\Configuration;
 use DDTrace\Encoders\Json;
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\StartSpanOptionsFactory;
@@ -35,9 +36,15 @@ use function DDTrace\Time\fromMicrotime;
  */
 class LaravelProvider extends ServiceProvider
 {
+    const NAME = 'laravel';
+
     /**  @inheritdoc */
     public function register()
     {
+        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+            return;
+        }
+
         if (!extension_loaded('ddtrace')) {
             trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
             return;
@@ -58,6 +65,10 @@ class LaravelProvider extends ServiceProvider
     /**  @inheritdoc */
     public function boot()
     {
+        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+            return;
+        }
+
         $tracer = GlobalTracer::get();
 
         // Trace middleware

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -41,7 +41,7 @@ class LaravelProvider extends ServiceProvider
     /**  @inheritdoc */
     public function register()
     {
-        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return;
         }
 
@@ -65,7 +65,7 @@ class LaravelProvider extends ServiceProvider
     /**  @inheritdoc */
     public function boot()
     {
-        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -4,12 +4,7 @@ namespace DDTrace\Integrations\Laravel\V5;
 
 use DDTrace;
 use DDTrace\Encoders\Json;
-use DDTrace\Integrations\Curl\CurlIntegration;
-use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
-use DDTrace\Integrations\Eloquent\EloquentIntegration;
-use DDTrace\Integrations\Memcached\MemcachedIntegration;
-use DDTrace\Integrations\PDO\PDOIntegration;
-use DDTrace\Integrations\Predis\PredisIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\StartSpanOptionsFactory;
 use DDTrace\Tags;
 use DDTrace\Tracer;
@@ -162,17 +157,8 @@ class LaravelProvider extends ServiceProvider
             }
         });
 
-        // Enable extension integrations
-        CurlIntegration::load();
-        ElasticSearchIntegration::load();
-        EloquentIntegration::load();
-        if (class_exists('Memcached')) {
-            MemcachedIntegration::load();
-        }
-        PDOIntegration::load();
-        if (class_exists('Predis\Client')) {
-            PredisIntegration::load();
-        }
+        // Enable other integrations
+        IntegrationsLoader::load();
 
         // Flushes traces to agent.
         register_shutdown_function(function () use ($scope) {

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -22,14 +22,11 @@ use OpenTracing\GlobalTracer;
  */
 class MemcachedIntegration
 {
+    const NAME = 'memcached';
+
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument Memcached', E_USER_WARNING);
-            return;
-        }
         if (!class_exists('Memcached')) {
-            trigger_error('Memcached is not loaded and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -9,14 +9,11 @@ use OpenTracing\GlobalTracer;
 
 class MysqliIntegration
 {
+    const NAME = 'mysqli';
+
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load mysqli integrations.', E_USER_WARNING);
-            return;
-        }
         if (!extension_loaded('mysqli')) {
-            trigger_error('mysqli is not loaded and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -8,6 +8,8 @@ use OpenTracing\GlobalTracer;
 
 class PDOIntegration
 {
+    const NAME = 'pdo';
+
     /**
      * @var array
      */
@@ -23,12 +25,7 @@ class PDOIntegration
      */
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument PDO', E_USER_WARNING);
-            return;
-        }
         if (!extension_loaded('PDO')) {
-            trigger_error('PDO is not loaded and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -14,6 +14,8 @@ const CMD_MAX_LEN = 1000;
 
 class PredisIntegration
 {
+    const NAME = 'predis';
+
     /**
      * @var array
      */
@@ -24,12 +26,7 @@ class PredisIntegration
      */
     public static function load()
     {
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('The ddtrace extension is required to instrument Predis', E_USER_WARNING);
-            return;
-        }
         if (!class_exists('\Predis\Client')) {
-            trigger_error('Predis is not loaded and cannot be instrumented', E_USER_WARNING);
             return;
         }
 

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Integrations\Symfony\V4;
 
+use DDTrace\Configuration;
 use DDTrace\Encoders\Json;
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tags;
@@ -27,9 +28,15 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SymfonyBundle extends Bundle
 {
+    const NAME = 'symfony';
+
     public function boot()
     {
         parent::boot();
+
+        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+            return;
+        }
 
         if (!extension_loaded('ddtrace')) {
             trigger_error('ddtrace extension required to load Symfony integration.', E_USER_WARNING);

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -3,11 +3,7 @@
 namespace DDTrace\Integrations\Symfony\V4;
 
 use DDTrace\Encoders\Json;
-use DDTrace\Integrations\Curl\CurlIntegration;
-use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
-use DDTrace\Integrations\Memcached\MemcachedIntegration;
-use DDTrace\Integrations\PDO\PDOIntegration;
-use DDTrace\Integrations\Predis\PredisIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tags;
 use DDTrace\Tracer;
 use DDTrace\Transport\Http;
@@ -120,16 +116,8 @@ class SymfonyBundle extends Bundle
             }
         );
 
-        // Enable extension integrations
-        CurlIntegration::load();
-        ElasticSearchIntegration::load();
-        PDOIntegration::load();
-        if (class_exists('Memcached')) {
-            MemcachedIntegration::load();
-        }
-        if (class_exists('Predis\Client')) {
-            PredisIntegration::load();
-        }
+        // Enable other integrations
+        IntegrationsLoader::load();
 
         // Flushes traces to agent.
         register_shutdown_function(function () use ($scope) {

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -34,7 +34,7 @@ class SymfonyBundle extends Bundle
     {
         parent::boot();
 
-        if (!Configuration::instance()->isIntegrationEnabled(self::NAME)) {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return;
         }
 

--- a/src/DDTrace/StartSpanOptionsFactory.php
+++ b/src/DDTrace/StartSpanOptionsFactory.php
@@ -22,7 +22,7 @@ class StartSpanOptionsFactory
      */
     public static function createForWebRequest(OTTracer $tracer, array $options = [], array $headers = [])
     {
-        $globalConfiguration = Configuration::instance();
+        $globalConfiguration = Configuration::get();
 
         if ($globalConfiguration->isDistributedTracingEnabled()
                 && $spanContext = $tracer->extract(\OpenTracing\Formats\HTTP_HEADERS, $headers)) {

--- a/tests/Integration/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integration/Integrations/Curl/CurlIntegrationTest.php
@@ -4,7 +4,7 @@ namespace DDTrace\Tests\Integration\Integrations\Curl;
 
 use DDTrace\Configuration;
 use DDTrace\Formats;
-use DDTrace\Integrations\Curl\CurlIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 use DDTrace\Util\ArrayKVStore;
@@ -18,7 +18,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        CurlIntegration::load();
+        IntegrationsLoader::load();
     }
 
     public function testLoad200UrlOnInit()

--- a/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integration/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Tests\Integration\Integrations\Curl;
 
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 use Elasticsearch\Client;
@@ -19,7 +20,7 @@ final class ElasticSearchIntegrationTest extends IntegrationTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        ElasticSearchIntegration::load();
+        IntegrationsLoader::load();
     }
 
     public function testNamespaceMethodNotExistsDoesNotCrashApps()

--- a/tests/Integration/Integrations/Guzzle/v5/GuzzleIntegrationTest.php
+++ b/tests/Integration/Integrations/Guzzle/v5/GuzzleIntegrationTest.php
@@ -3,12 +3,11 @@
 namespace DDTrace\Tests\Integration\Integrations\Guzzle\V5;
 
 use DDTrace\Configuration;
-use DDTrace\Integrations\Curl\CurlIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\Request;
 use GuzzleHttp\Ring\Client\MockHandler;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
-use DDTrace\Integrations\Guzzle\V5\GuzzleIntegration;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use OpenTracing\GlobalTracer;
 
@@ -21,8 +20,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        GuzzleIntegration::load();
-        CurlIntegration::load();
+        IntegrationsLoader::load();
     }
 
     protected function setUp()

--- a/tests/Integration/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integration/Integrations/Memcached/MemcachedTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integration\Integrations\Memcached;
 
 use DDTrace\Obfuscation;
-use DDTrace\Integrations;
+use DDTrace\Integrations\Memcached\MemcachedIntegration;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 
@@ -20,7 +20,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        Integrations\Memcached\MemcachedIntegration::load();
+        MemcachedIntegration::load();
     }
 
     protected function setUp()

--- a/tests/Integration/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integration/Integrations/Memcached/MemcachedTest.php
@@ -2,8 +2,8 @@
 
 namespace DDTrace\Tests\Integration\Integrations\Memcached;
 
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Obfuscation;
-use DDTrace\Integrations\Memcached\MemcachedIntegration;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 
@@ -20,7 +20,7 @@ final class MemcachedTest extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        MemcachedIntegration::load();
+        IntegrationsLoader::load();
     }
 
     protected function setUp()

--- a/tests/Integration/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integration/Integrations/Mysqli/MysqliTest.php
@@ -2,7 +2,7 @@
 
 namespace DDTrace\Tests\Integration\Integrations\Mysqli;
 
-use DDTrace\Integrations\Mysqli\MysqliIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 
@@ -18,7 +18,7 @@ final class MysqliTest extends IntegrationTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        MysqliIntegration::load();
+        IntegrationsLoader::load();
     }
 
     protected function setUp()

--- a/tests/Integration/Integrations/PDO/PDOTest.php
+++ b/tests/Integration/Integrations/PDO/PDOTest.php
@@ -2,7 +2,7 @@
 
 namespace DDTrace\Tests\Integration\Integrations\PDO;
 
-use DDTrace\Integrations\PDO\PDOIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 
@@ -16,7 +16,7 @@ final class PDOTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass()
     {
-        PDOIntegration::load();
+        IntegrationsLoader::load();
     }
 
     protected function setUp()

--- a/tests/Integration/Integrations/Predis/PredisTest.php
+++ b/tests/Integration/Integrations/Predis/PredisTest.php
@@ -2,7 +2,7 @@
 
 namespace DDTrace\Tests\Integration\Integrations\Predis;
 
-use DDTrace\Integrations\Predis\PredisIntegration;
+use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Integration\Common\IntegrationTestCase;
 use DDTrace\Tests\Integration\Common\SpanAssertion;
 use Predis\Response\Status;
@@ -15,7 +15,7 @@ final class PredisTest extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        PredisIntegration::load();
+        IntegrationsLoader::load();
     }
 
     protected function setUp()

--- a/tests/Unit/Configuration/EnvVariableRegistryTest.php
+++ b/tests/Unit/Configuration/EnvVariableRegistryTest.php
@@ -52,4 +52,37 @@ final class EnvVariableRegistryTest extends BaseTestCase
         putenv('DD_SOME_TEST_PARAMETER=0   ');
         $this->assertFalse($registry->boolValue('some.test.parameter', true));
     }
+
+    public function testInArrayNotSet()
+    {
+        $registry = new EnvVariableRegistry();
+        $this->assertFalse($registry->inArray('some.test.parameter', 'name'));
+    }
+
+    public function testInArraySet()
+    {
+        $registry = new EnvVariableRegistry();
+        putenv('DD_SOME_TEST_PARAMETER=value1,value2');
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value1'));
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value2'));
+        $this->assertFalse($registry->inArray('some.test.parameter', 'value3'));
+    }
+
+    public function testInArrayCaseInsensitive()
+    {
+        $registry = new EnvVariableRegistry();
+        putenv('DD_SOME_TEST_PARAMETER=vAlUe1,VaLuE2');
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value1'));
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value2'));
+        $this->assertFalse($registry->inArray('some.test.parameter', 'value3'));
+    }
+
+    public function testInArrayWhiteSpaceBetweenDefinitions()
+    {
+        $registry = new EnvVariableRegistry();
+        putenv('DD_SOME_TEST_PARAMETER= value1    ,     value2     ');
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value1'));
+        $this->assertTrue($registry->inArray('some.test.parameter', 'value2'));
+        $this->assertFalse($registry->inArray('some.test.parameter', 'value3'));
+    }
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace DDTrace\Tests\Unit;
+
+use DDTrace\Configuration;
+
+final class ConfigurationTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        putenv('DD_TRACE_ENABLED');
+        putenv('DD_DISTRIBUTED_TRACING');
+        putenv('DD_PRIORITY_SAMPLING');
+        putenv('DD_INTEGRATIONS_DISABLED');
+    }
+
+    public function testTracerEnabledByDefault()
+    {
+        $this->assertTrue(Configuration::get()->isEnabled());
+    }
+
+    public function testTracerDisabled()
+    {
+        putenv('DD_TRACE_ENABLED=false');
+        $this->assertFalse(Configuration::get()->isEnabled());
+    }
+
+    public function testDistributedTracingEnabledByDefault()
+    {
+        $this->assertTrue(Configuration::get()->isDistributedTracingEnabled());
+    }
+
+    public function testDistributedTracingDisabled()
+    {
+        putenv('DD_DISTRIBUTED_TRACING=false');
+        $this->assertFalse(Configuration::get()->isDistributedTracingEnabled());
+    }
+
+    public function testPrioritySamplingEnabledByDefault()
+    {
+        $this->assertTrue(Configuration::get()->isPrioritySamplingEnabled());
+    }
+
+    public function testPrioritySamplingDisabled()
+    {
+        putenv('DD_PRIORITY_SAMPLING=false');
+        $this->assertFalse(Configuration::get()->isPrioritySamplingEnabled());
+    }
+
+    public function testAllIntegrationsEnabledByDefault()
+    {
+        $this->assertTrue(Configuration::get()->isIntegrationEnabled('any_one'));
+    }
+
+    public function testIntegrationsDisabled()
+    {
+        putenv('DD_INTEGRATIONS_DISABLED=one,two');
+        $this->assertFalse(Configuration::get()->isIntegrationEnabled('one'));
+        $this->assertFalse(Configuration::get()->isIntegrationEnabled('two'));
+        $this->assertTrue(Configuration::get()->isIntegrationEnabled('three'));
+    }
+
+    public function testIntegrationsDisabledIfGlobalDisabled()
+    {
+        putenv('DD_INTEGRATIONS_DISABLED=one');
+        putenv('DD_TRACE_ENABLED=false');
+        $this->assertFalse(Configuration::get()->isIntegrationEnabled('one'));
+        $this->assertFalse(Configuration::get()->isIntegrationEnabled('two'));
+    }
+}

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -18,6 +18,7 @@ final class CurlHeadersMapTest extends Framework\TestCase
         $expectedButFrameworks = array_diff($expected, $this->normalize(self::FRAMEWORKS));
         $autoLoaded = $this->normalize(array_keys(IntegrationsLoader::LIBRARIES));
 
+        // If this test fails you need to add an entry to IntegrationsLoader::LIBRARIES array.
         $this->assertEquals(array_values($expectedButFrameworks), array_values($autoLoaded));
     }
 

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DDTrace\Tests\Unit\Integrations;
+
+use DDTrace\Integrations\IntegrationsLoader;
+use PHPUnit\Framework;
+
+final class CurlHeadersMapTest extends Framework\TestCase
+{
+    const FRAMEWORKS = [
+        'laravel',
+        'symfony',
+    ];
+
+    public function testWeDidNotForgetToRegisterALibraryForAutoLoading()
+    {
+        $expected = $this->normalize(glob(__DIR__ . '/../../../src/DDTrace/Integrations/*', GLOB_ONLYDIR));
+        $expectedButFrameworks = array_diff($expected, $this->normalize(self::FRAMEWORKS));
+        $autoLoaded = $this->normalize(array_keys(IntegrationsLoader::LIBRARIES));
+
+        $this->assertEquals(array_values($expectedButFrameworks), array_values($autoLoaded));
+    }
+
+    /**
+     * Normalizes integrations folders/names to a simplified format suitable for easy comparison.
+     *
+     * @param array $array_map
+     * @return array
+     */
+    private function normalize(array $array_map)
+    {
+        return array_map(function ($entry) {
+            if (strrpos($entry, '/')) {
+                $name = substr($entry, strrpos($entry, '/') + 1);
+            } else {
+                $name = $entry;
+            }
+            return strtolower($name);
+        }, $array_map);
+    }
+}


### PR DESCRIPTION
### Description

This PR adds the possibility to have a unique and safe way to load all the libraries (not frameworks) integrations and to disable specific ones by means of env variable.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
