### PR TITLE
Refactor the README and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,117 @@
 # Contributing to dd-trace-php
 
-As an open source project we welcome contributions of many forms, but due to the experimental pre-beta nature
-of this repository, you should reach out before starting work on any major code changes.
-This will ensure we avoid duplicating work, or that your code can't be merged due to a rapidly changing
-base. If you have any questions, create a [GitHub issue][1] and reach us!
+As an open-source project we welcome contributions of many forms, but due to the experimental pre-beta nature of this repository, you should [reach out to us](https://github.com/DataDog/dd-trace-php/issues) before starting work on any major code changes. This will ensure we avoid duplicating work, or that your code can't be merged due to a rapidly changing base.
 
-[1]: https://github.com/DataDog/dd-trace-php/issues
+## Getting set up with Docker
+
+The easiest way to get the development environment set up is to install [Docker](https://www.docker.com/) and run the following [Docker Compose](https://docs.docker.com/compose/) command from the project root to start the containers.
+
+```bash
+$ docker-compose up -d
+```
+
+This will run the [preconfigured docker images](https://hub.docker.com/r/datadog/docker-library/) that we provide for the different PHP versions.
+
+- PHP 5.6: `datadog/docker-library:ddtrace_php_5_6`
+- PHP 7.0: `datadog/docker-library:ddtrace_php_7_0`
+- PHP 7.1: `datadog/docker-library:ddtrace_php_7_1`
+- PHP 7.2: `datadog/docker-library:ddtrace_php_7_2`
+
+To access a `bash` from the PHP 7.2 container, run the following:
+
+```bash
+$ docker-compose run --rm 7.2 bash
+```
+
+Once inside the container, install the dependencies with Composer.
+
+```bash
+$ composer install
+```
+
+Then install the `ddtrace` extension.
+
+```bash
+$ composer install-ext
+```
+
+> **Note:** You'll need to run the above `install-ext` command to install the `ddtrace` extension every time you access the container's bash for the first time.
+
+You can check that the extension was installed properly.
+
+```bash
+$ php --ri=ddtrace
+```
+
+You should see output similar to the following:
+
+```
+ddtrace
+
+
+Datadog PHP tracer extension
+For help, check out the documentation at https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started
+(c) Datadog 2018
+
+Datadog tracing support => enabled
+Version => 0.7.0-beta
+```
+
+When you're done with development, you can stop and remove the containers with the following:
+
+```bash
+$ docker-compose down
+```
+
+### Running the tests
+
+In order to run all the tracer tests:
+
+```bash
+$ composer test
+```
+
+> **Note:** The `composer test` command is a wrapper around `phpunit`, so you can use all the common [options](https://phpunit.de/manual/5.7/en/textui.html#textui.clioptions) that you would with `phpunit`. However you need prepend the options list with the additional `--` dashes that `composer` requires:
+
+```bash
+# Run a suite and a filter
+$ composer test -- --testsuite=unit --filter=Predis
+```
+
+In order to run the `phpt` tests for the php extension:
+
+```bash
+$ composer test-ext
+```
+
+### PHP linting
+
+The PHP tracer conforms to the [PSR-2 coding style guide](https://www.php-fig.org/psr/psr-2/). The code style is checked with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) which can be invoked with the following command:
+
+```bash
+$ composer lint
+```
+
+To try to automatically fix the code style, you can run:
+
+```bash
+$ composer fix-lint
+```
+
+### Static Analyzer
+
+The [PHPStan static analyzer](https://github.com/phpstan/phpstan) is part of the build checks when submitting a PR. To ensure your contribution passes the static analyzer, run the following:
+
+```bash
+$ composer static-analyze
+```
+
+> **Note:** The static analyzer only works on PHP 7.1 builds and greater.
+
+## Sending a pull request (PR)
+
+There are a number of checks that are run automatically with [CircleCI](https://circleci.com/gh/DataDog/dd-trace-php/tree/master) when a PR is submitted. To ensure your PHP code changes pass the CircleCI checks, make sure to run all the same checks before submitting a PR.
+
+```bash
+$ composer test && composer lint && composer static-analyze
+```


### PR DESCRIPTION
### Description

This PR is the first attempt to make it easier to get up and running with the PHP tracer by focusing on the README as a first-stop for new users. This doesn't cover all the bases, but at least gets us a little closer to a better developer experience. :)

Do we need to update the changelog for this?

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
