### PR TITLE
Fix noop tracer issues with Laravel integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file - [read more
 - Properly set http status code tag in Laravel 4 integration #195
 - Agent calls traced when using Symfony 3 integration #197
 - Fix for trace and span ID's that were improperly serialized on the wire in distributed tracing contexts #204
+- Fix noop tracer issues with Laravel integration #220
 
 ## [0.8.1]
 ### Fixed

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -37,16 +37,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function register()
     {
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
-            return;
-        }
-
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
-            return;
-        }
-
-        if (getenv('APP_ENV') != 'dd_testing' && php_sapi_name() == 'cli') {
+        if (!$this->shouldLoad()) {
             return;
         }
 
@@ -62,7 +53,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function boot()
     {
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
+        if (!$this->shouldLoad()) {
             return;
         }
 
@@ -149,6 +140,25 @@ class LaravelProvider extends ServiceProvider
         $span->setTag(Tags\RESOURCE_NAME, $resource);
 
         return $scope;
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldLoad()
+    {
+        if ('cli' === PHP_SAPI && 'dd_testing' !== getenv('APP_ENV')) {
+            return false;
+        }
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
+            return false;
+        }
+        if (!extension_loaded('ddtrace')) {
+            trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Frameworks/Laravel/Version_5_7/config/app.php
+++ b/tests/Frameworks/Laravel/Version_5_7/config/app.php
@@ -163,7 +163,7 @@ return [
         /*
          * 3rd parties
          */
-        DDTrace\Integrations\LaravelProvider::class,
+        DDTrace\Integrations\Laravel\v5\LaravelProvider::class,
     ],
 
     /*

--- a/tests/Frameworks/Laravel/Version_5_7/config/app.php
+++ b/tests/Frameworks/Laravel/Version_5_7/config/app.php
@@ -163,7 +163,7 @@ return [
         /*
          * 3rd parties
          */
-        DDTrace\Integrations\Laravel\v5\LaravelProvider::class,
+        DDTrace\Integrations\Laravel\V5\LaravelProvider::class,
     ],
 
     /*


### PR DESCRIPTION
### Description

This should fix the issue brought up in #216. I also updated the config in the test app for Laravel 5 to keep the deprecated messages from showing up when running the tests. :)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
