### PR TITLE
Attach exceptions to spans

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -123,6 +123,8 @@
                         <file name="dd_trace_method_binds_called_object.phpt" role="test" />
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />
+                        <file name="exception_handling_php5.phpt" role="test" />
+                        <file name="exception_handling.phpt" role="test" />
                         <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -1,9 +1,12 @@
 #ifndef DISPATCH_COMPAT_H
 #define DISPATCH_COMPAT_H
-#include "Zend/zend_types.h"
+
+#include <Zend/zend_types.h>
+
 #include "compat_zend_string.h"
 #include "dispatch.h"
 #include "env_config.h"
+#include "span.h"
 
 #if PHP_VERSION_ID < 70000
 #include "dispatch_compat_php5.h"
@@ -82,5 +85,11 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
                                      zval *user_retval TSRMLS_DC);
 
 void ddtrace_copy_function_args(zend_execute_data *execute_data, zval *user_args);
+
+#if PHP_VERSION_ID < 70000
+void ddtrace_span_attach_exception(ddtrace_span_t *span, zval *exception);
+#else
+void ddtrace_span_attach_exception(ddtrace_span_t *span, zend_object *exception);
+#endif
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -5,6 +5,7 @@
 
 #include <ext/spl/spl_exceptions.h>
 
+#include "compatibility.h"
 #include "ddtrace.h"
 #include "debug.h"
 #include "dispatch.h"
@@ -272,5 +273,12 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
 
     zval_ptr_dtor(&rv);
     zend_fcall_info_args_clear(&fci, 0);
+}
+
+void ddtrace_span_attach_exception(ddtrace_span_t *span, zend_object *exception) {
+    if (exception) {
+        GC_ADDREF(exception);
+        span->exception = exception;
+    }
 }
 #endif  // PHP_VERSION_ID >= 70000

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -1,10 +1,12 @@
 #include <Zend/zend.h>
 #include <Zend/zend_exceptions.h>
+#include <Zend/zend_interfaces.h>
 #include <php.h>
 
 #include <ext/spl/spl_exceptions.h>
 
 #include "ddtrace.h"
+#include "dispatch_compat.h"
 #include "mpack/mpack.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
@@ -173,31 +175,124 @@ int ddtrace_serialize_simple_array(zval *trace, zval *retval TSRMLS_DC) {
 }
 
 #if PHP_VERSION_ID < 70000
-#define ADD_ELEMENT_IF_PROP_TYPE(name, type)                                                                    \
-    do {                                                                                                        \
-        zval *prop =                                                                                            \
-            zend_read_property(ddtrace_ce_span_data, span->span_data, (name), sizeof((name)) - 1, 1 TSRMLS_CC); \
-        if (Z_TYPE_P(prop) == (type)) {                                                                         \
-            zval *value;                                                                                        \
-            ALLOC_ZVAL(value);                                                                                  \
-            INIT_PZVAL_COPY(value, prop);                                                                       \
-            zval_copy_ctor(value);                                                                              \
-            add_assoc_zval(el, (name), value);                                                                  \
-        }                                                                                                       \
-    } while (0);
+static zval *_read_span_property(zval *span_data, const char *name, size_t name_len TSRMLS_DC) {
+    return zend_read_property(ddtrace_ce_span_data, span_data, name, name_len, 1 TSRMLS_CC);
+}
+
+static void _add_assoc_zval(zval *el, const char *name, zval *prop) {
+    zval *value;
+    ALLOC_ZVAL(value);
+    INIT_PZVAL_COPY(value, prop);
+    zval_copy_ctor(value);
+    add_assoc_zval(el, name, value);
+}
+
+void _serialize_exception(zval *el, zval *meta, ddtrace_span_t *span TSRMLS_DC) {
+    zval *exception, *msg, *stack;
+    zend_uint class_name_len;
+    const char *class_name;
+    int dup;
+    exception = span->exception;
+
+    add_assoc_long(el, "error", 1);
+
+    dup = zend_get_object_classname(exception, &class_name, &class_name_len TSRMLS_CC);
+
+    zend_call_method_with_0_params(&exception, Z_OBJCE_P(exception), NULL, "getmessage", &msg);
+    zend_call_method_with_0_params(&exception, Z_OBJCE_P(exception), NULL, "gettraceasstring", &stack);
+
+    /* add_assoc_stringl does not actually mutate the string, but we've either
+     * already made a copy, or it will when it duplicates with dup param, so
+     * if it did it should still be safe. */
+    add_assoc_stringl(meta, "error.name", (char *)class_name, class_name_len, dup);
+    add_assoc_zval(meta, "error.msg", msg);
+    add_assoc_zval(meta, "error.stack", stack);
+}
+
+void _serialize_meta(zval *el, ddtrace_span_t *span TSRMLS_DC) {
+    zval *meta = _read_span_property(span->span_data, "meta", sizeof("meta") - 1 TSRMLS_CC);
+    BOOL_T should_free = TRUE;
+
+    if (!meta || Z_TYPE_P(meta) != IS_ARRAY) {
+        ALLOC_INIT_ZVAL(meta);
+        array_init(meta);
+    } else {
+        should_free = FALSE;
+        Z_ADDREF_P(meta);
+    }
+
+    if (span->exception) {
+        _serialize_exception(el, meta, span TSRMLS_CC);
+    }
+
+    // Add meta only if it has elements
+    if (zend_hash_num_elements(Z_ARRVAL_P(meta))) {
+        add_assoc_zval(el, "meta", meta);
+    } else {
+        zval_dtor(meta);
+
+        if (should_free) {
+            efree(meta);
+        }
+    }
+}
+
 #else
-#define ADD_ELEMENT_IF_PROP_TYPE(name, type)                                                                         \
-    do {                                                                                                             \
-        zval rv;                                                                                                     \
-        zval *prop =                                                                                                 \
-            zend_read_property(ddtrace_ce_span_data, span->span_data, (name), sizeof((name)) - 1, 1, &rv TSRMLS_CC); \
-        if (Z_TYPE_P(prop) == (type)) {                                                                              \
-            zval value;                                                                                              \
-            ZVAL_COPY(&value, prop);                                                                                 \
-            add_assoc_zval(el, (name), &value);                                                                      \
-        }                                                                                                            \
-    } while (0);
+static zval *_read_span_property(zval *span_data, const char *name, size_t name_len) {
+    zval rv;
+    return zend_read_property(ddtrace_ce_span_data, span_data, name, name_len, 1, &rv);
+}
+
+static void _add_assoc_zval(zval *el, const char *name, zval *prop) {
+    zval value;
+    ZVAL_COPY(&value, prop);
+    add_assoc_zval(el, (name), &value);
+}
+
+void _serialize_exception(zval *el, zval *meta, ddtrace_span_t *span) {
+    zval exception, name, msg, stack;
+    ZVAL_OBJ(&exception, span->exception);
+
+    add_assoc_long(el, "error", 1);
+
+    ZVAL_STR(&name, Z_OBJCE(exception)->name);
+    zend_call_method_with_0_params(&exception, Z_OBJCE(exception), NULL, "getmessage", &msg);
+    zend_call_method_with_0_params(&exception, Z_OBJCE(exception), NULL, "gettraceasstring", &stack);
+
+    _add_assoc_zval(meta, "error.name", &name);
+    add_assoc_zval(meta, "error.msg", &msg);
+    add_assoc_zval(meta, "error.stack", &stack);
+}
+
+void _serialize_meta(zval *el, ddtrace_span_t *span) {
+    zval meta_zv, *meta = _read_span_property(span->span_data, "meta", sizeof("meta") - 1);
+
+    if (!meta || Z_TYPE_P(meta) != IS_ARRAY) {
+        meta = &meta_zv;
+        array_init(meta);
+    } else {
+        Z_ADDREF_P(meta);
+    }
+
+    if (span->exception) {
+        _serialize_exception(el, meta, span);
+    }
+
+    if (zend_array_count(Z_ARRVAL_P(meta))) {
+        add_assoc_zval(el, "meta", meta);
+    } else {
+        zval_ptr_dtor(meta);
+    }
+}
 #endif
+
+#define ADD_ELEMENT_IF_PROP_TYPE(name, type)                                                 \
+    do {                                                                                     \
+        zval *prop = _read_span_property(span->span_data, name, sizeof(name) - 1 TSRMLS_CC); \
+        if (Z_TYPE_P(prop) == (type)) {                                                      \
+            _add_assoc_zval(el, name, prop);                                                 \
+        }                                                                                    \
+    } while (0);
 
 void ddtrace_serialize_span_to_array(ddtrace_span_t *span, zval *array TSRMLS_DC) {
     zval *el;
@@ -221,12 +316,10 @@ void ddtrace_serialize_span_to_array(ddtrace_span_t *span, zval *array TSRMLS_DC
     ADD_ELEMENT_IF_PROP_TYPE("resource", IS_STRING);
     ADD_ELEMENT_IF_PROP_TYPE("service", IS_STRING);
     ADD_ELEMENT_IF_PROP_TYPE("type", IS_STRING);
-    ADD_ELEMENT_IF_PROP_TYPE("meta", IS_ARRAY);
-    ADD_ELEMENT_IF_PROP_TYPE("metrics", IS_ARRAY);
 
-    if (span->exception) {
-        // TODO Serialize exception
-    }
+    _serialize_meta(el, span TSRMLS_CC);
+
+    ADD_ELEMENT_IF_PROP_TYPE("metrics", IS_ARRAY);
 
     add_next_index_zval(array, el);
 }

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -6,9 +6,13 @@
 
 #include "compatibility.h"
 
-typedef struct _ddtrace_span_t {
+typedef struct ddtrace_span_t {
     zval *span_data;
+#if PHP_VERSION_ID < 70000
     zval *exception;
+#else
+    zend_object *exception;
+#endif
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;
@@ -17,7 +21,7 @@ typedef struct _ddtrace_span_t {
         uint64_t duration_start;
         uint64_t duration;
     };
-    struct _ddtrace_span_t *next;
+    struct ddtrace_span_t *next;
 } ddtrace_span_t;
 
 void ddtrace_init_span_stacks(TSRMLS_D);

--- a/src/ext/trace.c
+++ b/src/ext/trace.c
@@ -41,6 +41,7 @@ void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc,
     dd_trace_stop_span_time(span);
 
     ddtrace_copy_function_args(execute_data, &user_args);
+    ddtrace_span_attach_exception(span, EG(exception));
 
     if (fcall_status == SUCCESS && !EG(exception) && Z_TYPE(dispatch->callable) == IS_OBJECT) {
         int orig_error_reporting = EG(error_reporting);

--- a/tests/ext/sandbox/exception_handling.phpt
+++ b/tests/ext/sandbox/exception_handling.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Exceptions get attached to spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: PHP 5 has its own test'); ?>
+--FILE--
+<?php
+
+function outer() {
+    inner();
+}
+function inner() {
+    throw new Exception("datadog");
+}
+
+dd_trace_function("outer", function() {});
+dd_trace_function("inner", function() {});
+
+try {
+    outer();
+} catch (Exception $e) {
+    $stack = dd_trace_serialize_closed_spans();
+    echo "Stack size: ", count($stack), "\n";
+
+    $span = $stack[0];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+
+    $span = $stack[1];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+}
+
+?>
+--EXPECTF--
+Stack size: 2
+error: 1
+Exception name: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner()
+#1 %s: outer()
+#2 {main}
+error: 1
+Exception name: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner()
+#1 %s: outer()
+#2 {main}
+

--- a/tests/ext/sandbox/exception_handling_php5.phpt
+++ b/tests/ext/sandbox/exception_handling_php5.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Exceptions get attached to spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not yet supported'); ?>
+<?php if (PHP_VERSION_ID >= 70000) die('skip: PHP 5 only test'); ?>
+--FILE--
+<?php
+
+function outer() {
+    inner();
+}
+function inner() {
+    throw new Exception("datadog");
+}
+
+dd_trace_function("outer", function() {});
+dd_trace_function("inner", function() {});
+
+try {
+    outer();
+} catch (Exception $e) {
+    $stack = dd_trace_serialize_closed_spans();
+    echo "Stack size: ", count($stack), "\n";
+
+    $span = $stack[0];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+
+    $span = $stack[1];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception name: ", $span['meta']['error.name'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+}
+
+?>
+--EXPECTF--
+Stack size: 2
+error: 1
+Exception name: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner()
+#1 %s: outer()
+#2 %s: outer()
+#3 %s: unknown()
+#4 {main}
+error: 1
+Exception name: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner()
+#1 %s: outer()
+#2 %s: outer()
+#3 %s: unknown()
+#4 {main}
+


### PR DESCRIPTION
### Description

This will attach exceptions to open spans that were traced through the new `dd_trace_function`/`dd_trace_method` API.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
