### PR TITLE
Handle all reported memory leaks in 5.6 and 7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file - [read more
 ## [UNRELEASED]
 
 ### Fixed
-- Memory leaks in this and return value handling in PHP 7.x
+- Memory leaks in `this` object and return value handling in PHP 5.6 and 7.x
 
 ## [0.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [UNRELEASED]
 
+### Fixed
+- Memory leaks in this and return value handling in PHP 7.x
+
 ## [0.11.0]
 
 **WARNING: THIS IS A BREAKING CHANGE RELEASE**

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -74,9 +74,6 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
-    zend_hash_init(&DDTRACE_G(class_lookup), 8, NULL, (dtor_func_t)table_dtor, 0);
-    zend_hash_init(&DDTRACE_G(function_lookup), 8, NULL, (dtor_func_t)ddtrace_class_lookup_free, 0);
-
     ddtrace_dispatch_init(TSRMLS_C);
     ddtrace_dispatch_inject();
 
@@ -192,6 +189,8 @@ static PHP_FUNCTION(dd_trace) {
                                     "unexpected parameter combination, expected (class, function, closure) "
                                     "or (function, closure)");
         }
+
+        zval_ptr_dtor(callable);
         RETURN_BOOL(0);
     }
 #endif

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -213,10 +213,6 @@ static PHP_FUNCTION(dd_trace) {
     zend_bool rv = ddtrace_trace(clazz, Z_STR_P(function), callable TSRMLS_CC);
 #endif
 
-#if PHP_VERSION_ID < 70000
-    FREE_ZVAL(function);
-#endif
-
     RETURN_BOOL(rv);
 }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -155,7 +155,8 @@ static PHP_MINFO_FUNCTION(ddtrace) {
 
 static PHP_FUNCTION(dd_trace) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
-    STRING_T *function = NULL;
+    zval *function = NULL;
+    zval *class_name = NULL;
     zend_class_entry *clazz = NULL;
     zval *callable = NULL;
 
@@ -163,42 +164,48 @@ static PHP_FUNCTION(dd_trace) {
         RETURN_BOOL(0);
     }
 
-#if PHP_VERSION_ID < 70000
-    ALLOC_INIT_ZVAL(function);
-
-    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "Csz", &clazz,
-                                 &Z_STRVAL_P(function), &Z_STRLEN_P(function), &callable) != SUCCESS &&
-        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "sz", &Z_STRVAL_P(function),
-                                 &Z_STRLEN_P(function), &callable) != SUCCESS) {
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "zzz", &class_name, &function,
+                                 &callable) != SUCCESS &&
+        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "zz", &function, &callable) !=
+            SUCCESS) {
         if (!DDTRACE_G(ignore_missing_overridables)) {
-            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
-                                    "unexpected parameter combination, expected (class, function, closure) "
-                                    "or (function, closure)");
+            zend_throw_exception_ex(
+                spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
+                "unexpected parameter combination, expected (class, function, closure) or (function, closure)");
         }
 
         RETURN_BOOL(0);
     }
     DD_PRINTF("Function name: %s", Z_STRVAL_P(function));
 
-#else
-    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "CSz", &clazz, &function, &callable) !=
-            SUCCESS &&
-        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "Sz", &function, &callable) != SUCCESS) {
-        if (!DDTRACE_G(ignore_missing_overridables)) {
-            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0,
-                                    "unexpected parameter combination, expected (class, function, closure) "
-                                    "or (function, closure)");
+    if (class_name && Z_TYPE_P(class_name) == IS_STRING) {
+        clazz = zend_fetch_class_by_name(Z_STR_P(class_name), NULL, ZEND_FETCH_CLASS_DEFAULT | ZEND_FETCH_CLASS_SILENT);
+        if (!clazz) {
+            zval_ptr_dtor(class_name);
+            if (function) {
+                zval_ptr_dtor(function);
+            }
+            RETURN_BOOL(0);
         }
+    }
 
-        zval_ptr_dtor(callable);
+    if (!function || Z_TYPE_P(function) != IS_STRING) {
+        if (class_name) {
+            zval_ptr_dtor(class_name);
+        }
+        zval_ptr_dtor(function);
         RETURN_BOOL(0);
     }
-#endif
-    zend_bool rv = ddtrace_trace(clazz, function, callable TSRMLS_CC);
+
+    zend_bool rv = ddtrace_trace(clazz, Z_STR_P(function), callable TSRMLS_CC);
 
 #if PHP_VERSION_ID < 70000
     FREE_ZVAL(function);
 #endif
+
+    // if (function) {
+    //     zval_ptr_dtor(function);
+    // }
     RETURN_BOOL(rv);
 }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -185,6 +185,11 @@ static PHP_FUNCTION(dd_trace) {
             if (function) {
                 zval_ptr_dtor(function);
             }
+
+            if (!DDTRACE_G(ignore_missing_overridables)) {
+                zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "class not found");
+            }
+
             RETURN_BOOL(0);
         }
     }
@@ -203,9 +208,6 @@ static PHP_FUNCTION(dd_trace) {
     FREE_ZVAL(function);
 #endif
 
-    // if (function) {
-    //     zval_ptr_dtor(function);
-    // }
     RETURN_BOOL(rv);
 }
 

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -137,7 +137,7 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
         efree(fci.params);
     }
 #else
-    if (fci.params){
+    if (fci.params) {
         zend_fcall_info_args_clear(&fci, 0);
     }
 #endif
@@ -147,7 +147,10 @@ _exit_cleanup:
     if (this) {
         Z_DELREF_P(this);
     }
-
+#else
+    if (this) {
+        Z_DELREF_P(this);
+    }
 #endif
     zval_dtor(&closure);
 }

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -136,6 +136,10 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
     if (fci.params) {
         efree(fci.params);
     }
+#else
+    if (fci.params){
+        zend_fcall_info_args_clear(&fci, 0);
+    }
 #endif
 
 _exit_cleanup:
@@ -204,7 +208,7 @@ static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data
         common_scope_length = ZSTR_LEN(fbc->common.scope->name);
 #endif
     }
-    DD_PRINTF("Loaded object id: %0lx", object);
+    DD_PRINTF("Loaded object id: %p", (void *)object);
 
     ddtrace_dispatch_t *dispatch;
 

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -143,16 +143,11 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
 #endif
 
 _exit_cleanup:
-#if PHP_VERSION_ID < 70000
     if (this) {
         Z_DELREF_P(this);
     }
-#else
-    if (this) {
-        Z_DELREF_P(this);
-    }
-#endif
-    zval_dtor(&closure);
+
+    Z_DELREF(closure);
 }
 
 static int is_anonymous_closure(zend_function *fbc, const char *function_name, uint32_t *function_name_length_p) {

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -285,8 +285,13 @@ static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data
         execute_fcall(dispatch, execute_data, &return_value TSRMLS_CC);
 
         if (return_value != NULL) {
-            EX_TMP_VAR(execute_data, opline->result.var)->var.ptr = return_value;
+            if (RETURN_VALUE_USED(opline)) {
+                EX_TMP_VAR(execute_data, opline->result.var)->var.ptr = return_value;
+            } else {
+                zval_ptr_dtor(&return_value);
+            }
         }
+
 #else
         zval rv;
         INIT_ZVAL(rv);

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -7,8 +7,12 @@
 #if PHP_VERSION_ID < 70000
 #include "dispatch_compat_php5.h"
 void ddtrace_class_lookup_free(void *zv);
+
+#define ddtrace_zval_ptr_dtor(x) zval_dtor(x)
 #else
 void ddtrace_class_lookup_free(zval *zv);
+
+#define ddtrace_zval_ptr_dtor(x) zval_ptr_dtor(x)
 #define INIT_ZVAL(x) ZVAL_NULL(&x)
 #endif
 

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -2,10 +2,9 @@
 #if PHP_VERSION_ID >= 70000
 
 #include "ddtrace.h"
+#include "debug.h"
 #include "dispatch.h"
 #include "dispatch_compat.h"
-#include "debug.h"
-
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -4,6 +4,8 @@
 #include "ddtrace.h"
 #include "dispatch.h"
 #include "dispatch_compat.h"
+#include "debug.h"
+
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
@@ -23,10 +25,11 @@ zend_function *ddtrace_function_get(const HashTable *table, zend_string *name) {
 
 void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
     zend_string_release(dispatch->function);
-    zval_dtor(&dispatch->callable);
+    zval_ptr_dtor(&dispatch->callable);
 }
 
 void ddtrace_class_lookup_free(zval *zv) {
+    DD_PRINTF("freeing %p", (void *)zv);
     ddtrace_dispatch_t *dispatch = Z_PTR_P(zv);
     ddtrace_dispatch_free_owned_data(dispatch);
     efree(dispatch);

--- a/tests/ext/enable_throw_exception_if_overridable_doesnt_exist.phpt
+++ b/tests/ext/enable_throw_exception_if_overridable_doesnt_exist.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Toggle checking if overridable method/function exists or not
+Toggle checking if overrided class doesn't exist
 --INI--
 ddtrace.ignore_missing_overridables=0
 --FILE--
@@ -14,4 +14,4 @@ try {
 
 ?>
 --EXPECTF--
-unexpected parameter combination, expected (class, function, closure) or (function, closure)
+class not found


### PR DESCRIPTION
### Description

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] TODO in separate PR: Tests added for this feature/bug - requires a debug Build of PHP vm to properly report memory freed by PHP's memory management.
