### PR TITLE
Support for global tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [UNRELEASED]
 
+### Added
+ - support for global tags #273
+
 ## [0.11.0]
 
 **WARNING: THIS IS A BREAKING CHANGE RELEASE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file - [read more
 ## [UNRELEASED]
 
 ### Added
- - support for global tags #273
+- support for global tags #273
 
 ## [0.11.0]
 

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -86,6 +86,14 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Returns the global tags to be set on all spans.
+     */
+    public function getGlobalTags()
+    {
+        return $this->associativeStringArrayValue('trace.global.tags');
+    }
+
+    /**
      * The name of the application.
      *
      * @param string $default

--- a/src/DDTrace/Configuration/AbstractConfiguration.php
+++ b/src/DDTrace/Configuration/AbstractConfiguration.php
@@ -67,6 +67,16 @@ abstract class AbstractConfiguration implements Registry
     /**
      * {@inheritdoc}
      *
+     * Reads a configuration property into an associative string => string array.
+     */
+    public function associativeStringArrayValue($key)
+    {
+        return $this->registry->associativeStringArrayValue($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * Allows users to access configuration properties by name instead of calling explicit methods.
      */
     public function inArray($key, $name)

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -103,6 +103,48 @@ class EnvVariableRegistry implements Registry
     }
 
     /**
+     * Given a string like 'key1:value1,key2:value2', it returns an associative array
+     * ['key1'=> 'value1', 'key2'=> 'value2']
+     *
+     * @param string $key
+     * @return string[]
+     */
+    public function associativeStringArrayValue($key)
+    {
+        $default = [];
+
+        if (!isset($this->registry[$key])) {
+            $value = self::get($key);
+
+            if (null === $value) {
+                $this->registry[$key] = $default;
+            }
+
+            // For now we provide no escaping
+            $this->registry[$key] = [];
+            $elements = explode(',', $value);
+            foreach ($elements as $element) {
+                $keyAndValue = explode(':', $element);
+
+                if (count($keyAndValue) !== 2) {
+                    continue;
+                }
+
+                $keyFragment = trim($keyAndValue[0]);
+                $valueFragment = trim($keyAndValue[1]);
+
+                if (empty($keyFragment)) {
+                    continue;
+                }
+
+                $this->registry[$key][$keyFragment] = $valueFragment;
+            }
+        }
+
+        return $this->registry[$key];
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function inArray($key, $name)

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -119,7 +119,7 @@ class EnvVariableRegistry implements Registry
         $value = self::get($key);
 
         if (null === $value) {
-            return $this->registry[$key] = $default;
+            return $default;
         }
 
         // For now we provide no escaping

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -111,34 +111,35 @@ class EnvVariableRegistry implements Registry
      */
     public function associativeStringArrayValue($key)
     {
+        if (isset($this->registry[$key])) {
+            return $this->registry[$key];
+        }
+
         $default = [];
+        $value = self::get($key);
 
-        if (!isset($this->registry[$key])) {
-            $value = self::get($key);
+        if (null === $value) {
+            return $this->registry[$key] = $default;
+        }
 
-            if (null === $value) {
-                $this->registry[$key] = $default;
+        // For now we provide no escaping
+        $this->registry[$key] = [];
+        $elements = explode(',', $value);
+        foreach ($elements as $element) {
+            $keyAndValue = explode(':', $element);
+
+            if (count($keyAndValue) !== 2) {
+                continue;
             }
 
-            // For now we provide no escaping
-            $this->registry[$key] = [];
-            $elements = explode(',', $value);
-            foreach ($elements as $element) {
-                $keyAndValue = explode(':', $element);
+            $keyFragment = trim($keyAndValue[0]);
+            $valueFragment = trim($keyAndValue[1]);
 
-                if (count($keyAndValue) !== 2) {
-                    continue;
-                }
-
-                $keyFragment = trim($keyAndValue[0]);
-                $valueFragment = trim($keyAndValue[1]);
-
-                if (empty($keyFragment)) {
-                    continue;
-                }
-
-                $this->registry[$key][$keyFragment] = $valueFragment;
+            if (empty($keyFragment)) {
+                continue;
             }
+
+            $this->registry[$key][$keyFragment] = $valueFragment;
         }
 
         return $this->registry[$key];

--- a/src/DDTrace/Configuration/Registry.php
+++ b/src/DDTrace/Configuration/Registry.php
@@ -37,6 +37,15 @@ interface Registry
     public function floatValue($key, $default, $min = null, $max = null);
 
     /**
+     * Given a string like 'key1:value1,key2:value2', it returns an associative array
+     * ['key1'=> 'value1', 'key2'=> 'value2']
+     *
+     * @param string $key
+     * @return string[]
+     */
+    public function associativeStringArrayValue($key);
+
+    /**
      * Returns whether or not a given case-insensitive name is contained in a configuration property.
      *
      * @param string $key

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -95,6 +95,7 @@ final class Tracer implements TracerInterface
         ];
         $this->config = array_merge($this->config, $config);
         $this->reset();
+        $this->config['global_tags'] = array_merge($this->config['global_tags'], $this->globalConfig->getGlobalTags());
     }
 
     /**

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -217,6 +217,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
             'isAutofinishSpansEnabled' => false,
             'isDistributedTracingEnabled' => false,
             'isPrioritySamplingEnabled' => false,
+            'getGlobalTags' => [],
         ]));
 
         $this->isolateTracer(function () use (&$found) {

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -144,6 +144,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             'isAutofinishSpansEnabled' => false,
             'isDistributedTracingEnabled' => false,
             'isPrioritySamplingEnabled' => false,
+            'getGlobalTags' => [],
         ]));
 
         $this->isolateTracer(function () use (&$found, $client) {

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -136,6 +136,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             'isAutofinishSpansEnabled' => false,
             'isDistributedTracingEnabled' => false,
             'isPrioritySamplingEnabled' => false,
+            'getGlobalTags' => [],
         ]));
 
         $this->isolateTracer(function () use (&$found, $client) {

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -13,6 +13,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Laravel/Version_4_2/public/index.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
+        ]);
+    }
+
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec
@@ -40,11 +47,17 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
+                            'some.key1' => 'value',
+                            'some.key2' => 'value2',
                         ]),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
-                    SpanAssertion::build('laravel.action', 'laravel', 'web', 'simple'),
+                    SpanAssertion::build('laravel.action', 'laravel', 'web', 'simple')
+                        ->withExactTags([
+                            'some.key1' => 'value',
+                            'some.key2' => 'value2',
+                        ]),
                     SpanAssertion::exists('laravel.event.handle'),
                 ],
                 'A simple GET request with a view' => [
@@ -54,7 +67,11 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.action'),
                     SpanAssertion::exists('laravel.event.handle'),
-                    SpanAssertion::build('laravel.view.render', 'laravel', 'web', 'simple_view'),
+                    SpanAssertion::build('laravel.view.render', 'laravel', 'web', 'simple_view')
+                        ->withExactTags([
+                            'some.key1' => 'value',
+                            'some.key2' => 'value2',
+                        ]),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
                 ],
@@ -65,7 +82,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'laravel.route.action' => 'HomeController@error',
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500'
+                            'http.status_code' => '500',
+                            'some.key1' => 'value',
+                            'some.key2' => 'value2',
                         ]),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
@@ -74,6 +93,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         ->withExactTags([
                             'error.msg' => 'Controller error',
                             'error.type' => 'Exception',
+                            'some.key1' => 'value',
+                            'some.key2' => 'value2',
                         ])
                         ->withExistingTagsNames(['error.stack'])
                         ->setError(),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -13,6 +13,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_4/web/app.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_APP_NAME' => 'test_symfony_34',
+        ]);
+    }
+
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec
@@ -35,7 +42,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'A simple GET request returning a string' => [
                     SpanAssertion::build(
                         'symfony.request',
-                        'symfony',
+                        'test_symfony_34',
                         'web',
                         'simple'
                     )
@@ -57,7 +64,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
                         'symfony.request',
-                        'symfony',
+                        'test_symfony_34',
                         'web',
                         'simple_view'
                     )
@@ -74,7 +81,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::build(
                         'symfony.templating.render',
-                        'symfony',
+                        'test_symfony_34',
                         'web',
                         'Twig_Environment twig_template.html.twig'
                     ),
@@ -85,7 +92,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'A GET request with an exception' => [
                     SpanAssertion::build(
                         'symfony.request',
-                        'symfony',
+                        'test_symfony_34',
                         'web',
                         'error'
                     )

--- a/tests/Unit/Configuration/EnvVariableRegistryTest.php
+++ b/tests/Unit/Configuration/EnvVariableRegistryTest.php
@@ -133,6 +133,16 @@ final class EnvVariableRegistryTest extends BaseTestCase
         $this->assertFalse($registry->inArray('some.test.parameter', 'value3'));
     }
 
+    public function testAssociativeStringArrayNotPersistingDefaultValue()
+    {
+        $registry = new EnvVariableRegistry();
+        $this->assertSame([], $registry->associativeStringArrayValue('some.test.parameter'));
+
+        putenv('DD_SOME_TEST_PARAMETER=key:value');
+
+        $this->assertSame(['key' => 'value'], $registry->associativeStringArrayValue('some.test.parameter'));
+    }
+
     /**
      * @dataProvider associativeStringArrayDataProvider
      * @param string|null $env

--- a/tests/Unit/Configuration/EnvVariableRegistryTest.php
+++ b/tests/Unit/Configuration/EnvVariableRegistryTest.php
@@ -132,4 +132,40 @@ final class EnvVariableRegistryTest extends BaseTestCase
         $this->assertTrue($registry->inArray('some.test.parameter', 'value2'));
         $this->assertFalse($registry->inArray('some.test.parameter', 'value3'));
     }
+
+    /**
+     * @dataProvider associativeStringArrayDataProvider
+     * @param string|null $env
+     * @param string $expected
+     */
+    public function testAssociativeStringArray($env, $expected)
+    {
+        if (null !== $env) {
+            putenv('DD_SOME_TEST_PARAMETER=' . $env);
+        }
+        $registry = new EnvVariableRegistry();
+        $this->assertSame($expected, $registry->associativeStringArrayValue('some.test.parameter'));
+    }
+
+    public function associativeStringArrayDataProvider()
+    {
+        return [
+
+            'env not set' => [null, []],
+
+            'empty string' => ['', []],
+
+            'only key' => ['only_key', []],
+
+            'empty key' => [':value', []],
+
+            'one value' => ['  key:   value    ', ['key' => 'value']],
+
+            'multiple values' => ['  key1:   value1  , key2 :value2  ', ['key1' => 'value1', 'key2' => 'value2']],
+
+            'preserves case' => ['  kEy1:   vAlUe1  ', ['kEy1' => 'vAlUe1']],
+
+            'tolerant to errors' => ['  kEy1:   vAlUe1 : wrong  ', []],
+        ];
+    }
 }

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -184,6 +184,7 @@ final class TracerTest extends BaseTestCase
             'isAutofinishSpansEnabled' => true,
             'isPrioritySamplingEnabled' => false,
             'isDebugModeEnabled' => false,
+            'getGlobalTags' => [],
         ]));
 
         $transport = new DebugTransport();
@@ -208,5 +209,25 @@ final class TracerTest extends BaseTestCase
     {
         $tracer = new Tracer(new NoopTransport());
         $this->assertNull($tracer->getRootScope());
+    }
+
+    public function testHonorGlobalTags()
+    {
+        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
+            'isAutofinishSpansEnabled' => true,
+            'isPrioritySamplingEnabled' => false,
+            'isDebugModeEnabled' => false,
+            'getGlobalTags' => [
+                'key1' => 'value1',
+                'key2' => 'value2',
+            ],
+        ]));
+
+        $transport = new DebugTransport();
+        $tracer = new Tracer($transport);
+        $span = $tracer->startSpan('some_operation');
+
+        $this->assertSame('value1', $span->getAllTags()['key1']);
+        $this->assertSame('value2', $span->getAllTags()['key2']);
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for global tags that will be set in each span. They can be defined through the env `DD_TRACE_GLOBAL_TAGS=key1:valu1,key2:value2`

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
