### PR TITLE
Fix Symfony template rendering spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Symfony template rendering spans #359
+
 ## [0.15.1]
 
 ### Added

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -2,12 +2,9 @@
 
 namespace DDTrace\Integrations\Symfony;
 
-use DDTrace\Contracts\Span;
 use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
-use DDTrace\Util\TryCatchFinally;
 use DDTrace\Util\Versions;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class SymfonyIntegration
 {

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -173,6 +173,7 @@ class SymfonyBundle extends Bundle
         dd_trace('Symfony\Bundle\TwigBundle\TwigEngine', 'render', $renderTraceCallback);
         dd_trace('Symfony\Component\Templating\DelegatingEngine', 'render', $renderTraceCallback);
         dd_trace('Symfony\Component\Templating\PhpEngine', 'render', $renderTraceCallback);
+        dd_trace('Twig\Environment', 'render', $renderTraceCallback);
         dd_trace('Twig_Environment', 'render', $renderTraceCallback);
     }
 

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -144,17 +144,20 @@ class SymfonyBundle extends Bundle
             }
         );
 
-        // Tracing templating engine
-        dd_trace('Twig_Environment', 'render', function () use ($appName) {
+        // Tracing templating engines
+        $renderTraceCallback = function () use ($appName) {
             $args = func_get_args();
-
             $scope = GlobalTracer::get()->startActiveSpan('symfony.templating.render');
             $span = $scope->getSpan();
             $span->setTag(Tag::SERVICE_NAME, $appName);
             $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
             $span->setTag(Tag::RESOURCE_NAME, get_class($this) . ' ' . $args[0]);
             return TryCatchFinally::executePublicMethod($scope, $this, 'render', $args);
-        });
+        };
+
+        // Tracing templating engine
+        dd_trace('Twig_Environment', 'render', $renderTraceCallback);
+        dd_trace('Twig\Environment', 'render', $renderTraceCallback);
     }
 
     /**

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -60,6 +60,13 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     {
         return [
             'ddtrace.request_init_hook' => __DIR__ . '/../../bridge/dd_wrap_autoloader.php',
+            // The following values should be made configurable from the outside. I could not get env XDEBUG_CONFIG
+            // to work setting it both in docker-compose.yml and in `getEnvs()` above, but that should be the best
+            // option.
+            'xdebug.remote_enable' => 1,
+            'xdebug.remote_host' => 'host.docker.internal',
+            'xdebug.remote_autostart' => 1,
+            'xdebug.remote_port' => '9001', // Port 9000 is used by the request re-player
         ];
     }
 

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -106,6 +106,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -79,6 +79,12 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    SpanAssertion::build(
+                        'symfony.templating.render',
+                        'test_symfony_34',
+                        'web',
+                        'Twig\Environment twig_template.html.twig'
+                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -107,6 +113,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -80,6 +80,12 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    SpanAssertion::build(
+                        'symfony.templating.render',
+                        'test_symfony_42',
+                        'web',
+                        'Twig\Environment twig_template.html.twig'
+                    ),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -108,6 +114,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                     SpanAssertion::exists('symfony.kernel.handleException'),
                     SpanAssertion::exists('symfony.kernel.exception'),
+                    SpanAssertion::exists('symfony.templating.render'),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),


### PR DESCRIPTION
### Description

Symfony changed the way it auto-loads the twig template engine passing from `Twig_Environment` to psr4 `Twig\Environment`.

This PR adds the support for the latest to support both users that have and have not the latest releases.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
