### PR TITLE
Fix type-o in command to install .deb packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can install the extension from a package download. First [download the appro
 $ rpm -ivh datadog-php-tracer.rpm
 
 # using DEB package (Debian Jessie+ , Ubuntu 14.04+)
-$ deb -i datadog-php-tracer.deb
+$ dpkg -i datadog-php-tracer.deb
 
 # using APK package (Alpine)
 $ apk add datadog-php-tracer.apk --allow-untrusted

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,7 +17,7 @@ You can install the extension from a package download. First [download the appro
 $ rpm -ivh datadog-php-tracer.rpm
 
 # using DEB package (Debian Jessie+ , Ubuntu 14.04+)
-$ deb -i datadog-php-tracer.deb
+$ dpkg -i datadog-php-tracer.deb
 
 # using APK package (Alpine)
 $ apk add datadog-php-tracer.apk --allow-untrusted


### PR DESCRIPTION
### Description

Just a quick type-o fix in the docs. :)

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
