### PR TITLE
Refactor opcode handler entry

### DIFF
--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -30,30 +30,17 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 #define EX(x) ((execute_data)->x)
 #endif
 
-#if PHP_VERSION_ID < 70000
-static ddtrace_dispatch_t *lookup_dispatch(const HashTable *lookup, ddtrace_lookup_data_t *lookup_data) {
-    if (lookup_data->function_name_length == 0) {
-        lookup_data->function_name_length = strlen(lookup_data->function_name);
-    }
-
-    char *key = zend_str_tolower_dup(lookup_data->function_name, lookup_data->function_name_length);
+static ddtrace_dispatch_t *find_function_dispatch(const HashTable *lookup, zval *fname) {
+    char *key = zend_str_tolower_dup(Z_STRVAL_P(fname), Z_STRLEN_P(fname));
     ddtrace_dispatch_t *dispatch = NULL;
-    dispatch = zend_hash_str_find_ptr(lookup, key, lookup_data->function_name_length);
+    dispatch = zend_hash_str_find_ptr(lookup, key, Z_STRLEN_P(fname));
 
     efree(key);
     return dispatch;
 }
-#else
-static ddtrace_dispatch_t *lookup_dispatch(const HashTable *lookup, ddtrace_lookup_data_t *lookup_data) {
-    zend_string *key = zend_string_tolower(lookup_data->function_name);
-    ddtrace_dispatch_t *dispatch = zend_hash_find_ptr(lookup, key);
-    zend_string_release(key);
-    return dispatch;
-}
-#endif
 
-static ddtrace_dispatch_t *find_dispatch(const zend_class_entry *class, ddtrace_lookup_data_t *lookup_data TSRMLS_DC) {
-    if (!lookup_data->function_name) {
+static ddtrace_dispatch_t *find_method_dispatch(const zend_class_entry *class, zval *fname TSRMLS_DC) {
+    if (!fname || !Z_STRVAL_P(fname)) {
         return NULL;
     }
     HashTable *class_lookup = NULL;
@@ -70,7 +57,7 @@ static ddtrace_dispatch_t *find_dispatch(const zend_class_entry *class, ddtrace_
 
     ddtrace_dispatch_t *dispatch = NULL;
     if (class_lookup) {
-        dispatch = lookup_dispatch(class_lookup, lookup_data);
+        dispatch = find_function_dispatch(class_lookup, fname);
     }
 
     if (dispatch) {
@@ -78,28 +65,27 @@ static ddtrace_dispatch_t *find_dispatch(const zend_class_entry *class, ddtrace_
     }
 
     if (class->parent) {
-        return find_dispatch(class->parent, lookup_data TSRMLS_CC);
+        return find_method_dispatch(class->parent, fname TSRMLS_CC);
     } else {
         return NULL;
     }
 }
 
-#if PHP_VERSION_ID < 70000
-zend_function *fcall_fbc(zend_execute_data *execute_data TSRMLS_DC) {
-    zend_op *opline = EX(opline);
-    zend_function *fbc = NULL;
-    zval *fname = opline->op1.zv;
+ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC) {
+    zend_class_entry *class = NULL;
 
-    if (CACHED_PTR(opline->op1.literal->cache_slot)) {
-        return CACHED_PTR(opline->op1.literal->cache_slot);
-    } else if (EXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(fname), Z_STRLEN_P(fname) + 1,
-                                             Z_HASH_P(fname), (void **)&fbc) == SUCCESS)) {
-        return fbc;
-    } else {
-        return NULL;
+    if (this) {
+        class = Z_OBJCE_P(this);
+    } else if ((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
+        // Check for class on static method static
+        class = fbc->common.scope;
     }
+
+    if (class) {
+        return find_method_dispatch(class, fname TSRMLS_CC);
+    }
+    return find_function_dispatch(DDTRACE_G(function_lookup), fname);
 }
-#endif
 
 static void execute_fcall(ddtrace_dispatch_t *dispatch, zval *this, zend_execute_data *execute_data,
                           zval **return_value_ptr TSRMLS_DC) {
@@ -213,211 +199,98 @@ _exit_cleanup:
     Z_DELREF(closure);
 }
 
-static int is_anonymous_closure(zend_function *fbc, ddtrace_lookup_data_t *lookup) {
-    if (!(fbc->common.fn_flags & ZEND_ACC_CLOSURE) || !lookup->function_name) {
-        return 0;
-    }
-
-    /* This checks for a "{closure}" prefix, not a complete string. PHP adds
-     * null characters to the closure name to separate different parts, which
-     * is why this works at all. */
-    /* todo: why do we do this check at all? */
-#if PHP_VERSION_ID < 70000
-    if (lookup->function_name_length == 0) {
-        lookup->function_name_length = strlen(lookup->function_name);
-    }
-    if ((lookup->function_name_length == (sizeof("{closure}") - 1)) &&
-        strcmp(lookup->function_name, "{closure}") == 0) {
-        return 1;
-    } else {
-        return 0;
-    }
-#else
-    if ((ZSTR_LEN(lookup->function_name) == (sizeof("{closure}") - 1)) &&
-        strcmp((ZSTR_VAL(lookup->function_name)), "{closure}") == 0) {
-        return 1;
-    } else {
-        return 0;
-    }
-#endif
-}
-
-static zend_always_inline zend_bool wrap_and_run(zend_execute_data *execute_data,
-                                                 ddtrace_lookup_data_t *lookup_data TSRMLS_DC) {
+static zend_always_inline void wrap_and_run(zend_execute_data *execute_data,
+                                                 zend_function *fbc, ddtrace_dispatch_t *dispatch TSRMLS_DC) {
     zval *this = ddtrace_this(execute_data);
-    DD_PRINTF("Loaded $this object ptr: %p", (void *)this);
-
-    ddtrace_dispatch_t *dispatch = NULL;
-
-    zend_class_entry *class = NULL;
-
-    if (this) {
-        class = Z_OBJCE_P(this);
-    }
-
-    // Check for class on static method static
-    if (!this && (DDTRACE_G(original_context).fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
-        class = DDTRACE_G(original_context).fbc->common.scope;
-    }
-
-    if (class) {
-        dispatch = find_dispatch(class, lookup_data TSRMLS_CC);
-    } else {
-        dispatch = lookup_dispatch(DDTRACE_G(function_lookup), lookup_data);
-    }
-
-    if (dispatch && !dispatch->busy) {
-        ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
-        dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
 #if PHP_VERSION_ID < 50500
-        zval *original_object = EX(object);
-        if (EX(opline)->opcode == ZEND_DO_FCALL) {
-            zend_op *opline = EX(opline);
-            zend_ptr_stack_3_push(&EG(arg_types_stack), FBC(), EX(object), EX(called_scope));
+    zval *original_object = EX(object);
+    if (EX(opline)->opcode == ZEND_DO_FCALL) {
+        zend_op *opline = EX(opline);
+        zend_ptr_stack_3_push(&EG(arg_types_stack), FBC(), EX(object), EX(called_scope));
 
-            if (CACHED_PTR(opline->op1.literal->cache_slot)) {
-                EX(function_state).function = CACHED_PTR(opline->op1.literal->cache_slot);
-            } else {
-                EX(function_state).function = fcall_fbc(execute_data TSRMLS_CC);
-                CACHE_PTR(opline->op1.literal->cache_slot, EX(function_state).function);
-            }
+        if (CACHED_PTR(opline->op1.literal->cache_slot)) {
+            EX(function_state).function = CACHED_PTR(opline->op1.literal->cache_slot);
+        } else {
+            EX(function_state).function = fbc;
+            CACHE_PTR(opline->op1.literal->cache_slot, EX(function_state).function);
+        }
 
-            EX(object) = NULL;
-        }
-        if (this) {
-            EX(object) = original_object;
-        }
+        EX(object) = NULL;
+    }
+    if (this) {
+        EX(object) = original_object;
+    }
 #endif
-        const zend_op *opline = EX(opline);
+    const zend_op *opline = EX(opline);
 
 #if PHP_VERSION_ID < 50500
 #define EX_T(offset) (*(temp_variable *)((char *)EX(Ts) + offset))
-        zval rv;
-        INIT_ZVAL(rv);
+    zval rv;
+    INIT_ZVAL(rv);
 
-        zval **return_value = NULL;
-        zval *rv_ptr = &rv;
+    zval **return_value = NULL;
+    zval *rv_ptr = &rv;
 
-        if (RETURN_VALUE_USED(opline)) {
-            EX_T(opline->result.var).var.ptr = &EG(uninitialized_zval);
-            EX_T(opline->result.var).var.ptr_ptr = NULL;
+    if (RETURN_VALUE_USED(opline)) {
+        EX_T(opline->result.var).var.ptr = &EG(uninitialized_zval);
+        EX_T(opline->result.var).var.ptr_ptr = NULL;
 
-            return_value = NULL;
+        return_value = NULL;
+    } else {
+        return_value = &rv_ptr;
+    }
+
+    if (RETURN_VALUE_USED(opline)) {
+        temp_variable *ret = &EX_T(opline->result.var);
+
+        if (EG(return_value_ptr_ptr) && *EG(return_value_ptr_ptr)) {
+            ret->var.ptr = *EG(return_value_ptr_ptr);
+            ret->var.ptr_ptr = EG(return_value_ptr_ptr);
         } else {
-            return_value = &rv_ptr;
+            ret->var.ptr = NULL;
+            ret->var.ptr_ptr = &ret->var.ptr;
         }
 
-        if (RETURN_VALUE_USED(opline)) {
-            temp_variable *ret = &EX_T(opline->result.var);
+        ret->var.fcall_returned_reference =
+            (DDTRACE_G(original_context).fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) != 0;
+        return_value = ret->var.ptr_ptr;
+    }
 
-            if (EG(return_value_ptr_ptr) && *EG(return_value_ptr_ptr)) {
-                ret->var.ptr = *EG(return_value_ptr_ptr);
-                ret->var.ptr_ptr = EG(return_value_ptr_ptr);
-            } else {
-                ret->var.ptr = NULL;
-                ret->var.ptr_ptr = &ret->var.ptr;
-            }
+    execute_fcall(dispatch, this, execute_data, return_value TSRMLS_CC);
+    EG(return_value_ptr_ptr) = EX(original_return_value);
 
-            ret->var.fcall_returned_reference =
-                (DDTRACE_G(original_context).fbc->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) != 0;
-            return_value = ret->var.ptr_ptr;
+    if (!RETURN_VALUE_USED(opline) && return_value && *return_value) {
+        zval_delref_p(*return_value);
+        if (Z_REFCOUNT_PP(return_value) == 0) {
+            efree(*return_value);
+            *return_value = NULL;
         }
-
-        execute_fcall(dispatch, this, execute_data, return_value TSRMLS_CC);
-        EG(return_value_ptr_ptr) = EX(original_return_value);
-
-        if (!RETURN_VALUE_USED(opline) && return_value && *return_value) {
-            zval_delref_p(*return_value);
-            if (Z_REFCOUNT_PP(return_value) == 0) {
-                efree(*return_value);
-                *return_value = NULL;
-            }
-        }
+    }
 
 #elif PHP_VERSION_ID < 70000
-        zval *return_value = NULL;
-        execute_fcall(dispatch, this, execute_data, &return_value TSRMLS_CC);
+    zval *return_value = NULL;
+    execute_fcall(dispatch, this, execute_data, &return_value TSRMLS_CC);
 
-        if (return_value != NULL) {
-            if (RETURN_VALUE_USED(opline)) {
-                EX_TMP_VAR(execute_data, opline->result.var)->var.ptr = return_value;
-            } else {
-                zval_ptr_dtor(&return_value);
-            }
+    if (return_value != NULL) {
+        if (RETURN_VALUE_USED(opline)) {
+            EX_TMP_VAR(execute_data, opline->result.var)->var.ptr = return_value;
+        } else {
+            zval_ptr_dtor(&return_value);
         }
+    }
 
 #else
-        zval rv;
-        INIT_ZVAL(rv);
+    zval rv;
+    INIT_ZVAL(rv);
 
-        zval *return_value = (RETURN_VALUE_USED(opline) ? EX_VAR(EX(opline)->result.var) : &rv);
-        execute_fcall(dispatch, this, EX(call), &return_value TSRMLS_CC);
+    zval *return_value = (RETURN_VALUE_USED(opline) ? EX_VAR(EX(opline)->result.var) : &rv);
+    execute_fcall(dispatch, this, EX(call), &return_value TSRMLS_CC);
 
-        if (!RETURN_VALUE_USED(opline)) {
-            zval_dtor(&rv);
-        }
-#endif
-
-        dispatch->busy = 0;
-        ddtrace_class_lookup_release(dispatch);
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
-static zend_always_inline zend_function *get_current_fbc(zend_execute_data *execute_data TSRMLS_DC) {
-    zend_function *fbc = NULL;
-
-#if PHP_VERSION_ID < 70000
-    if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
-        fbc = FBC();
-    } else {
-        fbc = fcall_fbc(execute_data TSRMLS_CC);
-#ifdef ZTS
-        (void)TSRMLS_C;
-#endif  // ZTS
-    }
-#else
-    fbc = EX(call)->func;
-#endif
-    return fbc;
-}
-
-static zend_always_inline zend_bool is_function_wrappable(zend_execute_data *execute_data, zend_function *fbc,
-                                                          ddtrace_lookup_data_t *lookup_data) {
-    if (!fbc) {
-        DD_PRINTF("No function obj found, skipping lookup");
-        return 0;
-    }
-
-#if PHP_VERSION_ID < 70000
-    if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
-        lookup_data->function_name = fbc->common.function_name;
-    } else {
-        zval *fname = EX(opline)->op1.zv;
-
-        lookup_data->function_name = Z_STRVAL_P(fname);
-        lookup_data->function_name_length = Z_STRLEN_P(fname);
-    }
-#else
-    fbc = EX(call)->func;
-    if (fbc->common.function_name) {
-        lookup_data->function_name = fbc->common.function_name;
+    if (!RETURN_VALUE_USED(opline)) {
+        zval_dtor(&rv);
     }
 #endif
-    if (!lookup_data->function_name) {
-        DD_PRINTF("No function name, skipping lookup");
-        return 0;
-    }
-
-    if (is_anonymous_closure(fbc, lookup_data)) {
-        DD_PRINTF("Anonymous closure, skipping lookup");
-        return 0;
-    }
-
-    return 1;
 }
 
 #define CTOR_CALL_BIT 0x1
@@ -470,18 +343,14 @@ static int _default_dispatch(zend_execute_data *execute_data TSRMLS_DC) {
 }
 
 int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
-    DD_PRINTF("OPCODE: %s", zend_get_opcode_name(EX(opline)->opcode));
-    if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
-        DDTRACE_G(function_lookup) == NULL) {
+    zend_function *current_fbc = NULL;
+    ddtrace_dispatch_t *dispatch = NULL;
+    if (!ddtrace_should_trace_call(execute_data, &current_fbc, &dispatch TSRMLS_CC)) {
         return _default_dispatch(execute_data TSRMLS_CC);
     }
+    ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
+    dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
-    zend_function *current_fbc = get_current_fbc(execute_data TSRMLS_CC);
-    ddtrace_lookup_data_t lookup_data = {0};
-
-    if (!is_function_wrappable(execute_data, current_fbc, &lookup_data)) {
-        return _default_dispatch(execute_data TSRMLS_CC);
-    }
     // Store original context for forwarding the call from userland
     zend_function *previous_fbc = DDTRACE_G(original_context).fbc;
     DDTRACE_G(original_context).fbc = current_fbc;
@@ -509,18 +378,18 @@ int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
     DDTRACE_G(original_context).calling_ce = Z_OBJ(execute_data->This) ? Z_OBJ(execute_data->This)->ce : NULL;
 #endif
 
-    zend_bool wrapped = wrap_and_run(execute_data, &lookup_data TSRMLS_CC);
+    wrap_and_run(execute_data, current_fbc, dispatch TSRMLS_CC);
 
     // Restore original context
     DDTRACE_G(original_context).calling_ce = previous_calling_ce;
     DDTRACE_G(original_context).this = previous_this;
     DDTRACE_G(original_context).calling_fbc = previous_calling_fbc;
     DDTRACE_G(original_context).fbc = previous_fbc;
-    if (wrapped) {
-        return update_opcode_leave(execute_data TSRMLS_CC);
-    } else {
-        return _default_dispatch(execute_data TSRMLS_CC);
-    }
+
+    dispatch->busy = 0;
+    ddtrace_class_lookup_release(dispatch);
+
+    return update_opcode_leave(execute_data TSRMLS_CC);
 }
 
 void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *dispatch) { dispatch->acquired++; }

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -199,8 +199,7 @@ _exit_cleanup:
     Z_DELREF(closure);
 }
 
-static zend_always_inline void wrap_and_run(zend_execute_data *execute_data,
-                                                 ddtrace_dispatch_t *dispatch TSRMLS_DC) {
+static zend_always_inline void wrap_and_run(zend_execute_data *execute_data, ddtrace_dispatch_t *dispatch TSRMLS_DC) {
     zval *this = ddtrace_this(execute_data);
 
 #if PHP_VERSION_ID < 50500

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -200,7 +200,7 @@ _exit_cleanup:
 }
 
 static zend_always_inline void wrap_and_run(zend_execute_data *execute_data,
-                                                 zend_function *fbc, ddtrace_dispatch_t *dispatch TSRMLS_DC) {
+                                                 ddtrace_dispatch_t *dispatch TSRMLS_DC) {
     zval *this = ddtrace_this(execute_data);
 
 #if PHP_VERSION_ID < 50500
@@ -212,7 +212,7 @@ static zend_always_inline void wrap_and_run(zend_execute_data *execute_data,
         if (CACHED_PTR(opline->op1.literal->cache_slot)) {
             EX(function_state).function = CACHED_PTR(opline->op1.literal->cache_slot);
         } else {
-            EX(function_state).function = fbc;
+            EX(function_state).function = DDTRACE_G(original_context).fbc;
             CACHE_PTR(opline->op1.literal->cache_slot, EX(function_state).function);
         }
 
@@ -378,7 +378,7 @@ int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
     DDTRACE_G(original_context).calling_ce = Z_OBJ(execute_data->This) ? Z_OBJ(execute_data->This)->ce : NULL;
 #endif
 
-    wrap_and_run(execute_data, current_fbc, dispatch TSRMLS_CC);
+    wrap_and_run(execute_data, dispatch TSRMLS_CC);
 
     // Restore original context
     DDTRACE_G(original_context).calling_ce = previous_calling_ce;

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -13,15 +13,6 @@ typedef struct _ddtrace_dispatch_t {
     uint32_t acquired;
 } ddtrace_dispatch_t;
 
-typedef struct _ddtrace_lookup_data_t {
-#if PHP_VERSION_ID < 70000
-    const char *function_name;
-    uint32_t function_name_length;
-#else
-    zend_string *function_name;
-#endif
-} ddtrace_lookup_data_t;
-
 ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC);
 zend_bool ddtrace_trace(zval *, zval *, zval *TSRMLS_DC);
 int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -22,6 +22,7 @@ typedef struct _ddtrace_lookup_data_t {
 #endif
 } ddtrace_lookup_data_t;
 
+ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC);
 zend_bool ddtrace_trace(zval *, zval *, zval *TSRMLS_DC);
 int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
 void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -68,6 +68,7 @@ void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch);
 HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);
 void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);
-int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc, ddtrace_dispatch_t **dispatch TSRMLS_DC);
+int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
+                              ddtrace_dispatch_t **dispatch TSRMLS_DC);
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -70,6 +70,6 @@ HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);
 void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);
 BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
-                              ddtrace_dispatch_t **dispatch TSRMLS_DC);
+                                 ddtrace_dispatch_t **dispatch TSRMLS_DC);
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -3,6 +3,7 @@
 #include "Zend/zend_types.h"
 #include "compat_zend_string.h"
 #include "dispatch.h"
+#include "env_config.h"
 
 #if PHP_VERSION_ID < 70000
 #include "dispatch_compat_php5.h"
@@ -68,7 +69,7 @@ void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch);
 HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);
 void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);
-int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
+BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
                               ddtrace_dispatch_t **dispatch TSRMLS_DC);
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -68,5 +68,6 @@ void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch);
 HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);
 void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);
+int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc, ddtrace_dispatch_t **dispatch TSRMLS_DC);
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -246,7 +246,8 @@ static zend_function *_get_current_fbc(zend_execute_data *execute_data TSRMLS_DC
     }
 }
 
-int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc, ddtrace_dispatch_t **dispatch TSRMLS_DC) {
+int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
+                              ddtrace_dispatch_t **dispatch TSRMLS_DC) {
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
         DDTRACE_G(function_lookup) == NULL) {
         return 0;
@@ -261,7 +262,7 @@ int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **f
     if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
         ZVAL_STRING(fname, (*fbc)->common.function_name, 0);
     } else if (EX(opline)->op1.zv) {
-        fname = EX(opline)->op1.zv; 
+        fname = EX(opline)->op1.zv;
     } else {
         return 0;
     }
@@ -273,7 +274,7 @@ int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **f
 
     zval *this = ddtrace_this(execute_data);
     *dispatch = ddtrace_find_dispatch(this, *fbc, fname TSRMLS_CC);
-    if(!*dispatch || (*dispatch)->busy) {
+    if (!*dispatch || (*dispatch)->busy) {
         return 0;
     }
 

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -9,6 +9,7 @@
 #include "debug.h"
 #include "dispatch.h"
 #include "dispatch_compat.h"
+#include "env_config.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
@@ -246,15 +247,15 @@ static zend_function *_get_current_fbc(zend_execute_data *execute_data TSRMLS_DC
     }
 }
 
-int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
+BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
                               ddtrace_dispatch_t **dispatch TSRMLS_DC) {
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
         DDTRACE_G(function_lookup) == NULL) {
-        return 0;
+        return FALSE;
     }
     *fbc = _get_current_fbc(execute_data TSRMLS_CC);
     if (!*fbc) {
-        return 0;
+        return FALSE;
     }
 
     zval zv, *fname;
@@ -264,20 +265,20 @@ int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **f
     } else if (EX(opline)->op1.zv) {
         fname = EX(opline)->op1.zv;
     } else {
-        return 0;
+        return FALSE;
     }
 
     // Don't trace closures
     if ((*fbc)->common.fn_flags & ZEND_ACC_CLOSURE) {
-        return 0;
+        return FALSE;
     }
 
     zval *this = ddtrace_this(execute_data);
     *dispatch = ddtrace_find_dispatch(this, *fbc, fname TSRMLS_CC);
     if (!*dispatch || (*dispatch)->busy) {
-        return 0;
+        return FALSE;
     }
 
-    return 1;
+    return TRUE;
 }
 #endif  // PHP 5

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -248,7 +248,7 @@ static zend_function *_get_current_fbc(zend_execute_data *execute_data TSRMLS_DC
 }
 
 BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
-                              ddtrace_dispatch_t **dispatch TSRMLS_DC) {
+                                 ddtrace_dispatch_t **dispatch TSRMLS_DC) {
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
         DDTRACE_G(function_lookup) == NULL) {
         return FALSE;

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -227,4 +227,56 @@ void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TS
     zend_fcall_info_args_clear(&fci, 1);
     zval_dtor(&args);
 }
+
+static zend_function *_get_current_fbc(zend_execute_data *execute_data TSRMLS_DC) {
+    if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
+        return FBC();
+    }
+    zend_op *opline = EX(opline);
+    zend_function *fbc = NULL;
+    zval *fname = opline->op1.zv;
+
+    if (CACHED_PTR(opline->op1.literal->cache_slot)) {
+        return CACHED_PTR(opline->op1.literal->cache_slot);
+    } else if (EXPECTED(zend_hash_quick_find(EG(function_table), Z_STRVAL_P(fname), Z_STRLEN_P(fname) + 1,
+                                             Z_HASH_P(fname), (void **)&fbc) == SUCCESS)) {
+        return fbc;
+    } else {
+        return NULL;
+    }
+}
+
+int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc, ddtrace_dispatch_t **dispatch TSRMLS_DC) {
+    if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
+        DDTRACE_G(function_lookup) == NULL) {
+        return 0;
+    }
+    *fbc = _get_current_fbc(execute_data TSRMLS_CC);
+    if (!*fbc) {
+        return 0;
+    }
+
+    zval zv, *fname;
+    fname = &zv;
+    if (EX(opline)->opcode == ZEND_DO_FCALL_BY_NAME) {
+        ZVAL_STRING(fname, (*fbc)->common.function_name, 0);
+    } else if (EX(opline)->op1.zv) {
+        fname = EX(opline)->op1.zv; 
+    } else {
+        return 0;
+    }
+
+    // Don't trace closures
+    if ((*fbc)->common.fn_flags & ZEND_ACC_CLOSURE) {
+        return 0;
+    }
+
+    zval *this = ddtrace_this(execute_data);
+    *dispatch = ddtrace_find_dispatch(this, *fbc, fname TSRMLS_CC);
+    if(!*dispatch || (*dispatch)->busy) {
+        return 0;
+    }
+
+    return 1;
+}
 #endif  // PHP 5

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -126,7 +126,7 @@ void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TS
 }
 
 BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
-                              ddtrace_dispatch_t **dispatch TSRMLS_DC) {
+                                 ddtrace_dispatch_t **dispatch TSRMLS_DC) {
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
         DDTRACE_G(function_lookup) == NULL) {
         return FALSE;

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -124,7 +124,8 @@ void ddtrace_forward_call(zend_execute_data *execute_data, zval *return_value TS
     zval_ptr_dtor(&fname);
 }
 
-int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc, ddtrace_dispatch_t **dispatch TSRMLS_DC) {
+int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
+                              ddtrace_dispatch_t **dispatch TSRMLS_DC) {
     if (DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request) || DDTRACE_G(class_lookup) == NULL ||
         DDTRACE_G(function_lookup) == NULL) {
         return 0;
@@ -150,7 +151,7 @@ int ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **f
     zval *this = ddtrace_this(execute_data);
     *dispatch = ddtrace_find_dispatch(this, *fbc, &fname TSRMLS_CC);
     zval_ptr_dtor(&fname);
-    if(!*dispatch || (*dispatch)->busy) {
+    if (!*dispatch || (*dispatch)->busy) {
         return 0;
     }
 


### PR DESCRIPTION
### Description

In order to wrap up #491, we needed to refactor the entry into the opcode handler `ddtrace_wrap_fcall()`. The check for "should we trace this?" has been bubbled up to `ddtrace_wrap_fcall()` instead of being spread around to several function calls. There were also a few functions that we inlined which allowed us to remove extra code.

This will allow us (we think) to forward the original call at the C level and append the tracing closure cleanly for #491.

Thanks @morrisonlevi for pair programming this one with me. :)

### Readiness checklist
- ~~[ ] [Changelog entry](docs/changelog.md) added, if necessary~~
- ~~[ ] Tests added for this feature/bug~~
