### PR TITLE
Fix memory leaks from coms and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file - [read more
 - Shutdown span flushing blocking the process when forked #493
 - Memory access errors in cases when PHP code was run after extension data was freed on request shutdown #505
 - Request init hook working when open_basedir restriction is in effect #505
+- Ensure global resources are freed in shutdown #521 #523
 
 ### Changed
 - Remove `zend_execute_ex` override and trace `ZEND_DO_UCALL` #519

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -105,6 +105,13 @@ BOOL_T ddtrace_coms_initialize() {
 }
 
 void ddtrace_coms_shutdown() {
+    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    if (current_stack) {
+        if (current_stack->data) {
+	    free(current_stack->data);
+        }
+        free(current_stack);
+    }
     if (ddtrace_coms_global_state.stacks) {
         free(ddtrace_coms_global_state.stacks);
         ddtrace_coms_global_state.stacks = NULL;

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -108,7 +108,7 @@ void ddtrace_coms_shutdown() {
     ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
     if (current_stack) {
         if (current_stack->data) {
-	    free(current_stack->data);
+            free(current_stack->data);
         }
         free(current_stack);
     }

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -251,6 +251,7 @@ static void *writer_loop(void *_) {
         signal_data_processed(writer);
     } while (running);
 
+    ddtrace_coms_shutdown();
     signal_writer_finished(writer);
     return NULL;
 }

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -70,27 +70,27 @@ void ddtrace_config_shutdown(void) {
     // read all values to memoize them
 
     // CHAR returns a copy of a value that we need to free
-#define CHAR(getter_name, env_name, default, ...)                                      \
-    do {                                                                               \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                     \
-        if (ddtrace_memoized_configuration.getter_name) {                              \
-            free(ddtrace_memoized_configuration.getter_name);                          \
-            ddtrace_memoized_configuration.getter_name = NULL;                         \
-        }                                                                              \
-        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;                 \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                   \
+#define CHAR(getter_name, env_name, default, ...)                      \
+    do {                                                               \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
+        if (ddtrace_memoized_configuration.getter_name) {              \
+            free(ddtrace_memoized_configuration.getter_name);          \
+            ddtrace_memoized_configuration.getter_name = NULL;         \
+        }                                                              \
+        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
     } while (0);
-#define INT(getter_name, env_name, default, ...)                                                              \
-    do {                                                                                                      \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                            \
-        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;                                         \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                          \
+#define INT(getter_name, env_name, default, ...)                       \
+    do {                                                               \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
+        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
     } while (0);
-#define BOOL(getter_name, env_name, default, ...)                                                              \
-    do {                                                                                                       \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                             \
-        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;                                          \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                           \
+#define BOOL(getter_name, env_name, default, ...)                      \
+    do {                                                               \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
+        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
     } while (0);
 
     DD_CONFIGURATION

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -1,10 +1,14 @@
 #ifndef DD_CONFIGURATION_H
 #define DD_CONFIGURATION_H
+
+#include "compatibility.h"
+
 struct ddtrace_memoized_configuration_t;
 extern struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration;
 
-void ddtrace_initialize_config();
-void ddtrace_reload_config();
+void ddtrace_initialize_config(COMPAT_CTX_D);
+void ddtrace_reload_config(COMPAT_CTX_D);
+void ddtrace_config_shutdown(void);
 
 #define DD_CONFIGURATION                                                                                  \
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                 \

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -488,7 +488,7 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
     RETVAL_FALSE;
     if (fn && fn_len > 0) {
         if (FUNCTION_NAME_MATCHES("ddtrace_reload_config")) {
-            ddtrace_reload_config(COMPAT_CTX_CC);
+            ddtrace_reload_config(COMPAT_CTX_C);
             RETVAL_TRUE;
         } else if (FUNCTION_NAME_MATCHES("init_and_start_writer")) {
             RETVAL_BOOL(ddtrace_coms_init_and_start_writer());

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -488,7 +488,7 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
     RETVAL_FALSE;
     if (fn && fn_len > 0) {
         if (FUNCTION_NAME_MATCHES("ddtrace_reload_config")) {
-            ddtrace_reload_config();
+            ddtrace_reload_config(COMPAT_CTX_CC);
             RETVAL_TRUE;
         } else if (FUNCTION_NAME_MATCHES("init_and_start_writer")) {
             RETVAL_BOOL(ddtrace_coms_init_and_start_writer());

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -90,7 +90,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     // when extension is properly unloaded disable the at_exit hook
     ddtrace_coms_disable_atexit_hook();
     ddtrace_coms_flush_shutdown_writer_synchronous();
-    ddtrace_coms_shutdown();
+    ddtrace_config_shutdown();
 
     return SUCCESS;
 }

--- a/tests/ext/segfault_backtrace_disabled.phpt
+++ b/tests/ext/segfault_backtrace_disabled.phpt
@@ -2,7 +2,8 @@
 Don't Dump backtrace when segmentation fault signal is raised and config is defalt
 --SKIPIF--
 <?php
-preg_match("/alpine/i", file_get_contents("/etc/os-release")) and die("skip Unsupported LIBC");
+if (getenv('SKIP_ASAN')) die("skip: intentionally causes segfaults");
+if (file_exists("/etc/os-release") && preg_match("/alpine/i", file_get_contents("/etc/os-release"))) die("skip Unsupported LIBC");
 ?>
 --FILE--
 <?php

--- a/tests/ext/segfault_backtrace_enabled.phpt
+++ b/tests/ext/segfault_backtrace_enabled.phpt
@@ -3,6 +3,7 @@ Dump backtrace when segmentation fault signal is raised and config enables it
 --SKIPIF--
 <?php
 preg_match("/alpine/i", file_get_contents("/etc/os-release")) and die("skip Unsupported LIBC");
+if (getenv('SKIP_ASAN')) die("skip: intentionally causes segfaults");
 ?>
 --ENV--
 DD_LOG_BACKTRACE=1


### PR DESCRIPTION
### Description
Continuing the work started in PR #521, this cleans up the leaks in communications and configuration. With this merged, we'll be able to run ddtrace with ASAN and get meaningful results. 

TODO: add a  PHP 7.4+debug+asan build to our CI. 

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [ ] Tests added for this feature/bug