### PR TITLE
Add temp workaround for Drupal DBAL bug

### DIFF
--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -31,6 +31,15 @@ class PDOIntegration
             return Integration::NOT_AVAILABLE;
         }
 
+        /**
+         * Workaround for the Drupal DBAL bug.
+         * Delete this `if` block once the bug is fixed.
+         * @see https://github.com/DataDog/dd-trace-php/pull/284
+         */
+        if (defined('DRUPAL_CORE_COMPATIBILITY')) {
+            return Integration::NOT_AVAILABLE;
+        }
+
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace('PDO', '__construct', function () {
             $args = func_get_args();


### PR DESCRIPTION
### Description

Until we're able to properly address #284, this PR disables the PDO integration when Drupal is detected.

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
