### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 ### Added
+
+### Fixed
+
+## [0.9.0]
+### Added
 - PHP code compatibility with PHP 5.4 #194
 - Move framework tests to tests root folder #198
 - Move integrations tests to tests root folder #200
@@ -181,7 +186,8 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - OpenTracing compliance tha can be used for manual instrumentation
 
-[Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.8.1...HEAD
+[Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/DataDog/dd-trace-php/compare/0.8.1...0.9.0
 [0.8.1]: https://github.com/DataDog/dd-trace-php/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/DataDog/dd-trace-php/compare/0.7.1...0.8.0
 [0.7.1]: https://github.com/DataDog/dd-trace-php/compare/0.7.0...0.7.1

--- a/package.xml
+++ b/package.xml
@@ -10,9 +10,9 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2018-12-14</date>
+    <date>2019-01-07</date>
     <version>
-        <release>0.8.1</release>
+        <release>0.9.0</release>
         <api>0.8.1</api>
     </version>
     <stability>
@@ -21,8 +21,20 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-        * Update Symfony 3 and 4 docs #184
-        * Package installation on custom PHP setups lacking conf.d support #188
+        ### Added
+        - PHP code compatibility with PHP 5.4 #194
+        - Move framework tests to tests root folder #198
+        - Move integrations tests to tests root folder #200
+        - Allow testing of multiple library versions #203
+        - Downgrade of phpunit to 4.* in order to prepare for php 5.4 #208
+        - Configurable autofinishing of unfinished spans on tracer flush #217
+
+        ### Fixed
+        - Predis integration supporting constructor options as an object #187 - thanks @raffaellopaletta
+        - Properly set http status code tag in Laravel 4 integration #195
+        - Agent calls traced when using Symfony 3 integration #197
+        - Fix for trace and span ID's that were improperly serialized on the wire in distributed tracing contexts #204
+        - Fix noop tracer issues with Laravel integration #220
     </notes>
     <contents>
         <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
     <date>2019-01-07</date>
     <version>
         <release>0.9.0</release>
-        <api>0.8.1</api>
+        <api>0.9.0</api>
     </version>
     <stability>
         <release>beta</release>

--- a/src/DDTrace/Version.php
+++ b/src/DDTrace/Version.php
@@ -2,4 +2,4 @@
 
 namespace DDTrace\Version;
 
-const VERSION = '0.8.1-beta';
+const VERSION = '0.9.0-beta';

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "0.8.1-beta"
+#define PHP_DDTRACE_VERSION "0.9.0-beta"
 #endif


### PR DESCRIPTION
### Description

Version bump for `0.9.0` release.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~[ ] Tests added for this feature/bug~
