### PR TITLE
Properly set http status code tag in Laravel 4 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file - [docs/chan
 ### Added
 - PHP code compatibility with PHP 5.4 #194
 
+### Fixed
+- Properly set http status code tag in Laravel 4 integration #195
+
 ## [0.8.1]
 ### Fixed
 - Update Symfony 3 and 4 docs #184


### PR DESCRIPTION
### Description

We previously used an hook that may not be called in certain situations. We moved the hook the the router's dispatch method which is always called instead when serving a response.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
