### PR TITLE
Disable PHP 7.3 being packaged to avoid shipping binaries for unsupported  (yet) PHP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,11 +431,11 @@ workflows:
           name: "Compile PHP 72"
           docker_image: "datadog/docker-library:ddtrace_centos_6_php_7_2"
           so_suffix: "20170718"
-      - compile_extension:
-          requires: [ 'Code Checkout' ]
-          name: "Compile PHP 73"
-          docker_image: "datadog/docker-library:ddtrace_centos_7_php_73"
-          so_suffix: "20180731"
+      # - compile_extension:
+      #     requires: [ 'Code Checkout' ]
+      #     name: "Compile PHP 73"
+      #     docker_image: "datadog/docker-library:ddtrace_centos_7_php_73"
+      #     so_suffix: "20180731"
       - compile_extension:
           requires: [ 'Code Checkout' ]
           name: "Compile PHP 56-zts"
@@ -456,11 +456,11 @@ workflows:
           name: "Compile PHP 72-zts"
           docker_image: "circleci/php:7.2-zts"
           so_suffix: "20170718-zts"
-      - compile_extension:
-          requires: [ 'Code Checkout' ]
-          name: "Compile PHP 73-zts"
-          docker_image: "circleci/php:7.3-zts"
-          so_suffix: "20180731-zts"
+      # - compile_extension:
+      #     requires: [ 'Code Checkout' ]
+      #     name: "Compile PHP 73-zts"
+      #     docker_image: "circleci/php:7.3-zts"
+      #     so_suffix: "20180731-zts"
       - "package extension":
           requires:
             - "Compile PHP 54"
@@ -468,12 +468,12 @@ workflows:
             - "Compile PHP 70"
             - "Compile PHP 71"
             - "Compile PHP 72"
-            - "Compile PHP 73"
+            # - "Compile PHP 73"
             - "Compile PHP 56-zts"
             - "Compile PHP 70-zts"
             - "Compile PHP 71-zts"
             - "Compile PHP 72-zts"
-            - "Compile PHP 73-zts"
+            # - "Compile PHP 73-zts"
       - "package verification":
           requires:
             - "package extension"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,6 +487,10 @@ workflows:
       - "Code Checkout"
       - compile_extension:
           requires: [ 'Code Checkout' ]
+          name: "PHP 73 Compilation test"
+          docker_image: "datadog/docker-library:ddtrace_centos_7_php_73"
+      - compile_extension:
+          requires: [ 'Code Checkout' ]
           name: "PHP 55 Compilation test"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
       - compile_extension:


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [ ] ~[Changelog entry](docs/changelog.md) added, if necessary~ 
- [x] Tests added for this feature/bug
