### PR TITLE
Agent calls traced when using Symfony 3 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file - [docs/chan
 
 ### Fixed
 - Properly set http status code tag in Laravel 4 integration #195
+- Agent calls traced when using Symfony 3 integration #197
 
 ## [0.8.1]
 ### Fixed

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -148,12 +148,6 @@ class SymfonyBundle extends Bundle
         // Enable other integrations
         IntegrationsLoader::load();
 
-        // Flushes traces to agent.
-        register_shutdown_function(function () use ($scope) {
-            $scope->close();
-            GlobalTracer::get()->flush();
-        });
-
         // Tracing templating engines
         $renderTraceCallback = function () use ($appName) {
             $args = func_get_args();


### PR DESCRIPTION
### Description

We add a duplicate registration of the shutdown hook where we flush the traces. On the second call the the tracer finds the curl span from the previous curl request to the agent a flushes it.
As a immediate remedy we remove the duplicate shutdown hook registration.
In the long term we may prefer to isolate the registration of the shutdown hook function to a separate function, so that it will be easier to mock such call in test and make sure that it is only executed once.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
