### PR TITLE
Make tests less brittle

### DIFF
--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -1,12 +1,9 @@
 --TEST--
 dd_trace_serialize_msgpack() error conditions
---INI--
-display_errors=0
 --FILE--
 <?php
 array_map(function ($data) {
-    echo json_encode($data) . ' -> ';
-    var_dump(dd_trace_serialize_msgpack($data));
+    var_dump($data, dd_trace_serialize_msgpack($data));
     echo "\n";
 }, [
     true,
@@ -15,11 +12,24 @@ array_map(function ($data) {
     ['bar', stream_context_create()],
 ]);
 ?>
---EXPECT--
-true -> bool(false)
+--EXPECTF--
+bool(true)
+bool(false)
 
-"foo" -> bool(false)
+string(3) "foo"
+bool(false)
 
-[{}] -> bool(false)
+array(1) {
+  [0]=>
+  object(stdClass)#%d (0) {
+  }
+}
+bool(false)
 
- -> bool(false)
+array(2) {
+  [0]=>
+  string(3) "bar"
+  [1]=>
+  resource(%d) of type (stream-context)
+}
+bool(false)

--- a/tests/ext/dd_trace_serialize_msgpack_error_strict.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error_strict.phpt
@@ -2,11 +2,10 @@
 dd_trace_serialize_msgpack() error conditions in strict mode
 --INI--
 ddtrace.strict_mode=1
-display_errors=0
 --FILE--
 <?php
 array_map(function ($data) {
-    echo json_encode($data) . ' -> ';
+    var_dump($data);
     try {
         dd_trace_serialize_msgpack($data);
     } catch (\InvalidArgumentException $e) {
@@ -20,11 +19,24 @@ array_map(function ($data) {
     ['bar', stream_context_create()],
 ]);
 ?>
---EXPECT--
-true -> Expected an array
+--EXPECTF--
+bool(true)
+Expected an array
 
-"foo" -> Expected an array
+string(3) "foo"
+Expected an array
 
-[{}] -> Serialize values must be of type array, string, int, float, bool or null
+array(1) {
+  [0]=>
+  object(stdClass)#%d (0) {
+  }
+}
+Serialize values must be of type array, string, int, float, bool or null
 
- -> Serialize values must be of type array, string, int, float, bool or null
+array(2) {
+  [0]=>
+  string(3) "bar"
+  [1]=>
+  resource(%d) of type (stream-context)
+}
+Serialize values must be of type array, string, int, float, bool or null


### PR DESCRIPTION
### Description

As @remicollet pointed out in #394, the error-condition tests for `dd_trace_serialize_msgpack()` fail in PHP 5.4 due to the test's reliance on `json_encode()` which has different error-condition behavior depending on the PHP version. This PR refactors the tests so that they don't rely on `json_encode()`.

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- [x] Tests added for this feature/bug
