### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,7 +52,7 @@ $ sudo make install
 #### Bash one-liner
 
 ```bash
-$ (cd $(mktemp -d); curl -L https://github.com/DataDog/dd-trace-php/archive/master.tar.gz | tar x --strip-components=1 && phpize && ./configure && make && sudo make install )
+$ (cd $(mktemp -d); curl -L https://github.com/DataDog/dd-trace-php/archive/master.tar.gz | tar zx --strip-components=1 && phpize && ./configure && make && sudo make install )
 ```
 
 ### Enabling the extension


### PR DESCRIPTION
Running the bash one-liner without modification yields the following:
```
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
```

There is a missing z in the `tar` arguments. Adding this allows the command to complete successfully.

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
