### PR TITLE
Configurable autofinishing of unfinished spans on tracer flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file - [read more
 - Move integrations tests to tests root folder #200
 - Allow testing of multiple library versions #203
 - Downgrade of phpunit to 4.* in order to prepare for php 5.4 #208
+- Configurable autofinishing of unfinished spans on tracer flush #217
 
 ### Fixed
 - Predis integration supporting constructor options as an object #187 - thanks @raffaellopaletta

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -193,9 +193,10 @@ dd_trace("CustomDriver", "doWork", function (...$args) {
 
 It is possible to configure the agent connections parameters by means of env variables.
 
-| Env variable               | Default     | Note                                                |
-|----------------------------|-------------|-----------------------------------------------------|
-| `DD_TRACE_ENABLED`         | `true`      | Globally enables the tracer                         |
-| `DD_INTEGRATIONS_DISABLED` |             | CSV list of disabled extensions, e.g. `curl,mysqli` |
-| `DD_AGENT_HOST`            | `localhost` | The agent host name                                 |
-| `DD_TRACE_AGENT_PORT`      | `8126`      | The trace agent port number                         |
+| Env variable               | Default     | Note                                                                   |
+|----------------------------|-------------|------------------------------------------------------------------------|
+| `DD_TRACE_ENABLED`         | `true`      | Globally enables the tracer                                            |
+| `DD_INTEGRATIONS_DISABLED` |             | CSV list of disabled extensions, e.g. `curl,mysqli`                    |
+| `DD_AGENT_HOST`            | `localhost` | The agent host name                                                    |
+| `DD_TRACE_AGENT_PORT`      | `8126`      | The trace agent port number                                            |
+| `DD_AUTOFINISH_SPANS`      | `false`     | Whether or not spans are automatically finished when tracer is flushed |

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -42,10 +42,10 @@ class Configuration extends AbstractConfiguration
 
     /**
      * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.
-     * Motivation: We had users reporting that in some cases they have manual end-points that `echo` some content
-     * and than just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still
-     * be called, most of the spans would be unfinished and thus discarded. With this option enabled spans are
-     * automatically finished (if not finished yet) when the tracer is flushed.
+     * Motivation: We had users reporting that in some cases they have manual end-points that `echo` some content and
+     * then just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still be
+     * called, many spans would be unfinished and thus discarded. With this option enabled spans are automatically
+     * finished (if not finished yet) when the tracer is flushed.
      *
      * @return bool
      */

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -42,12 +42,16 @@ class Configuration extends AbstractConfiguration
 
     /**
      * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.
+     * Motivation: We had users reporting that in some cases they have manual end-points that `echo` some content
+     * and than just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still
+     * be called, most of the spans would be unfinished and thus discarded. With this option enabled spans are
+     * automatically finished (if not finished yet) when the tracer is flushed.
      *
      * @return bool
      */
     public function isAutofinishSpansEnabled()
     {
-        return $this->boolValue('autofinish.span', false);
+        return $this->boolValue('autofinish.spans', false);
     }
 
     /**

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -41,6 +41,16 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.
+     *
+     * @return bool
+     */
+    public function isAutofinishSpansEnabled()
+    {
+        return $this->boolValue('autofinish.span', false);
+    }
+
+    /**
      * Whether or not a specific integration is enabled.
      *
      * @param string $name

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -262,13 +262,18 @@ final class Tracer implements OpenTracingTracer
     {
         $tracesToBeSent = [];
 
+        $autoFinishSpans = $this->globalConfig->isAutofinishSpansEnabled();
+
         foreach ($this->traces as $trace) {
             $traceToBeSent = [];
 
             foreach ($trace as $span) {
                 if (!$span->isFinished()) {
-                    $traceToBeSent = null;
-                    break;
+                    if (!$autoFinishSpans) {
+                        $traceToBeSent = null;
+                        break;
+                    }
+                    $span->finish();
                 }
                 $traceToBeSent[] = $span;
             }

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -188,6 +188,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
     {
         $found = [];
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
+            'isAutofinishSpansEnabled' => false,
             'isDistributedTracingEnabled' => false,
             'isPrioritySamplingEnabled' => false,
         ]));

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -114,6 +114,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
         $client = new Client();
         $found = [];
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
+            'isAutofinishSpansEnabled' => false,
             'isDistributedTracingEnabled' => false,
             'isPrioritySamplingEnabled' => false,
         ]));

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Unit;
 
+use DDTrace\Configuration;
 use DDTrace\Sampling\PrioritySampling;
 use DDTrace\SpanContext;
 use DDTrace\Tags;
@@ -9,9 +10,8 @@ use DDTrace\Tests\DebugTransport;
 use DDTrace\Time;
 use DDTrace\Tracer;
 use DDTrace\Transport\Noop as NoopTransport;
-use PHPUnit\Framework;
 
-final class TracerTest extends Framework\TestCase
+final class TracerTest extends BaseTestCase
 {
     const OPERATION_NAME = 'test_span';
     const ANOTHER_OPERATION_NAME = 'test_span2';
@@ -164,5 +164,35 @@ final class TracerTest extends Framework\TestCase
             'child_of' => $distributedTracingContext,
         ]);
         $this->assertSame(PrioritySampling::USER_REJECT, $tracer->getPrioritySampling());
+    }
+
+    public function testUnfinishedSpansAreNotSentOnFlush()
+    {
+        $transport = new DebugTransport();
+        $tracer = new Tracer($transport);
+        $tracer->startActiveSpan('root');
+        $tracer->startActiveSpan('child');
+
+        $tracer->flush();
+
+        $this->assertEmpty($transport->getTraces());
+    }
+
+    public function testUnfinishedSpansCanBeFinishedOnFlush()
+    {
+        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
+            'isAutofinishSpansEnabled' => true,
+            'isPrioritySamplingEnabled' => false,
+        ]));
+
+        $transport = new DebugTransport();
+        $tracer = new Tracer($transport);
+        $tracer->startActiveSpan('root');
+        $tracer->startActiveSpan('child');
+
+        $tracer->flush();
+        $sent = $transport->getTraces();
+        $this->assertSame('root', $sent[0][0]->getOperationName());
+        $this->assertSame('child', $sent[0][1]->getOperationName());
     }
 }


### PR DESCRIPTION
### Description

We had users reporting that in some cases they have manual end-points that `echo` some content and then just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still be called, many spans would be unfinished and thus discarded. With this option enabled spans are automatically finished (if not finished yet) when the tracer is flushed.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
