### PR TITLE
Sanitize url in web spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Fixed
 - Resource name on Symfony 2.x requests served through controllers #341
+- Sanitize url in web spans #344
 
 ## [0.15.0]
 

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -86,9 +86,9 @@ final class GuzzleIntegration
     private function setUrlTag(Span $span, $request)
     {
         if (is_a($request, '\GuzzleHttp\Message\RequestInterface')) {
-            $span->setTag(Tag::HTTP_URL, Urls::sanitize($request->getUrl()));
+            $span->setTag(Tag::HTTP_URL, $request->getUrl());
         } elseif (is_a($request, '\Psr\Http\Message\RequestInterface')) {
-            $span->setTag(Tag::HTTP_URL, Urls::sanitize($request->getUri()));
+            $span->setTag(Tag::HTTP_URL, $request->getUri());
         }
     }
 
@@ -99,12 +99,12 @@ final class GuzzleIntegration
     private function setStatusCodeTag(Span $span, $response)
     {
         if (is_a($response, '\GuzzleHttp\Message\ResponseInterface')) {
-            $span->setTag(Tag::HTTP_STATUS_CODE, Urls::sanitize($response->getStatusCode()), true);
+            $span->setTag(Tag::HTTP_STATUS_CODE, $response->getStatusCode(), true);
         } elseif (is_a($response, '\Psr\Http\Message\ResponseInterface')) {
-            $span->setTag(Tag::HTTP_STATUS_CODE, Urls::sanitize($response->getStatusCode()), true);
+            $span->setTag(Tag::HTTP_STATUS_CODE, $response->getStatusCode(), true);
         } elseif (is_a($response, '\GuzzleHttp\Promise\Promise')) {
             $response->then(function ($response) use ($span) {
-                $span->setTag(Tag::HTTP_STATUS_CODE, Urls::sanitize($response->getStatusCode()), true);
+                $span->setTag(Tag::HTTP_STATUS_CODE, $response->getStatusCode(), true);
             });
         }
     }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -5,6 +5,7 @@ namespace DDTrace;
 use DDTrace\Contracts\Span as SpanInterface;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Exceptions\InvalidSpanArgument;
+use DDTrace\Http\Urls;
 use Exception;
 use InvalidArgumentException;
 use Throwable;
@@ -201,6 +202,10 @@ final class Span implements SpanInterface
         if ($key === Tag::SPAN_TYPE) {
             $this->type = $value;
             return;
+        }
+
+        if ($key === Tag::HTTP_URL) {
+            $value = Urls::sanitize((string)$value);
         }
 
         $this->tags[$key] = (string)$value;

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -191,6 +191,15 @@ final class SpanTest extends Framework\TestCase
         $span->setTag(1, self::TAG_VALUE);
     }
 
+    public function testHttpUrlIsSanitizedInTag()
+    {
+        $span = $this->createSpan();
+        $url = 'https://example.com/some/path/index.php?some=param&other=param';
+
+        $span->setTag(Tag::HTTP_URL, $url);
+        $this->assertSame('https://example.com/some/path/index.php', $span->getAllTags()[Tag::HTTP_URL]);
+    }
+
     private function createSpan()
     {
         $context = SpanContext::createAsRoot();


### PR DESCRIPTION
This PR move urls sanitization to the span when a tag is recorded with name
http.url. Previously we did it manually in every place and forgot to do it in quite
a few of them

In order to sanitize we use the already available Urls::sanitize() method.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
