### PR TITLE
Ensure function name is copied and zval is recreated in php 7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file - [read more](docs/changelog.md).
 
 ## [Unreleased]
+### Fixed
+- Ensure Function name is safely copied to avoid freeing persistent string #333
 
 ## [0.14.1]
 

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -110,18 +110,16 @@ zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable TS
 
     ddtrace_dispatch_t dispatch;
     memset(&dispatch, 0, sizeof(ddtrace_dispatch_t));
-
-    dispatch.function_name = *function_name;  // method/function names are case insensitive in PHP
     dispatch.callable = *callable;
 
 #if PHP_VERSION_ID < 70000
     ZVAL_STRINGL(&dispatch.function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name), 1);
 #else
-    zval_copy_ctor(&dispatch.function_name);
+    ZVAL_STRINGL(&dispatch.function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name));
 #endif
     zval_copy_ctor(&dispatch.callable);
 
-    ddtrace_downcase_zval(&dispatch.function_name);
+    ddtrace_downcase_zval(&dispatch.function_name);  // method/function names are case insensitive in PHP
 
     if (ddtrace_dispatch_store(overridable_lookup, &dispatch)) {
         return 1;


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
