### PR TITLE
Route not set in symfony 3.4 when user calls exit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file - [read more
 - Symfony 4.2 traces generation #280
 - Drupal crashes (temporary workaround) #285
 - Tracing of http status code in generic web requests #288
+- Route not set in symfony 3.4 when user calls exit() #289
 
 ## [0.12.2]
 

--- a/src/DDTrace/Util/TryCatchFinally.php
+++ b/src/DDTrace/Util/TryCatchFinally.php
@@ -2,8 +2,8 @@
 
 namespace DDTrace\Util;
 
+use DDTrace\Contracts\Scope;
 use DDTrace\Contracts\Span;
-use DDTrace\Scope;
 
 /**
  * PHP 5.4 compatible methods to workaround the missing try-catch-finally block.

--- a/tests/Frameworks/Symfony/Version_3_4/src/AppBundle/Controller/HomeController.php
+++ b/tests/Frameworks/Symfony/Version_3_4/src/AppBundle/Controller/HomeController.php
@@ -31,4 +31,13 @@ class HomeController extends Controller
         // replace this example code with whatever you need
         return new Response($templating->render('php_template.template.php', []));
     }
+
+    /**
+     * @Route("/terminated_by_exit", name="terminated_by_exit")
+     */
+    public function actionBeingTerminatedByExit(Request $request)
+    {
+        echo "This is calculated by some service";
+        exit();
+    }
 }

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V3_4;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_3_4/web/app.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_AUTOFINISH_SPANS' => 'true',
+        ]);
+    }
+
+    public function testEndpointThatExitsWithNoProcess()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Endpoint that invoke exit()', '/terminated_by_exit'));
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'symfony.request',
+                'symfony',
+                'web',
+                'terminated_by_exit'
+            )
+                ->withExactTags([
+                    'symfony.route.action' => 'AppBundle\Controller\HomeController@actionBeingTerminatedByExit',
+                    'symfony.route.name' => 'terminated_by_exit',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/terminated_by_exit',
+                    'http.status_code' => '200',
+                ]),
+            SpanAssertion::exists('symfony.kernel.handle'),
+            SpanAssertion::exists('symfony.kernel.request'),
+            SpanAssertion::exists('symfony.kernel.controller'),
+            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+        ]);
+    }
+}


### PR DESCRIPTION
### Description

When users have an endpoint which `echo` some content and then `exit()` some info such as the route name was not properly traced. This PR correct the way route is set adding an hook when this can be done and that handles this case.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
