### PR TITLE
Sandboxed integration: PDO

### DIFF
--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -58,6 +58,7 @@ require __DIR__ . '/../src/DDTrace/ScopeManager.php';
 require __DIR__ . '/../src/DDTrace/Integrations/AbstractIntegrationConfiguration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/DefaultIntegrationConfiguration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Integration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/SandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php';

--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -64,6 +64,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Predis/PredisIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/IntegrationsLoader.php';
 require __DIR__ . '/../src/DDTrace/Integrations/PDO/PDOIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Eloquent/EloquentIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Curl/CurlIntegration.php';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,8 @@ services:
 
   mysql_integration:
     image: mysql:5.6
-    # ports:
-    #   - "0.0.0.0:3306:3306"
+    ports:
+      - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=test
       - MYSQL_PASSWORD=test

--- a/package.xml
+++ b/package.xml
@@ -127,6 +127,7 @@
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />
                         <file name="drop_spans.phpt" role="test" />
+                        <file name="errors_are_flagged_from_userland.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
                         <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -143,7 +143,11 @@ class Configuration extends AbstractConfiguration
      */
     public function isSandboxEnabled()
     {
-        return $this->boolValue('trace.sandbox.enabled', false);
+        // Sandbox API not available on < PHP 5.6 yet
+        if (PHP_VERSION_ID < 50600) {
+            return false;
+        }
+        return $this->boolValue('trace.sandbox.enabled', true);
     }
 
     /**

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -137,6 +137,16 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Whether or not sandboxed tracing closures are enabled.
+     *
+     * @return bool
+     */
+    public function isSandboxEnabled()
+    {
+        return $this->boolValue('trace.sandbox.enabled', false);
+    }
+
+    /**
      * The name of the application.
      *
      * @param string $default

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -27,7 +27,7 @@ final class GuzzleIntegration extends Integration
      */
     private static $instance;
 
-    protected function __construct()
+    public function __construct()
     {
         parent::__construct();
         $this->codeTracer = CodeTracer::getInstance();

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -4,7 +4,6 @@ namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
-use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\GlobalTracer;
 
@@ -23,7 +22,7 @@ abstract class Integration
     /**
      * @var DefaultIntegrationConfiguration|mixed
      */
-    private $configuration;
+    protected $configuration;
 
     /**
      * @return string The integration name.
@@ -61,14 +60,6 @@ abstract class Integration
     public function requiresExplicitTraceAnalyticsEnabling()
     {
         return true;
-    }
-
-    public function addTraceAnalyticsIfEnabled(SpanData $span)
-    {
-        if (!$this->configuration->isTraceAnalyticsEnabled()) {
-            return;
-        }
-        $span->metrics[Tag::ANALYTICS_KEY] = $this->configuration->getTraceAnalyticsSampleRate();
     }
 
     /**

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -4,6 +4,7 @@ namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
+use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\GlobalTracer;
 
@@ -60,6 +61,14 @@ abstract class Integration
     public function requiresExplicitTraceAnalyticsEnabling()
     {
         return true;
+    }
+
+    public function addTraceAnalyticsIfEnabled(SpanData $span)
+    {
+        if (!$this->configuration->isTraceAnalyticsEnabled()) {
+            return;
+        }
+        $span->metrics[Tag::ANALYTICS_KEY] = $this->configuration->getTraceAnalyticsSampleRate();
     }
 
     /**

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -30,7 +30,7 @@ abstract class Integration
     abstract public function getName();
 
 
-    protected function __construct()
+    public function __construct()
     {
         $this->configuration = $this->buildConfiguration();
     }

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -127,7 +127,8 @@ class IntegrationsLoader
             }
 
             if (strpos($class, 'SandboxedIntegration') !== false) {
-                $this->loadings[$name] = $class::get()->init();
+                $integration = new $class();
+                $this->loadings[$name] = $integration->init();
             } else {
                 $this->loadings[$name] = $class::load();
             }

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -72,7 +72,7 @@ class IntegrationsLoader
     public function __construct(array $integrations)
     {
         $this->integrations = $integrations;
-        // Sandboxed integrations - eventually this will replace all the integrations
+        // Sandboxed integrations get loaded with a feature flag
         if (Configuration::get()->isSandboxEnabled()) {
             $this->integrations[PDOSandboxedIntegration::NAME] = '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
         }
@@ -126,7 +126,11 @@ class IntegrationsLoader
                 continue;
             }
 
-            $this->loadings[$name] = call_user_func([$class, 'load']);
+            if (strpos($class, 'SandboxedIntegration') !== false) {
+                $this->loadings[$name] = $class::get()->init();
+            } else {
+                $this->loadings[$name] = $class::load();
+            }
             $this->logResult($name, $this->loadings[$name]);
         }
     }

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -14,6 +14,7 @@ use DDTrace\Integrations\Memcached\MemcachedIntegration;
 use DDTrace\Integrations\Mongo\MongoIntegration;
 use DDTrace\Integrations\Mysqli\MysqliIntegration;
 use DDTrace\Integrations\PDO\PDOIntegration;
+use DDTrace\Integrations\PDO\PDOSandboxedIntegration;
 use DDTrace\Integrations\Predis\PredisIntegration;
 use DDTrace\Integrations\Slim\SlimIntegration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration;
@@ -71,6 +72,10 @@ class IntegrationsLoader
     public function __construct(array $integrations)
     {
         $this->integrations = $integrations;
+        // Sandboxed integrations - eventually this will replace all the integrations
+        if (Configuration::get()->isSandboxEnabled()) {
+            $this->integrations[PDOSandboxedIntegration::NAME] = '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
+        }
     }
 
     /**
@@ -180,6 +185,12 @@ class IntegrationsLoader
     public static function load()
     {
         self::get()->loadAll();
+    }
+
+    public static function reload()
+    {
+        self::$instance = null;
+        self::load();
     }
 
     public function reset()

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -387,14 +387,15 @@ class PDOIntegration extends Integration
 
     public static function storeConnectionParams($pdo, array $constructorArgs)
     {
+        $hash = is_object($pdo) ? spl_object_hash($pdo) : '';
         if (count($constructorArgs) > 0) {
             $tags = self::parseDsn($constructorArgs[0]);
             if (isset($constructorArgs[1])) {
                 $tags['db.user'] = $constructorArgs[1];
             }
-            self::$connections[spl_object_hash($pdo)] = $tags;
+            self::$connections[$hash] = $tags;
         } else {
-            self::$connections[spl_object_hash($pdo)] = array();
+            self::$connections[$hash] = array();
         }
     }
 
@@ -404,15 +405,15 @@ class PDOIntegration extends Integration
             // When an error occurs 'FALSE' will be returned in place of the statement.
             return;
         }
-        $pdoHash = spl_object_hash($pdo);
+        $pdoHash = is_object($pdo) ? spl_object_hash($pdo) : '';
         if (isset(self::$connections[$pdoHash])) {
-            self::$statements[spl_object_hash($stmt)] = $pdoHash;
+            self::$statements[is_object($stmt) ? spl_object_hash($stmt) : ''] = $pdoHash;
         }
     }
 
     public static function setConnectionTags($pdo, $span)
     {
-        $hash = spl_object_hash($pdo);
+        $hash = is_object($pdo) ? spl_object_hash($pdo) : '';
         if (!isset(self::$connections[$hash])) {
             return;
         }
@@ -424,7 +425,7 @@ class PDOIntegration extends Integration
 
     public static function setStatementTags($stmt, $span)
     {
-        $stmtHash = spl_object_hash($stmt);
+        $stmtHash = is_object($stmt) ? spl_object_hash($stmt) : '';
         if (!isset(self::$statements[$stmtHash])) {
             return;
         }

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -43,6 +43,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
 
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace_method('PDO', '__construct', function (SpanData $span, array $args) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = $span->resource = 'PDO.__construct';
             $span->service = 'PDO';
             $span->type = Type::SQL;
@@ -51,6 +54,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
 
         // public int PDO::exec(string $query)
         dd_trace_method('PDO', 'exec', function (SpanData $span, array $args, $retval) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = 'PDO.exec';
             $span->resource = $args[0];
             $span->service = 'PDO';
@@ -71,6 +77,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
         // public int PDO::exec(string $query)
         dd_trace_method('PDO', 'query', function (SpanData $span, array $args, $retval) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = 'PDO.query';
             $span->resource = $args[0];
             $span->service = 'PDO';
@@ -88,6 +97,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
 
         // public bool PDO::commit ( void )
         dd_trace_method('PDO', 'commit', function (SpanData $span) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = $span->resource = 'PDO.commit';
             $span->service = 'PDO';
             $span->type = Type::SQL;
@@ -96,6 +108,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
 
         // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
         dd_trace_method('PDO', 'prepare', function (SpanData $span, array $args, $retval) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = 'PDO.prepare';
             $span->resource = $args[0];
             $span->service = 'PDO';
@@ -106,6 +121,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
 
         // public bool PDOStatement::execute ([ array $input_parameters ] )
         dd_trace_method('PDOStatement', 'execute', function (SpanData $span, array $args, $retval) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
             $span->name = 'PDOStatement.execute';
             $span->resource = $this->queryString;
             $span->service = 'PDO';

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -2,12 +2,12 @@
 
 namespace DDTrace\Integrations\PDO;
 
-use DDTrace\Integrations\Integration;
+use DDTrace\Integrations\SandboxedIntegration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
 
-class PDOSandboxedIntegration extends Integration
+class PDOSandboxedIntegration extends SandboxedIntegration
 {
     const NAME = 'pdo';
 
@@ -22,22 +22,6 @@ class PDOSandboxedIntegration extends Integration
     private static $statements = [];
 
     /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function getInstance()
-    {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    /**
      * @return string The integration name.
      */
     public function getName()
@@ -46,13 +30,13 @@ class PDOSandboxedIntegration extends Integration
     }
 
     /**
-     * Static method to add instrumentation to PDO requests
+     * Add instrumentation to PDO requests
      */
-    public static function load()
+    public function init()
     {
         if (!extension_loaded('PDO')) {
             // PDO is provided through an extension and not through a class loader.
-            return Integration::NOT_AVAILABLE;
+            return SandboxedIntegration::NOT_AVAILABLE;
         }
 
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
@@ -73,7 +57,7 @@ class PDOSandboxedIntegration extends Integration
                 'db.rowcount' => (string) $retval,
             ];
             PDOSandboxedIntegration::setConnectionTags($this, $span);
-            PDOSandboxedIntegration::getInstance()->addTraceAnalyticsIfEnabled($span);
+            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
         });
 
         // public PDOStatement PDO::query(string $query)
@@ -93,7 +77,7 @@ class PDOSandboxedIntegration extends Integration
                 PDOSandboxedIntegration::storeStatementFromConnection($this, $retval);
             }
             PDOSandboxedIntegration::setConnectionTags($this, $span);
-            PDOSandboxedIntegration::getInstance()->addTraceAnalyticsIfEnabled($span);
+            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
         });
 
         // public bool PDO::commit ( void )
@@ -124,10 +108,10 @@ class PDOSandboxedIntegration extends Integration
                 'db.rowcount' => (string) $this->rowCount(),
             ];
             PDOSandboxedIntegration::setStatementTags($this, $span);
-            PDOSandboxedIntegration::getInstance()->addTraceAnalyticsIfEnabled($span);
+            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
         });
 
-        return Integration::LOADED;
+        return SandboxedIntegration::LOADED;
     }
 
     private static function parseDsn($dsn)

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -58,9 +58,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.exec';
-            $span->resource = $args[0];
             $span->service = 'PDO';
             $span->type = Type::SQL;
+            $span->resource = (string) $args[0];
             if (is_numeric($retval)) {
                 $span->meta = [
                     'db.rowcount' => (string) $retval,
@@ -81,9 +81,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.query';
-            $span->resource = $args[0];
             $span->service = 'PDO';
             $span->type = Type::SQL;
+            $span->resource = (string) $args[0];
             if ($retval instanceof \PDOStatement) {
                 $span->meta = [
                     'db.rowcount' => (string) $retval->rowCount(),
@@ -112,9 +112,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.prepare';
-            $span->resource = $args[0];
             $span->service = 'PDO';
             $span->type = Type::SQL;
+            $span->resource = (string) $args[0];
             PDOSandboxedIntegration::setConnectionTags($this, $span);
             PDOSandboxedIntegration::storeStatementFromConnection($this, $retval);
         });
@@ -125,9 +125,9 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDOStatement.execute';
-            $span->resource = $this->queryString;
             $span->service = 'PDO';
             $span->type = Type::SQL;
+            $span->resource = (string) $this->queryString;
             if ($retval === true) {
                 $span->meta = [
                     'db.rowcount' => (string) $this->rowCount(),
@@ -200,7 +200,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
     {
         $tags = self::parseDsn($constructorArgs[0]);
         if (isset($constructorArgs[1])) {
-            $tags['db.user'] = $constructorArgs[1];
+            $tags['db.user'] = (string) $constructorArgs[1];
         }
         self::$connections[spl_object_hash($pdo)] = $tags;
         return $tags;
@@ -225,7 +225,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
             return;
         }
         foreach (self::$connections[$hash] as $tag => $value) {
-            $span->meta[$tag] = $value;
+            $span->meta[$tag] = (string) $value;
         }
     }
 
@@ -239,7 +239,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
             return;
         }
         foreach (self::$connections[self::$statements[$stmtHash]] as $tag => $value) {
-            $span->meta[$tag] = $value;
+            $span->meta[$tag] = (string) $value;
         }
     }
 }

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -1,0 +1,434 @@
+<?php
+
+namespace DDTrace\Integrations\PDO;
+
+use DDTrace\Integrations\Integration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+use DDTrace\GlobalTracer;
+
+class PDOSandboxedIntegration extends Integration
+{
+    const NAME = 'pdo';
+
+    /**
+     * @var array
+     */
+    private static $connections = [];
+
+    /**
+     * @var array
+     */
+    private static $statements = [];
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Static method to add instrumentation to PDO requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('PDO')) {
+            // PDO is provided through an extension and not through a class loader.
+            return Integration::NOT_AVAILABLE;
+        }
+
+        // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
+        dd_trace('PDO', '__construct', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                PDOSandboxedIntegration::getInstance(),
+                'PDO.__construct'
+            );
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, 'db');
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::RESOURCE_NAME, 'PDO.__construct');
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            try {
+                dd_trace_forward_call();
+                PDOSandboxedIntegration::storeConnectionParams($this, func_get_args());
+                PDOSandboxedIntegration::detectError($span, $this);
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $this;
+        });
+
+        // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
+        /*
+        dd_trace_method('PDO', '__construct', function (SpanData $span, array $args) {
+            $span->name = $span->resource = 'PDO.__construct';
+            $span->service = 'PDO';
+            $span->type = 'db';
+            // TODO Bind $this to tracing closure
+            $span->meta = PDOSandboxedIntegration::storeConnectionParams($this, $args);
+        });
+        */
+
+        // public int PDO::exec(string $query)
+        dd_trace('PDO', 'exec', function ($statement) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOSandboxedIntegration::getInstance(), 'PDO.exec');
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::RESOURCE_NAME, $statement);
+            $span->setTraceAnalyticsCandidate();
+            PDOSandboxedIntegration::setConnectionTags($this, $span);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = dd_trace_forward_call();
+                PDOSandboxedIntegration::detectError($span, $this);
+                $span->setTag('db.rowcount', $result);
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        // public PDOStatement PDO::query(string $query)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_COLUMN, int $colno)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
+        // public int PDO::exec(string $query)
+        dd_trace('PDO', 'query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOSandboxedIntegration::getInstance(), 'PDO.query');
+            $args = func_get_args();
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::RESOURCE_NAME, $args[0]);
+            $span->setTraceAnalyticsCandidate();
+            PDOSandboxedIntegration::setConnectionTags($this, $span);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = dd_trace_forward_call();
+                PDOSandboxedIntegration::detectError($span, $this);
+                PDOSandboxedIntegration::storeStatementFromConnection($this, $result);
+                try {
+                    $span->setTag('db.rowcount', $result !== false ? $result->rowCount() : '');
+                } catch (\Exception $e) {
+                }
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        // public bool PDO::commit ( void )
+        dd_trace('PDO', 'commit', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOSandboxedIntegration::getInstance(), 'PDO.commit');
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            PDOSandboxedIntegration::setConnectionTags($this, $span);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = dd_trace_forward_call();
+                PDOSandboxedIntegration::detectError($span, $this);
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
+        /*
+        dd_trace_method('PDO', 'prepare', function (SpanData $span, array $args, $retval) {
+            $span->name = 'PDO.prepare';
+            $span->resource = $args[0];
+            $span->service = 'PDO';
+            $span->type = 'db';
+            // TODO Bind $this to tracing closure
+            $span->meta = PDOSandboxedIntegration::storeConnectionParams($this, $args);
+
+            PDOSandboxedIntegration::setConnectionTags($this, $span);
+            PDOSandboxedIntegration::storeStatementFromConnection($this, $retval);
+        });
+        */
+
+        // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
+        dd_trace('PDO', 'prepare', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $args = func_get_args();
+            $scope = $tracer->startIntegrationScopeAndSpan(PDOSandboxedIntegration::getInstance(), 'PDO.prepare');
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::RESOURCE_NAME, $args[0]);
+            PDOSandboxedIntegration::setConnectionTags($this, $span);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = dd_trace_forward_call();
+                PDOSandboxedIntegration::storeStatementFromConnection($this, $result);
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        // public bool PDOStatement::execute ([ array $input_parameters ] )
+        dd_trace('PDOStatement', 'execute', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                PDOSandboxedIntegration::getInstance(),
+                'PDOStatement.execute'
+            );
+            $span = $scope->getSpan();
+            $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::RESOURCE_NAME, $this->queryString);
+            $span->setTraceAnalyticsCandidate();
+            PDOSandboxedIntegration::setStatementTags($this, $span);
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            $result = null;
+            try {
+                $result = dd_trace_forward_call();
+                PDOSandboxedIntegration::detectError($span, $this);
+                try {
+                    $span->setTag('db.rowcount', $this->rowCount());
+                } catch (\Exception $e) {
+                }
+            } catch (\Exception $e) {
+                PDOSandboxedIntegration::setErrorOnException($span, $e);
+                $thrown = $e;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        return Integration::LOADED;
+    }
+
+    /**
+     * @param \DDTrace\Span $span
+     * @param \PDO|\PDOStatement $pdo_or_statement
+     */
+    public static function detectError($span, $pdo_or_statement)
+    {
+        $errorCode = $pdo_or_statement->errorCode();
+        // Error codes follows the ANSI SQL-92 convention of 5 total chars:
+        //   - 2 chars for class value
+        //   - 3 chars for subclass value
+        // Non error class values are: '00', '01', 'IM'
+        // @see: http://php.net/manual/en/pdo.errorcode.php
+        if (strlen($errorCode) != 5) {
+            return;
+        }
+
+        $class = strtoupper(substr($errorCode, 0, 2));
+        if (in_array($class, ['00', '01', 'IM'])) {
+            // Not an error
+            return;
+        }
+        $errorInfo = $pdo_or_statement->errorInfo();
+        $span->setRawError(
+            'SQL error: ' . $errorCode . '. Driver error: ' . $errorInfo[1],
+            get_class($pdo_or_statement) . ' error'
+        );
+    }
+
+    /**
+     * @param \DDTrace\Span $span
+     * @param \PDO $pdo
+     * @param null $exception
+     */
+    public static function setErrorOnException($span, $exception)
+    {
+        $span->setRawError(
+            self::extractErrorInfo($exception->getMessage()),
+            get_class($exception)
+        );
+    }
+
+    private static function extractErrorInfo($message)
+    {
+        $matches = [];
+        $isKnownFormat = preg_match('/^(SQLSTATE\[\w.*\] \[\d.*\]).*/', $message, $matches);
+        return $isKnownFormat ? ('Sql error: ' . $matches[1]) : 'Sql error';
+    }
+
+    private static function parseDsn($dsn)
+    {
+        $engine = substr($dsn, 0, strpos($dsn, ':'));
+        $tags = ['db.engine' => $engine];
+        $valStrings = explode(';', substr($dsn, strlen($engine) + 1));
+        foreach ($valStrings as $valString) {
+            if (!strpos($valString, '=')) {
+                continue;
+            }
+            list($key, $value) = explode('=', $valString);
+            switch ($key) {
+                case 'charset':
+                    $tags['db.charset'] = $value;
+                    break;
+                case 'dbname':
+                    $tags['db.name'] = $value;
+                    break;
+                case 'host':
+                    $tags[Tag::TARGET_HOST] = $value;
+                    break;
+                case 'port':
+                    $tags[Tag::TARGET_PORT] = $value;
+                    break;
+            }
+        }
+
+        return $tags;
+    }
+
+    public static function storeConnectionParams($pdo, array $constructorArgs)
+    {
+        $tags = self::parseDsn($constructorArgs[0]);
+        if (isset($constructorArgs[1])) {
+            $tags['db.user'] = $constructorArgs[1];
+        }
+        self::$connections[spl_object_hash($pdo)] = $tags;
+        return $tags;
+    }
+
+    public static function storeStatementFromConnection($pdo, $stmt)
+    {
+        if (!$stmt) {
+            // When an error occurs 'FALSE' will be returned in place of the statement.
+            return;
+        }
+        $pdoHash = spl_object_hash($pdo);
+        if (isset(self::$connections[$pdoHash])) {
+            self::$statements[spl_object_hash($stmt)] = $pdoHash;
+        }
+    }
+
+    public static function setConnectionTags($pdo, $span)
+    {
+        $hash = spl_object_hash($pdo);
+        if (!isset(self::$connections[$hash])) {
+            return;
+        }
+
+        foreach (self::$connections[$hash] as $tag => $value) {
+            $span->setTag($tag, $value);
+        }
+    }
+
+    public static function setStatementTags($stmt, $span)
+    {
+        $stmtHash = spl_object_hash($stmt);
+        if (!isset(self::$statements[$stmtHash])) {
+            return;
+        }
+        if (!isset(self::$connections[self::$statements[$stmtHash]])) {
+            return;
+        }
+
+        foreach (self::$connections[self::$statements[$stmtHash]] as $tag => $value) {
+            $span->setTag($tag, $value);
+        }
+    }
+}

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -39,6 +39,8 @@ class PDOSandboxedIntegration extends SandboxedIntegration
             return SandboxedIntegration::NOT_AVAILABLE;
         }
 
+        $integration = $this;
+
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace_method('PDO', '__construct', function (SpanData $span, array $args) {
             $span->name = $span->resource = 'PDO.__construct';
@@ -48,7 +50,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public int PDO::exec(string $query)
-        dd_trace_method('PDO', 'exec', function (SpanData $span, array $args, $retval) {
+        dd_trace_method('PDO', 'exec', function (SpanData $span, array $args, $retval) use ($integration) {
             $span->name = 'PDO.exec';
             $span->resource = $args[0];
             $span->service = 'PDO';
@@ -59,7 +61,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 ];
             }
             PDOSandboxedIntegration::setConnectionTags($this, $span);
-            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
+            $integration->addTraceAnalyticsIfEnabled($span);
             PDOSandboxedIntegration::detectError($this, $span);
         });
 
@@ -68,7 +70,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
         // public int PDO::exec(string $query)
-        dd_trace_method('PDO', 'query', function (SpanData $span, array $args, $retval) {
+        dd_trace_method('PDO', 'query', function (SpanData $span, array $args, $retval) use ($integration) {
             $span->name = 'PDO.query';
             $span->resource = $args[0];
             $span->service = 'PDO';
@@ -80,7 +82,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 PDOSandboxedIntegration::storeStatementFromConnection($this, $retval);
             }
             PDOSandboxedIntegration::setConnectionTags($this, $span);
-            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
+            $integration->addTraceAnalyticsIfEnabled($span);
             PDOSandboxedIntegration::detectError($this, $span);
         });
 
@@ -103,7 +105,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public bool PDOStatement::execute ([ array $input_parameters ] )
-        dd_trace_method('PDOStatement', 'execute', function (SpanData $span, array $args, $retval) {
+        dd_trace_method('PDOStatement', 'execute', function (SpanData $span, array $args, $retval) use ($integration) {
             $span->name = 'PDOStatement.execute';
             $span->resource = $this->queryString;
             $span->service = 'PDO';
@@ -114,7 +116,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 ];
             }
             PDOSandboxedIntegration::setStatementTags($this, $span);
-            PDOSandboxedIntegration::get()->addTraceAnalyticsIfEnabled($span);
+            $integration->addTraceAnalyticsIfEnabled($span);
             PDOSandboxedIntegration::detectError($this, $span);
         });
 

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DDTrace\Integrations;
+
+abstract class SandboxedIntegration extends Integration
+{
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function get()
+    {
+        if (null === self::$instance) {
+            self::$instance = new static();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Load the integration
+     *
+     * @return int
+     */
+    abstract public function init();
+}

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -8,22 +8,6 @@ use DDTrace\Tag;
 abstract class SandboxedIntegration extends Integration
 {
     /**
-     * @var self
-     */
-    private static $instance;
-
-    /**
-     * @return self
-     */
-    public static function get()
-    {
-        if (null === self::$instance) {
-            self::$instance = new static();
-        }
-        return self::$instance;
-    }
-
-    /**
      * Load the integration
      *
      * @return int

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -2,6 +2,9 @@
 
 namespace DDTrace\Integrations;
 
+use DDTrace\SpanData;
+use DDTrace\Tag;
+
 abstract class SandboxedIntegration extends Integration
 {
     /**
@@ -26,4 +29,12 @@ abstract class SandboxedIntegration extends Integration
      * @return int
      */
     abstract public function init();
+
+    public function addTraceAnalyticsIfEnabled(SpanData $span)
+    {
+        if (!$this->configuration->isTraceAnalyticsEnabled()) {
+            return;
+        }
+        $span->metrics[Tag::ANALYTICS_KEY] = $this->configuration->getTraceAnalyticsSampleRate();
+    }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -347,11 +347,12 @@ final class Tracer implements TracerInterface
      */
     public function getTracesAsArray()
     {
-        $tracesToBeSent = [];
+        $internalSpans = dd_trace_serialize_closed_spans();
+        $tracesToBeSent = $internalSpans ? [$internalSpans] : [];
         $autoFinishSpans = $this->globalConfig->isAutofinishSpansEnabled();
 
         foreach ($this->traces as $trace) {
-            $traceToBeSent = dd_trace_serialize_closed_spans();
+            $traceToBeSent = [];
             foreach ($trace as $span) {
                 if ($span->duration === null) { // is span not finished
                     if (!$autoFinishSpans) {

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -224,6 +224,9 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span TSRMLS_DC) {
     }
 
     _serialize_exception(el, meta, span TSRMLS_CC);
+    if (!span->exception && zend_hash_exists(Z_ARRVAL_P(meta), "error.msg", sizeof("error.msg"))) {
+        add_assoc_long(el, "error", 1);
+    }
     if (span->parent_id == 0) {
         add_assoc_long(meta, "system.pid", (uint) span->pid);
     }
@@ -282,6 +285,12 @@ void _serialize_meta(zval *el, ddtrace_span_t *span) {
     meta = &meta_zv;
 
     _serialize_exception(el, meta, span);
+    if (!span->exception) {
+        zval *error = zend_hash_str_find_ptr(Z_ARR_P(meta), "error.msg", sizeof("error.msg") - 1);
+        if (error) {
+            add_assoc_long(el, "error", 1);
+        }
+    }
     if (span->parent_id == 0) {
         add_assoc_long(meta, "system.pid", (zend_long) span->pid);
     }

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -228,7 +228,7 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span TSRMLS_DC) {
         add_assoc_long(el, "error", 1);
     }
     if (span->parent_id == 0) {
-        add_assoc_long(meta, "system.pid", (uint) span->pid);
+        add_assoc_long(meta, "system.pid", (uint)span->pid);
     }
 
     // Add meta only if it has elements
@@ -292,7 +292,7 @@ void _serialize_meta(zval *el, ddtrace_span_t *span) {
         }
     }
     if (span->parent_id == 0) {
-        add_assoc_long(meta, "system.pid", (zend_long) span->pid);
+        add_assoc_long(meta, "system.pid", (zend_long)span->pid);
     }
 
     if (zend_array_count(Z_ARRVAL_P(meta))) {

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -206,7 +206,7 @@ static void _serialize_exception(zval *el, zval *meta, ddtrace_span_t *span TSRM
     /* add_assoc_stringl does not actually mutate the string, but we've either
      * already made a copy, or it will when it duplicates with dup param, so
      * if it did it should still be safe. */
-    add_assoc_stringl(meta, "error.name", (char *)class_name, class_name_len, needs_copied);
+    add_assoc_stringl(meta, "error.type", (char *)class_name, class_name_len, needs_copied);
     add_assoc_zval(meta, "error.msg", msg);
     add_assoc_zval(meta, "error.stack", stack);
 }
@@ -263,7 +263,7 @@ static void _serialize_exception(zval *el, zval *meta, ddtrace_span_t *span) {
     zend_call_method_with_0_params(&exception, Z_OBJCE(exception), NULL, "getmessage", &msg);
     zend_call_method_with_0_params(&exception, Z_OBJCE(exception), NULL, "gettraceasstring", &stack);
 
-    _add_assoc_zval_copy(meta, "error.name", &name);
+    _add_assoc_zval_copy(meta, "error.type", &name);
     add_assoc_zval(meta, "error.msg", &msg);
     add_assoc_zval(meta, "error.stack", &stack);
 }

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -2,6 +2,7 @@
 
 #include <php.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "ddtrace.h"
 #include "dispatch_compat.h"
@@ -81,6 +82,7 @@ ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
     span->trace_id = DDTRACE_G(root_span_id);
     span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);
     span->exception = NULL;
+    span->pid = getpid();
     // Start time is nanoseconds from unix epoch
     // @see https://docs.datadoghq.com/api/?lang=python#send-traces
     span->start = _get_nanoseconds(USE_REALTIME_CLOCK);

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -3,6 +3,7 @@
 #include <Zend/zend_types.h>
 #include <php.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #include "compatibility.h"
 
@@ -21,6 +22,7 @@ typedef struct ddtrace_span_t {
         uint64_t duration_start;
         uint64_t duration;
     };
+    pid_t pid;
     struct ddtrace_span_t *next;
 } ddtrace_span_t;
 

--- a/src/ext/trace.c
+++ b/src/ext/trace.c
@@ -58,10 +58,17 @@ void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc,
 
     BOOL_T keep_span = TRUE;
     if (fcall_status == SUCCESS && Z_TYPE(dispatch->callable) == IS_OBJECT) {
+        zend_error_handling error_handling;
         int orig_error_reporting = EG(error_reporting);
         EG(error_reporting) = 0;
+#if PHP_VERSION_ID < 70000
+        zend_replace_error_handling(EH_SUPPRESS, NULL, &error_handling TSRMLS_CC);
+#else
+        zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
+#endif
         keep_span = ddtrace_execute_tracing_closure(&dispatch->callable, span->span_data, execute_data, &user_args,
                                                     user_retval, exception TSRMLS_CC);
+        zend_restore_error_handling(&error_handling TSRMLS_CC);
         EG(error_reporting) = orig_error_reporting;
         // If the tracing closure threw an exception, ignore it to not impact the original call
         if (EG(exception)) {

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -12,35 +12,25 @@ abstract class IntegrationTestCase extends TestCase
     use TracerTestTrait, SpanAssertionTrait;
 
     /**
-     * @var SpanChecker
-     */
-    private $spanChecker;
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->spanChecker = new SpanChecker($this);
-    }
-
-    /**
      * Checks the exact match of a set of SpanAssertion with the provided Spans.
      *
-     * @param $traces
+     * @param array[] $traces
      * @param SpanAssertion[] $expectedSpans
+     * @param bool $isSandbox
      */
-    public function assertSpans($traces, $expectedSpans)
+    public function assertSpans($traces, $expectedSpans, $isSandbox = false)
     {
-        $this->assertExpectedSpans($this, $traces, $expectedSpans);
+        $this->assertExpectedSpans($traces, $expectedSpans, $isSandbox);
     }
 
     /**
      * Checks that the provide span exists in the provided traces and matches expectations.
      *
-     * @param Span[][] $traces
+     * @param array[] $traces
      * @param SpanAssertion $expectedSpan
      */
     public function assertOneSpan($traces, SpanAssertion $expectedSpan)
     {
-        $this->assertOneExpectedSpan($this, $traces, $expectedSpan);
+        $this->assertOneExpectedSpan($traces, $expectedSpan);
     }
 }

--- a/tests/Common/Model/DummyIntegration.php
+++ b/tests/Common/Model/DummyIntegration.php
@@ -28,7 +28,7 @@ final class DummyIntegration extends Integration
      * DummyIntegration constructor.
      * @param $name
      */
-    protected function __construct($name)
+    public function __construct($name)
     {
         parent::__construct();
         $this->name = $name;

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -21,6 +21,7 @@ final class SpanAssertion
     private $resource = SpanAssertion::NOT_TESTED;
     private $onlyCheckExistence = false;
     private $isTraceAnalyticsCandidate = false;
+    private $isSandboxedTraceAnalyticsCandidate = false;
 
     /**
      * @param string $name
@@ -259,6 +260,23 @@ final class SpanAssertion
     public function isTraceAnalyticsCandidate()
     {
         return $this->isTraceAnalyticsCandidate;
+    }
+
+    /**
+     * @return self
+     */
+    public function setSandboxedTraceAnalyticsCandidate()
+    {
+        $this->isSandboxedTraceAnalyticsCandidate = true;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSandboxedTraceAnalyticsCandidate()
+    {
+        return $this->isSandboxedTraceAnalyticsCandidate;
     }
 
     /**

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Common;
 
+use DDTrace\Configuration;
 use DDTrace\Tag;
 
 final class SpanAssertion
@@ -21,7 +22,6 @@ final class SpanAssertion
     private $resource = SpanAssertion::NOT_TESTED;
     private $onlyCheckExistence = false;
     private $isTraceAnalyticsCandidate = false;
-    private $isSandboxedTraceAnalyticsCandidate = false;
 
     /**
      * @param string $name
@@ -91,9 +91,10 @@ final class SpanAssertion
     /**
      * @param string|null $errorType The expected error.type
      * @param string|null $errorMessage The expected error.msg
+     * @param bool $exceptionThrown If we would expect error.stack (sandbox only)
      * @return $this
      */
-    public function setError($errorType = null, $errorMessage = null)
+    public function setError($errorType = null, $errorMessage = null, $exceptionThrown = false)
     {
         $this->hasError = true;
         if (isset($this->exactTags[Tag::ERROR_TYPE])) {
@@ -106,6 +107,9 @@ final class SpanAssertion
         }
         if (null !== $errorMessage) {
             $this->exactTags[Tag::ERROR_MSG] = $errorMessage;
+        }
+        if ($exceptionThrown && Configuration::get()->isSandboxEnabled()) {
+            $this->existingTags[] = Tag::ERROR_STACK;
         }
         return $this;
     }
@@ -192,7 +196,7 @@ final class SpanAssertion
     }
 
     /**
-     * @return string
+     * @return string[]
      */
     public function getExactTags()
     {
@@ -260,23 +264,6 @@ final class SpanAssertion
     public function isTraceAnalyticsCandidate()
     {
         return $this->isTraceAnalyticsCandidate;
-    }
-
-    /**
-     * @return self
-     */
-    public function setSandboxedTraceAnalyticsCandidate()
-    {
-        $this->isSandboxedTraceAnalyticsCandidate = true;
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isSandboxedTraceAnalyticsCandidate()
-    {
-        return $this->isSandboxedTraceAnalyticsCandidate;
     }
 
     /**

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -115,12 +115,12 @@ final class SpanAssertion
     }
 
     /**
-     * @param array $tags
+     * @param array|string $tags
      * @return $this
      */
-    public function withExactTags(array $tags)
+    public function withExactTags($tags)
     {
-        if (is_array($this->exactTags)) {
+        if (is_array($this->exactTags) && is_array($tags)) {
             $this->exactTags = array_merge($this->exactTags, $tags);
         } else {
             $this->exactTags = $tags;

--- a/tests/Common/SpanAssertionTrait.php
+++ b/tests/Common/SpanAssertionTrait.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Common;
 
-use DDTrace\Span;
 use PHPUnit\Framework\TestCase;
 
 trait SpanAssertionTrait
@@ -10,32 +9,31 @@ trait SpanAssertionTrait
     /**
      * Checks the exact match of a set of SpanAssertion with the provided Spans.
      *
-     * @param $testCase
-     * @param $traces
+     * @param array[] $traces
      * @param SpanAssertion[] $expectedSpans
+     * @param bool $isSandbox
      */
-    public function assertExpectedSpans($testCase, $traces, $expectedSpans)
+    public function assertExpectedSpans($traces, $expectedSpans, $isSandbox = false)
     {
-        (new SpanChecker($testCase))->assertSpans($traces, $expectedSpans);
+        (new SpanChecker())->assertSpans($traces, $expectedSpans, $isSandbox);
     }
 
     /**
      * Checks that the provide span exists in the provided traces and matches expectations.
      *
-     * @param TestCase $testCase
      * @param array[] $traces
      * @param SpanAssertion $expectedSpan
      */
-    public function assertOneExpectedSpan($testCase, $traces, SpanAssertion $expectedSpan)
+    public function assertOneExpectedSpan($traces, SpanAssertion $expectedSpan)
     {
-        $spanChecker = new SpanChecker($testCase);
+        $spanChecker = new SpanChecker();
 
         $found = array_filter($spanChecker->flattenTraces($traces), function ($span) use ($expectedSpan) {
             return $span['name'] === $expectedSpan->getOperationName();
         });
 
         if (empty($found)) {
-            $testCase->fail('Span not found in traces: ' . $expectedSpan->getOperationName());
+            TestCase::fail('Span not found in traces: ' . $expectedSpan->getOperationName());
         } else {
             $spanChecker->assertSpan($found[0], $expectedSpan);
         }

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Common;
 
+use DDTrace\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -105,6 +106,13 @@ final class SpanChecker
             foreach ($exp->getExistingTagNames($hasNoPid) as $tagName) {
                 $this->testCase->assertArrayHasKey($tagName, $span['meta']);
             }
+        }
+        if ($exp->isSandboxedTraceAnalyticsCandidate()) {
+            TestCase::assertArrayHasKey(
+                Tag::ANALYTICS_KEY,
+                isset($span['metrics']) ? $span['metrics'] : [],
+                $namePrefix . 'Trace Analytics key expected but not found'
+            );
         }
         if ($exp->getExactMetrics() !== SpanAssertion::NOT_TESTED) {
             $this->testCase->assertEquals(

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Common;
 
+use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
 use PHPUnit\Framework\TestCase;
 
@@ -16,6 +17,10 @@ final class SpanIntegrationChecker
     public function defineIntegrationsByPattern()
     {
         // <regex pattern> => <integration class>
+        $pdoIntegration = 'DDTrace\Integrations\PDO\PDOIntegration';
+        if (Configuration::get()->isSandboxEnabled()) {
+            $pdoIntegration = 'DDTrace\Integrations\PDO\PDOSandboxedIntegration';
+        }
         return [
             // Prepend your operation names with custom for custom spans to have the span check disabled
             '/custom.*/' => null,
@@ -27,7 +32,7 @@ final class SpanIntegrationChecker
             '/Memcached.*/' => 'DDTrace\Integrations\Memcached\MemcachedIntegration',
             '/Mongo(Client)|(DB)|(Collection).*/' => 'DDTrace\Integrations\Mongo\MongoIntegration',
             '/mysqli.*/' => 'DDTrace\Integrations\Mysqli\MysqliIntegration',
-            '/PDO(.)|(Statement).*/' => 'DDTrace\Integrations\PDO\PDOIntegration',
+            '/PDO(.)|(Statement).*/' => $pdoIntegration,
             '/Predis.*/' => 'DDTrace\Integrations\Predis\PredisIntegration',
             '/symfony.*/' => 'DDTrace\Integrations\Symfony\SymfonyIntegration',
             '/web.*/' => 'DDTrace\Integrations\Web\WebIntegration',

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -18,7 +18,7 @@ trait TracerTestTrait
     /**
      * @param $fn
      * @param null $tracer
-     * @return Span[][]
+     * @return array[]
      */
     public function isolateTracer($fn, $tracer = null)
     {
@@ -38,7 +38,7 @@ trait TracerTestTrait
     /**
      * @param $fn
      * @param null $tracer
-     * @return Span[][]
+     * @return array[]
      */
     public function isolateLimitedTracer($fn, $tracer = null)
     {
@@ -211,8 +211,8 @@ trait TracerTestTrait
     }
 
     /**
-     * @param $fn
-     * @return Span[][]
+     * @param \Closure $fn
+     * @return array[]
      */
     public function simulateWebRequestTracer($fn)
     {
@@ -238,7 +238,7 @@ trait TracerTestTrait
 
     /**
      * @param DebugTransport $transport
-     * @return Span[][]
+     * @return array[]
      */
     protected function flushAndGetTraces($transport)
     {
@@ -252,7 +252,7 @@ trait TracerTestTrait
     /**
      * @param $name string
      * @param $fn
-     * @return Span[][]
+     * @return array[]
      */
     public function inTestScope($name, $fn)
     {

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -104,7 +104,7 @@ trait TracerTestTrait
      *
      * @param $fn
      * @param null $tracer
-     * @return Span[][]
+     * @return array[]
      * @throws \Exception
      */
     public function tracesFromWebRequest($fn, $tracer = null)

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -33,7 +33,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build('laravel.request', 'laravel', 'web', 'HomeController@simple simple_route')

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Laravel/V5_7/PipelineTracingTest.php
+++ b/tests/Integrations/Laravel/V5_7/PipelineTracingTest.php
@@ -25,7 +25,7 @@ class PipelineTracingTest extends WebFrameworkTestCase
             $response = $this->call($spec);
             $this->assertSame('done', $response);
         });
-        $this->assertExpectedSpans($this, $traces, [
+        $this->assertExpectedSpans($traces, [
             SpanAssertion::exists('laravel.request'),
             SpanAssertion::build(
                 'laravel.pipeline.pipe',
@@ -44,7 +44,7 @@ class PipelineTracingTest extends WebFrameworkTestCase
             $response = $this->call($spec);
             $this->assertSame('done1/done2', $response);
         });
-        $this->assertExpectedSpans($this, $traces, [
+        $this->assertExpectedSpans($traces, [
             SpanAssertion::exists('laravel.request'),
             SpanAssertion::build(
                 'laravel.pipeline.pipe',

--- a/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/PDO/BrokenPDOStatement.php
+++ b/tests/Integrations/PDO/BrokenPDOStatement.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\PDO;
+
+class BrokenPDOStatement
+{
+    private $query;
+
+    public function __construct($query)
+    {
+        $this->query = $query;
+    }
+
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    // No __toString() magic method
+}

--- a/tests/Integrations/PDO/CustomPDO.php
+++ b/tests/Integrations/PDO/CustomPDO.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\PDO;
+
+class CustomPDO extends \PDO
+{
+    public function prepare($statement, $options = [])
+    {
+        $query = $statement instanceof BrokenPDOStatement
+            ? $statement->getQuery()
+            : (string) $statement;
+        return parent::prepare($query, $options);
+    }
+}

--- a/tests/Integrations/PDO/CustomPDOStatement.php
+++ b/tests/Integrations/PDO/CustomPDOStatement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\PDO;
+
+class CustomPDOStatement
+{
+    private $query;
+
+    public function __construct($query)
+    {
+        $this->query = $query;
+    }
+
+    public function __toString()
+    {
+        return $this->query;
+    }
+}

--- a/tests/Integrations/PDO/PDOSandboxedTest.php
+++ b/tests/Integrations/PDO/PDOSandboxedTest.php
@@ -4,395 +4,66 @@ namespace DDTrace\Tests\Integrations\PDO;
 
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
-use DDTrace\Tests\Common\SpanAssertion;
 
-final class PDOSandboxedTest extends IntegrationTestCase
+final class PDOSandboxedTest extends PDOTest
 {
-    const MYSQL_DATABASE = 'test';
-    const MYSQL_USER = 'test';
-    const MYSQL_PASSWORD = 'test';
-    const MYSQL_HOST = 'mysql_integration';
+    const IS_SANDBOX = true;
+
+    // phpcs:disable
+    const ERROR_CONSTRUCT = 'SQLSTATE[HY000] [1045] Access denied for user \'wrong_user\'@\'%s\' (using password: YES)';
+    const ERROR_EXEC = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY)\' at line 1';
+    const ERROR_QUERY = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1';
+    const ERROR_STATEMENT = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1';
+    // phpcs:enable
 
     public static function setUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        IntegrationTestCase::setUpBeforeClass();
         putenv('DD_TRACE_SANDBOX_ENABLED=true');
         putenv('DD_PDO_ANALYTICS_ENABLED=true');
         IntegrationsLoader::reload();
     }
 
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        putenv('DD_PDO_ANALYTICS_ENABLED');
+        putenv('DD_TRACE_SANDBOX_ENABLED');
+    }
+
     protected function setUp()
     {
-        parent::setUp();
         if (PHP_VERSION_ID < 50600) {
             $this->markTestSkipped('Sandbox API not available on < PHP 5.6');
             return;
         }
-        $this->setUpDatabase();
+        parent::setUp();
     }
 
-    protected function tearDown()
-    {
-        $this->clearDatabase();
-        parent::tearDown();
-    }
-
-    public function testPDOConstructOk()
-    {
-        $traces = $this->isolateTracer(function () {
-                $this->pdoInstance();
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
-                ->withExactTags($this->baseTags()),
-        ]);
-    }
-
-    public function testPDOConstructError()
-    {
-        $traces = $this->isolateTracer(function () {
-            try {
-                new \PDO($this->mysqlDns(), 'wrong_user', 'wrong_password');
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.user' => 'wrong_user',
-                ]))
-                // phpcs:disable
-                ->setException('PDOException', 'SQLSTATE[HY000] [1045] Access denied for user \'wrong_user\'@\'%s\' (using password: YES)'),
-                // phpcs:enable
-        ]);
-    }
-
-    public function testPDOExecOk()
-    {
-        $query = "INSERT INTO tests (id, name) VALUES (100, 'Sam')";
-        $traces = $this->isolateTracer(function () use ($query) {
-            $pdo = $this->pdoInstance();
-            $pdo->beginTransaction();
-            $pdo->exec($query);
-            $pdo->commit();
-            $pdo = null;
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::exists('PDO.commit'),
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
-                ->setSandboxedTraceAnalyticsCandidate()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.rowcount' => '1',
-                ])),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOExecError()
-    {
-        $query = "WRONG QUERY)";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $pdo->beginTransaction();
-                $pdo->exec($query);
-                $pdo->commit();
-                $pdo = null;
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::exists('PDO.commit'),
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOExecException()
-    {
-        $query = "WRONG QUERY)";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-                $pdo->beginTransaction();
-                $pdo->exec($query);
-                $pdo->commit();
-                $pdo = null;
-                $this->fail('Should throw an exception');
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                // phpcs:disable
-                ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY)\' at line 1')
-                // phpcs:enable
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOQuery()
-    {
-        $query = "SELECT * FROM tests WHERE id=1";
-        $traces = $this->isolateTracer(function () use ($query) {
-            $pdo = $this->pdoInstance();
-            $pdo->query($query);
-            $pdo = null;
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.rowcount' => '1',
-                ])),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOQueryError()
-    {
-        $query = "WRONG QUERY";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $pdo->query($query);
-                $pdo = null;
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOQueryException()
-    {
-        $query = "WRONG QUERY";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-                $pdo->query($query);
-                $pdo = null;
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                // phpcs:disable
-                ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1')
-                // phpcs:enable
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOCommit()
-    {
-        $query = "INSERT INTO tests (id, name) VALUES (100, 'Sam')";
-        $traces = $this->isolateTracer(function () use ($query) {
-            $pdo = $this->pdoInstance();
-            $pdo->beginTransaction();
-            $pdo->exec($query);
-            $pdo->commit();
-            $pdo = null;
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.commit', 'PDO', 'sql', 'PDO.commit')
-                ->withExactTags(array_merge($this->baseTags(), [])),
-            SpanAssertion::exists('PDO.exec'),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOStatementOk()
-    {
-        $query = "SELECT * FROM tests WHERE id = ?";
-        $traces = $this->isolateTracer(function () use ($query) {
-            $pdo = $this->pdoInstance();
-            $stmt = $pdo->prepare($query);
-            $stmt->execute([1]);
-            $results = $stmt->fetchAll();
-            $this->assertEquals('Tom', $results[0]['name']);
-            $stmt->closeCursor();
-            $stmt = null;
-            $pdo = null;
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build(
-                'PDOStatement.execute',
-                'PDO',
-                'sql',
-                "SELECT * FROM tests WHERE id = ?"
-            )
-                ->setTraceAnalyticsCandidate()
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.rowcount' => '1',
-                ])),
-            SpanAssertion::build(
-                'PDO.prepare',
-                'PDO',
-                'sql',
-                "SELECT * FROM tests WHERE id = ?"
-            )->withExactTags(array_merge($this->baseTags(), [])),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOStatementError()
-    {
-        $query = "WRONG QUERY";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $stmt = $pdo->prepare($query);
-                $stmt->execute([1]);
-                $stmt->fetchAll();
-                $stmt->closeCursor();
-                $stmt = null;
-                $pdo = null;
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
-                ->setTraceAnalyticsCandidate()
-                ->setError('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
-                    ->withExactTags($this->baseTags()),
-            SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    public function testPDOStatementException()
-    {
-        $query = "WRONG QUERY";
-        $traces = $this->isolateTracer(function () use ($query) {
-            try {
-                $pdo = $this->pdoInstance();
-                $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-                $stmt = $pdo->prepare($query);
-                $stmt->execute([1]);
-                $stmt->fetchAll();
-                $stmt->closeCursor();
-                $stmt = null;
-                $pdo = null;
-            } catch (\PDOException $ex) {
-            }
-        });
-        $this->assertSpans($traces, [
-            SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', $query)
-                ->setTraceAnalyticsCandidate()
-                // phpcs:disable
-                ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1')
-                // phpcs:enable
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::build('PDO.prepare', 'PDO', 'sql', $query)
-                ->withExactTags($this->baseTags()),
-            SpanAssertion::exists('PDO.__construct'),
-        ]);
-    }
-
-    // Add limited tracer to sandboxed closures
-    /*
+    // Remove this fake test after limited tracer added to sandbox API
     public function testLimitedTracerPDO()
     {
-        $query = "SELECT * FROM tests WHERE id = ?";
-        $traces = $this->isolateLimitedTracer(function () use ($query) {
-            $pdo = $this->pdoInstance();
-            $stmt = $pdo->prepare($query);
-            $stmt->execute([1]);
-            $results = $stmt->fetchAll();
-            $this->assertEquals('Tom', $results[0]['name']);
-            $stmt->closeCursor();
-            $stmt = null;
-            $pdo = null;
-        });
-
-        $this->assertEmpty($traces);
+        $this->assertTrue(true);
     }
-    */
 
     // @see https://github.com/DataDog/dd-trace-php/issues/510
     public function testPDOStatementsAreReleased()
     {
         $query = "SELECT * FROM tests WHERE id = ?";
-        $traces = $this->isolateTracer(function () use ($query) {
-            $pdo = new \PDO(
-                $this->mysqlDns(),
-                self::MYSQL_USER,
-                self::MYSQL_PASSWORD,
-                [\PDO::ATTR_EMULATE_PREPARES => false]
-            );
-            $stmt = $pdo->prepare($query);
-            $stmt->execute([1]);
-            unset($stmt);
+        $pdo = new \PDO(
+            $this->mysqlDns(),
+            self::MYSQL_USER,
+            self::MYSQL_PASSWORD,
+            [\PDO::ATTR_EMULATE_PREPARES => false]
+        );
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([1]);
+        unset($stmt);
 
-            $pdo->prepare($query)->execute([2]);
+        $pdo->prepare($query)->execute([2]);
 
-            $closedCount = $pdo->query("SHOW SESSION STATUS LIKE 'Com_stmt_close'")->fetchColumn(1);
+        $closedCount = $pdo->query("SHOW SESSION STATUS LIKE 'Com_stmt_close'")->fetchColumn(1);
 
-            $this->assertEquals(2, $closedCount);
-        });
-    }
-
-    private function pdoInstance()
-    {
-        return new \PDO($this->mysqlDns(), self::MYSQL_USER, self::MYSQL_PASSWORD);
-    }
-
-    private function setUpDatabase()
-    {
-        $this->isolateTracer(function () {
-            $pdo = $this->pdoInstance();
-            $pdo->beginTransaction();
-            $pdo->exec("
-                CREATE TABLE tests (
-                    id integer not null primary key,
-                    name varchar(100)
-                )
-            ");
-            $pdo->exec("INSERT INTO tests (id, name) VALUES (1, 'Tom')");
-            $pdo->commit();
-            $dbh = null;
-        });
-    }
-
-    private function clearDatabase()
-    {
-        $this->isolateTracer(function () {
-            $pdo = $this->pdoInstance();
-            $pdo->beginTransaction();
-            $pdo->exec("DROP TABLE tests");
-            $pdo->commit();
-            $dbh = null;
-        });
-    }
-
-    public function mysqlDns()
-    {
-        return "mysql:host=" . self::MYSQL_HOST . ";dbname=" . self::MYSQL_DATABASE;
-    }
-
-    private function baseTags()
-    {
-        return [
-            'db.engine' => 'mysql',
-            'out.host' => self::MYSQL_HOST,
-            'db.name' => self::MYSQL_DATABASE,
-            'db.user' => self::MYSQL_USER,
-        ];
+        $this->assertEquals(2, $closedCount);
     }
 }

--- a/tests/Integrations/PDO/PDOSandboxedTest.php
+++ b/tests/Integrations/PDO/PDOSandboxedTest.php
@@ -24,6 +24,10 @@ final class PDOSandboxedTest extends IntegrationTestCase
     protected function setUp()
     {
         parent::setUp();
+        if (PHP_VERSION_ID < 50600) {
+            $this->markTestSkipped('Sandbox API not available on < PHP 5.6');
+            return;
+        }
         $this->setUpDatabase();
     }
 

--- a/tests/Integrations/PDO/PDOSandboxedTest.php
+++ b/tests/Integrations/PDO/PDOSandboxedTest.php
@@ -61,7 +61,9 @@ final class PDOSandboxedTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.user' => 'wrong_user',
                 ]))
+                // phpcs:disable
                 ->setException('PDOException', 'SQLSTATE[HY000] [1045] Access denied for user \'wrong_user\'@\'%s\' (using password: YES)'),
+                // phpcs:enable
         ]);
     }
 
@@ -127,7 +129,9 @@ final class PDOSandboxedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
+                // phpcs:disable
                 ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY)\' at line 1')
+                // phpcs:enable
                 ->withExactTags($this->baseTags()),
             SpanAssertion::exists('PDO.__construct'),
         ]);
@@ -186,7 +190,9 @@ final class PDOSandboxedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
+                // phpcs:disable
                 ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1')
+                // phpcs:enable
                 ->withExactTags($this->baseTags()),
             SpanAssertion::exists('PDO.__construct'),
         ]);
@@ -289,7 +295,9 @@ final class PDOSandboxedTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
+                // phpcs:disable
                 ->setException('PDOException', 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\' at line 1')
+                // phpcs:enable
                 ->withExactTags($this->baseTags()),
             SpanAssertion::build('PDO.prepare', 'PDO', 'sql', $query)
                 ->withExactTags($this->baseTags()),
@@ -297,7 +305,7 @@ final class PDOSandboxedTest extends IntegrationTestCase
         ]);
     }
 
-    // TODO Add limited tracer to sandboxed closures
+    // Add limited tracer to sandboxed closures
     /*
     public function testLimitedTracerPDO()
     {

--- a/tests/Integrations/PDO/PDOSandboxedTest.php
+++ b/tests/Integrations/PDO/PDOSandboxedTest.php
@@ -40,12 +40,6 @@ final class PDOSandboxedTest extends PDOTest
         parent::setUp();
     }
 
-    // Remove this fake test after limited tracer added to sandbox API
-    public function testLimitedTracerPDO()
-    {
-        $this->assertTrue(true);
-    }
-
     // @see https://github.com/DataDog/dd-trace-php/issues/510
     public function testPDOStatementsAreReleased()
     {

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -418,7 +418,7 @@ class PDOTest extends IntegrationTestCase
         return "mysql:host=" . self::MYSQL_HOST . ";dbname=" . self::MYSQL_DATABASE;
     }
 
-    private function baseTags()
+    protected function baseTags()
     {
         return [
             'db.engine' => 'mysql',

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -6,13 +6,22 @@ use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 
-define('MYSQL_DATABASE', 'test');
-define('MYSQL_USER', 'test');
-define('MYSQL_PASSWORD', 'test');
-define('MYSQL_HOST', 'mysql_integration');
-
-final class PDOTest extends IntegrationTestCase
+class PDOTest extends IntegrationTestCase
 {
+    const IS_SANDBOX = false;
+
+    const MYSQL_DATABASE = 'test';
+    const MYSQL_USER = 'test';
+    const MYSQL_PASSWORD = 'test';
+    const MYSQL_HOST = 'mysql_integration';
+
+    // phpcs:disable
+    const ERROR_CONSTRUCT = 'Sql error: SQLSTATE[HY000] [1045]';
+    const ERROR_EXEC = 'Sql error';
+    const ERROR_QUERY = 'Sql error';
+    const ERROR_STATEMENT = 'Sql error';
+    // phpcs:enable
+
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
@@ -32,18 +41,18 @@ final class PDOTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testPDOContructOk()
+    public function testPDOConstructOk()
     {
         $traces = $this->isolateTracer(function () {
                 $this->pdoInstance();
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
-                ->withExactTags([]),
-        ]);
+                ->withExactTags($this->baseTags()),
+        ], static::IS_SANDBOX);
     }
 
-    public function testPDOContructError()
+    public function testPDOConstructError()
     {
         $traces = $this->isolateTracer(function () {
             try {
@@ -53,8 +62,11 @@ final class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
-                ->setError('PDOException', 'Sql error: SQLSTATE[HY000] [1045]'),
-        ]);
+                ->withExactTags(array_merge($this->baseTags(), [
+                    'db.user' => 'wrong_user',
+                ]))
+                ->setError('PDOException', static::ERROR_CONSTRUCT, true),
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOExecOk()
@@ -75,7 +87,7 @@ final class PDOTest extends IntegrationTestCase
                     'db.rowcount' => '1',
                 ])),
             SpanAssertion::exists('PDO.commit'),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOExecError()
@@ -96,11 +108,9 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.rowcount' => '',
-                ])),
+                ->withExactTags($this->baseTags()),
             SpanAssertion::exists('PDO.commit'),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOExecException()
@@ -122,9 +132,9 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDOException', 'Sql error')
+                ->setError('PDOException', static::ERROR_EXEC, true)
                 ->withExactTags($this->baseTags()),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOQuery()
@@ -142,7 +152,7 @@ final class PDOTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.rowcount' => '1',
                 ])),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOQueryError()
@@ -161,10 +171,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
-                ->withExactTags(array_merge($this->baseTags(), [
-                    'db.rowcount' => '',
-                ])),
-        ]);
+                ->withExactTags($this->baseTags()),
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOQueryException()
@@ -183,9 +191,9 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDOException', 'Sql error')
+                ->setError('PDOException', static::ERROR_QUERY, true)
                 ->withExactTags($this->baseTags()),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOCommit()
@@ -202,8 +210,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::exists('PDO.exec'),
             SpanAssertion::build('PDO.commit', 'PDO', 'sql', 'PDO.commit')
-                ->withExactTags(array_merge($this->baseTags(), [])),
-        ]);
+                ->withExactTags($this->baseTags()),
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOStatementOk()
@@ -226,7 +234,7 @@ final class PDOTest extends IntegrationTestCase
                 'PDO',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
-            )->withExactTags(array_merge($this->baseTags(), [])),
+            )->withExactTags($this->baseTags()),
             SpanAssertion::build(
                 'PDOStatement.execute',
                 'PDO',
@@ -237,7 +245,7 @@ final class PDOTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                 'db.rowcount' => 1,
                 ])),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOStatementIsCorrectlyClosedOnUnset()
@@ -254,6 +262,7 @@ final class PDOTest extends IntegrationTestCase
             $stmt2->execute([10]);
             $stmt2->fetch();
         });
+        $this->addToAssertionCount(1);
     }
 
     public function testPDOStatementCausesActiveQueriesError()
@@ -273,7 +282,7 @@ final class PDOTest extends IntegrationTestCase
 
             $this->fail("Expected exception PDOException not thrown");
         } catch (\PDOException $ex) {
-            // ignore
+            $this->addToAssertionCount(1);
         }
     }
 
@@ -295,14 +304,12 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
-                ->withExactTags(array_merge($this->baseTags(), [])),
+                ->withExactTags($this->baseTags()),
             SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
-                ->setTraceAnalyticsCandidate()
-                ->setError('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
-                    ->withExactTags(array_merge($this->baseTags(), [
-                        'db.rowcount' => 0,
-                    ])),
-        ]);
+                ->settraceanalyticscandidate()
+                ->seterror('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
+                    ->withExactTags($this->baseTags()),
+        ], static::IS_SANDBOX);
     }
 
     public function testPDOStatementException()
@@ -324,12 +331,12 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
-                ->withExactTags(array_merge($this->baseTags(), [])),
+                ->withExactTags($this->baseTags()),
             SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDOException', 'Sql error')
+                ->setError('PDOException', static::ERROR_STATEMENT, true)
                 ->withExactTags($this->baseTags()),
-        ]);
+        ], static::IS_SANDBOX);
     }
 
     public function testLimitedTracerPDO()
@@ -351,7 +358,7 @@ final class PDOTest extends IntegrationTestCase
 
     private function pdoInstance($opts = null)
     {
-        $instance =  new \PDO($this->mysqlDns(), MYSQL_USER, MYSQL_PASSWORD, $opts);
+        $instance =  new \PDO($this->mysqlDns(), self::MYSQL_USER, self::MYSQL_PASSWORD, $opts);
 
         return $instance;
     }
@@ -408,16 +415,16 @@ final class PDOTest extends IntegrationTestCase
 
     public function mysqlDns()
     {
-        return "mysql:host=" . MYSQL_HOST . ";dbname=" . MYSQL_DATABASE;
+        return "mysql:host=" . self::MYSQL_HOST . ";dbname=" . self::MYSQL_DATABASE;
     }
 
     private function baseTags()
     {
         return [
             'db.engine' => 'mysql',
-            'out.host' => MYSQL_HOST,
-            'db.name' => MYSQL_DATABASE,
-            'db.user' => MYSQL_USER,
+            'out.host' => self::MYSQL_HOST,
+            'db.name' => self::MYSQL_DATABASE,
+            'db.user' => self::MYSQL_USER,
         ];
     }
 }

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -16,7 +16,7 @@ final class PDOTest extends IntegrationTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        putenv('DD_TRACE_SANDBOX_ENABLED');
+        putenv('DD_TRACE_SANDBOX_ENABLED=false');
         IntegrationsLoader::reload();
     }
 

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -23,7 +23,7 @@ final class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, [
+        $this->assertExpectedSpans($traces, [
             SpanAssertion::build(
                 'web.request',
                 'web.request',

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -23,7 +23,7 @@ final class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, [
+        $this->assertExpectedSpans($traces, [
             SpanAssertion::build(
                 'web.request',
                 'web.request',

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -25,7 +25,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -25,7 +25,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -33,7 +33,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -33,7 +33,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build(

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -25,7 +25,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($this, $traces, $spanExpectations);
+        $this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -31,7 +31,6 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
         });
 
         $this->assertExpectedSpans(
-            $this,
             $traces,
             [
                 SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@index default')

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -35,6 +35,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isEnabled' => false,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
 
         DummyIntegration1::$value = Integration::LOADED;
@@ -50,6 +51,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
             'isEnabled' => true,
             'isIntegrationEnabled' => false,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
 
         DummyIntegration1::$value = Integration::LOADED;
@@ -65,6 +67,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -82,6 +85,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -105,6 +109,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 
@@ -128,6 +133,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
             'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
+            'isSandboxEnabled' => false,
         ]));
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
 

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -14,6 +14,12 @@ final class IntegrationsLoaderTest extends BaseTestCase
         'integration_2' => 'DDTrace\Tests\Unit\Integrations\DummyIntegration2',
     ];
 
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        putenv('DD_TRACE_SANDBOX_ENABLED=false');
+    }
+
     public function testGlobalLoaderDefaultsToOfficiallySupportedIntegrations()
     {
         $this->assertEquals(

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -110,7 +110,7 @@ array(5) {
     ["type"]=>
     string(7) "BarType"
     ["meta"]=>
-    array(4) {
+    array(5) {
       ["args.0"]=>
       string(18) "tracing is awesome"
       ["retval.thoughts"]=>
@@ -118,6 +118,8 @@ array(5) {
       ["retval.first"]=>
       string(5) "first"
       ["retval.rand"]=>
+      int(%d)
+      ["system.pid"]=>
       int(%d)
     }
     ["metrics"]=>
@@ -159,7 +161,7 @@ array(5) {
     string(6) "AddOne"
   }
   [3]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -170,9 +172,14 @@ array(5) {
     int(%d)
     ["name"]=>
     string(6) "AddOne"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
   [4]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -183,6 +190,11 @@ array(5) {
     int(%d)
     ["name"]=>
     string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
 }
 array(0) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -23,7 +23,7 @@ int(9)
 ---
 array(1) {
   [0]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -34,6 +34,11 @@ array(1) {
     int(%d)
     ["name"]=>
     string(8) "ArraySum"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
 }
 array(0) {

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -40,7 +40,7 @@ array (
 ---
 array(1) {
   [0]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -51,6 +51,11 @@ array(1) {
     int(%d)
     ["name"]=>
     string(15) "filter_to_array"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
 }
 array(0) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -118,7 +118,7 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(4) {
+    array(5) {
       ["args.0"]=>
       string(18) "tracing is awesome"
       ["retval.thoughts"]=>
@@ -126,6 +126,8 @@ array(3) {
       ["retval.first"]=>
       string(5) "first"
       ["retval.rand"]=>
+      int(%d)
+      ["system.pid"]=>
       int(%d)
     }
     ["metrics"]=>
@@ -159,7 +161,7 @@ array(3) {
     }
   }
   [2]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -170,6 +172,11 @@ array(3) {
     int(%d)
     ["name"]=>
     string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
 }
 array(0) {

--- a/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
@@ -112,7 +112,7 @@ array(1) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["args.0"]=>
       int(42)
       ["args.1.0"]=>
@@ -120,6 +120,8 @@ array(1) {
       ["retval"]=>
       string(48) "New fav num is 42 with 3 colors and pink on top
 "
+      ["system.pid"]=>
+      int(%d)
     }
   }
 }

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Errors from userland will be flagged on span
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function testErrorFromUserland()
+{
+    echo "testErrorFromUserland()\n";
+}
+
+dd_trace_function('testErrorFromUserland', function (SpanData $span) {
+    $span->name = 'testErrorFromUserland';
+    $span->meta = ['error.msg' => 'Foo error'];
+});
+
+testErrorFromUserland();
+
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+testErrorFromUserland()
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    int(%d)
+    ["span_id"]=>
+    int(%d)
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(21) "testErrorFromUserland"
+    ["error"]=>
+    int(1)
+    ["meta"]=>
+    array(2) {
+      ["error.msg"]=>
+      string(9) "Foo error"
+      ["system.pid"]=>
+      int(%d)
+    }
+  }
+}

--- a/tests/ext/sandbox/exception_handling.phpt
+++ b/tests/ext/sandbox/exception_handling.phpt
@@ -23,13 +23,13 @@ try {
 
     $span = $stack[0];
     echo "error: ", $span['error'], "\n";
-    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
     echo "Exception msg: ", $span['meta']['error.msg'], "\n";
     echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
 
     $span = $stack[1];
     echo "error: ", $span['error'], "\n";
-    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
     echo "Exception msg: ", $span['meta']['error.msg'], "\n";
     echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
 }
@@ -38,14 +38,14 @@ try {
 --EXPECTF--
 Stack size: 2
 error: 1
-Exception name: Exception
+Exception type: Exception
 Exception msg: datadog
 Exception stack:
 #0 %s: inner()
 #1 %s: outer()
 #2 {main}
 error: 1
-Exception name: Exception
+Exception type: Exception
 Exception msg: datadog
 Exception stack:
 #0 %s: inner()

--- a/tests/ext/sandbox/exception_handling_php5.phpt
+++ b/tests/ext/sandbox/exception_handling_php5.phpt
@@ -24,13 +24,13 @@ try {
 
     $span = $stack[0];
     echo "error: ", $span['error'], "\n";
-    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
     echo "Exception msg: ", $span['meta']['error.msg'], "\n";
     echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
 
     $span = $stack[1];
     echo "error: ", $span['error'], "\n";
-    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
     echo "Exception msg: ", $span['meta']['error.msg'], "\n";
     echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
 }
@@ -39,7 +39,7 @@ try {
 --EXPECTF--
 Stack size: 2
 error: 1
-Exception name: Exception
+Exception type: Exception
 Exception msg: datadog
 Exception stack:
 #0 %s: inner()
@@ -48,7 +48,7 @@ Exception stack:
 #3 %s: unknown()
 #4 {main}
 error: 1
-Exception name: Exception
+Exception type: Exception
 Exception msg: datadog
 Exception stack:
 #0 %s: inner()

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -52,7 +52,7 @@ Test::testFoo() fav num: %d
 ---
 array(3) {
   [0]=>
-  array(5) {
+  array(6) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -63,6 +63,11 @@ array(3) {
     int(%d)
     ["name"]=>
     string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
   }
   [1]=>
   array(6) {


### PR DESCRIPTION
### Description

This PR adds a sandboxed integration for PDO which is enabled by default (but disabled on < PHP 5.6 since the sandbox API is not supported on those versions.)

The sandboxed integration can be disabled by setting `DD_TRACE_SANDBOX_ENABLED=false` which will force the tracer to fall back to the original PDO integration.

One thing to note - the sandboxed integrations do not have support for a limited tracer but that feature can be added in a separate PR.

### Readiness checklist
- [ ] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug

### Reviewer checklist
- [ ] Appropriate labels assigned
- [ ] Milestone set
