### PR TITLE
Add configure flag to enable debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Changed
+- Removed `dd_trace_noop()` from non-debug builds of ddtrace #373
+
+### Added
+- Configure flag `--enable-ddtrace-debug` to build ddtrace with debug symbols and expose debug messages #373
+
 ## [0.16.0]
 
 ### Changed

--- a/config.m4
+++ b/config.m4
@@ -1,4 +1,5 @@
 PHP_ARG_ENABLE(ddtrace, whether to enable Datadog tracing support,[  --enable-ddtrace   Enable Datadog training support])
+PHP_ARG_ENABLE(ddtrace-debug, whether ddtrace should be built in debug mode,[  --enable-ddtrace-debug Build Datadog tracing in debug mode],, no)
 
 PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,[  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
@@ -8,6 +9,11 @@ if test "$PHP_DDTRACE" != "no"; then
 	  EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
 	  PHP_SUBST(EXTRA_LDFLAGS)
     PHP_SUBST(EXTRA_CFLAGS)
+  fi
+
+  if test "$PHP_DDTRACE_DEBUG" != "no"; then
+    AC_DEFINE(DDTRACE_DEBUG, 1, [ ])
+    STD_CFLAGS="-g -O0 -Wall"
   fi
 
   PHP_NEW_EXTENSION(ddtrace, src/ext/ddtrace.c src/ext/dispatch_setup.c src/ext/dispatch.c src/ext/request_hooks.c src/ext/compat_zend_string.c src/ext/dispatch_compat_php5.c src/ext/dispatch_compat_php7.c src/ext/backtrace.c src/ext/logging.c src/ext/env_config.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -150,8 +150,13 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     php_info_print_box_end();
 
     php_info_print_table_start();
-    php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
+    php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "Disabled" : "Enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
+#ifdef DDTRACE_DEBUG
+    php_info_print_table_row(2, "Datadog tracing debugging", "Enabled");
+#else
+    php_info_print_table_row(2, "Datadog tracing debugging", "Disabled");
+#endif
     php_info_print_table_end();
 
     DISPLAY_INI_ENTRIES();
@@ -271,6 +276,7 @@ static PHP_FUNCTION(dd_trace_reset) {
     RETURN_BOOL(1);
 }
 
+#ifdef DDTRACE_DEBUG
 // method used to be able to easily breakpoint the execution at specific PHP line in GDB
 static PHP_FUNCTION(dd_trace_noop) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
@@ -282,9 +288,14 @@ static PHP_FUNCTION(dd_trace_noop) {
 
     RETURN_BOOL(1);
 }
+#endif
 
-static const zend_function_entry ddtrace_functions[] = {PHP_FE(dd_trace, NULL) PHP_FE(dd_trace_reset, NULL) PHP_FE(
-    dd_trace_noop, NULL) PHP_FE(dd_untrace, NULL) PHP_FE(dd_trace_disable_in_request, NULL) ZEND_FE_END};
+static const zend_function_entry ddtrace_functions[] = {
+    PHP_FE(dd_trace, NULL) PHP_FE(dd_trace_reset, NULL)
+#ifdef DDTRACE_DEBUG
+        PHP_FE(dd_trace_noop, NULL)
+#endif
+            PHP_FE(dd_untrace, NULL) PHP_FE(dd_trace_disable_in_request, NULL) ZEND_FE_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,    PHP_DDTRACE_EXTNAME,    ddtrace_functions,
                                           PHP_MINIT(ddtrace),        PHP_MSHUTDOWN(ddtrace), PHP_RINIT(ddtrace),

--- a/src/ext/debug.h
+++ b/src/ext/debug.h
@@ -14,7 +14,7 @@
         fflush(stderr);                                                              \
     } while (0)
 
-#ifdef DEBUG
+#ifdef DDTRACE_DEBUG
 #define DD_PRINTF(fmt, ...) __DD_PRINTF(fmt, ##__VA_ARGS__)
 #define DD_PRINT_HASH(ht)                                                              \
     do {                                                                               \


### PR DESCRIPTION
### Description

This PR makes it easy to enable a debug build of ddtrace using the `--enable-ddtrace-debug` config flag. If this flag is present during the configure step, ddtrace will be built with debug symbols and debug messages will be exposed. Additionally, the `dd_trace_noop()` function is moved to debug-only builds. An added advantage of this is that it makes it easy to check if debug mode is enabled in userspace (for example if we need to check for debug mode in a test in the future).

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
