### PR TITLE
Fix issue where error traces don't appear in "Total Errors" panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+
+- Error traces don't appear in "Total Errors" panel #375
+
 ## [0.16.0]
 
 ### Changed

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -210,6 +210,9 @@ final class Span implements SpanInterface
 
         if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
             $this->hasError = true;
+            if (!isset($this->tags[Tag::ERROR_TYPE])) {
+                $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+            }
         }
 
         $this->tags[$key] = (string)$value;

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Common;
 
+use DDTrace\Tag;
 
 final class SpanAssertion
 {
@@ -79,6 +80,9 @@ final class SpanAssertion
     public function setError()
     {
         $this->hasError = true;
+        if (!isset($this->exactTags[Tag::ERROR_TYPE])) {
+            $this->existingTags[] = Tag::ERROR_TYPE;
+        }
         return $this;
     }
 

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -75,13 +75,23 @@ final class SpanAssertion
     }
 
     /**
+     * @param string|null $errorType The expected error.type
+     * @param string|null $errorMessage The expected error.msg
      * @return $this
      */
-    public function setError()
+    public function setError($errorType = null, $errorMessage = null)
     {
         $this->hasError = true;
-        if (!isset($this->exactTags[Tag::ERROR_TYPE])) {
+        if (isset($this->exactTags[Tag::ERROR_TYPE])) {
+            return $this;
+        }
+        if (null !== $errorType) {
+            $this->exactTags[Tag::ERROR_TYPE] = $errorType;
+        } else {
             $this->existingTags[] = Tag::ERROR_TYPE;
+        }
+        if (null !== $errorMessage) {
+            $this->exactTags[Tag::ERROR_MSG] = $errorMessage;
         }
         return $this;
     }
@@ -92,7 +102,11 @@ final class SpanAssertion
      */
     public function withExactTags(array $tags)
     {
-        $this->exactTags = $tags;
+        if (is_array($this->exactTags)) {
+            $this->exactTags = array_merge($this->exactTags, $tags);
+        } else {
+            $this->exactTags = $tags;
+        }
         return $this;
     }
 

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -116,10 +116,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://10.255.255.1/',
                     'http.status_code' => '0',
-                    'error.type' => 'curl error',
                 ])
                 ->withExistingTagsNames(['error.msg'])
-                ->setError(),
+                ->setError('curl error'),
         ]);
     }
 
@@ -138,10 +137,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://10.255.255.1/',
                     'http.status_code' => '0',
-                    'error.type' => 'curl error',
                 ])
                 ->withExistingTagsNames(['error.msg'])
-                ->setError(),
+                ->setError('curl error'),
         ]);
     }
 
@@ -160,10 +158,8 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://__i_am_not_real__.invalid/',
                     'http.status_code' => '0',
-                    'error.msg' => 'Could not resolve host: __i_am_not_real__.invalid',
-                    'error.type' => 'curl error',
                 ])
-                ->setError(),
+                ->setError('curl error', 'Could not resolve host: __i_am_not_real__.invalid'),
         ]);
     }
 

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -92,13 +92,11 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     SpanAssertion::exists('laravel.event.handle'),
                     SpanAssertion::build('laravel.action', 'laravel', 'web', 'error')
                         ->withExactTags([
-                            'error.msg' => 'Controller error',
-                            'error.type' => 'Exception',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
                         ])
                         ->withExistingTagsNames(['error.stack'])
-                        ->setError(),
+                        ->setError('Exception', 'Controller error'),
                     SpanAssertion::exists('laravel.event.handle'),
                 ],
             ]

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -53,11 +53,7 @@ final class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
-                ->setError()
-                ->withExactTags([
-                    'error.type' => 'PDOException',
-                    'error.msg' => 'Sql error: SQLSTATE[HY000] [1045]',
-                ]),
+                ->setError('PDOException', 'Sql error: SQLSTATE[HY000] [1045]'),
         ]);
     }
 
@@ -97,11 +93,9 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
-                ->setError()
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.rowcount' => '',
-                    'error.msg' => 'SQL error: 42000. Driver error: 1064',
-                    'error.type' => 'PDO error',
                 ])),
             SpanAssertion::exists('PDO.commit'),
         ]);
@@ -125,11 +119,8 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
-                ->setError()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'error.msg' => 'Sql error',
-                    'error.type' => 'PDOException',
-                ])),
+                ->setError('PDOException', 'Sql error')
+                ->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -164,11 +155,9 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
-                ->setError()
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.rowcount' => '',
-                    'error.msg' => 'SQL error: 42000. Driver error: 1064',
-                    'error.type' => 'PDO error',
                 ])),
         ]);
     }
@@ -188,11 +177,8 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
-                ->setError()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'error.msg' => 'Sql error',
-                    'error.type' => 'PDOException',
-                ])),
+                ->setError('PDOException', 'Sql error')
+                ->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -266,11 +252,9 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
                 ->withExactTags(array_merge($this->baseTags(), [])),
             SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
-                ->setError()
+                ->setError('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
                     ->withExactTags(array_merge($this->baseTags(), [
                         'db.rowcount' => 0,
-                        'error.msg' => 'SQL error: 42000. Driver error: 1064',
-                        'error.type' => 'PDOStatement error',
                     ])),
         ]);
     }
@@ -296,11 +280,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
                 ->withExactTags(array_merge($this->baseTags(), [])),
             SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
-                ->setError()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'error.msg' => 'Sql error',
-                    'error.type' => 'PDOException',
-                ])),
+                ->setError('PDOException', 'Sql error')
+                ->withExactTags($this->baseTags()),
         ]);
     }
 

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -89,7 +89,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'error'
                     )
-                        ->setError()
                         ->withExactTags([
                             'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
                             'symfony.route.name' => 'error',
@@ -99,6 +98,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
+                        ->setError()
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -94,11 +94,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'symfony.route.name' => 'error',
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
-                            'error.msg' => 'An exception occurred',
-                            'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
-                        ->setError()
+                        ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -96,7 +96,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'error'
                     )
-                        ->setError()
                         ->withExactTags([
                             'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
                             'symfony.route.name' => 'error',
@@ -106,6 +105,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
+                        ->setError()
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -101,11 +101,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'symfony.route.name' => 'error',
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
-                            'error.msg' => 'An exception occurred',
-                            'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
-                        ->setError()
+                        ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -102,11 +102,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'symfony.route.name' => 'error',
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error',
-                            'error.msg' => 'An exception occurred',
-                            'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
-                        ->setError()
+                        ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -97,7 +97,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'error'
                     )
-                        ->setError()
                         ->withExactTags([
                             'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
                             'symfony.route.name' => 'error',
@@ -107,6 +106,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'error.type' => 'Exception',
                             'http.status_code' => '500',
                         ])
+                        ->setError()
                         ->withExistingTagsNames(['error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),


### PR DESCRIPTION
### Description

Error traces do not appear under the "Total Errors" panel in the APM UI unless `error.type` is set. This PR ensures that `error.type` is set with 500-level HTTP responses.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
