### PR TITLE
Use cached hash function results in PHP 7.x  + disable all internals of tracing when its not needed 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,8 +478,12 @@ workflows:
       - "Code Checkout"
       - compile_extension:
           requires: [ 'Code Checkout' ]
-          name: "test compile PHP 55"
+          name: "PHP 55 Compile test "
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
+          name: "HP 56 Compile - zts"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-zts"
       - unit_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 54 Unit tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,16 @@ jobs:
     working_directory: ~/datadog
     docker: [ image: 'circleci/buildpack-deps:latest' ]
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
       - checkout
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
       - <<: *STEP_ATTACH_WORKSPACE
       - persist_to_workspace:
           root: '.'
@@ -478,11 +487,11 @@ workflows:
       - "Code Checkout"
       - compile_extension:
           requires: [ 'Code Checkout' ]
-          name: "PHP 55 Compile test "
+          name: "PHP 55 Compilation test"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
       - compile_extension:
           requires: [ 'Code Checkout' ]
-          name: "HP 56 Compile - zts"
+          name: "PHP 56-zts Compilation test"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-zts"
       - unit_tests:
           requires: [ 'Code Checkout' ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Changed
+- When shutdown hook is executed we disable all tracing to avoid creating unnecessary spans #361
+- Inside request init hook we disable all function tracing when we decide not to trace #361
+
 ### Added
 - Disable request_init_hook functionality in presence of blacklisted modules #345
 - Integration-level configuration #354
+- `dd_trace_disable_in_request` function which disables all function tracing until request ends #361
 
 ### Fixed
 - Symfony template rendering spans #359

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -5,10 +5,12 @@ namespace DDTrace\Bridge;
 require_once __DIR__ . '/functions.php';
 
 if (php_sapi_name() == 'cli' && getenv('APP_ENV') != 'dd_testing') {
+    dd_trace_disable_in_request();
     return;
 }
 
 if (!dd_tracing_enabled()) {
+    dd_trace_disable_in_request();
     return;
 }
 

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -32,6 +32,8 @@ final class Bootstrap
         self::registerOpenTracing();
 
         register_shutdown_function(function () {
+            dd_trace_disable_in_request(); //disable function tracing to speedup shutdown
+
             $tracer = GlobalTracer::get();
             $scopeManager = $tracer->getScopeManager();
             $scopeManager->close();

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -93,6 +93,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
 
 static PHP_RINIT_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
+    DDTRACE_G(disable) = 0;
 
 #if defined(ZTS) && PHP_VERSION_ID >= 70000
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -101,6 +102,9 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     if (DDTRACE_G(disable)) {
         return SUCCESS;
     }
+
+
+    DDTRACE_G(in_request_shutdown) = 0;
 
     ddtrace_dispatch_init(TSRMLS_C);
 
@@ -122,7 +126,8 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     if (DDTRACE_G(disable)) {
         return SUCCESS;
     }
-
+    DDTRACE_G(in_request_shutdown) = 1;
+    DDTRACE_G(disable) = 1;
     ddtrace_dispatch_destroy(TSRMLS_C);
 
     return SUCCESS;

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -5,6 +5,7 @@ extern zend_module_entry ddtrace_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
+zend_bool in_request_shutdown;
 char *request_init_hook;
 char *internal_blacklisted_modules_regexp;
 zend_bool strict_mode;

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -5,7 +5,7 @@ extern zend_module_entry ddtrace_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
-zend_bool in_request_shutdown;
+zend_bool disable_in_current_request;
 char *request_init_hook;
 char *internal_blacklisted_modules_regexp;
 zend_bool strict_mode;

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -48,12 +48,12 @@ zend_class_entry *get_executed_scope(void) {
 #if PHP_VERSION_ID < 70000
 static ddtrace_dispatch_t *lookup_dispatch(const HashTable *lookup, ddtrace_lookup_data_t *lookup_data) {
     if (lookup_data->function_name_length == 0) {
-        ookup_data->function_name_length = strlen(function_name);
+        lookup_data->function_name_length = strlen(lookup_data->function_name);
     }
 
     char *key = zend_str_tolower_dup(lookup_data->function_name, lookup_data->function_name_length);
     ddtrace_dispatch_t *dispatch = NULL;
-    dispatch = zend_hash_str_find_ptr(lookup, key, ookup_data->function_name_length);
+    dispatch = zend_hash_str_find_ptr(lookup, key, lookup_data->function_name_length);
 
     efree(key);
     return dispatch;
@@ -213,9 +213,10 @@ static int is_anonymous_closure(zend_function *fbc, ddtrace_lookup_data_t *looku
     }
 #if PHP_VERSION_ID < 70000
     if (lookup->function_name_length == 0) {
-        lookup->function_name_length = strlen(function_name);
+        lookup->function_name_length = strlen(lookup->function_name);
     }
-    if ((lookup->function_name_length == (sizeof("{closure}") - 1)) && strcmp(function_name, "{closure}") == 0) {
+    if ((lookup->function_name_length == (sizeof("{closure}") - 1)) &&
+        strcmp(lookup->function_name, "{closure}") == 0) {
         return 1;
     } else {
         return 0;
@@ -388,7 +389,7 @@ static zend_always_inline zend_bool is_function_wrappable(zend_execute_data *exe
 #if PHP_VERSION_ID < 70000
     if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
         if (fbc) {
-            lookup_data->function_name = Z_STRVAL_P(fname);
+            lookup_data->function_name = fbc->common.function_name;
         }
     } else {
         zval *fname = EX(opline)->op1.zv;

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -461,6 +461,10 @@ int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
     uint32_t function_name_length = 0;
     DD_PRINTF("OPCODE: %s", zend_get_opcode_name(EX(opline)->opcode));
 
+    if (DDTRACE_G(disable)){
+        return default_dispatch(execute_data TSRMLS_CC);
+    }
+
     zend_function *current_fbc = get_current_fbc(execute_data);
 
     if (!is_function_wrappable(execute_data, current_fbc, &function_name, &function_name_length)) {

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -467,7 +467,7 @@ int default_dispatch(zend_execute_data *execute_data TSRMLS_DC) {
 int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
     DD_PRINTF("OPCODE: %s", zend_get_opcode_name(EX(opline)->opcode));
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request)) {
-        return default_dispatch(execute_data);
+        return default_dispatch(execute_data TSRMLS_CC);
     }
 
     zend_function *current_fbc = get_current_fbc(execute_data);

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -21,7 +21,6 @@ typedef struct _ddtrace_lookup_data_t {
 #endif
 } ddtrace_lookup_data_t;
 
-
 zend_bool ddtrace_trace(zval *, zval *, zval *TSRMLS_DC);
 int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
 void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -12,6 +12,16 @@ typedef struct _ddtrace_dispatch_t {
     uint32_t acquired;
 } ddtrace_dispatch_t;
 
+typedef struct _ddtrace_lookup_data_t {
+#if PHP_VERSION_ID < 70000
+    const char *function_name;
+    uint32_t function_name_length;
+#else
+    zend_string *function_name;
+#endif
+} ddtrace_lookup_data_t;
+
+
 zend_bool ddtrace_trace(zval *, zval *, zval *TSRMLS_DC);
 int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
 void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -43,6 +43,25 @@ static zend_always_inline zval *ddtrace_this(zend_execute_data *execute_data) {
 }
 #undef _EX
 
+#if PHP_VERSION_ID >= 70000
+static zend_always_inline int ddtrace_is_all_lower(zend_string *s){
+    unsigned char *c, *e;
+
+    c = (unsigned char *)ZSTR_VAL(s);
+	e = c + ZSTR_LEN(s);
+
+    int rv = 1;
+	while (c < e) {
+		if (isupper(*c)) {
+            rv = 0;
+            break;
+        }
+		c++;
+	}
+    return rv;
+}
+#endif // PHP7.x
+
 void ddtrace_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fci, zval **result TSRMLS_DC);
 zend_function *ddtrace_function_get(const HashTable *table, zval *name);
 void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch);

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -44,23 +44,23 @@ static zend_always_inline zval *ddtrace_this(zend_execute_data *execute_data) {
 #undef _EX
 
 #if PHP_VERSION_ID >= 70000
-static zend_always_inline int ddtrace_is_all_lower(zend_string *s){
+static zend_always_inline int ddtrace_is_all_lower(zend_string *s) {
     unsigned char *c, *e;
 
     c = (unsigned char *)ZSTR_VAL(s);
-	e = c + ZSTR_LEN(s);
+    e = c + ZSTR_LEN(s);
 
     int rv = 1;
-	while (c < e) {
-		if (isupper(*c)) {
+    while (c < e) {
+        if (isupper(*c)) {
             rv = 0;
             break;
         }
-		c++;
-	}
+        c++;
+    }
     return rv;
 }
-#endif // PHP7.x
+#endif  // PHP7.x
 
 void ddtrace_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fci, zval **result TSRMLS_DC);
 zend_function *ddtrace_function_get(const HashTable *table, zval *name);

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -14,35 +14,22 @@ void ddtrace_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fci, 
     fci->retval = *result;
 }
 
-int is_all_lower(zend_string *s){
-    unsigned char *c, *e;
-
-    c = (unsigned char *)ZSTR_VAL(s);
-	e = c + ZSTR_LEN(s);
-
-    int rv = 1;
-	while (c < e) {
-		if (isupper(*c)) {
-            rv = 0;
-            break;
-        }
-		c++;
-	}
-    return rv;
-}
-
 zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     if (Z_TYPE_P(name) != IS_STRING) {
         return NULL;
     }
 
-    zend_string *key = Z_STR_P(name);
-    if (!is_all_lower(key)){
-        key = zend_string_tolower(Z_STR_P(name));
+    zend_string *to_free = NULL, *key = Z_STR_P(name);
+    if (!ddtrace_is_all_lower(key)){
+        key = zend_string_tolower(key);
+        to_free = key;
     }
 
     zend_function *ptr = zend_hash_find_ptr(table, key);
-    zend_string_release(key);
+
+    if (to_free){
+        zend_string_release(to_free);
+    }
     return ptr;
 }
 

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -20,14 +20,14 @@ zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     }
 
     zend_string *to_free = NULL, *key = Z_STR_P(name);
-    if (!ddtrace_is_all_lower(key)){
+    if (!ddtrace_is_all_lower(key)) {
         key = zend_string_tolower(key);
         to_free = key;
     }
 
     zend_function *ptr = zend_hash_find_ptr(table, key);
 
-    if (to_free){
+    if (to_free) {
         zend_string_release(to_free);
     }
     return ptr;

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -14,14 +14,34 @@ void ddtrace_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fci, 
     fci->retval = *result;
 }
 
+int is_all_lower(zend_string *s){
+    unsigned char *c, *e;
+
+    c = (unsigned char *)ZSTR_VAL(s);
+	e = c + ZSTR_LEN(s);
+
+    int rv = 1;
+	while (c < e) {
+		if (isupper(*c)) {
+            rv = 0;
+            break;
+        }
+		c++;
+	}
+    return rv;
+}
+
 zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     if (Z_TYPE_P(name) != IS_STRING) {
         return NULL;
     }
 
-    zend_string *key = zend_string_tolower(Z_STR_P(name));
-    zend_function *ptr = zend_hash_find_ptr(table, key);
+    zend_string *key = Z_STR_P(name);
+    if (!is_all_lower(key)){
+        key = zend_string_tolower(Z_STR_P(name));
+    }
 
+    zend_function *ptr = zend_hash_find_ptr(table, key);
     zend_string_release(key);
     return ptr;
 }

--- a/tests/ext/disable_tracing_disables_tracing.phpt
+++ b/tests/ext/disable_tracing_disables_tracing.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Disable tracing disables all tracing from happening
+--FILE--
+<?php
+class Test {
+    public function m(){
+        return 'METHOD' . PHP_EOL;
+    }
+}
+
+dd_trace("Test", "m", function($arg){
+    return 'HOOK ' . $this->m();
+});
+
+echo (new Test())->m("HOOK");
+dd_trace_disable_in_request();
+echo (new Test())->m("HOOK");
+
+?>
+--EXPECT--
+HOOK METHOD
+METHOD

--- a/tests/ext/protected_method_hook.phpt
+++ b/tests/ext/protected_method_hook.phpt
@@ -5,6 +5,25 @@ Check protected method can be overwritten and we are able to call original.
 
 class Test
 {
+
+    // public $blah = "Fsfafasfas" ;
+    function __construct()
+    {
+        // $this->blah = 1;
+    }
+
+    function __isset($isset){
+        dd_trace_noop();
+        return true;
+    }
+
+    function __get($name) {
+        dd_trace_noop();
+        echo "hello";
+
+        return "!";
+    }
+
     public function m()
     {
         echo "METHOD" . PHP_EOL;
@@ -13,6 +32,7 @@ class Test
 
     protected function protected_method()
     {
+        echo $this->blah . PHP_EOL;
         echo "PROTECTED METHOD" . PHP_EOL;
     }
 }

--- a/tests/ext/protected_method_hook.phpt
+++ b/tests/ext/protected_method_hook.phpt
@@ -5,25 +5,6 @@ Check protected method can be overwritten and we are able to call original.
 
 class Test
 {
-
-    // public $blah = "Fsfafasfas" ;
-    function __construct()
-    {
-        // $this->blah = 1;
-    }
-
-    function __isset($isset){
-        dd_trace_noop();
-        return true;
-    }
-
-    function __get($name) {
-        dd_trace_noop();
-        echo "hello";
-
-        return "!";
-    }
-
     public function m()
     {
         echo "METHOD" . PHP_EOL;
@@ -32,7 +13,6 @@ class Test
 
     protected function protected_method()
     {
-        echo $this->blah . PHP_EOL;
         echo "PROTECTED METHOD" . PHP_EOL;
     }
 }


### PR DESCRIPTION
### Description

This PR changes the implementation slightly to honor PHP 7.x cached hash calculations. 
In addition a new function has been implemented `dd_trace_disable_in_request` which is used to disable tracing when its no longer needed in order to  avoid spending CPU time unnecesarily
<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
