### PR TITLE
Request init hook version sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+### Fixed
+- Edge case where the extension version and userland version can get out of sync #488
+
 ## [0.28.1]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ BUILD_DIR := tmp/build_$(BUILD_SUFFIX)
 SO_FILE := $(BUILD_DIR)/modules/ddtrace.so
 WALL_FLAGS := -Wall -Wextra
 CFLAGS := -O2 $(WALL_FLAGS)
-VERSION:=$(shell cat src/DDTrace/Tracer.php | grep VERSION | awk '{print $$NF}' | cut -d\' -f2)
-VERSION_WITHOUT_SUFFIX:=$(shell cat src/DDTrace/Tracer.php | grep VERSION | awk '{print $$NF}' | cut -d\' -f2 | cut -d- -f1)
+VERSION:=$(shell cat src/DDTrace/version.php | grep return | awk '{print $$2}' | cut -d\' -f2)
+VERSION_WITHOUT_SUFFIX:=$(shell cat src/DDTrace/version.php | grep return | awk '{print $$2}' | cut -d\' -f2 | cut -d- -f1)
 
 INI_FILE := /usr/local/etc/php/conf.d/ddtrace.ini
 
@@ -143,6 +143,7 @@ verify_version:
 	@grep -q "<release>$(VERSION_WITHOUT_SUFFIX)</release>" package.xml || (echo package.xml release version missmatch && exit 1)
 	@grep -q "<api>$(VERSION_WITHOUT_SUFFIX)</api>" package.xml || (echo package.xml api version missmatch && exit 1)
 	@grep -q "#define PHP_DDTRACE_VERSION \"$(VERSION)" src/ext/version.h || (echo src/ext/version.h Version missmatch && exit 1)
+	@grep -q "const VERSION = '$(VERSION)" src/DDTrace/Tracer.php || (echo src/DDTrace/Tracer.php Version missmatch && exit 1)
 	@echo "All version files match"
 
 verify_package_xml:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,7 @@
     1. Make sure that the changelog is up to date, if not fix it.
     1. Make sure bottom links are up to date.
     1. Update the version number in `src/DDTrace/Tracer.php`.
+    1. Update the version number in `src/DDTrace/version.php`.
     1. Update the version number in `src/ext/version.h`.
     1. Update `package.xml` (versions, date, notes) and run `$ pear package-validate package.xml`.
     1. Create the PR and ask for code review.

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -2,6 +2,16 @@
 
 namespace DDTrace\Bridge;
 
+if (!defined('DD_TRACE_VERSION')
+    || !file_exists(__DIR__ . '/../src/DDTrace/version.php')) {
+    function_exists('dd_trace_disable_in_request') && dd_trace_disable_in_request();
+    return;
+}
+if (DD_TRACE_VERSION !== include __DIR__ . '/../src/DDTrace/version.php') {
+    function_exists('dd_trace_disable_in_request') && dd_trace_disable_in_request();
+    return;
+}
+
 if (PHP_VERSION_ID < 70000) {
     date_default_timezone_set(@date_default_timezone_get());
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -26,7 +26,10 @@ final class Tracer implements TracerInterface
 {
     use LoggingTrait;
 
-    const VERSION = '0.28.1';
+    /**
+     * @deprecated Use Tracer::version() instead
+     */
+    const VERSION = '0.28.1'; // Update ./version.php too
 
     /**
      * @var Span[][]
@@ -103,6 +106,11 @@ final class Tracer implements TracerInterface
      * @var TraceAnalyticsProcessor
      */
     private $traceAnalyticsProcessor;
+
+    /**
+     * @var string|null
+     */
+    private static $version;
 
     /**
      * @param Transport $transport
@@ -521,5 +529,16 @@ final class Tracer implements TracerInterface
         }
 
         return $rootScope->getSpan();
+    }
+
+    /**
+     * @return string
+     */
+    public static function version()
+    {
+        if (empty(self::$version)) {
+            self::$version = include __DIR__ . '/version.php';
+        }
+        return self::$version;
     }
 }

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -55,7 +55,7 @@ final class Http implements Transport
         $this->setHeader('Datadog-Meta-Lang', 'php');
         $this->setHeader('Datadog-Meta-Lang-Version', \PHP_VERSION);
         $this->setHeader('Datadog-Meta-Lang-Interpreter', \PHP_SAPI);
-        $this->setHeader('Datadog-Meta-Tracer-Version', \DDTrace\Tracer::VERSION);
+        $this->setHeader('Datadog-Meta-Tracer-Version', DD_TRACE_VERSION);
     }
 
     /**

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -1,0 +1,3 @@
+<?php
+
+return '0.28.1'; // Update Tracer::VERSION too

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -59,6 +59,7 @@ static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, s
 
 static PHP_MINIT_FUNCTION(ddtrace) {
     UNUSED(type);
+    REGISTER_STRING_CONSTANT("DD_TRACE_VERSION", PHP_DDTRACE_VERSION, CONST_CS | CONST_PERSISTENT);
     ZEND_INIT_MODULE_GLOBALS(ddtrace, php_ddtrace_init_globals, NULL);
     REGISTER_INI_ENTRIES();
 

--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -25,7 +25,7 @@ class AutoInstrumentationTest extends BaseTestCase
 
     public function autoInstrumentationScenarios()
     {
-        $currentTracerVersion = Tracer::VERSION;
+        $currentTracerVersion = Tracer::version();
         return [
             // In a typical scenario, when the user does not declare a dependency on datadog/dd-trace in the composer
             // file we should pick the tracer from the installed bundle

--- a/tests/AutoInstrumentation/scenarios/autoloader_die_on_not_found/index.php
+++ b/tests/AutoInstrumentation/scenarios/autoloader_die_on_not_found/index.php
@@ -13,4 +13,4 @@ class AutoloaderDieOnNotFound
 
 spl_autoload_register('AutoloaderDieOnNotFound::load');
 
-echo DDTrace\Tracer::VERSION;
+echo DDTrace\Tracer::version();

--- a/tests/AutoInstrumentation/scenarios/autoloader_includes_even_non_existing/index.php
+++ b/tests/AutoInstrumentation/scenarios/autoloader_includes_even_non_existing/index.php
@@ -18,4 +18,4 @@ spl_autoload_register('AutoloaderTryAlwaysToLoadFile::load');
 // such classes are not found and we get to the `AutoloaderTryAlwaysToLoadFile` it tries to include a non existing
 // files, causing and error.
 
-echo DDTrace\Tracer::VERSION;
+echo DDTrace\Tracer::version();

--- a/tests/AutoInstrumentation/scenarios/composer_without_ddtrace_dependency/index.php
+++ b/tests/AutoInstrumentation/scenarios/composer_without_ddtrace_dependency/index.php
@@ -2,4 +2,4 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-echo DDTrace\Tracer::VERSION;
+echo DDTrace\Tracer::version();

--- a/tests/AutoInstrumentation/scenarios/symfony_33_private_loader/index.php
+++ b/tests/AutoInstrumentation/scenarios/symfony_33_private_loader/index.php
@@ -39,6 +39,6 @@ namespace My\App {
     // Looking for a class that does not exist, will cause the private Symfony 3.3's class loader method to be fired.
     class_exists('I\Dont\Exist');
 
-    echo \DDTrace\Tracer::VERSION;
+    echo \DDTrace\Tracer::version();
 }
 

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -148,7 +148,7 @@ final class HttpTest extends BaseTestCase
         $this->assertEquals('php', $traceRequest['headers']['Datadog-Meta-Lang']);
         $this->assertEquals(\PHP_VERSION, $traceRequest['headers']['Datadog-Meta-Lang-Version']);
         $this->assertEquals(\PHP_SAPI, $traceRequest['headers']['Datadog-Meta-Lang-Interpreter']);
-        $this->assertEquals(Tracer::VERSION, $traceRequest['headers']['Datadog-Meta-Tracer-Version']);
+        $this->assertEquals(Tracer::version(), $traceRequest['headers']['Datadog-Meta-Tracer-Version']);
     }
 
     public function testSetHeader()


### PR DESCRIPTION
### Description

This PR does version checks in the request init hook to ensure that the version of the extension matches the version in userland code. If the versions don't match, then the tracer does not run. This prevents the extension and PHP code from getting out of sync (which can happen after upgrading the tracer and before restarting the SAPI.)

The extension version is exposed via a new userland constant `DD_TRACE_VERSION`.

One thing to keep in mind. Until we remove `Tracer::VERSION`, we need to update the version number in three places for version bumps:

1. **src/ext/version.h**
2. **src/DDTrace/Tracer.php** (`Tracer::VERSION`; deprecated in this PR)
3. **src/DDTrace/version.php** (new; accessed via `Tracer::version()`)

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
