### PR TITLE
Fix compile-time error on PHP 7.3

### DIFF
--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -43,7 +43,11 @@ HashTable *ddtrace_new_class_lookup(zend_class_entry *clazz) {
 }
 
 zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
+#if PHP_VERSION_ID >= 70300
+    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & IS_ARRAY_PERSISTENT);
+#else
     ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & HASH_FLAG_PERSISTENT);
+#endif
 
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
     return zend_hash_update_ptr(lookup, dispatch->function, dispatch) != NULL;


### PR DESCRIPTION
### Description

In PHP 7.3 there was a [small BC](https://github.com/php/php-src/blob/1c850bfcca97e0456a716a1889b5cf6c5e477cd8/UPGRADING.INTERNALS#L77-L78) that affected ddtrace which was pointed out in #212. This PR doesn't officially offer PHP 7.3 support (we still need to add the proper Docker containers, etc), but ddtrace will at least compile for 7.3 now. I didn't want to make too many changes that would cause more work for @pawelchcki's open work. :)

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
