### PR TITLE
Fix invalid memory access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file - [read more
 ## [Unreleased]
 ### Fixed
 - Accessing freed memory when instrumentation code un/instrumented itself #314
+- Freeing `$this` object prematurely in PHP-FPM VM #317
 
 ## [0.13.3]
 

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -157,12 +157,9 @@ _exit_cleanup:
     if (this) {
 #if PHP_VERSION_ID < 70000
         Z_DELREF_P(this);
-
 #else
-        zend_function *constructor = Z_OBJ_HT_P(this)->get_constructor(Z_OBJ_P(this));
-
-        if ((get_executed_scope() != dispatch->clazz) || constructor) {
-            Z_DELREF_P(this);
+        if (EX_CALL_INFO() & ZEND_CALL_RELEASE_THIS) {
+            OBJ_RELEASE(Z_OBJ(execute_data->This));
         }
 #endif
     }


### PR DESCRIPTION
### Description

`This` object handled in the wrapping function needs to be safely released eg when it was created in a closure. 
Before this change we tried to guess those situatios, but while this did work in all cases hapenning in our tests it didn't correctly address all cases, thus in php-fpm in a few instances the This object was freed prematurely, causing memory access problems further down object processing line.

This PR reuses mechanism used e.g. in processing of zend_closure, which checks if the this objects needs to be freed in call info data, which should be correctly set if the This objects needs to be released.
<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
