### PR TITLE
Add loose support for Lumen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file - [docs/changelog.md](read more).
 
 ## [Unreleased]
+### Added
+- Support for Lumen via the Laravel service provider #180
 
 ## [0.7.1] - 2018-12-07
 ### Added

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -94,15 +94,27 @@ composer update
 
 #### Laravel integration
 
-To enable Laravel integration we need to configure a new Provider in `config/app.php`
+To enable [Laravel](https://laravel.com/) integration we need to configure a new provider in `config/app.php`
 
 ```php
     'providers' => [
 # .....
-      'DDTrace\Integrations\LaravelProvider',
+      # Laravel 5
+      'DDTrace\Integrations\Laravel\V5\LaravelProvider',
+      # Laravel 4
+      'DDTrace\Integrations\Laravel\V4\LaravelProvider',
 ```
 
 Now your Laravel application should start sending traces to the Datadog agent running on localhost (in default configuration). The Datadog agent must have APM enabled; see https://docs.datadoghq.com/tracing/setup/ for instructions on installing and configuring the agent.
+
+#### Lumen integration
+
+To enable [Lumen](https://lumen.laravel.com/) integration we need to add a new provider in `bootstrap/app.php`.
+
+```php
+# Lumen 5
+$app->register('DDTrace\Integrations\Laravel\V5\LaravelProvider');
+```
 
 #### Symfony integration
 

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelProvider.php
@@ -135,7 +135,7 @@ class LaravelProvider extends ServiceProvider
         $startSpanOptions = StartSpanOptionsFactory::createForWebRequest(
             $tracer,
             [
-                'start_time' => fromMicrotime(LARAVEL_START),
+                'start_time' => defined('LARAVEL_START') ? fromMicrotime(LARAVEL_START) : DDTrace\Time\now(),
             ],
             $this->app->make('request')->header()
         );


### PR DESCRIPTION
### Description

This PR adds loose support for [Lumen](https://lumen.laravel.com/) via the Laravel service provider. It also updates the docs with Lumen integration instructions and updates the Laravel docs to point to the correct service provider locations.

It should be noted that this doesn't offer "official" support for Lumen (with integration tests for Lumen as well as Lumen-scoped tags, etc) but this small change will at least make the Laravel service provider compatible with Lumen. :)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
