### PR TITLE
Trigger of autoloader un-tracing did not respect object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Composer php compatibility declaration #247
 - Add missing files to PECL releases #252
+- Trigger of autoloader un-tracing did not respect object #256
 
 ## [0.10.0]
 


### PR DESCRIPTION
### Description

Before we we using a class name as trigger to stop hooking into `spl_autoload_register` calls. The problem is that in some cases we receive directly objects in place of classes, so we needed to handle that case.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
