### PR TITLE
Append hostname to root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Tracer limited mode, stopping span creation when memory use raises to 80% of current PHP memory limit #437
 - Configurable Curl timeouts `DD_TRACE_AGENT_TIMEOUT` and `DD_TRACE_AGENT_CONNECT_TIMEOUT` when communicating with the agent #150
+- Configurable `DD_TRACE_REPORT_HOSTNAME` reporting of hostname via root span #441
 
 ### Fixed
 - Generation of `E_WARNING` in certain contexts of PHP 5 installs when the `date.timezone` INI setting is not set #435

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -121,6 +121,16 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Append hostname as a root span tag
+     *
+     * @return bool
+     */
+    public function isHostnameReportingEnabled()
+    {
+        return $this->boolValue('trace.report.hostname', false);
+    }
+
+    /**
      * The name of the application.
      *
      * @param string $default

--- a/src/DDTrace/Tag.php
+++ b/src/DDTrace/Tag.php
@@ -29,6 +29,7 @@ class Tag
     const TARGET_PORT = 'out.port';
     const BYTES_OUT = 'net.out.bytes';
     const ANALYTICS_KEY = '_dd1.sr.eausr';
+    const HOSTNAME = '_dd.hostname';
 
     // Elasticsearch
     const ELASTICSEARCH_BODY = 'elasticsearch.body';

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -61,7 +61,8 @@ final class Tracer implements TracerInterface
          * Enabled, when false, returns a no-op implementation of the Tracer.
          */
         'enabled' => true,
-        /** GlobalTags holds a set of tags that will be automatically applied to
+        /**
+         * GlobalTags holds a set of tags that will be automatically applied to
          * all spans.
          */
         'global_tags' => [],
@@ -312,6 +313,10 @@ final class Tracer implements TracerInterface
             return;
         }
 
+        if ($this->globalConfig->isHostnameReportingEnabled()) {
+            $this->addHostnameToRootSpan();
+        }
+
         if (self::isLogDebugActive()) {
             self::logDebug('Flushing {count} traces, {spanCount} spans', [
                 'count' => count($this->traces),
@@ -381,6 +386,17 @@ final class Tracer implements TracerInterface
         }
 
         return $tracesToBeSent;
+    }
+
+    private function addHostnameToRootSpan()
+    {
+        $hostname = gethostname();
+        if ($hostname !== false) {
+            $span = $this->getRootScope()->getSpan();
+            if ($span !== null) {
+                $span->setTag(Tag::HOSTNAME, $hostname);
+            }
+        }
     }
 
     private function record(Span $span)

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -253,7 +253,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
     public function testDistributedTracingIsNotPropagatedIfDisabled()
     {
         $found = [];
-        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
+        Configuration::replace(\Mockery::mock(Configuration::get(), [
             'isAutofinishSpansEnabled' => false,
             'isAnalyticsEnabled' => false,
             'isDistributedTracingEnabled' => false,


### PR DESCRIPTION
### Description

a Very simple PR :) adds hostname to a root span when enabled (only at very last moment to avoid people being able to easily overwrite this hostname).

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
