### PR TITLE
Fix accessing freed memory when instrumentation code un/instrumented itself 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file - [read more](docs/changelog.md).
 
 ## [Unreleased]
+### Fixed
+- Accessing freed memory when instrumentation code un/instrumented itself #314
 
 ## [0.13.3]
 

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -244,8 +244,8 @@ static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data
     }
 
     if (dispatch && !dispatch->busy) {
-        ddtrace_class_lookup_acquire(dispatch); // protecting against dispatch being freed during php code execution
-        dispatch->busy = 1;  // guard against recursion, catching only topmost execution
+        ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
+        dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
 #if PHP_VERSION_ID < 50600
         if (EX(opline)->opcode == ZEND_DO_FCALL) {
@@ -466,11 +466,9 @@ int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
     return default_dispatch(execute_data TSRMLS_CC);
 }
 
-void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *dispatch){
-    dispatch->acquired++;
-}
+void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *dispatch) { dispatch->acquired++; }
 
-void ddtrace_class_lookup_release(ddtrace_dispatch_t *dispatch){
+void ddtrace_class_lookup_release(ddtrace_dispatch_t *dispatch) {
     if (dispatch->acquired > 0) {
         dispatch->acquired--;
     }

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -6,13 +6,16 @@
 
 typedef struct _ddtrace_dispatch_t {
     zval callable;
-    zend_uchar flags;
+    zend_bool busy;
+    uint32_t acquired;
     zend_class_entry *clazz;
     STRING_T *function;
 } ddtrace_dispatch_t;
 
 zend_bool ddtrace_trace(zend_class_entry *, STRING_T *, zval *TSRMLS_DC);
 int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
+void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);
+void ddtrace_class_lookup_release(ddtrace_dispatch_t *);
 void ddtrace_dispatch_init(TSRMLS_D);
 void ddtrace_dispatch_inject(TSRMLS_D);
 void ddtrace_dispatch_destroy(TSRMLS_D);

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -1,7 +1,9 @@
 #ifndef DISPATCH_H
 #define DISPATCH_H
 
-#include "Zend/zend_types.h"
+#include <Zend/zend_types.h>
+#include <stdint.h>
+
 #include "compat_zend_string.h"
 
 typedef struct _ddtrace_dispatch_t {

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -6,11 +6,11 @@
 
 #if PHP_VERSION_ID < 70000
 #include "dispatch_compat_php5.h"
-void ddtrace_class_lookup_free(void *zv);
+void ddtrace_class_lookup_release_compat(void *zv);
 
 #define ddtrace_zval_ptr_dtor(x) zval_dtor(x)
 #else
-void ddtrace_class_lookup_free(zval *zv);
+void ddtrace_class_lookup_release_compat(zval *zv);
 
 #define ddtrace_zval_ptr_dtor(x) zval_ptr_dtor(x)
 #define INIT_ZVAL(x) ZVAL_NULL(&x)

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -27,7 +27,7 @@ void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
     zval_ptr_dtor(&dispatch->callable);
 }
 
-void ddtrace_class_lookup_release_compat(zval *zv){
+void ddtrace_class_lookup_release_compat(zval *zv) {
     DD_PRINTF("freeing %p", (void *)zv);
     ddtrace_dispatch_t *dispatch = Z_PTR_P(zv);
     ddtrace_class_lookup_release(dispatch);

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -41,7 +41,7 @@ static inline void dispatch_table_dtor(void *zv) {
 
 void ddtrace_dispatch_init(TSRMLS_D) {
     zend_hash_init(&DDTRACE_G(class_lookup), 8, NULL, (dtor_func_t)dispatch_table_dtor, 0);
-    zend_hash_init(&DDTRACE_G(function_lookup), 8, NULL, (dtor_func_t)ddtrace_class_lookup_free, 0);
+    zend_hash_init(&DDTRACE_G(function_lookup), 8, NULL, (dtor_func_t)ddtrace_class_lookup_release_compat, 0);
 }
 
 void ddtrace_dispatch_destroy(TSRMLS_D) {

--- a/tests/ext/used_dispatch_shouldn_t_be_freed.phpt
+++ b/tests/ext/used_dispatch_shouldn_t_be_freed.phpt
@@ -1,0 +1,22 @@
+--TEST--
+xxx
+--FILE--
+<?php
+function test($a){
+    dd_trace("test", function($a){
+        return 'NEW HOOK ' . test($a);
+    });
+    return 'METHOD ' . $a;
+}
+
+dd_trace("test", function($a){
+    return 'OLD HOOK ' . test($a);
+});
+
+echo test("exec_a") . PHP_EOL;
+echo test("exec_b") . PHP_EOL;
+
+?>
+--EXPECT--
+OLD HOOK METHOD exec_a
+NEW HOOK METHOD exec_b

--- a/tests/ext/used_dispatch_shouldn_t_be_freed.phpt
+++ b/tests/ext/used_dispatch_shouldn_t_be_freed.phpt
@@ -1,5 +1,5 @@
 --TEST--
-xxx
+Check if we can safely override instrumentation from within instrumentation.
 --FILE--
 <?php
 function test($a){


### PR DESCRIPTION
### Description
In rare cases where instrumented code have actually removed/changed existing instrumentation of its own execution a freed pointer was accessed when removing recursion guard. 

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
