### PR TITLE
Disable request_hook_init if blacklisted module has beed detected 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,84 +453,84 @@ workflows:
             - "PHP 71 zts 20160303-zts"
             - "PHP 72 zts 20170718-zts"
             - "PHP 73 zts 20180731-zts"
-      # - "package verification":
-      #     requires:
-      #       - "package extension"
+      - "package verification":
+          requires:
+            - "package extension"
       - verify_package:
           requires: [ "package extension" ]
           name: "webdevops/php:7.1"
           docker_image: webdevops/php:7.1
           package_type: deb
-  # build:
-  #   jobs:
-  #     - unit_tests:
-  #         name: "PHP 54 Unit tests"
-  #         image_tag: ddtrace_alpine_php-5.4-debug
-  #     - unit_tests:
-  #         name: "PHP 56 Unit tests"
-  #         image_tag: ddtrace_alpine_php-5.6-debug
-  #     - unit_tests:
-  #         name: "PHP 70 Unit tests"
-  #         image_tag: ddtrace_alpine_php-7.0-debug
-  #     - unit_tests:
-  #         name: "PHP 71 Unit tests"
-  #         image_tag: ddtrace_alpine_php-7.1-debug
-  #     - unit_tests:
-  #         name: "PHP 72 Unit tests"
-  #         image_tag: ddtrace_alpine_php-7.2-debug
-  #     # - unit_tests:
-  #     #     name: "PHP 70 Unit tests-zts"
-  #     #     image_tag: ddtrace_alpine_php-7.0-zts-debug # zts build is failing atm due to 2 memory leaks
-  #     # - unit_tests:
-  #     #     name: "PHP 73 Unit tests"
-  #     #     version: "7.3" # TODO: unit test for 7.3 are failing due to memory leaks - 7.3 not yet officially supported
-  #     - integration_tests:
-  #         name: "PHP 54 Integration tests"
-  #         image_tag: "ddtrace_alpine_php-5.4-debug"
-  #         integration_testsuite: "test-integrations-54"
-  #     - integration_tests:
-  #         name: "PHP 56 Integration tests"
-  #         integration_testsuite: "test-integrations-56"
-  #         image_tag: "ddtrace_alpine_php-5.6-debug"
-  #     - integration_tests:
-  #         name: "PHP 70 Integration tests"
-  #         integration_testsuite: "test-integrations-70"
-  #         image_tag: "ddtrace_alpine_php-7.0-debug"
-  #     - integration_tests:
-  #         name: "PHP 71 Integration tests"
-  #         integration_testsuite: "test-integrations-71"
-  #         image_tag: "ddtrace_alpine_php-7.1-debug"
-  #     - integration_tests:
-  #         name: "PHP 72 Integration tests"
-  #         integration_testsuite: "test-integrations-72"
-  #         image_tag: "ddtrace_alpine_php-7.2-debug"
-  #     # - integration_tests:
-  #     #     name: "PHP 73 Integration tests"
-  #     #     integration_testsuite: "test-integrations-72" # not yet defined for 7.3
-  #     #     image_tag: "ddtrace_alpine_php-7.3-debug" # image is missing proper mcrypt support - to be investigated
-  #     - integration_tests:
-  #         name: "PHP 54 Web integration tests"
-  #         image_tag: "ddtrace_alpine_php-5.4-debug"
-  #         integration_testsuite: "test-web-54"
-  #     - integration_tests:
-  #         name: "PHP 56 Web integration tests"
-  #         integration_testsuite: "test-web-56"
-  #         image_tag: "ddtrace_php_5_6"
-  #     - integration_tests:
-  #         name: "PHP 70 Web integration tests"
-  #         integration_testsuite: "test-web-70"
-  #         image_tag: "ddtrace_alpine_php-7.0-debug"
-  #     - integration_tests:
-  #         name: "PHP 71 Web integration tests"
-  #         integration_testsuite: "test-web-71"
-  #         image_tag: "ddtrace_alpine_php-7.1-debug"
-  #     - integration_tests:
-  #         name: "PHP 72 Web integration tests"
-  #         integration_testsuite: "test-web-72"
-  #         image_tag: "ddtrace_php_7_2"
-  #     # - integration_tests:
-  #     #     name: "PHP 73 Web integration tests"
-  #     #     integration_testsuite: "test-web-72" # not yet defined for 7.3
-  #     #     image_tag: "ddtrace_alpine_php-7.3-debug"
-  #     - "Lint files"
-  #     - "Static Analysis"
+  build:
+    jobs:
+      - unit_tests:
+          name: "PHP 54 Unit tests"
+          image_tag: ddtrace_alpine_php-5.4-debug
+      - unit_tests:
+          name: "PHP 56 Unit tests"
+          image_tag: ddtrace_alpine_php-5.6-debug
+      - unit_tests:
+          name: "PHP 70 Unit tests"
+          image_tag: ddtrace_alpine_php-7.0-debug
+      - unit_tests:
+          name: "PHP 71 Unit tests"
+          image_tag: ddtrace_alpine_php-7.1-debug
+      - unit_tests:
+          name: "PHP 72 Unit tests"
+          image_tag: ddtrace_alpine_php-7.2-debug
+      # - unit_tests:
+      #     name: "PHP 70 Unit tests-zts"
+      #     image_tag: ddtrace_alpine_php-7.0-zts-debug # zts build is failing atm due to 2 memory leaks
+      # - unit_tests:
+      #     name: "PHP 73 Unit tests"
+      #     version: "7.3" # TODO: unit test for 7.3 are failing due to memory leaks - 7.3 not yet officially supported
+      - integration_tests:
+          name: "PHP 54 Integration tests"
+          image_tag: "ddtrace_alpine_php-5.4-debug"
+          integration_testsuite: "test-integrations-54"
+      - integration_tests:
+          name: "PHP 56 Integration tests"
+          integration_testsuite: "test-integrations-56"
+          image_tag: "ddtrace_alpine_php-5.6-debug"
+      - integration_tests:
+          name: "PHP 70 Integration tests"
+          integration_testsuite: "test-integrations-70"
+          image_tag: "ddtrace_alpine_php-7.0-debug"
+      - integration_tests:
+          name: "PHP 71 Integration tests"
+          integration_testsuite: "test-integrations-71"
+          image_tag: "ddtrace_alpine_php-7.1-debug"
+      - integration_tests:
+          name: "PHP 72 Integration tests"
+          integration_testsuite: "test-integrations-72"
+          image_tag: "ddtrace_alpine_php-7.2-debug"
+      # - integration_tests:
+      #     name: "PHP 73 Integration tests"
+      #     integration_testsuite: "test-integrations-72" # not yet defined for 7.3
+      #     image_tag: "ddtrace_alpine_php-7.3-debug" # image is missing proper mcrypt support - to be investigated
+      - integration_tests:
+          name: "PHP 54 Web integration tests"
+          image_tag: "ddtrace_alpine_php-5.4-debug"
+          integration_testsuite: "test-web-54"
+      - integration_tests:
+          name: "PHP 56 Web integration tests"
+          integration_testsuite: "test-web-56"
+          image_tag: "ddtrace_php_5_6"
+      - integration_tests:
+          name: "PHP 70 Web integration tests"
+          integration_testsuite: "test-web-70"
+          image_tag: "ddtrace_alpine_php-7.0-debug"
+      - integration_tests:
+          name: "PHP 71 Web integration tests"
+          integration_testsuite: "test-web-71"
+          image_tag: "ddtrace_alpine_php-7.1-debug"
+      - integration_tests:
+          name: "PHP 72 Web integration tests"
+          integration_testsuite: "test-web-72"
+          image_tag: "ddtrace_php_7_2"
+      # - integration_tests:
+      #     name: "PHP 73 Web integration tests"
+      #     integration_testsuite: "test-web-72" # not yet defined for 7.3
+      #     image_tag: "ddtrace_alpine_php-7.3-debug"
+      - "Lint files"
+      - "Static Analysis"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,13 +302,35 @@ jobs:
       - <<: *STEP_STORE_TEST_RESULTS
       - <<: *STEP_STORE_ARTIFACTS
 
+  verify_package:
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+      package_type:
+        type: string
+    docker: [ image: << parameters.docker_image >> ]
+    steps:
+      - attach_workspace:
+          at: ~/datadog
+      - run: sh dockerfiles/verify_packages/verify_<< parameters.package_type >>.sh
+
+  "Packaging Code Checkout":
+    working_directory: ~/datadog
+    docker: [ image: 'circleci/buildpack-deps:latest' ]
+    steps:
+      - checkout
+      - attach_workspace: { at: ~/datadog }
+      - persist_to_workspace:
+          root: '.'
+          paths: ['./']
+
   "PHP 54 20100412": &5_4_ARTIFACT_BUILD
     working_directory: ~/datadog
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_6_php_5_4' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_5_4' ]
     environment:
       CFLAGS: "-O2 -Wall -Wextra"
     steps:
-      - checkout
       - attach_workspace:
           at: ~/datadog
       - run:
@@ -326,20 +348,20 @@ jobs:
 
   "PHP 56 20131106": &ARTIFACT_BUILD
     <<: *5_4_ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_6_php_56' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_56' ]
     environment: { CFLAGS: "-O2 -Wall -Wextra" }
 
   "PHP 70 20151012":
     <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_6_php_70' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_70' ]
 
   "PHP 71 20160303":
     <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_6_php_71' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_71' ]
 
   "PHP 72 20170718":
     <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_6_php_72' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_72' ]
 
   "PHP 73 20180731":
     <<: *ARTIFACT_BUILD
@@ -369,7 +391,6 @@ jobs:
     <<: *ARTIFACT_BUILD
     docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
     steps:
-      - checkout
       - attach_workspace:
           at: ~/datadog
       - run:
@@ -379,7 +400,7 @@ jobs:
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
       - persist_to_workspace:
           root: '.'
-          paths: ['./build/packages']
+          paths: ['./build/packages', 'dockerfiles/verify_packages']
 
   "package verification":
     working_directory: ~/datadog
@@ -400,13 +421,15 @@ workflows:
   version: 2
   build_packages:
     jobs:
+      - "Packaging Code Checkout"
       - "PHP 54 20100412": &BUILD_PACKAGE_FORKFLOW
-          filters:
-            tags:
-              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            branches:
-              # Always build on master
-              ignore: /^(?!master).*/
+          requires: [ 'Packaging Code Checkout' ]
+          filters: {}
+            # tags:
+            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            # branches:
+            #   # Always build on master
+            #   ignore: /^(?!master).*/
       - "PHP 56 20131106": *BUILD_PACKAGE_FORKFLOW
       - "PHP 70 20151012": *BUILD_PACKAGE_FORKFLOW
       - "PHP 71 20160303": *BUILD_PACKAGE_FORKFLOW
@@ -430,79 +453,84 @@ workflows:
             - "PHP 71 zts 20160303-zts"
             - "PHP 72 zts 20170718-zts"
             - "PHP 73 zts 20180731-zts"
-      - "package verification":
-          requires:
-            - "package extension"
-  build:
-    jobs:
-      - unit_tests:
-          name: "PHP 54 Unit tests"
-          image_tag: ddtrace_alpine_php-5.4-debug
-      - unit_tests:
-          name: "PHP 56 Unit tests"
-          image_tag: ddtrace_alpine_php-5.6-debug
-      - unit_tests:
-          name: "PHP 70 Unit tests"
-          image_tag: ddtrace_alpine_php-7.0-debug
-      - unit_tests:
-          name: "PHP 71 Unit tests"
-          image_tag: ddtrace_alpine_php-7.1-debug
-      - unit_tests:
-          name: "PHP 72 Unit tests"
-          image_tag: ddtrace_alpine_php-7.2-debug
-      # - unit_tests:
-      #     name: "PHP 70 Unit tests-zts"
-      #     image_tag: ddtrace_alpine_php-7.0-zts-debug # zts build is failing atm due to 2 memory leaks
-      # - unit_tests:
-      #     name: "PHP 73 Unit tests"
-      #     version: "7.3" # TODO: unit test for 7.3 are failing due to memory leaks - 7.3 not yet officially supported
-      - integration_tests:
-          name: "PHP 54 Integration tests"
-          image_tag: "ddtrace_alpine_php-5.4-debug"
-          integration_testsuite: "test-integrations-54"
-      - integration_tests:
-          name: "PHP 56 Integration tests"
-          integration_testsuite: "test-integrations-56"
-          image_tag: "ddtrace_alpine_php-5.6-debug"
-      - integration_tests:
-          name: "PHP 70 Integration tests"
-          integration_testsuite: "test-integrations-70"
-          image_tag: "ddtrace_alpine_php-7.0-debug"
-      - integration_tests:
-          name: "PHP 71 Integration tests"
-          integration_testsuite: "test-integrations-71"
-          image_tag: "ddtrace_alpine_php-7.1-debug"
-      - integration_tests:
-          name: "PHP 72 Integration tests"
-          integration_testsuite: "test-integrations-72"
-          image_tag: "ddtrace_alpine_php-7.2-debug"
-      # - integration_tests:
-      #     name: "PHP 73 Integration tests"
-      #     integration_testsuite: "test-integrations-72" # not yet defined for 7.3
-      #     image_tag: "ddtrace_alpine_php-7.3-debug" # image is missing proper mcrypt support - to be investigated
-      - integration_tests:
-          name: "PHP 54 Web integration tests"
-          image_tag: "ddtrace_alpine_php-5.4-debug"
-          integration_testsuite: "test-web-54"
-      - integration_tests:
-          name: "PHP 56 Web integration tests"
-          integration_testsuite: "test-web-56"
-          image_tag: "ddtrace_php_5_6"
-      - integration_tests:
-          name: "PHP 70 Web integration tests"
-          integration_testsuite: "test-web-70"
-          image_tag: "ddtrace_alpine_php-7.0-debug"
-      - integration_tests:
-          name: "PHP 71 Web integration tests"
-          integration_testsuite: "test-web-71"
-          image_tag: "ddtrace_alpine_php-7.1-debug"
-      - integration_tests:
-          name: "PHP 72 Web integration tests"
-          integration_testsuite: "test-web-72"
-          image_tag: "ddtrace_php_7_2"
-      # - integration_tests:
-      #     name: "PHP 73 Web integration tests"
-      #     integration_testsuite: "test-web-72" # not yet defined for 7.3
-      #     image_tag: "ddtrace_alpine_php-7.3-debug"
-      - "Lint files"
-      - "Static Analysis"
+      # - "package verification":
+      #     requires:
+      #       - "package extension"
+      - verify_package:
+          requires: [ "package extension" ]
+          name: "webdevops/php:7.1"
+          docker_image: webdevops/php:7.1
+          package_type: deb
+  # build:
+  #   jobs:
+  #     - unit_tests:
+  #         name: "PHP 54 Unit tests"
+  #         image_tag: ddtrace_alpine_php-5.4-debug
+  #     - unit_tests:
+  #         name: "PHP 56 Unit tests"
+  #         image_tag: ddtrace_alpine_php-5.6-debug
+  #     - unit_tests:
+  #         name: "PHP 70 Unit tests"
+  #         image_tag: ddtrace_alpine_php-7.0-debug
+  #     - unit_tests:
+  #         name: "PHP 71 Unit tests"
+  #         image_tag: ddtrace_alpine_php-7.1-debug
+  #     - unit_tests:
+  #         name: "PHP 72 Unit tests"
+  #         image_tag: ddtrace_alpine_php-7.2-debug
+  #     # - unit_tests:
+  #     #     name: "PHP 70 Unit tests-zts"
+  #     #     image_tag: ddtrace_alpine_php-7.0-zts-debug # zts build is failing atm due to 2 memory leaks
+  #     # - unit_tests:
+  #     #     name: "PHP 73 Unit tests"
+  #     #     version: "7.3" # TODO: unit test for 7.3 are failing due to memory leaks - 7.3 not yet officially supported
+  #     - integration_tests:
+  #         name: "PHP 54 Integration tests"
+  #         image_tag: "ddtrace_alpine_php-5.4-debug"
+  #         integration_testsuite: "test-integrations-54"
+  #     - integration_tests:
+  #         name: "PHP 56 Integration tests"
+  #         integration_testsuite: "test-integrations-56"
+  #         image_tag: "ddtrace_alpine_php-5.6-debug"
+  #     - integration_tests:
+  #         name: "PHP 70 Integration tests"
+  #         integration_testsuite: "test-integrations-70"
+  #         image_tag: "ddtrace_alpine_php-7.0-debug"
+  #     - integration_tests:
+  #         name: "PHP 71 Integration tests"
+  #         integration_testsuite: "test-integrations-71"
+  #         image_tag: "ddtrace_alpine_php-7.1-debug"
+  #     - integration_tests:
+  #         name: "PHP 72 Integration tests"
+  #         integration_testsuite: "test-integrations-72"
+  #         image_tag: "ddtrace_alpine_php-7.2-debug"
+  #     # - integration_tests:
+  #     #     name: "PHP 73 Integration tests"
+  #     #     integration_testsuite: "test-integrations-72" # not yet defined for 7.3
+  #     #     image_tag: "ddtrace_alpine_php-7.3-debug" # image is missing proper mcrypt support - to be investigated
+  #     - integration_tests:
+  #         name: "PHP 54 Web integration tests"
+  #         image_tag: "ddtrace_alpine_php-5.4-debug"
+  #         integration_testsuite: "test-web-54"
+  #     - integration_tests:
+  #         name: "PHP 56 Web integration tests"
+  #         integration_testsuite: "test-web-56"
+  #         image_tag: "ddtrace_php_5_6"
+  #     - integration_tests:
+  #         name: "PHP 70 Web integration tests"
+  #         integration_testsuite: "test-web-70"
+  #         image_tag: "ddtrace_alpine_php-7.0-debug"
+  #     - integration_tests:
+  #         name: "PHP 71 Web integration tests"
+  #         integration_testsuite: "test-web-71"
+  #         image_tag: "ddtrace_alpine_php-7.1-debug"
+  #     - integration_tests:
+  #         name: "PHP 72 Web integration tests"
+  #         integration_testsuite: "test-web-72"
+  #         image_tag: "ddtrace_php_7_2"
+  #     # - integration_tests:
+  #     #     name: "PHP 73 Web integration tests"
+  #     #     integration_testsuite: "test-web-72" # not yet defined for 7.3
+  #     #     image_tag: "ddtrace_alpine_php-7.3-debug"
+  #     - "Lint files"
+  #     - "Static Analysis"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,12 +424,12 @@ workflows:
       - "Packaging Code Checkout"
       - "PHP 54 20100412": &BUILD_PACKAGE_FORKFLOW
           requires: [ 'Packaging Code Checkout' ]
-          filters: {}
-            # tags:
-            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            # branches:
-            #   # Always build on master
-            #   ignore: /^(?!master).*/
+          filters:
+            tags:
+              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            branches:
+              # Always build on master
+              ignore: /^(?!master).*/
       - "PHP 56 20131106": *BUILD_PACKAGE_FORKFLOW
       - "PHP 70 20151012": *BUILD_PACKAGE_FORKFLOW
       - "PHP 71 20160303": *BUILD_PACKAGE_FORKFLOW

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Added
+- Disable request_init_hook functionality in presence of blacklisted modules #345
+
 ## [0.15.1]
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,14 +52,18 @@ services:
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }
   '7.0': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_0' }
   '7.0-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-debug' }
+  '7.0-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-zts' }
   '7.1': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_1' }
   '7.1-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-debug' }
+  '7.1-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-zts' }
   '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
   '7.2': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_2' }
   '7.2-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-debug' }
+  '7.2-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-zts' }
   '7.3': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3' }
   '7.3-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-debug' }
   '7.3-zts-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts-debug' }
+  '7.3-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts' }
   'ubuntu-16.04-7.1': { <<: *base_php_service, build: 'dockerfiles/ubuntu-16.04-php-7.1' }
   'ubuntu-18.04-7.2': { <<: *base_php_service, build: 'dockerfiles/ubuntu-18.04-php-7.2' }
   'fpm': { <<: *base_php_service, image: 'circleci/ruby:2.5', depends_on: [] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ x-aliases:
 services:
   '5.4': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_5_4' }
   '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
+  '5.5': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5' }
+  '5.5-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5-debug' }
   '5.6': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_php_5_6' }
   '5.6-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-debug' }
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ x-aliases:
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
 
 services:
-  '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
   '5.4': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_5_4' }
+  '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
   '5.6': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_php_5_6' }
   '5.6-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-debug' }
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }
@@ -52,13 +52,14 @@ services:
   '7.0-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-debug' }
   '7.1': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_1' }
   '7.1-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-debug' }
-  'ubuntu-16.04-7.1': { <<: *base_php_service, build: 'dockerfiles/ubuntu-16.04-php-7.1' }
-  'ubuntu-18.04-7.2': { <<: *base_php_service, build: 'dockerfiles/ubuntu-18.04-php-7.2' }
+  '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
   '7.2': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_2' }
   '7.2-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-debug' }
-  '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
+  '7.3': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3' }
   '7.3-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-debug' }
   '7.3-zts-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts-debug' }
+  'ubuntu-16.04-7.1': { <<: *base_php_service, build: 'dockerfiles/ubuntu-16.04-php-7.1' }
+  'ubuntu-18.04-7.2': { <<: *base_php_service, build: 'dockerfiles/ubuntu-18.04-php-7.2' }
   'fpm': { <<: *base_php_service, image: 'circleci/ruby:2.5', depends_on: [] }
 
   mysql_integration:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
   '5.5': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5' }
   '5.5-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5-debug' }
   '5.6': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_php_5_6' }
+  '5.6-original': { <<: *base_56_service, image: 'circleci/php:5.6-zts' }
   '5.6-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-debug' }
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }
   '7.0': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_0' }

--- a/dockerfiles/verify_packages/verify_deb.sh
+++ b/dockerfiles/verify_packages/verify_deb.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -xe
+dpkg -i build/packages/*.deb
+php -m | grep ddtrace
+php -r 'echo phpversion("ddtrace") . PHP_EOL;'

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -1,10 +1,11 @@
-#if defined(__GLIBC__) || defined(__APPLE__)
-#include <execinfo.h>
 #include <php.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#if defined(__GLIBC__) || defined(__APPLE__)
+#include <execinfo.h>
 
 #include "backtrace.h"
 #include "ddtrace.h"
@@ -16,20 +17,19 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 void ddtrace_backtrace_handler(int sig) {
     TSRMLS_FETCH();
 
-    ddtrace_log_err("Datadog PHP Trace extension (DEBUG MODE)" TSRMLS_CC);
-    ddtrace_log_errf("Received Signal %d" TSRMLS_CC, sig);
+    ddtrace_log_err("Datadog PHP Trace extension (DEBUG MODE)");
+    ddtrace_log_errf("Received Signal %d", sig);
     void *array[MAX_STACK_SIZE];
     size_t size = backtrace(array, MAX_STACK_SIZE);
 
-    ddtrace_log_err(
-        "Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime" TSRMLS_CC);
-    ddtrace_log_err("Backtrace:" TSRMLS_CC);
+    ddtrace_log_err("Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime");
+    ddtrace_log_err("Backtrace:");
 
     char **backtraces = backtrace_symbols(array, size);
     if (backtraces) {
         size_t i;
         for (i = 0; i < size; i++) {
-            ddtrace_log_err(backtraces[i] TSRMLS_CC);
+            ddtrace_log_err(backtraces[i]);
         }
         free(backtraces);
     }
@@ -50,13 +50,13 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
         handler_installed = 1;
     }
 }
-#else //defined(__GLIBC__) || defined(__APPLE__)
+#else  // defined(__GLIBC__) || defined(__APPLE__)
 #ifdef ZTS
 void ddtrace_install_backtrace_handler(TSRMLS_D) {
     UNUSED(TSRML_C);
     // NOOP
 }
-#else //ZTS
+#else   // ZTS
 void ddtrace_install_backtrace_handler() {
     // NOOP
 }

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -50,10 +50,15 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
         handler_installed = 1;
     }
 }
-#else
-void ddtrace_install_backtrace_handler(TSRMLS_D) {
+#else //defined(__GLIBC__) || defined(__APPLE__)
 #ifdef ZTS
+void ddtrace_install_backtrace_handler(TSRMLS_D) {
     UNUSED(TSRML_C);
-#endif  // ZTS
+    // NOOP
 }
+#else //ZTS
+void ddtrace_install_backtrace_handler() {
+    // NOOP
+}
+#endif  // ZTS
 #endif  // GLIBC

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -52,9 +52,7 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
 }
 #else  // defined(__GLIBC__) || defined(__APPLE__)
 #if defined(ZTS) && PHP_VERSION_ID < 70000
-void ddtrace_install_backtrace_handler(TSRMLS_D) {
-    (void)(TSRMLS_C);
-}
+void ddtrace_install_backtrace_handler(TSRMLS_D) { (void)(TSRMLS_C); }
 #else   // ZTS
 void ddtrace_install_backtrace_handler() {
     // NOOP

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -51,10 +51,9 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
     }
 }
 #else  // defined(__GLIBC__) || defined(__APPLE__)
-#ifdef ZTS
+#if defined(ZTS) && PHP_VERSION_ID < 70000
 void ddtrace_install_backtrace_handler(TSRMLS_D) {
-    UNUSED(TSRML_C);
-    // NOOP
+    (void)(TSRMLS_C);
 }
 #else   // ZTS
 void ddtrace_install_backtrace_handler() {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -104,7 +104,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     ddtrace_dispatch_init(TSRMLS_C);
 
-    if (DDTRACE_G(internal_blacklisted_modules_regexp) && !dd_no_blacklisted_modules(DDTRACE_G(internal_blacklisted_modules_regexp))) {
+    if (DDTRACE_G(internal_blacklisted_modules_regexp) && !dd_no_blacklisted_modules(TSRMLS_C)) {
         return SUCCESS;
     }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -52,6 +52,8 @@ ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 
 PHP_INI_BEGIN()
 STD_PHP_INI_ENTRY("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals, ddtrace_globals)
+STD_PHP_INI_ENTRY("ddtrace.internal_blacklisted_modules_regexp", "/ioncube/i", PHP_INI_SYSTEM, OnUpdateString,
+                  internal_blacklisted_modules_regexp, zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateString, request_init_hook,
                   zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_ENTRY("ddtrace.strict_mode", "0", PHP_INI_SYSTEM, OnUpdateBool, strict_mode, zend_ddtrace_globals,
@@ -101,6 +103,11 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     }
 
     ddtrace_dispatch_init(TSRMLS_C);
+
+    if (DDTRACE_G(internal_blacklisted_modules_regexp) &&
+        !dd_no_blacklisted_modules(DDTRACE_G(internal_blacklisted_modules_regexp))) {
+        return SUCCESS;
+    }
 
     if (DDTRACE_G(request_init_hook)) {
         DD_PRINTF("%s", DDTRACE_G(request_init_hook));

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -104,8 +104,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     ddtrace_dispatch_init(TSRMLS_C);
 
-    if (DDTRACE_G(internal_blacklisted_modules_regexp) &&
-        !dd_no_blacklisted_modules(DDTRACE_G(internal_blacklisted_modules_regexp))) {
+    if (DDTRACE_G(internal_blacklisted_modules_regexp) && !dd_no_blacklisted_modules(DDTRACE_G(internal_blacklisted_modules_regexp))) {
         return SUCCESS;
     }
 

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -6,6 +6,7 @@ extern zend_module_entry ddtrace_module_entry;
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
 char *request_init_hook;
+char *internal_blacklisted_modules_regexp;
 zend_bool strict_mode;
 
 HashTable class_lookup;

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -7,7 +7,7 @@ void _ddtrace_log_errf(TSRMLS_FC const char *format, ...) {
 
     va_start(args, format);
     vspprintf(&buffer, 0, format, args);
-    ddtrace_log_err(buffer TSRMLS_CC);
+    ddtrace_log_err(buffer);
 
     efree(buffer);
     va_end(args);

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -1,7 +1,7 @@
 #include "logging.h"
 #include <php.h>
 
-void ddtrace_log_errf(const char *format TSRMLS_DC, ...) {
+void _ddtrace_log_errf(TSRMLS_FC const char *format, ...) {
     va_list args;
     char *buffer;
 

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -2,8 +2,15 @@
 #define DD_LOGGING_H
 #include <php.h>
 
-#define ddtrace_log_err(message) php_log_err(message)
+#ifdef ZTS
+#define TSRMLS_FC TSRMLS_D,
+#define ddtrace_log_errf(...) _ddtrace_log_errf(TSRMLS_C, __VA_ARGS__)
+#else
+#define TSRMLS_FC
+#define ddtrace_log_errf(...) _ddtrace_log_errf(__VA_ARGS__)
+#endif
 
-void ddtrace_log_errf(const char *format TSRMLS_DC, ...);
+#define ddtrace_log_err(message) php_log_err(message TSRMLS_CC)
+void _ddtrace_log_errf(TSRMLS_FC const char *format, ...);
 
 #endif  // DD_LOGGING_H

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -2,7 +2,7 @@
 #define DD_LOGGING_H
 #include <php.h>
 
-#ifdef ZTS
+#if defined(ZTS) && PHP_VERSION_ID < 70000
 #define TSRMLS_FC TSRMLS_D,
 #define ddtrace_log_errf(...) _ddtrace_log_errf(TSRMLS_C, __VA_ARGS__)
 #else

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -1,41 +1,49 @@
 #include "request_hooks.h"
 #include "compat_zend_string.h"
+#include "ddtrace.h"
+#include "logging.h"
 
 #include <Zend/zend.h>
 #include <Zend/zend_compile.h>
 #include <php_main.h>
+
 #if PHP_VERSION_ID >= 70000
 #include <php/ext/pcre/php_pcre.h>
 #else
 #include <ext/pcre/php_pcre.h>
 #endif
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
 #if PHP_VERSION_ID < 70000
-int dd_no_blacklisted_modules(char *blacklist_regexp) {
+int dd_no_blacklisted_modules(TSRMLS_D) {
+    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
     zend_module_entry *module;
     pcre *pce;
     int re_options, rv = 1;
     pcre_extra *re_extra;
 
-	HashPosition pos;
+    HashPosition pos;
 
-    if ((pce = pcre_get_compiled_regex(blacklist_regexp, &re_extra, &re_options)) != NULL) {
-		zend_hash_internal_pointer_reset_ex(&module_registry, &pos);
+    if ((pce = pcre_get_compiled_regex(blacklist_regexp, &re_extra, &re_options TSRMLS_CC)) != NULL) {
+        zend_hash_internal_pointer_reset_ex(&module_registry, &pos);
 
-        while (zend_hash_get_current_data_ex(&module_registry, (void *) &module, &pos) != FAILURE) {
-			if (!pcre_exec(pce, re_extra, module->name, strlen(module->name), 0, re_options, NULL, 0)) {
-                php_error(E_WARNING, "Found blacklisted module: %s, disabling conflicting functionality", module->name);
+        while (zend_hash_get_current_data_ex(&module_registry, (void *)&module, &pos) != FAILURE) {
+            if (!pcre_exec(pce, re_extra, module->name, strlen(module->name), 0, re_options, NULL, 0)) {
+                ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
                 rv = 0;
                 break;
             }
-			zend_hash_move_forward_ex(&module_registry, &pos);
-		}
+            zend_hash_move_forward_ex(&module_registry, &pos);
+        }
     }
 
     return rv;
 }
 
 #elif PHP_VERSION_ID < 70300
-int dd_no_blacklisted_modules(char *blacklist_regexp) {
+int dd_no_blacklisted_modules(TSRMLS_D) {
+    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
     zend_module_entry *module;
     pcre *pce;
     int re_options, rv = 1;
@@ -46,7 +54,7 @@ int dd_no_blacklisted_modules(char *blacklist_regexp) {
     if ((pce = pcre_get_compiled_regex(pattern, &re_extra, &re_options)) != NULL) {
         ZEND_HASH_FOREACH_PTR(&module_registry, module) {
             if (!pcre_exec(pce, re_extra, module->name, strlen(module->name), 0, re_options, NULL, 0)) {
-                php_error(E_WARNING, "Found blacklisted module: %s, disabling conflicting functionality", module->name);
+                ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
                 rv = 0;
                 break;
             }
@@ -58,7 +66,8 @@ int dd_no_blacklisted_modules(char *blacklist_regexp) {
     return rv;
 }
 #else
-int dd_no_blacklisted_modules(char *blacklist_regexp) {
+int dd_no_blacklisted_modules(TSRMLS_D) {
+    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
     zend_module_entry *module;
     pcre2_code *pce;
     int rv = 1;
@@ -70,8 +79,9 @@ int dd_no_blacklisted_modules(char *blacklist_regexp) {
         pcre2_match_data *match_data = php_pcre_create_match_data(capture_count, pce);
         if (match_data) {
             ZEND_HASH_FOREACH_PTR(&module_registry, module) {
-                if (pcre2_match(pce, (PCRE2_SPTR)module->name, strlen(module->name), 0, re_options, match_data, php_pcre_mctx()) > 0) {
-                    php_error(E_WARNING, "Found blacklisted module: %s, disabling conflicting functionality", module->name);
+                if (pcre2_match(pce, (PCRE2_SPTR)module->name, strlen(module->name), 0, re_options, match_data,
+                                php_pcre_mctx()) > 0) {
+                    ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
                     rv = 0;
                     break;
                 }

--- a/src/ext/request_hooks.h
+++ b/src/ext/request_hooks.h
@@ -5,5 +5,6 @@
 #include <php.h>
 
 int dd_execute_php_file(const char *filename TSRMLS_DC);
+int dd_no_blacklisted_modules(const char *blacklist_regexp);
 
 #endif  // REQUEST_HOOKS_H

--- a/src/ext/request_hooks.h
+++ b/src/ext/request_hooks.h
@@ -5,6 +5,6 @@
 #include <php.h>
 
 int dd_execute_php_file(const char *filename TSRMLS_DC);
-int dd_no_blacklisted_modules(const char *blacklist_regexp);
+int dd_no_blacklisted_modules(char *blacklist_regexp);
 
 #endif  // REQUEST_HOOKS_H

--- a/src/ext/request_hooks.h
+++ b/src/ext/request_hooks.h
@@ -5,6 +5,6 @@
 #include <php.h>
 
 int dd_execute_php_file(const char *filename TSRMLS_DC);
-int dd_no_blacklisted_modules(char *blacklist_regexp);
+int dd_no_blacklisted_modules(TSRMLS_D);
 
 #endif  // REQUEST_HOOKS_H

--- a/tests/ext/request_init_hook_check_blacklisted_modules.phpt
+++ b/tests/ext/request_init_hook_check_blacklisted_modules.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Do not prepend request hook if offending module has been detected
+--INI--
+ddtrace.request_init_hook=tests/ext/simple_sanity_check.phpt
+ddtrace.internal_blacklisted_modules_regexp=/ddtrace/
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Warning: Found blacklisted module: ddtrace, disabling conflicting functionality in Unknown on line 0
+Request start

--- a/tests/ext/request_init_hook_check_blacklisted_modules.phpt
+++ b/tests/ext/request_init_hook_check_blacklisted_modules.phpt
@@ -9,5 +9,5 @@ echo "Request start" . PHP_EOL;
 
 ?>
 --EXPECT--
-Warning: Found blacklisted module: ddtrace, disabling conflicting functionality in Unknown on line 0
+Found blacklisted module: ddtrace, disabling conflicting functionality
 Request start


### PR DESCRIPTION
### Description

Some extensions have known incompatibilities with our extension, this PR adds option to disable functions which can cause unexpected errors with specified extensions

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
