### PR TITLE
One-liner API to enable tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,35 +82,21 @@ Once the `ddtrace` extension and Composer package is installed, you can start tr
 
 ### Manual instrumentation
 
-If you are using another framework or CMS that is not listed above, you can manually instrument the tracer by wrapping your application code with a [root span](https://docs.datadoghq.com/tracing/visualization/#spans) from the [tracer](https://docs.datadoghq.com/tracing/visualization/#trace).
+If you are using another framework or CMS that is not listed above, you can manually instrument the tracer with one line in early script execution.
 
 ```php
-use DDTrace\Tracer;
-use OpenTracing\GlobalTracer;
-use DDTrace\Integrations\IntegrationsLoader;
-
-// Creates a tracer with default transport and propagators
-$tracer = new Tracer();
-
-// Sets a global tracer (singleton)
-GlobalTracer::set($tracer);
-// Flushes traces to agent on script shutdown
-register_shutdown_function(function() {
-    GlobalTracer::get()->flush();
-});
-
-// Enable the built-in integrations
-IntegrationsLoader::load();
-
-// Start a root span
-$span = $tracer->startSpan('my_base_trace');
-
-// Run your application here
-// $myApplication->run();
-
-// Close the root span after the application code has finished
-$span->finish();
+\DDTrace\Tracer::init('my_base_trace');
 ```
+
+The `Tracer::init()` method has an optional second parameter of [configuration settings](docs/getting_started.md#configuration-settings).
+
+Amongst other things, this method sets a global singleton instance of the tracer which can be accessed at any time via `\DDTrace\GlobalTracer::get()`.
+
+```php
+$tracer = \DDTrace\GlobalTracer::get();
+```
+
+### Setting the API key
 
 Notice we didn't specify an [API key](https://app.datadoghq.com/account/settings#api) or any web endpoints. That's because the API key is set at the [agent layer](https://docs.datadoghq.com/agent/?tab=agentv6), so the PHP code just needs to know the hostname and port of the agent to send traces to Datadog. By default the PHP tracer will assume the agent hostname is `localhost` and the port is `8126`. If you need to change these values, check out the [configuration documentation](docs/getting_started.md#configuration).
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -187,7 +187,7 @@ For Symfony Flex applications, add the bundle in `config/bundles.php`:
 If you are using another framework or CMS that is not listed above, you can manually instrument the tracer with one line in early script execution.
 
 ```php
-\DDTrace\Tracer::init('my_base_trace');
+\DDTrace\Tracer::init('My Application');
 ```
 
 Amongst other things, this method sets a global singleton instance of the tracer which can be accessed at any time via `\DDTrace\GlobalTracer::get()`.
@@ -202,7 +202,6 @@ The `DDTrace\Tracer::init()` method takes an array as the second parameter which
 
 | Name           | Type                      | Value                                       | Default
 | -------------- | ------------------------- | ------------------------------------------- | -------------------------------------------------------
-| `service_name` | `string`                  | The name of the application                 | `PHP_SAPI`
 | `global_tags`  | `array`                   | Tags that will be added to every span       | `[]`
 | `debug`        | `bool`                    | Toggle debug mode                           | `false`
 | `logger`       | `Psr\Log\LoggerInterface` | An instance of a [PSR-3] logger.            | `null`
@@ -214,10 +213,10 @@ The `DDTrace\Tracer::init()` method takes an array as the second parameter which
 
 ```php
 \DDTrace\Tracer::init(
-    'my_base_trace',
+    'My Application',
     [
-        'service_name' => 'My Application',
         'global_tags' => ['foo' => 'bar'],
+        'debug' => true,
         'transport' => new DDTrace\Stream(new DDTrace\Json()),
     ]
 );


### PR DESCRIPTION
### Description

This is a WIP PR to start a discussion around what an API might look like to enable the tracer with one line. I'm using a "documentation first" approach to make sure we make a solid API before going for the implementation. Essentially my proposal to kick things off is to add this line to early script execution:

```php
\DDTrace\Tracer::init('My Application');
```

I've documented the features in more detail in the PR. Feel free to post any thoughts! :)

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
