### PR TITLE
Handle MasterSlaveReplication connections

### DIFF
--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -225,7 +225,7 @@ class PredisIntegration extends Integration
             $connection = $predis->getConnection();
 
             if ($connection instanceof \Predis\Connection\Aggregate\MasterSlaveReplication) {
-                $connection = $connection->getCurrent() ?? $connection->getMaster();
+                $connection = $connection->getCurrent() ? $connection->getCurrent() : $connection->getMaster();
             }
             $identifier = (string)$connection;
 

--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -222,7 +222,13 @@ class PredisIntegration extends Integration
         $tags = [];
 
         try {
-            $identifier = (string)$predis->getConnection();
+            $connection = $predis->getConnection();
+
+            if ($connection instanceof \Predis\Connection\Aggregate\MasterSlaveReplication) {
+                $connection = $connection->getCurrent() ?? $connection->getMaster();
+            }
+            $identifier = (string)$connection;
+
             list($host, $port) = explode(':', $identifier);
             $tags[Tag::TARGET_HOST] = $host;
             $tags[Tag::TARGET_PORT] = $port;


### PR DESCRIPTION
At the moment, DD causes errors in some situations when using predis/predis, when predis is using master-slave replication. This was discussed in #315 

There may be a couple of points of discussion around this:
- What should happen when `Client::getConnection()` returns a `MasterSlaveReplication` connection, but the connection hasn't been used yet, so `MasterSlaveReplication::connection` is empty. In our use case (and thus in this PR) we ask it to return the master, but this might not be preferred behaviour?

- I looked at writing a test to cover this, but I was struggling to get my head around how your tests work, and I couldn't actually create a breaking test in the first place to fix! If someone can point me in the right direction @SammyK @pawelchcki the  I'll take another look at getting a test to play nice!!