### PR TITLE
WIP: Re-add missing functionality after security update broke existing spans

### DIFF
--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -106,6 +106,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -79,6 +79,12 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    SpanAssertion::build(
+                        'symfony.templating.render',
+                        'test_symfony_34',
+                        'web',
+                        'Twig_Environment twig_template.html.twig'
+                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -107,6 +113,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -80,6 +80,12 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    SpanAssertion::build(
+                        'symfony.templating.render',
+                        'test_symfony_42',
+                        'web',
+                        'Twig_Environment twig_template.html.twig'
+                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -108,6 +114,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),


### PR DESCRIPTION
Reverts DataDog/dd-trace-php#355
I might have approved the original PR too quickly. 

On second glance it looks to me that this failing test have detected correctly that a small security update to the framework removed part of functionality we provide.

/cc @SammyK @labbati 