### PR TITLE
Logging more span's info when in debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/ext/*.mem
 tmp-php.ini
 tmp/opcache*
 *.orig
+benchmark.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Span::setResource as a legit method # 287
+- Logging more span's info when in debug mode # 292
 
 ### Fixed
 - Memory leak and misshandling of return value in PHP 5.4 #281

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -94,15 +94,15 @@ final class Json implements Encoder
         }
 
         self:self::logDebug(
-        "Encoding span '{id}' op: '{operation}' serv: '{service}' res: '{resource}' type '{type}'",
-        [
-            'id' => $span->getSpanId(),
-            'operation' => $span->getOperationName(),
-            'service' => $span->getService(),
-            'resource' => $span->getResource(),
-            'type' => $span->getType(),
-        ]
-    );
+            "Encoding span '{id}' op: '{operation}' serv: '{service}' res: '{resource}' type '{type}'",
+            [
+                'id' => $span->getSpanId(),
+                'operation' => $span->getOperationName(),
+                'service' => $span->getService(),
+                'resource' => $span->getResource(),
+                'type' => $span->getType(),
+            ]
+        );
         self::logDebug('Tags for span {id} \'tag:chars_count\' are: {lengths}', [
             'id' => $span->getSpanId(),
             'lengths' => implode(',', $lengths),

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -84,7 +84,7 @@ final class Json implements Encoder
      */
     private function logSpanDetailsIfDebug(Span $span)
     {
-        if (!self::isLogLevelActive(LogLevel::DEBUG)) {
+        if (!self::isLogDebugActive()) {
             return;
         }
 
@@ -93,7 +93,7 @@ final class Json implements Encoder
             $lengths[] = "$tagName:" . strlen($tagValue);
         }
 
-        self:self::logDebug(
+        self::logDebug(
             "Encoding span '{id}' op: '{operation}' serv: '{service}' res: '{resource}' type '{type}'",
             [
                 'id' => $span->getSpanId(),

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -55,9 +55,9 @@ final class Json implements Encoder
      */
     private function encodeSpan(Span $span, Tracer $tracer)
     {
-        self::whenDebugIsEnabled(function () use ($span) {
+        if (self::isLogDebugActive()) {
             $this->logSpanDetailsIfDebug($span);
-        });
+        }
 
         $json = json_encode($this->spanToArray($span, $tracer));
         if (false === $json) {

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -55,7 +55,10 @@ final class Json implements Encoder
      */
     private function encodeSpan(Span $span, Tracer $tracer)
     {
-        $this->logSpanDetailsIfDebug($span);
+        self::whenDebugIsEnabled(function () use ($span) {
+            $this->logSpanDetailsIfDebug($span);
+        });
+
         $json = json_encode($this->spanToArray($span, $tracer));
         if (false === $json) {
             $this->logger->debug("Failed to json-encode span: " . json_last_error_msg());
@@ -84,10 +87,6 @@ final class Json implements Encoder
      */
     private function logSpanDetailsIfDebug(Span $span)
     {
-        if (!self::isLogDebugActive()) {
-            return;
-        }
-
         $lengths = [];
         foreach ($span->getAllTags() as $tagName => $tagValue) {
             $lengths[] = "$tagName:" . strlen($tagValue);

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -8,10 +8,14 @@ use DDTrace\Encoder;
 use DDTrace\GlobalTracer;
 use DDTrace\Log\Logger;
 use DDTrace\Log\LoggerInterface;
+use DDTrace\Log\LoggingTrait;
+use DDTrace\Log\LogLevel;
 use DDTrace\Sampling\PrioritySampling;
 
 final class Json implements Encoder
 {
+    use LoggingTrait;
+
     /**
      * @var LoggerInterface
      */
@@ -51,6 +55,7 @@ final class Json implements Encoder
      */
     private function encodeSpan(Span $span, Tracer $tracer)
     {
+        $this->logSpanDetailsIfDebug($span);
         $json = json_encode($this->spanToArray($span, $tracer));
         if (false === $json) {
             $this->logger->debug("Failed to json-encode span: " . json_last_error_msg());
@@ -70,6 +75,38 @@ final class Json implements Encoder
             '"span_id":' . $span->getSpanId(),
             '"parent_id":' . $span->getParentId(),
         ], $json);
+    }
+
+    /**
+     * Logs a Span's detailed info.
+     *
+     * @param Span $span
+     */
+    private function logSpanDetailsIfDebug(Span $span)
+    {
+        if (!self::isLogLevelActive(LogLevel::DEBUG)) {
+            return;
+        }
+
+        $lengths = [];
+        foreach ($span->getAllTags() as $tagName => $tagValue) {
+            $lengths[] = "$tagName:" . strlen($tagValue);
+        }
+
+        self:self::logDebug(
+        "Encoding span '{id}' op: '{operation}' serv: '{service}' res: '{resource}' type '{type}'",
+        [
+            'id' => $span->getSpanId(),
+            'operation' => $span->getOperationName(),
+            'service' => $span->getService(),
+            'resource' => $span->getResource(),
+            'type' => $span->getType(),
+        ]
+    );
+        self::logDebug('Tags for span {id} \'tag:chars_count\' are: {lengths}', [
+            'id' => $span->getSpanId(),
+            'lengths' => implode(',', $lengths),
+        ]);
     }
 
     /**

--- a/src/DDTrace/Log/AbstractLogger.php
+++ b/src/DDTrace/Log/AbstractLogger.php
@@ -21,10 +21,10 @@ abstract class AbstractLogger implements LoggerInterface
 
         # all() have all levels ordered from highest to lowest
         # all preceding levels to given $level will be marked as enabled
-        $found = false;
+        $enabled = false;
         foreach (array_reverse(LogLevel::all()) as $knownLevel) {
-            $found = $found || ($level === $knownLevel);
-            $this->enabledLevels[$knownLevel] = $found || false;
+            $enabled = $enabled || ($level === $knownLevel);
+            $this->enabledLevels[$knownLevel] = $enabled;
         }
     }
 

--- a/src/DDTrace/Log/AbstractLogger.php
+++ b/src/DDTrace/Log/AbstractLogger.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DDTrace\Log;
+
+/**
+ * An abstract logger.
+ */
+abstract class AbstractLogger implements LoggerInterface
+{
+    /**
+     * @var array A map - 'name' => true|false - of enabled levels.
+     */
+    private $enabledLevels = [];
+
+    /**
+     * @param string $level
+     */
+    public function __construct($level)
+    {
+        // At the moment we only support debug or off.
+        foreach (LogLevel::all() as $knownLevel) {
+            $this->enabledLevels[$knownLevel] = $level === LogLevel::DEBUG;
+        }
+    }
+
+    /**
+     * @param string $level
+     * @return bool
+     */
+    public function isLevelActive($level)
+    {
+        return (bool)$this->enabledLevels[$level];
+    }
+}

--- a/src/DDTrace/Log/AbstractLogger.php
+++ b/src/DDTrace/Log/AbstractLogger.php
@@ -17,9 +17,14 @@ abstract class AbstractLogger implements LoggerInterface
      */
     public function __construct($level)
     {
-        // At the moment we only support debug or off.
-        foreach (LogLevel::all() as $knownLevel) {
-            $this->enabledLevels[$knownLevel] = $level === LogLevel::DEBUG;
+        $level = trim(strtolower($level));
+
+        # all() have all levels ordered from highest to lowest
+        # all preceding levels to given $level will be marked as enabled
+        $found = false;
+        foreach (array_reverse(LogLevel::all()) as $knownLevel) {
+            $found = $found || ($level === $knownLevel);
+            $this->enabledLevels[$knownLevel] = $found || false;
         }
     }
 

--- a/src/DDTrace/Log/ErrorLogLogger.php
+++ b/src/DDTrace/Log/ErrorLogLogger.php
@@ -5,7 +5,7 @@ namespace DDTrace\Log;
 /**
  * An implementation of the DDTrace\LoggerInterface that logs to the error_log.
  */
-class ErrorLogLogger implements LoggerInterface
+class ErrorLogLogger extends AbstractLogger
 {
     use InterpolateTrait;
 
@@ -20,7 +20,7 @@ class ErrorLogLogger implements LoggerInterface
     {
         // As a first draft, we do not implement logging levels. This logger is simply enabled when property
         // trace.debug = true and all messages are shown.
-        $this->emit(self::DEBUG, $message, $context);
+        $this->emit(LogLevel::DEBUG, $message, $context);
     }
 
     /**
@@ -35,7 +35,7 @@ class ErrorLogLogger implements LoggerInterface
     {
         // As a first draft, we do not implement logging levels. This logger is simply enabled when property
         // trace.debug = true and all messages are shown.
-        $this->emit(self::WARNING, $message, $context);
+        $this->emit(LogLevel::WARNING, $message, $context);
     }
 
     /**
@@ -50,7 +50,7 @@ class ErrorLogLogger implements LoggerInterface
     {
         // As a first draft, we do not implement logging levels. This logger is simply enabled when property
         // trace.debug = true and all messages are shown.
-        $this->emit(self::ERROR, $message, $context);
+        $this->emit(LogLevel::ERROR, $message, $context);
     }
 
     /**
@@ -60,6 +60,10 @@ class ErrorLogLogger implements LoggerInterface
      */
     private function emit($level, $message, array $context = [])
     {
+        if (!$this->isLevelActive($level)) {
+            return;
+        }
+
         $interpolatedMessage = $this->interpolate($message, $context);
         $date = date(\DateTime::ATOM);
         error_log("[$date] [ddtrace] [$level] - $interpolatedMessage");

--- a/src/DDTrace/Log/LogLevel.php
+++ b/src/DDTrace/Log/LogLevel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DDTrace\Log;
+
+/**
+ * Known log levels.
+ */
+final class LogLevel
+{
+    /**
+     * Const list from https://www.php-fig.org/psr/psr-3/
+     */
+    const EMERGENCY = 'emergency';
+    const ALERT     = 'alert';
+    const CRITICAL  = 'critical';
+    const ERROR     = 'error';
+    const WARNING   = 'warning';
+    const NOTICE    = 'notice';
+    const INFO      = 'info';
+    const DEBUG     = 'debug';
+
+    /**
+     * All the log levels.
+     *
+     * @return string[]
+     */
+    public static function all()
+    {
+        return [
+            self::EMERGENCY,
+            self::ALERT,
+            self::CRITICAL,
+            self::ERROR,
+            self::WARNING,
+            self::NOTICE,
+            self::INFO,
+            self::DEBUG,
+        ];
+    }
+}

--- a/src/DDTrace/Log/Logger.php
+++ b/src/DDTrace/Log/Logger.php
@@ -33,7 +33,9 @@ final class Logger
     {
         if (self::$logger === null) {
             $config = Configuration::get();
-            self::$logger = $config->isDebugModeEnabled() ? new ErrorLogLogger() : new NullLogger();
+            self::$logger = $config->isDebugModeEnabled()
+                ? new ErrorLogLogger(LogLevel::DEBUG)
+                : new NullLogger(LogLevel::EMERGENCY);
         }
         return self::$logger;
     }

--- a/src/DDTrace/Log/LoggerInterface.php
+++ b/src/DDTrace/Log/LoggerInterface.php
@@ -8,18 +8,6 @@ namespace DDTrace\Log;
 interface LoggerInterface
 {
     /**
-     * Const list from https://www.php-fig.org/psr/psr-3/
-     */
-    const EMERGENCY = 'emergency';
-    const ALERT     = 'alert';
-    const CRITICAL  = 'critical';
-    const ERROR     = 'error';
-    const WARNING   = 'warning';
-    const NOTICE    = 'notice';
-    const INFO      = 'info';
-    const DEBUG     = 'debug';
-
-    /**
      * Logs a message at the debug level.
      *
      * @param string $message
@@ -48,4 +36,10 @@ interface LoggerInterface
      * @return void
      */
     public function error($message, array $context = array());
+
+    /**
+     * @param string $level
+     * @return bool
+     */
+    public function isLevelActive($level);
 }

--- a/src/DDTrace/Log/LoggingTrait.php
+++ b/src/DDTrace/Log/LoggingTrait.php
@@ -38,11 +38,10 @@ trait LoggingTrait
     }
 
     /**
-     * @param string $level
      * @return bool
      */
-    protected static function isLogLevelActive($level)
+    protected static function isLogDebugActive()
     {
-        return Logger::get()->isLevelActive($level);
+        return Logger::get()->isLevelActive(LogLevel::DEBUG);
     }
 }

--- a/src/DDTrace/Log/LoggingTrait.php
+++ b/src/DDTrace/Log/LoggingTrait.php
@@ -38,10 +38,12 @@ trait LoggingTrait
     }
 
     /**
-     * @return bool
+     * @param \Closure $classback
      */
-    protected static function isLogDebugActive()
+    protected static function whenDebugIsEnabled(\Closure $classback)
     {
-        return Logger::get()->isLevelActive(LogLevel::DEBUG);
+        if (Logger::get()->isLevelActive(LogLevel::DEBUG)) {
+            $classback();
+        }
     }
 }

--- a/src/DDTrace/Log/LoggingTrait.php
+++ b/src/DDTrace/Log/LoggingTrait.php
@@ -36,4 +36,13 @@ trait LoggingTrait
     {
         Logger::get()->error($message, $context);
     }
+
+    /**
+     * @param string $level
+     * @return bool
+     */
+    protected static function isLogLevelActive($level)
+    {
+        return Logger::get()->isLevelActive($level);
+    }
 }

--- a/src/DDTrace/Log/LoggingTrait.php
+++ b/src/DDTrace/Log/LoggingTrait.php
@@ -38,12 +38,10 @@ trait LoggingTrait
     }
 
     /**
-     * @param \Closure $classback
+     * @return bool
      */
-    protected static function whenDebugIsEnabled(\Closure $classback)
+    protected static function isLogDebugActive()
     {
-        if (Logger::get()->isLevelActive(LogLevel::DEBUG)) {
-            $classback();
-        }
+        return Logger::get()->isLevelActive(LogLevel::DEBUG);
     }
 }

--- a/src/DDTrace/Log/NullLogger.php
+++ b/src/DDTrace/Log/NullLogger.php
@@ -5,7 +5,7 @@ namespace DDTrace\Log;
 /**
  * An implementation of the DDTrace\LoggerInterface that logs nothing.
  */
-final class NullLogger implements LoggerInterface
+final class NullLogger extends AbstractLogger
 {
     /**
      * Logs a debug at the debug level.
@@ -39,5 +39,14 @@ final class NullLogger implements LoggerInterface
      */
     public function error($message, array $context = array())
     {
+    }
+
+    /**
+     * @param string $level
+     * @return bool
+     */
+    public function isLevelActive($level)
+    {
+        return false;
     }
 }

--- a/src/DDTrace/Log/PsrLogger.php
+++ b/src/DDTrace/Log/PsrLogger.php
@@ -5,7 +5,7 @@ namespace DDTrace\Log;
 /**
  * An implementation of the DDTrace\LoggerInterface that uses Psr\Log under the hood.
  */
-final class PsrLogger implements LoggerInterface
+final class PsrLogger extends AbstractLogger
 {
     /**
      * @var \Psr\Log\LoggerInterface
@@ -14,14 +14,17 @@ final class PsrLogger implements LoggerInterface
 
     /**
      * @param \Psr\Log\LoggerInterface $psrLogger
+     * @param string $level
      */
-    public function __construct($psrLogger)
+    public function __construct($psrLogger, $level = LogLevel::INFO)
     {
         if (!is_a($psrLogger, '\Psr\Log\LoggerInterface')) {
             throw new \InvalidArgumentException(
                 '\DDTrace\Log\PsrLogger constructor arg must implement \Psr\Log\LoggerInterface'
             );
         }
+
+        parent::__construct($level);
         $this->psrLogger = $psrLogger;
     }
 

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -4,6 +4,7 @@ namespace DDTrace;
 
 use DDTrace\Encoders\Json;
 use DDTrace\Log\LoggingTrait;
+use DDTrace\Log\LogLevel;
 use DDTrace\Propagators\CurlHeadersMap;
 use DDTrace\Propagators\Noop as NoopPropagator;
 use DDTrace\Propagators\TextMap;
@@ -262,7 +263,12 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        self::logDebug('Flushing {count} traces', ['count' => count($this->traces)]);
+        if (self::isLogLevelActive(LogLevel::DEBUG)) {
+            self::logDebug('Flushing {count} traces, {spanCount} spans', [
+                'count' => count($this->traces),
+                'spanCount' => $this->getSpanCount(),
+            ]);
+        }
 
         $tracesToBeSent = $this->shiftFinishedTraces();
 
@@ -379,5 +385,22 @@ final class Tracer implements TracerInterface
     public function getPrioritySampling()
     {
         return $this->prioritySampling;
+    }
+
+    /**
+     * Returns the number of spans currently registered in the tracer.
+     *
+     * @return int
+     */
+    private function getSpanCount()
+    {
+        $count = 0;
+
+        // Spans are arranged in an array of arrays.
+        foreach ($this->traces as $spansInTrace) {
+            $count += count($spansInTrace);
+        }
+
+        return $count;
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -4,7 +4,6 @@ namespace DDTrace;
 
 use DDTrace\Encoders\Json;
 use DDTrace\Log\LoggingTrait;
-use DDTrace\Log\LogLevel;
 use DDTrace\Propagators\CurlHeadersMap;
 use DDTrace\Propagators\Noop as NoopPropagator;
 use DDTrace\Propagators\TextMap;
@@ -263,12 +262,12 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        if (self::isLogDebugActive()) {
+        self::whenDebugIsEnabled(function () {
             self::logDebug('Flushing {count} traces, {spanCount} spans', [
                 'count' => count($this->traces),
                 'spanCount' => $this->getSpanCount(),
             ]);
-        }
+        });
 
         $tracesToBeSent = $this->shiftFinishedTraces();
 

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -262,12 +262,12 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        self::whenDebugIsEnabled(function () {
+        if (self::isLogDebugActive()) {
             self::logDebug('Flushing {count} traces, {spanCount} spans', [
                 'count' => count($this->traces),
                 'spanCount' => $this->getSpanCount(),
             ]);
-        });
+        }
 
         $tracesToBeSent = $this->shiftFinishedTraces();
 

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -263,7 +263,7 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        if (self::isLogLevelActive(LogLevel::DEBUG)) {
+        if (self::isLogDebugActive()) {
             self::logDebug('Flushing {count} traces, {spanCount} spans', [
                 'count' => count($this->traces),
                 'spanCount' => $this->getSpanCount(),

--- a/tests/DebugLogger.php
+++ b/tests/DebugLogger.php
@@ -2,14 +2,20 @@
 
 namespace DDTrace\Tests;
 
+use DDTrace\Log\AbstractLogger;
 use DDTrace\Log\InterpolateTrait;
-use DDTrace\Log\LoggerInterface;
+use DDTrace\Log\LogLevel;
 
-class DebugLogger implements LoggerInterface
+class DebugLogger extends AbstractLogger
 {
     use InterpolateTrait;
 
     private $records = [];
+
+    public function __construct()
+    {
+        parent::__construct(LogLevel::DEBUG);
+    }
 
     /**
      * @param string $message
@@ -18,7 +24,7 @@ class DebugLogger implements LoggerInterface
     public function debug($message, array $context = [])
     {
         $this->records[] = [
-            LoggerInterface::DEBUG,
+            LogLevel::DEBUG,
             $this->interpolate($message, $context),
         ];
     }
@@ -30,7 +36,7 @@ class DebugLogger implements LoggerInterface
     public function warning($message, array $context = array())
     {
         $this->records[] = [
-            LoggerInterface::WARNING,
+            LogLevel::WARNING,
             $this->interpolate($message, $context),
         ];
     }
@@ -42,7 +48,7 @@ class DebugLogger implements LoggerInterface
     public function error($message, array $context = array())
     {
         $this->records[] = [
-            LoggerInterface::ERROR,
+            LogLevel::ERROR,
             $this->interpolate($message, $context),
         ];
     }

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -16,6 +16,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
+            'DD_TRACE_DEBUG' => 'true',
             'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
         ]);
     }


### PR DESCRIPTION
### Description

We had one single error report from a customer that span encoding went out of memory. In order to answer the following questions we need to add a few info to our logs (only in debug mode).

1) is out of memory caused by too many spans?
2) is out of memory caused by a very large method’s argument added to a manually created span?
3) is out of memory caused by a very large method’s argument added to an automatically created span?
4) is memory leak/recursion problem in our encoder?

At the same time calculating some of the info above may be computationally expansive. For this reason this PR also partially refactor the logging engine to provide the log level information as a boolean.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
