### PR TITLE
Temporarily remove Mongo tests from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,6 @@ aliases:
       - MYSQL_USER=test
       - MYSQL_DATABASE=test
 
-  - &IMAGE_DOCKER_MONGODB
-    image: mongo:4
-    name: mongodb_integration
-    command: [mongod, --smallfiles]
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=test
-      - MONGO_INITDB_ROOT_PASSWORD=test
-
   - &IMAGE_DOCKER_REQUEST_REPLAYER
     image: php:7.2
     name: request_replayer
@@ -115,11 +107,6 @@ aliases:
       name: Waiting for Dockerized request replayer
       command: dockerize -wait tcp://request_replayer:80/clear-dumped-data -timeout 2m
 
-  - &STEP_WAIT_MONGODB
-    run:
-      name: Waiting for Dockerized MongoDB
-      command: dockerize -wait tcp://mongodb_integration:27017 -timeout 1m
-
   - &STEP_PERSIST_TO_WORKSPACE
     persist_to_workspace:
       root: '.'
@@ -169,7 +156,6 @@ executors:
       - <<: *IMAGE_DOCKER_REDIS
       - <<: *IMAGE_DOCKER_MEMCHACED
       - <<: *IMAGE_DOCKER_MYSQL
-      - <<: *IMAGE_DOCKER_MONGODB
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
 
 jobs:
@@ -280,7 +266,6 @@ jobs:
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
-      - <<: *STEP_WAIT_MONGODB
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - run:
           name: Run auto-instrumentation tests

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,6 @@
             "@composer scenario default",
             "@composer test -- tests/Integrations/Curl",
             "@composer test -- tests/Integrations/Memcached",
-            "@composer test -- tests/Integrations/Mongo",
             "@composer test -- tests/Integrations/Mysqli",
             "@composer test -- tests/Integrations/PDO",
             "@composer scenario elasticsearch1",


### PR DESCRIPTION
### Description

Since the Mongo tests have stopped working and are blocking all the PR's, this PR disables the mongo tests until we can fix the flaky mongo image on the CircleCI side. Once we fix the image, we can simply revert this commit to bring them back.

```bash
$ git revert 4a2692e
```

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- ~~[ ] Tests added for this feature/bug~~
