### PR TITLE
Disable centos 7.0 verification build, and disable cache to ensure other steps are correctly performed

### DIFF
--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -1,7 +1,7 @@
 JESSIE_PHP_VERSIONS:=5.6.jessie 7.0.jessie 7.1.jessie 7.2.jessie
 STRETCH_PHP_VERSIONS:=5.6.stretch 7.0.stretch 7.1.stretch 7.2.stretch
-CENTOS6_PHP_VERSIONS=56.centos6 70.centos6 71.centos6
-CENTOS7_PHP_VERSIONS=56.centos7 70.centos7 71.centos7 72.centos7
+CENTOS6_PHP_VERSIONS=56.centos6 71.centos6 # 70.centos6 - 7.0 is no longer provided by the repository used in tests
+CENTOS7_PHP_VERSIONS=56.centos7 71.centos7 72.centos7 # 70.centos7
 CENTOS7_MANUAL_PHP_VERSIONS=71.centos7-compiled
 ALPINE_PHP_VERSIONS=5.6.alpine 7.0.alpine 7.1.alpine 7.2.alpine 5.6-zts.alpine 7.0-zts.alpine 7.1-zts.alpine 7.2-zts.alpine
 
@@ -13,27 +13,27 @@ all: $(JESSIE_PHP_VERSIONS) $(CENTOS6_PHP_VERSIONS) $(CENTOS7_PHP_VERSIONS) $(AL
 
 $(JESSIE_PHP_VERSIONS): %.jessie:
 	@echo Building Debian Jessie - PHP $*
-	@docker build -t deb_jessie:$* --build-arg php_version=$* -f dockerfiles/verify_packages/debian_jessie/Dockerfile .
+	docker build --no-cache -t deb_jessie:$* --build-arg php_version=$* -f dockerfiles/verify_packages/debian_jessie/Dockerfile .
 
 $(STRETCH_PHP_VERSIONS): %.stretch:
 	@echo Building Debian Stretch - PHP $*
-	@docker build -t deb_jessie:$* --build-arg php_version=$* -f dockerfiles/verify_packages/debian_stretch/Dockerfile .
+	@docker build --no-cache -t deb_jessie:$* --build-arg php_version=$* -f dockerfiles/verify_packages/debian_stretch/Dockerfile .
 
 $(CENTOS7_PHP_VERSIONS): %.centos7:
 	@echo Building Centos 7 - PHP $*
-	@docker build -t centos_7:$* --build-arg php_version=$* -f dockerfiles/verify_packages/centos7/Dockerfile .
+	@docker build --no-cache -t centos_7:$* --build-arg php_version=$* -f dockerfiles/verify_packages/centos7/Dockerfile .
 
 $(CENTOS7_MANUAL_PHP_VERSIONS): %.centos7-compiled:
 	@echo Building Centos 7 - PHP $*
-	@docker build -t centos_7_compiled:$* -f dockerfiles/verify_packages/centos7-compiled/Dockerfile .
+	@docker build --no-cache -t centos_7_compiled:$* -f dockerfiles/verify_packages/centos7-compiled/Dockerfile .
 
 $(CENTOS6_PHP_VERSIONS): %.centos6:
 	@echo Building Centos 6 - PHP $*
-	@docker build -t centos_6:$* --build-arg php_version=$* -f dockerfiles/verify_packages/centos6/Dockerfile .
+	@docker build --no-cache -t centos_6:$* --build-arg php_version=$* -f dockerfiles/verify_packages/centos6/Dockerfile .
 
 $(ALPINE_PHP_VERSIONS): %.alpine:
 	@echo Building Alpine - PHP $*
 	@test -f dockerfiles/verify_packages/alpine/Dockerfile && rm dockerfiles/verify_packages/alpine/Dockerfile || true
 	@sed -e "s/%%php_version%%/$*-alpine/g" dockerfiles/verify_packages/alpine/Dockerfile.template > dockerfiles/verify_packages/alpine/Dockerfile
-	@docker build -t alpine_php:$* -f dockerfiles/verify_packages/alpine/Dockerfile .
+	@docker build --no-cache -t alpine_php:$* -f dockerfiles/verify_packages/alpine/Dockerfile .
 	@test -f dockerfiles/verify_packages/alpine/Dockerfile && rm dockerfiles/verify_packages/alpine/Dockerfile || true


### PR DESCRIPTION
### Description

This PR disables parts of package build verifcation steps because of no longer supported package sources used in those  steps.

### Readiness checklist
- [x] ~[Changelog entry](docs/changelog.md) added, if necessary~
- [x] Tests added for this feature/bug
