### PR TITLE
Implementation of `limited` tracer state in which most spans should not be created 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file - [read more](docs/changelog.md).
 
 ## [Unreleased]
+### Added
+- Tracer limited mode where spans are not created to preserve resources #417
 
 ### Fixed
 - Error when a subclassed integration returns an object that cannot be cast as a string #423

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -61,6 +61,20 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Created Spans limit - integrations can still create spans above this limit but
+     * those should be guaranteed to be low volume.
+     *
+     * -1 means no limit
+     *
+     * @return int
+     */
+    public function getSpansLimit()
+    {
+        return (int)$this->floatValue('spans.limit', 1000);
+    }
+
+
+    /**
      * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.
      * Motivation: We had users reporting that in some cases they have manual end-points that `echo` some content and
      * then just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still be

--- a/src/DDTrace/Contracts/Tracer.php
+++ b/src/DDTrace/Contracts/Tracer.php
@@ -16,6 +16,16 @@ use DDTrace\StartSpanOptions;
 interface Tracer
 {
     /**
+     * Checks if Tracer is in limited mode.
+     *
+     * Tracer needs to handle any operation even if its in limited mode,
+     * however users can opt not to use tracer when its in limited mode.
+     *
+     * @return bool
+     */
+    public function limited();
+
+    /**
      * Returns the current {@link ScopeManager}, which may be a noop but may not be null.
      *
      * @return ScopeManager

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -44,13 +44,17 @@ class CurlIntegration extends Integration
 
         dd_trace('curl_exec', function ($ch) use ($integration) {
             $tracer = GlobalTracer::get();
+            CurlIntegration::injectDistributedTracingHeaders($ch);
+
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = $tracer->startIntegrationScopeAndSpan($integration, 'curl_exec');
             $span = $scope->getSpan();
             $span->setTraceAnalyticsCandidate();
             $span->setTag(Tag::SERVICE_NAME, 'curl');
             $span->setTag(Tag::SPAN_TYPE, Type::HTTP_CLIENT);
-
-            CurlIntegration::injectDistributedTracingHeaders($ch);
 
             $result = dd_trace_forward_call();
             if ($result === false && $span instanceof Span) {

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -143,6 +143,10 @@ class ElasticSearchIntegration extends Integration
         // Endpoints
         dd_trace('Elasticsearch\Endpoints\AbstractEndpoint', 'performRequest', function () {
             $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = $tracer->startIntegrationScopeAndSpan(
                 ElasticSearchIntegration::getInstance(),
                 "Elasticsearch.Endpoint.performRequest"
@@ -194,12 +198,17 @@ class ElasticSearchIntegration extends Integration
         $class = 'Elasticsearch\Client';
 
         dd_trace($class, $name, function () use ($name, $isTraceAnalyticsCandidate) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
             $params = [];
             if (isset($args[0])) {
                 list($params) = $args;
             }
-            $tracer = GlobalTracer::get();
+
             $scope = $tracer->startIntegrationScopeAndSpan(
                 ElasticSearchIntegration::getInstance(),
                 "Elasticsearch.Client.$name"
@@ -241,6 +250,10 @@ class ElasticSearchIntegration extends Integration
     {
         dd_trace($class, $name, function () use ($class, $name) {
             $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $operationName = str_replace('\\', '.', "$class.$name");
             $scope = $tracer->startIntegrationScopeAndSpan(ElasticSearchIntegration::getInstance(), $operationName);
             $span = $scope->getSpan();
@@ -278,12 +291,16 @@ class ElasticSearchIntegration extends Integration
         $class = 'Elasticsearch\Namespaces\\' . $namespace;
 
         dd_trace($class, $name, function () use ($namespace, $name) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
             $params = [];
             if (isset($args[0])) {
                 list($params) = $args;
             }
-            $tracer = GlobalTracer::get();
             $scope = $tracer->startIntegrationScopeAndSpan(
                 ElasticSearchIntegration::getInstance(),
                 "Elasticsearch.$namespace.$name"

--- a/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php
@@ -41,7 +41,12 @@ class EloquentIntegration extends Integration
 
         // getModels($columns = ['*'])
         dd_trace('Illuminate\Database\Eloquent\Builder', 'getModels', function () use ($integration) {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.get');
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'eloquent.get');
             $span = $scope->getSpan();
             $sql = $this->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -53,8 +58,13 @@ class EloquentIntegration extends Integration
 
         // performInsert(Builder $query)
         dd_trace('Illuminate\Database\Eloquent\Model', 'performInsert', function () use ($integration) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             list($eloquentQueryBuilder) = func_get_args();
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.insert');
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'eloquent.insert');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -67,7 +77,12 @@ class EloquentIntegration extends Integration
         // performUpdate(Builder $query)
         dd_trace('Illuminate\Database\Eloquent\Model', 'performUpdate', function () use ($integration) {
             list($eloquentQueryBuilder) = func_get_args();
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.update');
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'eloquent.update');
             $span = $scope->getSpan();
             $sql = $eloquentQueryBuilder->getQuery()->toSql();
             $span->setTag(Tag::RESOURCE_NAME, $sql);
@@ -79,7 +94,12 @@ class EloquentIntegration extends Integration
 
         // public function delete()
         dd_trace('Illuminate\Database\Eloquent\Model', 'delete', function () use ($integration) {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan($integration, 'eloquent.delete');
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'eloquent.delete');
             $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::SQL);
 
             return include __DIR__ . '/../../try_catch_finally.php';

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -114,9 +114,10 @@ final class GuzzleIntegration extends Integration
     /**
      * @return \Closure
      */
-    private function buildLimitTracerCallback(){
+    private function buildLimitTracerCallback()
+    {
         $self = $this;
-        return function(array $args) use ($self) {
+        return function (array $args) use ($self) {
             if (!Configuration::get()->isDistributedTracingEnabled()) {
                 return null;
             }
@@ -125,7 +126,7 @@ final class GuzzleIntegration extends Integration
             $tracer = GlobalTracer::get();
             $activeSpan = GlobalTracer::get()->getActiveSpan();
 
-            if ($activeSpan){
+            if ($activeSpan) {
                 $self->applyDistributedTracingHeaders($activeSpan, $request);
             }
         };

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -74,6 +74,7 @@ final class GuzzleIntegration extends Integration
         $this->codeTracer->tracePublicMethod(
             'GuzzleHttp\Client',
             'send',
+            $this->buildLimitTracerCallback(),
             $this->buildPreCallback('send'),
             $postCallback,
             $integration,
@@ -82,6 +83,7 @@ final class GuzzleIntegration extends Integration
         $this->codeTracer->tracePublicMethod(
             'GuzzleHttp\Client',
             'transfer',
+            $this->buildLimitTracerCallback(),
             $this->buildPreCallback('transfer'),
             $postCallback,
             $integration,
@@ -106,6 +108,26 @@ final class GuzzleIntegration extends Integration
             $span->setTag(Tag::HTTP_METHOD, $request->getMethod());
             $self->setUrlTag($span, $request);
             $span->setTag(Tag::RESOURCE_NAME, $method);
+        };
+    }
+
+    /**
+     * @return \Closure
+     */
+    private function buildLimitTracerCallback(){
+        $self = $this;
+        return function(array $args) use ($self) {
+            if (!Configuration::get()->isDistributedTracingEnabled()) {
+                return null;
+            }
+
+            list($request) = $args;
+            $tracer = GlobalTracer::get();
+            $activeSpan = GlobalTracer::get()->getActiveSpan();
+
+            if ($activeSpan){
+                $self->applyDistributedTracingHeaders($activeSpan, $request);
+            }
         };
     }
 

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -122,7 +122,12 @@ abstract class Integration
             $postCallHook,
             $integration
         ) {
-            $scope = GlobalTracer::get()->startActiveSpan($className . '.' . $method);
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startActiveSpan($className . '.' . $method);
             $span = $scope->getSpan();
 
             if (null !== $integration) {

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -60,64 +60,111 @@ class MemcachedIntegration extends Integration
 
         // bool Memcached::add ( string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'add', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'add', func_get_args());
         });
 
         // bool Memcached::addByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'addByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'addByKey', func_get_args());
         });
 
         // bool Memcached::append ( string $key , string $value )
         dd_trace('Memcached', 'append', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'append', func_get_args());
         });
 
         // bool Memcached::appendByKey ( string $server_key , string $key , string $value )
         dd_trace('Memcached', 'appendByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'appendByKey', func_get_args());
         });
 
         // bool Memcached::cas ( float $cas_token , string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'cas', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCas($this, func_get_args());
         });
 
         // bool Memcached::casByKey ( float $cas_token , string $server_key , string $key , mixed $value
         //     [, int $expiration ] )
         dd_trace('Memcached', 'casByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCasByKey($this, func_get_args());
         });
 
         // int Memcached::decrement ( string $key [, int $offset = 1 [, int $initial_value = 0
         //     [, int $expiry = 0 ]]] )
         dd_trace('Memcached', 'decrement', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'decrement', func_get_args());
         });
 
         // int Memcached::decrementByKey ( string $server_key , string $key
         //      [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
         dd_trace('Memcached', 'decrementByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'decrementByKey', func_get_args());
         });
 
         // bool Memcached::delete ( string $key [, int $time = 0 ] )
         dd_trace('Memcached', 'delete', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'delete', func_get_args());
         });
 
         // bool Memcached::deleteByKey ( string $server_key , string $key [, int $time = 0 ] )
         dd_trace('Memcached', 'deleteByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'deleteByKey', func_get_args());
         });
 
         // array Memcached::deleteMulti ( array $keys [, int $time = 0 ] )
         dd_trace('Memcached', 'deleteMulti', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceMulti($this, 'deleteMulti', func_get_args());
         });
 
         // bool Memcached::deleteMultiByKey ( string $server_key , array $keys [, int $time = 0 ] )
         dd_trace('Memcached', 'deleteMultiByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
             return MemcachedIntegration::traceMultiByKey($this, 'deleteMultiByKey', func_get_args());
         });
 
@@ -228,10 +275,6 @@ class MemcachedIntegration extends Integration
     public static function traceCommand($memcached, $command, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
@@ -255,10 +298,6 @@ class MemcachedIntegration extends Integration
     public static function traceCommandByKey($memcached, $command, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
@@ -281,10 +320,6 @@ class MemcachedIntegration extends Integration
     public static function traceCas($memcached, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             'Memcached.cas'
@@ -305,10 +340,6 @@ class MemcachedIntegration extends Integration
     public static function traceCasByKey($memcached, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             'Memcached.casByKey'
@@ -331,10 +362,6 @@ class MemcachedIntegration extends Integration
     public static function traceMulti($memcached, $command, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
@@ -354,10 +381,6 @@ class MemcachedIntegration extends Integration
     public static function traceMultiByKey($memcached, $command, $args)
     {
         $tracer = GlobalTracer::get();
-        if ($tracer->limited()) {
-            return dd_trace_forward_call();
-        }
-
         $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -123,7 +123,11 @@ class MemcachedIntegration extends Integration
 
         // bool Memcached::flush ([ int $delay = 0 ] )
         dd_trace('Memcached', 'flush', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 MemcachedIntegration::getInstance(),
                 'Memcached.flush'
             );
@@ -223,7 +227,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceCommand($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
         );
@@ -245,7 +254,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceCommandByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
         );
@@ -266,7 +280,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceCas($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             'Memcached.cas'
         );
@@ -285,7 +304,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceCasByKey($memcached, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             'Memcached.casByKey'
         );
@@ -306,7 +330,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceMulti($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
         );
@@ -324,7 +353,12 @@ class MemcachedIntegration extends Integration
 
     public static function traceMultiByKey($memcached, $command, $args)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+        $tracer = GlobalTracer::get();
+        if ($tracer->limited()) {
+            return dd_trace_forward_call();
+        }
+
+        $scope = $tracer->startIntegrationScopeAndSpan(
             MemcachedIntegration::getInstance(),
             "Memcached.$command"
         );

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -165,6 +165,7 @@ class MemcachedIntegration extends Integration
             if (GlobalTracer::get()->limited()) {
                 return dd_trace_forward_call();
             }
+
             return MemcachedIntegration::traceMultiByKey($this, 'deleteMultiByKey', func_get_args());
         });
 
@@ -174,6 +175,7 @@ class MemcachedIntegration extends Integration
             if ($tracer->limited()) {
                 return dd_trace_forward_call();
             }
+
             $scope = $tracer->startIntegrationScopeAndSpan(
                 MemcachedIntegration::getInstance(),
                 'Memcached.flush'
@@ -189,83 +191,147 @@ class MemcachedIntegration extends Integration
 
         // mixed Memcached::get ( string $key [, callable $cache_cb [, int &$flags ]] )
         dd_trace('Memcached', 'get', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'get', func_get_args());
         });
 
         // mixed Memcached::getByKey ( string $server_key , string $key [, callable $cache_cb [, int $flags ]] )
         dd_trace('Memcached', 'getByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'getByKey', func_get_args());
         });
 
         // mixed Memcached::getMulti ( array $keys [, int $flags ] )
         dd_trace('Memcached', 'getMulti', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceMulti($this, 'getMulti', func_get_args());
         });
 
         // array Memcached::getMultiByKey ( string $server_key , array $keys [, int $flags ] )
         dd_trace('Memcached', 'getMultiByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceMultiByKey($this, 'getMultiByKey', func_get_args());
         });
 
         // int Memcached::increment ( string $key [, int $offset = 1 [, int $initial_value = 0
         //     [, int $expiry = 0 ]]] )
         dd_trace('Memcached', 'increment', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'increment', func_get_args());
         });
 
         // int Memcached::incrementByKey ( string $server_key , string $key [, int $offset = 1
         //     [, int $initial_value = 0 [, int $expiry = 0 ]]] )
         dd_trace('Memcached', 'incrementByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'incrementByKey', func_get_args());
         });
 
         // bool Memcached::prepend ( string $key , string $value )
         dd_trace('Memcached', 'prepend', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'prepend', func_get_args());
         });
 
         // bool Memcached::prependByKey ( string $server_key , string $key , string $value )
         dd_trace('Memcached', 'prependByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'prependByKey', func_get_args());
         });
 
         // bool Memcached::replace ( string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'replace', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'replace', func_get_args());
         });
 
         // bool Memcached::replaceByKey ( string $server_key , string $key , mixed $value [, int $expiration  ] )
         dd_trace('Memcached', 'replaceByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'replaceByKey', func_get_args());
         });
 
         // bool Memcached::set ( string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'set', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'set', func_get_args());
         });
 
         // bool Memcached::setByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
         dd_trace('Memcached', 'setByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'setByKey', func_get_args());
         });
 
         // bool Memcached::setMulti ( array $items [, int $expiration ] )
         dd_trace('Memcached', 'setMulti', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceMulti($this, 'setMulti', func_get_args());
         });
 
         // bool Memcached::setMultiByKey ( string $server_key , array $items [, int $expiration ] )
         dd_trace('Memcached', 'setMultiByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceMultiByKey($this, 'setMultiByKey', func_get_args());
         });
 
         // bool Memcached::touch ( string $key , int $expiration )
         dd_trace('Memcached', 'touch', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommand($this, 'touch', func_get_args());
         });
 
         // bool Memcached::touchByKey ( string $server_key , string $key , int $expiration )
         dd_trace('Memcached', 'touchByKey', function () {
+            if (GlobalTracer::get()->limited()) {
+                return dd_trace_forward_call();
+            }
+
             return MemcachedIntegration::traceCommandByKey($this, 'touchByKey', func_get_args());
         });
 

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -50,6 +50,11 @@ class MysqliIntegration extends Integration
         //      [, int $port = ini_get("mysqli.default_port")
         //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
         dd_trace('mysqli_connect', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = MysqliIntegration::initScope('mysqli_connect', 'mysqli_connect');
             $span = $scope->getSpan();
 
@@ -85,6 +90,11 @@ class MysqliIntegration extends Integration
         //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
         $mysqli_constructor = PHP_MAJOR_VERSION > 5 ? '__construct' : 'mysqli';
         dd_trace('mysqli', $mysqli_constructor, function () use ($mysqli_constructor) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = MysqliIntegration::initScope('mysqli.__construct', 'mysqli.__construct');
             /** @var \DDTrace\Span $span */
             $span = $scope->getSpan();
@@ -114,6 +124,11 @@ class MysqliIntegration extends Integration
 
         // mixed mysqli_query ( mysqli $link , string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
         dd_trace('mysqli_query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             list($mysqli, $query) = func_get_args();
 
             $scope = MysqliIntegration::initScope('mysqli_query', $query);
@@ -134,6 +149,11 @@ class MysqliIntegration extends Integration
 
         // mysqli_stmt mysqli_prepare ( mysqli $link , string $query )
         dd_trace('mysqli_prepare', function ($mysqli, $query) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = MysqliIntegration::initScope('mysqli_prepare', $query);
             /** @var \DDTrace\Span $span */
             $span = $scope->getSpan();
@@ -151,6 +171,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli_commit ( mysqli $link [, int $flags [, string $name ]] )
         dd_trace('mysqli_commit', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
             list($mysqli) = $args;
             $resource = MysqliIntegration::retrieveQuery($mysqli, 'mysqli_commit');
@@ -172,6 +197,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli_stmt_execute ( mysqli_stmt $stmt )
         dd_trace('mysqli_stmt_execute', function ($stmt) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_execute');
             $scope = MysqliIntegration::initScope('mysqli_stmt_execute', $resource);
 
@@ -184,6 +214,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli_stmt_get_result ( mysqli_stmt $stmt )
         dd_trace('mysqli_stmt_get_result', function ($stmt) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_get_result');
             $result = dd_trace_forward_call();
 
@@ -195,6 +230,11 @@ class MysqliIntegration extends Integration
 
         // mixed mysqli::query ( string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
         dd_trace('mysqli', 'query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             list($query) = func_get_args();
             $scope = MysqliIntegration::initScope('mysqli.query', $query);
             /** @var \DDTrace\Span $span */
@@ -213,6 +253,11 @@ class MysqliIntegration extends Integration
 
         // mysqli_stmt mysqli::prepare ( string $query )
         dd_trace('mysqli', 'prepare', function ($query) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $scope = MysqliIntegration::initScope('mysqli.prepare', $query);
             /** @var \DDTrace\Span $span */
             $span = $scope->getSpan();
@@ -227,6 +272,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli::commit ([ int $flags [, string $name ]] )
         dd_trace('mysqli', 'commit', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
             $resource = MysqliIntegration::retrieveQuery($this, 'mysqli.commit');
             $scope = MysqliIntegration::initScope('mysqli.commit', $resource);
@@ -243,6 +293,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli_stmt::execute ( void )
         dd_trace('mysqli_stmt', 'execute', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.execute');
             $scope = MysqliIntegration::initScope('mysqli_stmt.execute', $resource);
             $scope->getSpan()->setTraceAnalyticsCandidate();
@@ -251,6 +306,11 @@ class MysqliIntegration extends Integration
 
         // bool mysqli_stmt::execute ( void )
         dd_trace('mysqli_stmt', 'get_result', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.get_result');
             $scope = MysqliIntegration::initScope('mysqli_stmt.get_result', $resource);
             $afterResult = function ($result) use ($resource) {

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -66,7 +66,12 @@ class PDOIntegration extends Integration
 
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace('PDO', '__construct', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PDOIntegration::getInstance(),
                 'PDO.__construct'
             );
@@ -96,7 +101,12 @@ class PDOIntegration extends Integration
 
         // public int PDO::exec(string $query)
         dd_trace('PDO', 'exec', function ($statement) {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.exec');
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.exec');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -130,8 +140,13 @@ class PDOIntegration extends Integration
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
         // public int PDO::exec(string $query)
         dd_trace('PDO', 'query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.query');
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.query');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -165,7 +180,12 @@ class PDOIntegration extends Integration
 
         // public bool PDO::commit ( void )
         dd_trace('PDO', 'commit', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.commit');
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.commit');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -192,8 +212,13 @@ class PDOIntegration extends Integration
 
         // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
         dd_trace('PDO', 'prepare', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.prepare');
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.prepare');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
             $span->setTag(Tag::SERVICE_NAME, 'PDO');
@@ -221,7 +246,12 @@ class PDOIntegration extends Integration
 
         // public bool PDOStatement::execute ([ array $input_parameters ] )
         dd_trace('PDOStatement', 'execute', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PDOIntegration::getInstance(),
                 'PDOStatement.execute'
             );

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -6,7 +6,6 @@ use DDTrace\Integrations\Integration;
 use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\GlobalTracer;
-use DDTrace\Util\Versions;
 use Predis\Configuration\OptionsInterface;
 use Predis\Pipeline\Pipeline;
 
@@ -55,11 +54,17 @@ class PredisIntegration extends Integration
     {
         // public Predis\Client::__construct ([ mixed $dsn [, mixed $options ]] )
         dd_trace('Predis\Client', '__construct', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PredisIntegration::getInstance(),
                 'Predis.Client.__construct'
             );
             $span = $scope->getSpan();
+
             $span->setTag(Tag::SPAN_TYPE, Type::CACHE);
             $span->setTag(Tag::SERVICE_NAME, 'redis');
             $span->setTag(Tag::RESOURCE_NAME, 'Predis.Client.__construct');
@@ -84,7 +89,12 @@ class PredisIntegration extends Integration
 
         // public void Predis\Client::connect()
         dd_trace('Predis\Client', 'connect', function () {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PredisIntegration::getInstance(),
                 'Predis.Client.connect'
             );
@@ -99,11 +109,16 @@ class PredisIntegration extends Integration
 
         // public mixed Predis\Client::executeCommand(CommandInterface $command)
         dd_trace('Predis\Client', 'executeCommand', function ($command) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $arguments = $command->getArguments();
             array_unshift($arguments, $command->getId());
             $query = PredisIntegration::formatArguments($arguments);
 
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PredisIntegration::getInstance(),
                 'Predis.Client.executeCommand'
             );
@@ -121,9 +136,14 @@ class PredisIntegration extends Integration
 
         // public mixed Predis\Client::executeRaw(array $arguments, bool &$error)
         dd_trace('Predis\Client', 'executeRaw', function ($arguments, &$error = null) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $query = PredisIntegration::formatArguments($arguments);
 
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PredisIntegration::getInstance(),
                 'Predis.Client.executeRaw'
             );
@@ -158,7 +178,12 @@ class PredisIntegration extends Integration
 
         // protected array Predis\Pipeline::executePipeline(ConnectionInterface $connection, \SplQueue $commands)
         dd_trace('Predis\Pipeline\Pipeline', 'executePipeline', function ($connection, $commands) {
-            $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
                 PredisIntegration::getInstance(),
                 'Predis.Pipeline.executePipeline'
             );

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -18,6 +18,14 @@ final class NoopTracer implements TracerInterface
     /**
      * {@inheritdoc}
      */
+    public function limited()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getActiveSpan()
     {
         return NoopSpan::create();

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -125,9 +125,8 @@ final class Tracer implements TracerInterface
 
     public function limited()
     {
-        return $this->spansLimit > 0 && ($this->spansCreated > $this->spansLimit);
+        return $this->spansLimit >= 0 && ($this->spansCreated >= $this->spansLimit);
     }
-
 
     /**
      * Resets this tracer to its original state.

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -113,6 +113,12 @@ final class Tracer implements TracerInterface
         $this->traceAnalyticsProcessor = new TraceAnalyticsProcessor();
     }
 
+    public function limited()
+    {
+        return false;
+    }
+
+
     /**
      * Resets this tracer to its original state.
      */

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -68,6 +68,16 @@ final class Tracer implements TracerInterface
     ];
 
     /**
+     * @var int
+     * */
+    private $spansCreated = 0;
+
+    /**
+     * @var int
+     * */
+    private $spansLimit = -1;
+
+    /**
      * @var ScopeManager
      */
     private $scopeManager;
@@ -115,7 +125,7 @@ final class Tracer implements TracerInterface
 
     public function limited()
     {
-        return false;
+        return $this->spansLimit > 0 && ($this->spansCreated > $this->spansLimit);
     }
 
 
@@ -127,6 +137,8 @@ final class Tracer implements TracerInterface
         $this->scopeManager = new ScopeManager();
         $this->globalConfig = Configuration::get();
         $this->sampler = new ConfigurableSampler();
+        $this->spansLimit = $this->globalConfig->getSpansLimit();
+        $this->spansCreated = 0;
         $this->traces = [];
     }
 
@@ -151,6 +163,8 @@ final class Tracer implements TracerInterface
      */
     public function startSpan($operationName, $options = [])
     {
+        $this->spansCreated++;
+
         if (!$this->config['enabled']) {
             return NoopSpan::create();
         }

--- a/src/DDTrace/Util/CodeTracer.php
+++ b/src/DDTrace/Util/CodeTracer.php
@@ -48,8 +48,14 @@ final class CodeTracer
             $integration,
             $isTraceAnalyticsCandidate
         ) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
             $args = func_get_args();
-            $scope = GlobalTracer::get()->startActiveSpan($className . '.' . $method);
+            $scope = $tracer->startActiveSpan($className . '.' . $method);
+
             $span = $scope->getSpan();
 
             if ($integration) {
@@ -67,7 +73,7 @@ final class CodeTracer
             $returnVal = null;
             $thrownException = null;
             try {
-                $returnVal = call_user_func_array([$this, $method], $args);
+                $returnVal = dd_trace_forward_call();
             } catch (\Exception $e) {
                 $span->setError($e);
                 $thrownException = $e;

--- a/src/DDTrace/Util/CodeTracer.php
+++ b/src/DDTrace/Util/CodeTracer.php
@@ -52,7 +52,7 @@ final class CodeTracer
         ) {
             $tracer = GlobalTracer::get();
             if ($tracer->limited()) {
-                if ($limitedTracerCallHook){
+                if ($limitedTracerCallHook) {
                     $limitedTracerCallHook(func_get_args());
                 }
 

--- a/src/DDTrace/Util/CodeTracer.php
+++ b/src/DDTrace/Util/CodeTracer.php
@@ -35,6 +35,7 @@ final class CodeTracer
     public function tracePublicMethod(
         $className,
         $method,
+        \Closure $limitedTracerCallHook = null,
         \Closure $preCallHook = null,
         \Closure $postCallHook = null,
         Integration $integration = null,
@@ -43,6 +44,7 @@ final class CodeTracer
         dd_trace($className, $method, function () use (
             $className,
             $method,
+            $limitedTracerCallHook,
             $preCallHook,
             $postCallHook,
             $integration,
@@ -50,6 +52,10 @@ final class CodeTracer
         ) {
             $tracer = GlobalTracer::get();
             if ($tracer->limited()) {
+                if ($limitedTracerCallHook){
+                    $limitedTracerCallHook(func_get_args());
+                }
+
                 return dd_trace_forward_call();
             }
 

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -10,6 +10,7 @@ use DDTrace\Tests\DebugTransport;
 use DDTrace\Tracer;
 use DDTrace\Transport\Http;
 use DDTrace\GlobalTracer;
+use DDTrace\Configuration;
 
 
 trait TracerTestTrait
@@ -31,6 +32,27 @@ trait TracerTestTrait
 
         // Checking spans belong to the proper integration
         $this->assertSpansBelongsToProperIntegration($this->readTraces($tracer));
+
+        return $this->flushAndGetTraces($transport);
+    }
+
+
+    /**
+     * @param $fn
+     * @param null $tracer
+     * @return Span[][]
+     */
+    public function isolateLimitedTracer($fn, $tracer = null)
+    {
+        Configuration::replace(\Mockery::mock(Configuration::get(), [
+            'getSpansLimit' => 0
+        ]));
+
+        $transport = new DebugTransport();
+        $tracer = $tracer ?: new Tracer($transport);
+        GlobalTracer::set($tracer);
+
+        $fn($tracer);
 
         return $this->flushAndGetTraces($transport);
     }

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -319,11 +319,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
     public function testTracerRunningAtLimitedCapacityCurlWorksWithoutARootSpan()
     {
         $found = [];
-        Configuration::replace(\Mockery::mock(Configuration::get(), [
-            'getSpansLimit' => 0
-        ]));
-
-        $traces = $this->isolateTracer(function () use (&$found) {
+        $traces = $this->isolateLimitedTracer(function () use (&$found) {
             /** @var Tracer $tracer */
             $ch = curl_init(self::URL . '/headers');
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -340,6 +340,6 @@ final class CurlIntegrationTest extends IntegrationTestCase
         $this->assertArrayNotHasKey('X-Datadog-Parent-Id', $found['headers']);
         $this->assertArrayNotHasKey('X-Datadog-Sampling-Priority', $found['headers']);
 
-        $this->assertEquals(0, sizeof($traces));
+        $this->assertEmpty($traces);
     }
 }

--- a/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -221,6 +221,58 @@ final class ElasticSearchIntegrationTest extends IntegrationTestCase
         ]);
     }
 
+    public function testLimitedTracer()
+    {
+        $client = $this->client();
+        $traces = $this->isolateTracer(function () use ($client, $docs) {
+            $client->indices()->delete(['index' => 'my_index']);
+            $client->index([
+                'id' => 1,
+                'index' => 'my_index',
+                'type' => 'my_type',
+                'body' => ['my' => 'body'],
+            ]);
+            $client->indices()->flush();
+            $docs = $client->search([
+                'search_type' => 'scan',
+                'scroll' => '1s',
+                'size' => 1,
+                'index' => 'my_index',
+                'body' => [
+                    'query' => [
+                        'match_all' => [],
+                    ],
+                ],
+            ]);
+
+            // Now we loop until the scroll "cursors" are exhausted
+            $scroll_id = $docs['_scroll_id'];
+            while (\true) {
+                // Execute a Scroll request
+                $response = $client->scroll(
+                    [
+                        "scroll_id" => $scroll_id,
+                        "scroll" => "1s",
+                    ]
+                );
+
+                // Check to see if we got any search hits from the scroll
+                if (count($response['hits']['hits']) > 0) {
+                    // If yes, Do Work Here
+
+                    // Get new scroll_id
+                    // Must always refresh your _scroll_id!  It can change sometimes
+                    $scroll_id = $response['_scroll_id'];
+                } else {
+                    // No results, scroll cursor is empty.  You've exported all the data
+                    break;
+                }
+            }
+        });
+
+        $this->assertEmpty($traces);
+    }
+
     public function testScroll()
     {
         $client = $this->client();

--- a/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -224,7 +224,7 @@ final class ElasticSearchIntegrationTest extends IntegrationTestCase
     public function testLimitedTracer()
     {
         $client = $this->client();
-        $traces = $this->isolateTracer(function () use ($client, $docs) {
+        $traces = $this->isolateLimitedTracer(function () use ($client) {
             $client->indices()->delete(['index' => 'my_index']);
             $client->index([
                 'id' => 1,

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -205,10 +205,11 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             $span->finish();
         });
 
+        $this->assertEquals(1, sizeof($traces[0]));
+
         // trace is: custom
         $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Trace-Id']);
         $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Parent-Id']);
-        $this->assertEquals(1, sizeof($traces[0]));
 
         $this->assertSame('1', $found['headers']['X-Datadog-Sampling-Priority']);
         // existing headers are honored

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -151,13 +151,8 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
     {
         $client = new Client();
         $found = [];
-        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isAutofinishSpansEnabled' => false,
-            'isAnalyticsEnabled' => false,
+        Configuration::replace(\Mockery::mock(Configuration::get(), [
             'isDistributedTracingEnabled' => false,
-            'isPrioritySamplingEnabled' => false,
-            'getGlobalTags' => [],
-            'isDebugModeEnabled' => false,
         ]));
 
         $this->isolateTracer(function () use (&$found, $client) {
@@ -175,5 +170,48 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
         $this->assertArrayNotHasKey('X-Datadog-Trace-Id', $found['headers']);
         $this->assertArrayNotHasKey('X-Datadog-Parent-Id', $found['headers']);
         $this->assertArrayNotHasKey('X-Datadog-Sampling-Priority', $found['headers']);
+    }
+
+    public function testLimitedTracer()
+    {
+        $traces = $this->isolateLimitedTracer(function () {
+            $this->getMockedClient()->get('http://example.com');
+
+            $request = new Request('put', 'http://example.com');
+            $this->getMockedClient()->send($request);
+        });
+
+        $this->assertEmpty($traces);
+    }
+
+    public function testLimitedTracerDistributedTracingIsPropagated()
+    {
+        $client = new Client();
+        $found = [];
+
+        $traces = $this->isolateLimitedTracer(function () use (&$found, $client) {
+            /** @var Tracer $tracer */
+            $tracer = GlobalTracer::get();
+            $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
+            $span = $tracer->startActiveSpan('custom')->getSpan();
+
+            $response = $client->get(self::URL . '/headers', [
+                'headers' => [
+                    'honored' => 'preserved_value',
+                ],
+            ]);
+
+            $found = $response->json();
+            $span->finish();
+        });
+
+        // trace is: custom
+        $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Trace-Id']);
+        $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Parent-Id']);
+        $this->assertEquals(1, sizeof($traces[0]));
+
+        $this->assertSame('1', $found['headers']['X-Datadog-Sampling-Priority']);
+        // existing headers are honored
+        $this->assertSame('preserved_value', $found['headers']['Honored']);
     }
 }

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -136,13 +136,8 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
     {
         $client = $this->getRealClient();
         $found = [];
-        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isAutofinishSpansEnabled' => false,
-            'isAnalyticsEnabled' => false,
+        Configuration::replace(\Mockery::mock(Configuration::get(), [
             'isDistributedTracingEnabled' => false,
-            'isPrioritySamplingEnabled' => false,
-            'getGlobalTags' => [],
-            'isDebugModeEnabled' => false,
         ]));
 
         $this->isolateTracer(function () use (&$found, $client) {
@@ -160,5 +155,48 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
         $this->assertArrayNotHasKey('X-Datadog-Trace-Id', $found['headers']);
         $this->assertArrayNotHasKey('X-Datadog-Parent-Id', $found['headers']);
         $this->assertArrayNotHasKey('X-Datadog-Sampling-Priority', $found['headers']);
+    }
+
+    public function testLimitedTracer()
+    {
+        $traces = $this->isolateLimitedTracer(function () {
+            $this->getMockedClient()->get('http://example.com');
+
+            $request = new Request('put', 'http://example.com');
+            $this->getMockedClient()->send($request);
+        });
+
+        $this->assertEmpty($traces);
+    }
+
+    public function testLimitedTracerDistributedTracingIsPropagated()
+    {
+        $client = new Client();
+        $found = [];
+
+        $traces = $this->isolateLimitedTracer(function () use (&$found, $client) {
+            /** @var Tracer $tracer */
+            $tracer = GlobalTracer::get();
+            $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
+            $span = $tracer->startActiveSpan('custom')->getSpan();
+
+            $response = $client->get(self::URL . '/headers', [
+                'headers' => [
+                    'honored' => 'preserved_value',
+                ],
+            ]);
+
+            $found = json_decode($response->getBody(), 1);
+            $span->finish();
+        });
+
+        // trace is: custom
+        $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Trace-Id']);
+        $this->assertSame($traces[0][0]['span_id'], (int) $found['headers']['X-Datadog-Parent-Id']);
+        $this->assertEquals(1, sizeof($traces[0]));
+
+        $this->assertSame('1', $found['headers']['X-Datadog-Sampling-Priority']);
+        // existing headers are honored
+        $this->assertSame('preserved_value', $found['headers']['Honored']);
     }
 }

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -191,6 +191,24 @@ final class MemcachedTest extends IntegrationTestCase
         ]);
     }
 
+    public function testLimitedTracerDeleteMulti()
+    {
+        $traces = $this->isolateLimitedTracer(function () {
+            $this->client->add('key1', 'value1');
+            $this->client->add('key2', 'value2');
+
+            $this->assertSame('value1', $this->client->get('key1'));
+            $this->assertSame('value2', $this->client->get('key2'));
+
+            $this->client->deleteMulti(['key1', 'key2']);
+
+            $this->assertFalse($this->client->get('key1'));
+            $this->assertFalse($this->client->get('key2'));
+        });
+
+        $this->assertEmpty($traces);
+    }
+
     public function testDeleteMulti()
     {
         $traces = $this->isolateTracer(function () {

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -298,12 +298,8 @@ final class PDOTest extends IntegrationTestCase
 
     public function testLimitedTracerPDO()
     {
-        Configuration::replace(\Mockery::mock(Configuration::get(), [
-            'getSpansLimit' => 0
-        ]));
-
         $query = "SELECT * FROM tests WHERE id = ?";
-        $traces = $this->isolateTracer(function () use ($query) {
+        $traces = $this->isolateLimitedTracer(function () use ($query) {
             $pdo = $this->pdoInstance();
             $stmt = $pdo->prepare($query);
             $stmt->execute([1]);
@@ -313,6 +309,7 @@ final class PDOTest extends IntegrationTestCase
             $stmt = null;
             $pdo = null;
         });
+
         $this->assertEmpty($traces);
     }
 

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Integrations\PDO;
 
+use DDTrace\Configuration;
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
@@ -293,6 +294,26 @@ final class PDOTest extends IntegrationTestCase
                 ->setError('PDOException', 'Sql error')
                 ->withExactTags($this->baseTags()),
         ]);
+    }
+
+    public function testLimitedTracerPDO()
+    {
+        Configuration::replace(\Mockery::mock(Configuration::get(), [
+            'getSpansLimit' => 0
+        ]));
+
+        $query = "SELECT * FROM tests WHERE id = ?";
+        $traces = $this->isolateTracer(function () use ($query) {
+            $pdo = $this->pdoInstance();
+            $stmt = $pdo->prepare($query);
+            $stmt->execute([1]);
+            $results = $stmt->fetchAll();
+            $this->assertEquals('Tom', $results[0]['name']);
+            $stmt->closeCursor();
+            $stmt = null;
+            $pdo = null;
+        });
+        $this->assertEmpty($traces);
     }
 
     private function pdoInstance()

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -160,6 +160,42 @@ final class PredisTest extends IntegrationTestCase
         ]);
     }
 
+    public function testLimitedTracesPredisSetCommand()
+    {
+        $traces = $this->isolateTracer(function () {
+            $client = new \Predis\Client([ "host" => $this->host ]);
+            $client->set('foo', 'value');
+        });
+
+        $this->assertEmpty($traces);
+    }
+
+    public function testLimitedTracesPredisGetCommand()
+    {
+        $traces = $this->isolateLimitedTracer(function () {
+            $client = new \Predis\Client([ "host" => $this->host ]);
+            $client->set('key', 'value');
+            $this->assertSame('value', $client->get('key'));
+        });
+
+        $this->assertEmpty($traces);
+    }
+
+    public function testLimitedTracerPredisPipeline()
+    {
+        $traces = $this->isolateLimitedTracer(function () {
+            $client = new \Predis\Client([ "host" => $this->host ]);
+            list($responsePing, $responseFlush) = $client->pipeline(function ($pipe) {
+                $pipe->ping();
+                $pipe->flushdb();
+            });
+            $this->assertInstanceOf('Predis\Response\Status', $responsePing);
+            $this->assertInstanceOf('Predis\Response\Status', $responseFlush);
+        });
+
+        $this->assertEmpty($traces);
+    }
+
     private function baseTags()
     {
         return [

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -162,7 +162,7 @@ final class PredisTest extends IntegrationTestCase
 
     public function testLimitedTracesPredisSetCommand()
     {
-        $traces = $this->isolateTracer(function () {
+        $traces = $this->isolateLimitedTracer(function () {
             $client = new \Predis\Client([ "host" => $this->host ]);
             $client->set('foo', 'value');
         });

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -181,6 +181,7 @@ final class TracerTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isAutofinishSpansEnabled' => true,
             'isPrioritySamplingEnabled' => false,
+            'getSpansLimit' => 1000,
             'isDebugModeEnabled' => false,
             'getGlobalTags' => [],
         ]));
@@ -214,6 +215,7 @@ final class TracerTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isAutofinishSpansEnabled' => true,
             'isPrioritySamplingEnabled' => false,
+            'getSpansLimit' => 1000,
             'isDebugModeEnabled' => false,
             'getGlobalTags' => [
                 'key1' => 'value1',


### PR DESCRIPTION
### Description

Tracer will enter `limited()` state after creating 1000 (configurable number) spans. In limited state most integrations should stop creating new spans while maintaining all other operation like distributed tracing, etc. 

Note to reviewers:
I've changed the concept of `ready()` to its own reverse `limited()` somehow it felt more natural this way.

It still means a ton of Ifs in the code needed to be added. And I added them for all integrations + tests.


~Trying to explore some concepts how to best implement optional traces. This skeleton PR is my best idea so far :D (it's probably not objectively best so open to all and every feedback) 
/cc: @SammyK @labbati~

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

~I've considered changing existing api to return null spans or adding higher level abstractions. And this felt the cleanest.~

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
