### PR TITLE
Add cap to payloads sent to the Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file - [read more
 ## [Unreleased]
 
 ### Changed
-
 - Request init hook module blacklist now avoids miss matching partial matches #372
+- Add 10MB cap to payloads sent to the Agent #388
 
 ## [0.17.0]
 

--- a/tests/Common/TestLogger.php
+++ b/tests/Common/TestLogger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DDTrace\Tests\Common;
+
+use DDTrace\Log\LoggerInterface;
+
+final class TestLogger implements LoggerInterface
+{
+    public $lastLog = '';
+
+    public function debug($message, array $context = [])
+    {
+        $this->log($message, $context);
+    }
+
+    public function warning($message, array $context = [])
+    {
+        $this->log($message, $context);
+    }
+
+    public function error($message, array $context = [])
+    {
+        $this->log($message, $context);
+    }
+
+    public function isLevelActive($level)
+    {
+        return true;
+    }
+
+    private function log($message, array $context = [])
+    {
+        $this->lastLog = $message . ' ' . json_encode($context);
+    }
+}

--- a/tests/Unit/Transport/HttpTest.php
+++ b/tests/Unit/Transport/HttpTest.php
@@ -2,10 +2,28 @@
 
 namespace DDTrace\Tests\Unit\Transport;
 
+use DDTrace\Encoder;
 use DDTrace\Encoders\Json;
+use DDTrace\Log\Logger;
+use DDTrace\Tests\Common\TestLogger;
 use DDTrace\Tests\Unit\BaseTestCase;
 use DDTrace\Tests\Unit\CleanEnvTrait;
 use DDTrace\Transport\Http;
+
+final class FooEncoder implements Encoder
+{
+    public $payload = '';
+
+    public function encodeTraces(array $traces)
+    {
+        return $this->payload = json_encode($traces);
+    }
+
+    public function getContentType()
+    {
+        return '';
+    }
+}
 
 final class HttpTest extends BaseTestCase
 {
@@ -41,5 +59,29 @@ final class HttpTest extends BaseTestCase
         putenv('DD_AGENT_HOST=other_host');
         $httpTransport = new Http(new Json());
         $this->assertEquals('http://other_host:8126/v0.3/traces', $httpTransport->getConfig()['endpoint']);
+    }
+
+    public function testPayloadsOver10MBFail()
+    {
+        $logger = new TestLogger();
+        Logger::set($logger);
+        $httpTransport = new Http(new FooEncoder());
+        // Once encoded, this will send a payload that is 4 bytes over 10MB due to the added: [""]
+        $tenMBString = str_repeat('a', Http::AGENT_REQUEST_BODY_LIMIT);
+        $httpTransport->send([$tenMBString]);
+        $this->assertContains('dropping request', $logger->lastLog);
+    }
+
+    public function testPayloadsExactly10MBPass()
+    {
+        $logger = new TestLogger();
+        Logger::set($logger);
+        $encoder = new FooEncoder();
+        $httpTransport = new Http($encoder);
+        // The -4 bytes is to account for the added: [""]
+        $tenMBString = str_repeat('a', Http::AGENT_REQUEST_BODY_LIMIT - 4);
+        $httpTransport->send([$tenMBString]);
+        $this->assertNotContains('dropping request', $logger->lastLog);
+        $this->assertSame(Http::AGENT_REQUEST_BODY_LIMIT, strlen($encoder->payload));
     }
 }


### PR DESCRIPTION
### Description

The Agent has a [10MB payload cap](https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/api.go#L31) which isn't an issue for us right now, but when/if we start buffering traces sent to the Agent, this will be an issue to account for. The main reason is that the Agent will return a successful 200 response for payloads over the 10MB limit and will drop all the traces quietly.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
