### PR TITLE
Fix ZTS builds, remove COMPAT_CTX_*

### DIFF
--- a/src/ext/compatibility.h
+++ b/src/ext/compatibility.h
@@ -1,6 +1,8 @@
 #ifndef DD_COMPATIBILITY_H
 #define DD_COMPATIBILITY_H
 
+#include <TSRM/TSRM.h>
+
 #define UNUSED_1(x) (void)(x)
 #define UNUSED_2(x, y) \
     do {               \
@@ -52,23 +54,6 @@
 #define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c)
 #define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval*)list)[arg_num]))
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
-#endif
-
-// make code with optional thread context portable
-#if ZTS
-// D - define (define)
-#define COMPAT_CTX_D TSRMLS_D
-// DC - defone with comma (..., define)
-#define COMPAT_CTX_DC TSRMLS_DC
-// C - pass context (ctx)
-#define COMPAT_CTX_C TSRMLS_C
-// DC - pass context with comma (..., ctx)
-#define COMPAT_CTX_CC TSRMLS_CC
-#else
-#define COMPAT_CTX_D
-#define COMPAT_CTX_DC
-#define COMPAT_CTX_C
-#define COMPAT_CTX_CC
 #endif
 
 #endif  // DD_COMPATIBILITY_H

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -14,7 +14,7 @@ struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {
 #undef INT
         PTHREAD_MUTEX_INITIALIZER};
 
-void ddtrace_reload_config(COMPAT_CTX_D) {
+void ddtrace_reload_config(TSRMLS_D) {
 #define CHAR(getter_name, ...)                            \
     if (ddtrace_memoized_configuration.getter_name) {     \
         free(ddtrace_memoized_configuration.getter_name); \
@@ -29,34 +29,34 @@ void ddtrace_reload_config(COMPAT_CTX_D) {
 #undef INT
 #undef BOOL
     // repopulate config
-    ddtrace_initialize_config(COMPAT_CTX_C);
+    ddtrace_initialize_config(TSRMLS_C);
 }
 
-void ddtrace_initialize_config(COMPAT_CTX_D) {
+void ddtrace_initialize_config(TSRMLS_D) {
     // read all values to memoize them
 
     // CHAR returns a copy of a value that we need to free
-#define CHAR(getter_name, env_name, default, ...)                                      \
-    do {                                                                               \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                     \
-        ddtrace_memoized_configuration.getter_name =                                   \
-            ddtrace_get_c_string_config_with_default(env_name, default COMPAT_CTX_CC); \
-        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                  \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                   \
+#define CHAR(getter_name, env_name, default, ...)                                  \
+    do {                                                                           \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                 \
+        ddtrace_memoized_configuration.getter_name =                               \
+            ddtrace_get_c_string_config_with_default(env_name, default TSRMLS_CC); \
+        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;              \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);               \
     } while (0);
-#define INT(getter_name, env_name, default, ...)                                                              \
-    do {                                                                                                      \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                            \
-        ddtrace_memoized_configuration.getter_name = ddtrace_get_int_config(env_name, default COMPAT_CTX_CC); \
-        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                         \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                          \
+#define INT(getter_name, env_name, default, ...)                                                          \
+    do {                                                                                                  \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                        \
+        ddtrace_memoized_configuration.getter_name = ddtrace_get_int_config(env_name, default TSRMLS_CC); \
+        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                     \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                      \
     } while (0);
-#define BOOL(getter_name, env_name, default, ...)                                                              \
-    do {                                                                                                       \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                             \
-        ddtrace_memoized_configuration.getter_name = ddtrace_get_bool_config(env_name, default COMPAT_CTX_CC); \
-        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                          \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                           \
+#define BOOL(getter_name, env_name, default, ...)                                                          \
+    do {                                                                                                   \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                         \
+        ddtrace_memoized_configuration.getter_name = ddtrace_get_bool_config(env_name, default TSRMLS_CC); \
+        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                      \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                       \
     } while (0);
 
     DD_CONFIGURATION

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -6,8 +6,8 @@
 struct ddtrace_memoized_configuration_t;
 extern struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration;
 
-void ddtrace_initialize_config(COMPAT_CTX_D);
-void ddtrace_reload_config(COMPAT_CTX_D);
+void ddtrace_initialize_config(TSRMLS_D);
+void ddtrace_reload_config(TSRMLS_D);
 void ddtrace_config_shutdown(void);
 
 #define DD_CONFIGURATION                                                                                  \

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -601,7 +601,7 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
     RETVAL_FALSE;
     if (fn && fn_len > 0) {
         if (FUNCTION_NAME_MATCHES("ddtrace_reload_config")) {
-            ddtrace_reload_config(COMPAT_CTX_C);
+            ddtrace_reload_config(TSRMLS_C);
             RETVAL_TRUE;
         } else if (FUNCTION_NAME_MATCHES("init_and_start_writer")) {
             RETVAL_BOOL(ddtrace_coms_init_and_start_writer());

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include "compat_zend_string.h"
+#include "compatibility.h"
 
 typedef struct _ddtrace_dispatch_t {
     zval callable, function_name;

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -8,11 +8,11 @@
 #define TRUE (1)
 #define FALSE (0)
 
-BOOL_T ddtrace_get_bool_config(char *name, BOOL_T def COMPAT_CTX_DC);
-char *ddtrace_get_c_string_config(char *name COMPAT_CTX_DC);
-int64_t ddtrace_get_int_config(char *name, int64_t def COMPAT_CTX_DC);
-uint32_t ddtrace_get_uint32_config(char *name, uint32_t def COMPAT_CTX_DC);
-char *ddtrace_get_c_string_config_with_default(char *name, const char *def COMPAT_CTX_DC);
+BOOL_T ddtrace_get_bool_config(char *name, BOOL_T def TSRMLS_DC);
+char *ddtrace_get_c_string_config(char *name TSRMLS_DC);
+int64_t ddtrace_get_int_config(char *name, int64_t def TSRMLS_DC);
+uint32_t ddtrace_get_uint32_config(char *name, uint32_t def TSRMLS_DC);
+char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRMLS_DC);
 char *ddtrace_strdup(const char *c);
 
 #endif  // DD_ENV_CONFIG_H

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -13,9 +13,9 @@
 #endif
 
 #define ddtrace_log_err(message) php_log_err(message TSRMLS_CC)
-#define ddtrace_log_debug(message)      \
-    if (get_dd_trace_debug()) {         \
-        php_log_err(message TSRMLS_CC); \
+#define ddtrace_log_debug(message) \
+    if (get_dd_trace_debug()) {    \
+        ddtrace_log_err(message);  \
     }
 void _ddtrace_log_errf(TSRMLS_FC const char *format, ...);
 

--- a/src/ext/random.h
+++ b/src/ext/random.h
@@ -4,6 +4,8 @@
 #include <php.h>
 #include <stdint.h>
 
+#include "compatibility.h"
+
 #define DD_TRACE_DEBUG_PRNG_SEED "DD_TRACE_DEBUG_PRNG_SEED"
 
 // We keep a separate stack for span ID generation since spans are

--- a/src/ext/request_hooks.h
+++ b/src/ext/request_hooks.h
@@ -4,6 +4,8 @@
 #include <Zend/zend_types.h>
 #include <php.h>
 
+#include "compatibility.h"
+
 int dd_execute_php_file(const char *filename TSRMLS_DC);
 int dd_no_blacklisted_modules(TSRMLS_D);
 

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -4,6 +4,8 @@
 #include <php.h>
 #include <stdint.h>
 
+#include "compatibility.h"
+
 typedef struct _ddtrace_span_t {
     zval *span_data;
     zval *exception;


### PR DESCRIPTION
### Description

PHP7 already had compat macros, so the previous COMPAT_CTX_ macros
were pointless. They did mask some ZTS issues, which is why they
are removed.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
