### PR TITLE
CakePHP v2 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file - [read more
 - Tracer limited mode, stopping span creation when memory use raises to 80% of current PHP memory limit #437
 - Configurable Curl timeouts `DD_TRACE_AGENT_TIMEOUT` and `DD_TRACE_AGENT_CONNECT_TIMEOUT` when communicating with the agent #150
 - Configurable `DD_TRACE_REPORT_HOSTNAME` reporting of hostname via root span #441
+- Support for CakePHP v2 and Cake Console v2 #436
 
 ### Fixed
 - Generation of `E_WARNING` in certain contexts of PHP 5 installs when the `date.timezone` INI setting is not set #435

--- a/bridge/dd_optional_deps_autoloader.php
+++ b/bridge/dd_optional_deps_autoloader.php
@@ -19,6 +19,7 @@ class OptionalDepsAutoloader
         "DDTrace\\OpenTracer\\Scope" => 'DDTrace/OpenTracer/Scope.php',
         "DDTrace\\OpenTracer\\ScopeManager" => 'DDTrace/OpenTracer/ScopeManager.php',
         "DDTrace\\OpenTracer\\SpanContext" => 'DDTrace/OpenTracer/SpanContext.php',
+        "DDTrace\\Integrations\\CakePHP\\V2\\CakePHPIntegrationLoader" => 'DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php',
         "DDTrace\\Integrations\\Symfony\\V4\\SymfonyBundle" => 'DDTrace/Integrations/Symfony/V4/SymfonyBundle.php',
         "DDTrace\\Integrations\\Symfony\\V3\\SymfonyBundle" => 'DDTrace/Integrations/Symfony/V3/SymfonyBundle.php',
         "DDTrace\\Integrations\\Laravel\\V5\\LaravelIntegrationLoader" => 'DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php',

--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -58,6 +58,7 @@ require __DIR__ . '/../src/DDTrace/ScopeManager.php';
 require __DIR__ . '/../src/DDTrace/Integrations/AbstractIntegrationConfiguration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/DefaultIntegrationConfiguration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Integration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Predis/PredisIntegration.php';

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Bridge;
 
 if (PHP_VERSION_ID < 70000) {
-    date_default_timezone_set(date_default_timezone_get());
+    date_default_timezone_set(@date_default_timezone_get());
 }
 
 require_once __DIR__ . '/functions.php';

--- a/composer.json
+++ b/composer.json
@@ -201,6 +201,8 @@
             "@composer scenario default"
         ],
         "test-web-54": [
+            "@cakephp-28-update",
+            "@cakephp-28-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@zend-framework-1-test",
@@ -208,6 +210,8 @@
             "@custom-framework-autoloaded-test"
         ],
         "test-web-56": [
+            "@cakephp-28-update",
+            "@cakephp-28-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@symfony-23-update",
@@ -312,6 +316,9 @@
         "test-unit": "phpunit --colors=always --configuration=phpunit.xml --testsuite=unit",
 
         "test-auto-instrumentation": "phpunit --colors=always --configuration=phpunit.xml --testsuite=auto-instrumentation",
+
+        "cakephp-28-update": "composer --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
+        "cakephp-28-test": "@composer test -- --testsuite=cakephp-28-test",
 
         "laravel-42-update": "composer --working-dir=tests/Frameworks/Laravel/Version_4_2 update",
         "laravel-42-optimize": "@php tests/Frameworks/Laravel/Version_4_2/artisan optimize",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "prefer-stable": true,
     "scripts": {
         "fix-lint": "phpcbf",
-        "lint": "phpcs -s --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php",
+        "lint": "phpcs -s --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php,tests/request_replayer/",
         "lint-5.4": "phpcs -s --runtime-set testVersion 5.4-7.3 --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php",
         "static-analyze": "phpstan analyse --level=2 src",
         "run-agent": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,13 +115,13 @@ services:
       - "8126:8126"
 
   request_replayer:
-    image: php:7.2
+    image: php:7.3
     working_dir: /var/www
+    volumes:
+      - ./tests/request_replayer:/var/www
     ports:
-      - 9000:80
-    environment:
-      DD_REQUEST_DUMPER_FILE: dump.json
-    command: sh -c "curl --output index.php https://raw.githubusercontent.com/DataDog/dd-trace-php/master/tests/request_replayer/index.php -q && php -S 0.0.0.0:80 index.php"
+      - 9090:80
+    command: sh -c "php -S 0.0.0.0:80 index.php"
 
   agent:
     image: datadog/agent:latest

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,10 @@
         <testsuite name="integration">
             <directory>tests/Integration/</directory>
         </testsuite>
+        <testsuite name="cakephp-28-test">
+            <directory>tests/Integrations/CakePHP/V2_8</directory>
+            <directory>tests/Integrations/CLI/CakePHP/V2_8</directory>
+        </testsuite>
         <testsuite name="laravel-58-test">
             <file>tests/Integrations/Laravel/V5_8/CommonScenariosTest.php</file>
             <directory>tests/Integrations/CLI/Laravel/V5_8</directory>

--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -67,8 +67,9 @@ class CakePHPIntegration extends Integration
         // Web bootstrap
         dd_trace('Dispatcher', '__construct', $initCakeV2);
         // CLI bootstrap
+        // Once auto-instrumentation has been added for non-autoloaded projects,
+        // uncomment the following line and delete the if block below it
         //dd_trace('ShellDispatcher', 'run', $initCakeV2);
-        // Temporary workaround until we fix request_init_hook for non-autoloaded projects
         if ('cli' === PHP_SAPI) {
             dd_trace('App', 'init', $initCakeV2);
         }

--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace DDTrace\Integrations\CakePHP;
+
+use DDTrace\Configuration;
+use DDTrace\Integrations\CakePHP\V2\CakePHPIntegrationLoader;
+use DDTrace\Integrations\Integration;
+
+/**
+ * The base Laravel integration which delegates loading to the appropriate integration version.
+ */
+class CakePHPIntegration extends Integration
+{
+    const NAME = 'cakephp';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresExplicitTraceAnalyticsEnabling()
+    {
+        return false;
+    }
+
+    /**
+     * Loads the integration.
+     *
+     * @return int
+     */
+    public static function load()
+    {
+        if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        $integration = self::getInstance();
+
+        // CakePHP v2.x - we don't need to check for v3 since it does not have \Dispatcher or \ShellDispatcher
+        $initCakeV2 = function () use ($integration) {
+            $loader = new CakePHPIntegrationLoader();
+            $loader->load($integration);
+            return dd_trace_forward_call();
+        };
+        // Web bootstrap
+        dd_trace('Dispatcher', '__construct', $initCakeV2);
+        // CLI bootstrap
+        //dd_trace('ShellDispatcher', 'run', $initCakeV2);
+        // Temporary workaround until we fix request_init_hook for non-autoloaded projects
+        if ('cli' === PHP_SAPI) {
+            dd_trace('App', 'init', $initCakeV2);
+        }
+
+        // Trace CakePHP v3 entry point here...
+
+        return self::LOADED;
+    }
+
+    public static function getAppName()
+    {
+        $name = Configuration::get()->appName();
+        if ($name) {
+            return $name;
+        }
+        return self::NAME;
+    }
+}

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -71,20 +71,6 @@ class CakePHPIntegrationLoader
             return include __DIR__ . '/../../../try_catch_finally.php';
         });
 
-        // Create a trace span for every event fired
-        dd_trace('CakeEventManager', 'dispatch', function ($event) use ($integration) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                //return dd_trace_forward_call();
-            }
-            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'cakephp.event');
-            $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
-            $name = $event instanceof CakeEvent ? $event->name() : $event;
-            $scope->getSpan()->setTag(Tag::RESOURCE_NAME, $name);
-            $scope->getSpan()->setTag('cakephp.event.name', $name);
-            return include __DIR__ . '/../../../try_catch_finally.php';
-        });
-
         /**
          * CakePHP Console
          */

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -34,18 +34,18 @@ class CakePHPIntegrationLoader
         $this->rootSpan->overwriteOperationName('cakephp.request');
         $this->rootSpan->setTag(Tag::SERVICE_NAME, CakePHPIntegration::getAppName());
 
-        $self = $this;
+        $loader = $this;
 
-        dd_trace('Controller', 'invokeAction', function (CakeRequest $request) use ($self) {
-            $self->rootSpan->setTag(
+        dd_trace('Controller', 'invokeAction', function (CakeRequest $request) use ($loader) {
+            $loader->rootSpan->setTag(
                 Tag::RESOURCE_NAME,
                 $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action']
             );
-            $self->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
-            $self->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
-            $self->rootSpan->setTag('cakephp.route.action', $request->params['action']);
+            $loader->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
+            $loader->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
+            $loader->rootSpan->setTag('cakephp.route.action', $request->params['action']);
             if (isset($request->params['plugin'])) {
-                $self->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
+                $loader->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
             }
             return dd_trace_forward_call();
         });
@@ -57,8 +57,8 @@ class CakePHPIntegrationLoader
         // - Controller::appError()
         // - Exception.handler
         // - Exception.renderer
-        dd_trace('ExceptionRenderer', '__construct', function ($exception) use ($self) {
-            $self->rootSpan->setError($exception);
+        dd_trace('ExceptionRenderer', '__construct', function ($exception) use ($loader) {
+            $loader->rootSpan->setError($exception);
             return dd_trace_forward_call();
         });
 
@@ -81,9 +81,9 @@ class CakePHPIntegrationLoader
          */
         //dd_trace('ShellDispatcher', '__construct', function () use ($self) {
         // Temporary workaround until we fix request_init_hook for non-autoloaded projects
-        dd_trace('ShellDispatcher', 'dispatch', function () use ($self) {
-            $self->rootSpan->overwriteOperationName('cakephp.console');
-            $self->rootSpan->setTag(
+        dd_trace('ShellDispatcher', 'dispatch', function () use ($loader) {
+            $loader->rootSpan->overwriteOperationName('cakephp.console');
+            $loader->rootSpan->setTag(
                 Tag::RESOURCE_NAME,
                 !empty($_SERVER['argv'][1]) ? 'cake_console ' . $_SERVER['argv'][1] : 'cake_console'
             );

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -21,7 +21,12 @@ class CakePHPIntegrationLoader
 
     public function load(CakePHPIntegration $integration)
     {
-        echo "This makes it work...\n";
+        // Very strange workaround to get the integration to load in tests
+        // We need to find this bug in the CLI SAPI's built-in web server
+        // Once the bug is fixed we can remove this line block
+        if ('true' === getenv('DD_TEST_INTEGRATION')) {
+            echo ' ';
+        }
         $this->rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
         // Overwrite the default web integration
         $this->rootSpan->setIntegration($integration);

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DDTrace\Integrations\CakePHP\V2;
+
+use CakeEvent;
+use CakeRequest;
+use DDTrace\GlobalTracer;
+use DDTrace\Integrations\CakePHP\CakePHPIntegration;
+use DDTrace\Integrations\Integration;
+use DDTrace\Contracts\Span;
+use DDTrace\Tag;
+use DDTrace\Type;
+use Router;
+
+class CakePHPIntegrationLoader
+{
+    /**
+     * @var Span
+     */
+    public $rootSpan;
+
+    public function load(CakePHPIntegration $integration)
+    {
+        echo "This makes it work...\n";
+        $this->rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
+        // Overwrite the default web integration
+        $this->rootSpan->setIntegration($integration);
+        $this->rootSpan->setTraceAnalyticsCandidate();
+        $this->rootSpan->overwriteOperationName('cakephp.request');
+        $this->rootSpan->setTag(Tag::SERVICE_NAME, CakePHPIntegration::getAppName());
+
+        $self = $this;
+
+        dd_trace('Controller', 'invokeAction', function (CakeRequest $request) use ($self) {
+            $self->rootSpan->setTag(
+                Tag::RESOURCE_NAME,
+                $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action']
+            );
+            $self->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
+            $self->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
+            $self->rootSpan->setTag('cakephp.route.action', $request->params['action']);
+            if (isset($request->params['plugin'])) {
+                $self->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
+            }
+            return dd_trace_forward_call();
+        });
+
+        // This only traces the default exception renderer
+        // We can remove this when we auto-trace exceptions and errors
+        // Other possible places to trace
+        // - ErrorHandler::handleException()
+        // - Controller::appError()
+        // - Exception.handler
+        // - Exception.renderer
+        dd_trace('ExceptionRenderer', '__construct', function ($exception) use ($self) {
+            $self->rootSpan->setError($exception);
+            return dd_trace_forward_call();
+        });
+
+        // Create a trace span for every template rendered
+        dd_trace('View', 'render', function () use ($integration) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'cakephp.view');
+            $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
+            $file = $this->viewPath . '/' . $this->view . $this->ext;
+            $scope->getSpan()->setTag(Tag::RESOURCE_NAME, $file);
+            $scope->getSpan()->setTag('cakephp.view', $file);
+            return include __DIR__ . '/../../../try_catch_finally.php';
+        });
+
+        // Create a trace span for every event fired
+        dd_trace('CakeEventManager', 'dispatch', function ($event) use ($integration) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                //return dd_trace_forward_call();
+            }
+            $scope = $tracer->startIntegrationScopeAndSpan($integration, 'cakephp.event');
+            $scope->getSpan()->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
+            $name = $event instanceof CakeEvent ? $event->name() : $event;
+            $scope->getSpan()->setTag(Tag::RESOURCE_NAME, $name);
+            $scope->getSpan()->setTag('cakephp.event.name', $name);
+            return include __DIR__ . '/../../../try_catch_finally.php';
+        });
+
+        /**
+         * CakePHP Console
+         */
+        //dd_trace('ShellDispatcher', '__construct', function () use ($self) {
+        // Temporary workaround until we fix request_init_hook for non-autoloaded projects
+        dd_trace('ShellDispatcher', 'dispatch', function () use ($self) {
+            $self->rootSpan->overwriteOperationName('cakephp.console');
+            $self->rootSpan->setTag(
+                Tag::RESOURCE_NAME,
+                !empty($_SERVER['argv'][1]) ? 'cake_console ' . $_SERVER['argv'][1] : 'cake_console'
+            );
+            return dd_trace_forward_call();
+        });
+
+        // This is called from the exception handler and doesn't get traced
+        // We can remove this when we auto-trace exceptions and errors
+        dd_trace('ConsoleErrorHandler', 'handleException', function ($exception) {
+            $span = GlobalTracer::get()->getActiveSpan();
+            $span->setError($exception);
+            return dd_trace_forward_call();
+        });
+
+        return Integration::LOADED;
+    }
+}

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
+use DDTrace\Integrations\CakePHP\CakePHPIntegration;
 use DDTrace\Integrations\Curl\CurlIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
 use DDTrace\Integrations\Eloquent\EloquentIntegration;
@@ -40,6 +41,7 @@ class IntegrationsLoader
      * @var array
      */
     public static $officiallySupportedIntegrations = [
+        CakePHPIntegration::NAME => '\DDTrace\Integrations\CakePHP\CakePHPIntegration',
         CurlIntegration::NAME => '\DDTrace\Integrations\Curl\CurlIntegration',
         ElasticSearchIntegration::NAME => '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
         EloquentIntegration::NAME => '\DDTrace\Integrations\Eloquent\EloquentIntegration',

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -71,7 +71,6 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             'xdebug.remote_enable' => 1,
             'xdebug.remote_host' => 'host.docker.internal',
             'xdebug.remote_autostart' => 1,
-            'xdebug.remote_port' => '9001', // Port 9000 is used by the request re-player
         ];
     }
 

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -52,6 +52,8 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
         return [
             'DD_TEST_INTEGRATION' => 'true',
             'DD_TRACE_ENCODER' => 'json',
+            'DD_TRACE_AGENT_TIMEOUT' => '10000',
+            'DD_TRACE_AGENT_CONNECT_TIMEOUT' => '10000',
         ];
     }
 

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Config/core.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Config/core.php
@@ -53,7 +53,9 @@
  */
 	Configure::write('Error', array(
 		'handler' => 'ErrorHandler::handleError',
-		'level' => E_ALL & ~E_DEPRECATED,
+		// Prevents the following error on PHP 5.4:
+		// Strict Error: Non-static method ShellDispatcher::_stop() should not be called statically
+		'level' => E_ALL & ~E_DEPRECATED & ~E_STRICT,
 		'trace' => true
 	));
 

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Controller/ErrorController.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Controller/ErrorController.php
@@ -1,0 +1,11 @@
+<?php
+
+App::uses('AppController', 'Controller');
+
+class ErrorController extends AppController
+{
+	public function index()
+	{
+		throw new \Exception('Foo error');
+	}
+}

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Controller/SimpleController.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Controller/SimpleController.php
@@ -1,0 +1,12 @@
+<?php
+
+App::uses('AppController', 'Controller');
+
+class SimpleController extends AppController
+{
+	public function index()
+	{
+		$this->autoRender = false;
+		echo 'Hello.';
+	}
+}

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Controller/SimpleViewController.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Controller/SimpleViewController.php
@@ -1,0 +1,10 @@
+<?php
+
+App::uses('AppController', 'Controller');
+
+class SimpleViewController extends AppController
+{
+	public function index()
+	{
+	}
+}

--- a/tests/Frameworks/CakePHP/Version_2_8/app/View/SimpleView/index.ctp
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/View/SimpleView/index.ctp
@@ -1,0 +1,2 @@
+<h1>Simple HTML view</h1>
+<p>Hello.</p>

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI\CakePHP\V2_8;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Integrations\CLI\CLITestCase;
+
+final class CommonScenariosTest extends CLITestCase
+{
+    protected function getScriptLocation()
+    {
+        return __DIR__ . '/../../../../Frameworks/CakePHP/Version_2_8/app/Console/cake.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE_NAME' => 'cake_console_test_app',
+        ]);
+    }
+
+    public function testCommandWithNoArguments()
+    {
+        $traces = $this->getTracesFromCommand();
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'cakephp.console',
+                'cake_console_test_app',
+                'cli',
+                'cake_console'
+            )->withExactTags([
+                'integration.name' => 'cakephp',
+            ])
+        ]);
+    }
+
+    public function testCommandWithArgument()
+    {
+        $traces = $this->getTracesFromCommand('command_list');
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'cakephp.console',
+                'cake_console_test_app',
+                'cli',
+                'cake_console command_list'
+            )->withExactTags([
+                'integration.name' => 'cakephp',
+            ])
+        ]);
+    }
+
+    // We can uncomment this when we auto-trace exceptions and errors
+    /*
+    public function testCommandWithError()
+    {
+        // This error generates a lot of output to the CLI so we mute it
+        $this->setOutputCallback(function() {});
+
+        $traces = $this->getTracesFromCommand('foo_error');
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build(
+                'cakephp.console',
+                'cake_console_test_app',
+                'cli',
+                'cake_console foo_error'
+            )->withExactTags([
+                'integration.name' => 'cakephp',
+            ])->withExistingTagsNames([
+                'error.msg',
+                'error.stack'
+            ])->setError()
+        ]);
+    }
+    */
+}

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -53,11 +53,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         'integration.name' => 'cakephp',
                     ]),
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -73,12 +68,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         'integration.name' => 'cakephp',
                     ]),
-
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.beforeRender'),
-
                     SpanAssertion::build(
                         'cakephp.view',
                         'cakephp_test_app',
@@ -88,23 +77,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'cakephp.view' => 'SimpleView/index.ctp',
                         'integration.name' => 'cakephp',
                     ]),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeLayout'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.afterLayout'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
-
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -123,14 +95,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     ])->withExistingTagsNames([
                         'error.stack'
                     ])->setError(null, 'Foo error'),
-
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.beforeRender'),
-
                     SpanAssertion::build(
                         'cakephp.view',
                         'cakephp_test_app',
@@ -140,25 +104,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'cakephp.view' => 'Errors/index.ctp',
                         'integration.name' => 'cakephp',
                     ]),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeLayout'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
-
-                    SpanAssertion::exists('cakephp.event', 'View.afterLayout'),
-                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
-
-                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
                 ],
             ]
         );

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CakePHP\V2_8;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+final class CommonScenariosTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/CakePHP/Version_2_8/app/webroot/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE_NAME' => 'cakephp_test_app',
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSpecs
+     * @param RequestSpec $spec
+     * @param array $spanExpectations
+     * @throws \Exception
+     */
+    public function testScenario(RequestSpec $spec, array $spanExpectations)
+    {
+        $traces = $this->tracesFromWebRequest(function () use ($spec) {
+            $this->call($spec);
+        });
+
+        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+    }
+
+    public function provideSpecs()
+    {
+        return $this->buildDataProvider(
+            [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'cakephp.request',
+                        'cakephp_test_app',
+                        'web',
+                        'GET SimpleController@index'
+                    )->withExactTags([
+                        'cakephp.route.controller' => 'simple',
+                        'cakephp.route.action' => 'index',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                        'integration.name' => 'cakephp',
+                    ]),
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'cakephp.request',
+                        'cakephp_test_app',
+                        'web',
+                        'GET SimpleViewController@index'
+                    )->withExactTags([
+                        'cakephp.route.controller' => 'simple_view',
+                        'cakephp.route.action' => 'index',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                        'integration.name' => 'cakephp',
+                    ]),
+
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.beforeRender'),
+
+                    SpanAssertion::build(
+                        'cakephp.view',
+                        'cakephp_test_app',
+                        'web',
+                        'SimpleView/index.ctp'
+                    )->withExactTags([
+                        'cakephp.view' => 'SimpleView/index.ctp',
+                        'integration.name' => 'cakephp',
+                    ]),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeLayout'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.afterLayout'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
+
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'cakephp.request',
+                        'cakephp_test_app',
+                        'web',
+                        'GET ErrorController@index'
+                    )->withExactTags([
+                        'cakephp.route.controller' => 'error',
+                        'cakephp.route.action' => 'index',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        // CakePHP doesn't appear to set the proper error code
+                        'http.status_code' => '200',
+                        'integration.name' => 'cakephp',
+                    ])->withExistingTagsNames([
+                        'error.stack'
+                    ])->setError(null, 'Foo error'),
+
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.beforeDispatch'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.initialize'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.startup'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.beforeRender'),
+
+                    SpanAssertion::build(
+                        'cakephp.view',
+                        'cakephp_test_app',
+                        'web',
+                        'Errors/index.ctp'
+                    )->withExactTags([
+                        'cakephp.view' => 'Errors/index.ctp',
+                        'integration.name' => 'cakephp',
+                    ]),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRender'),
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRender'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeLayout'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.beforeRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+                    SpanAssertion::exists('cakephp.event', 'View.afterRenderFile'),
+
+                    SpanAssertion::exists('cakephp.event', 'View.afterLayout'),
+                    SpanAssertion::exists('cakephp.event', 'Controller.shutdown'),
+
+                    SpanAssertion::exists('cakephp.event', 'Dispatcher.afterDispatch'),
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Description

This PR adds tracing support for CakePHP v2 and also includes support for Cake Console.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
