### PR TITLE
Add PECL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ $ composer require datadog/dd-trace opentracing/opentracing:@dev
 
 #### Installing the extension (from a package)
 
-Next we'll install the `ddtrace` extension.
+Next we'll install the `ddtrace` extension. The easiest way to install the extension is from [PECL](https://pecl.php.net/package/datadog_trace).
 
-First [download the appropriate package](https://github.com/DataDog/dd-trace-php/releases) from the releases page. Then install the package with one of the commands below.
+```bash
+$ sudo pecl install datadog_trace-beta
+```
+
+If you don't have `pecl` installed, you can install the extension from a package download. First [download the appropriate package](https://github.com/DataDog/dd-trace-php/releases) from the releases page. Then install the package with one of the commands below.
 
 ```bash
 # using RPM package (RHEL/Centos 6+, Fedora 20+)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,28 @@ To provide a great out-of-the-box experience that automatically instruments comm
 
 Datadog’s PHP extension (`ddtrace`) allows introspection of arbitrary PHP code.
 
-At this moment it is only distributed in source code form, and requires manual compilation.
+The easiest way to install the extension is from [PECL](https://pecl.php.net/package/datadog_trace).
+
+```bash
+$ sudo pecl install datadog_trace-beta
+```
+
+If you don't have `pecl` installed, you can install the extension from a package download. First [download the appropriate package](https://github.com/DataDog/dd-trace-php/releases) from the releases page. Then install the package with one of the commands below.
+
+```bash
+# using RPM package (RHEL/Centos 6+, Fedora 20+)
+$ rpm -ivh datadog-php-tracer.rpm
+
+# using DEB package (Debian Jessie+ , Ubuntu 14.04+)
+$ deb -i datadog-php-tracer.deb
+
+# using APK package (Alpine)
+$ apk add datadog-php-tracer.apk --allow-untrusted
+
+# using tar.gz archive (Other distributions using libc6)
+$ tar -xf datadog-php-tracer.tar.gz -C /
+  /opt/datadog-php/bin/post-install.sh
+```
 
 ### Compiling and installing the extension manually
 

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,51 @@
     </notes>
     <contents>
         <dir name="/">
+            <dir name="src">
+                <dir name="ext">
+                    <file name="compat_zend_string.c" role="src" />
+                    <file name="compat_zend_string.h" role="src" />
+                    <file name="ddtrace.c" role="src" />
+                    <file name="ddtrace.h" role="src" />
+                    <file name="debug.h" role="src" />
+                    <file name="dispatch.c" role="src" />
+                    <file name="dispatch.h" role="src" />
+                    <file name="dispatch_compat.h" role="src" />
+                    <file name="dispatch_compat_php5.c" role="src" />
+                    <file name="dispatch_compat_php5.h" role="src" />
+                    <file name="dispatch_compat_php7.c" role="src" />
+                    <file name="dispatch_setup.c" role="src" />
+                    <file name="version.h" role="src" />
+                </dir>
+            </dir>
+            <dir name="tests">
+                <dir name="ext">
+                    <file name="access_modifier_method_access_hook.phpt" role="test" />
+                    <file name="access_modifier_property_access_hook.phpt" role="test" />
+                    <file name="case_insensitive_method_hook.phpt" role="test" />
+                    <file name="closure_accessing_outside_variables.phpt" role="test" />
+                    <file name="closure_set_inside_object_methods.phpt" role="test" />
+                    <file name="method_returning_array.phpt" role="test" />
+                    <file name="multiple_instrumentations.phpt" role="test" />
+                    <file name="namespaces.phpt" role="test" />
+                    <file name="overriding_construct.phpt" role="test" />
+                    <file name="overriding_method_defined_in_parent.phpt" role="test" />
+                    <file name="private_method_hook.phpt" role="test" />
+                    <file name="protected_method_hook.phpt" role="test" />
+                    <file name="recursion.phpt" role="test" />
+                    <file name="return_value_passed.phpt" role="test" />
+                    <file name="simple_function_hook.phpt" role="test" />
+                    <file name="simple_method_hook.phpt" role="test" />
+                    <file name="throw_exception.phpt" role="test" />
+                    <file name="variable_length_parameter_list.phpt" role="test" />
+                    <file name="with_params_function_hook.phpt" role="test" />
+                    <file name="with_params_method_hook.phpt" role="test" />
+                </dir>
+            </dir>
+            <file name="CHANGELOG.md" role="doc" />
             <file name="config.m4" role="src" />
+            <file name="LICENSE" role="doc" />
+            <file name="README.md" role="doc" />
         </dir>
     </contents>
     <dependencies>

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2019-01-04</date>
+    <date>2018-12-14</date>
     <version>
         <release>0.8.1</release>
         <api>0.8.1</api>
@@ -21,7 +21,8 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
--
+        * Update Symfony 3 and 4 docs #184
+        * Package installation on custom PHP setups lacking conf.d support #188
     </notes>
     <contents>
         <dir name="/">
@@ -75,10 +76,10 @@
     <dependencies>
         <required>
             <php>
-                <min>5.4</min>
+                <min>5.6</min>
             </php>
             <pearinstaller>
-                <min>1.10</min>
+                <min>1.4.0</min>
             </pearinstaller>
             <extension>
                 <name>json</name>
@@ -89,23 +90,4 @@
     <extsrcrelease>
         <configureoption name="enable-ddtrace-debug" default="no" prompt="Enable internal debugging in ddtrace" />
     </extsrcrelease>
-    <changelog>
-        <release>
-            <version>
-                <release>0.8.1</release>
-                <api>0.8.1</api>
-            </version>
-            <stability>
-                <release>beta</release>
-                <api>beta</api>
-            </stability>
-            <date>2018-12-14</date>
-            <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-            <notes>
-                * Update Symfony 3 and 4 docs #184
-                * Package installation on custom PHP setups lacking conf.d support #188
-
-            </notes>
-        </release>
-    </changelog>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -77,6 +77,7 @@
         <required>
             <php>
                 <min>5.6</min>
+                <max>7.2.99</max>
             </php>
             <pearinstaller>
                 <min>1.4.0</min>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+    <name>datadog_trace</name>
+    <channel>pear.php.net</channel>
+    <summary>APM and distributed tracing for PHP</summary>
+    <description>The Datadog PHP Tracer brings APM and distributed tracing to PHP.</description>
+    <lead>
+        <name>Sammy Kaye Powers</name>
+        <user>sammyk</user>
+        <email>sammyk@php.net</email>
+        <active>yes</active>
+    </lead>
+    <date>2019-01-04</date>
+    <version>
+        <release>0.8.1</release>
+        <api>0.8.1</api>
+    </version>
+    <stability>
+        <release>beta</release>
+        <api>beta</api>
+    </stability>
+    <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
+    <notes>
+-
+    </notes>
+    <contents>
+        <dir name="/">
+            <file name="config.m4" role="src" />
+        </dir>
+    </contents>
+    <dependencies>
+        <required>
+            <php>
+                <min>5.4</min>
+            </php>
+            <pearinstaller>
+                <min>1.10</min>
+            </pearinstaller>
+            <extension>
+                <name>json</name>
+            </extension>
+        </required>
+    </dependencies>
+    <providesextension>ddtrace</providesextension>
+    <extsrcrelease>
+        <configureoption name="enable-ddtrace-debug" default="no" prompt="Enable internal debugging in ddtrace" />
+    </extsrcrelease>
+    <changelog>
+        <release>
+            <version>
+                <release>0.8.1</release>
+                <api>0.8.1</api>
+            </version>
+            <stability>
+                <release>beta</release>
+                <api>beta</api>
+            </stability>
+            <date>2018-12-14</date>
+            <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
+            <notes>
+                * Update Symfony 3 and 4 docs #184
+                * Package installation on custom PHP setups lacking conf.d support #188
+
+            </notes>
+        </release>
+    </changelog>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package packagerversion="1.9.4" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
     <name>datadog_trace</name>
-    <channel>pear.php.net</channel>
+    <channel>pecl.php.net</channel>
     <summary>APM and distributed tracing for PHP</summary>
     <description>The Datadog PHP Tracer brings APM and distributed tracing to PHP.</description>
     <lead>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+<package packagerversion="1.9.4" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
     <name>datadog_trace</name>
     <channel>pear.php.net</channel>
     <summary>APM and distributed tracing for PHP</summary>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package packagerversion="1.9.4" version="2.1" xmlns="http://pear.php.net/dtd/package-2.1" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.1 http://pear.php.net/dtd/package-2.1.xsd">
+<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
     <name>datadog_trace</name>
     <channel>pear.php.net</channel>
     <summary>APM and distributed tracing for PHP</summary>

--- a/package2.xml
+++ b/package2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+<package packagerversion="1.9.4" version="2.1" xmlns="http://pear.php.net/dtd/package-2.1" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.1 http://pear.php.net/dtd/package-2.1.xsd">
     <name>datadog_trace</name>
     <channel>pear.php.net</channel>
     <summary>APM and distributed tracing for PHP</summary>


### PR DESCRIPTION
### Description

This PR adds the necessary metadata to build a package for [datadog_trace on PECL](https://pecl.php.net/package/datadog_trace).

To build, make sure any new files are added to the `package.xml` and validate the XML and then package it:

```bash
$ pear package-validate package.xml && pear package
```

Since ddtrace is still in beta, you can install it from PECL with the following:

```bash
$ sudo pecl install datadog_trace-beta
```

Once GA hits, you'll be able to just do:

```bash
$ sudo pecl install datadog_trace
```

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
