### PR TITLE
Only override execute on compilation step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Stack level too deep error due to changes in how PHP interprets Opcodes caused by the extension #477
+
 ## [0.27.2]
 
 ### Changed

--- a/package.xml
+++ b/package.xml
@@ -156,6 +156,7 @@
                     <file name="trace_static_method.phpt" role="test" />
                     <file name="used_dispatch_shouldn_t_be_freed.phpt" role="test" />
                     <file name="variable_length_parameter_list.phpt" role="test" />
+                    <file name="very_nested_functions.phpt" role="test" />
                     <file name="with_params_function_hook.phpt" role="test" />
                     <file name="with_params_method_hook.phpt" role="test" />
                 </dir>

--- a/tests/ext/very_nested_functions.phpt
+++ b/tests/ext/very_nested_functions.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Check if we can safely override function being called deep in the call stack
+--FILE--
+<?php
+function test($a){
+    return 'FUNCTION ' . $a;
+}
+
+dd_trace("test", function($a){
+    return 'OLD HOOK ' . test($a);
+});
+
+
+function callNested($nestLevel, $counter){
+    if ($nestLevel > 0) {
+        if ($nestLevel == 50) {
+            return test(callNested($nestLevel - 1, $counter + 1));
+        } else {
+            return callNested($nestLevel - 1, $counter + 1);
+        }
+    } else {
+        return test($counter);
+    }
+}
+
+echo callNested(100000, 0) . PHP_EOL;
+
+?>
+--EXPECT--
+OLD HOOK FUNCTION OLD HOOK FUNCTION 100000

--- a/tests/ext/very_nested_functions.phpt
+++ b/tests/ext/very_nested_functions.phpt
@@ -13,7 +13,8 @@ dd_trace("test", function($a){
 
 function callNested($nestLevel, $counter){
     if ($nestLevel > 0) {
-        if ($nestLevel == 50) {
+        // call another hooked function in the middle of the stack to check for possible edgecases
+        if ($nestLevel == 50000) {
             return test(callNested($nestLevel - 1, $counter + 1));
         } else {
             return callNested($nestLevel - 1, $counter + 1);


### PR DESCRIPTION
### Description

Overriding `zend_execute_ex` causes tail recursive calls to fail due to different codepaths taken by the opcode parsers based on `zend_execute_ex == execute_ex` check. This makes each subsequent call to tailrecursive function actually be put on stack which causes os error to be raised due to stack overflow.
<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
