### PR TITLE
Remove unused function that was moved to dispatch_table_dtor()

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -57,12 +57,6 @@ STD_PHP_INI_ENTRY("ddtrace.ignore_missing_overridables", "1", PHP_INI_SYSTEM, On
                   zend_ddtrace_globals, ddtrace_globals)
 PHP_INI_END()
 
-static inline void table_dtor(void *zv) {
-    HashTable *ht = *(HashTable **)zv;
-    zend_hash_destroy(ht);
-    efree(ht);
-}
-
 static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, sizeof(zend_ddtrace_globals)); }
 
 static PHP_MINIT_FUNCTION(ddtrace) {


### PR DESCRIPTION
### Description

Just removed a function that wasn't being invoked from anywhere. :)

### Readiness checklist
- [ ] ~~[Changelog entry](docs/changelog.md) added, if necessary~~
- [ ] ~~Tests added for this feature/bug~~
