### PR TITLE
Prefix invalid hostnames as service names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file - [read more
 - Edge case where the extension version and userland version can get out of sync #488
 
 ### Changed
-- Prefix invalid hostnames as service names with `:` #490
+- Prefix hostnames as service names with `host-` to ensure compatibility with the Agent #490
 
 ## [0.28.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file - [read more
 ### Fixed
 - Edge case where the extension version and userland version can get out of sync #488
 
+### Changed
+- Prefix invalid hostnames as service names with `:` #490
+
 ## [0.28.1]
 
 ### Fixed

--- a/src/DDTrace/Http/Urls.php
+++ b/src/DDTrace/Http/Urls.php
@@ -60,6 +60,22 @@ class Urls
     }
 
     /**
+     * Metadata keys must start with [a-zA-Z:] so IP addresses,
+     * for example, need to be prefixed with a valid character
+     *
+     * @param string $url
+     * @return string
+     */
+    public static function hostnameForTag($url)
+    {
+        $hostname = self::hostname($url);
+        if (0 === preg_match('/^\d.*$/', $hostname)) {
+            return $hostname;
+        }
+        return ':' . $hostname;
+    }
+
+    /**
      * Reduces cardinality of a url.
      *
      * @param string $url

--- a/src/DDTrace/Http/Urls.php
+++ b/src/DDTrace/Http/Urls.php
@@ -68,11 +68,7 @@ class Urls
      */
     public static function hostnameForTag($url)
     {
-        $hostname = self::hostname($url);
-        if (0 === preg_match('/^\d.*$/', $hostname)) {
-            return $hostname;
-        }
-        return ':' . $hostname;
+        return 'host-' . self::hostname($url);
     }
 
     /**

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -64,7 +64,7 @@ class CurlIntegration extends Integration
             $info = curl_getinfo($ch);
             $sanitizedUrl = Urls::sanitize($info['url']);
             if ($globalConfig->isHttpClientSplitByDomain()) {
-                $span->setTag(Tag::SERVICE_NAME, Urls::hostname($sanitizedUrl));
+                $span->setTag(Tag::SERVICE_NAME, Urls::hostnameForTag($sanitizedUrl));
             } else {
                 $span->setTag(Tag::SERVICE_NAME, 'curl');
             }

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -114,7 +114,7 @@ final class GuzzleIntegration extends Integration
                 $span->setTag(Tag::HTTP_URL, $url);
 
                 if (Configuration::get()->isHttpClientSplitByDomain()) {
-                    $span->setTag(Tag::SERVICE_NAME, Urls::hostname($url));
+                    $span->setTag(Tag::SERVICE_NAME, Urls::hostnameForTag($url));
                 }
             }
         };

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -354,7 +354,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build(
                 'curl_exec',
-                'httpbin_integration',
+                'host-httpbin_integration',
                 'http',
                 'http://httpbin_integration/status/200'
             )

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -224,29 +224,11 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             $this->getMockedClient()->get('http://example.com');
         });
         $this->assertSpans($traces, [
-            SpanAssertion::build('GuzzleHttp\Client.send', 'example.com', 'http', 'send')
+            SpanAssertion::build('GuzzleHttp\Client.send', 'host-example.com', 'http', 'send')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => 'http://example.com',
-                    'http.status_code' => '200',
-                ]),
-        ]);
-    }
-
-    public function testHostnameWithLeadingNumberWillHavePrefixedServiceName()
-    {
-        putenv('DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=true');
-
-        $traces = $this->isolateTracer(function () {
-            $this->getMockedClient()->get('http://1337example.com');
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('GuzzleHttp\Client.send', ':1337example.com', 'http', 'send')
-                ->setTraceAnalyticsCandidate()
-                ->withExactTags([
-                    'http.method' => 'GET',
-                    'http.url' => 'http://1337example.com',
                     'http.status_code' => '200',
                 ]),
         ]);

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -233,4 +233,22 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
                 ]),
         ]);
     }
+
+    public function testHostnameWithLeadingNumberWillHavePrefixedServiceName()
+    {
+        putenv('DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=true');
+
+        $traces = $this->isolateTracer(function () {
+            $this->getMockedClient()->get('http://1337example.com');
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::build('GuzzleHttp\Client.send', ':1337example.com', 'http', 'send')
+                ->setTraceAnalyticsCandidate()
+                ->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => 'http://1337example.com',
+                    'http.status_code' => '200',
+                ]),
+        ]);
+    }
 }

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -208,7 +208,7 @@ final class GuzzleIntegrationTest extends IntegrationTestCase
             $this->getMockedClient()->get('http://example.com');
         });
         $this->assertSpans($traces, [
-            SpanAssertion::build('GuzzleHttp\Client.transfer', 'example.com', 'http', 'transfer')
+            SpanAssertion::build('GuzzleHttp\Client.transfer', 'host-example.com', 'http', 'transfer')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.method' => 'GET',


### PR DESCRIPTION
### Description

The Agent [expects tags](https://github.com/DataDog/datadog-agent/blob/5da007b59095381240223f59b29916207c553c39/pkg/trace/api/normalizer.go#L296-L317) to begin with a nonnumeric unicode character. With the `DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=true` feature added in #459, service names (sent to the Agent via a tag) can begin with a number (IP addresses & hostnames that begin with a number).

For example, making a request to `2guysaroundtheworld.com` with `DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=true` results in an incorrect service name in the UI:

<img width="614" alt="Screen Shot 2019-07-01 at 10 04 17 AM" src="https://user-images.githubusercontent.com/578780/60455522-6c69be80-9beb-11e9-808f-0e298346111f.png">

~~This PR ensures that any hostname that begins with a number will be prefixed with a valid tag character, `:`. So the previous example becomes:~~ After some discussion, all hostnames are now automatically prefixed with `host-`.

<img width="651" alt="Screen Shot 2019-07-01 at 10 04 55 AM" src="https://user-images.githubusercontent.com/578780/60455570-8a372380-9beb-11e9-98ba-dcf8c54b81ef.png">

Service names that consist of IP addresses [are ignored by the Agent](https://github.com/DataDog/datadog-agent/blob/5da007b59095381240223f59b29916207c553c39/pkg/trace/api/normalizer.go#L336-L338) so the traces only appear in the UI as a partial trace or no trace at all. This PR ensures that service names that are IP addresses are prefixed with a valid character.

<img width="429" alt="Screen Shot 2019-07-01 at 10 05 48 AM" src="https://user-images.githubusercontent.com/578780/60455664-e306bc00-9beb-11e9-9d2b-c21ddd24b5e4.png">

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
