### PR TITLE
Avoid freeing configuration before writer is completely shutdown

### DIFF
--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -379,10 +379,11 @@ BOOL_T ddtrace_coms_on_request_finished() {
     return TRUE;
 }
 
+// Returns TRUE if writer is shutdown completely
 BOOL_T ddtrace_coms_flush_shutdown_writer_synchronous() {
     struct _writer_loop_data_t *writer = get_writer();
     if (!writer->thread) {
-        return FALSE;
+        return TRUE;
     }
 
     writer_set_shutdown_state(writer);
@@ -412,8 +413,9 @@ BOOL_T ddtrace_coms_flush_shutdown_writer_synchronous() {
         pthread_join(writer->thread->self, NULL);
         free(writer->thread);
         writer->thread = NULL;
+        return TRUE;
     }
-    return TRUE;
+    return FALSE;
 }
 
 BOOL_T ddtrace_coms_synchronous_flush(uint32_t timeout) {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -89,8 +89,10 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
 
     // when extension is properly unloaded disable the at_exit hook
     ddtrace_coms_disable_atexit_hook();
-    ddtrace_coms_flush_shutdown_writer_synchronous();
-    ddtrace_config_shutdown();
+    if (ddtrace_coms_flush_shutdown_writer_synchronous()) {
+        // if writer is ensured to be shutdown we can free up config resources safely
+        ddtrace_config_shutdown();
+    }
 
     return SUCCESS;
 }


### PR DESCRIPTION
### Description

Addresses potential issue of freeing memory used by the Writer before the writer is completely shutdown:

related #523 

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
