### PR TITLE
Stop prematurely freeing `this` pointer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ aliases:
   - &STEP_RUN_EXTENSION_TESTS
     run:
       name: Run extension tests with leak detection
-      command: TEST_PHP_JUNIT=$(pwd)/test-results/leak_test.xml REPORT_EXIT_STATUS=1 make test_c_mem
+      command: make test_extension_ci JUNIT_RESULTS_DIR=$(pwd)/test-results
 
   - &STEP_WAIT_AGENT
     run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file - [read more](docs/changelog.md).
 
 ## [Unreleased]
+### Fixed
+- 7.x handling of `$this` pointer passed to the closure causing errors in PHP VM #311
 
 ## [0.13.2]
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test_c: $(SO_FILE)
 	$(MAKE) -C $(BUILD_DIR) test TESTS="-q --show-all $(TESTS)"
 
 test_c_mem: $(SO_FILE)
-	$(MAKE) -C $(BUILD_DIR) test TESTS="-q --show-all -m $(TESTS) && grep -e 'errors="0"' ${TEST_PHP_JUNIT} )
+	$(MAKE) -C $(BUILD_DIR) test TESTS="-q --show-all -m $(TESTS)"
 
 test_extension_ci: $(SO_FILE)
 	( \

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -20,27 +20,27 @@
 #define RETURN_VALUE_USED(opline) (!((opline)->result_type & EXT_TYPE_UNUSED))
 #endif
 
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
 #if PHP_VERSION_ID < 70000
 #undef EX
 #define EX(x) ((execute_data)->x)
-#endif
 
-ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
-
+#else  // PHP7.0+
 // imported from PHP 7.2 as 7.0 missed this method
-zend_class_entry *get_executed_scope(void)
-{
-	zend_execute_data *ex = EG(current_execute_data);
+zend_class_entry *get_executed_scope(void) {
+    zend_execute_data *ex = EG(current_execute_data);
 
-	while (1) {
-		if (!ex) {
-			return NULL;
-		} else if (ex->func && (ZEND_USER_CODE(ex->func->type) || ex->func->common.scope)) {
-			return ex->func->common.scope;
-		}
-		ex = ex->prev_execute_data;
-	}
+    while (1) {
+        if (!ex) {
+            return NULL;
+        } else if (ex->func && (ZEND_USER_CODE(ex->func->type) || ex->func->common.scope)) {
+            return ex->func->common.scope;
+        }
+        ex = ex->prev_execute_data;
+    }
 }
+#endif
 
 static ddtrace_dispatch_t *lookup_dispatch(const HashTable *lookup, const char *function_name,
                                            uint32_t function_name_length) {

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -140,7 +140,16 @@ static void execute_fcall(ddtrace_dispatch_t *dispatch, zend_execute_data *execu
 
 _exit_cleanup:
     if (this) {
+#if PHP_VERSION_ID < 70000
         Z_DELREF_P(this);
+
+#else
+        zend_function *constructor = Z_OBJ_HT_P(this)->get_constructor(Z_OBJ_P(this));
+
+        if ((zend_get_executed_scope() != dispatch->clazz) || constructor) {
+            Z_DELREF_P(this);
+        }
+#endif
     }
 
     Z_DELREF(closure);


### PR DESCRIPTION
### Description
Fixes misconfiguration of CircleCI that allowed failing tests to pass. 
Fixes lifecycle management for `$this` pointer in the C extension

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
