### PR TITLE
Refactor ddtrace_execute_tracing_closure

### DIFF
--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -80,7 +80,8 @@ int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zv
 int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value, zend_fcall_info *fci,
                          zend_fcall_info_cache *fcc TSRMLS_DC);
 #endif
-void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data,
-                                     zval *user_retval TSRMLS_DC);
+void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zval *user_args, zval *user_retval TSRMLS_DC);
+
+void ddtrace_copy_function_args(zend_execute_data *execute_data, zval *user_args);
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -56,6 +56,11 @@ ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
     DDTRACE_G(open_spans_top) = span;
 
     span->span_data = (zval *)ecalloc(1, sizeof(zval));
+
+    /* On PHP 5 object_init_ex does not set refcount to 1, but on PHP 7 it does */
+#if PHP_VERSION_ID < 70000
+    Z_ADDREF_P(span->span_data);
+#endif
     object_init_ex(span->span_data, ddtrace_ce_span_data);
 
     // Peek at the active span ID before we push a new one onto the stack


### PR DESCRIPTION
### Description

This pushes the responsibility of copying the VM stack args onto
the fci object to the caller of ddtrace_execute_tracing_closure,
instead of ddtrace_execute_tracing_closure doing it.

This also cleans up some lifetime messiness of objects that the
ddtrace_execute_tracing_closure uses. This doesn't fix any bugs
when called from existing contexts, but are necessary if we want
to call this function from zend_execute hooks.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] ~Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
