### PR TITLE
Narrow the URL normalization rules boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file - [read more
 ### Added
 - Initial implementation of flushing spans via background thread #450
 
+### Changed
+- URL-normalization rule boundaries #457
+
 ## [0.25.0]
 
 ### Added

--- a/src/DDTrace/Http/Urls.php
+++ b/src/DDTrace/Http/Urls.php
@@ -14,11 +14,11 @@ class Urls
         // [1-5] = UUID version
         // [89ab] = UUID variant
         // @see https://en.wikipedia.org/wiki/Universally_unique_identifier#Format
-        '|\b([0-9a-f]{8}-?[0-9a-f]{4}-?[1-5][0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})\b|i',
+        '<(/)([0-9a-f]{8}-?[0-9a-f]{4}-?[1-5][0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})(/|$)>i',
         // 32-512 bit hex hashes
-        '|\b([0-9a-f]{8,128})\b|i',
+        '<(/)([0-9a-f]{8,128})(/|$)>i',
         // int's
-        '|\b([0-9]+)\b|',
+        '<(/)([0-9]+)(/|$)>',
     ];
 
     private $replacementPatterns = [];
@@ -66,6 +66,6 @@ class Urls
             }
         }
         // Fall back to default replacement rules
-        return preg_replace(self::$defaultPatterns, '?', $url);
+        return preg_replace(self::$defaultPatterns, '$1?$3', $url);
     }
 }

--- a/tests/Unit/Http/UrlsTest.php
+++ b/tests/Unit/Http/UrlsTest.php
@@ -47,8 +47,8 @@ final class UrlsTest extends Framework\TestCase
             ['/foo/123/bar', '/foo/?/bar'],
             ['/foo/a5b30c6b-8795-4b65-8343-4b08ed49e4da/bar', '/foo/?/bar'],
             ['/foo/a5b30c6b87954b6583434b08ed49e4da/bar', '/foo/?/bar'],
-            ['/talk/b07bb-speaker', '/talk/b07bb-speaker'],
-            ['/talk/b07bbaaf-speaker', '/talk/?-speaker'],
+            ['/talk/b07bbaaf-speaker', '/talk/b07bbaaf-speaker'], // "-" is not a URL boundary
+            ['/v1.0/users/1414', '/v1.0/users/?'],
             ['/city/1337/lexington', '/city/?/lexington'],
             ['/city/1337/london', '/city/?/london'],
             ['/api/v2/widget/42', '/api/v2/widget/?'],


### PR DESCRIPTION
### Description

Per #455, the URL normalization rules introduced in #442 are overly aggressive due to word boundaries that are too wide using `\b`. This PR narrows the word boundaries to `/` and `$`.

The specific edge case mentioned in #455 (`/v1.0/users/1414`) has been added to the test suite.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
