### PR TITLE
Fix failing Symfony tests

### DIFF
--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -106,7 +106,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -79,12 +79,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'test_symfony_34',
-                        'web',
-                        'Twig_Environment twig_template.html.twig'
-                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -113,7 +107,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -80,12 +80,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'test_symfony_42',
-                        'web',
-                        'Twig_Environment twig_template.html.twig'
-                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -114,7 +108,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),


### PR DESCRIPTION
### Description

The web tests for Symfony 3.3, 3.4 & 4.2 are failing due to a recent security patch where [the `render()` method now bypasses the `HttpKernel::handle()` method](https://github.com/symfony/symfony/commit/7f912bbb78377c2ea331b3da28363435fbd91337#diff-5740ef31c231cd679c9401de5515e9edR80). So this PR fixes the failing tests. :)

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- [x] Tests added for this feature/bug
