### PR TITLE
simplify regex which fails with 7.3

### DIFF
--- a/tests/ext/segfault_backtrace_enabled.phpt
+++ b/tests/ext/segfault_backtrace_enabled.phpt
@@ -17,4 +17,4 @@ Received Signal 11
 Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime
 Backtrace:
 .*ddtrace\.so.*ddtrace_backtrace_handler.*
-[\S\W\D\R]*
+.*

--- a/tests/ext/segfault_backtrace_enabled_via_env.phpt
+++ b/tests/ext/segfault_backtrace_enabled_via_env.phpt
@@ -17,4 +17,4 @@ Received Signal 11
 Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime
 Backtrace:
 .*ddtrace\.so.*ddtrace_backtrace_handler.*
-[\S\W\D\R]*
+.*

--- a/tests/ext/segfault_backtrace_enabled_via_env_disabled_in_ini.phpt
+++ b/tests/ext/segfault_backtrace_enabled_via_env_disabled_in_ini.phpt
@@ -19,4 +19,4 @@ Received Signal 11
 Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime
 Backtrace:
 .*ddtrace\.so.*ddtrace_backtrace_handler.*
-[\S\W\D\R]*
+.*


### PR DESCRIPTION
Test suite is failing with 7.3, because regex used is invalid:

```
TEST 29/41 [tests/ext/segfault_backtrace_enabled.phpt]
Warning: preg_match(): Compilation failed: escape sequence is invalid in character class at offset 215 in /builddir/build/BUILD/php-pecl-datadog-trace-0.20.0/NTS/run-tests.php on l
ine 2100
Warning: preg_match(): Compilation failed: escape sequence is invalid in character class at offset 9 in /builddir/build/BUILD/php-pecl-datadog-trace-0.20.0/NTS/run-tests.php on lin
e 2245
========DIFF========
006+ /lib64/libc.so.6(+0x37f40) [0x7f9380d54f40]
006- [\S\W\D\R]*
007+ /lib64/libc.so.6(kill+0xb) [0x7f9380d551bb]
008+ /usr/lib64/php/modules/posix.so(+0x41c7) [0x7f9380c671c7]
009+ /usr/bin/php(+0xfdf85) [0x55602c28cf85]
010+ /usr/bin/php(execute_ex+0x3329) [0x55602c4b55e9]
011+ /usr/bin/php(zend_execute+0x127) [0x55602c4bbe07]
012+ /usr/bin/php(zend_execute_scripts+0xcc) [0x55602c4320bc]
013+ /usr/bin/php(php_execute_script+0x350) [0x55602c3d3e70]
014+ /usr/bin/php(+0x32f3bf) [0x55602c4be3bf]
015+ /usr/bin/php(+0x10efca) [0x55602c29dfca]
016+ /lib64/libc.so.6(__libc_start_main+0xf3) [0x7f9380d40f33]
017+ /usr/bin/php(_start+0x2e) [0x55602c29e0ce]
========DONE========
FAIL Dump backtrace when segmentation fault signal is raised and config enables it [tests/ext/segfault_backtrace_enabled.phpt] 

```