### PR TITLE
Add support for the CLI SAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Error when a subclassed integration returns an object that cannot be cast as a string #423
 
+### Added
+- Tracing support from the CLI SAPI #422
+
 ## [0.21.0]
 
 ### Added
 - `dd_trace_forward_call()` to forward the original call from within a tracing closure #284
-- Tracing support from the CLI SAPI #422
 
 ### Fixed
 - `parent::` keyword not honored from a subclass when forwarding a call from a tracing closure #284

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Support for [Lumen](https://lumen.laravel.com/) 5.2+ #416
 - Tracing support from the CLI SAPI #422
+- Support for Laravel Artisan #422
 
 ## [0.22.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - `dd_trace_forward_call()` to forward the original call from within a tracing closure #284
+- Tracing support from the CLI SAPI #422
 
 ### Fixed
 - `parent::` keyword not honored from a subclass when forwarding a call from a tracing closure #284

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Added
 - Support for [Lumen](https://lumen.laravel.com/) 5.2+ #416
+- Tracing support from the CLI SAPI #422
 
 ## [0.22.0]
 
@@ -15,9 +16,6 @@ All notable changes to this project will be documented in this file - [read more
 
 ### Fixed
 - Error when a subclassed integration returns an object that cannot be cast as a string #423
-
-### Added
-- Tracing support from the CLI SAPI #422
 
 ## [0.21.0]
 

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -4,11 +4,6 @@ namespace DDTrace\Bridge;
 
 require_once __DIR__ . '/functions.php';
 
-if (php_sapi_name() == 'cli' && getenv('APP_ENV') != 'dd_testing') {
-    dd_trace_disable_in_request();
-    return;
-}
-
 if (!dd_tracing_enabled()) {
     dd_trace_disable_in_request();
     return;

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -9,6 +9,15 @@ namespace DDTrace\Bridge;
  */
 function dd_tracing_enabled()
 {
+    if ('cli' === PHP_SAPI) {
+        $cliEnabled = getenv('DD_TRACE_CLI_ENABLED');
+        if (false === $cliEnabled) {
+            return false;
+        }
+        $cliEnabled = strtolower(trim($cliEnabled));
+        return 'true' === $cliEnabled || '1' === $cliEnabled;
+    }
+
     $value = getenv('DD_TRACE_ENABLED');
     if (false === $value) {
         // Not setting the env means we default to enabled.

--- a/composer.json
+++ b/composer.json
@@ -321,7 +321,7 @@
         "laravel-57-test": "@composer test -- tests/Integrations/Laravel/V5_7/CommonScenariosTest.php",
 
         "laravel-58-update": "composer --working-dir=tests/Frameworks/Laravel/Version_5_8 update",
-        "laravel-58-test": "@composer test -- tests/Integrations/Laravel/V5_8/CommonScenariosTest.php",
+        "laravel-58-test": "@composer test -- --testsuite=laravel-58-test",
 
         "lumen-52-update": "composer --working-dir=tests/Frameworks/Lumen/Version_5_2 update",
         "lumen-52-test": "@composer test -- tests/Integrations/Lumen/V5_2/CommonScenariosTest.php",

--- a/composer.json
+++ b/composer.json
@@ -361,7 +361,7 @@
         "zend-framework-1-test": "@composer test -- tests/Integrations/ZendFramework/V1",
 
         "custom-framework-autoloaded-update": "composer --working-dir=tests/Frameworks/Custom/Version_Autoloaded update",
-        "custom-framework-autoloaded-test": "@composer test -- tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php"
+        "custom-framework-autoloaded-test": "@composer test -- --testsuite=custom-framework-autoloaded-test"
     },
     "extra": {
         "scenarios": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ x-aliases:
       environment:
         - REDIS_HOSTNAME=redis_integration
         - DDAGENT_HOSTNAME=ddagent_integration
-        - APP_ENV=dd_testing
       cap_add:
         - SYS_PTRACE
   - &base_54_service

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,10 @@
             <file>tests/Integrations/Laravel/V5_8/CommonScenariosTest.php</file>
             <directory>tests/Integrations/CLI/Laravel/V5_8</directory>
         </testsuite>
+        <testsuite name="custom-framework-autoloaded-test">
+            <file>tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php</file>
+            <directory>tests/Integrations/CLI/Custom/Autoloaded</directory>
+        </testsuite>
         <testsuite name="unit">
             <directory>tests/Unit/</directory>
         </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,10 @@
         <testsuite name="integration">
             <directory>tests/Integration/</directory>
         </testsuite>
+        <testsuite name="laravel-58-test">
+            <file>tests/Integrations/Laravel/V5_8/CommonScenariosTest.php</file>
+            <directory>tests/Integrations/CLI/Laravel/V5_8</directory>
+        </testsuite>
         <testsuite name="unit">
             <directory>tests/Unit/</directory>
         </testsuite>

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -95,7 +95,7 @@ final class Bootstrap
                 $options,
                 Request::getHeaders()
             );
-        $operationName = 'cli' === PHP_SAPI ? 'cli.command' : 'web.request';
+        $operationName = 'cli' === PHP_SAPI ? $_SERVER['argv'][0] : 'web.request';
         $span = $tracer->startRootSpan($operationName, $startSpanOptions)->getSpan();
         $span->setIntegration(WebIntegration::getInstance());
         $span->setTraceAnalyticsCandidate();

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -95,7 +95,7 @@ final class Bootstrap
                 $options,
                 Request::getHeaders()
             );
-        $operationName = 'cli' === PHP_SAPI ? $_SERVER['argv'][0] : 'web.request';
+        $operationName = 'cli' === PHP_SAPI ? basename($_SERVER['argv'][0]) : 'web.request';
         $span = $tracer->startRootSpan($operationName, $startSpanOptions)->getSpan();
         $span->setIntegration(WebIntegration::getInstance());
         $span->setTraceAnalyticsCandidate();

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -175,14 +175,11 @@ abstract class Integration
      */
     protected static function shouldLoad($name)
     {
-        if ('cli' === PHP_SAPI && 'dd_testing' !== getenv('APP_ENV')) {
-            return false;
-        }
         if (!Configuration::get()->isIntegrationEnabled($name)) {
             return false;
         }
         if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
+            trigger_error('ddtrace extension required to load integration.', E_USER_WARNING);
             return false;
         }
 

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -133,9 +133,6 @@ class LaravelProvider extends ServiceProvider
      */
     private function shouldLoad()
     {
-        if ('cli' === PHP_SAPI && 'dd_testing' !== getenv('APP_ENV')) {
-            return false;
-        }
         if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
             return false;
         }

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -152,9 +152,6 @@ class LaravelIntegrationLoader
      */
     private function shouldLoad()
     {
-        if ('cli' === PHP_SAPI && 'dd_testing' !== getenv('APP_ENV')) {
-            return false;
-        }
         if (!Configuration::get()->isIntegrationEnabled(LaravelIntegration::NAME)) {
             return false;
         }

--- a/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
@@ -109,9 +109,6 @@ final class LumenIntegrationLoader
      */
     private function shouldLoad()
     {
-        if ('cli' === PHP_SAPI && 'dd_testing' !== getenv('APP_ENV')) {
-            return false;
-        }
         if (!Configuration::get()->isIntegrationEnabled(LumenIntegration::NAME)) {
             return false;
         }

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -48,10 +48,6 @@ class SymfonyBundle extends Bundle
             return;
         }
 
-        if (getenv('APP_ENV') != 'dd_testing' && php_sapi_name() == 'cli') {
-            return;
-        }
-
         $tracer = GlobalTracer::get();
 
         // Create a span that starts from when Symfony first boots

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -48,10 +48,6 @@ class SymfonyBundle extends Bundle
             return;
         }
 
-        if (php_sapi_name() == 'cli') {
-            return;
-        }
-
         $tracer = GlobalTracer::get();
         $appName = $this->getAppName();
 

--- a/tests/Frameworks/Custom/Version_Autoloaded/run
+++ b/tests/Frameworks/Custom/Version_Autoloaded/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$simple = new App\SimpleController;
+$simple->render();

--- a/tests/Frameworks/Laravel/Version_4_2/phpunit.xml
+++ b/tests/Frameworks/Laravel/Version_4_2/phpunit.xml
@@ -16,7 +16,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="APP_ENV" value="dd_testing"/>
         <env name="LARAVEL_VERSION" value="Version_4_2"/>
         <env name="BOOTSTRAP_SCRIPT" value="bootstrap/start.php"/>
     </php>

--- a/tests/Frameworks/Laravel/Version_5_7/phpunit.xml
+++ b/tests/Frameworks/Laravel/Version_5_7/phpunit.xml
@@ -19,7 +19,6 @@
         </whitelist>
     </filter>
     <php>
-        <env name="APP_ENV" value="dd_testing"/>
         <env name="APP_NAME" value="laravel_test_app"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>

--- a/tests/Frameworks/Symfony/Version_3_4/app/AppKernel.php
+++ b/tests/Frameworks/Symfony/Version_3_4/app/AppKernel.php
@@ -19,15 +19,12 @@ class AppKernel extends Kernel
             new AppBundle\AppBundle(),
         ];
 
-        if (in_array($this->getEnvironment(), ['dev', 'dd_testing'], true)) {
+        if ('dev' === $this->getEnvironment()) {
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-
-            if ('dev' === $this->getEnvironment()) {
-                $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
-            }
+            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
         }
 
         return $bundles;

--- a/tests/Frameworks/Symfony/Version_3_4/phpunit.xml.dist
+++ b/tests/Frameworks/Symfony/Version_3_4/phpunit.xml.dist
@@ -9,7 +9,6 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="APP_ENV" value="dd_testing"/>
         <server name="KERNEL_CLASS" value="AppKernel" />
     </php>
 

--- a/tests/Integrations/CLI/CLITestCase.php
+++ b/tests/Integrations/CLI/CLITestCase.php
@@ -59,8 +59,8 @@ abstract class CLITestCase extends IntegrationTestCase
      */
     public function getTracesFromCommand($arguments = '')
     {
-        $envs = (string) new EnvSerializer(self::getEnvs());
-        $inis = (string) new IniSerializer(self::getInis());
+        $envs = (string) new EnvSerializer(static::getEnvs());
+        $inis = (string) new IniSerializer(static::getInis());
         $script = escapeshellarg($this->getScriptLocation());
         $arguments = escapeshellarg($arguments);
         `$envs php $inis $script $arguments`;

--- a/tests/Integrations/CLI/CLITestCase.php
+++ b/tests/Integrations/CLI/CLITestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI;
+
+use DDTrace\Tests\Common\IntegrationTestCase;
+
+/**
+ * A basic class to be extended when testing CLI integrations.
+ */
+abstract class CLITestCase extends IntegrationTestCase
+{
+    /**
+     * The location of the script to execute
+     *
+     * @return string
+     */
+    abstract protected function getScriptLocation();
+
+    /**
+     * Get additional envs
+     *
+     * @return array
+     */
+    protected static function getEnvs()
+    {
+        return [
+            'DD_TRACE_CLI_ENABLED' => 'true',
+            'DD_TEST_INTEGRATION' => 'true',
+            'DD_TRACE_ENCODER' => 'json',
+        ];
+    }
+
+    /**
+     * Get additional INI directives to be set in the CLI
+     *
+     * @return array
+     */
+    protected static function getInis()
+    {
+        return [
+            'ddtrace.request_init_hook' => __DIR__ . '/../../bridge/dd_wrap_autoloader.php',
+        ];
+    }
+
+    /**
+     * Run a command from the CLI
+     *
+     * @param string $arguments
+     * @return string
+     */
+    public function runCommand($arguments = '')
+    {
+        $envs = (string) new EnvSerializer(self::getEnvs());
+        $inis = (string) new IniSerializer(self::getInis());
+        $script = escapeshellarg($this->getScriptLocation());
+        $arguments = escapeshellarg($arguments);
+        return `$envs php $inis $script $arguments`;
+    }
+}

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Integrations\CLI\CLITestCase;
+
+final class CommonScenariosTest extends CLITestCase
+{
+    protected function getScriptLocation()
+    {
+        return __DIR__ . '/../../../../Frameworks/Custom/Version_Autoloaded/run';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_APP_NAME' => 'console_test_app',
+        ]);
+    }
+
+    public function testCommandWithNoArguments()
+    {
+        $traces = $this->getTracesFromCommand();
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'run',
+                'console_test_app',
+                'cli',
+                'run'
+            )->withExactTags([
+                'integration.name' => 'web',
+            ])
+        ]);
+    }
+}

--- a/tests/Integrations/CLI/EnvSerializer.php
+++ b/tests/Integrations/CLI/EnvSerializer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI;
+
+/**
+ * Serialize an associative array into env var string for CLI commands
+ */
+final class EnvSerializer
+{
+    private $envs;
+
+    /**
+     * @param array $envs
+     */
+    public function __construct(array $envs)
+    {
+        $this->envs = $envs;
+    }
+
+    public function __toString()
+    {
+        $envs = [];
+        foreach ($this->envs as $name => $value) {
+            $envs[] = $name . '=' . escapeshellarg($value);
+        }
+        return implode(' ', $envs);
+    }
+}

--- a/tests/Integrations/CLI/IniSerializer.php
+++ b/tests/Integrations/CLI/IniSerializer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI;
+
+/**
+ * Serialize an associative array into INI string for CLI SAPI
+ */
+final class IniSerializer
+{
+    private $inis;
+
+    /**
+     * @param array $inis
+     */
+    public function __construct(array $inis)
+    {
+        $this->inis = $inis;
+    }
+
+    public function __toString()
+    {
+        $inis = [];
+        foreach ($this->inis as $name => $value) {
+            $inis[] = '-d' . $name . '=' . escapeshellarg($value);
+        }
+        return implode(' ', $inis);
+    }
+}

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -25,7 +25,7 @@ final class CommonScenariosTest extends CLITestCase
 
         $this->assertSpans($traces, [
             SpanAssertion::build(
-                'artisan',
+                'laravel.artisan',
                 'artisan_test_app',
                 'cli',
                 'artisan'
@@ -35,66 +35,38 @@ final class CommonScenariosTest extends CLITestCase
         ]);
     }
 
-    /*
-    public function provideSpecs()
+    public function testCommandWithArgument()
     {
-        return $this->buildDataProvider(
-            [
-                'A simple GET request returning a string' => [
-                    SpanAssertion::build(
-                        'laravel.request',
-                        'laravel_test_app',
-                        'web',
-                        'App\Http\Controllers\CommonSpecsController@simple simple_route'
-                    )->withExactTags([
-                        'laravel.route.name' => 'simple_route',
-                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                        'integration.name' => 'laravel',
-                    ]),
-                ],
-                'A simple GET request with a view' => [
-                    SpanAssertion::build(
-                        'laravel.request',
-                        'laravel_test_app',
-                        'web',
-                        'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
-                    )->withExactTags([
-                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple_view',
-                        'http.status_code' => '200',
-                        'integration.name' => 'laravel',
-                    ])->withExistingTagsNames(['laravel.route.name']),
-                    SpanAssertion::build(
-                        'laravel.view',
-                        'laravel_test_app',
-                        'web',
-                        'laravel.view'
-                    )->withExactTags([
-                        'integration.name' => 'laravel',
-                    ]),
-                ],
-                'A GET request with an exception' => [
-                    SpanAssertion::build(
-                        'laravel.request',
-                        'laravel_test_app',
-                        'web',
-                        'App\Http\Controllers\CommonSpecsController@error unnamed_route'
-                    )->withExactTags([
-                        'laravel.route.name' => '',
-                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/error',
-                        'http.status_code' => '500',
-                        'integration.name' => 'laravel',
-                    ])->setError(),
-                    SpanAssertion::exists('laravel.view')
-                ],
-            ]
-        );
+        $traces = $this->getTracesFromCommand('route:list');
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'laravel.artisan',
+                'artisan_test_app',
+                'cli',
+                'artisan route:list'
+            )->withExactTags([
+                'integration.name' => 'laravel',
+            ])
+        ]);
     }
-    */
+
+    public function testCommandWithError()
+    {
+        $traces = $this->getTracesFromCommand('foo:error');
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'laravel.artisan',
+                'artisan_test_app',
+                'cli',
+                'artisan foo:error'
+            )->withExactTags([
+                'integration.name' => 'laravel',
+            ])->withExistingTagsNames([
+                'error.msg',
+                'error.stack'
+            ])->setError()
+        ]);
+    }
 }

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -21,9 +21,7 @@ final class CommonScenariosTest extends CLITestCase
 
     public function testCommandWithNoArguments()
     {
-        $traces = $this->isolateTracer(function () {
-            $this->runCommand();
-        });
+        $traces = $this->getTracesFromCommand();
 
         $this->assertSpans($traces, [
             SpanAssertion::build(

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI\Laravel\V5_8;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Integrations\CLI\CLITestCase;
+
+final class CommonScenariosTest extends CLITestCase
+{
+    protected function getScriptLocation()
+    {
+        return __DIR__ . '/../../../../Frameworks/Laravel/Version_5_8/artisan';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'APP_NAME' => 'artisan_test_app',
+        ]);
+    }
+
+    public function testCommandWithNoArguments()
+    {
+        $traces = $this->isolateTracer(function () {
+            $this->runCommand();
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'artisan',
+                'artisan_test_app',
+                'cli',
+                'artisan'
+            )->withExactTags([
+                'integration.name' => 'laravel',
+            ])
+        ]);
+    }
+
+    /*
+    public function provideSpecs()
+    {
+        return $this->buildDataProvider(
+            [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'laravel.request',
+                        'laravel_test_app',
+                        'web',
+                        'App\Http\Controllers\CommonSpecsController@simple simple_route'
+                    )->withExactTags([
+                        'laravel.route.name' => 'simple_route',
+                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                        'integration.name' => 'laravel',
+                    ]),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'laravel.request',
+                        'laravel_test_app',
+                        'web',
+                        'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
+                    )->withExactTags([
+                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                        'integration.name' => 'laravel',
+                    ])->withExistingTagsNames(['laravel.route.name']),
+                    SpanAssertion::build(
+                        'laravel.view',
+                        'laravel_test_app',
+                        'web',
+                        'laravel.view'
+                    )->withExactTags([
+                        'integration.name' => 'laravel',
+                    ]),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'laravel.request',
+                        'laravel_test_app',
+                        'web',
+                        'App\Http\Controllers\CommonSpecsController@error unnamed_route'
+                    )->withExactTags([
+                        'laravel.route.name' => '',
+                        'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                        'integration.name' => 'laravel',
+                    ])->setError(),
+                    SpanAssertion::exists('laravel.view')
+                ],
+            ]
+        );
+    }
+    */
+}

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -2,6 +2,8 @@
 
 namespace DDTrace\Tests;
 
+use DDTrace\Tests\Integrations\CLI\EnvSerializer;
+use DDTrace\Tests\Integrations\CLI\IniSerializer;
 use Symfony\Component\Process\Process;
 
 /**
@@ -120,12 +122,10 @@ class WebServer
      */
     private function getSerializedEnvsForCli()
     {
-        $all = array_merge($this->defaultEnvs, $this->envs);
-        $forCli = [];
-        foreach ($all as $name => $value) {
-            $forCli[] = $name . "=" . escapeshellarg($value);
-        }
-        return implode(' ', $forCli);
+        $serializer = new EnvSerializer(
+            array_merge($this->defaultEnvs, $this->envs)
+        );
+        return (string) $serializer;
     }
 
     /**
@@ -135,11 +135,9 @@ class WebServer
      */
     private function getSerializedIniForCli()
     {
-        $all = array_merge($this->defaultInis, $this->inis);
-        $forCli = [];
-        foreach ($all as $name => $value) {
-            $forCli[] = "-d" . $name . "=" . escapeshellarg($value);
-        }
-        return implode(' ', $forCli);
+        $serializer = new IniSerializer(
+            array_merge($this->defaultInis, $this->inis)
+        );
+        return (string) $serializer;
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for tracing custom PHP CLI scripts and Laravel Artisan. This feature is disabled by default. To enable, set the env var `DD_TRACE_CLI_ENABLED=true`.

~~This PR adds support for the CLI SAPI by removing the `PHP_SAPI` and `getenv('APP_ENV')` checks.~~

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
