### PR TITLE
Fix invalid package.xml syntax

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -59,7 +59,7 @@
                     <file name="serializer.c" role="src" />
                     <file name="serializer.h" role="src" />
                     <file name="version.h" role="src" />
-                    <file name="compatibility.h" role="src">
+                    <file name="compatibility.h" role="src" />
                     <dir name="mpack">
                         <file name="AUTHORS.md" role="doc" />
                         <file name="CHANGELOG.md" role="doc" />


### PR DESCRIPTION
### Description

The *package.xml* syntax is not valid so this fixes that. :)

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- ~~[ ] Tests added for this feature/bug~~
