### PR TITLE
Speed up `composer update` commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -355,23 +355,23 @@
         "symfony-23-update": "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_2_3 update",
         "symfony-23-test": "@composer test -- tests/Integrations/Symfony/V2_3",
 
-        "symfony-28-update": "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_2_8 update",
+        "symfony-28-update": "SYMFONY_ENV=prod php -d memory_limit=-1 /usr/local/bin/composer --prefer-dist --no-dev --no-suggest --working-dir=tests/Frameworks/Symfony/Version_2_8 update",
         "symfony-28-test": "@composer test -- tests/Integrations/Symfony/V2_8",
 
         "symfony-33-update": [
-            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_3_3 update",
+            "SYMFONY_ENV=prod php -d memory_limit=-1 /usr/local/bin/composer --prefer-dist --no-dev --no-suggest --working-dir=tests/Frameworks/Symfony/Version_3_3 update",
             "php tests/Frameworks/Symfony/Version_3_3/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-33-test": "@composer test -- tests/Integrations/Symfony/V3_3",
 
         "symfony-34-update": [
-            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_3_4 update",
+            "SYMFONY_ENV=prod php -d memory_limit=-1 /usr/local/bin/composer --prefer-dist --no-dev --no-suggest --working-dir=tests/Frameworks/Symfony/Version_3_4 update",
             "php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-34-test": "@composer test -- tests/Integrations/Symfony/V3_4",
 
         "symfony-42-update": [
-            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_4_2 update",
+            "SYMFONY_ENV=prod php -d memory_limit=-1 /usr/local/bin/composer --prefer-dist --no-dev --no-suggest --working-dir=tests/Frameworks/Symfony/Version_4_2 update",
             "php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-42-test": "@composer test -- tests/Integrations/Symfony/V4_2",

--- a/composer.json
+++ b/composer.json
@@ -327,60 +327,58 @@
 
         "test-auto-instrumentation": "phpunit --colors=always --configuration=phpunit.xml --testsuite=auto-instrumentation",
 
-        "cakephp-28-update": "composer --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
+        "fast-update": "php -d memory_limit=-1 /usr/local/bin/composer --prefer-dist --no-dev --no-suggest",
+
+        "cakephp-28-update": "@fast-update -- --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
         "cakephp-28-test": "@composer test -- --testsuite=cakephp-28-test",
 
-        "laravel-42-update": "composer --working-dir=tests/Frameworks/Laravel/Version_4_2 update",
+        "laravel-42-update": "@fast-update -- --working-dir=tests/Frameworks/Laravel/Version_4_2 update",
         "laravel-42-optimize": "@php tests/Frameworks/Laravel/Version_4_2/artisan optimize",
         "laravel-42-test": "@composer test -- tests/Integrations/Laravel/V4",
 
-        "laravel-57-update": "composer --working-dir=tests/Frameworks/Laravel/Version_5_7 update",
+        "laravel-57-update": "@fast-update -- --working-dir=tests/Frameworks/Laravel/Version_5_7 update",
         "laravel-57-test": "@composer test -- tests/Integrations/Laravel/V5_7/CommonScenariosTest.php",
 
-        "laravel-58-update": "composer --working-dir=tests/Frameworks/Laravel/Version_5_8 update",
+        "laravel-58-update": "@fast-update -- --working-dir=tests/Frameworks/Laravel/Version_5_8 update",
         "laravel-58-test": "@composer test -- --testsuite=laravel-58-test",
 
-        "lumen-52-update": "composer --working-dir=tests/Frameworks/Lumen/Version_5_2 update",
+        "lumen-52-update": "@fast-update -- --working-dir=tests/Frameworks/Lumen/Version_5_2 update",
         "lumen-52-test": "@composer test -- tests/Integrations/Lumen/V5_2/CommonScenariosTest.php",
-        "lumen-56-update": "composer --working-dir=tests/Frameworks/Lumen/Version_5_6 update",
+        "lumen-56-update": "@fast-update -- --working-dir=tests/Frameworks/Lumen/Version_5_6 update",
         "lumen-56-test": "@composer test -- tests/Integrations/Lumen/V5_6/CommonScenariosTest.php",
-        "lumen-58-update": "composer --working-dir=tests/Frameworks/Lumen/Version_5_8 update",
+        "lumen-58-update": "@fast-update -- --working-dir=tests/Frameworks/Lumen/Version_5_8 update",
         "lumen-58-test": "@composer test -- tests/Integrations/Lumen/V5_8/CommonScenariosTest.php",
 
-        "slim-312-update": "composer --working-dir=tests/Frameworks/Slim/Version_3_12 update",
+        "slim-312-update": "@fast-update -- --working-dir=tests/Frameworks/Slim/Version_3_12 update",
         "slim-312-test": "@composer test -- --testsuite=slim-312-test",
 
-        "symfony-23-update": [
-            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_2_3 update"
-        ],
+        "symfony-23-update": "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_2_3 update",
         "symfony-23-test": "@composer test -- tests/Integrations/Symfony/V2_3",
 
-        "symfony-28-update": [
-            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_2_8 update"
-        ],
+        "symfony-28-update": "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_2_8 update",
         "symfony-28-test": "@composer test -- tests/Integrations/Symfony/V2_8",
 
         "symfony-33-update": [
-            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_3_3 update",
+            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_3_3 update",
             "php tests/Frameworks/Symfony/Version_3_3/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-33-test": "@composer test -- tests/Integrations/Symfony/V3_3",
 
         "symfony-34-update": [
-            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_3_4 update",
+            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_3_4 update",
             "php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-34-test": "@composer test -- tests/Integrations/Symfony/V3_4",
 
         "symfony-42-update": [
-            "php -d memory_limit=-1 /usr/local/bin/composer --working-dir=tests/Frameworks/Symfony/Version_4_2 update",
+            "@fast-update -- --working-dir=tests/Frameworks/Symfony/Version_4_2 update",
             "php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod"
         ],
         "symfony-42-test": "@composer test -- tests/Integrations/Symfony/V4_2",
 
         "zend-framework-1-test": "@composer test -- tests/Integrations/ZendFramework/V1",
 
-        "custom-framework-autoloaded-update": "composer --working-dir=tests/Frameworks/Custom/Version_Autoloaded update",
+        "custom-framework-autoloaded-update": "@fast-update -- --working-dir=tests/Frameworks/Custom/Version_Autoloaded update",
         "custom-framework-autoloaded-test": "@composer test -- --testsuite=custom-framework-autoloaded-test"
     },
     "extra": {


### PR DESCRIPTION
### Description

This PR speeds up the Composer scripts that run an update by adding a few configuration flags. Here's a broad look at the execution time for a Composer update before the patch:

```bash
$ time composer laravel-58-update
[...]

real  3m10.883s
user  0m21.910s
sys 0m8.520s
```

And here it is after the patch:

```bash
$ rm -Rf tests/Frameworks/Laravel/Version_5_8/vendor/
$ time composer laravel-58-update
[...]

real  1m10.803s
user  0m15.280s
sys 0m5.950s
```

A diff of the response times:

```diff
-real  3m10.883s
+real  1m10.803s
-user  0m21.910s
+user  0m15.280s
-sys 0m8.520s
+sys 0m5.950s
```

In another PR, we could look at committing the **composer.lock** files so we can run a super-fast `composer install` on all the framework tests. The side effect is that the latest versions of things won't be downloaded. So we'd need to discuss some possible solutions to that. For example, we could possibly set up a daily script to run a full `composer update` & commit the updated  **composer.lock** files. But just wanted to open a conversation around that. :)

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- ~~[ ] Tests added for this feature/bug~~
