### PR TITLE
Integration aware spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Disable request_init_hook functionality in presence of blacklisted modules #345
 - Integration-level configuration #354
+- Integration aware spans #360
 
 ### Fixed
 - Symfony template rendering spans #359

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -5,6 +5,7 @@ namespace DDTrace;
 use DDTrace\Encoders\Json;
 use DDTrace\Http\Request;
 use DDTrace\Integrations\IntegrationsLoader;
+use DDTrace\Integrations\Web\WebIntegration;
 use DDTrace\Transport\Http;
 
 /**
@@ -95,6 +96,7 @@ final class Bootstrap
             );
         $operationName = 'cli' === PHP_SAPI ? 'cli.command' : 'web.request';
         $span = $tracer->startRootSpan($operationName, $startSpanOptions)->getSpan();
+        $span ->setIntegration(new WebIntegration());
         $span->setTag(
             Tag::SERVICE_NAME,
             Configuration::get()->appName($operationName)

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -96,7 +96,7 @@ final class Bootstrap
             );
         $operationName = 'cli' === PHP_SAPI ? 'cli.command' : 'web.request';
         $span = $tracer->startRootSpan($operationName, $startSpanOptions)->getSpan();
-        $span ->setIntegration(new WebIntegration());
+        $span ->setIntegration(WebIntegration::getInstance());
         $span->setTag(
             Tag::SERVICE_NAME,
             Configuration::get()->appName($operationName)

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -96,7 +96,7 @@ final class Bootstrap
             );
         $operationName = 'cli' === PHP_SAPI ? 'cli.command' : 'web.request';
         $span = $tracer->startRootSpan($operationName, $startSpanOptions)->getSpan();
-        $span ->setIntegration(WebIntegration::getInstance());
+        $span ->setIntegration(new WebIntegration());
         $span->setTag(
             Tag::SERVICE_NAME,
             Configuration::get()->appName($operationName)

--- a/src/DDTrace/Contracts/Span.php
+++ b/src/DDTrace/Contracts/Span.php
@@ -186,4 +186,10 @@ interface Span
      * @return array
      */
     public function getAllTags();
+
+    /**
+     * @param Integration $integration
+     * @return self
+     */
+    public function setIntegration(Integration $integration);
 }

--- a/src/DDTrace/Contracts/Span.php
+++ b/src/DDTrace/Contracts/Span.php
@@ -192,4 +192,9 @@ interface Span
      * @return self
      */
     public function setIntegration(Integration $integration);
+
+    /**
+     * @return null|Integration
+     */
+    public function getIntegration();
 }

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -60,6 +60,17 @@ interface Tracer
     public function startActiveSpan($operationName, $options = []);
 
     /**
+     * Starts an active span for a supported integration and store the integration that originated the span in the
+     * span itself.
+     *
+     * @param Integration $integration
+     * @param string $operationName
+     * @param array $options
+     * @return Scope
+     */
+    public function startIntegrationScopeAndSpan(Integration $integration, $operationName, $options = []);
+
+    /**
      * Starts and returns a new span representing a unit of work.
      *
      * Whenever `child_of` reference is not passed then

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -9,7 +9,6 @@ use DDTrace\GlobalTracer;
 use DDTrace\Log\Logger;
 use DDTrace\Log\LoggerInterface;
 use DDTrace\Log\LoggingTrait;
-use DDTrace\Log\LogLevel;
 use DDTrace\Sampling\PrioritySampling;
 
 final class Json implements Encoder

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -146,6 +146,14 @@ final class Json implements Encoder
             $arraySpan['metrics']['_sampling_priority_v1'] = $prioritySampling;
         }
 
+        // This is only for testing purposes and possibly temporary as we may want to add integration name the span's
+        // metadata in a consistent way across various tracers.
+        if (null !== $span->getIntegration()
+                && false !== ($integrationTest = getenv('DD_TEST_INTEGRATION'))
+                && in_array($integrationTest, ['1', 'true'])) {
+            $arraySpan['meta']['integration.name'] = $span->getIntegration()->getName();
+        }
+
         return $arraySpan;
     }
 }

--- a/src/DDTrace/Encoders/Json.php
+++ b/src/DDTrace/Encoders/Json.php
@@ -146,7 +146,7 @@ final class Json implements Encoder
             $arraySpan['metrics']['_sampling_priority_v1'] = $prioritySampling;
         }
 
-        // This is only for testing purposes and possibly temporary as we may want to add integration name the span's
+        // This is only for testing purposes and possibly temporary as we may want to add integration name to the span's
         // metadata in a consistent way across various tracers.
         if (null !== $span->getIntegration()
                 && false !== ($integrationTest = getenv('DD_TEST_INTEGRATION'))

--- a/src/DDTrace/Integrations/AbstractIntegration.php
+++ b/src/DDTrace/Integrations/AbstractIntegration.php
@@ -12,9 +12,25 @@ abstract class AbstractIntegration implements \DDTrace\Contracts\Integration
      */
     private $configuration;
 
-    public function __construct()
+    /**
+     * @var static
+     */
+    private static $instance;
+
+    protected function __construct()
     {
         $this->configuration = $this->buildConfiguration();
+    }
+
+    /**
+     * @return static
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new static();
+        }
+        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Integrations/AbstractIntegration.php
+++ b/src/DDTrace/Integrations/AbstractIntegration.php
@@ -12,25 +12,9 @@ abstract class AbstractIntegration implements \DDTrace\Contracts\Integration
      */
     private $configuration;
 
-    /**
-     * @var static
-     */
-    private static $instance;
-
-    protected function __construct()
+    public function __construct()
     {
         $this->configuration = $this->buildConfiguration();
-    }
-
-    /**
-     * @return static
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new static();
-        }
-        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -16,7 +16,7 @@ use DDTrace\GlobalTracer;
 /**
  * Integration for curl php client.
  */
-final class CurlIntegration extends AbstractIntegration
+class CurlIntegration extends AbstractIntegration
 {
     const NAME = 'curl';
 

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -39,11 +39,13 @@ class CurlIntegration extends AbstractIntegration
             return Integration::NOT_AVAILABLE;
         }
 
+        // Waiting for refactoring from static to singleton.
+        $integration = self::getInstance();
         $globalConfig = Configuration::get();
 
-        dd_trace('curl_exec', function ($ch) {
+        dd_trace('curl_exec', function ($ch) use ($integration) {
             $tracer = GlobalTracer::get();
-            $scope = $tracer->startActiveSpan('curl_exec');
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'curl_exec');
             $span = $scope->getSpan();
             $span->setTag(Tag::SERVICE_NAME, 'curl');
             $span->setTag(Tag::SPAN_TYPE, Type::HTTP_CLIENT);

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -16,7 +16,7 @@ use DDTrace\GlobalTracer;
 /**
  * Integration for curl php client.
  */
-class CurlIntegration extends AbstractIntegration
+final class CurlIntegration extends AbstractIntegration
 {
     const NAME = 'curl';
 

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -40,7 +40,7 @@ class CurlIntegration extends AbstractIntegration
         }
 
         // Waiting for refactoring from static to singleton.
-        $integration = self::getInstance();
+        $integration = new self();
         $globalConfig = Configuration::get();
 
         dd_trace('curl_exec', function ($ch) use ($integration) {

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -12,26 +12,10 @@ use DDTrace\Type;
 /**
  * ElasticSearch driver v1 Integration
  */
-class ElasticSearchIntegration extends AbstractIntegration
+final class ElasticSearchIntegration extends AbstractIntegration
 {
     const NAME = 'elasticsearch';
     const DEFAULT_SERVICE_NAME = 'elasticsearch';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -18,6 +18,22 @@ class ElasticSearchIntegration extends AbstractIntegration
     const DEFAULT_SERVICE_NAME = 'elasticsearch';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -12,10 +12,26 @@ use DDTrace\Type;
 /**
  * ElasticSearch driver v1 Integration
  */
-final class ElasticSearchIntegration extends AbstractIntegration
+class ElasticSearchIntegration extends AbstractIntegration
 {
     const NAME = 'elasticsearch';
     const DEFAULT_SERVICE_NAME = 'elasticsearch';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -129,7 +129,10 @@ class ElasticSearchIntegration extends AbstractIntegration
         dd_trace('Elasticsearch\Endpoints\AbstractEndpoint', 'performRequest', function () {
             $args = func_get_args();
             $tracer = GlobalTracer::get();
-            $scope = $tracer->startActiveSpan("Elasticsearch.Endpoint.performRequest");
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                ElasticSearchIntegration::getInstance(),
+                "Elasticsearch.Endpoint.performRequest"
+            );
             $span = $scope->getSpan();
 
             $span->setTag(Tag::SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
@@ -182,7 +185,10 @@ class ElasticSearchIntegration extends AbstractIntegration
                 list($params) = $args;
             }
             $tracer = GlobalTracer::get();
-            $scope = $tracer->startActiveSpan("Elasticsearch.Client.$name");
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                ElasticSearchIntegration::getInstance(),
+                "Elasticsearch.Client.$name"
+            );
             $span = $scope->getSpan();
 
             $span->setTag(Tag::SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
@@ -231,7 +237,7 @@ class ElasticSearchIntegration extends AbstractIntegration
 
             $tracer = GlobalTracer::get();
             $operationName = str_replace('\\', '.', "$class.$name");
-            $scope = $tracer->startActiveSpan($operationName);
+            $scope = $tracer->startIntegrationScopeAndSpan(ElasticSearchIntegration::getInstance(), $operationName);
             $span = $scope->getSpan();
 
             $span->setTag(Tag::SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);
@@ -273,7 +279,10 @@ class ElasticSearchIntegration extends AbstractIntegration
                 list($params) = $args;
             }
             $tracer = GlobalTracer::get();
-            $scope = $tracer->startActiveSpan("Elasticsearch.$namespace.$name");
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                ElasticSearchIntegration::getInstance(),
+                "Elasticsearch.$namespace.$name"
+            );
             $span = $scope->getSpan();
 
             $span->setTag(Tag::SERVICE_NAME, ElasticSearchIntegration::DEFAULT_SERVICE_NAME);

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -9,25 +9,9 @@ use DDTrace\Type;
 use DDTrace\Util\TryCatchFinally;
 use DDTrace\GlobalTracer;
 
-class EloquentIntegration extends AbstractIntegration
+final class EloquentIntegration extends AbstractIntegration
 {
     const NAME = 'eloquent';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -23,10 +23,12 @@ class EloquentIntegration extends AbstractIntegration
 
     public static function load()
     {
+        $integration = self::getInstance();
+
         // getModels($columns = ['*'])
-        dd_trace('Illuminate\Database\Eloquent\Builder', 'getModels', function () {
+        dd_trace('Illuminate\Database\Eloquent\Builder', 'getModels', function () use ($integration) {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('eloquent.get');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.get');
             $span = $scope->getSpan();
             $sql = $this->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -37,10 +39,10 @@ class EloquentIntegration extends AbstractIntegration
         });
 
         // performInsert(Builder $query)
-        dd_trace('Illuminate\Database\Eloquent\Model', 'performInsert', function () {
+        dd_trace('Illuminate\Database\Eloquent\Model', 'performInsert', function () use ($integration) {
             $args = func_get_args();
             $eloquentQueryBuilder = $args[0];
-            $scope = GlobalTracer::get()->startActiveSpan('eloquent.insert');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.insert');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -51,10 +53,10 @@ class EloquentIntegration extends AbstractIntegration
         });
 
         // performUpdate(Builder $query)
-        dd_trace('Illuminate\Database\Eloquent\Model', 'performUpdate', function () {
+        dd_trace('Illuminate\Database\Eloquent\Model', 'performUpdate', function () use ($integration) {
             $args = func_get_args();
             $eloquentQueryBuilder = $args[0];
-            $scope = GlobalTracer::get()->startActiveSpan('eloquent.update');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.update');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -65,8 +67,8 @@ class EloquentIntegration extends AbstractIntegration
         });
 
         // public function delete()
-        dd_trace('Illuminate\Database\Eloquent\Model', 'delete', function () {
-            $scope = GlobalTracer::get()->startActiveSpan('eloquent.delete');
+        dd_trace('Illuminate\Database\Eloquent\Model', 'delete', function () use ($integration) {
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.delete');
             $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::SQL);
 
             return TryCatchFinally::executePublicMethod($scope, $this, 'delete', []);

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -14,6 +14,22 @@ class EloquentIntegration extends AbstractIntegration
     const NAME = 'eloquent';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -9,9 +9,25 @@ use DDTrace\Type;
 use DDTrace\Util\TryCatchFinally;
 use DDTrace\GlobalTracer;
 
-final class EloquentIntegration extends AbstractIntegration
+class EloquentIntegration extends AbstractIntegration
 {
     const NAME = 'eloquent';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -22,10 +22,26 @@ final class GuzzleIntegration extends AbstractIntegration
      */
     private $codeTracer;
 
+    /**
+     * @var self
+     */
+    private static $instance;
+
     public function __construct()
     {
         parent::__construct();
         $this->codeTracer = CodeTracer::getInstance();
+    }
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -22,10 +22,26 @@ final class GuzzleIntegration extends AbstractIntegration
      */
     private $codeTracer;
 
-    protected function __construct()
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    public function __construct()
     {
         parent::__construct();
         $this->codeTracer = CodeTracer::getInstance();
+    }
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -54,17 +54,21 @@ final class GuzzleIntegration extends AbstractIntegration
             $self->setStatusCodeTag($span, $response);
         };
 
+        $integration = GuzzleIntegration::getInstance();
+
         $this->codeTracer->tracePublicMethod(
             'GuzzleHttp\Client',
             'send',
             $this->buildPreCallback('send'),
-            $postCallback
+            $postCallback,
+            $integration
         );
         $this->codeTracer->tracePublicMethod(
             'GuzzleHttp\Client',
             'transfer',
             $this->buildPreCallback('transfer'),
-            $postCallback
+            $postCallback,
+            $integration
         );
 
         return Integration::LOADED;

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -22,26 +22,10 @@ final class GuzzleIntegration extends AbstractIntegration
      */
     private $codeTracer;
 
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    public function __construct()
+    protected function __construct()
     {
         parent::__construct();
         $this->codeTracer = CodeTracer::getInstance();
-    }
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
     }
 
     /**

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
+use DDTrace\Contracts\Integration as IntegrationContract;
 use DDTrace\Tag;
 use DDTrace\Span;
 use DDTrace\GlobalTracer;
@@ -43,13 +44,13 @@ abstract class Integration extends AbstractIntegration
      * @param string $method
      * @param \Closure|null $preCallHook
      * @param \Closure|null $postCallHook
-     * @param Integration|null $integration
+     * @param IntegrationContract|null $integration
      */
     protected static function traceMethod(
         $method,
         \Closure $preCallHook = null,
         \Closure $postCallHook = null,
-        Integration $integration = null
+        IntegrationContract $integration = null
     ) {
         $className = static::CLASS_NAME;
         $integrationClass = get_called_class();

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -23,7 +23,6 @@ abstract class Integration extends AbstractIntegration
     {
         // See comment on the commented out abstract function definition.
         static::loadIntegration();
-
         return self::LOADED;
     }
 

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -43,9 +43,14 @@ abstract class Integration extends AbstractIntegration
      * @param string $method
      * @param \Closure|null $preCallHook
      * @param \Closure|null $postCallHook
+     * @param Integration|null $integration
      */
-    protected static function traceMethod($method, \Closure $preCallHook = null, \Closure $postCallHook = null)
-    {
+    protected static function traceMethod(
+        $method,
+        \Closure $preCallHook = null,
+        \Closure $postCallHook = null,
+        Integration $integration = null
+    ) {
         $className = static::CLASS_NAME;
         $integrationClass = get_called_class();
         dd_trace($className, $method, function () use (
@@ -53,11 +58,17 @@ abstract class Integration extends AbstractIntegration
             $integrationClass,
             $method,
             $preCallHook,
-            $postCallHook
+            $postCallHook,
+            $integration
         ) {
             $args = func_get_args();
             $scope = GlobalTracer::get()->startActiveSpan($className . '.' . $method);
             $span = $scope->getSpan();
+
+            if (null !== $integration) {
+                $span->setIntegration($integration);
+            }
+
             $integrationClass::setDefaultTags($span, $method);
             if (null !== $preCallHook) {
                 $preCallHook($span, $args);

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -15,6 +15,22 @@ class LaravelIntegration extends AbstractIntegration
     const NAME = 'laravel';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -10,9 +10,25 @@ use DDTrace\Util\Versions;
 /**
  * The base Laravel integration which delegates loading to the appropriate integration version.
  */
-final class LaravelIntegration extends AbstractIntegration
+class LaravelIntegration extends AbstractIntegration
 {
     const NAME = 'laravel';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -10,25 +10,9 @@ use DDTrace\Util\Versions;
 /**
  * The base Laravel integration which delegates loading to the appropriate integration version.
  */
-class LaravelIntegration extends AbstractIntegration
+final class LaravelIntegration extends AbstractIntegration
 {
     const NAME = 'laravel';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -115,7 +115,10 @@ class LaravelProvider extends ServiceProvider
      */
     public static function buildBaseScope($operation, $resource)
     {
-        $scope = GlobalTracer::get()->startActiveSpan($operation);
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            \DDTrace\Integrations\Laravel\LaravelIntegration::getInstance(),
+            $operation
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
         $span->setTag(Tag::SERVICE_NAME, self::getAppName());

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -52,6 +52,8 @@ class LaravelProvider extends ServiceProvider
 
             $requestSpan = $self->rootScope->getSpan();
             $requestSpan->overwriteOperationName('laravel.request');
+            // Overwriting the default web integration
+            $requestSpan->setIntegration(\DDTrace\Integrations\Laravel\LaravelIntegration::getInstance());
             $requestSpan->setTag(Tag::SERVICE_NAME, $appName);
 
             $response = call_user_func_array([$this, 'handle'], func_get_args());

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -129,7 +129,10 @@ class LaravelIntegrationLoader
         // Create a trace span for every template rendered
         // public function get($path, array $data = array())
         dd_trace('Illuminate\View\Engines\CompilerEngine', 'get', function ($path, $data = array()) {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(LaravelIntegration::getInstance(), 'laravel.view');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                LaravelIntegration::getInstance(),
+                'laravel.view'
+            );
             $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
             return TryCatchFinally::executePublicMethod($scope, $this, 'get', [$path, $data]);
         });

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -36,6 +36,8 @@ class LaravelIntegrationLoader
 
             list($route, $request) = $args;
             $span = $self->rootScope->getSpan();
+            // Overwriting the default web integration
+            $span->setIntegration(LaravelIntegration::getInstance());
             $span->setTag(
                 Tag::RESOURCE_NAME,
                 $route->getActionName() . ' ' . (Route::currentRouteName() ?: 'unnamed_route')

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -109,7 +109,10 @@ class LaravelIntegrationLoader
                     $handlerMethod = $this->method;
                     dd_trace($class, $handlerMethod, function () use ($handlerMethod) {
                         $args = func_get_args();
-                        $scope = GlobalTracer::get()->startActiveSpan('laravel.pipeline.pipe');
+                        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                            \DDTrace\Integrations\Laravel\LaravelIntegration::getInstance(),
+                            'laravel.pipeline.pipe'
+                        );
                         $span = $scope->getSpan();
                         $span->setTag(Tag::RESOURCE_NAME, get_class($this) . '::' . $handlerMethod);
                         $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
@@ -124,7 +127,7 @@ class LaravelIntegrationLoader
         // Create a trace span for every template rendered
         // public function get($path, array $data = array())
         dd_trace('Illuminate\View\Engines\CompilerEngine', 'get', function ($path, $data = array()) {
-            $scope = GlobalTracer::get()->startActiveSpan('laravel.view');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(LaravelIntegration::getInstance(), 'laravel.view');
             $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
             return TryCatchFinally::executePublicMethod($scope, $this, 'get', [$path, $data]);
         });

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -23,9 +23,25 @@ use DDTrace\GlobalTracer;
  * might be different for each key. setMultiByKey does, since you're pinning a
  * specific server.
  */
-final class MemcachedIntegration extends AbstractIntegration
+class MemcachedIntegration extends AbstractIntegration
 {
     const NAME = 'memcached';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -23,25 +23,9 @@ use DDTrace\GlobalTracer;
  * might be different for each key. setMultiByKey does, since you're pinning a
  * specific server.
  */
-class MemcachedIntegration extends AbstractIntegration
+final class MemcachedIntegration extends AbstractIntegration
 {
     const NAME = 'memcached';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -121,7 +121,7 @@ class MemcachedIntegration extends AbstractIntegration
         // bool Memcached::flush ([ int $delay = 0 ] )
         dd_trace('Memcached', 'flush', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('Memcached.flush');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.flush');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
             $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -234,7 +234,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCommand($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan("Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -251,7 +251,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCommandByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan("Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -267,7 +267,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCas($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan('Memcached.cas');
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.cas');
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -283,7 +283,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCasByKey($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan('Memcached.casByKey');
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.casByKey');
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -301,7 +301,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceMulti($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan("Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -316,7 +316,7 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceMultiByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startActiveSpan("Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -7,7 +7,6 @@ use DDTrace\Integrations\AbstractIntegration;
 use DDTrace\Obfuscation;
 use DDTrace\Tag;
 use DDTrace\Type;
-use DDTrace\Util\Versions;
 use DDTrace\Util\TryCatchFinally;
 use DDTrace\GlobalTracer;
 
@@ -27,6 +26,22 @@ use DDTrace\GlobalTracer;
 class MemcachedIntegration extends AbstractIntegration
 {
     const NAME = 'memcached';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -136,7 +136,10 @@ class MemcachedIntegration extends AbstractIntegration
         // bool Memcached::flush ([ int $delay = 0 ] )
         dd_trace('Memcached', 'flush', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.flush');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                MemcachedIntegration::getInstance(),
+                'Memcached.flush'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
             $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -249,7 +252,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCommand($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            "Memcached.$command"
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -266,7 +272,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCommandByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            "Memcached.$command"
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -282,7 +291,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCas($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.cas');
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            'Memcached.cas'
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -298,7 +310,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceCasByKey($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), 'Memcached.casByKey');
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            'Memcached.casByKey'
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -316,7 +331,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceMulti($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            "Memcached.$command"
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');
@@ -331,7 +349,10 @@ class MemcachedIntegration extends AbstractIntegration
 
     public static function traceMultiByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MemcachedIntegration::getInstance(), "Memcached.$command");
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            MemcachedIntegration::getInstance(),
+            "Memcached.$command"
+        );
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::MEMCACHED);
         $span->setTag(Tag::SERVICE_NAME, 'memcached');

--- a/src/DDTrace/Integrations/Mongo/MongoClientIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoClientIntegration.php
@@ -29,6 +29,7 @@ final class MongoClientIntegration extends Integration
         // MongoClient::__construct ([ string $server = "mongodb://localhost:27017"
         // [, array $options = array("connect" => TRUE) [, array $driver_options ]]] )
         self::traceMethod('__construct', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_SERVER, Obfuscation::dsn($args[0]));
                 $dbName = self::extractDatabaseNameFromDsn($args[0]);
@@ -42,23 +43,31 @@ final class MongoClientIntegration extends Integration
         });
         // MongoCollection MongoClient::selectCollection ( string $db , string $collection )
         self::traceMethod('selectCollection', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, $args[0]);
             $span->setTag(Tag::MONGODB_COLLECTION, $args[1]);
         });
         // MongoDB MongoClient::selectDB ( string $name )
         self::traceMethod('selectDB', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, $args[0]);
         });
         // bool MongoClient::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
         });
+
+        $setIntegration = function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
+        };
+
         // Methods that don't need extra tags added
-        self::traceMethod('getHosts');
-        self::traceMethod('getReadPreference');
-        self::traceMethod('getWriteConcern');
-        self::traceMethod('listDBs');
-        self::traceMethod('setWriteConcern');
+        self::traceMethod('getHosts', $setIntegration);
+        self::traceMethod('getReadPreference', $setIntegration);
+        self::traceMethod('getWriteConcern', $setIntegration);
+        self::traceMethod('listDBs', $setIntegration);
+        self::traceMethod('setWriteConcern', $setIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoClientIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoClientIntegration.php
@@ -26,6 +26,8 @@ final class MongoClientIntegration extends Integration
             return;
         }
 
+        $mongoIntegration = MongoIntegration::getInstance();
+
         // MongoClient::__construct ([ string $server = "mongodb://localhost:27017"
         // [, array $options = array("connect" => TRUE) [, array $driver_options ]]] )
         self::traceMethod('__construct', function (Span $span, array $args) {
@@ -40,34 +42,30 @@ final class MongoClientIntegration extends Integration
             if (isset($args[1]['db'])) {
                 $span->setTag(Tag::MONGODB_DATABASE, $args[1]['db']);
             }
-        });
+        }, null, $mongoIntegration);
         // MongoCollection MongoClient::selectCollection ( string $db , string $collection )
         self::traceMethod('selectCollection', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, $args[0]);
             $span->setTag(Tag::MONGODB_COLLECTION, $args[1]);
-        });
+        }, null, $mongoIntegration);
         // MongoDB MongoClient::selectDB ( string $name )
         self::traceMethod('selectDB', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, $args[0]);
-        });
+        }, null, $mongoIntegration);
         // bool MongoClient::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
-        });
-
-        $setIntegration = function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
-        };
+        }, null, $mongoIntegration);
 
         // Methods that don't need extra tags added
-        self::traceMethod('getHosts', $setIntegration);
-        self::traceMethod('getReadPreference', $setIntegration);
-        self::traceMethod('getWriteConcern', $setIntegration);
-        self::traceMethod('listDBs', $setIntegration);
-        self::traceMethod('setWriteConcern', $setIntegration);
+        self::traceMethod('getHosts', null, null, $mongoIntegration);
+        self::traceMethod('getReadPreference', null, null, $mongoIntegration);
+        self::traceMethod('getWriteConcern', null, null, $mongoIntegration);
+        self::traceMethod('listDBs', null, null, $mongoIntegration);
+        self::traceMethod('setWriteConcern', null, null, $mongoIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
@@ -49,7 +49,7 @@ final class MongoCollectionIntegration extends Integration
             if (isset($ref['$ref'])) {
                 $span->setTag(Tag::MONGODB_COLLECTION, $ref['$ref']);
             }
-        }, null, $mongoIntegration);
+        }, $mongoIntegration);
         // array MongoCollection::distinct ( string $key [, array $query ] )
         self::traceMethod('distinct', function (Span $span, array $args) {
             if (isset($args[1])) {

--- a/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
@@ -27,17 +27,20 @@ final class MongoCollectionIntegration extends Integration
 
         // MongoCollection::__construct ( MongoDB $db , string $name )
         self::traceMethod('__construct', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, (string) $args[0]);
             $span->setTag(Tag::MONGODB_COLLECTION, $args[1]);
         });
         // int MongoCollection::count ([ array $query = array() [, array $options = array() ]] )
         self::traceMethod('count', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
         });
         // array MongoCollection::createDBRef ( mixed $document_or_id )
         self::traceMethod('createDBRef', null, function (Span $span, $ref) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (!is_array($ref)) {
                 return;
             }
@@ -50,29 +53,34 @@ final class MongoCollectionIntegration extends Integration
         });
         // array MongoCollection::distinct ( string $key [, array $query ] )
         self::traceMethod('distinct', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[1])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[1]));
             }
         });
         // MongoCursor MongoCollection::find ([ array $query = array() [, array $fields = array() ]] )
         self::traceMethod('find', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
         });
         // array MongoCollection::findAndModify ( array $query [, array $update [, array $fields [, array $options ]]] )
         self::traceMethod('findAndModify', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
         });
         // array MongoCollection::findOne ([ array $query = array() [, array $fields = array()
         // [, array $options = array() ]]] )
         self::traceMethod('findOne', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
         });
         // array MongoCollection::getDBRef ( array $ref )
         self::traceMethod('getDBRef', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0]['$id'])) {
                 $span->setTag(Tag::MONGODB_BSON_ID, $args[0]['$id']);
             }
@@ -82,38 +90,46 @@ final class MongoCollectionIntegration extends Integration
         });
         // bool|array MongoCollection::remove ([ array $criteria = array() [, array $options = array() ]] )
         self::traceMethod('remove', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
         });
         // bool MongoCollection::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
         });
         // bool|array MongoCollection::update ( array $criteria , array $new_object [, array $options = array() ] )
         self::traceMethod('update', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
         });
+
+        $setIntegration = function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
+        };
+
         // Methods that don't need extra tags added
-        self::traceMethod('aggregate');
-        self::traceMethod('aggregateCursor');
-        self::traceMethod('batchInsert');
-        self::traceMethod('createIndex');
-        self::traceMethod('deleteIndex');
-        self::traceMethod('deleteIndexes');
-        self::traceMethod('drop');
-        self::traceMethod('getIndexInfo');
-        self::traceMethod('getName');
-        self::traceMethod('getReadPreference');
-        self::traceMethod('getWriteConcern');
-        self::traceMethod('group');
-        self::traceMethod('insert');
-        self::traceMethod('parallelCollectionScan');
-        self::traceMethod('save');
-        self::traceMethod('setWriteConcern');
-        self::traceMethod('validate');
+        self::traceMethod('aggregate', $setIntegration);
+        self::traceMethod('aggregateCursor', $setIntegration);
+        self::traceMethod('batchInsert', $setIntegration);
+        self::traceMethod('createIndex', $setIntegration);
+        self::traceMethod('deleteIndex', $setIntegration);
+        self::traceMethod('deleteIndexes', $setIntegration);
+        self::traceMethod('drop', $setIntegration);
+        self::traceMethod('getIndexInfo', $setIntegration);
+        self::traceMethod('getName', $setIntegration);
+        self::traceMethod('getReadPreference', $setIntegration);
+        self::traceMethod('getWriteConcern', $setIntegration);
+        self::traceMethod('group', $setIntegration);
+        self::traceMethod('insert', $setIntegration);
+        self::traceMethod('parallelCollectionScan', $setIntegration);
+        self::traceMethod('save', $setIntegration);
+        self::traceMethod('setWriteConcern', $setIntegration);
+        self::traceMethod('validate', $setIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php
@@ -25,22 +25,21 @@ final class MongoCollectionIntegration extends Integration
             return;
         }
 
+        $mongoIntegration = MongoIntegration::getInstance();
+
         // MongoCollection::__construct ( MongoDB $db , string $name )
         self::traceMethod('__construct', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_DATABASE, (string) $args[0]);
             $span->setTag(Tag::MONGODB_COLLECTION, $args[1]);
-        });
+        }, null, $mongoIntegration);
         // int MongoCollection::count ([ array $query = array() [, array $options = array() ]] )
         self::traceMethod('count', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
-        });
+        }, null, $mongoIntegration);
         // array MongoCollection::createDBRef ( mixed $document_or_id )
         self::traceMethod('createDBRef', null, function (Span $span, $ref) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (!is_array($ref)) {
                 return;
             }
@@ -50,86 +49,74 @@ final class MongoCollectionIntegration extends Integration
             if (isset($ref['$ref'])) {
                 $span->setTag(Tag::MONGODB_COLLECTION, $ref['$ref']);
             }
-        });
+        }, null, $mongoIntegration);
         // array MongoCollection::distinct ( string $key [, array $query ] )
         self::traceMethod('distinct', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[1])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[1]));
             }
-        });
+        }, null, $mongoIntegration);
         // MongoCursor MongoCollection::find ([ array $query = array() [, array $fields = array() ]] )
         self::traceMethod('find', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
-        });
+        }, null, $mongoIntegration);
         // array MongoCollection::findAndModify ( array $query [, array $update [, array $fields [, array $options ]]] )
         self::traceMethod('findAndModify', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
-        });
+        }, null, $mongoIntegration);
         // array MongoCollection::findOne ([ array $query = array() [, array $fields = array()
         // [, array $options = array() ]]] )
         self::traceMethod('findOne', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
-        });
+        }, null, $mongoIntegration);
         // array MongoCollection::getDBRef ( array $ref )
         self::traceMethod('getDBRef', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0]['$id'])) {
                 $span->setTag(Tag::MONGODB_BSON_ID, $args[0]['$id']);
             }
             if (isset($args[0]['$ref'])) {
                 $span->setTag(Tag::MONGODB_COLLECTION, $args[0]['$ref']);
             }
-        });
+        }, null, $mongoIntegration);
         // bool|array MongoCollection::remove ([ array $criteria = array() [, array $options = array() ]] )
         self::traceMethod('remove', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
-        });
+        }, null, $mongoIntegration);
         // bool MongoCollection::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
-        });
+        }, null, $mongoIntegration);
         // bool|array MongoCollection::update ( array $criteria , array $new_object [, array $options = array() ] )
         self::traceMethod('update', function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]));
             }
-        });
-
-        $setIntegration = function (Span $span, array $args) {
-            $span->setIntegration(MongoIntegration::getInstance());
-        };
+        }, null, $mongoIntegration);
 
         // Methods that don't need extra tags added
-        self::traceMethod('aggregate', $setIntegration);
-        self::traceMethod('aggregateCursor', $setIntegration);
-        self::traceMethod('batchInsert', $setIntegration);
-        self::traceMethod('createIndex', $setIntegration);
-        self::traceMethod('deleteIndex', $setIntegration);
-        self::traceMethod('deleteIndexes', $setIntegration);
-        self::traceMethod('drop', $setIntegration);
-        self::traceMethod('getIndexInfo', $setIntegration);
-        self::traceMethod('getName', $setIntegration);
-        self::traceMethod('getReadPreference', $setIntegration);
-        self::traceMethod('getWriteConcern', $setIntegration);
-        self::traceMethod('group', $setIntegration);
-        self::traceMethod('insert', $setIntegration);
-        self::traceMethod('parallelCollectionScan', $setIntegration);
-        self::traceMethod('save', $setIntegration);
-        self::traceMethod('setWriteConcern', $setIntegration);
-        self::traceMethod('validate', $setIntegration);
+        self::traceMethod('aggregate', null, null, $mongoIntegration);
+        self::traceMethod('aggregateCursor', null, null, $mongoIntegration);
+        self::traceMethod('batchInsert', null, null, $mongoIntegration);
+        self::traceMethod('createIndex', null, null, $mongoIntegration);
+        self::traceMethod('deleteIndex', null, null, $mongoIntegration);
+        self::traceMethod('deleteIndexes', null, null, $mongoIntegration);
+        self::traceMethod('drop', null, null, $mongoIntegration);
+        self::traceMethod('getIndexInfo', null, null, $mongoIntegration);
+        self::traceMethod('getName', null, null, $mongoIntegration);
+        self::traceMethod('getReadPreference', null, null, $mongoIntegration);
+        self::traceMethod('getWriteConcern', null, null, $mongoIntegration);
+        self::traceMethod('group', null, null, $mongoIntegration);
+        self::traceMethod('insert', null, null, $mongoIntegration);
+        self::traceMethod('parallelCollectionScan', null, null, $mongoIntegration);
+        self::traceMethod('save', null, null, $mongoIntegration);
+        self::traceMethod('setWriteConcern', null, null, $mongoIntegration);
+        self::traceMethod('validate', null, null, $mongoIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoDBIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoDBIntegration.php
@@ -27,6 +27,7 @@ final class MongoDBIntegration extends Integration
 
         // array MongoDB::command ( array $command [, array $options = array() [, string &$hash ]] )
         self::traceMethod('command', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0]['query'])) {
                 $span->setTag(Tag::MONGODB_QUERY, json_encode($args[0]['query']));
             }
@@ -38,6 +39,7 @@ final class MongoDBIntegration extends Integration
         });
         // array MongoDB::createDBRef ( string $collection , mixed $document_or_id )
         self::traceMethod('createDBRef', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_COLLECTION, $args[0]);
         }, function (Span $span, $ref) {
             if (is_array($ref) && isset($ref['$id'])) {
@@ -46,39 +48,49 @@ final class MongoDBIntegration extends Integration
         });
         // MongoCollection MongoDB::createCollection ( string $name [, array $options ] )
         self::traceMethod('createCollection', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_COLLECTION, $args[0]);
         });
         // MongoCollection MongoDB::selectCollection ( string $name )
         self::traceMethod('selectCollection', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_COLLECTION, $args[0]);
         });
         // array MongoDB::getDBRef ( array $ref )
         self::traceMethod('getDBRef', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0]['$ref'])) {
                 $span->setTag(Tag::MONGODB_COLLECTION, $args[0]['$ref']);
             }
         });
         // int MongoDB::setProfilingLevel ( int $level )
         self::traceMethod('setProfilingLevel', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_PROFILING_LEVEL, $args[0]);
         });
         // bool MongoDB::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
         });
+
+        $setIntegration = function (Span $span, array $args) {
+            $span->setIntegration(MongoIntegration::getInstance());
+        };
+
         // Methods that don't need extra tags added
-        self::traceMethod('drop');
-        self::traceMethod('execute');
-        self::traceMethod('getCollectionInfo');
-        self::traceMethod('getCollectionNames');
-        self::traceMethod('getGridFS');
-        self::traceMethod('getProfilingLevel');
-        self::traceMethod('getReadPreference');
-        self::traceMethod('getWriteConcern');
-        self::traceMethod('lastError');
-        self::traceMethod('listCollections');
-        self::traceMethod('repair');
-        self::traceMethod('setWriteConcern');
+        self::traceMethod('drop', $setIntegration);
+        self::traceMethod('execute', $setIntegration);
+        self::traceMethod('getCollectionInfo', $setIntegration);
+        self::traceMethod('getCollectionNames', $setIntegration);
+        self::traceMethod('getGridFS', $setIntegration);
+        self::traceMethod('getProfilingLevel', $setIntegration);
+        self::traceMethod('getReadPreference', $setIntegration);
+        self::traceMethod('getWriteConcern', $setIntegration);
+        self::traceMethod('lastError', $setIntegration);
+        self::traceMethod('listCollections', $setIntegration);
+        self::traceMethod('repair', $setIntegration);
+        self::traceMethod('setWriteConcern', $setIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoDBIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoDBIntegration.php
@@ -25,6 +25,8 @@ final class MongoDBIntegration extends Integration
             return;
         }
 
+        $mongoIntegration = MongoIntegration::getInstance();
+
         // array MongoDB::command ( array $command [, array $options = array() [, string &$hash ]] )
         self::traceMethod('command', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
@@ -36,7 +38,7 @@ final class MongoDBIntegration extends Integration
             } elseif (isset($args[1]['timeout'])) {
                 $span->setTag(Tag::MONGODB_TIMEOUT, $args[1]['timeout']);
             }
-        });
+        }, null, $mongoIntegration);
         // array MongoDB::createDBRef ( string $collection , mixed $document_or_id )
         self::traceMethod('createDBRef', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
@@ -45,52 +47,52 @@ final class MongoDBIntegration extends Integration
             if (is_array($ref) && isset($ref['$id'])) {
                 $span->setTag(Tag::MONGODB_BSON_ID, (string) $ref['$id']);
             }
-        });
+        }, $mongoIntegration);
         // MongoCollection MongoDB::createCollection ( string $name [, array $options ] )
         self::traceMethod('createCollection', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_COLLECTION, $args[0]);
-        });
+        }, null, $mongoIntegration);
         // MongoCollection MongoDB::selectCollection ( string $name )
         self::traceMethod('selectCollection', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_COLLECTION, $args[0]);
-        });
+        }, null, $mongoIntegration);
         // array MongoDB::getDBRef ( array $ref )
         self::traceMethod('getDBRef', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             if (isset($args[0]['$ref'])) {
                 $span->setTag(Tag::MONGODB_COLLECTION, $args[0]['$ref']);
             }
-        });
+        }, null, $mongoIntegration);
         // int MongoDB::setProfilingLevel ( int $level )
         self::traceMethod('setProfilingLevel', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_PROFILING_LEVEL, $args[0]);
-        });
+        }, null, $mongoIntegration);
         // bool MongoDB::setReadPreference ( string $read_preference [, array $tags ] )
         self::traceMethod('setReadPreference', function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
             $span->setTag(Tag::MONGODB_READ_PREFERENCE, $args[0]);
-        });
+        }, null, $mongoIntegration);
 
         $setIntegration = function (Span $span, array $args) {
             $span->setIntegration(MongoIntegration::getInstance());
         };
 
         // Methods that don't need extra tags added
-        self::traceMethod('drop', $setIntegration);
-        self::traceMethod('execute', $setIntegration);
-        self::traceMethod('getCollectionInfo', $setIntegration);
-        self::traceMethod('getCollectionNames', $setIntegration);
-        self::traceMethod('getGridFS', $setIntegration);
-        self::traceMethod('getProfilingLevel', $setIntegration);
-        self::traceMethod('getReadPreference', $setIntegration);
-        self::traceMethod('getWriteConcern', $setIntegration);
-        self::traceMethod('lastError', $setIntegration);
-        self::traceMethod('listCollections', $setIntegration);
-        self::traceMethod('repair', $setIntegration);
-        self::traceMethod('setWriteConcern', $setIntegration);
+        self::traceMethod('drop', null, null, $mongoIntegration);
+        self::traceMethod('execute', null, null, $mongoIntegration);
+        self::traceMethod('getCollectionInfo', null, null, $mongoIntegration);
+        self::traceMethod('getCollectionNames', null, null, $mongoIntegration);
+        self::traceMethod('getGridFS', null, null, $mongoIntegration);
+        self::traceMethod('getProfilingLevel', null, null, $mongoIntegration);
+        self::traceMethod('getReadPreference', null, null, $mongoIntegration);
+        self::traceMethod('getWriteConcern', null, null, $mongoIntegration);
+        self::traceMethod('lastError', null, null, $mongoIntegration);
+        self::traceMethod('listCollections', null, null, $mongoIntegration);
+        self::traceMethod('repair', null, null, $mongoIntegration);
+        self::traceMethod('setWriteConcern', null, null, $mongoIntegration);
     }
 
     /**

--- a/src/DDTrace/Integrations/Mongo/MongoIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoIntegration.php
@@ -14,6 +14,22 @@ final class MongoIntegration extends AbstractIntegration
     const NAME = 'mongo';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Mongo/MongoIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoIntegration.php
@@ -14,22 +14,6 @@ final class MongoIntegration extends AbstractIntegration
     const NAME = 'mongo';
 
     /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -15,6 +15,22 @@ class MysqliIntegration extends AbstractIntegration
     const NAME = 'mysqli';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -293,7 +293,7 @@ class MysqliIntegration extends AbstractIntegration
      */
     public static function initScope($operationName, $resource)
     {
-        $scope = GlobalTracer::get()->startActiveSpan($operationName);
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MysqliIntegration::getInstance(), $operationName);
         /** @var \DDTrace\Span $span */
         $span = $scope->getSpan();
         $span->setTag(Tag::SPAN_TYPE, Type::SQL);

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -10,25 +10,9 @@ use DDTrace\Util\ObjectKVStore;
 use DDTrace\Util\TryCatchFinally;
 use DDTrace\GlobalTracer;
 
-class MysqliIntegration extends AbstractIntegration
+final class MysqliIntegration extends AbstractIntegration
 {
     const NAME = 'mysqli';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -10,9 +10,25 @@ use DDTrace\Util\ObjectKVStore;
 use DDTrace\Util\TryCatchFinally;
 use DDTrace\GlobalTracer;
 
-final class MysqliIntegration extends AbstractIntegration
+class MysqliIntegration extends AbstractIntegration
 {
     const NAME = 'mysqli';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -8,7 +8,7 @@ use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\GlobalTracer;
 
-class PDOIntegration extends AbstractIntegration
+final class PDOIntegration extends AbstractIntegration
 {
     const NAME = 'pdo';
 
@@ -21,22 +21,6 @@ class PDOIntegration extends AbstractIntegration
      * @var array
      */
     private static $statements = [];
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -23,6 +23,22 @@ class PDOIntegration extends AbstractIntegration
     private static $statements = [];
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -8,7 +8,7 @@ use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\GlobalTracer;
 
-final class PDOIntegration extends AbstractIntegration
+class PDOIntegration extends AbstractIntegration
 {
     const NAME = 'pdo';
 
@@ -21,6 +21,22 @@ final class PDOIntegration extends AbstractIntegration
      * @var array
      */
     private static $statements = [];
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -52,7 +52,10 @@ class PDOIntegration extends AbstractIntegration
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace('PDO', '__construct', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('PDO.__construct');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PDOIntegration::getInstance(),
+                'PDO.__construct'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -79,7 +82,7 @@ class PDOIntegration extends AbstractIntegration
 
         // public int PDO::exec(string $query)
         dd_trace('PDO', 'exec', function ($statement) {
-            $scope = GlobalTracer::get()->startActiveSpan('PDO.exec');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.exec');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -113,7 +116,7 @@ class PDOIntegration extends AbstractIntegration
         // public int PDO::exec(string $query)
         dd_trace('PDO', 'query', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('PDO.query');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.query');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -146,7 +149,7 @@ class PDOIntegration extends AbstractIntegration
 
         // public bool PDO::commit ( void )
         dd_trace('PDO', 'commit', function () {
-            $scope = GlobalTracer::get()->startActiveSpan('PDO.commit');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.commit');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -174,7 +177,7 @@ class PDOIntegration extends AbstractIntegration
         // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
         dd_trace('PDO', 'prepare', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('PDO.prepare');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.prepare');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -203,7 +206,10 @@ class PDOIntegration extends AbstractIntegration
         // public bool PDOStatement::execute ([ array $input_parameters ] )
         dd_trace('PDOStatement', 'execute', function () {
             $params = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('PDOStatement.execute');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PDOIntegration::getInstance(),
+                'PDOStatement.execute'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -26,6 +26,22 @@ class PredisIntegration extends AbstractIntegration
     private static $connections = [];
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -41,7 +41,10 @@ class PredisIntegration extends AbstractIntegration
         // public Predis\Client::__construct ([ mixed $dsn [, mixed $options ]] )
         dd_trace('Predis\Client', '__construct', function () {
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan('Predis.Client.__construct');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PredisIntegration::getInstance(),
+                'Predis.Client.__construct'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');
@@ -67,7 +70,10 @@ class PredisIntegration extends AbstractIntegration
 
         // public void Predis\Client::connect()
         dd_trace('Predis\Client', 'connect', function () {
-            $scope = GlobalTracer::get()->startActiveSpan('Predis.Client.connect');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PredisIntegration::getInstance(),
+                'Predis.Client.connect'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');
@@ -83,7 +89,10 @@ class PredisIntegration extends AbstractIntegration
             array_unshift($arguments, $command->getId());
             $query = PredisIntegration::formatArguments($arguments);
 
-            $scope = GlobalTracer::get()->startActiveSpan('Predis.Client.executeCommand');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PredisIntegration::getInstance(),
+                'Predis.Client.executeCommand'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');
@@ -99,7 +108,10 @@ class PredisIntegration extends AbstractIntegration
         dd_trace('Predis\Client', 'executeRaw', function ($arguments, &$error = null) {
             $query = PredisIntegration::formatArguments($arguments);
 
-            $scope = GlobalTracer::get()->startActiveSpan('Predis.Client.executeRaw');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PredisIntegration::getInstance(),
+                'Predis.Client.executeRaw'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');
@@ -130,7 +142,10 @@ class PredisIntegration extends AbstractIntegration
 
         // protected array Predis\Pipeline::executePipeline(ConnectionInterface $connection, \SplQueue $commands)
         dd_trace('Predis\Pipeline\Pipeline', 'executePipeline', function ($connection, $commands) {
-            $scope = GlobalTracer::get()->startActiveSpan('Predis.Pipeline.executePipeline');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                PredisIntegration::getInstance(),
+                'Predis.Pipeline.executePipeline'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -16,7 +16,7 @@ const VALUE_MAX_LEN = 100;
 const VALUE_TOO_LONG_MARK = "...";
 const CMD_MAX_LEN = 1000;
 
-final class PredisIntegration extends AbstractIntegration
+class PredisIntegration extends AbstractIntegration
 {
     const NAME = 'predis';
 
@@ -24,6 +24,22 @@ final class PredisIntegration extends AbstractIntegration
      * @var array
      */
     private static $connections = [];
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -16,7 +16,7 @@ const VALUE_MAX_LEN = 100;
 const VALUE_TOO_LONG_MARK = "...";
 const CMD_MAX_LEN = 1000;
 
-class PredisIntegration extends AbstractIntegration
+final class PredisIntegration extends AbstractIntegration
 {
     const NAME = 'predis';
 
@@ -24,22 +24,6 @@ class PredisIntegration extends AbstractIntegration
      * @var array
      */
     private static $connections = [];
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/SingletonIntegration.php
+++ b/src/DDTrace/Integrations/SingletonIntegration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DDTrace\Integrations;
+
+abstract class SingletonIntegration implements \DDTrace\Contracts\Integration
+{
+    private static $instance;
+
+    /**
+     * @return \DDTrace\Contracts\Integration
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new static();
+        }
+
+        return self::$instance;
+    }
+}

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -96,7 +96,7 @@ class SymfonyIntegration extends AbstractIntegration
      */
     public function setupResourceNameTracingV2()
     {
-        $self = this;
+        $self = $this;
 
         dd_trace('Symfony\Component\HttpKernel\Event\FilterControllerEvent', 'setController', function () use ($self) {
             $args = func_get_args();

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -13,6 +13,22 @@ class SymfonyIntegration extends AbstractIntegration
     const BUNDLE_NAME = 'datadog_symfony_bundle';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -57,9 +57,7 @@ class SymfonyIntegration extends AbstractIntegration
             $result = call_user_func_array([$this, 'boot'], func_get_args());
 
             $name = SymfonyIntegration::BUNDLE_NAME;
-            if (!isset($this->bundles[$name])
-                    && defined('\Symfony\Component\HttpKernel\Kernel::VERSION')
-            ) {
+            if (!isset($this->bundles[$name]) && defined('\Symfony\Component\HttpKernel\Kernel::VERSION')) {
                 $version = \Symfony\Component\HttpKernel\Kernel::VERSION;
 
                 $bundle = null;

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -7,26 +7,10 @@ use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\AbstractIntegration;
 use DDTrace\Util\Versions;
 
-class SymfonyIntegration extends AbstractIntegration
+final class SymfonyIntegration extends AbstractIntegration
 {
     const NAME = 'symfony';
     const BUNDLE_NAME = 'datadog_symfony_bundle';
-
-    /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -7,10 +7,26 @@ use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\AbstractIntegration;
 use DDTrace\Util\Versions;
 
-final class SymfonyIntegration extends AbstractIntegration
+class SymfonyIntegration extends AbstractIntegration
 {
     const NAME = 'symfony';
     const BUNDLE_NAME = 'datadog_symfony_bundle';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
     /**
      * @return string The integration name.

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -6,6 +6,7 @@ use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
 use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Symfony\SymfonyIntegration as DDSymfonyIntegration;
+use DDTrace\Integrations\Symfony\SymfonyIntegration;
 use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\Util\TryCatchFinally;
@@ -71,7 +72,10 @@ class SymfonyBundle extends Bundle
                 /** @var Request $request */
                 $request = $args[0];
 
-                $scope = GlobalTracer::get()->startActiveSpan('symfony.kernel.handle');
+                $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                    SymfonyIntegration::getInstance(),
+                    'symfony.kernel.handle'
+                );
                 $symfonyRequestSpan->setTag(Tag::HTTP_METHOD, $request->getMethod());
                 $symfonyRequestSpan->setTag(Tag::HTTP_URL, $request->getUriForPath($request->getPathInfo()));
 
@@ -107,7 +111,10 @@ class SymfonyBundle extends Bundle
             'Symfony\Component\HttpKernel\HttpKernel',
             'handleException',
             function (\Exception $e, Request $request, $type) use ($symfonyRequestSpan) {
-                $scope = GlobalTracer::get()->startActiveSpan('symfony.kernel.handleException');
+                $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                    SymfonyIntegration::getInstance(),
+                    'symfony.kernel.handleException'
+                );
                 $symfonyRequestSpan->setError($e);
 
                 // PHP 5.4 compliant try-catch-finally block.
@@ -144,7 +151,10 @@ class SymfonyBundle extends Bundle
 
                         dd_trace($dispatcherClass, 'dispatch', function () use (&$request, &$symfonyRequestSpan) {
                             $args = func_get_args();
-                            $scope = GlobalTracer::get()->startActiveSpan('symfony.' . $args[0]);
+                            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                                SymfonyIntegration::getInstance(),
+                                'symfony.' . $args[0]
+                            );
                             SymfonyBundle::injectRouteInfo($args, $request, $symfonyRequestSpan);
                             return TryCatchFinally::executePublicMethod($scope, $this, 'dispatch', $args);
                         });
@@ -159,7 +169,10 @@ class SymfonyBundle extends Bundle
         $renderTraceCallback = function () use ($appName) {
             $args = func_get_args();
 
-            $scope = GlobalTracer::get()->startActiveSpan('symfony.templating.render');
+            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+                SymfonyIntegration::getInstance(),
+                'symfony.templating.render'
+            );
             $span = $scope->getSpan();
             $span->setTag(Tag::SERVICE_NAME, $appName);
             $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -60,6 +60,8 @@ class SymfonyBundle extends Bundle
         $appName = $this->getAppName();
         $symfonyRequestSpan = $scope->getSpan();
         $symfonyRequestSpan->overwriteOperationName('symfony.request');
+        // Overwriting the default web integration
+        $symfonyRequestSpan->setIntegration(SymfonyIntegration::getInstance());
         $symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $appName);
         $request = null;
 

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -62,6 +62,8 @@ class SymfonyBundle extends Bundle
         $symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $appName);
         $symfonyRequestSpan->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
         $symfonyRequestSpan->overwriteOperationName('symfony.request');
+        // Overwriting the default web integration
+        $symfonyRequestSpan->setIntegration(SymfonyIntegration::getInstance());
         $request = null;
 
         // public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)

--- a/src/DDTrace/Integrations/Web/WebIntegration.php
+++ b/src/DDTrace/Integrations/Web/WebIntegration.php
@@ -5,7 +5,7 @@ namespace DDTrace\Integrations\Web;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\AbstractIntegration;
 
-final class WebIntegration extends AbstractIntegration
+class WebIntegration extends AbstractIntegration
 {
     const NAME = 'web';
 

--- a/src/DDTrace/Integrations/Web/WebIntegration.php
+++ b/src/DDTrace/Integrations/Web/WebIntegration.php
@@ -5,7 +5,7 @@ namespace DDTrace\Integrations\Web;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\AbstractIntegration;
 
-class WebIntegration extends AbstractIntegration
+final class WebIntegration extends AbstractIntegration
 {
     const NAME = 'web';
 

--- a/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations\ZendFramework\V1;
 
 use DDTrace\GlobalTracer;
+use DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration;
 use DDTrace\Tag;
 use Zend_Controller_Front;
 use Zend_Controller_Plugin_Abstract;
@@ -21,6 +22,8 @@ class TraceRequest extends Zend_Controller_Plugin_Abstract
             return;
         }
         $span = $scope->getSpan();
+        // Overwriting the default web integration
+        $span->setIntegration(ZendFrameworkIntegration::getInstance());
         $controller = $request->getControllerName();
         $action = $request->getActionName();
         $route = Zend_Controller_Front::getInstance()->getRouter()->getCurrentRouteName();

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
@@ -13,6 +13,22 @@ class ZendFrameworkIntegration extends Integration
     const NAME = 'zendframework';
 
     /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
      * @return string The integration name.
      */
     public function getName()

--- a/src/DDTrace/NoopSpan.php
+++ b/src/DDTrace/NoopSpan.php
@@ -7,6 +7,7 @@
 
 namespace DDTrace;
 
+use DDTrace\Contracts\Integration;
 use DDTrace\Contracts\Span as SpanInterface;
 
 final class NoopSpan implements SpanInterface
@@ -198,5 +199,14 @@ final class NoopSpan implements SpanInterface
     public function getAllTags()
     {
         return [];
+    }
+
+    /**
+     * @param Integration $integration
+     * @return self
+     */
+    public function setIntegration(Integration $integration)
+    {
+        return $this;
     }
 }

--- a/src/DDTrace/NoopSpan.php
+++ b/src/DDTrace/NoopSpan.php
@@ -209,4 +209,12 @@ final class NoopSpan implements SpanInterface
     {
         return $this;
     }
+
+    /**
+     * @return null|Integration
+     */
+    public function getIntegration()
+    {
+        return null;
+    }
 }

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -7,6 +7,8 @@
 
 namespace DDTrace;
 
+use DDTrace\Contracts\Integration;
+use DDTrace\Contracts\Scope;
 use DDTrace\Contracts\Span;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Contracts\Tracer as TracerInterface;
@@ -104,5 +106,19 @@ final class NoopTracer implements TracerInterface
     public function getSafeRootSpan()
     {
         return NoopSpan::create();
+    }
+
+    /**
+     * Starts an active span for a supported integration and store the integration that originated the span in the
+     * span itself.
+     *
+     * @param Integration $integration
+     * @param string $operationName
+     * @param array $options
+     * @return Scope
+     */
+    public function startIntegrationScopeAndSpan(Integration $integration, $operationName, $options = [])
+    {
+        return NoopScope::create();
     }
 }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -404,4 +404,12 @@ final class Span implements SpanInterface
         $this->integration = $integration;
         return $this;
     }
+
+    /**
+     * @return null|Integration
+     */
+    public function getIntegration()
+    {
+        return $this->integration;
+    }
 }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -90,15 +90,13 @@ final class Span implements SpanInterface
      * @param string $service
      * @param string $resource
      * @param int|null $startTime
-     * @param null $integration
      */
     public function __construct(
         $operationName,
         SpanContextInterface $context,
         $service,
         $resource,
-        $startTime = null,
-        $integration = null
+        $startTime = null
     ) {
         $this->context = $context;
         $this->operationName = (string)$operationName;

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace;
 
+use DDTrace\Contracts\Integration;
 use DDTrace\Contracts\Span as SpanInterface;
 use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Exceptions\InvalidSpanArgument;
@@ -78,19 +79,26 @@ final class Span implements SpanInterface
     private $hasError = false;
 
     /**
+     * @var Integration
+     */
+    private $integration = null;
+
+    /**
      * Span constructor.
      * @param string $operationName
      * @param SpanContextInterface $context
      * @param string $service
      * @param string $resource
      * @param int|null $startTime
+     * @param null $integration
      */
     public function __construct(
         $operationName,
         SpanContextInterface $context,
         $service,
         $resource,
-        $startTime = null
+        $startTime = null,
+        $integration = null
     ) {
         $this->context = $context;
         $this->operationName = (string)$operationName;
@@ -383,5 +391,17 @@ final class Span implements SpanInterface
     public function getAllBaggageItems()
     {
         return $this->context->getAllBaggageItems();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Integration $integration
+     * @return $this|SpanInterface
+     */
+    public function setIntegration(Integration $integration)
+    {
+        $this->integration = $integration;
+        return $this;
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace;
 
+use DDTrace\Contracts\Integration;
 use DDTrace\Encoders\Json;
 use DDTrace\Log\LoggingTrait;
 use DDTrace\Propagators\CurlHeadersMap;
@@ -212,6 +213,16 @@ final class Tracer implements TracerInterface
         }
 
         return $this->scopeManager->activate($span, $options->shouldFinishSpanOnClose());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startIntegrationScopeAndSpan(Integration $integration, $operationName, $options = [])
+    {
+        $scope = $this->startActiveSpan($operationName, $options);
+        $scope->getSpan()->setIntegration($integration);
+        return $scope;
     }
 
     /**

--- a/src/DDTrace/Util/CodeTracer.php
+++ b/src/DDTrace/Util/CodeTracer.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Util;
 
+use DDTrace\Contracts\Integration;
 use DDTrace\GlobalTracer;
 
 final class CodeTracer
@@ -28,18 +29,30 @@ final class CodeTracer
      * @param string $method
      * @param \Closure|null $preCallHook
      * @param \Closure|null $postCallHook
+     * @param Integration|null $integration
      */
-    public function tracePublicMethod($className, $method, \Closure $preCallHook = null, \Closure $postCallHook = null)
-    {
+    public function tracePublicMethod(
+        $className,
+        $method,
+        \Closure $preCallHook = null,
+        \Closure $postCallHook = null,
+        Integration $integration = null
+    ) {
         dd_trace($className, $method, function () use (
             $className,
             $method,
             $preCallHook,
-            $postCallHook
+            $postCallHook,
+            $integration
         ) {
             $args = func_get_args();
             $scope = GlobalTracer::get()->startActiveSpan($className . '.' . $method);
             $span = $scope->getSpan();
+
+            if ($integration) {
+                $span->setIntegration($integration);
+            }
+
             if (null !== $preCallHook) {
                 $preCallHook($span, $args);
             }

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -5,34 +5,49 @@ namespace DDTrace\Tests\Common;
 use DDTrace\Contracts\Span;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Checks that spans are assigned the proper integration.
+ */
 class SpanIntegrationChecker
 {
+    /**
+     * Returns the known matching patterns operation ==> integration class.
+     */
     public function defineIntegrationsByPattern()
     {
         // <regex pattern> => <integration class>
         return [
-            // Prepend your operation names with custom for custom spans
+            // Prepend your operation names with custom for custom spans to have the span check disabled
             '/custom.*/' => null,
             // Officially supported integrations
             '/curl_.*/' => 'DDTrace\Integrations\Curl\CurlIntegration',
             '/Elasticsearch(.).*/' => 'DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
             '/GuzzleHttp.*/' => 'DDTrace\Integrations\Guzzle\GuzzleIntegration',
+            '/laravel.*/' => 'DDTrace\Integrations\Laravel\LaravelIntegration',
             '/Memcached.*/' => 'DDTrace\Integrations\Memcached\MemcachedIntegration',
             '/Mongo(Client)|(DB)|(Collection).*/' => 'DDTrace\Integrations\Mongo\MongoIntegration',
             '/mysqli.*/' => 'DDTrace\Integrations\Mysqli\MysqliIntegration',
             '/PDO(.)|(Statement).*/' => 'DDTrace\Integrations\PDO\PDOIntegration',
             '/Predis.*/' => 'DDTrace\Integrations\Predis\PredisIntegration',
+            '/symfony.*/' => 'DDTrace\Integrations\Symfony\SymfonyIntegration',
+            '/web.*/' => 'DDTrace\Integrations\Web\WebIntegration',
+            '/zf.*/' => 'DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration',
         ];
     }
 
+    /**
+     * Checks that $span belongs to the proper integration.
+     *
+     * @param TestCase $test
+     * @param Span $span
+     */
     public function checkIntegration(TestCase $test, Span $span)
     {
         $here = get_class($this) . '::defineOwners()';
         $operationName = $span->getOperationName();
         $definitionFound = false;
 
-        foreach ($this->defineIntegrationsByPattern() as $operationNameRegex => $integrationClass)
-        {
+        foreach ($this->defineIntegrationsByPattern() as $operationNameRegex => $integrationClass) {
             if (preg_match($operationNameRegex, $operationName)) {
                 $definitionFound = true;
 
@@ -52,10 +67,8 @@ class SpanIntegrationChecker
         }
 
         if (false === $definitionFound) {
-            $message = "Span's integration check is enabled but no matching pattern found for operation " .
-                       "'$operationName' in '$here'. If you are testing an integration where spans are " .
-                       "recreated from a request re-player, e.g. web tests, you can disable integration check " .
-                       "using the param '\$checkIntegration = false'. If you are testing custom " .
+            $message = "No matching pattern found for operation " .
+                       "'$operationName' in '$here'. If you are testing custom " .
                        "spans you can use operation name 'custom.*' or register the name in '$here'";
             $test->fail($message);
         }

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DDTrace\Tests\Common;
+
+use DDTrace\Contracts\Span;
+use PHPUnit\Framework\TestCase;
+
+class SpanIntegrationChecker
+{
+    public function defineIntegrationsByPattern()
+    {
+        // <regex pattern> => <integration class>
+        return [
+            // Prepend your operation names with custom for custom spans
+            '/custom.*/' => null,
+            // Officially supported integrations
+            '/curl_.*/' => 'DDTrace\Integrations\Curl\CurlIntegration',
+            '/Elasticsearch(.).*/' => 'DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
+            '/GuzzleHttp.*/' => 'DDTrace\Integrations\Guzzle\GuzzleIntegration',
+            '/Memcached.*/' => 'DDTrace\Integrations\Memcached\MemcachedIntegration',
+            '/Mongo(Client)|(DB)|(Collection).*/' => 'DDTrace\Integrations\Mongo\MongoIntegration',
+            '/mysqli.*/' => 'DDTrace\Integrations\Mysqli\MysqliIntegration',
+            '/PDO(.)|(Statement).*/' => 'DDTrace\Integrations\PDO\PDOIntegration',
+            '/Predis.*/' => 'DDTrace\Integrations\Predis\PredisIntegration',
+        ];
+    }
+
+    public function checkIntegration(TestCase $test, Span $span)
+    {
+        $here = get_class($this) . '::defineOwners()';
+        $operationName = $span->getOperationName();
+        $definitionFound = false;
+
+        foreach ($this->defineIntegrationsByPattern() as $operationNameRegex => $integrationClass)
+        {
+            if (preg_match($operationNameRegex, $operationName)) {
+                $definitionFound = true;
+
+                if (null === $integrationClass && null !== $span->getIntegration()) {
+                    $message = "Unexpected integration found in span: $operationName.";
+                    $test->fail($message);
+                    break;
+                } elseif (null !== $integrationClass && null === $span->getIntegration()) {
+                    $message = "No integration defined in span for operation '$operationName'. " .
+                               "Expected '$integrationClass'";
+                    $test->fail($message);
+                    break;
+                } elseif (null !== $integrationClass && null !== $span->getIntegration()) {
+                    $test->assertInstanceOf($integrationClass, $span->getIntegration());
+                }
+            }
+        }
+
+        if (false === $definitionFound) {
+            $message = "Span's integration check is enabled but no matching pattern found for operation " .
+                       "'$operationName' in '$here'. If you are testing an integration where spans are " .
+                       "recreated from a request re-player, e.g. web tests, you can disable integration check " .
+                       "using the param '\$checkIntegration = false'. If you are testing custom " .
+                       "spans you can use operation name 'custom.*' or register the name in '$here'";
+            $test->fail($message);
+        }
+    }
+}

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -57,7 +57,7 @@ class SpanIntegrationChecker
                     break;
                 } elseif (null !== $integrationClass && null === $span->getIntegration()) {
                     $message = "No integration defined in span for operation '$operationName'. " .
-                               "Expected '$integrationClass'";
+                                "Expected '$integrationClass'";
                     $test->fail($message);
                     break;
                 } elseif (null !== $integrationClass && null !== $span->getIntegration()) {
@@ -68,8 +68,8 @@ class SpanIntegrationChecker
 
         if (false === $definitionFound) {
             $message = "No matching pattern found for operation " .
-                       "'$operationName' in '$here'. If you are testing custom " .
-                       "spans you can use operation name 'custom.*' or register the name in '$here'";
+                        "'$operationName' in '$here'. If you are testing custom " .
+                        "spans you can use operation name 'custom.*' or register the name in '$here'";
             $test->fail($message);
         }
     }

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Checks that spans are assigned the proper integration.
  */
-class SpanIntegrationChecker
+final class SpanIntegrationChecker
 {
     /**
      * Returns the known matching patterns operation ==> integration class.

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -49,7 +49,9 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected static function getEnvs()
     {
-        return [];
+        return [
+            'DD_TEST_INTEGRATION' => 'true',
+        ];
     }
 
     /**

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -11,7 +11,6 @@ use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tracer;
 use DDTrace\Util\ArrayKVStore;
 use DDTrace\GlobalTracer;
-use DDTrace\Util\Versions;
 
 final class CurlIntegrationTest extends IntegrationTestCase
 {
@@ -183,7 +182,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $ch = curl_init(self::URL . '/headers');
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -195,7 +194,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
             $span->finish();
         });
 
-        // trace is: some_operation
+        // trace is: custom
         $this->assertSame($traces[0][0]->getContext()->getSpanId(), $found['headers']['X-Datadog-Trace-Id']);
         // parent is: curl_exec
         $this->assertSame($traces[0][1]->getContext()->getSpanId(), $found['headers']['X-Datadog-Parent-Id']);
@@ -218,7 +217,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $ch = curl_init(self::URL . '/headers');
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -15,9 +15,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
 
     protected static function getEnvs()
     {
-        return [
+        return array_merge(parent::getEnvs(), [
             'APP_NAME' => 'custom_autoloaded_app',
-        ];
+        ]);
     }
 
     /**

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -17,7 +17,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'custom_autoloaded_app',
-            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -17,6 +17,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'custom_autoloaded_app',
+            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 
@@ -49,6 +50,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => '/simple',
                         'http.status_code' => '200',
+                        'integration.name' => 'web',
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -61,6 +63,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => '/simple_view',
                         'http.status_code' => '200',
+                        'integration.name' => 'web',
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -73,6 +76,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => '/error',
                         'http.status_code' => '500',
+                        'integration.name' => 'web',
                     ])->setError(),
                 ],
             ]

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -116,7 +116,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers', [
                 'headers' => [
@@ -128,7 +128,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             $span->finish();
         });
 
-        // trace is: some_operation
+        // trace is: custom
         $this->assertSame($traces[0][0]->getContext()->getSpanId(), $found['headers']['X-Datadog-Trace-Id']);
         // parent is: curl_exec, used under the hood
 
@@ -159,7 +159,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers');
 

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -108,7 +108,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers', [
                 'headers' => [
@@ -120,7 +120,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             $span->finish();
         });
 
-        // trace is: some_operation
+        // trace is: custom
         $this->assertSame($traces[0][0]->getContext()->getSpanId(), $found['headers']['X-Datadog-Trace-Id']);
         // parent is: curl_exec, used under the hood
         $this->assertSame($traces[0][2]->getContext()->getSpanId(), $found['headers']['X-Datadog-Parent-Id']);
@@ -144,7 +144,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('some_operation')->getSpan();
+            $span = $tracer->startActiveSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers');
 

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -18,7 +18,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
             'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
-            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -51,6 +51,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'integration.name' => 'laravel',
                         ]),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
@@ -59,6 +60,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         ->withExactTags([
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'integration.name' => 'laravel',
                         ]),
                     SpanAssertion::exists('laravel.event.handle'),
                 ],
@@ -73,6 +75,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         ->withExactTags([
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'integration.name' => 'laravel',
                         ]),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
@@ -87,6 +90,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'integration.name' => 'laravel',
                         ])->setError(),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
@@ -97,6 +101,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.type' => 'Exception',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'integration.name' => 'laravel',
                         ])
                         ->withExistingTagsNames(['error.stack'])
                         ->setError(),

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -18,6 +18,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
             'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
+            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -17,6 +17,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'laravel_test_app',
+            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -52,6 +52,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'integration.name' => 'laravel',
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -65,6 +66,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
+                        'integration.name' => 'laravel',
                     ])->withExistingTagsNames(['laravel.route.name']),
                     SpanAssertion::build(
                         'laravel.view',
@@ -85,6 +87,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
+                        'integration.name' => 'laravel',
                     ])->setError(),
                 ],
             ]

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -73,7 +73,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'laravel_test_app',
                         'web',
                         'laravel.view'
-                    ),
+                    )->withExactTags([
+                        'integration.name' => 'laravel',
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -17,7 +17,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'laravel_test_app',
-            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -15,9 +15,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
 
     protected static function getEnvs()
     {
-        return [
+        return array_merge(parent::getEnvs(), [
             'APP_NAME' => 'laravel_test_app',
-        ];
+        ]);
     }
 
     /**

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -17,6 +17,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'laravel_test_app',
+            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -73,7 +73,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'laravel_test_app',
                         'web',
                         'laravel.view'
-                    ),
+                    )->withExactTags([
+                        'integration.name' => 'laravel',
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -52,6 +52,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'integration.name' => 'laravel',
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -65,6 +66,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
+                        'integration.name' => 'laravel',
                     ])->withExistingTagsNames(['laravel.route.name']),
                     SpanAssertion::build(
                         'laravel.view',
@@ -85,6 +87,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
+                        'integration.name' => 'laravel',
                     ])->setError(),
                     SpanAssertion::exists('laravel.view')
                 ],

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -17,7 +17,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return [
             'APP_NAME' => 'laravel_test_app',
-            'DD_TEST_INTEGRATION' => 'true',
         ];
     }
 

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -15,9 +15,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
 
     protected static function getEnvs()
     {
-        return [
+        return array_merge(parent::getEnvs(), [
             'APP_NAME' => 'laravel_test_app',
-        ];
+        ]);
     }
 
     /**

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -6,7 +6,6 @@ use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 use Predis\Configuration\Options;
-use Predis\Response\Status;
 
 
 final class PredisTest extends IntegrationTestCase
@@ -27,7 +26,7 @@ final class PredisTest extends IntegrationTestCase
 
     public function testPredisIntegrationCreatesSpans()
     {
-        $traces = $this->inTestScope('redis.test', function () {
+        $traces = $this->inTestScope('custom_redis.test', function () {
             $client = new \Predis\Client([ "host" => $this->host ]);
             $value = 'bar';
 

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -40,6 +40,7 @@ final class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => '/',
                 'http.status_code' => '200',
+                'integration.name' => 'symfony',
             ]),
         ]);
     }

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -13,13 +13,6 @@ final class RouteNameTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_3/web/app.php';
     }
 
-    protected static function getEnvs()
-    {
-        return array_merge(parent::getEnvs(), [
-            'DD_TEST_INTEGRATION' => 'true',
-        ]);
-    }
-
     /**
      * @throws \Exception
      */

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -13,6 +13,13 @@ final class RouteNameTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_3/web/app.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TEST_INTEGRATION' => 'true',
+        ]);
+    }
+
     /**
      * @throws \Exception
      */

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -13,13 +13,6 @@ final class RouteNameTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_8/web/app.php';
     }
 
-    protected static function getEnvs()
-    {
-        return array_merge(parent::getEnvs(), [
-            'DD_TEST_INTEGRATION' => 'true',
-        ]);
-    }
-
     /**
      * @throws \Exception
      */

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -40,6 +40,7 @@ final class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => '/',
                 'http.status_code' => '200',
+                'integration.name' => 'symfony',
             ]),
         ]);
     }

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -13,6 +13,13 @@ final class RouteNameTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_8/web/app.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TEST_INTEGRATION' => 'true',
+        ]);
+    }
+
     /**
      * @throws \Exception
      */

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -13,13 +13,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/app.php';
     }
 
-    protected static function getEnvs()
-    {
-        return array_merge(parent::getEnvs(), [
-            'DD_TEST_INTEGRATION' => 'true',
-        ]);
-    }
-
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -13,6 +13,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/app.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TEST_INTEGRATION' => 'true',
+        ]);
+    }
+
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -52,6 +52,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -74,6 +75,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -84,7 +86,10 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                    ),
+                    )
+                        ->withExactTags([
+                            'integration.name' => 'symfony',
+                        ]),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -105,6 +110,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.msg' => 'An exception occurred',
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
+                            'integration.name' => 'symfony',
                         ])
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -39,6 +39,7 @@ final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/terminated_by_exit',
                     'http.status_code' => '200',
+                    'integration.name' => 'symfony',
                 ]),
             SpanAssertion::exists('symfony.kernel.handle'),
             SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -53,6 +53,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -75,6 +76,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -85,7 +87,10 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_34',
                         'web',
                         'Twig\Environment twig_template.html.twig'
-                    ),
+                    )
+                        ->withExactTags([
+                            'integration.name' => 'symfony',
+                        ]),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -106,6 +111,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.msg' => 'An exception occurred',
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
+                            'integration.name' => 'symfony',
                         ])
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -17,7 +17,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_APP_NAME' => 'test_symfony_34',
-            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -17,6 +17,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_APP_NAME' => 'test_symfony_34',
+            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -32,6 +32,7 @@ final class TemplateEnginesTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/alternate_templating',
                     'http.status_code' => '200',
+                    'integration.name' => 'symfony',
                 ]),
             SpanAssertion::exists('symfony.kernel.handle'),
             SpanAssertion::exists('symfony.kernel.request'),
@@ -42,7 +43,10 @@ final class TemplateEnginesTest extends WebFrameworkTestCase
                 'symfony',
                 'web',
                 'Symfony\Component\Templating\PhpEngine php_template.template.php'
-            ),
+            )
+                ->withExactTags([
+                    'integration.name' => 'symfony',
+                ]),
             SpanAssertion::exists('symfony.kernel.response'),
             SpanAssertion::exists('symfony.kernel.finish_request'),
             SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -18,6 +18,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
             'DD_TRACE_APP_NAME' => 'test_symfony_42',
+            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -18,7 +18,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
             'DD_TRACE_APP_NAME' => 'test_symfony_42',
-            'DD_TEST_INTEGRATION' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -54,6 +54,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -76,6 +77,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
+                            'integration.name' => 'symfony',
                         ]),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
@@ -86,7 +88,10 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_42',
                         'web',
                         'Twig\Environment twig_template.html.twig'
-                    ),
+                    )
+                        ->withExactTags([
+                            'integration.name' => 'symfony',
+                        ]),
                     SpanAssertion::exists('symfony.kernel.response'),
                     SpanAssertion::exists('symfony.kernel.finish_request'),
                     SpanAssertion::exists('symfony.kernel.terminate'),
@@ -107,6 +112,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.msg' => 'An exception occurred',
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
+                            'integration.name' => 'symfony',
                         ])
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -13,13 +13,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/ZendFramework/Version_1_12/public/index.php';
     }
 
-    protected static function getEnvs()
-    {
-        return array_merge(parent::getEnvs(), [
-            'DD_TEST_INTEGRATION' => 'true',
-        ]);
-    }
-
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -13,6 +13,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         return __DIR__ . '/../../../Frameworks/ZendFramework/Version_1_12/public/index.php';
     }
 
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TEST_INTEGRATION' => 'true',
+        ]);
+    }
+
     /**
      * @dataProvider provideSpecs
      * @param RequestSpec $spec
@@ -41,6 +48,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
+                            'integration.name' => 'zendframework',
                         ]),
                 ],
                 'A simple GET request with a view' => [
@@ -52,6 +60,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
+                            'integration.name' => 'zendframework',
                         ]),
                 ],
                 'A GET request with an exception' => [
@@ -63,6 +72,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
                             'http.status_code' => '500',
+                            'integration.name' => 'zendframework',
                         ])->setError(),
                 ],
             ]

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -225,7 +225,7 @@ final class TracerTest extends BaseTestCase
 
         $transport = new DebugTransport();
         $tracer = new Tracer($transport);
-        $span = $tracer->startSpan('some_operation');
+        $span = $tracer->startSpan('custom');
 
         $this->assertSame('value1', $span->getAllTags()['key1']);
         $this->assertSame('value2', $span->getAllTags()['key2']);


### PR DESCRIPTION
### Description

As a preparatory work to support Trace Analytics configuration from the PHP tracer, we opted for making Spans integration aware. With this in mind we can enable batch post processing and be totally aware of the specific integration, and consequently integration's configuration, that generated such span.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
