### PR TITLE
Disable tracing for specific URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Added
+- Disable tracing for specific URI's #293
+
 ### Fixed
 - Honor ddtrace provided by composer if user provided one #276
 
@@ -11,7 +14,6 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Span::setResource as a legit method # 287
 - Logging more span's info when in debug mode # 292
-- Disable tracing for specific URI's #293
 
 ### Fixed
 - Symfony 4.2 traces generation #280

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Span::setResource as a legit method # 287
 - Logging more span's info when in debug mode # 292
+- Disable tracing for specific URI's #293
 
 ### Fixed
 - Symfony 4.2 traces generation #280

--- a/bridge/dd_init.php
+++ b/bridge/dd_init.php
@@ -7,7 +7,8 @@ use DDTrace\Integrations\IntegrationsLoader;
 
 require_once __DIR__ . '/functions.php';
 
-if (!\DDTrace\Bridge\dd_tracing_enabled()) {
+if (!\DDTrace\Bridge\dd_tracing_enabled()
+    || !\DDTrace\Bridge\dd_tracing_route_enabled()) {
     return;
 }
 

--- a/bridge/dd_init.php
+++ b/bridge/dd_init.php
@@ -8,7 +8,7 @@ use DDTrace\Integrations\IntegrationsLoader;
 require_once __DIR__ . '/functions.php';
 
 if (!\DDTrace\Bridge\dd_tracing_enabled()
-    || !\DDTrace\Bridge\dd_tracing_route_enabled()) {
+        || !\DDTrace\Bridge\dd_tracing_route_enabled()) {
     return;
 }
 

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -8,7 +8,7 @@ if (php_sapi_name() == 'cli' && getenv('APP_ENV') != 'dd_testing') {
     return;
 }
 
-if (!dd_tracing_enabled()) {
+if (!dd_tracing_enabled() || !dd_tracing_route_enabled()) {
     return;
 }
 

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -37,7 +37,7 @@ function dd_tracing_route_enabled($requestUri = null)
     $uris = explode(',', $value);
     foreach ($uris as $uri) {
         $uriRegex = str_replace('\*', '.*', preg_quote(trim($uri), '~'));
-        if (1 === preg_match('~^'.$uriRegex.'$~', $requestUri)) {
+        if (1 === preg_match('~^' . $uriRegex . '$~', $requestUri)) {
             return false;
         }
     }

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -15,14 +15,14 @@ function dd_tracing_enabled()
 }
 
 /**
- * Checks the `DD_DISABLE_URI` env var for routes to disable the tracer on
+ * Checks the `DD_EXPERIMENTAL_DISABLE_URI` env var for routes to disable the tracer on
  *
  * @param string|null $requestUri
  * @return bool
  */
 function dd_tracing_route_enabled($requestUri = null)
 {
-    $value = getenv('DD_DISABLE_URI');
+    $value = getenv('DD_EXPERIMENTAL_DISABLE_URI');
     if (false === $value) {
         // Not setting the env means we default to enabled.
         return true;

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -36,7 +36,7 @@ function dd_tracing_route_enabled($requestUri = null)
 
     $uris = explode(',', $value);
     foreach ($uris as $uri) {
-        $uriRegex = str_replace('\*', '.*', preg_quote(trim($uri), '~'));
+        $uriRegex = str_replace('\*', '[^\/]*', preg_quote(trim($uri), '~'));
         if (1 === preg_match('~^' . $uriRegex . '$~', $requestUri)) {
             return false;
         }

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -11,7 +11,7 @@ function dd_tracing_enabled()
     }
 
     $value = strtolower(trim($value));
-    return !($value === '0' || $value === 'false');
+    return $value !== '0' && $value !== 'false';
 }
 
 /**

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -33,6 +33,9 @@ function dd_tracing_route_enabled($requestUri = null)
     if (!$requestUri) {
         return true;
     }
+    if (false !== $pos = strpos($requestUri, '?')) {
+        $requestUri = substr($requestUri, 0, $pos);
+    }
 
     $uris = explode(',', $value);
     foreach ($uris as $uri) {

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -22,7 +22,8 @@ final class Bootstrap
      */
     public static function tracerOnce()
     {
-        if (self::$bootstrapped) {
+        if (self::$bootstrapped
+                || !\DDTrace\Bridge\dd_tracing_route_enabled()) {
             return;
         }
 

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -57,6 +57,7 @@ namespace DDTrace\Tests\Unit
                 ['/users/' . mt_rand(), false],
                 ['/bar/test', true],
                 ['/bar/' . mt_rand() . '/test', false],
+                ['/bar/' . mt_rand() . '/test?foo=bar', false],
                 ['/bar/' . mt_rand() . '/more/test', true],
                 ['/slow/' . mt_rand() . '.php', false],
             ];

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DDTrace\Tests\Unit;
+
+require __DIR__ . '/../../bridge/functions.php';
+
+final class FunctionsTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        putenv('DD_TRACE_ENABLED');
+        putenv('DD_DISABLE_URI');
+    }
+
+    public function testTracerEnabledByDefault()
+    {
+        $this->assertTrue(\DDTrace\Bridge\dd_tracing_enabled());
+    }
+
+    public function testTracerDisabled()
+    {
+        putenv('DD_TRACE_ENABLED=false');
+        $this->assertFalse(\DDTrace\Bridge\dd_tracing_enabled());
+    }
+
+    public function testTracerEnabledForUrisByDefault()
+    {
+        $this->assertTrue(\DDTrace\Bridge\dd_tracing_route_enabled());
+    }
+
+    /**
+     * @dataProvider urisDataProvider
+     * @param string $uri
+     * @param bool $expected
+     */
+    public function testTracerEnabledOrDisabledForUris($uri, $expected)
+    {
+        putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/index.php?foo=*');
+
+        $this->assertSame(
+            $expected,
+            \DDTrace\Bridge\dd_tracing_route_enabled($uri)
+        );
+    }
+
+    public function urisDataProvider()
+    {
+        return [
+            ['', true],
+            ['/', true],
+            ['/foo', false],
+            ['/users', true],
+            ['/users/'.mt_rand(), false],
+            ['/bar/test', true],
+            ['/bar/'.mt_rand().'/more/test', false],
+            ['/index.php?foo='.mt_rand(), false],
+        ];
+    }
+}

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -13,7 +13,7 @@ namespace DDTrace\Tests\Unit
         {
             parent::setUp();
             putenv('DD_TRACE_ENABLED');
-            putenv('DD_DISABLE_URI');
+            putenv('DD_EXPERIMENTAL_DISABLE_URI');
         }
 
         public function testTracerEnabledByDefault()
@@ -39,7 +39,7 @@ namespace DDTrace\Tests\Unit
          */
         public function testTracerEnabledOrDisabledForUris($uri, $expected)
         {
-            putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/slow/*.php');
+            putenv('DD_EXPERIMENTAL_DISABLE_URI=/foo,/users/*,/bar/*/test,/slow/*.php');
 
             $this->assertSame(
                 $expected,

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -39,7 +39,7 @@ namespace DDTrace\Tests\Unit
          */
         public function testTracerEnabledOrDisabledForUris($uri, $expected)
         {
-            putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/index.php?foo=*');
+            putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/slow/*.php');
 
             $this->assertSame(
                 $expected,
@@ -56,8 +56,9 @@ namespace DDTrace\Tests\Unit
                 ['/users', true],
                 ['/users/' . mt_rand(), false],
                 ['/bar/test', true],
-                ['/bar/' . mt_rand() . '/more/test', false],
-                ['/index.php?foo=' . mt_rand(), false],
+                ['/bar/' . mt_rand() . '/test', false],
+                ['/bar/' . mt_rand() . '/more/test', true],
+                ['/slow/' . mt_rand() . '.php', false],
             ];
         }
     }

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -1,60 +1,64 @@
 <?php
 
-namespace DDTrace\Tests\Unit;
-
-require __DIR__ . '/../../bridge/functions.php';
-
-final class FunctionsTest extends BaseTestCase
+namespace
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        putenv('DD_TRACE_ENABLED');
-        putenv('DD_DISABLE_URI');
-    }
+    require __DIR__ . '/../../bridge/functions.php';
+}
 
-    public function testTracerEnabledByDefault()
+namespace DDTrace\Tests\Unit
+{
+    final class FunctionsTest extends BaseTestCase
     {
-        $this->assertTrue(\DDTrace\Bridge\dd_tracing_enabled());
-    }
+        protected function setUp()
+        {
+            parent::setUp();
+            putenv('DD_TRACE_ENABLED');
+            putenv('DD_DISABLE_URI');
+        }
 
-    public function testTracerDisabled()
-    {
-        putenv('DD_TRACE_ENABLED=false');
-        $this->assertFalse(\DDTrace\Bridge\dd_tracing_enabled());
-    }
+        public function testTracerEnabledByDefault()
+        {
+            $this->assertTrue(\DDTrace\Bridge\dd_tracing_enabled());
+        }
 
-    public function testTracerEnabledForUrisByDefault()
-    {
-        $this->assertTrue(\DDTrace\Bridge\dd_tracing_route_enabled());
-    }
+        public function testTracerDisabled()
+        {
+            putenv('DD_TRACE_ENABLED=false');
+            $this->assertFalse(\DDTrace\Bridge\dd_tracing_enabled());
+        }
 
-    /**
-     * @dataProvider urisDataProvider
-     * @param string $uri
-     * @param bool $expected
-     */
-    public function testTracerEnabledOrDisabledForUris($uri, $expected)
-    {
-        putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/index.php?foo=*');
+        public function testTracerEnabledForUrisByDefault()
+        {
+            $this->assertTrue(\DDTrace\Bridge\dd_tracing_route_enabled());
+        }
 
-        $this->assertSame(
-            $expected,
-            \DDTrace\Bridge\dd_tracing_route_enabled($uri)
-        );
-    }
+        /**
+         * @dataProvider urisDataProvider
+         * @param string $uri
+         * @param bool $expected
+         */
+        public function testTracerEnabledOrDisabledForUris($uri, $expected)
+        {
+            putenv('DD_DISABLE_URI=/foo,/users/*,/bar/*/test,/index.php?foo=*');
 
-    public function urisDataProvider()
-    {
-        return [
-            ['', true],
-            ['/', true],
-            ['/foo', false],
-            ['/users', true],
-            ['/users/'.mt_rand(), false],
-            ['/bar/test', true],
-            ['/bar/'.mt_rand().'/more/test', false],
-            ['/index.php?foo='.mt_rand(), false],
-        ];
+            $this->assertSame(
+                $expected,
+                \DDTrace\Bridge\dd_tracing_route_enabled($uri)
+            );
+        }
+
+        public function urisDataProvider()
+        {
+            return [
+                ['', true],
+                ['/', true],
+                ['/foo', false],
+                ['/users', true],
+                ['/users/' . mt_rand(), false],
+                ['/bar/test', true],
+                ['/bar/' . mt_rand() . '/more/test', false],
+                ['/index.php?foo=' . mt_rand(), false],
+            ];
+        }
     }
 }


### PR DESCRIPTION
### Description

Tracing for specific URI's can be disabled with a comma-separated list of URI's that support `*` as a wildcard. The list of URI's is supplied by the `DD_DISABLE_URI` env var. For example:

`DD_DISABLE_URI=/foo,/users/*,/index.php?foo=*`

To keep things simple and less bug-prone, I decided to add this functionality in the "proceduraly" part of the tracer to ensure this can be checked before any autoloading/detection/injection occurs.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
