### PR TITLE
Mark non-success HTTP statuses as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Symfony template rendering spans #359
 - Laravel integration user ID errors #363
+- Non-success HTTP response codes aren't properly categorized as errors in the APM UI #366
 
 ## [0.15.1]
 

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -208,6 +208,10 @@ final class Span implements SpanInterface
             $value = Urls::sanitize((string)$value);
         }
 
+        if ($key === Tag::HTTP_STATUS_CODE && $value >= 400) {
+            $this->hasError = true;
+        }
+
         $this->tags[$key] = (string)$value;
     }
 

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -208,7 +208,7 @@ final class Span implements SpanInterface
             $value = Urls::sanitize((string)$value);
         }
 
-        if ($key === Tag::HTTP_STATUS_CODE && $value >= 400) {
+        if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
             $this->hasError = true;
         }
 

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -73,7 +73,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => '/error',
                         'http.status_code' => '500',
-                    ]),
+                    ])->setError(),
                 ],
             ]
         );

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -86,7 +86,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
-                        ]),
+                        ])->setError(),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::exists('laravel.event.handle'),

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -84,7 +84,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ]),
+                    ])->setError(),
                 ],
             ]
         );

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -84,7 +84,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ]),
+                    ])->setError(),
                     SpanAssertion::exists('laravel.view')
                 ],
             ]

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -63,7 +63,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
                             'http.status_code' => '500',
-                        ]),
+                        ])->setError(),
                 ],
             ]
         );


### PR DESCRIPTION
### Description

When an HTTP response status is >= ~~400~~ 500, it  isn't always marked as an error. This PR ensures that all non-success HTTP status codes get marked as an error in the APM UI.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
