### PR TITLE
Cache a 'non-existing' bool  and string config lookup to speedup execution

### DIFF
--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -77,7 +77,7 @@ class EnvVariableRegistry implements Registry
         } elseif ($value === '0' || $value === 'false') {
             $this->registry[$key] = false;
         } else {
-            return $default;
+            $this->registry[$key] = $default;
         }
 
         return $this->registry[$key];

--- a/src/DDTrace/Configuration/EnvVariableRegistry.php
+++ b/src/DDTrace/Configuration/EnvVariableRegistry.php
@@ -53,8 +53,10 @@ class EnvVariableRegistry implements Registry
         $value = $this->get($key);
         if (null !== $value) {
             return $this->registry[$key] = $value;
+        } else {
+            return $this->registry[$key] = $default;
         }
-        return $default;
+        return $this->registry[$key];
     }
 
     /**


### PR DESCRIPTION
### Description

about 4 to 5 percentage points are wasted because this is not cached.

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
