### PR TITLE
Span::setResource as a legit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Added
+- Span::setResource as a legit method # 287
+
 ### Fixed
 - Symfony 4.2 traces generation #280
 - Drupal crashes (temporary workaround) #285

--- a/src/DDTrace/Contracts/Span.php
+++ b/src/DDTrace/Contracts/Span.php
@@ -49,6 +49,13 @@ interface Span
     public function overwriteOperationName($newOperationName);
 
     /**
+     * Sets the span's resource name.
+     *
+     * @param string $resource
+     */
+    public function setResource($resource);
+
+    /**
      * Adds a tag to the span.
      *
      * If there is a pre-existing tag set for key, it is overwritten.

--- a/src/DDTrace/NoopSpan.php
+++ b/src/DDTrace/NoopSpan.php
@@ -49,6 +49,13 @@ final class NoopSpan implements SpanInterface
     /**
      * {@inheritdoc}
      */
+    public function setResource($resource)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getTag($key)
     {
         return null;

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -227,13 +227,10 @@ final class Span implements SpanInterface
     }
 
     /**
-     * @deprecated
-     * @param string $resource
+     * {@inheritdoc}
      */
     public function setResource($resource)
     {
-        error_log('DEPRECATED: Method "DDTrace\Span\setResource" will be removed soon, '
-            . 'you should use DDTrace\Span::setTag(Tag::RESOURCE_NAME, $value) instead.');
         $this->setTag(Tag::RESOURCE_NAME, $resource);
     }
 

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -151,6 +151,14 @@ final class SpanTest extends Framework\TestCase
         $this->assertFalse($span->hasError());
     }
 
+    public function testSpanSetResource()
+    {
+        $span = $this->createSpan();
+        $span->setResource('modified_test_resource');
+
+        $this->assertSame('modified_test_resource', $span->getResource());
+    }
+
     /**
      * @expectedException \DDTrace\Exceptions\InvalidSpanArgument
      * @expectedExceptionMessage Error should be either Exception or Throwable, got integer.


### PR DESCRIPTION
### Description

We had deprecated `Span::setResource` back when we were implementing our tracer based on OpenTracing. The problem is that `setResource` method did exist in our `DDTrace\Span` class but not in our `DDTrace\NoopSpan` class.

This PR:
  1. adds the method declaration in the `DDTrace\Contracts\Span` interface
  1. removes the `@deprectated` annotation from `DDtrace\Span`
  1. adds the method to `DDTrace\NoopSpan`

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
