### PR TITLE
[Sandbox] Pass original call exception to tracing closure

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -126,6 +126,8 @@
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
                         <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
+                        <file name="exceptions_are_passed_to_the_tracing_closure.phpt" role="test" />
+                        <file name="exceptions_are_passed_to_the_tracing_closure_php5.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
                     <file name="destructor_called_when_this_gets_out_of_scope.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -128,6 +128,9 @@
                         <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_are_passed_to_the_tracing_closure.phpt" role="test" />
                         <file name="exceptions_are_passed_to_the_tracing_closure_php5.phpt" role="test" />
+                        <file name="exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
+                        <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
+                        <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
                     <file name="destructor_called_when_this_gets_out_of_scope.phpt" role="test" />

--- a/src/ext/dispatch_compat.h
+++ b/src/ext/dispatch_compat.h
@@ -71,25 +71,19 @@ zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *di
 void ddtrace_wrapper_forward_call_from_userland(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);
 BOOL_T ddtrace_should_trace_call(zend_execute_data *execute_data, zend_function **fbc,
                                  ddtrace_dispatch_t **dispatch TSRMLS_DC);
-
-/**
- * trace.c
- */
-#if PHP_VERSION_ID < 70000
-int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value TSRMLS_DC);
-#else
-int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value, zend_fcall_info *fci,
-                         zend_fcall_info_cache *fcc TSRMLS_DC);
-#endif
-void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data, zval *user_args,
-                                     zval *user_retval TSRMLS_DC);
-
 void ddtrace_copy_function_args(zend_execute_data *execute_data, zval *user_args);
 
 #if PHP_VERSION_ID < 70000
+int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value TSRMLS_DC);
 void ddtrace_span_attach_exception(ddtrace_span_t *span, zval *exception);
+void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data, zval *user_args,
+                                     zval *user_retval, zval *exception TSRMLS_DC);
 #else
+int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value, zend_fcall_info *fci,
+                         zend_fcall_info_cache *fcc TSRMLS_DC);
 void ddtrace_span_attach_exception(ddtrace_span_t *span, zend_object *exception);
+void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data, zval *user_args,
+                                     zval *user_retval, zend_object *exception TSRMLS_DC);
 #endif
 
 #endif  // DISPATCH_COMPAT_H

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -339,11 +339,12 @@ void ddtrace_copy_function_args(zend_execute_data *execute_data, zval *user_args
 }
 
 void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data, zval *user_args,
-                                     zval *user_retval TSRMLS_DC) {
+                                     zval *user_retval, zval *exception TSRMLS_DC) {
     zend_fcall_info fci = {0};
     zend_fcall_info_cache fcc = {0};
     zval *retval_ptr = NULL;
-    zval **args[3];
+    zval **args[4];
+    zval *null_zval = &EG(uninitialized_zval);
     zval *this = ddtrace_this(execute_data);
 
     if (zend_fcall_info_init(callable, 0, &fci, &fcc, NULL, NULL TSRMLS_CC) == FAILURE) {
@@ -372,8 +373,10 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
 
     // Arg 2: mixed $retval
     args[2] = &user_retval;
+    // Arg 3: Exception|null $exception
+    args[3] = exception ? &exception : &null_zval;
 
-    fci.param_count = 3;
+    fci.param_count = 4;
     fci.params = args;
     fci.retval_ptr_ptr = &retval_ptr;
 

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -226,12 +226,17 @@ void ddtrace_copy_function_args(zend_execute_data *execute_data, zval *user_args
 }
 
 void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *execute_data, zval *user_args,
-                                     zval *user_retval) {
+                                     zval *user_retval, zend_object *exception) {
     zend_fcall_info fci = {0};
     zend_fcall_info_cache fcc = {0};
     zval rv;
     INIT_ZVAL(rv);
-    zval args[3];
+    zval args[4];
+    zval exception_arg;
+    ZVAL_UNDEF(&exception_arg);
+    if (exception) {
+        ZVAL_OBJ(&exception_arg, exception);
+    }
     zval *this = ddtrace_this(execute_data);
 
     if (zend_fcall_info_init(callable, 0, &fci, &fcc, NULL, NULL) == FAILURE) {
@@ -257,7 +262,10 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
     // Arg 2: mixed $retval
     ZVAL_COPY(&args[2], user_retval);
 
-    fci.param_count = 3;
+    // Arg 3: Exception|null $exception
+    ZVAL_COPY(&args[3], &exception_arg);
+
+    fci.param_count = 4;
     fci.params = args;
     fci.retval = &rv;
 
@@ -271,6 +279,7 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
         ddtrace_log_debug("Could not execute tracing closure");
     }
 
+    zval_ptr_dtor(&exception_arg);
     zval_ptr_dtor(&rv);
     zend_fcall_info_args_clear(&fci, 0);
 }

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -279,7 +279,6 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
         ddtrace_log_debug("Could not execute tracing closure");
     }
 
-    zval_ptr_dtor(&exception_arg);
     zval_ptr_dtor(&rv);
     zend_fcall_info_args_clear(&fci, 0);
 }

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Exceptions from original call are passed to tracing closure (PHP 7)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP 5 tested in separate test'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+register_shutdown_function(function () {
+    array_map(function($span) {
+        echo $span['name'];
+        if (isset($span['meta']['error.msg'])) {
+            echo ' with exception: ' . $span['meta']['error.msg'];
+        }
+        echo PHP_EOL;
+    }, dd_trace_serialize_closed_spans());
+});
+
+function testExceptionIsNull()
+{
+    echo "testExceptionIsNull()\n";
+}
+
+function testExceptionIsPassed()
+{
+    echo "testExceptionIsPassed()\n";
+    throw new Exception('Oops!');
+}
+
+dd_trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
+    $span->name = 'TestNull';
+    var_dump($ex === null);
+});
+
+dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
+    $span->name = 'TestEx';
+    var_dump($ex instanceof Exception);
+});
+
+testExceptionIsNull();
+testExceptionIsPassed();
+echo "This line should not be run\n";
+?>
+--EXPECTF--
+testExceptionIsNull()
+bool(true)
+testExceptionIsPassed()
+bool(true)
+
+Fatal error: Uncaught %sOops!%sin %s:%d
+Stack trace:
+#0 %s(%d): testExceptionIsPassed()
+#1 {main}
+  thrown in %s on line %d
+TestEx with exception: Oops!
+TestNull

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
@@ -7,13 +7,7 @@ Exceptions from original call are passed to tracing closure (PHP 7)
 use DDTrace\SpanData;
 
 register_shutdown_function(function () {
-    array_map(function($span) {
-        echo $span['name'];
-        if (isset($span['meta']['error.msg'])) {
-            echo ' with exception: ' . $span['meta']['error.msg'];
-        }
-        echo PHP_EOL;
-    }, dd_trace_serialize_closed_spans());
+
 });
 
 function testExceptionIsNull()
@@ -38,19 +32,24 @@ dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args
 });
 
 testExceptionIsNull();
-testExceptionIsPassed();
-echo "This line should not be run\n";
+try {
+    testExceptionIsPassed();
+} catch (Exception $e) {
+    //
+}
+
+array_map(function($span) {
+    echo $span['name'];
+    if (isset($span['meta']['error.msg'])) {
+        echo ' with exception: ' . $span['meta']['error.msg'];
+    }
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
 ?>
 --EXPECTF--
 testExceptionIsNull()
 bool(true)
 testExceptionIsPassed()
 bool(true)
-
-Fatal error: Uncaught %sOops!%sin %s:%d
-Stack trace:
-#0 %s(%d): testExceptionIsPassed()
-#1 {main}
-  thrown in %s on line %d
 TestEx with exception: Oops!
 TestNull

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Exceptions from original call are passed to tracing closure (PHP 5)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 70000) die('skip PHP 7 tested in separate test'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+register_shutdown_function(function () {
+    array_map(function($span) {
+        echo $span['name'];
+        if (isset($span['meta']['error.msg'])) {
+            echo ' with exception: ' . $span['meta']['error.msg'];
+        }
+        echo PHP_EOL;
+    }, dd_trace_serialize_closed_spans());
+});
+
+function testExceptionIsNull()
+{
+    echo "testExceptionIsNull()\n";
+}
+
+function testExceptionIsPassed()
+{
+    echo "testExceptionIsPassed()\n";
+    throw new Exception('Oops!');
+}
+
+dd_trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
+    $span->name = 'TestNull';
+    var_dump($ex === null);
+});
+
+dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
+    $span->name = 'TestEx';
+    var_dump($ex instanceof Exception);
+});
+
+testExceptionIsNull();
+testExceptionIsPassed();
+echo "This line should not be run\n";
+?>
+--EXPECTF--
+testExceptionIsNull()
+bool(true)
+testExceptionIsPassed()
+bool(true)
+
+Fatal error: Uncaught %sOops!%sin %s:%d
+Stack trace:
+#0 %s(%d): testExceptionIsPassed()
+#1 %s(%d): unknown()
+#2 {main}
+  thrown in %s on line %d
+TestEx with exception: Oops!
+TestNull

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Exceptions from original call are passed to tracing closure (PHP 5)
 --SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 <?php if (PHP_VERSION_ID >= 70000) die('skip PHP 7 tested in separate test'); ?>
 --FILE--
 <?php

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
@@ -5,15 +5,6 @@ Exceptions from original call rethrown in tracing closure (PHP 7)
 <?php if (PHP_VERSION_ID < 70000) die('skip PHP 5 tested in separate test'); ?>
 --FILE--
 <?php
-register_shutdown_function(function () {
-    array_map(function($span) {
-        printf(
-            "%s with exception: %s\n",
-            $span['name'],
-            $span['meta']['error.msg']
-        );
-    }, dd_trace_serialize_closed_spans());
-});
 
 function a(){
     echo "a()\n";
@@ -25,15 +16,20 @@ dd_trace_function('a', function($s, $args, $r, $ex) {
     throw $ex;
 });
 
-a();
-echo "This line should not be run\n";
+try {
+    a();
+} catch (Exception $e) {
+    //
+}
+
+array_map(function($span) {
+    printf(
+        "%s with exception: %s\n",
+        $span['name'],
+        $span['meta']['error.msg']
+    );
+}, dd_trace_serialize_closed_spans());
 ?>
 --EXPECTF--
 a()
-
-Fatal error: Uncaught %sOops!%sin %s:%d
-Stack trace:
-#0 %s(%d): a()
-#1 {main}
-  thrown in %s on line %d
 a with exception: Oops!

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Exceptions from original call rethrown in tracing closure (PHP 7)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP 5 tested in separate test'); ?>
+--FILE--
+<?php
+register_shutdown_function(function () {
+    array_map(function($span) {
+        printf(
+            "%s with exception: %s\n",
+            $span['name'],
+            $span['meta']['error.msg']
+        );
+    }, dd_trace_serialize_closed_spans());
+});
+
+function a(){
+    echo "a()\n";
+    throw new Exception('Oops!');
+}
+
+dd_trace_function('a', function($s, $args, $r, $ex) {
+    $s->name = 'a';
+    throw $ex;
+});
+
+a();
+echo "This line should not be run\n";
+?>
+--EXPECTF--
+a()
+
+Fatal error: Uncaught %sOops!%sin %s:%d
+Stack trace:
+#0 %s(%d): a()
+#1 {main}
+  thrown in %s on line %d
+a with exception: Oops!

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Exceptions from original call rethrown in tracing closure (PHP 5)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID >= 70000) die('skip PHP 7 tested in separate test'); ?>
+--FILE--
+<?php
+register_shutdown_function(function () {
+    array_map(function($span) {
+        printf(
+            "%s with exception: %s\n",
+            $span['name'],
+            $span['meta']['error.msg']
+        );
+    }, dd_trace_serialize_closed_spans());
+});
+
+function a(){
+    echo "a()\n";
+    throw new Exception('Oops!');
+}
+
+dd_trace_function('a', function($s, $args, $r, $ex) {
+    $s->name = 'a';
+    throw $ex;
+});
+
+a();
+echo "This line should not be run\n";
+?>
+--EXPECTF--
+a()
+
+Fatal error: Uncaught %sOops!%sin %s:%d
+Stack trace:
+#0 %s(%d): a()
+#1 %s(%d): unknown()
+#2 {main}
+  thrown in %s on line %d
+a with exception: Oops!

--- a/tests/ext/sandbox/exceptions_in_tracing_closure_and_original_call.phpt
+++ b/tests/ext/sandbox/exceptions_in_tracing_closure_and_original_call.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Exceptions thrown in tracing closure and original call
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP 5 tested in separate test'); ?>
+--FILE--
+<?php
+class SubException extends Exception { }
+
+function a(){
+    echo "a()\n";
+    throw new SubException('Oops!');
+}
+
+dd_trace_function('a', function($span, $args, $r, $ex) {
+    var_dump($ex instanceof SubException);
+    throw new Exception('!');
+});
+
+try {
+    a();
+} catch (SubException $ex) {
+   echo "Caught SubException\n";
+}
+echo "Recovery successful\n";
+?>
+--EXPECTF--
+a()
+bool(true)
+Caught SubException
+Recovery successful


### PR DESCRIPTION
### Description

This PR adds a fourth parameter to sandboxed tracing closures that contains the exception thrown from the original call. If no exception was thrown, the argument passed in will be `null`.

```php
dd_trace_function('myFunc', function (SpanData $span, array $args, $retval, $ex) {
    if ($ex instanceof FooException) {
        echo "FooException thrown!\n";
    }
});
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
