### PR TITLE
PHP 5.5 Compilation support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,14 +330,19 @@ jobs:
       CFLAGS: ""
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p extensions
       - run:
-          name: Build extension .so
-          command: |
-              mkdir -p extensions
-              make all CFLAGS="-O2 -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
-              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>.so
-              make clean debug all ECHO_ARG="-e"
-              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>-debug.so
+          name: Build extension basic .so
+          command: make all CFLAGS="-O2 -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
+      - run:
+          name: Copy extension basic .so
+          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>.so
+      - run:
+          name: Build extension debug .so
+          command: make all CFLAGS="-g -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
+      - run:
+          name: Copy extension basic .so
+          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>-debug.so
       - persist_to_workspace:
           root: '.'
           paths: ['./extensions']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,8 @@ workflows:
           requires: [ 'Code Checkout' ]
           name: "PHP 56 Web integration tests"
           integration_testsuite: "test-web-56"
-          image_tag: "ddtrace_alpine_php-5.6-debug"
+          # image_tag: "ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debug
+          image_tag: "ddtrace_php_5_6"
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 70 Web integration tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,37 @@ jobs:
           at: ~/datadog
       - run: sh dockerfiles/verify_packages/verify_<< parameters.package_type >>.sh
 
-  "Packaging Code Checkout":
+  compile_extension:
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+      so_suffix:
+        type: string
+        default: unknown
+      catch_warnings:
+        type: boolean
+        default: true
+    docker: [ image: << parameters.docker_image >> ]
+    environment:
+      CFLAGS: ""
+    steps:
+      - attach_workspace:
+          at: ~/datadog
+      - run:
+          name: Build extension .so
+          command: |
+              mkdir -p extensions
+              make all CFLAGS="-O2 -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
+              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>.so
+              make clean debug all ECHO_ARG="-e"
+              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>-debug.so
+      - persist_to_workspace:
+          root: '.'
+          paths: ['./extensions']
+
+
+  "Code Checkout":
     working_directory: ~/datadog
     docker: [ image: 'circleci/buildpack-deps:latest' ]
     steps:
@@ -325,70 +355,8 @@ jobs:
           root: '.'
           paths: ['./']
 
-  "PHP 54 20100412": &5_4_ARTIFACT_BUILD
-    working_directory: ~/datadog
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_5_4' ]
-    environment:
-      CFLAGS: "-O2 -Wall -Wextra"
-    steps:
-      - attach_workspace:
-          at: ~/datadog
-      - run:
-          name: Build extension .so
-          command: |
-              mkdir -p extensions
-              make all CFLAGS="${CFLAGS}" ECHO_ARG="-e"
-              SUFFIX="$( echo "$CIRCLE_JOB" | awk '{print $NF}' )"
-              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-$SUFFIX.so
-              make clean debug all ECHO_ARG="-e"
-              cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-$SUFFIX-debug.so
-      - persist_to_workspace:
-          root: '.'
-          paths: ['./extensions']
-
-  "PHP 56 20131106": &ARTIFACT_BUILD
-    <<: *5_4_ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_56' ]
-    environment: { CFLAGS: "-O2 -Wall -Wextra" }
-
-  "PHP 70 20151012":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_70' ]
-
-  "PHP 71 20160303":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_71' ]
-
-  "PHP 72 20170718":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_72' ]
-
-  "PHP 73 20180731":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'datadog/docker-library:ddtrace_centos_7_php_73' ]
-
-  "PHP 56 zts 20131106-zts":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:5.6-zts' ]
-
-  "PHP 70 zts 20151012-zts":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:7.0-zts' ]
-
-  "PHP 71 zts 20160303-zts":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:7.1-zts' ]
-
-  "PHP 72 zts 20170718-zts":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:7.2-zts' ]
-
-  "PHP 73 zts 20180731-zts":
-    <<: *ARTIFACT_BUILD
-    docker: [ image: 'circleci/php:7.3-zts' ]
-
   "package extension":
-    <<: *ARTIFACT_BUILD
+    working_directory: ~/datadog
     docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
     steps:
       - attach_workspace:
@@ -421,38 +389,82 @@ workflows:
   version: 2
   build_packages:
     jobs:
-      - "Packaging Code Checkout"
-      - "PHP 54 20100412": &BUILD_PACKAGE_FORKFLOW
-          requires: [ 'Packaging Code Checkout' ]
-          filters:
-            tags:
-              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            branches:
-              # Always build on master
-              ignore: /^(?!master).*/
-      - "PHP 56 20131106": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 70 20151012": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 71 20160303": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 72 20170718": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 73 20180731": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 56 zts 20131106-zts": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 70 zts 20151012-zts": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 71 zts 20160303-zts": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 72 zts 20170718-zts": *BUILD_PACKAGE_FORKFLOW
-      - "PHP 73 zts 20180731-zts": *BUILD_PACKAGE_FORKFLOW
+      - "Code Checkout":
+          filters: {}
+            # tags:
+            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            # branches:
+            #   # Always build on master
+            #   ignore: /^(?!master).*/
+      - compile_extension:
+          name: "Compile PHP 54"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_5_4"
+          catch_warnings: false
+          so_suffix: "20100412"
+          requires: [ 'Code Checkout' ]
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 56"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_5_6"
+          so_suffix: "20131106"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 70"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_0"
+          so_suffix: "20151012"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 71"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_1"
+          so_suffix: "20160303"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 72"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_2"
+          so_suffix: "20170718"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 73"
+          docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_3"
+          so_suffix: "20180731"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 56-zts"
+          docker_image: "circleci/php:5.6-zts"
+          so_suffix: "20131106-zts"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 70-zts"
+          docker_image: "circleci/php:5.6-zts"
+          so_suffix: "20151012-zts"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 71-zts"
+          docker_image: "circleci/php:5.6-zts"
+          so_suffix: "20160303-zts"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 72-zts"
+          docker_image: "circleci/php:5.6-zts"
+          so_suffix: "20170718-zts"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "Compile PHP 73-zts"
+          docker_image: "circleci/php:5.6-zts"
+          so_suffix: "20180731-zts"
       - "package extension":
           requires:
-            - "PHP 54 20100412"
-            - "PHP 56 20131106"
-            - "PHP 70 20151012"
-            - "PHP 71 20160303"
-            - "PHP 72 20170718"
-            - "PHP 73 20180731"
-            - "PHP 56 zts 20131106-zts"
-            - "PHP 70 zts 20151012-zts"
-            - "PHP 71 zts 20160303-zts"
-            - "PHP 72 zts 20170718-zts"
-            - "PHP 73 zts 20180731-zts"
+            - "Compile PHP 54"
+            - "Compile PHP 56"
+            - "Compile PHP 70"
+            - "Compile PHP 71"
+            - "Compile PHP 72"
+            - "Compile PHP 73"
+            - "Compile PHP 56-zts"
+            - "Compile PHP 70-zts"
+            - "Compile PHP 71-zts"
+            - "Compile PHP 72-zts"
+            - "Compile PHP 73-zts"
       - "package verification":
           requires:
             - "package extension"
@@ -463,6 +475,11 @@ workflows:
           package_type: deb
   build:
     jobs:
+      - "Code Checkout"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "test compile PHP 55"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
       - unit_tests:
           name: "PHP 54 Unit tests"
           image_tag: ddtrace_alpine_php-5.4-debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,11 +186,12 @@ executors:
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
 
 jobs:
-  "Lint files": &lint_files
+  "Lint files":
+    working_directory: ~/datadog
     docker:
       - image: circleci/php:7.2-cli-node-browsers
     steps:
-      - checkout
+      - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - restore_cache:
           <<: *CACHE_NPM_KEY
@@ -235,10 +236,11 @@ jobs:
       - <<: *STEP_STORE_ARTIFACTS
 
   "Static Analysis":
+    working_directory: ~/datadog
     docker:
       - image: circleci/php:7.2
     steps:
-      - checkout
+      - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - run:
           name: Install phpstan
@@ -258,7 +260,6 @@ jobs:
       name: with_agent
       tag: << parameters.image_tag >>
     steps:
-      - checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
@@ -280,7 +281,6 @@ jobs:
       name: with_integrations
       tag: << parameters.image_tag >>
     steps:
-      - checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
@@ -311,8 +311,7 @@ jobs:
         type: string
     docker: [ image: << parameters.docker_image >> ]
     steps:
-      - attach_workspace:
-          at: ~/datadog
+      - <<: *STEP_ATTACH_WORKSPACE
       - run: sh dockerfiles/verify_packages/verify_<< parameters.package_type >>.sh
 
   compile_extension:
@@ -330,8 +329,7 @@ jobs:
     environment:
       CFLAGS: ""
     steps:
-      - attach_workspace:
-          at: ~/datadog
+      - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Build extension .so
           command: |
@@ -350,7 +348,7 @@ jobs:
     docker: [ image: 'circleci/buildpack-deps:latest' ]
     steps:
       - checkout
-      - attach_workspace: { at: ~/datadog }
+      - <<: *STEP_ATTACH_WORKSPACE
       - persist_to_workspace:
           root: '.'
           paths: ['./']
@@ -359,8 +357,7 @@ jobs:
     working_directory: ~/datadog
     docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
     steps:
-      - attach_workspace:
-          at: ~/datadog
+      - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Build packages
           command: make packages
@@ -375,9 +372,7 @@ jobs:
     machine:
       image: circleci/classic:latest
     steps:
-      - checkout
-      - attach_workspace:
-          at: ~/datadog
+      - <<: *STEP_ATTACH_WORKSPACE
       - run: mkdir -p test-results
       - run:
           name: Test installing packages on target systems
@@ -481,18 +476,23 @@ workflows:
           name: "test compile PHP 55"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
       - unit_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 54 Unit tests"
           image_tag: ddtrace_alpine_php-5.4-debug
       - unit_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 56 Unit tests"
           image_tag: ddtrace_alpine_php-5.6-debug
       - unit_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 70 Unit tests"
           image_tag: ddtrace_alpine_php-7.0-debug
       - unit_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 71 Unit tests"
           image_tag: ddtrace_alpine_php-7.1-debug
       - unit_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 72 Unit tests"
           image_tag: ddtrace_alpine_php-7.2-debug
       # - unit_tests:
@@ -502,52 +502,66 @@ workflows:
       #     name: "PHP 73 Unit tests"
       #     version: "7.3" # TODO: unit test for 7.3 are failing due to memory leaks - 7.3 not yet officially supported
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 54 Integration tests"
           image_tag: "ddtrace_alpine_php-5.4-debug"
           integration_testsuite: "test-integrations-54"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 56 Integration tests"
           integration_testsuite: "test-integrations-56"
           image_tag: "ddtrace_alpine_php-5.6-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 70 Integration tests"
           integration_testsuite: "test-integrations-70"
           image_tag: "ddtrace_alpine_php-7.0-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 71 Integration tests"
           integration_testsuite: "test-integrations-71"
           image_tag: "ddtrace_alpine_php-7.1-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 72 Integration tests"
           integration_testsuite: "test-integrations-72"
           image_tag: "ddtrace_alpine_php-7.2-debug"
       # - integration_tests:
+      #     requires: [ 'Code Checkout' ]
       #     name: "PHP 73 Integration tests"
       #     integration_testsuite: "test-integrations-72" # not yet defined for 7.3
       #     image_tag: "ddtrace_alpine_php-7.3-debug" # image is missing proper mcrypt support - to be investigated
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 54 Web integration tests"
           image_tag: "ddtrace_alpine_php-5.4-debug"
           integration_testsuite: "test-web-54"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 56 Web integration tests"
           integration_testsuite: "test-web-56"
-          image_tag: "ddtrace_php_5_6"
+          image_tag: "ddtrace_alpine_php-5.6-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 70 Web integration tests"
           integration_testsuite: "test-web-70"
           image_tag: "ddtrace_alpine_php-7.0-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 71 Web integration tests"
           integration_testsuite: "test-web-71"
           image_tag: "ddtrace_alpine_php-7.1-debug"
       - integration_tests:
+          requires: [ 'Code Checkout' ]
           name: "PHP 72 Web integration tests"
           integration_testsuite: "test-web-72"
           image_tag: "ddtrace_php_7_2"
       # - integration_tests:
+      #     requires: [ 'Code Checkout' ]
       #     name: "PHP 73 Web integration tests"
       #     integration_testsuite: "test-web-72" # not yet defined for 7.3
       #     image_tag: "ddtrace_alpine_php-7.3-debug"
-      - "Lint files"
-      - "Static Analysis"
+      - "Lint files":
+          requires: [ 'Code Checkout' ]
+      - "Static Analysis":
+          requires: [ 'Code Checkout' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,12 +390,12 @@ workflows:
   build_packages:
     jobs:
       - "Code Checkout":
-          filters: {}
-            # tags:
-            #   only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            # branches:
-            #   # Always build on master
-            #   ignore: /^(?!master).*/
+          filters:
+            tags:
+              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
+            branches:
+              # Always build on master
+              ignore: /^(?!master).*/
       - compile_extension:
           name: "Compile PHP 54"
           docker_image: "datadog/docker-library:ddtrace_centos_6_php_5_4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,16 +333,16 @@ jobs:
       - run: mkdir -p extensions
       - run:
           name: Build extension basic .so
-          command: make all CFLAGS="-O2 -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
+          command: make all CFLAGS="-O2 -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
       - run:
           name: Copy extension basic .so
-          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>.so
+          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>.so
       - run:
           name: Build extension debug .so
-          command: make all CFLAGS="-g -Wall -Wextra <<# catch_warnings >> -Werror <</ catch_warnings >>" ECHO_ARG="-e"
+          command: make all CFLAGS="-g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
       - run:
           name: Copy extension basic .so
-          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< so_suffix >>-debug.so
+          command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>-debug.so
       - persist_to_workspace:
           root: '.'
           paths: ['./extensions']
@@ -425,7 +425,7 @@ workflows:
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 73"
-          docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_3"
+          docker_image: "datadog/docker-library:ddtrace_centos_7_php_73"
           so_suffix: "20180731"
       - compile_extension:
           requires: [ 'Code Checkout' ]
@@ -435,22 +435,22 @@ workflows:
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 70-zts"
-          docker_image: "circleci/php:5.6-zts"
+          docker_image: "circleci/php:7.0-zts"
           so_suffix: "20151012-zts"
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 71-zts"
-          docker_image: "circleci/php:5.6-zts"
+          docker_image: "circleci/php:7.1-zts"
           so_suffix: "20160303-zts"
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 72-zts"
-          docker_image: "circleci/php:5.6-zts"
+          docker_image: "circleci/php:7.2-zts"
           so_suffix: "20170718-zts"
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 73-zts"
-          docker_image: "circleci/php:5.6-zts"
+          docker_image: "circleci/php:7.3-zts"
           so_suffix: "20180731-zts"
       - "package extension":
           requires:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
   '7.1': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_1' }
   '7.1-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-debug' }
   '7.1-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-zts' }
+  '7.1-centos6': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_centos_6_php_7_1' }
   '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
   '7.2': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_2' }
   '7.2-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-debug' }

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -91,7 +91,7 @@ static ddtrace_dispatch_t *find_dispatch(const zend_class_entry *class, const ch
     }
 }
 
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
 zend_function *fcall_fbc(zend_execute_data *execute_data) {
     zend_op *opline = EX(opline);
     zend_function *fbc = NULL;
@@ -201,7 +201,7 @@ static int is_anonymous_closure(zend_function *fbc, const char *function_name, u
 
 static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data, const char *function_name,
                                                  uint32_t function_name_length TSRMLS_DC) {
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
     zval *original_object = EX(object);
 #endif
 
@@ -237,7 +237,7 @@ static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data
         ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
         dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
         if (EX(opline)->opcode == ZEND_DO_FCALL) {
             zend_op *opline = EX(opline);
             zend_ptr_stack_3_push(&EG(arg_types_stack), FBC(), EX(object), EX(called_scope));
@@ -257,7 +257,7 @@ static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data
 #endif
         const zend_op *opline = EX(opline);
 
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
 #define EX_T(offset) (*(temp_variable *)((char *)EX(Ts) + offset))
         zval rv;
         INIT_ZVAL(rv);
@@ -343,7 +343,7 @@ static zend_always_inline zend_function *get_current_fbc(zend_execute_data *exec
     if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
         fbc = FBC();
     } else {
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
         fbc = fcall_fbc(execute_data);
 #else
         fbc = EX(function_state).function;
@@ -404,7 +404,7 @@ static zend_always_inline zend_bool is_function_wrappable(zend_execute_data *exe
 
 static int update_opcode_leave(zend_execute_data *execute_data TSRMLS_DC) {
     DD_PRINTF("Update opcode leave");
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
     EX(function_state).function = (zend_function *)EX(op_array);
     EX(function_state).arguments = NULL;
     EG(opline_ptr) = &EX(opline);

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -12,6 +12,9 @@
 #include <Zend/zend_exceptions.h>
 #include "debug.h"
 
+// avoid Older GCC being overly cautious over {0} struct initializer
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #define BUSY_FLAG 1
 
 #if PHP_VERSION_ID >= 70100

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -19,7 +19,7 @@ void ddtrace_class_lookup_release_compat(zval *zv);
 #define _EX(x) ((execute_data)->x)
 static zend_always_inline zval *ddtrace_this(zend_execute_data *execute_data) {
     zval *this = NULL;
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
     if (_EX(opline)->opcode != ZEND_DO_FCALL && _EX(object)) {
         this = _EX(object);
     }

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -61,7 +61,7 @@ static zend_always_inline void setup_fcal_name(zend_execute_data *execute_data, 
         fci->params = (zval ***)safe_emalloc(sizeof(zval *), fci->param_count, 0);
         zend_get_parameters_array_ex(fci->param_count, fci->params);
     }
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
     if (EG(return_value_ptr_ptr)) {
         fci->retval_ptr_ptr = EG(return_value_ptr_ptr);
     } else {
@@ -87,7 +87,7 @@ void ddtrace_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fci, 
 #endif
     }
 
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
     EX(original_return_value) = EG(return_value_ptr_ptr);
     EG(return_value_ptr_ptr) = result;
 #endif

--- a/src/ext/dispatch_compat_php5.h
+++ b/src/ext/dispatch_compat_php5.h
@@ -6,10 +6,14 @@
 #include "debug.h"
 #include "dispatch.h"
 
-#if PHP_VERSION_ID < 50600
+#if PHP_VERSION_ID < 50500
 #define FBC() EX(fbc)
 #define NUM_ADDITIONAL_ARGS() (0)
 #define OBJECT() EX(object)
+#elif PHP_VERSION_ID < 50600
+#define FBC() (EX(call)->fbc)
+#define NUM_ADDITIONAL_ARGS() (0)
+#define OBJECT() (EX(call) ? EX(call)->object : NULL)
 #else
 #define FBC() (EX(call)->fbc)
 #define NUM_ADDITIONAL_ARGS() EX(call)->num_additional_args

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -95,7 +95,8 @@ zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable TS
             zend_function *function = NULL;
             if (ddtrace_find_function(EG(function_table), function_name, &function) != SUCCESS) {
                 zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC,
-                                        "Failed to override function %z - the function does not exist", function_name);
+                                        "Failed to override function %s - the function does not exist",
+                                        Z_STRVAL_P(function_name));
             }
 
             return 0;


### PR DESCRIPTION
### Description

Tests still fail for 5.5
this PR makes the code compile on 5.5 and makes CI able to compile any custom compilation combination:
```
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   39
---------------------------------------------------------------------

Number of tests :   39                34
Tests skipped   :    5 ( 12.8%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    6 ( 15.4%) ( 17.6%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   28 ( 71.8%) ( 82.4%)
------------------------------------------
```

### Readiness checklist
- ~[ ] [Changelog entry](docs/changelog.md) added, if necessary~
- [x] Tests added for this feature/bug
