### PR TITLE
[ci] In CI disable tls check for 5.4 only to avoid Peer fingerprint mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ aliases:
       paths:
         - vendor/
 
+  - &STEP_COMPOSER_DISABLE_TLS
+    run:
+      name: Disabling tls for php < 5.6 (https://stackoverflow.com/questions/47527455/getting-an-error-peer-fingerprint-did-not-match-after-running-composer-update)
+      command: composer config disable-tls true
+
   - &STEP_COMPOSER_INSTALL
     run:
       name: Installing dependencies with composer
@@ -281,6 +286,7 @@ jobs:
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_CACHE_RESTORE
+      - <<: *STEP_COMPOSER_DISABLE_TLS
       - <<: *STEP_COMPOSER_INSTALL
       - <<: *STEP_COMPOSER_CACHE_SAVE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR


### PR DESCRIPTION
### Description

Very often php 5.4 tests were failing with [this same error](https://stackoverflow.com/questions/47527455/getting-an-error-peer-fingerprint-did-not-match-after-running-composer-update). Apparently the reason is PHP 5.4 having some issues with tls verification (https://github.com/composer/composer/blob/master/src/Composer/Util/RemoteFilesystem.php#L354). The solution proposed here is to disable tls only when downloading libraries using composer for php 5.4. This has no security implications as this is only done for tests execution and not during package build.

### Readiness checklist
- ~[ ] [Changelog entry](docs/changelog.md) added, if necessary~
- ~[ ] Tests added for this feature/bug~
