### PR TITLE
Reimplement blacklist as simple list to avoid problems with missing symbols between modules

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -52,8 +52,8 @@ ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 
 PHP_INI_BEGIN()
 STD_PHP_INI_ENTRY("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals, ddtrace_globals)
-STD_PHP_INI_ENTRY("ddtrace.internal_blacklisted_modules_regexp", "/ioncube/i", PHP_INI_SYSTEM, OnUpdateString,
-                  internal_blacklisted_modules_regexp, zend_ddtrace_globals, ddtrace_globals)
+STD_PHP_INI_ENTRY("ddtrace.internal_blacklisted_modules_list", "ionCube Loader,", PHP_INI_SYSTEM, OnUpdateString,
+                  internal_blacklisted_modules_list, zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateString, request_init_hook,
                   zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_ENTRY("ddtrace.strict_mode", "0", PHP_INI_SYSTEM, OnUpdateBool, strict_mode, zend_ddtrace_globals,
@@ -104,7 +104,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     ddtrace_dispatch_init(TSRMLS_C);
 
-    if (DDTRACE_G(internal_blacklisted_modules_regexp) && !dd_no_blacklisted_modules(TSRMLS_C)) {
+    if (DDTRACE_G(internal_blacklisted_modules_list) && !dd_no_blacklisted_modules(TSRMLS_C)) {
         return SUCCESS;
     }
 

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -6,7 +6,7 @@ extern zend_module_entry ddtrace_module_entry;
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
 char *request_init_hook;
-char *internal_blacklisted_modules_regexp;
+char *internal_blacklisted_modules_list;
 zend_bool strict_mode;
 
 HashTable class_lookup;

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -6,30 +6,22 @@
 #include <Zend/zend.h>
 #include <Zend/zend_compile.h>
 #include <php_main.h>
-
-#if PHP_VERSION_ID >= 70000
-#include <php/ext/pcre/php_pcre.h>
-#else
-#include <ext/pcre/php_pcre.h>
-#endif
+#include <string.h>
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 #if PHP_VERSION_ID < 70000
 int dd_no_blacklisted_modules(TSRMLS_D) {
-    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
+    char *blacklist = DDTRACE_G(internal_blacklisted_modules_list);
     zend_module_entry *module;
-    pcre *pce;
-    int re_options, rv = 1;
-    pcre_extra *re_extra;
-
+    int rv = 1;
     HashPosition pos;
 
-    if ((pce = pcre_get_compiled_regex(blacklist_regexp, &re_extra, &re_options TSRMLS_CC)) != NULL) {
+    if (blacklist) {
         zend_hash_internal_pointer_reset_ex(&module_registry, &pos);
 
         while (zend_hash_get_current_data_ex(&module_registry, (void *)&module, &pos) != FAILURE) {
-            if (!pcre_exec(pce, re_extra, module->name, strlen(module->name), 0, re_options, NULL, 0)) {
+            if (module && module->name && strstr(blacklist, module->name) != NULL) {
                 ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
                 rv = 0;
                 break;
@@ -41,19 +33,15 @@ int dd_no_blacklisted_modules(TSRMLS_D) {
     return rv;
 }
 
-#elif PHP_VERSION_ID < 70300
+#else
 int dd_no_blacklisted_modules(TSRMLS_D) {
-    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
+    char *blacklist = DDTRACE_G(internal_blacklisted_modules_list);
     zend_module_entry *module;
-    pcre *pce;
-    int re_options, rv = 1;
-    pcre_extra *re_extra;
-    zend_string *pattern;
+    int rv = 1;
 
-    pattern = zend_string_init(blacklist_regexp, strlen(blacklist_regexp), 0);
-    if ((pce = pcre_get_compiled_regex(pattern, &re_extra, &re_options)) != NULL) {
+    if (blacklist) {
         ZEND_HASH_FOREACH_PTR(&module_registry, module) {
-            if (!pcre_exec(pce, re_extra, module->name, strlen(module->name), 0, re_options, NULL, 0)) {
+            if (module && module->name && strstr(blacklist, module->name) != NULL) {
                 ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
                 rv = 0;
                 break;
@@ -62,36 +50,6 @@ int dd_no_blacklisted_modules(TSRMLS_D) {
         ZEND_HASH_FOREACH_END();
     }
 
-    zend_string_release(pattern);
-    return rv;
-}
-#else
-int dd_no_blacklisted_modules(TSRMLS_D) {
-    char *blacklist_regexp = DDTRACE_G(internal_blacklisted_modules_regexp);
-    zend_module_entry *module;
-    pcre2_code *pce;
-    int rv = 1;
-    uint32_t capture_count, re_options;
-    zend_string *pattern;
-
-    pattern = zend_string_init(blacklist_regexp, strlen(blacklist_regexp), 0);
-    if ((pce = pcre_get_compiled_regex(pattern, &capture_count, &re_options)) != NULL) {
-        pcre2_match_data *match_data = php_pcre_create_match_data(capture_count, pce);
-        if (match_data) {
-            ZEND_HASH_FOREACH_PTR(&module_registry, module) {
-                if (pcre2_match(pce, (PCRE2_SPTR)module->name, strlen(module->name), 0, re_options, match_data,
-                                php_pcre_mctx()) > 0) {
-                    ddtrace_log_errf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
-                    rv = 0;
-                    break;
-                }
-            }
-            ZEND_HASH_FOREACH_END();
-            php_pcre_free_match_data(match_data);
-        }
-    }
-
-    zend_string_release(pattern);
     return rv;
 }
 #endif

--- a/tests/ext/request_init_hook_check_blacklisted_modules.phpt
+++ b/tests/ext/request_init_hook_check_blacklisted_modules.phpt
@@ -2,7 +2,7 @@
 Do not prepend request hook if offending module has been detected
 --INI--
 ddtrace.request_init_hook=tests/ext/simple_sanity_check.phpt
-ddtrace.internal_blacklisted_modules_regexp=/ddtrace/
+ddtrace.internal_blacklisted_modules_list=ddtrace,some_other_module
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;


### PR DESCRIPTION
### Description

Before module blacklist was implement using pcre regexp which caused problems in some installations which differ in installed library versions which changed load order which caused the problem to surface.

This change avoids using php's pcre regexps.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
