### PR TITLE
Add INI settings to the info page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Changed
 
 ### Fixed
+- The INI settings now appear in `phpinfo()` and when running `$ php -i` #242
 
 ## [0.9.1]
 ### Added

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -152,6 +152,8 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
     php_info_print_table_end();
+
+    DISPLAY_INI_ENTRIES();
 }
 
 static PHP_FUNCTION(dd_trace) {


### PR DESCRIPTION
### Description

The INI settings aren't showing up when you run `$ php -i` or dump info with `phpinfo()`, so this PR adds them. :)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
