### PR TITLE
Change nightly version to 1.0.0-nightly

### DIFF
--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = 'nightly'; // Update ./version.php too
+    const VERSION = '1.0.0-nightly'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -1,3 +1,5 @@
 <?php
 
-return 'nightly'; // Update Tracer::VERSION too
+// Must begin with a number for Debian packaging requirements
+// Must use single-quotes for packaging script to work
+return '1.0.0-nightly'; // Update Tracer::VERSION too

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "nightly"
+#define PHP_DDTRACE_VERSION "1.0.0-nightly"
 #endif


### PR DESCRIPTION
The Debian packages require the version field to begin with a number, otherwise there is an error like:

> 'Version' field value 'nightly': version number does not start with digit

Improves on PR #497. 

### Readiness checklist
- [x] ~[Changelog entry](docs/changelog.md) added, if necessary~
- [x] Tests added for this feature/bug
