### PR TITLE
Fix compiler warning about uninitialized zval

### DIFF
--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -232,7 +232,7 @@ void ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_execu
     zval rv;
     INIT_ZVAL(rv);
     zval args[4];
-    zval exception_arg;
+    zval exception_arg = {0};
     ZVAL_UNDEF(&exception_arg);
     if (exception) {
         ZVAL_OBJ(&exception_arg, exception);


### PR DESCRIPTION
### Description

This tiny PR fixes a compiler warning about a possibly uninitialized zval.

### Readiness checklist
- ~~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~~
- ~~[ ] Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
