### PR TITLE
Increase resource_class for web integration jobs and fix clang-format-6.0 being removed from image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,14 +351,14 @@ jobs:
       - run:
           shell: /bin/bash -eo pipefail -l
           name: Build extension basic .so
-          command: make all CFLAGS="-std=c11 -O2 -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
+          command: make all CFLAGS="-std=gnu11 -O2 -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
       - run:
           name: Copy extension basic .so
           command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>.so
       - run:
           shell: /bin/bash -eo pipefail -l
           name: Build extension debug .so
-          command: make clean all CFLAGS="-std=c11 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
+          command: make clean all CFLAGS="-std=gnu11 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>" ECHO_ARG="-e"
       - run:
           name: Copy extension basic .so
           command: cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>-debug.so

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,11 +196,18 @@ jobs:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure
       - run:
-          name: Install clang-format 6.0
-          command: sudo apt -y install clang-format-6.0/testing
+          name: Install Clang
+          command: |
+              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+              (
+                echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main"
+                echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main"
+              ) | sudo tee /etc/apt/sources.list.d/llvm-toolchain.list
+              sudo apt-get update
+              sudo apt-get -y install clang-format
       - run:
           name: Run clang-format
-          command: make clang_format_check
+          command: make clang_format_check CLANG_FORMAT=clang-format
       - run:
           name: Check linting failure
           command: test -e .failure && exit 1 || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,10 @@ jobs:
         type: string
       lib_curl_command:
         type: string
+      resource_class:
+        type: string
+        default: medium
+    resource_class: << parameters.resource_class >>
     executor:
       name: with_integrations
       docker_image: << parameters.docker_image >>
@@ -617,18 +621,21 @@ workflows:
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 71 Web integration tests"
+          resource_class: medium+
           integration_testsuite: "test-web-71"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-7.1-debug"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 72 Web integration tests"
+          resource_class: medium+
           integration_testsuite: "test-web-72"
           docker_image: "datadog/docker-library:ddtrace_php_7_2"
           lib_curl_command: sudo apt update ; sudo apt-get -y install libcurl4-nss-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 73 Web integration tests"
+          resource_class: medium+
           integration_testsuite: "test-web-73"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-7.3-debug"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev

--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,13 @@ clang_find_files_to_lint:
 	-iname "*.h" -o -iname "*.c" \
 	-type f
 
+CLANG_FORMAT := clang-format-6.0
+
 clang_format_check:
 	@while read fname; do \
-		changes=$$(clang-format-6.0 -output-replacements-xml $$fname | grep -c "<replacement " || true); \
+		changes=$$($(CLANG_FORMAT) -output-replacements-xml $$fname | grep -c "<replacement " || true); \
 		if [ $$changes != 0 ]; then \
-			clang-format-6.0 -output-replacements-xml $$fname; \
+			$(CLANG_FORMAT) -output-replacements-xml $$fname; \
 			echo "$$fname did not pass clang-format, consider running: make clang_format_fix"; \
 			touch .failure; \
 		fi \

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -7,6 +7,7 @@
 #if defined(__GLIBC__) || defined(__APPLE__)
 
 #include <execinfo.h>
+
 #include "backtrace.h"
 #include "configuration.h"
 #include "ddtrace.h"

--- a/src/ext/circuit_breaker.c
+++ b/src/ext/circuit_breaker.c
@@ -1,4 +1,4 @@
-#include "macros.h"
+#include "circuit_breaker.h"
 
 #include <fcntl.h>
 #include <stdio.h>
@@ -9,8 +9,8 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "circuit_breaker.h"
 #include "env_config.h"
+#include "macros.h"
 
 dd_trace_circuit_breaker_t *dd_trace_circuit_breaker = NULL;
 

--- a/src/ext/circuit_breaker.h
+++ b/src/ext/circuit_breaker.h
@@ -2,6 +2,7 @@
 #define DD_CIRCUIT_BREAKER_H
 
 #include <stdint.h>
+
 #include "vendor_stdatomic.h"
 #include "version.h"
 

--- a/src/ext/compat_zend_string.c
+++ b/src/ext/compat_zend_string.c
@@ -1,4 +1,5 @@
 #include "compat_zend_string.h"
+
 #include "Zend/zend.h"
 #include "Zend/zend_API.h"
 #include "Zend/zend_types.h"

--- a/src/ext/compatibility.h
+++ b/src/ext/compatibility.h
@@ -40,10 +40,6 @@
 #endif
 
 #if PHP_VERSION_ID < 70000
-typedef int32_t zend_long;
-#endif
-
-#if PHP_VERSION_ID < 70000
 #define ZVAL_VARARG_PARAM(list, arg_num) (*list[arg_num])
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_BOOL && Z_LVAL_P(x) == 1)
 #define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c, 1)

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -1,3 +1,5 @@
+#include "coms.h"
+
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -5,7 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "coms.h"
 #include "env_config.h"
 #include "mpack.h"
 #include "vendor_stdatomic.h"

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -1,4 +1,4 @@
-#include "macros.h"
+#include "coms_curl.h"
 
 #include <curl/curl.h>
 #include <pthread.h>
@@ -11,8 +11,8 @@
 
 #include "compatibility.h"
 #include "coms.h"
-#include "coms_curl.h"
 #include "configuration.h"
+#include "macros.h"
 #include "vendor_stdatomic.h"
 
 #define HOST_FORMAT_STR "http://%s:%u/v0.4/traces"

--- a/src/ext/coms_debug.c
+++ b/src/ext/coms_debug.c
@@ -1,10 +1,11 @@
+#include "coms_debug.h"
+
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "coms.h"
-#include "coms_debug.h"
 
 #define DDTRACE_NUMBER_OF_DATA_TO_WRITE 2000
 #define DDTRACE_DATA_TO_WRITE "0123456789"

--- a/src/ext/coms_debug.h
+++ b/src/ext/coms_debug.h
@@ -1,5 +1,6 @@
 #ifndef DD_COMS_TEST_H
 #define DD_COMS_TEST_H
+#include <stdint.h>
 
 uint32_t ddtrace_coms_test_writers();
 uint32_t ddtrace_coms_test_consumer();

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -1,7 +1,8 @@
+#include "configuration.h"
+
 #include <stdlib.h>
 
 #include "TSRM.h"
-#include "configuration.h"
 #include "env_config.h"
 
 struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {

--- a/src/ext/configuration_php_iface.c
+++ b/src/ext/configuration_php_iface.c
@@ -1,8 +1,9 @@
+#include "configuration_php_iface.h"
+
 #include <php.h>
 
 #include "compatibility.h"
 #include "configuration.h"
-#include "configuration_php_iface.h"
 
 // eventually this will need to be rewritten to use hashmap populated at startup to perform lookup for performance
 // reasons however for low cardinality of envs of the same name this should be fast enough

--- a/src/ext/configuration_php_iface.h
+++ b/src/ext/configuration_php_iface.h
@@ -1,5 +1,6 @@
 #ifndef DD_CONFIGURATION_PHP_INTERFACE_H
 #define DD_CONFIGURATION_PHP_INTERFACE_H
+#include <Zend/zend.h>
 #include <Zend/zend_types.h>
 
 void ddtrace_php_get_configuration(zval *return_value, zval *zenv_name);

--- a/src/ext/configuration_render.h
+++ b/src/ext/configuration_render.h
@@ -2,6 +2,7 @@
 #define DD_CONFIGURATION_REDER_H
 #include <pthread.h>
 #include <string.h>
+
 #include "env_config.h"
 
 // this file uses X-Macro concept to render all helpful APIs for automatic setup and cleanup

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -8,6 +8,7 @@
 #include <php.h>
 #include <php_ini.h>
 #include <php_main.h>
+
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -350,7 +350,7 @@ static PHP_FUNCTION(dd_trace_dd_get_memory_limit) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
-    RETURN_LONG(get_memory_limit(TSRMLS_C));
+    RETURN_LONG(ddtrace_get_memory_limit(TSRMLS_C));
 }
 
 /* {{{ proto bool dd_trace_check_memory_under_limit() */
@@ -358,11 +358,11 @@ static PHP_FUNCTION(dd_trace_check_memory_under_limit) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
-    static zend_long limit = -1;
+    static int64_t limit = -1;
     static zend_bool fetched_limit = 0;
     if (!fetched_limit) {  // cache get_memory_limit() result to make this function blazing fast
         fetched_limit = 1;
-        limit = get_memory_limit(TSRMLS_C);
+        limit = ddtrace_get_memory_limit(TSRMLS_C);
     }
 
     if (limit > 0) {

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -1,16 +1,16 @@
-#include <php.h>
-#include <ext/spl/spl_exceptions.h>
-
-#include "ddtrace.h"
 #include "dispatch.h"
 
 #include <Zend/zend.h>
-#include "compat_zend_string.h"
-#include "dispatch_compat.h"
-
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
+#include <php.h>
+
+#include <ext/spl/spl_exceptions.h>
+
+#include "compat_zend_string.h"
+#include "ddtrace.h"
 #include "debug.h"
+#include "dispatch_compat.h"
 
 // avoid Older GCC being overly cautious over {0} struct initializer
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -2,6 +2,7 @@
 #define DISPATCH_H
 
 #include <Zend/zend_types.h>
+#include <php.h>
 #include <stdint.h>
 
 #include "compat_zend_string.h"

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -2,6 +2,7 @@
 #if PHP_VERSION_ID < 70000
 
 #include <Zend/zend_exceptions.h>
+
 #include <ext/spl/spl_exceptions.h>
 
 #include "ddtrace.h"

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -2,6 +2,7 @@
 #if PHP_VERSION_ID >= 70000
 
 #include <Zend/zend_exceptions.h>
+
 #include <ext/spl/spl_exceptions.h>
 
 #include "ddtrace.h"

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -1,16 +1,15 @@
+#include <Zend/zend.h>
+#include <Zend/zend_closures.h>
+#include <Zend/zend_exceptions.h>
 #include <php.h>
+
 #include <ext/spl/spl_exceptions.h>
 
+#include "compat_zend_string.h"
 #include "ddtrace.h"
 #include "debug.h"
 #include "dispatch.h"
-
-#include <Zend/zend.h>
-#include "compat_zend_string.h"
 #include "dispatch_compat.h"
-
-#include <Zend/zend_closures.h>
-#include <Zend/zend_exceptions.h>
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 user_opcode_handler_t ddtrace_old_fcall_handler;

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -1,7 +1,9 @@
+// clang-format off
+#include <php.h>
 #include <Zend/zend.h>
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
-#include <php.h>
+// clang-format on
 
 #include <ext/spl/spl_exceptions.h>
 

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -1,10 +1,11 @@
+#include "env_config.h"
+
 #include <SAPI.h>
 #include <Zend/zend_types.h>
 #include <php.h>
 #include <stdint.h>
 
 #include "coms_curl.h"
-#include "env_config.h"
 
 #define EQUALS(stra, stra_len, literal_strb) \
     (stra_len == (sizeof(literal_strb) - 1) && memcmp(stra, literal_strb, sizeof(literal_strb) - 1) == 0)

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -1,4 +1,9 @@
+// clang-format off
+#include <php.h>
+#include "compatibility.h"
+
 #include "env_config.h"
+// clang-format on
 
 #include <SAPI.h>
 #include <Zend/zend_types.h>

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -1,4 +1,5 @@
 #include "logging.h"
+
 #include <php.h>
 
 void _ddtrace_log_errf(TSRMLS_FC const char *format, ...) {

--- a/src/ext/memory_limit.c
+++ b/src/ext/memory_limit.c
@@ -7,6 +7,7 @@
 #include <php.h>
 #include <php_ini.h>
 #include <php_main.h>
+
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
 

--- a/src/ext/memory_limit.c
+++ b/src/ext/memory_limit.c
@@ -20,10 +20,10 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
-zend_long get_memory_limit(TSRMLS_D) {
+int64_t ddtrace_get_memory_limit(TSRMLS_D) {
     char *raw_memory_limit = get_dd_trace_memory_limit();
     size_t len = 0;
-    zend_long limit = -1;
+    int64_t limit = -1;
 
     if (raw_memory_limit) {
         len = strlen(raw_memory_limit);

--- a/src/ext/memory_limit.h
+++ b/src/ext/memory_limit.h
@@ -1,12 +1,10 @@
 #ifndef DD_TRACE_MEMORY_LIMIT_H
 #define DD_TRACE_MEMORY_LIMIT_H
 
-#include <php.h>
-
 #include "compatibility.h"
 
 #define ALLOWED_MAX_MEMORY_USE_IN_PERCENT_OF_MEMORY_LIMIT 0.8
 
-zend_long get_memory_limit(TSRMLS_D);
+int64_t ddtrace_get_memory_limit(TSRMLS_D);
 
 #endif  // DD_TRACE_MEMORY_LIMIT_H

--- a/src/ext/random.c
+++ b/src/ext/random.c
@@ -1,8 +1,10 @@
+#include "random.h"
+
 #include <php.h>
+
 #include <ext/standard/php_rand.h>
 
 #include "configuration.h"
-#include "random.h"
 #include "third-party/mt19937-64.h"
 
 void dd_trace_seed_prng(TSRMLS_D) {

--- a/src/ext/random.h
+++ b/src/ext/random.h
@@ -1,6 +1,7 @@
 #ifndef DD_RANDOM_H
 #define DD_RANDOM_H
 #include <Zend/zend_types.h>
+#include <php.h>
 
 #define DD_TRACE_DEBUG_PRNG_SEED "DD_TRACE_DEBUG_PRNG_SEED"
 

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -1,12 +1,13 @@
 #include "request_hooks.h"
-#include "compat_zend_string.h"
-#include "ddtrace.h"
-#include "logging.h"
 
 #include <Zend/zend.h>
 #include <Zend/zend_compile.h>
 #include <php_main.h>
 #include <string.h>
+
+#include "compat_zend_string.h"
+#include "ddtrace.h"
+#include "logging.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -1,6 +1,7 @@
 #include <Zend/zend.h>
 #include <Zend/zend_exceptions.h>
 #include <php.h>
+
 #include <ext/spl/spl_exceptions.h>
 
 #include "ddtrace.h"

--- a/src/ext/vendor_stdatomic.h
+++ b/src/ext/vendor_stdatomic.h
@@ -79,7 +79,10 @@
 #endif
 
 #if !defined(__CLANG_ATOMICS)
-#define _Atomic(T) struct {volatile __typeof__(T) __val; }
+#define _Atomic(T)                    \
+    struct {                          \
+        volatile __typeof__(T) __val; \
+    }
 #endif
 
 /*


### PR DESCRIPTION
### Description

Some of our tests started to exhaust all available memory when installing code through composer.
This PR fixes that

Additionally clang-format stopped working due to being removed from Debian repos. - newer version needed to reformat the files putting module header at the top, which caused some compilation configurations to break

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->

### Readiness checklist
- [x] ~[Changelog entry](docs/changelog.md) added, if necessary~
- [x] ~Tests added for this feature/bug~
