### PR TITLE
Make package verification use Machine type in order do correctly use newer docker-compose based verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,8 +508,9 @@ jobs:
     docker: [ image: 'circleci/php:7.2-zts' ]
 
   "package extension":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:7.2' ]
+    working_directory: ~/datadog
+    machine:
+      image: circleci/classic:latest
     steps:
       - checkout
       - attach_workspace:
@@ -522,7 +523,6 @@ jobs:
           command: make packages
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
-      - setup_remote_docker
       - run:
           name: Test installing packages on target systems
           command: make -f dockerfiles/verify_packages/Makefile
@@ -532,12 +532,12 @@ workflows:
   build_packages:
     jobs:
       - "5.4 20100412": &BUILD_PACKAGE_FORKFLOW
-          filters:
-            tags:
-              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            branches:
-              # Always build on master
-              ignore: /^(?!master).*/
+          filters: {}
+            # tags:
+            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            # branches:
+            #   # Always build on master
+            #   ignore: /^(?!master).*/
       - "5.6 20131106": *BUILD_PACKAGE_FORKFLOW
       - "7.0 20151012": *BUILD_PACKAGE_FORKFLOW
       - "7.1 20160303": *BUILD_PACKAGE_FORKFLOW
@@ -557,12 +557,12 @@ workflows:
             - "7.0 zts 20151012-zts"
             - "7.1 zts 20160303-zts"
             - "7.2 zts 20170718-zts"
-  build:
-    jobs:
-      - "Lint files"
-      - "Static Analysis"
-      - "php-5.4"
-      - "php-5.6"
-      - "php-7.0"
-      - "php-7.1"
-      - "php-7.2"
+  # build:
+  #   jobs:
+  #     - "Lint files"
+  #     - "Static Analysis"
+  #     - "php-5.4"
+  #     - "php-5.6"
+  #     - "php-7.0"
+  #     - "php-7.1"
+  #     - "php-7.2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,9 +508,8 @@ jobs:
     docker: [ image: 'circleci/php:7.2-zts' ]
 
   "package extension":
-    working_directory: ~/datadog
-    machine:
-      image: circleci/classic:latest
+    <<: *ARTIFACT_BUILD
+    docker: [ image: 'circleci/php:7.2' ]
     steps:
       - checkout
       - attach_workspace:
@@ -523,6 +522,18 @@ jobs:
           command: make packages
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
+      - persist_to_workspace:
+          root: '.'
+          paths: ['./build/packages']
+
+  "package verification":
+    working_directory: ~/datadog
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/datadog
       - run:
           name: Test installing packages on target systems
           command: make -f dockerfiles/verify_packages/Makefile
@@ -532,12 +543,12 @@ workflows:
   build_packages:
     jobs:
       - "5.4 20100412": &BUILD_PACKAGE_FORKFLOW
-          filters: {}
-            # tags:
-            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            # branches:
-            #   # Always build on master
-            #   ignore: /^(?!master).*/
+          filters:
+            tags:
+              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            branches:
+              # Always build on master
+              ignore: /^(?!master).*/
       - "5.6 20131106": *BUILD_PACKAGE_FORKFLOW
       - "7.0 20151012": *BUILD_PACKAGE_FORKFLOW
       - "7.1 20160303": *BUILD_PACKAGE_FORKFLOW
@@ -557,12 +568,15 @@ workflows:
             - "7.0 zts 20151012-zts"
             - "7.1 zts 20160303-zts"
             - "7.2 zts 20170718-zts"
-  # build:
-  #   jobs:
-  #     - "Lint files"
-  #     - "Static Analysis"
-  #     - "php-5.4"
-  #     - "php-5.6"
-  #     - "php-7.0"
-  #     - "php-7.1"
-  #     - "php-7.2"
+      - "package verification":
+          requires:
+            - "package extension"
+  build:
+    jobs:
+      - "Lint files"
+      - "Static Analysis"
+      - "php-5.4"
+      - "php-5.6"
+      - "php-7.0"
+      - "php-7.1"
+      - "php-7.2"

--- a/dockerfiles/verify_packages/docker-compose.yml
+++ b/dockerfiles/verify_packages/docker-compose.yml
@@ -1,21 +1,16 @@
-version: '3.6'
-
-x-aliases:
-  - &base_build
-      ulimits:
-        core: 99999999999
-      stdin_open: true
-      tty: true
-      volumes:
-        - ../../:/build_src
-      cap_add:
-        - SYS_PTRACE
-  - &base_centos_build
-      dockerfile: 'Dockerfile_centos'
-      context: ./
+version: '3.2'
 
 services:
-  '5.4-centos6': { <<: *base_build, build: { <<: *base_centos_build, args: { PHP_VERSION: 54 } } }
+  '5.4-centos6': &base_build
+    ulimits: { core: 99999999999 }
+    stdin_open: true
+    tty: true
+    volumes: [ '../../:/build_src' ]
+    cap_add: [ SYS_PTRACE ]
+    build: &base_centos_build
+      dockerfile: 'Dockerfile_centos'
+      context: ./
+      args: { PHP_VERSION: 54 }
   '5.6-centos6': { <<: *base_build, build: { <<: *base_centos_build, args: { PHP_VERSION: 56 } } }
   '7.0-centos6': { <<: *base_build, build: { <<: *base_centos_build, args: { PHP_VERSION: 70 } } }
   '7.1-centos6': { <<: *base_build, build: { <<: *base_centos_build, args: { PHP_VERSION: 71 } } }


### PR DESCRIPTION
### Description
Make package verification use Machine type in order do correctly use newer docker-compose based verification.

Before running docker-compose on remote docker, caused problems with mounting volumes. 

By using machine type - we're able to use docker-machine volumes to allow faster verification of built packages. 