### PR TITLE
Replace hex string ID's with unsigned-63-bit ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file - [docs/chan
 ### Fixed
 - Properly set http status code tag in Laravel 4 integration #195
 - Agent calls traced when using Symfony 3 integration #197
+- Fix for trace and span ID's that were improperly serialized on the wire in distributed tracing contexts #204
 
 ## [0.8.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-All notable changes to this project will be documented in this file - [docs/changelog.md](read more).
+All notable changes to this project will be documented in this file - [read more](docs/changelog.md).
 
 ## [Unreleased]
 ### Added

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -66,19 +66,10 @@ final class Json implements Encoder
         ], [
             '"start":' . $span->getStartTime() . '000',
             '"duration":' . $span->getDuration() . '000',
-            '"trace_id":' . $this->hex2dec($span->getTraceId()),
-            '"span_id":' . $this->hex2dec($span->getSpanId()),
-            '"parent_id":' . $this->hex2dec($span->getParentId()),
+            '"trace_id":' . $span->getTraceId(),
+            '"span_id":' . $span->getSpanId(),
+            '"parent_id":' . $span->getParentId(),
         ], $json);
-    }
-
-    /**
-     * @param string $hex
-     * @return string
-     */
-    private function hex2dec($hex)
-    {
-        return base_convert($hex, 16, 10);
     }
 
     /**

--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -157,7 +157,15 @@ final class SpanContext implements OpenTracingSpanContext
 
     private static function nextId()
     {
-        return bin2hex(random_bytes(8));
+        /*
+         * Trace and span ID's need to be unsigned-63-bit-int strings in
+         * order to work well with other APM integrations. Since the tracer
+         * is not in a cryptographic context, we don't need to use PHP's
+         * CSPRNG random_bytes(); instead the more performant mt_rand()
+         * will do. And since all integers in PHP are signed, an int
+         * between 1 & PHP_INT_MAX will be 63-bit.
+         */
+        return (string) mt_rand(1, PHP_INT_MAX);
     }
 
     /**

--- a/tests/Unit/Encoders/JsonTest.php
+++ b/tests/Unit/Encoders/JsonTest.php
@@ -35,7 +35,7 @@ JSON
 "service":"test_service","start":1518038421211969000,"error":0}]]
 JSON;
 
-        $context = new SpanContext('160e7072ff7bd5f1', '160e7072ff7bd5f2');
+        $context = new SpanContext('1589331357723252209', '1589331357723252210');
         $span = new Span(
             'test_name',
             $context,

--- a/tests/Unit/Propagators/CurlHeadersMapTest.php
+++ b/tests/Unit/Propagators/CurlHeadersMapTest.php
@@ -13,8 +13,8 @@ final class CurlHeadersMapTest extends Framework\TestCase
 {
     const BAGGAGE_ITEM_KEY = 'test_key';
     const BAGGAGE_ITEM_VALUE = 'test_value';
-    const TRACE_ID = '1c42b4de015cc315';
-    const SPAN_ID = '1c42b4de015cc316';
+    const TRACE_ID = '1589331357723252209';
+    const SPAN_ID = '1589331357723252210';
 
     /**
      * @var Tracer

--- a/tests/Unit/Propagators/TextMapTest.php
+++ b/tests/Unit/Propagators/TextMapTest.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Unit\Propagators;
 
-use DDTrace\Encoders\Json;
 use DDTrace\Propagators\TextMap;
 use DDTrace\SpanContext;
 use DDTrace\Tests\DebugTransport;
@@ -14,8 +13,8 @@ final class TextMapTest extends Framework\TestCase
 {
     const BAGGAGE_ITEM_KEY = 'test_key';
     const BAGGAGE_ITEM_VALUE = 'test_value';
-    const TRACE_ID = '1c42b4de015cc315';
-    const SPAN_ID = '1c42b4de015cc316';
+    const TRACE_ID = '1589331357723252209';
+    const SPAN_ID = '1589331357723252210';
 
     /**
      * @var Tracer


### PR DESCRIPTION
### Description

In order to play well with other APM integrations in distributed tracing contexts, the trace and span ID's need to be unsigned-63-bit ints.

At first glance, it looks like the PHP tracer uses 64-bit hex string ID's for traces & spans; and [it does](https://github.com/DataDog/dd-trace-php/blob/87d21a7d25d4a95b8d8ea5bcdb91451636b1e461/src/DDTrace/SpanContext.php#L160), but these [get encoded as 63-bit base-10 ints](https://github.com/DataDog/dd-trace-php/blob/87d21a7d25d4a95b8d8ea5bcdb91451636b1e461/src/DDTrace/Encoders/Json.php#L69-L71) before sending traces to the agent.

The bug manifests itself in the context of distributed traces which [serialize on the wire as hex string ID's](https://github.com/DataDog/dd-trace-php/blob/87d21a7d25d4a95b8d8ea5bcdb91451636b1e461/src/DDTrace/Propagators/TextMap.php#L37-L38).

This PR fixes this issue by moving the domain logic related to trace & span ID's to the context in which they are generated (namely `SpanContext`). This ensures that future uses of the ID's in other contexts won't suffer from this same bug.

It should be noted that traces that are run on 32-bit architectures will generate unsigned-31-bit ints for the trace and span ID's.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
