### PR TITLE
Linting check fails on master due to missing space after comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file - [read more
 - Downgrade of phpunit to 4.* in order to prepare for php 5.4 #208
 
 ### Fixed
+- Predis integration supporting constructor options as an object #187 - thanks @raffaellopaletta
 - Properly set http status code tag in Laravel 4 integration #195
 - Agent calls traced when using Symfony 3 integration #197
 - Fix for trace and span ID's that were improperly serialized on the wire in distributed tracing contexts #204

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -60,7 +60,7 @@ final class PredisTest extends IntegrationTestCase
         $options = new Options();
 
         $traces = $this->isolateTracer(function () use ($options) {
-            $client = new \Predis\Client([ "host" => $this->host ],$options);
+            $client = new \Predis\Client([ "host" => $this->host ], $options);
             $this->assertNotNull($client);
         });
 


### PR DESCRIPTION
### Description

Fix linting error merged to master.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
