### PR TITLE
Debug mode for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file - [read more
 - Composer PHP compatibility declaration #247
 - Add missing files to PECL releases #252
 - Trigger of autoloader un-tracing did not respect object #256
+- Debug mode for logging #261
 
 ## [0.10.0]
 

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -20,6 +20,16 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Whether or not debug mode is enabled.
+     *
+     * @return bool
+     */
+    public function isDebugModeEnabled()
+    {
+        return $this->boolValue('trace.debug', false);
+    }
+
+    /**
      * Whether or not distributed tracing is enabled globally.
      *
      * @return bool

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -215,7 +215,7 @@ class PDOIntegration
             return $result;
         });
 
-        Integration::LOADED;
+        return Integration::LOADED;
     }
 
     /**

--- a/src/DDTrace/Log/ErrorLogLogger.php
+++ b/src/DDTrace/Log/ErrorLogLogger.php
@@ -31,7 +31,7 @@ class ErrorLogLogger implements LoggerInterface
      *
      * @return void
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = [])
     {
         // As a first draft, we do not implement logging levels. This logger is simply enabled when property
         // trace.debug = true and all messages are shown.
@@ -46,7 +46,7 @@ class ErrorLogLogger implements LoggerInterface
      *
      * @return void
      */
-    public function error($message, array $context = array())
+    public function error($message, array $context = [])
     {
         // As a first draft, we do not implement logging levels. This logger is simply enabled when property
         // trace.debug = true and all messages are shown.

--- a/src/DDTrace/Log/ErrorLogLogger.php
+++ b/src/DDTrace/Log/ErrorLogLogger.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace DDTrace\Log;
+
+/**
+ * An implementation of the DDTrace\LoggerInterface that logs to the error_log.
+ */
+class ErrorLogLogger implements LoggerInterface
+{
+    use InterpolateTrait;
+
+    /**
+     * Logs a debug message. Substitution is provided as specified in:
+     * https://www.php-fig.org/psr/psr-3/
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function debug($message, array $context = [])
+    {
+        // As a first draft, we do not implement logging levels. This logger is simply enabled when property
+        // trace.debug = true and all messages are shown.
+        $this->emit(self::DEBUG, $message, $context);
+    }
+
+    /**
+     * Logs a warning at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = array())
+    {
+        // As a first draft, we do not implement logging levels. This logger is simply enabled when property
+        // trace.debug = true and all messages are shown.
+        $this->emit(self::WARNING, $message, $context);
+    }
+
+    /**
+     * Logs a error at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = array())
+    {
+        // As a first draft, we do not implement logging levels. This logger is simply enabled when property
+        // trace.debug = true and all messages are shown.
+        $this->emit(self::ERROR, $message, $context);
+    }
+
+    /**
+     * @param string $message
+     * @param array $context
+     * @param string $level
+     */
+    private function emit($level, $message, array $context = [])
+    {
+        $interpolatedMessage = $this->interpolate($message, $context);
+        $date = date(\DateTime::ATOM);
+        error_log("[$date] [$level] - $interpolatedMessage");
+    }
+}

--- a/src/DDTrace/Log/ErrorLogLogger.php
+++ b/src/DDTrace/Log/ErrorLogLogger.php
@@ -62,6 +62,6 @@ class ErrorLogLogger implements LoggerInterface
     {
         $interpolatedMessage = $this->interpolate($message, $context);
         $date = date(\DateTime::ATOM);
-        error_log("[$date] [$level] - $interpolatedMessage");
+        error_log("[$date] [ddtrace] [$level] - $interpolatedMessage");
     }
 }

--- a/src/DDTrace/Log/InterpolateTrait.php
+++ b/src/DDTrace/Log/InterpolateTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DDTrace\Log;
+
+/**
+ * Provides methods to interpolate log messages.
+ */
+trait InterpolateTrait
+{
+    /**
+     * Interpolates context values into the message placeholders. Example code from:
+     * https://www.php-fig.org/psr/psr-3/
+     *
+     * @param string $message
+     * @param array $context
+     * @return string
+     */
+    public function interpolate($message, array $context = [])
+    {
+        // build a replacement array with braces around the context keys
+        $replace = array();
+        foreach ($context as $key => $val) {
+            // check that the value can be casted to string
+            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
+                $replace['{' . $key . '}'] = $val;
+            }
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr($message, $replace);
+    }
+}

--- a/src/DDTrace/Log/Logger.php
+++ b/src/DDTrace/Log/Logger.php
@@ -2,6 +2,8 @@
 
 namespace DDTrace\Log;
 
+use DDTrace\Configuration;
+
 /**
  * A global logger holder. Can be configured to use a specific logger. If not configured, it returns a NullLogger.
  */
@@ -30,8 +32,17 @@ final class Logger
     public static function get()
     {
         if (self::$logger === null) {
-            self::$logger = new NullLogger();
+            $config = Configuration::get();
+            self::$logger = $config->isDebugModeEnabled() ? new ErrorLogLogger() : new NullLogger();
         }
         return self::$logger;
+    }
+
+    /**
+     * Reset the logger.
+     */
+    public static function reset()
+    {
+        self::$logger = null;
     }
 }

--- a/src/DDTrace/Log/LoggerInterface.php
+++ b/src/DDTrace/Log/LoggerInterface.php
@@ -8,7 +8,19 @@ namespace DDTrace\Log;
 interface LoggerInterface
 {
     /**
-     * Detailed debug information.
+     * Const list from https://www.php-fig.org/psr/psr-3/
+     */
+    const EMERGENCY = 'emergency';
+    const ALERT     = 'alert';
+    const CRITICAL  = 'critical';
+    const ERROR     = 'error';
+    const WARNING   = 'warning';
+    const NOTICE    = 'notice';
+    const INFO      = 'info';
+    const DEBUG     = 'debug';
+
+    /**
+     * Logs a message at the debug level.
      *
      * @param string $message
      * @param array  $context
@@ -16,4 +28,24 @@ interface LoggerInterface
      * @return void
      */
     public function debug($message, array $context = array());
+
+    /**
+     * Logs a warning at the debug level.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = array());
+
+    /**
+     * Logs a error at the debug level.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = array());
 }

--- a/src/DDTrace/Log/LoggerInterface.php
+++ b/src/DDTrace/Log/LoggerInterface.php
@@ -37,7 +37,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning($message, array $context = array());
+    public function warning($message, array $context = []);
 
     /**
      * Logs a error at the debug level.

--- a/src/DDTrace/Log/LoggingTrait.php
+++ b/src/DDTrace/Log/LoggingTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DDTrace\Log;
+
+trait LoggingTrait
+{
+    /**
+     * Emits a log message at debug level.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    protected static function logDebug($message, array $context = [])
+    {
+        Logger::get()->debug($message, $context);
+    }
+
+    /**
+     * Emits a log message at warning level.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    protected static function logWarning($message, array $context = [])
+    {
+        Logger::get()->warning($message, $context);
+    }
+
+    /**
+     * Emits a log message at error level.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    protected static function logError($message, array $context = [])
+    {
+        Logger::get()->error($message, $context);
+    }
+}

--- a/src/DDTrace/Log/NullLogger.php
+++ b/src/DDTrace/Log/NullLogger.php
@@ -5,15 +5,39 @@ namespace DDTrace\Log;
 /**
  * An implementation of the DDTrace\LoggerInterface that logs nothing.
  */
-class NullLogger implements LoggerInterface
+final class NullLogger implements LoggerInterface
 {
     /**
-     * Does not emit any debug message.
+     * Logs a debug at the debug level.
      *
      * @param string $message
      * @param array $context
      */
     public function debug($message, array $context = array())
+    {
+    }
+
+    /**
+     * Logs a warning at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = array())
+    {
+    }
+
+    /**
+     * Logs a error at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = array())
     {
     }
 }

--- a/src/DDTrace/Log/NullLogger.php
+++ b/src/DDTrace/Log/NullLogger.php
@@ -25,7 +25,7 @@ final class NullLogger implements LoggerInterface
      *
      * @return void
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = [])
     {
     }
 

--- a/src/DDTrace/Log/PsrLogger.php
+++ b/src/DDTrace/Log/PsrLogger.php
@@ -44,7 +44,7 @@ final class PsrLogger implements LoggerInterface
      *
      * @return void
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = [])
     {
         $this->psrLogger->warning($message, $context);
     }

--- a/src/DDTrace/Log/PsrLogger.php
+++ b/src/DDTrace/Log/PsrLogger.php
@@ -5,7 +5,7 @@ namespace DDTrace\Log;
 /**
  * An implementation of the DDTrace\LoggerInterface that uses Psr\Log under the hood.
  */
-class PsrLogger implements LoggerInterface
+final class PsrLogger implements LoggerInterface
 {
     /**
      * @var \Psr\Log\LoggerInterface
@@ -34,5 +34,31 @@ class PsrLogger implements LoggerInterface
     public function debug($message, array $context = array())
     {
         $this->psrLogger->debug($message, $context);
+    }
+
+    /**
+     * Logs a warning at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->psrLogger->warning($message, $context);
+    }
+
+    /**
+     * Logs a error at the debug level.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = array())
+    {
+        $this->psrLogger->error($message, $context);
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -3,6 +3,7 @@
 namespace DDTrace;
 
 use DDTrace\Encoders\Json;
+use DDTrace\Log\LoggingTrait;
 use DDTrace\Propagators\CurlHeadersMap;
 use DDTrace\Propagators\Noop as NoopPropagator;
 use DDTrace\Propagators\TextMap;
@@ -17,6 +18,8 @@ use DDTrace\Contracts\Tracer as TracerInterface;
 
 final class Tracer implements TracerInterface
 {
+    use LoggingTrait;
+
     const VERSION = '0.11.0-beta';
 
     /**
@@ -258,9 +261,12 @@ final class Tracer implements TracerInterface
             return;
         }
 
+        self::logDebug('Flushing {count} traces', ['count' => count($this->traces)]);
+
         $tracesToBeSent = $this->shiftFinishedTraces();
 
         if (empty($tracesToBeSent)) {
+            self::logDebug('No finished traces to be sent to the agent');
             return;
         }
 
@@ -332,6 +338,10 @@ final class Tracer implements TracerInterface
         }
 
         $this->traces[$span->getTraceId()][$span->getSpanId()] = $span;
+        self::logDebug('New span {operation} {resource} recorded.', [
+            'operation' => $span->getOperationName(),
+            'resource' => $span->getResource(),
+        ]);
     }
 
     /**

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -5,8 +5,6 @@ namespace DDTrace\Transport;
 use DDTrace\Configuration;
 use DDTrace\Contracts\Tracer;
 use DDTrace\Encoder;
-use DDTrace\Log\Logger;
-use DDTrace\Log\LoggerInterface;
 use DDTrace\Log\LoggingTrait;
 use DDTrace\Sampling\PrioritySampling;
 use DDTrace\Transport;
@@ -41,17 +39,11 @@ final class Http implements Transport
      */
     private $config;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    public function __construct(Encoder $encoder, LoggerInterface $logger = null, array $config = [])
+    public function __construct(Encoder $encoder, array $config = [])
     {
         $this->configure($config);
 
         $this->encoder = $encoder;
-        $this->logger = $logger ?: Logger::get();
 
         $this->setHeader('Datadog-Meta-Lang', 'php');
         $this->setHeader('Datadog-Meta-Lang-Version', \PHP_VERSION);
@@ -79,7 +71,7 @@ final class Http implements Transport
     public function send(array $traces)
     {
         $tracesPayload = $this->encoder->encodeTraces($traces);
-        self::logDebug('About to send to the agent {count} traces.', ['count' => count($traces)]);
+        self::logDebug('About to send to the agent {count} traces', ['count' => count($traces)]);
 
         // We keep the endpoint configuration option for backward compatibility instead of moving to an 'agent base url'
         // concept, but this should be probably revisited in the future.

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -44,7 +44,7 @@ trait TracerTestTrait
         // Clearing existing dumped file
         $this->resetRequestDumper();
 
-        $transport = new Http(new Json(), null, ['endpoint' => self::$agentRequestDumperUrl]);
+        $transport = new Http(new Json(), ['endpoint' => self::$agentRequestDumperUrl]);
         $tracer = $tracer ?: new Tracer($transport);
         GlobalTracer::set($tracer);
 

--- a/tests/DebugLogger.php
+++ b/tests/DebugLogger.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DDTrace\Tests;
+
+use DDTrace\Log\InterpolateTrait;
+use DDTrace\Log\LoggerInterface;
+
+class DebugLogger implements LoggerInterface
+{
+    use InterpolateTrait;
+
+    private $records = [];
+
+    /**
+     * @param string $message
+     * @param array $context
+     */
+    public function debug($message, array $context = array())
+    {
+        $this->records[] = [
+            LoggerInterface::DEBUG,
+            $this->interpolate($message, $context),
+        ];
+    }
+
+    /**
+     * @param string $message
+     * @param array $context
+     */
+    public function warning($message, array $context = array())
+    {
+        $this->records[] = [
+            LoggerInterface::WARNING,
+            $this->interpolate($message, $context),
+        ];
+    }
+
+    /**
+     * @param string $message
+     * @param array $context
+     */
+    public function error($message, array $context = array())
+    {
+        $this->records[] = [
+            LoggerInterface::ERROR,
+            $this->interpolate($message, $context),
+        ];
+    }
+
+    /**
+     * @param string $level
+     * @param string $message
+     * @return bool
+     */
+    public function has($level, $message)
+    {
+        return count(array_filter($this->records, function($record) use ($level, $message) {
+            return $record[0] === $level && $record[1] === $message;
+        })) > 0;
+    }
+
+    /**
+     * @return array
+     */
+    public function all()
+    {
+        return $this->records;
+    }
+}

--- a/tests/DebugLogger.php
+++ b/tests/DebugLogger.php
@@ -54,7 +54,7 @@ class DebugLogger implements LoggerInterface
      */
     public function has($level, $message)
     {
-        return count(array_filter($this->records, function($record) use ($level, $message) {
+        return count(array_filter($this->records, function ($record) use ($level, $message) {
             return $record[0] === $level && $record[1] === $message;
         })) > 0;
     }

--- a/tests/DebugLogger.php
+++ b/tests/DebugLogger.php
@@ -15,7 +15,7 @@ class DebugLogger implements LoggerInterface
      * @param string $message
      * @param array $context
      */
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = [])
     {
         $this->records[] = [
             LoggerInterface::DEBUG,

--- a/tests/DebugLogger.php
+++ b/tests/DebugLogger.php
@@ -60,6 +60,16 @@ class DebugLogger implements LoggerInterface
     }
 
     /**
+     * @param string $level
+     * @param string $message
+     * @return bool
+     */
+    public function hasOnly($level, $message)
+    {
+        return count($this->all()) === 1 && $this->has($level, $message);
+    }
+
+    /**
      * @return array
      */
     public function all()

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Tests\Unit;
 
 use DDTrace\Log\Logger;
+use DDTrace\Tests\DebugLogger;
 use DDTrace\Util\Versions;
 use PHPUnit\Framework;
 
@@ -19,5 +20,16 @@ abstract class BaseTestCase extends Framework\TestCase
     protected function matchesPhpVersion($version)
     {
         return Versions::phpVersionMatches($version);
+    }
+
+    /**
+     * Sets and return a debug logger which accumulates log messages.
+     * @return DebugLogger
+     */
+    protected function withDebugLogger()
+    {
+        $logger = new DebugLogger();
+        Logger::set($logger);
+        return $logger;
     }
 }

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Unit;
 
+use DDTrace\Log\Logger;
 use DDTrace\Util\Versions;
 use PHPUnit\Framework;
 
@@ -11,6 +12,7 @@ abstract class BaseTestCase extends Framework\TestCase
     protected function tearDown()
     {
         \Mockery::close();
+        Logger::reset();
         parent::tearDown();
     }
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -13,6 +13,7 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_DISTRIBUTED_TRACING');
         putenv('DD_PRIORITY_SAMPLING');
         putenv('DD_INTEGRATIONS_DISABLED');
+        putenv('DD_TRACE_DEBUG');
     }
 
     public function testTracerEnabledByDefault()
@@ -24,6 +25,17 @@ final class ConfigurationTest extends BaseTestCase
     {
         putenv('DD_TRACE_ENABLED=false');
         $this->assertFalse(Configuration::get()->isEnabled());
+    }
+
+    public function testDebugModeDisabledByDefault()
+    {
+        $this->assertFalse(Configuration::get()->isDebugModeEnabled());
+    }
+
+    public function testDebugModeCanBeEnabled()
+    {
+        putenv('DD_TRACE_DEBUG=true');
+        $this->assertTrue(Configuration::get()->isDebugModeEnabled());
     }
 
     public function testDistributedTracingEnabledByDefault()

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -48,6 +48,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => true,
             'isIntegrationEnabled' => false,
+            'isDebugModeEnabled' => false,
         ]));
 
         DummyIntegration1::$value = Integration::LOADED;
@@ -62,6 +63,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
+            'isDebugModeEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -78,6 +80,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
+            'isDebugModeEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -100,6 +103,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
+            'isDebugModeEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -122,6 +126,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
+            'isDebugModeEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 

--- a/tests/Unit/ScopeManagerTest.php
+++ b/tests/Unit/ScopeManagerTest.php
@@ -5,9 +5,8 @@ namespace DDTrace\Tests\Unit;
 use DDTrace\ScopeManager;
 use DDTrace\Tracer;
 use DDTrace\Transport\Noop as NoopTransport;
-use PHPUnit\Framework;
 
-final class ScopeManagerTest extends Framework\TestCase
+final class ScopeManagerTest extends BaseTestCase
 {
     const OPERATION_NAME = 'test_name';
 

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -183,6 +183,7 @@ final class TracerTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isAutofinishSpansEnabled' => true,
             'isPrioritySamplingEnabled' => false,
+            'isDebugModeEnabled' => false,
         ]));
 
         $transport = new DebugTransport();

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -4,11 +4,11 @@ namespace DDTrace\Tests\Unit\Transport;
 
 use DDTrace\Encoders\Json;
 use DDTrace\Log\NullLogger;
+use DDTrace\Tests\Unit\BaseTestCase;
 use DDTrace\Tests\Unit\CleanEnvTrait;
 use DDTrace\Transport\Http;
-use PHPUnit\Framework;
 
-final class HttpTest extends Framework\TestCase
+final class HttpTest extends BaseTestCase
 {
     use CleanEnvTrait;
 

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -3,7 +3,6 @@
 namespace DDTrace\Tests\Unit\Transport;
 
 use DDTrace\Encoders\Json;
-use DDTrace\Log\NullLogger;
 use DDTrace\Tests\Unit\BaseTestCase;
 use DDTrace\Tests\Unit\CleanEnvTrait;
 use DDTrace\Transport\Http;
@@ -19,28 +18,28 @@ final class HttpTest extends BaseTestCase
 
     public function testConfigWithDefaultValues()
     {
-        $httpTransport = new Http(new Json(), new NullLogger());
+        $httpTransport = new Http(new Json());
         $this->assertEquals('http://localhost:8126/v0.3/traces', $httpTransport->getConfig()['endpoint']);
     }
 
     public function testConfig()
     {
         $endpoint = '__end_point___';
-        $httpTransport = new Http(new Json(), new NullLogger(), ['endpoint' => $endpoint]);
+        $httpTransport = new Http(new Json(), ['endpoint' => $endpoint]);
         $this->assertEquals($endpoint, $httpTransport->getConfig()['endpoint']);
     }
 
     public function testConfigPortFromEnv()
     {
         putenv('DD_TRACE_AGENT_PORT=8888');
-        $httpTransport = new Http(new Json(), new NullLogger());
+        $httpTransport = new Http(new Json());
         $this->assertEquals('http://localhost:8888/v0.3/traces', $httpTransport->getConfig()['endpoint']);
     }
 
     public function testConfigHostFromEnv()
     {
         putenv('DD_AGENT_HOST=other_host');
-        $httpTransport = new Http(new Json(), new NullLogger());
+        $httpTransport = new Http(new Json());
         $this->assertEquals('http://other_host:8126/v0.3/traces', $httpTransport->getConfig()['endpoint']);
     }
 }


### PR DESCRIPTION
### Description

This PR add a new setting `DD_TRACE_DEBUG` which defaults to `false` and when it is turned on it dumps a number of useful info to the logger. For now we do not implement logging levels as it will come later on.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug