### PR TITLE
Make dd_trace_serialize_msgpack() tests more cross-platform friendly

### DIFF
--- a/tests/ext/dd_trace_serialize_msgpack.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack.phpt
@@ -5,6 +5,8 @@ The "EXPECT" section was generated with the following tool:
 https://github.com/ludocode/msgpack-tools
 Example command:
 $ echo '{"compact": true, "schema": 0}' | json2msgpack | hexdump
+--SKIPIF--
+<?php if (PHP_INT_SIZE !== 8) die('skip test for 64-bit platforms only'); ?>
 --FILE--
 <?php
 function dd_trace_unserialize_trace_hex($message) {

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_serialize_msgpack() error conditions
+--INI--
+display_errors=0
 --FILE--
 <?php
 array_map(function ($data) {

--- a/tests/ext/dd_trace_serialize_msgpack_error_strict.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error_strict.phpt
@@ -2,6 +2,7 @@
 dd_trace_serialize_msgpack() error conditions in strict mode
 --INI--
 ddtrace.strict_mode=1
+display_errors=0
 --FILE--
 <?php
 array_map(function ($data) {


### PR DESCRIPTION
### Description

This PR fixes most of the failing tests in #394 by making the `dd_trace_serialize_msgpack()` tests more predictable on more platforms.

### Readiness checklist
~~- [ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- [x] Tests added for this feature/bug
