### PR TITLE
Tracing of http status code in generic web requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Symfony 4.2 traces generation #280
 - Drupal crashes (temporary workaround) #285
+- Tracing of http status code in generic web requests #288
 
 ## [0.12.2]
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	excludes_analyse:
+		- src/DDTrace/Bootstrap.php
 		- src/DDTrace/Util/CodeTracer.php
 		- src/DDTrace/Integrations
 		- src/DDTrace/OpenTracer

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -86,6 +86,23 @@ final class Bootstrap
         if ('cli' !== PHP_SAPI) {
             $span->setTag(Tag::HTTP_METHOD, $_SERVER['REQUEST_METHOD']);
             $span->setTag(Tag::HTTP_URL, $_SERVER['REQUEST_URI']);
+            // Status code defaults to 200, will be later on changed when http_response_code will be called
+            $span->setTag(Tag::HTTP_STATUS_CODE, 200);
         }
+
+        dd_trace('header', function () use ($span) {
+            $args = func_get_args();
+            $argsCount = count($args);
+            error_log("Called header: " . $args[0]);
+            if ($argsCount === 1) {
+                $result = header($args[0]);
+            } elseif ($argsCount === 2) {
+                $result = header($args[0], $args[1]);
+            } else {
+                $result = header($args[0], $args[1], $args[2]);
+            }
+
+            return $result;
+        });
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -48,6 +48,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'http.method' => 'GET',
                         'http.url' => '/simple',
+                        'http.status_code' => '200',
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -59,6 +60,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'http.method' => 'GET',
                         'http.url' => '/simple_view',
+                        'http.status_code' => '200',
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -70,6 +72,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'http.method' => 'GET',
                         'http.url' => '/error',
+                        'http.status_code' => '500',
                     ]),
                 ],
             ]


### PR DESCRIPTION
### Description

Previously we did not set an http status code for generic web requests. This PR introduces such functionality.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
