### PR TITLE
Fix in-tree builds

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,19 +5,25 @@ PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,[ 
 if test "$PHP_DDTRACE" != "no"; then
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     EXTRA_LDFLAGS="-lasan"
-	  EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-	  PHP_SUBST(EXTRA_LDFLAGS)
+    EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+    PHP_SUBST(EXTRA_LDFLAGS)
     PHP_SUBST(EXTRA_CFLAGS)
   fi
 
   PHP_NEW_EXTENSION(ddtrace, src/ext/ddtrace.c src/ext/memory_limit.c src/ext/configuration.c src/ext/configuration_php_iface.c src/ext/circuit_breaker.c src/ext/dispatch_setup.c src/ext/dispatch.c src/ext/third-party/mt19937-64.c src/ext/random.c src/ext/coms.c src/ext/coms_curl.c src/ext/coms_debug.c src/ext/request_hooks.c src/ext/compat_zend_string.c src/ext/dispatch_compat_php5.c src/ext/dispatch_compat_php7.c src/ext/backtrace.c src/ext/logging.c src/ext/env_config.c src/ext/serializer.c src/ext/mpack/mpack.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
   PHP_ADD_BUILD_DIR($ext_builddir/src/ext, 1)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/ext/mpack, 1)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/ext/third-party, 1)
 
-  PHP_CHECK_LIBRARY(rt, shm_open, [EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lrt"])
-  PHP_CHECK_LIBRARY(curl, curl_easy_setopt, [EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lcurl"])
-  PHP_SUBST(EXTRA_LDFLAGS)
+  PHP_CHECK_LIBRARY(rt, shm_open, [
+    PHP_ADD_LIBRARY(rt, yes, DDTRACE_SHARED_LIBADD)
+  ])
+  PHP_CHECK_LIBRARY(curl, curl_easy_setopt, [
+    PHP_ADD_LIBRARY(curl, yes, DDTRACE_SHARED_LIBADD)
+  ])
+  PHP_SUBST(DDTRACE_SHARED_LIBADD)
 
-  PHP_ADD_INCLUDE($ext_builddir)
-  PHP_ADD_INCLUDE($ext_builddir/src/ext)
-  PHP_ADD_INCLUDE($ext_builddir/src/ext/mpack)
+  PHP_ADD_INCLUDE($ext_srcdir)
+  PHP_ADD_INCLUDE($ext_srcdir/src/ext)
+  PHP_ADD_INCLUDE($ext_srcdir/src/ext/mpack)
 fi

--- a/php_ddtrace.h
+++ b/php_ddtrace.h
@@ -1,0 +1,8 @@
+#ifndef PHP_DDTRACE_H
+#define PHP_DDTRACE_H
+
+#include "src/ext/ddtrace.h"
+
+#define phpext_ddtrace_ptr &ddtrace_module_entry
+
+#endif

--- a/src/ext/circuit_breaker.c
+++ b/src/ext/circuit_breaker.c
@@ -76,12 +76,14 @@ static uint64_t current_timestamp_monotonic_usec() {
 }
 
 static int64_t get_max_consecutive_failures() {
+    TSRMLS_FETCH();
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_MAX_CONSECUTIVE_FAILURES,
                                   DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES
                                   COMPAT_CTX_CC);
 }
 
 static int64_t get_retry_time_usec() {
+    TSRMLS_FETCH();
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_RETRY_TIME_MSEC,
                                   DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC
                                   COMPAT_CTX_CC) *

--- a/src/ext/circuit_breaker.c
+++ b/src/ext/circuit_breaker.c
@@ -78,15 +78,13 @@ static uint64_t current_timestamp_monotonic_usec() {
 static int64_t get_max_consecutive_failures() {
     TSRMLS_FETCH();
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_MAX_CONSECUTIVE_FAILURES,
-                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES
-                                  COMPAT_CTX_CC);
+                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES COMPAT_CTX_CC);
 }
 
 static int64_t get_retry_time_usec() {
     TSRMLS_FETCH();
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_RETRY_TIME_MSEC,
-                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC
-                                  COMPAT_CTX_CC) *
+                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC COMPAT_CTX_CC) *
            1000;
 }
 

--- a/src/ext/circuit_breaker.c
+++ b/src/ext/circuit_breaker.c
@@ -77,12 +77,14 @@ static uint64_t current_timestamp_monotonic_usec() {
 
 static int64_t get_max_consecutive_failures() {
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_MAX_CONSECUTIVE_FAILURES,
-                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES);
+                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES
+                                  COMPAT_CTX_CC);
 }
 
 static int64_t get_retry_time_usec() {
     return ddtrace_get_int_config(DD_TRACE_CIRCUIT_BREAKER_ENV_RETRY_TIME_MSEC,
-                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC) *
+                                  DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC
+                                  COMPAT_CTX_CC) *
            1000;
 }
 

--- a/src/ext/compatibility.h
+++ b/src/ext/compatibility.h
@@ -50,6 +50,7 @@
 #endif
 
 // make code with optional thread context portable
+#include "TSRM/TSRM.h"
 #if ZTS
 // D - define (define)
 #define COMPAT_CTX_D TSRMLS_D


### PR DESCRIPTION
This allows checking out the repo into ext/ddtrace of PHP's source, running the PHP's buildconf script, configuring with --enable-ddtrace, and it will build ddtrace as part of PHP. This is useful for development reasons. For instance, we can use `run-tests.php` with its `--asan` flag, which does not work correctly for out-of-tree builds.

Note that there are several ZTS fixes. I am unsure why the out of tree builds did not trigger these issues, but they were definitely required for in tree builds to work.

I haven't added any tests for ensuring the in-tree build works yet, but it has worked locally on 5.6 and 7.4 branches.