### PR TITLE
Add root span/scope tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Request init hook configuration allowing running arbitrary code before actual request execution #175
-- `Tracer::startRootSpan()` to track the root `Scope` instance which can be accessed with `Tracer::getRootSpan()` #241
+- `Tracer::startRootScope()` to track the root `Scope` instance which can be accessed with `Tracer::getRootScope()` #241
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Request init hook configuration allowing running arbitrary code before actual request execution #175
-- `Tracer::startRootScope()` to track the root `Scope` instance which can be accessed with `Tracer::getRootScope()` #241
+- `Tracer::startRootSpan()` to track the root `Scope` instance which can be accessed with `Tracer::getRootScope()` #241
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Request init hook configuration allowing running arbitrary code before actual request execution #175
+- `Tracer::startRootSpan()` to track the root `Scope` instance which can be accessed with `Tracer::getRootSpan()` #241
 
 ### Changed
 

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -129,7 +129,7 @@ interface Tracer
     public function getPrioritySampling();
 
     /**
-     * @return Scope
+     * @return Scope|null
      */
     public function getRootSpan();
 }

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -127,4 +127,9 @@ interface Tracer
      * @return mixed
      */
     public function getPrioritySampling();
+
+    /**
+     * @return Scope
+     */
+    public function getRootSpan();
 }

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -129,11 +129,14 @@ interface Tracer
     public function getPrioritySampling();
 
     /**
+     * This behaves just like Tracer::startActiveSpan(), but it saves the Scope instance
+     * on the tracer to be accessed later by Tracer::getRootScope().
+     *
      * @param string $operationName
      * @param array $options
      * @return Scope
      */
-    public function startRootScope($operationName, $options = []);
+    public function startRootSpan($operationName, $options = []);
 
     /**
      * @return Scope|null

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -129,7 +129,14 @@ interface Tracer
     public function getPrioritySampling();
 
     /**
+     * @param string $operationName
+     * @param array $options
+     * @return Scope
+     */
+    public function startRootScope($operationName, $options = []);
+
+    /**
      * @return Scope|null
      */
-    public function getRootSpan();
+    public function getRootScope();
 }

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -82,7 +82,15 @@ final class NoopTracer implements TracerInterface
     /**
      * {@inheritdoc}
      */
-    public function getRootSpan()
+    public function startRootScope($operationName, $options = [])
+    {
+        return NoopScope::create();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRootScope()
     {
         return NoopScope::create();
     }

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -82,7 +82,7 @@ final class NoopTracer implements TracerInterface
     /**
      * {@inheritdoc}
      */
-    public function startRootScope($operationName, $options = [])
+    public function startRootSpan($operationName, $options = [])
     {
         return NoopScope::create();
     }

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -46,7 +46,6 @@ final class NoopTracer implements TracerInterface
      */
     public function startActiveSpan($operationName, $finishSpanOnClose = true, $options = [])
     {
-
         return NoopScope::create();
     }
 
@@ -78,5 +77,13 @@ final class NoopTracer implements TracerInterface
     public function getPrioritySampling()
     {
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRootSpan()
+    {
+        return NoopScope::create();
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -65,9 +65,9 @@ final class Tracer implements TracerInterface
     private $scopeManager;
 
     /**
-     * @var ScopeInterface
+     * @var ScopeInterface|null
      */
-    private $rootSpan;
+    private $rootScope;
 
     /**
      * @var Configuration
@@ -158,21 +158,19 @@ final class Tracer implements TracerInterface
     }
 
     /**
-     * @param string $operationName
-     * @param array $options
-     * @return ScopeInterface
+     * {@inheritdoc}
      */
-    public function startRootSpan($operationName, $options = [])
+    public function startRootScope($operationName, $options = [])
     {
-        return $this->rootSpan = $this->startActiveSpan($operationName, $options);
+        return $this->rootScope = $this->startActiveSpan($operationName, $options);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getRootSpan()
+    public function getRootScope()
     {
-        return $this->rootSpan;
+        return $this->rootScope;
     }
 
     /**

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -168,7 +168,7 @@ final class Tracer implements TracerInterface
     }
 
     /**
-     * @return ScopeInterface
+     * {@inheritdoc}
      */
     public function getRootSpan()
     {

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -11,6 +11,7 @@ use DDTrace\Sampling\Sampler;
 use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use DDTrace\Exceptions\UnsupportedFormat;
+use DDTrace\Contracts\Scope as ScopeInterface;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Contracts\Tracer as TracerInterface;
 
@@ -62,6 +63,11 @@ final class Tracer implements TracerInterface
      * @var ScopeManager
      */
     private $scopeManager;
+
+    /**
+     * @var ScopeInterface
+     */
+    private $rootSpan;
 
     /**
      * @var Configuration
@@ -149,6 +155,24 @@ final class Tracer implements TracerInterface
         $this->record($span);
 
         return $span;
+    }
+
+    /**
+     * @param string $operationName
+     * @param array $options
+     * @return ScopeInterface
+     */
+    public function startRootSpan($operationName, $options = [])
+    {
+        return $this->rootSpan = $this->startActiveSpan($operationName, $options);
+    }
+
+    /**
+     * @return ScopeInterface
+     */
+    public function getRootSpan()
+    {
+        return $this->rootSpan;
     }
 
     /**

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -160,7 +160,7 @@ final class Tracer implements TracerInterface
     /**
      * {@inheritdoc}
      */
-    public function startRootScope($operationName, $options = [])
+    public function startRootSpan($operationName, $options = [])
     {
         return $this->rootScope = $this->startActiveSpan($operationName, $options);
     }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -202,4 +202,10 @@ final class TracerTest extends BaseTestCase
         $span = $tracer->startRootSpan(self::OPERATION_NAME);
         $this->assertSame($span, $tracer->getRootSpan());
     }
+
+    public function testIfNoRootSpanExistsItWillBeNull()
+    {
+        $tracer = new Tracer(new NoopTransport());
+        $this->assertNull($tracer->getRootSpan());
+    }
 }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -195,4 +195,11 @@ final class TracerTest extends BaseTestCase
         $this->assertSame('root', $sent[0][0]->getOperationName());
         $this->assertSame('child', $sent[0][1]->getOperationName());
     }
+
+    public function testSpanStartedAtRootCanBeAccessedLater()
+    {
+        $tracer = new Tracer(new NoopTransport());
+        $span = $tracer->startRootSpan(self::OPERATION_NAME);
+        $this->assertSame($span, $tracer->getRootSpan());
+    }
 }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -199,13 +199,13 @@ final class TracerTest extends BaseTestCase
     public function testSpanStartedAtRootCanBeAccessedLater()
     {
         $tracer = new Tracer(new NoopTransport());
-        $span = $tracer->startRootSpan(self::OPERATION_NAME);
-        $this->assertSame($span, $tracer->getRootSpan());
+        $scope = $tracer->startRootScope(self::OPERATION_NAME);
+        $this->assertSame($scope, $tracer->getRootScope());
     }
 
-    public function testIfNoRootSpanExistsItWillBeNull()
+    public function testIfNoRootScopeExistsItWillBeNull()
     {
         $tracer = new Tracer(new NoopTransport());
-        $this->assertNull($tracer->getRootSpan());
+        $this->assertNull($tracer->getRootScope());
     }
 }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -199,7 +199,7 @@ final class TracerTest extends BaseTestCase
     public function testSpanStartedAtRootCanBeAccessedLater()
     {
         $tracer = new Tracer(new NoopTransport());
-        $scope = $tracer->startRootScope(self::OPERATION_NAME);
+        $scope = $tracer->startRootSpan(self::OPERATION_NAME);
         $this->assertSame($scope, $tracer->getRootScope());
     }
 


### PR DESCRIPTION
### Description

This PR adds a way to track the root span so that it can be modified later in the script execution. This is important for integrations that don't have a way of hooking into the request/routing/etc early on in the script execution when the tracer is inited.

It works just like `Tracer::startActiveSpan()`, but it saves the `Scope` instance on the tracer to be accessed later by `Tracer::getRootScope()`.

```php
$tracer->startRootSpan('my_root_span');
// ...do lots of stuff...
$scope = $tracer->getRootScope();
// ..add tags and whatnot
```

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
