### PR TITLE
Add `dd_trace_reset` function, and stop throwing exceptions when overriding missing methods 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Test installing packages on target systems
-          command: make -j 2 -f dockerfiles/verify_packages/Makefile
+          command: make -f dockerfiles/verify_packages/Makefile
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 ### Added
+- Ability to reset all overrides via `dd_trace_reset`
+
+### Changed
+- By default do not throw an exception when method or function doesn't exist
 
 ### Fixed
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -33,8 +33,10 @@
 
 #if PHP_VERSION_ID < 70000
 #define PHP5_UNUSED(...) UNUSED(__VA_ARGS__)
+#define PHP7_UNUSED(...) /* unused unused */
 #else
 #define PHP5_UNUSED(...) /* unused unused */
+#define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
 #endif
 
 ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
@@ -176,8 +178,8 @@ static PHP_FUNCTION(dd_trace) {
 }
 
 static PHP_FUNCTION(dd_trace_reset) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
-    UNUSED(execute_data);
+    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -168,7 +168,23 @@ static PHP_FUNCTION(dd_trace) {
     RETURN_BOOL(rv);
 }
 
-static const zend_function_entry ddtrace_functions[] = {PHP_FE(dd_trace, NULL) ZEND_FE_END};
+static PHP_FUNCTION(dd_trace_reset){
+    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(execute_data);
+
+    if (DDTRACE_G(disable)) {
+        RETURN_BOOL(0);
+    }
+
+    ddtrace_dispatch_reset();
+    RETURN_BOOL(1);
+}
+
+static const zend_function_entry ddtrace_functions[] = {
+    PHP_FE(dd_trace, NULL)
+    PHP_FE(dd_trace_reset, NULL)
+    ZEND_FE_END
+};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,    PHP_DDTRACE_EXTNAME,    ddtrace_functions,
                                           PHP_MINIT(ddtrace),        PHP_MSHUTDOWN(ddtrace), PHP_RINIT(ddtrace),

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -28,8 +28,15 @@
         UNUSED_1(y);      \
         UNUSED_1(z);      \
     } while (0)
-#define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, ARITY, ...) UNUSED_##ARITY
-#define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 3, 2, 1)(__VA_ARGS__)
+#define UNUSED_4(x, y, z, q) \
+    do {                     \
+        UNUSED_1(x);         \
+        UNUSED_1(y);         \
+        UNUSED_1(z);         \
+        UNUSED_1(q);         \
+    } while (0)
+#define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, _4, ARITY, ...) UNUSED_##ARITY
+#define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 4, 3, 2, 1)(__VA_ARGS__)
 
 #if PHP_VERSION_ID < 70000
 #define PHP5_UNUSED(...) UNUSED(__VA_ARGS__)

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -6,7 +6,6 @@ extern zend_module_entry ddtrace_module_entry;
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
 zend_bool ignore_missing_overridables;
-zend_bool lookup;
 HashTable class_lookup;
 HashTable function_lookup;
 ZEND_END_MODULE_GLOBALS(ddtrace)

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -5,6 +5,8 @@ extern zend_module_entry ddtrace_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
+zend_bool ignore_missing_overridables;
+zend_bool lookup;
 HashTable class_lookup;
 HashTable function_lookup;
 ZEND_END_MODULE_GLOBALS(ddtrace)

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -101,11 +101,11 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
     if (zend_fcall_info_init(&closure, 0, &fci, &fcc, NULL, &error TSRMLS_CC) != SUCCESS) {
         if (func->common.scope) {
             zend_throw_exception_ex(
-                spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "cannot use return value set for %s::%s as function: %s",
+                spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "cannot set override for %s::%s - %s",
                 STRING_VAL(func->common.scope->name), STRING_VAL(func->common.function_name), error);
         } else {
             zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
-                                    "cannot use return value set for %s as function: %s",
+                                    "cannot set override for %s - %s",
                                     STRING_VAL(func->common.function_name), error);
         }
         if (error) {

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -99,15 +99,17 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
 #endif
 
     if (zend_fcall_info_init(&closure, 0, &fci, &fcc, NULL, &error TSRMLS_CC) != SUCCESS) {
-        if (func->common.scope) {
-            zend_throw_exception_ex(
-                spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "cannot set override for %s::%s - %s",
-                STRING_VAL(func->common.scope->name), STRING_VAL(func->common.function_name), error);
-        } else {
-            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
-                                    "cannot set override for %s - %s",
-                                    STRING_VAL(func->common.function_name), error);
+        if (!DDTRACE_G(ignore_missing_overridables)) {
+            if (func->common.scope) {
+                zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
+                                        "cannot set override for %s::%s - %s", STRING_VAL(func->common.scope->name),
+                                        STRING_VAL(func->common.function_name), error);
+            } else {
+                zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "cannot set override for %s - %s",
+                                        STRING_VAL(func->common.function_name), error);
+            }
         }
+
         if (error) {
             efree(error);
         }

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -16,4 +16,6 @@ int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
 void ddtrace_dispatch_init();
 void ddtrace_dispatch_inject();
 void ddtrace_dispatch_destroy();
+void ddtrace_dispatch_reset();
+
 #endif  // DISPATCH_H

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -44,6 +44,11 @@ void ddtrace_dispatch_destroy(TSRMLS_D) {
     zend_hash_destroy(&DDTRACE_G(function_lookup));
 }
 
+void ddtrace_dispatch_reset(TSRMLS_D) {
+    zend_hash_clean(&DDTRACE_G(class_lookup));
+    zend_hash_clean(&DDTRACE_G(function_lookup));
+}
+
 void ddtrace_dispatch_inject() {
 /**
  * Replacing zend_execute_ex with anything other than original

--- a/tests/ext/enable_throw_exception_if_overridable_doesnt_exist.phpt
+++ b/tests/ext/enable_throw_exception_if_overridable_doesnt_exist.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Toggle checking if overridable method/function exists or not
+--INI--
+ddtrace.ignore_missing_overridables=0
+--FILE--
+<?php
+try {
+    dd_trace("ThisClassDoesntExists", "m", function(){
+        return  $this->m() . "METHOD HOOK" . PHP_EOL;
+    });
+} catch (InvalidArgumentException $ex) {
+    echo $ex->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECTF--
+unexpected parameter combination, expected (class, function, closure) or (function, closure)

--- a/tests/ext/reset_configured_overrides.phpt
+++ b/tests/ext/reset_configured_overrides.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Configured overrides can be safely reset.
+--FILE--
+<?php
+class Test {
+    public function m(){
+        return "METHOD" . PHP_EOL;
+    }
+}
+
+dd_trace("Test", "m", function(){
+    return  $this->m() . "METHOD HOOK" . PHP_EOL;
+});
+
+function test(){
+    return "FUNCTION" . PHP_EOL;
+}
+
+dd_trace("test", function(){
+    return test() . "FUNCTION HOOK" . PHP_EOL;
+});
+
+$object = new Test();
+echo $object->m();
+echo test();
+
+echo (dd_trace_reset() ? "TRUE": "FALSE") . PHP_EOL;
+
+echo $object->m();
+echo test();
+
+dd_trace("Test", "m", function(){
+    return  $this->m() . "METHOD HOOK2" . PHP_EOL;
+});
+
+dd_trace("test", function(){
+    return test() . "FUNCTION HOOK2" . PHP_EOL;
+});
+
+echo $object->m();
+echo test();
+
+?>
+--EXPECT--
+METHOD
+METHOD HOOK
+FUNCTION
+FUNCTION HOOK
+TRUE
+METHOD
+FUNCTION
+METHOD
+METHOD HOOK2
+FUNCTION
+FUNCTION HOOK2

--- a/tests/ext/silently_check_if_overridable_exists.phpt
+++ b/tests/ext/silently_check_if_overridable_exists.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Do not throw exceptions when veryfying if class/method and function existst.
+Do not throw exceptions when veryfying if class/method and function exists.
 --FILE--
 <?php
 

--- a/tests/ext/silently_check_if_overridable_exists.phpt
+++ b/tests/ext/silently_check_if_overridable_exists.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Toggle checking if overridable method/function exists or not
+--FILE--
+<?php
+
+dd_trace("ThisClassDoesntExists", "m", function(){});
+dd_trace("this_function_doesnt_exist", function(){});
+
+echo "no exception thrown";
+
+?>
+--EXPECT--
+no exception thrown

--- a/tests/ext/silently_check_if_overridable_exists.phpt
+++ b/tests/ext/silently_check_if_overridable_exists.phpt
@@ -1,13 +1,38 @@
 --TEST--
-Toggle checking if overridable method/function exists or not
+Do not throw exceptions when veryfying if class/method and function existst.
 --FILE--
 <?php
 
-dd_trace("ThisClassDoesntExists", "m", function(){});
-dd_trace("this_function_doesnt_exist", function(){});
+class ExampleClass
+{
+    function this_method_exists(){
 
-echo "no exception thrown";
+    }
+}
+
+function this_function_exists(){
+
+}
+
+function format_bool($rv) {
+    return ($rv ? "TRUE" : "FALSE" ) . PHP_EOL;
+}
+
+echo format_bool(dd_trace("ThisClassDoesntExists", "m", function(){}));
+echo format_bool(dd_trace("ExampleClass", "this_method_exists", function(){}));
+echo format_bool(dd_trace("ExampleClass", "method_doesnt_exist", function(){}));
+
+echo format_bool(dd_trace("this_function_doesnt_exist", function(){}));
+echo format_bool(dd_trace("this_function_exists", function(){}));
+
+echo  "no exception thrown" . PHP_EOL;
+
 
 ?>
 --EXPECT--
+FALSE
+TRUE
+FALSE
+FALSE
+TRUE
 no exception thrown


### PR DESCRIPTION
### Description

- `dd_trace_reset` simply resets the lookup hashes to initial state, allowing removing of existing overrides - mostly usable for tests

- Exception throwing behavior is controlled by `ddtrace.ignore_missing_overridables` ini setting that defaults to `true`

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
