### PR TITLE
Build packages for "build" branch names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
               only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
             branches:
               # Always build on master
-              ignore: /^(?!master).*/
+              only: /^.*(master|build).*$/
       - compile_extension:
           name: "Compile PHP 54"
           docker_image: "datadog/docker-library:ddtrace_centos_6_php_5_4"


### PR DESCRIPTION
### Description

This change will make CI build package artifacts when the branch name contains the word "build". So this one should be built.

### Readiness checklist
~~- [ ] [Changelog entry](docs/changelog.md) added, if necessary~~
~~- [ ] Tests added for this feature/bug~~
