### PR TITLE
Fix timezone warning in PHP 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Generation of `E_WARNING` in certain contexts of PHP 5 installs when the `date.timezone` INI setting is not set #435
+
 ## [0.23.0]
 
 **NOTE: We changed the way the service name can be configured. Now you must use `DD_SERVICE_NAME` instead of `DD_TRACE_APP_NAME` for consistency with other tracers. Usage of `DD_TRACE_APP_NAME` is now deprecated and will be removed in a future release.**

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -2,6 +2,10 @@
 
 namespace DDTrace\Bridge;
 
+if (PHP_VERSION_ID < 70000) {
+    date_default_timezone_set(date_default_timezone_get());
+}
+
 require_once __DIR__ . '/functions.php';
 
 if (!dd_tracing_enabled()) {


### PR DESCRIPTION
### Description

In PHP 5 there was a warning that would be raised when doing date/time manipulation if the default timezone wasn't set. The PHP tracer can cause this warning on systems that don't have the default timezone set from an INI setting [when the logger date stamps a log entry](https://github.com/DataDog/dd-trace-php/blob/638b1f1cb8dc4c82da196572df183ef65e6ca2a6/src/DDTrace/Log/ErrorLogLogger.php#L68).

```
Warning: date(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /opt/datadog-php/dd-trace-sources/src/DDTrace/Log/ErrorLogLogger.php on line 68
```

This PR ensures we don't inadvertently generate warnings on PHP 5 installs with no value set for `date.timezone`.

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
