### PR TITLE
Fix backtrace handler being run more than once, and inform about max stacktrace size reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Stack level too deep error due to changes in how PHP interprets Opcodes caused by the extension #477
 
+### Changed
+- Backtrace handler will be run only once and will display information about maximum stack size being reached #478
+
 ## [0.27.2]
 
 ### Changed

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -14,13 +14,27 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
+struct _backtrace_data_t {
+    BOOL_T handler_already_run;
+    BOOL_T handler_installed;
+};
+
+static struct _backtrace_data_t backtrace_globals = {FALSE, FALSE};
+
 void ddtrace_backtrace_handler(int sig) {
+    if (backtrace_globals.handler_already_run) {
+        exit(sig);
+    }
+    backtrace_globals.handler_already_run = TRUE;
     TSRMLS_FETCH();
 
     ddtrace_log_err("Datadog PHP Trace extension (DEBUG MODE)");
     ddtrace_log_errf("Received Signal %d", sig);
     void *array[MAX_STACK_SIZE];
     size_t size = backtrace(array, MAX_STACK_SIZE);
+    if (size == MAX_STACK_SIZE) {
+        ddtrace_log_err("Note: max stacktrace size reached");
+    }
 
     ddtrace_log_err("Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime");
     ddtrace_log_err("Backtrace:");
@@ -44,10 +58,8 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
 
     static int handler_installed = 0;
     if (!handler_installed) {
-        fflush(stderr);
-
         signal(SIGSEGV, ddtrace_backtrace_handler);
-        handler_installed = 1;
+        backtrace_globals.handler_installed = TRUE;
     }
 }
 #else  // defined(__GLIBC__) || defined(__APPLE__)

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -56,8 +56,7 @@ void ddtrace_install_backtrace_handler(TSRMLS_D) {
         return;
     }
 
-    static int handler_installed = 0;
-    if (!handler_installed) {
+    if (!backtrace_globals.handler_installed) {
         signal(SIGSEGV, ddtrace_backtrace_handler);
         backtrace_globals.handler_installed = TRUE;
     }


### PR DESCRIPTION
### Description
In cases of stack overflow exception the backtrace handler can be run more than one time. This PR fixes that case and informs user when max stacktrace size (to be printed) have been reached indicating a possible stackoverflow type error.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
