### PR TITLE
ensure __GLIBC__ properly defined before using it

### DIFF
--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -1,11 +1,12 @@
-#if defined(__GLIBC__) || defined(__APPLE__)
-#include <execinfo.h>
 #include <php.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
+#if defined(__GLIBC__) || defined(__APPLE__)
+
+#include <execinfo.h>
 #include "backtrace.h"
 #include "ddtrace.h"
 #include "env_config.h"


### PR DESCRIPTION
Discovered while working a a build warning

```
/dev/shm/BUILD/php-pecl-datadog-trace-0.15.1/NTS/src/ext/backtrace.c:54:6: warning: type of 'TSRMLS_D' defaults to 'int' [-Wimplicit-int]
 void ddtrace_install_backtrace_handler(TSRMLS_D) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Tracking this issue, the bas code is selected as __GLIBC__ is tested before all include, where it is defined.
