### PR TITLE
Wrap zend_execute_ex() instead of using opcode handlers

### DIFF
--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -27,10 +27,6 @@ HashTable class_lookup;
 HashTable function_lookup;
 zend_bool log_backtrace;
 ddtrace_original_context original_context;
-
-user_opcode_handler_t ddtrace_old_fcall_handler;
-user_opcode_handler_t ddtrace_old_icall_handler;
-user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
 ZEND_END_MODULE_GLOBALS(ddtrace)
 
 #ifdef ZTS

--- a/tests/ext/exception_handler_methods.phpt
+++ b/tests/ext/exception_handler_methods.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Methods invoked by the exception handler will get traced
+--FILE--
+<?php
+class FooErrorHandler
+{
+    public static function handle(Exception $e)
+    {
+        echo "There was an error: \n";
+        printf("    %s\n\n", $e->getMessage());
+    }
+}
+
+dd_trace('FooErrorHandler', 'handle', function() {
+    echo "**TRACED**\n";
+    return dd_trace_forward_call();
+});
+
+set_exception_handler('FooErrorHandler::handle');
+
+$e = new Exception('Oops! Foo error');
+
+echo "Manual call:\n";
+FooErrorHandler::handle($e);
+
+echo "Handler call:\n";
+throw $e;
+?>
+--EXPECT--
+Manual call:
+**TRACED**
+There was an error:
+    Oops! Foo error
+
+Handler call:
+**TRACED**
+There was an error:
+    Oops! Foo error


### PR DESCRIPTION
### Description

This is a WIP to see if wrapping `zend_execute_ex()` is more stable than depending on opcode handlers.

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
