### PR TITLE
Downgrade of phpunit to 4.* in order to prepare for php 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file - [read more
 - Move framework tests to tests root folder #198
 - Move integrations tests to tests root folder #200
 - Allow testing of multiple library versions #203
+- Downgrade of phpunit to 4.* in order to prepare for php 5.4 #208
 
 ### Fixed
 - Properly set http status code tag in Laravel 4 integration #195

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "phpcompatibility/phpcompatibility-passwordcompat": "^1.0",
         "phpcompatibility/phpcompatibility-symfony": "*",
         "phpstan/phpstan": "^0.10.5",
-        "phpunit/phpunit": "^5.7.19",
+        "phpunit/phpunit": "^4",
         "squizlabs/php_codesniffer": "^3.3.0",
         "symfony/process": "*"
     },

--- a/src/DDTrace/Util/TryCatchFinally.php
+++ b/src/DDTrace/Util/TryCatchFinally.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Util;
 
 use DDTrace\Scope;
+use DDTrace\SpanInterface;
 
 /**
  * PHP 5.4 compatible methods to workaround the missing try-catch-finally block.
@@ -24,6 +25,7 @@ class TryCatchFinally
     {
         $thrown = null;
         $result = null;
+        /** @var SpanInterface $span */
         $span = $scope->getSpan();
         try {
             $result = call_user_func_array([$instance, $method], $args);
@@ -57,6 +59,7 @@ class TryCatchFinally
     {
         $thrown = null;
         $result = null;
+        /** @var SpanInterface $span */
         $span = $scope->getSpan();
         try {
             $result = call_user_func_array($function, $args);

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -151,10 +151,12 @@ final class SpanTest extends Framework\TestCase
         $this->assertFalse($span->hasError());
     }
 
+    /**
+     * @expectedException \DDTrace\Exceptions\InvalidSpanArgument
+     * @expectedExceptionMessage Error should be either Exception or Throwable, got integer.
+     */
     public function testSpanErrorFailsForInvalidError()
     {
-        $this->expectException('DDTrace\Exceptions\InvalidSpanArgument');
-        $this->expectExceptionMessage('Error should be either Exception or Throwable, got integer.');
         $span = $this->createSpan();
         $span->setError(1);
     }
@@ -171,10 +173,12 @@ final class SpanTest extends Framework\TestCase
         $this->assertEquals(self::ANOTHER_TYPE, $span->getType());
     }
 
+    /**
+     * @expectedException \DDTrace\Exceptions\InvalidSpanArgument
+     * @expectedExceptionMessage Invalid key type in given span tags. Expected string, got integer.
+     */
     public function testAddTagsFailsForInvalidTagKey()
     {
-        $this->expectException('DDTrace\Exceptions\InvalidSpanArgument');
-        $this->expectExceptionMessage('Invalid key type in given span tags. Expected string, got integer.');
         $span = $this->createSpan();
         $span->setTag(1, self::TAG_VALUE);
     }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -79,9 +79,12 @@ final class TracerTest extends Framework\TestCase
         $this->assertEquals($parentScope->getSpan()->getService(), $childScope->getSpan()->getService());
     }
 
+    /**
+     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
+
+     */
     public function testInjectThrowsUnsupportedFormatException()
     {
-        $this->expectException('OpenTracing\Exceptions\UnsupportedFormat');
         $context = SpanContext::createAsRoot();
         $carrier = [];
 
@@ -100,9 +103,11 @@ final class TracerTest extends Framework\TestCase
         $tracer->inject($context, self::FORMAT, $carrier);
     }
 
+    /**
+     * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
+     */
     public function testExtractThrowsUnsupportedFormatException()
     {
-        $this->expectException('OpenTracing\Exceptions\UnsupportedFormat');
         $carrier = [];
         $tracer = new Tracer(new NoopTransport());
         $tracer->extract(self::FORMAT, $carrier);

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -81,7 +81,6 @@ final class TracerTest extends Framework\TestCase
 
     /**
      * @expectedException \OpenTracing\Exceptions\UnsupportedFormat
-
      */
     public function testInjectThrowsUnsupportedFormatException()
     {

--- a/tests/Unit/Util/TryCatchFinallyTest.php
+++ b/tests/Unit/Util/TryCatchFinallyTest.php
@@ -95,7 +95,6 @@ namespace DDTrace\Tests\Unit\Util {
 
         /**
          * @expectedException \DDTrace\Tests\Unit\Util\CustomException
-         * @throws \Exception
          */
         public function testExecutePublicMethodExceptionReThrown()
         {
@@ -171,7 +170,6 @@ namespace DDTrace\Tests\Unit\Util {
 
         /**
          * @expectedException \DDTrace\Tests\Unit\Util\CustomException
-         * @throws \Exception
          */
         public function testExecuteFunctionExceptionReThrown()
         {

--- a/tests/Unit/Util/TryCatchFinallyTest.php
+++ b/tests/Unit/Util/TryCatchFinallyTest.php
@@ -93,11 +93,14 @@ namespace DDTrace\Tests\Unit\Util {
             $this->assertTrue($scope->getSpan()->isFinished());
         }
 
+        /**
+         * @expectedException \DDTrace\Tests\Unit\Util\CustomException
+         * @throws \Exception
+         */
         public function testExecutePublicMethodExceptionReThrown()
         {
             $instance = new DummyClass();
             $scope = $this->tracer->startActiveSpan('my.operation');
-            $this->expectException('DDTrace\Tests\Unit\Util\CustomException');
             TryCatchFinally::executePublicMethod($scope, $instance, 'throwsException');
         }
 
@@ -166,10 +169,13 @@ namespace DDTrace\Tests\Unit\Util {
             $this->assertTrue($scope->getSpan()->isFinished());
         }
 
+        /**
+         * @expectedException \DDTrace\Tests\Unit\Util\CustomException
+         * @throws \Exception
+         */
         public function testExecuteFunctionExceptionReThrown()
         {
             $scope = $this->tracer->startActiveSpan('my.operation');
-            $this->expectException('DDTrace\Tests\Unit\Util\CustomException');
             TryCatchFinally::executeFunction($scope, 'tryCatchFinallyGlobalCallbackException');
         }
 


### PR DESCRIPTION
### Description

PHPUnit 5.x requires php 5.6+. In order to support the soon-to-land php 5.4 we had to downgrade to PHPUnit 4.*

The following checks were performed to make sure that we do not see false positives:
 - Mockery expectations on method calls are asserted
 - Native PHPUnit assertions still work
 - Exceptions have been moved to docblock-based exceptions expectations

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
