### PR TITLE
Fix Memory leak when garbage collecting empty span stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Memory leak when garbage collecting span stacks #469
+
 ## [0.27.0]
 
 ### Added

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -5,7 +5,7 @@
 #include "env_config.h"
 #include "vendor_stdatomic.h"
 
-#define DD_TRACE_COMS_STACK_SIZE (1024 * 1024 * 10)  // 5 MB
+#define DD_TRACE_COMS_STACK_SIZE (1024 * 1024 * 10)  // 10 MB
 #define DD_TRACE_COMS_STACKS_BACKLOG_SIZE 10
 
 typedef struct ddtrace_coms_stack_t {
@@ -23,8 +23,12 @@ typedef struct ddtrace_coms_state_t {
     _Atomic(uint32_t) next_group_id;
 } ddtrace_coms_state_t;
 
-inline static uint32_t ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack) {
+inline static BOOL_T ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack) {
     return atomic_load(&stack->refcount) == 0;
+}
+
+inline static BOOL_T ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
+    return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
 BOOL_T ddtrace_coms_rotate_stack();

--- a/tests/ext/dd_trace_coms_test_parallel_writer_consistency.phpt
+++ b/tests/ext/dd_trace_coms_test_parallel_writer_consistency.phpt
@@ -46,7 +46,6 @@ bar
 bytes_written 4400030
 a
 bytes_written 13
-bytes_written 0
 foo
 bar
 bytes_written 4400030


### PR DESCRIPTION
### Description

Code responsible for stack allocation was not correctly freeing old stacks. On top of that - those were thrown away even if unused and brand new. These changes make it so that current stack which is empty will not thrown away.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug
