### PR TITLE
Remove zend_execute_ex override and trace ZEND_DO_UCALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file - [read more
 - Memory access errors in cases when PHP code was run after extension data was freed on request shutdown #505
 - Request init hook working when open_basedir restriction is in effect #505
 
+### Changed
+- Remove `zend_execute_ex` override and trace `ZEND_DO_UCALL` #519
+
 ## [0.29.0]
 
 ### Fixed

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -33,6 +33,7 @@ ddtrace_original_context original_context;
 
 user_opcode_handler_t ddtrace_old_fcall_handler;
 user_opcode_handler_t ddtrace_old_icall_handler;
+user_opcode_handler_t ddtrace_old_ucall_handler;
 user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
 ZEND_END_MODULE_GLOBALS(ddtrace)
 

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -16,63 +16,14 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 user_opcode_handler_t ddtrace_old_fcall_handler;
 user_opcode_handler_t ddtrace_old_icall_handler;
+user_opcode_handler_t ddtrace_old_ucall_handler;
 user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
 
 #if PHP_VERSION_ID >= 70000
-static void (*ddtrace_original_execute_ex)(zend_execute_data *TSRMLS_DC);
-static zend_op_array *(*ddtrace_original_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
-
-// dummy zend_execute_ex hook - shouldn't actually be used outside of file compilation
-// in PHP 7+ this is used to ensure compilation step creates opcodes necessary for opcode handlers to work
-static void php_execute(zend_execute_data *execute_data TSRMLS_DC) {
-    zend_execute_ex = execute_ex;
-
-    if (ddtrace_original_execute_ex) {
-        ddtrace_original_execute_ex(execute_data TSRMLS_CC);
-    } else {
-        execute_ex(execute_data TSRMLS_CC);
-    }
-}
-
-static zend_op_array *php_compile(zend_file_handle *file_handle, int type TSRMLS_DC) {
-    zend_op_array *op_array;
-    zend_execute_ex = php_execute;
-
-    op_array = ddtrace_original_compile_file(file_handle, type TSRMLS_CC);
-
-    if (ddtrace_original_execute_ex) {
-        zend_execute_ex = ddtrace_original_execute_ex;
-    } else {
-        zend_execute_ex = execute_ex;
-    }
-
-    return op_array;
-}
-
 static inline void dispatch_table_dtor(zval *zv) {
     zend_hash_destroy(Z_PTR_P(zv));
     efree(Z_PTR_P(zv));
 }
-
-#if PHP_VERSION_ID >= 70300
-static int (*ddtrace_original_post_startup_cb)(void);
-
-static int php_post_startup_cb(void) {
-    if (ddtrace_original_post_startup_cb) {
-        int (*callback)(void) = ddtrace_original_post_startup_cb;
-        ddtrace_original_post_startup_cb =
-            NULL;  // guard against possible recursion if callback is calling zend_post_startup_cb directly
-        if (callback() != SUCCESS) {
-            return FAILURE;
-        }
-    }
-    ddtrace_original_compile_file = zend_compile_file;
-    zend_compile_file = php_compile;
-
-    return SUCCESS;
-}
-#endif  // PHP_VERSION >= 70300
-
 #else
 static inline void dispatch_table_dtor(void *zv) {
     HashTable *ht = *(HashTable **)zv;
@@ -125,18 +76,11 @@ void ddtrace_dispatch_inject(TSRMLS_D) {
  * opcode instead of ZEND_DO_UCALL for user defined functions
  */
 #if PHP_VERSION_ID >= 70000
-    ddtrace_original_execute_ex = zend_execute_ex;
-
-// for PHP 7.3+ this needs to be set in zend_post_startup_cb
-#if PHP_VERSION_ID < 70300
-    ddtrace_original_compile_file = zend_compile_file;
-    zend_compile_file = php_compile;
-#else
-    ddtrace_original_post_startup_cb = zend_post_startup_cb;
-    zend_post_startup_cb = php_post_startup_cb;
-#endif  // PHP_VERSION_ID < 70300
     DDTRACE_G(ddtrace_old_icall_handler) = zend_get_user_opcode_handler(ZEND_DO_ICALL);
     zend_set_user_opcode_handler(ZEND_DO_ICALL, ddtrace_wrap_fcall);
+
+    DDTRACE_G(ddtrace_old_ucall_handler) = zend_get_user_opcode_handler(ZEND_DO_UCALL);
+    zend_set_user_opcode_handler(ZEND_DO_UCALL, ddtrace_wrap_fcall);
 #endif
     DDTRACE_G(ddtrace_old_fcall_handler) = zend_get_user_opcode_handler(ZEND_DO_FCALL);
     zend_set_user_opcode_handler(ZEND_DO_FCALL, ddtrace_wrap_fcall);


### PR DESCRIPTION
### Description

This PR removes the `zend_execute_ex` override which allows the VM to behave under its normal conditions and allows the opcode `ZEND_DO_UCALL` to be emitted. As a result, this PR registers the opcode handler for `ZEND_DO_UCALL` as well.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- ~~[ ] Tests added for this feature/bug~~
