### PR TITLE
Misfunctioning tls in php 5.4 auto-instrumentation tests

### DIFF
--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -54,7 +54,9 @@ class AutoInstrumentationTest extends BaseTestCase
         $here = __DIR__;
         $scenarioFolder = $this->buildScenarioAbsPath($scenario);
         exec("cd $scenarioFolder && composer update -q && cd $here", $output, $return);
-        $this->assertSame(0, $return);
+        if (0 !== $return) {
+            $this->fail('Error while preparing the env: ' . implode("\n", $output));
+        }
     }
 
     private function buildScenarioAbsPath($scenario)

--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -53,7 +53,11 @@ class AutoInstrumentationTest extends BaseTestCase
     {
         $here = __DIR__;
         $scenarioFolder = $this->buildScenarioAbsPath($scenario);
-        exec("cd $scenarioFolder && composer update -q && cd $here", $output, $return);
+        exec(
+            "cd $scenarioFolder && composer config disable-tls true && composer update -q && cd $here",
+            $output,
+            $return
+        );
         if (0 !== $return) {
             $this->fail('Error while preparing the env: ' . implode("\n", $output));
         }


### PR DESCRIPTION
### Description

Disable tls when updating dependencies for auto-instrumentation tests.

### Readiness checklist
- ~[ ] [Changelog entry](docs/changelog.md) added, if necessary~
- ~[ ] Tests added for this feature/bug~
