### PR TITLE
Put changes under correct heading in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,20 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
-## [0.20.0]
-
 ### Added
-- Force tracing or discarding trace via special Span tag (manual.keep and manual.drop) #409
 - `dd_trace_forward_call()` to forward the original call from within a tracing closure #284
 
 ### Fixed
 - `parent::` keyword not honored from a subclass when forwarding a call from a tracing closure #284
-- Resource use by caching configuration values instead of processing data on every access #406
 - Private and protected callable strings not resolved properly from a tracing closure #303
+
+## [0.20.0]
+
+### Added
+- Force tracing or discarding trace via special Span tag (manual.keep and manual.drop) #409
+
+### Fixed
+- Resource use by caching configuration values instead of processing data on every access #406
 
 ## [0.19.1]
 


### PR DESCRIPTION
### Description

With the last rebase I accidentally put the changes under the wrong heading. This fixes that. :)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
