### PR TITLE
Replicate in tests autoloader that die() on class not found

### DIFF
--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -46,6 +46,11 @@ class AutoInstrumentationTest extends BaseTestCase
             // an issue when we run `class_exist` during the first phases of auto-instrumentation because the loader
             // would try to `include_once` a file (e.g. 'DDTrace/Tracer.php') that does not exists.
             ['autoloader_includes_even_non_existing', $currentTracerVersion, false],
+
+            // In some cases, autoloaders exit() or die() if they don't find a class. This test makes sure that in our
+            // auto-instrumentation code we never try to `class_exists()`, `method_exists()` or `defined()` outside of
+            // DDTrace namespace.
+            ['autoloader_die_on_not_found', $currentTracerVersion, false],
         ];
     }
 

--- a/tests/AutoInstrumentation/scenarios/autoloader_die_on_not_found/index.php
+++ b/tests/AutoInstrumentation/scenarios/autoloader_die_on_not_found/index.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Replicating cases when the class loader dies if file not found.
+ */
+class AutoloaderDieOnNotFound
+{
+    public static function load($class)
+    {
+        die('I/Do/Not/Exist.php');
+    }
+}
+
+spl_autoload_register('AutoloaderDieOnNotFound::load');
+
+echo DDTrace\Tracer::VERSION;


### PR DESCRIPTION
### Description

Some of our users rely on autoloaders that `die()` or `exit()` when tey do not found a class. Previously we were not compatible with this behavior. Version 0.14.0 added compatibility with such class loaders. This PR simply add a test to make sure that we keep this compatibility alive.

### Readiness checklist
- ~[ ] [Changelog entry](docs/changelog.md) added, if necessary~
- [x] Tests added for this feature/bug~
