### PR TITLE
Resource name on Symfony 2.x requests served through controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Resource name on Symfony 2.x requests served through controllers #341
+
 ## [0.15.0]
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -257,6 +257,11 @@
         "laravel-57-update": "composer --working-dir=tests/Frameworks/Laravel/Version_5_7 update",
         "laravel-57-test": "@composer test -- tests/Integrations/Laravel/V5/CommonScenariosTest.php",
 
+        "symfony-28-update": [
+            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_2_8 update"
+        ],
+        "symfony-28-test": "@composer test -- tests/Integrations/Symfony/V2_8",
+
         "symfony-33-update": [
             "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_3_3 update",
             "php tests/Frameworks/Symfony/Version_3_3/bin/console cache:clear --no-warmup --env=prod"

--- a/composer.json
+++ b/composer.json
@@ -189,8 +189,6 @@
         "test-web-54": [
             "@laravel-42-update",
             "@laravel-42-test",
-            "@symfony-28-update",
-            "@symfony-28-test",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-update",
             "@custom-framework-autoloaded-test"

--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,8 @@
         "test-web-54": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-28-update",
+            "@symfony-28-test",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-update",
             "@custom-framework-autoloaded-test"
@@ -196,6 +198,8 @@
         "test-web-56": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-28-update",
+            "@symfony-28-test",
             "@symfony-33-update",
             "@symfony-33-test",
             "@symfony-34-update",
@@ -207,6 +211,8 @@
         "test-web-70": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-28-update",
+            "@symfony-28-test",
             "@symfony-33-update",
             "@symfony-33-test",
             "@symfony-34-update",
@@ -220,6 +226,8 @@
             "@laravel-42-test",
             "@laravel-57-update",
             "@laravel-57-test",
+            "@symfony-28-update",
+            "@symfony-28-test",
             "@symfony-33-update",
             "@symfony-33-test",
             "@symfony-34-update",
@@ -235,6 +243,8 @@
             "@laravel-42-test",
             "@laravel-57-update",
             "@laravel-57-test",
+            "@symfony-28-update",
+            "@symfony-28-test",
             "@symfony-33-update",
             "@symfony-33-test",
             "@symfony-34-update",

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -142,4 +142,11 @@ interface Tracer
      * @return Scope|null
      */
     public function getRootScope();
+
+    /**
+     * Returns the root span or null and never throws an exception.
+     *
+     * @return Span|null
+     */
+    public function getSafeRootSpan();
 }

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -2,8 +2,12 @@
 
 namespace DDTrace\Integrations\Symfony;
 
+use DDTrace\Contracts\Span;
+use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
+use DDTrace\Util\TryCatchFinally;
 use DDTrace\Util\Versions;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 class SymfonyIntegration
 {
@@ -18,6 +22,8 @@ class SymfonyIntegration
 
     private function doLoad()
     {
+        $self = $this;
+
         // This is necessary because Symfony\Component\HttpKernel\Kernel::boot it is not properly traced if we do not
         // wrap the context when it is called, which if Symfony\Component\HttpKernel\Kernel::handle.
         dd_trace('Symfony\Component\HttpKernel\Kernel', 'handle', function () {
@@ -25,7 +31,7 @@ class SymfonyIntegration
             return call_user_func_array([$this, 'handle'], $args);
         });
 
-        dd_trace('Symfony\Component\HttpKernel\Kernel', 'boot', function () {
+        dd_trace('Symfony\Component\HttpKernel\Kernel', 'boot', function () use ($self) {
             $result = call_user_func_array([$this, 'boot'], func_get_args());
 
             $name = SymfonyIntegration::BUNDLE_NAME;
@@ -39,6 +45,11 @@ class SymfonyIntegration
                     $bundle = new \DDTrace\Integrations\Symfony\V3\SymfonyBundle();
                 } elseif (Versions::versionMatches('4', $version)) {
                     $bundle = new \DDTrace\Integrations\Symfony\V4\SymfonyBundle();
+                } elseif (Versions::versionMatches('2', $version)) {
+                    // We do not register the bundle as we do not fully support Symfony 2.8 yet. And probably we won't
+                    // use bundles in the future anymore
+                    $bundle = null;
+                    $self->setupResourceNameTracingV2();
                 }
 
                 if ($bundle) {
@@ -56,5 +67,41 @@ class SymfonyIntegration
         });
 
         return Integration::LOADED;
+    }
+
+    /**
+     * Resource name assignment for Symfony 2.
+     */
+    public function setupResourceNameTracingV2()
+    {
+        dd_trace('Symfony\Component\HttpKernel\Event\FilterControllerEvent', 'setController', function () {
+            $args = func_get_args();
+            $controllerInfo = $args[0];
+            $resourceParts = [];
+
+            // Controller info can be provided in various ways.
+            if (is_string($controllerInfo)) {
+                $resourceParts[] = $controllerInfo;
+            } elseif (is_array($controllerInfo) && count($controllerInfo) === 2) {
+                if (is_object($controllerInfo[0])) {
+                    $resourceParts[] = get_class($controllerInfo[0]);
+                } elseif (is_string($controllerInfo[0])) {
+                    $resourceParts[] = $controllerInfo[0];
+                }
+
+                if (is_string($controllerInfo[1])) {
+                    $resourceParts[] = $controllerInfo[1];
+                }
+            }
+
+            if (count($resourceParts) > 0) {
+                $tracer = GlobalTracer::get();
+                if ($rootSpan = $tracer->getSafeRootSpan()) {
+                    $rootSpan->setResource(implode(' ', $resourceParts));
+                }
+            }
+
+            return call_user_func_array([$this, 'setController'], $args);
+        });
     }
 }

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -7,6 +7,7 @@
 
 namespace DDTrace;
 
+use DDTrace\Contracts\Span;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Contracts\Tracer as TracerInterface;
 
@@ -93,5 +94,15 @@ final class NoopTracer implements TracerInterface
     public function getRootScope()
     {
         return NoopScope::create();
+    }
+
+    /**
+     * Returns the root span or null and never throws an exception.
+     *
+     * @return Span|null
+     */
+    public function getSafeRootSpan()
+    {
+        return NoopSpan::create();
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -13,6 +13,7 @@ use DDTrace\Transport\Http;
 use DDTrace\Transport\Noop as NoopTransport;
 use DDTrace\Exceptions\UnsupportedFormat;
 use DDTrace\Contracts\Scope as ScopeInterface;
+use DDTrace\Contracts\Span as SpanInterface;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Contracts\Tracer as TracerInterface;
 
@@ -401,5 +402,21 @@ final class Tracer implements TracerInterface
         }
 
         return $count;
+    }
+
+    /**
+     * Returns the root span or null and never throws an exception.
+     *
+     * @return SpanInterface|null
+     */
+    public function getSafeRootSpan()
+    {
+        $rootScope = $this->getRootScope();
+
+        if (empty($rootScope)) {
+            return null;
+        }
+
+        return $rootScope->getSpan();
     }
 }

--- a/tests/Frameworks/Symfony/Version_2_8/.gitattributes
+++ b/tests/Frameworks/Symfony/Version_2_8/.gitattributes
@@ -1,4 +1,0 @@
-*/ linguist-generated
-.*/ linguist-generated
-* linguist-generated
-*.* linguist-generated

--- a/tests/Frameworks/Symfony/Version_2_8/src/AppBundle/Controller/DefaultController.php
+++ b/tests/Frameworks/Symfony/Version_2_8/src/AppBundle/Controller/DefaultController.php
@@ -11,7 +11,7 @@ class DefaultController extends Controller
     /**
      * @Route("/", name="homepage")
      */
-    public function indexAction(Request $request)
+    public function testingRouteNameAction(Request $request)
     {
         // replace this example code with whatever you need
         return $this->render('default/index.html.twig', array(

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V2_8;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class RouteNameTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_2_8/web/app_dev.php';
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testResource2UriMapping()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec  = GetSpec::create('Resource name properly set to route', '/');
+            $this->call($spec);
+        });
+
+        $this->assertExpectedSpans($this, $traces, [
+            SpanAssertion::build(
+                'web.request',
+                'web.request',
+                'web',
+                'AppBundle\Controller\DefaultController testingRouteNameAction'
+            )->withExactTags([
+                'http.method' => 'GET',
+                'http.url' => '/',
+                'http.status_code' => '200',
+            ]),
+        ]);
+    }
+}


### PR DESCRIPTION
### Description

Properly set resource names on Symfony 2.x controllers.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
