### PR TITLE
Zend integration incompatibility with Yii

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+## [0.12.2]
+
+### Fixed
+- Zend integration incompatibility with Yii #282
+
 ## [0.12.1]
 
 ### Fixed
@@ -269,7 +274,8 @@ At an high level here are the breaking changes we introduced:
 ### Added
 - OpenTracing compliance tha can be used for manual instrumentation
 
-[Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.12.1...HEAD
+[Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.12.2...HEAD
+[0.12.1]: https://github.com/DataDog/dd-trace-php/compare/0.12.1...0.12.2
 [0.12.1]: https://github.com/DataDog/dd-trace-php/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/DataDog/dd-trace-php/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/DataDog/dd-trace-php/compare/0.10.0...0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,7 +275,7 @@ At an high level here are the breaking changes we introduced:
 - OpenTracing compliance tha can be used for manual instrumentation
 
 [Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.12.2...HEAD
-[0.12.1]: https://github.com/DataDog/dd-trace-php/compare/0.12.1...0.12.2
+[0.12.2]: https://github.com/DataDog/dd-trace-php/compare/0.12.1...0.12.2
 [0.12.1]: https://github.com/DataDog/dd-trace-php/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/DataDog/dd-trace-php/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/DataDog/dd-trace-php/compare/0.10.0...0.11.0

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations\ZendFramework;
 
 use DDTrace\Integrations\Integration;
+use DDTrace\Util\Runtime;
 
 /**
  * Zend framework integration loader.
@@ -19,6 +20,12 @@ class ZendFrameworkIntegration extends Integration
     public static function load()
     {
         if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        // Some frameworks, e.g. Yii registers autoloaders that fails with non-psr4 classes. For this reason the
+        // Zend framework integration is not compatible with some of them
+        if (Runtime::isAutoloaderRegistered('YiiBase', 'autoload')) {
             return self::NOT_AVAILABLE;
         }
 

--- a/src/DDTrace/Util/Runtime.php
+++ b/src/DDTrace/Util/Runtime.php
@@ -5,7 +5,7 @@ namespace DDTrace\Util;
 /**
  * Utilities related tot he PHP runtime
  */
-class Runtime
+final class Runtime
 {
     /**
      * Tells whether or not a given autoloader is registered.

--- a/src/DDTrace/Util/Runtime.php
+++ b/src/DDTrace/Util/Runtime.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DDTrace\Util;
+
+/**
+ * Utilities related tot he PHP runtime
+ */
+class Runtime
+{
+    /**
+     * Tells whether or not a given autoloader is registered.
+     *
+     * @param string $class
+     * @param string $method
+     * @return bool
+     */
+    public static function isAutoloaderRegistered($class, $method)
+    {
+        $class = trim($class, '\\');
+        $autoloaders = spl_autoload_functions();
+        foreach ($autoloaders as $autoloader) {
+            if (!is_array($autoloader) || count($autoloader) !== 2) {
+                continue;
+            }
+
+            $registeredAutoloader = $autoloader[0];
+            $registeredMethod = $autoloader[1];
+            if (is_string($registeredAutoloader)) {
+                $compareClass = trim($registeredAutoloader, '\\');
+            } elseif (is_object($registeredAutoloader)) {
+                $compareClass = trim(get_class($registeredAutoloader), '\\');
+            } else {
+                continue;
+            }
+
+            if ($compareClass === $class && $registeredMethod === $method) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a fix to make Zend integration compatible with framework such as Yii. Changes have been tested locally, integration tests will be added immediately after.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
