### PR TITLE
Avoid reserved word "fn"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -119,7 +119,7 @@
                     <file name="dd_trace_method.phpt" role="test" />
                     <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                     <file name="dd_trace_push_span_id.phpt" role="test" />
-                    <file name="desctructor_called_when_this_gets_out_of_scope.phpt" role="test" />
+                    <file name="destructor_called_when_this_gets_out_of_scope.phpt" role="test" />
                     <file name="enable_throw_exception_if_overridable_doesnt_exist.phpt" role="test" />
                     <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
                     <file name="from_php_7_3_test_user_streams_consumed_bug.phpt" role="test" />

--- a/tests/ext/destructor_called_when_this_gets_out_of_scope.phpt
+++ b/tests/ext/destructor_called_when_this_gets_out_of_scope.phpt
@@ -16,18 +16,18 @@ class Test {
 dd_trace("Test", "m", function() {
     return dd_trace_forward_call() . " OVERRIDE";
 });
-function fn() {
+function func() {
     $test = new Test();
     echo $test->m() . PHP_EOL;
-    echo "FN" . PHP_EOL;
+    echo "FUNC" . PHP_EOL;
 }
 
-fn();
+func();
 echo "FINISH" . PHP_EOL;
 ?>
 
 --EXPECT--
 M OVERRIDE
-FN
+FUNC
 DESTRUCT
 FINISH


### PR DESCRIPTION
In PHP 7.4 and forward "fn" is a keyword.
Also fixes misspelling in the name of the file.

I'm unsure whether to target 0.30.1 or master for this change.