### PR TITLE
Release This as soon as wrapping closure is finished and scope is left

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -119,6 +119,7 @@
                     <file name="dd_trace_method.phpt" role="test" />
                     <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                     <file name="dd_trace_push_span_id.phpt" role="test" />
+                    <file name="desctructor_called_when_this_gets_out_of_scope.phpt" role="test" />
                     <file name="enable_throw_exception_if_overridable_doesnt_exist.phpt" role="test" />
                     <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
                     <file name="from_php_7_3_test_user_streams_consumed_bug.phpt" role="test" />

--- a/src/ext/compatibility.h
+++ b/src/ext/compatibility.h
@@ -39,6 +39,11 @@
 #define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
 #endif
 
+#if PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70300
+#define GC_ADDREF(x) (++GC_REFCOUNT(x))
+#define GC_DELREF(x) (--GC_REFCOUNT(x))
+#endif
+
 #if PHP_VERSION_ID < 70000
 #define ZVAL_VARARG_PARAM(list, arg_num) (*list[arg_num])
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_BOOL && Z_LVAL_P(x) == 1)

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -336,13 +336,13 @@ static PHP_FUNCTION(dd_trace_function) {
 
 static PHP_FUNCTION(dd_trace_serialize_closed_spans) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    PHP7_UNUSED(execute_data);
     ddtrace_serialize_closed_spans(return_value TSRMLS_CC);
 }
 
 // Invoke the function/method from the original context
 static PHP_FUNCTION(dd_trace_forward_call) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -30,9 +30,8 @@ static zend_always_inline zval *ddtrace_this(zend_execute_data *execute_data) {
     }
 #else
     if (_EX(call)) {
-        this = &(_EX(call)->This);
-        if (Z_OBJ_P(this) == NULL) {
-            this = NULL;
+        if (Z_OBJ(_EX(call)->This) != NULL) {
+            this = &(_EX(call)->This);
         }
     }
 #endif

--- a/tests/ext/desctructor_called_when_this_gets_out_of_scope.phpt
+++ b/tests/ext/desctructor_called_when_this_gets_out_of_scope.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test if desctructor is called when variable goes out of scope
+--FILE--
+<?php
+
+class Test {
+    function m() {
+        return "M";
+    }
+    function __destruct()
+    {
+        echo "DESTRUCT" . PHP_EOL;
+    }
+}
+
+dd_trace("Test", "m", function() {
+    return dd_trace_forward_call() . " OVERRIDE";
+});
+function fn() {
+    $test = new Test();
+    echo $test->m() . PHP_EOL;
+    echo "FN" . PHP_EOL;
+}
+
+fn();
+echo "FINISH" . PHP_EOL;
+?>
+
+--EXPECT--
+M OVERRIDE
+FN
+DESTRUCT
+FINISH


### PR DESCRIPTION
### Description

After passing This to a closure, we were not releasing it in correct time when it was requested by the compiled opcodes. 

This PR releases This and closure object when first is requested, and when not needed anymore.

This fixes any code that expects the destructor to be called as soon as possible to free up resources (db connections etc).

<!---
Any description you feel is relevant and gives more background to this PR, if necessary
-->
### Related Issues:
https://github.com/DataDog/dd-trace-php/issues/510
https://github.com/DataDog/dd-trace-php/issues/451

### Readiness checklist
- [x] ~[Changelog entry](docs/changelog.md) added, if necessary~
- [x] Tests added for this feature/bug

### Reviewer checklist
- [x] Appropriate labels assigned
- [x] Milestone set
