### PR TITLE
Ignore objects sent to Span::setTag()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - `parent::` keyword not honored from a subclass when forwarding a call from a tracing closure #284
 - Private and protected callable strings not resolved properly from a tracing closure #303
+- Error when a subclassed integration returns an object that cannot be cast as a string #423
 
 ## [0.20.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Error when a subclassed integration returns an object that cannot be cast as a string #423
+
 ## [0.21.0]
 
 ### Added
@@ -12,7 +15,6 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - `parent::` keyword not honored from a subclass when forwarding a call from a tracing closure #284
 - Private and protected callable strings not resolved properly from a tracing closure #303
-- Error when a subclassed integration returns an object that cannot be cast as a string #423
 
 ## [0.20.0]
 

--- a/src/DDTrace/Contracts/Span.php
+++ b/src/DDTrace/Contracts/Span.php
@@ -67,7 +67,7 @@ interface Span
      * If the span is already finished, a warning should be logged.
      *
      * @param string $key
-     * @param string|bool|int|float $value
+     * @param mixed $value
      * @param boolean $setIfFinished
      * @return void
      */

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -116,9 +116,9 @@ final class GuzzleIntegration extends Integration
     private function setUrlTag(Span $span, $request)
     {
         if (is_a($request, '\GuzzleHttp\Message\RequestInterface')) {
-            $span->setTag(Tag::HTTP_URL, $request->getUrl());
+            $span->setTag(Tag::HTTP_URL, (string) $request->getUrl());
         } elseif (is_a($request, '\Psr\Http\Message\RequestInterface')) {
-            $span->setTag(Tag::HTTP_URL, $request->getUri());
+            $span->setTag(Tag::HTTP_URL, (string) $request->getUri());
         }
     }
 

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -134,6 +134,11 @@ final class Span extends SpanData
         if ($key !== (string)$key) {
             throw InvalidSpanArgument::forTagKey($key);
         }
+        // Since sub classes can change the return value of a known method,
+        // we quietly ignore values that could cause errors when converting to string
+        if (is_object($value) && $key !== Tag::ERROR) {
+            return;
+        }
 
         if (array_key_exists($key, self::$specialTags)) {
             if ($key === Tag::ERROR) {

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -96,6 +96,14 @@ final class SpanTest extends Framework\TestCase
         $this->assertFalse($span->hasError());
     }
 
+    public function testSpanTagWithObjectIsIgnored()
+    {
+        $span = $this->createSpan();
+        $span->setTag('foo', new \stdClass);
+
+        $this->assertNull($span->getTag('foo'));
+    }
+
     public function testLogWithErrorBoolProperlyMarksError()
     {
         $span = $this->createSpan();

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -99,7 +99,7 @@ final class SpanTest extends Framework\TestCase
     public function testSpanTagWithObjectIsIgnored()
     {
         $span = $this->createSpan();
-        $span->setTag('foo', new \stdClass);
+        $span->setTag('foo', new \stdClass());
 
         $this->assertNull($span->getTag('foo'));
     }


### PR DESCRIPTION
### Description

In cases where a subclass changes the return value of a known method, the `$value` sent to `Span::setTag()` can be an object that has no `__toString` magic method. This causes an error when trying to cast the value to a string. This is the root cause of #332.

The following repro illustrates what can happen within a traced integration:

```php
class FakePDO
{
    public function exec()
    {
        return 42;
    }
}

class MyPDO extends FakePDO
{
    public function exec()
    {
        $obj = new \stdClass;
        $obj->rows = parent::exec();
        return $obj;
    }
}

dd_trace('FakePDO', 'exec', function() {
    var_dump($this->exec()); // Assumes return value is an int
});

(new MyPDO())->exec();
```

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
