### PR TITLE
Fix API change with Symfony 4.x EventDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Fix API change with Symfony 4.x EventDispatcher #466
+
 ## [0.26.0]
 
 ### Added


### PR DESCRIPTION
### Description

The [API for `Symfony\Component\EventDispatcher\EventDispatcher::dispatch()` has changed](https://github.com/symfony/event-dispatcher/blob/861c10069b0a073618c7c2d60eacbccafa72f697/EventDispatcher.php#L51). This PR supports both the old and the new API.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
