### PR TITLE
Symfony 2.3 web tests for resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Added
+- Symfony 2.3 web tests for resource name #349
+
 ### Fixed
 - Resource name on Symfony 2.x requests served through controllers #341
 - Sanitize url in web spans #344

--- a/composer.json
+++ b/composer.json
@@ -189,8 +189,6 @@
         "test-web-54": [
             "@laravel-42-update",
             "@laravel-42-test",
-            "@symfony-23-update",
-            "@symfony-23-test",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-update",
             "@custom-framework-autoloaded-test"

--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,8 @@
         "test-web-54": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-23-update",
+            "@symfony-23-test",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-update",
             "@custom-framework-autoloaded-test"
@@ -196,6 +198,8 @@
         "test-web-56": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-23-update",
+            "@symfony-23-test",
             "@symfony-28-update",
             "@symfony-28-test",
             "@symfony-33-update",
@@ -209,6 +213,8 @@
         "test-web-70": [
             "@laravel-42-update",
             "@laravel-42-test",
+            "@symfony-23-update",
+            "@symfony-23-test",
             "@symfony-28-update",
             "@symfony-28-test",
             "@symfony-33-update",
@@ -224,6 +230,8 @@
             "@laravel-42-test",
             "@laravel-57-update",
             "@laravel-57-test",
+            "@symfony-23-update",
+            "@symfony-23-test",
             "@symfony-28-update",
             "@symfony-28-test",
             "@symfony-33-update",
@@ -241,6 +249,8 @@
             "@laravel-42-test",
             "@laravel-57-update",
             "@laravel-57-test",
+            "@symfony-23-update",
+            "@symfony-23-test",
             "@symfony-28-update",
             "@symfony-28-test",
             "@symfony-33-update",
@@ -264,6 +274,11 @@
 
         "laravel-57-update": "composer --working-dir=tests/Frameworks/Laravel/Version_5_7 update",
         "laravel-57-test": "@composer test -- tests/Integrations/Laravel/V5/CommonScenariosTest.php",
+
+        "symfony-23-update": [
+            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_2_3 update"
+        ],
+        "symfony-23-test": "@composer test -- tests/Integrations/Symfony/V2_3",
 
         "symfony-28-update": [
             "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_2_8 update"

--- a/tests/Frameworks/Symfony/Version_2_3/.gitattributes
+++ b/tests/Frameworks/Symfony/Version_2_3/.gitattributes
@@ -1,4 +1,0 @@
-*/ linguist-generated
-.*/ linguist-generated
-* linguist-generated
-*.* linguist-generated

--- a/tests/Frameworks/Symfony/Version_2_3/src/AppBundle/Controller/DefaultController.php
+++ b/tests/Frameworks/Symfony/Version_2_3/src/AppBundle/Controller/DefaultController.php
@@ -11,11 +11,11 @@ class DefaultController extends Controller
     /**
      * @Route("/", name="homepage")
      */
-    public function indexAction(Request $request)
+    public function testingRouteNameAction(Request $request)
     {
         // replace this example code with whatever you need
         return $this->render('default/index.html.twig', array(
-            'base_dir' => realpath($this->container->getParameter('kernel.root_dir').'/..'),
+            'base_dir' => realpath($this->container->getParameter('kernel.root_dir').'/..').DIRECTORY_SEPARATOR,
         ));
     }
 }

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\Symfony\V2_8;
+namespace DDTrace\Tests\Integrations\Symfony\V2_3;
 
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
@@ -10,7 +10,7 @@ final class RouteNameTest extends WebFrameworkTestCase
 {
     protected static function getAppIndexScript()
     {
-        return __DIR__ . '/../../../Frameworks/Symfony/Version_2_8/web/app.php';
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_2_3/web/app.php';
     }
 
     /**


### PR DESCRIPTION
### Description

Add Symfony 2.3 web tests for resource name setting

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
