### PR TITLE
WordPress 4.8 core tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,6 +673,14 @@ workflows:
           requires: [ "Framework tests" ]
           framework_target: symfony_no_ddtrace
           name: "Symfony baseline testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
+          framework_target: wordpress
+          name: "WordPress testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
+          framework_target: wordpress_no_ddtrace
+          name: "WordPress baseline testsuite"
       - verify_package:
           requires: [ "package extension" ]
           name: "webdevops/php:7.1"

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
     "prefer-stable": true,
     "scripts": {
         "fix-lint": "phpcbf",
-        "lint": "phpcs -s --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php",
-        "lint-5.4": "phpcs -s --runtime-set testVersion 5.4-7.3 --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php",
+        "lint": "phpcs -s --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php,dockerfiles/",
+        "lint-5.4": "phpcs -s --runtime-set testVersion 5.4-7.3 --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php,dockerfiles/",
         "static-analyze": "phpstan analyse --level=2 src",
         "run-agent": [
             "docker run -p 8126:8126 -e \"DD_APM_ENABLED=true\" -e \"DD_BIND_HOST=0.0.0.0\" -e \"DD_API_KEY=invalid_key_but_this_is_fine\" --rm datadog/docker-dd-agent",

--- a/dockerfiles/frameworks/nginx_file_server/.gitignore
+++ b/dockerfiles/frameworks/nginx_file_server/.gitignore
@@ -1,0 +1,1 @@
+ddtrace.deb

--- a/dockerfiles/frameworks/src/Dockerfile
+++ b/dockerfiles/frameworks/src/Dockerfile
@@ -14,7 +14,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     apt-get update; \
-    apt-get install -y $(for V in 7.0 7.1 7.2 7.3; do \
+    apt-get install -y $(for V in 5.6 7.0 7.1 7.2 7.3; do \
         echo \
         php${V}-fpm \
         php${V}-apcu \
@@ -163,5 +163,28 @@ ADD flow/patch.patch ./
 RUN set -xe; \
     git apply *.patch
 
+CMD [ "./run.sh" ]
+
+FROM base AS wordpress
+ENV DD_SERVICE_NAME=wordpress
+ARG WORDPRESS_VERSION_TAG=4.8.10
+RUN set -xe; \
+  apt-get update; \
+  apt-get install -y default-mysql-client; \
+  apt-get clean
+
+RUN set -xe; \
+    git clone --depth 1 --branch ${WORDPRESS_VERSION_TAG} git://develop.git.wordpress.org/ /home/wordpress; \
+    cd /home/wordpress; \
+    switch_php 5.6; \
+    composer require --dev phpunit/phpunit ^5
+
+WORKDIR /home/wordpress
+ADD wordpress/wp-tests-config.php ./
+ADD wordpress/run.sh ./
+ADD wordpress/${WORDPRESS_VERSION_TAG}.patch ./
+
+RUN set -xe; \
+    git apply *.patch
 
 CMD [ "./run.sh" ]

--- a/dockerfiles/frameworks/src/wordpress/4.8.10.patch
+++ b/dockerfiles/frameworks/src/wordpress/4.8.10.patch
@@ -1,0 +1,88 @@
+From 2aaf78135f6d0570abeb24bdbfa6e18f0a307930 Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Wed, 11 Sep 2019 20:47:07 +0000
+Subject: [PATCH] Patch
+
+---
+ tests/phpunit/tests/basic.php                | 2 +-
+ tests/phpunit/tests/image/editor_imagick.php | 2 ++
+ tests/phpunit/tests/import/import.php        | 2 +-
+ tests/phpunit/tests/import/parser.php        | 2 +-
+ tests/phpunit/tests/import/postmeta.php      | 2 +-
+ 5 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/tests/phpunit/tests/basic.php b/tests/phpunit/tests/basic.php
+index 0d145f6..4c04551 100644
+--- a/tests/phpunit/tests/basic.php
++++ b/tests/phpunit/tests/basic.php
+@@ -13,7 +13,7 @@ class Tests_Basic extends WP_UnitTestCase {
+
+ 		$license = file_get_contents( ABSPATH . 'license.txt' );
+ 		preg_match( '#Copyright 2011-(\d+) by the contributors#', $license, $matches );
+-		$this_year = date( 'Y' );
++		$this_year = '2018';
+ 		$this->assertEquals( $this_year, trim( $matches[1] ), "license.txt's year needs to be updated to $this_year." );
+ 	}
+
+diff --git a/tests/phpunit/tests/image/editor_imagick.php b/tests/phpunit/tests/image/editor_imagick.php
+index e113b77..770fb97 100644
+--- a/tests/phpunit/tests/image/editor_imagick.php
++++ b/tests/phpunit/tests/image/editor_imagick.php
+@@ -420,6 +420,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
+ 	 * Test rotating an image 180 deg
+ 	 */
+ 	public function test_rotate() {
++		$this->markTestSkipped('Test fails out of the box');
+ 		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
+
+ 		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
+@@ -439,6 +440,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
+ 	 * Test flipping an image
+ 	 */
+ 	public function test_flip() {
++		$this->markTestSkipped('Test fails out of the box');
+ 		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
+
+ 		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
+diff --git a/tests/phpunit/tests/import/import.php b/tests/phpunit/tests/import/import.php
+index 9303444..fa0bcbb 100644
+--- a/tests/phpunit/tests/import/import.php
++++ b/tests/phpunit/tests/import/import.php
+@@ -18,7 +18,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
+ 		add_filter( 'import_allow_create_users', '__return_true' );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+diff --git a/tests/phpunit/tests/import/parser.php b/tests/phpunit/tests/import/parser.php
+index 890fd0a..3e2ee20 100644
+--- a/tests/phpunit/tests/import/parser.php
++++ b/tests/phpunit/tests/import/parser.php
+@@ -16,7 +16,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
+ 			define( 'WP_LOAD_IMPORTERS', true );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+diff --git a/tests/phpunit/tests/import/postmeta.php b/tests/phpunit/tests/import/postmeta.php
+index bf468a1..0fd8dae 100644
+--- a/tests/phpunit/tests/import/postmeta.php
++++ b/tests/phpunit/tests/import/postmeta.php
+@@ -16,7 +16,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
+ 			define( 'WP_LOAD_IMPORTERS', true );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+--
+2.20.1
+

--- a/dockerfiles/frameworks/src/wordpress/run.sh
+++ b/dockerfiles/frameworks/src/wordpress/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+
+for cnt in {1..100}; do
+    mysql -h mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_functional_testing;' && break || true
+    sleep 1
+done
+
+vendor/bin/phpunit

--- a/dockerfiles/frameworks/src/wordpress/wp-tests-config.php
+++ b/dockerfiles/frameworks/src/wordpress/wp-tests-config.php
@@ -1,0 +1,64 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress install defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', 'wordpress_functional_testing' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', '' );
+define( 'DB_HOST', 'mysql' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define('AUTH_KEY',         'B?xL|x=s6|8/Yi3ZW(]MVoxO-O:8taK91C$wfDpZ$`(Zo2ak*q J^+ir9s.|qwu3');
+define('SECURE_AUTH_KEY',  'SJ?)H|@e9Ezad3+LbS:j^7^lIN7-$.40-s,bM]a4{;P@cD+J8;X]jWbUaVA1<VG ');
+define('LOGGED_IN_KEY',    'MJ4N7Woe^gy5{ 9?WR4S6H8Z>nns?6tMwCt#,:xeQ g,$bT9d<4VN/(lhXR#z6QL');
+define('NONCE_KEY',        '.V+R ZJ$6-RG5|wqlv)HOTI_Rdj<aDUz(q])*N{#7VBk/U&`o|,_q;^$mN0o!m-j');
+define('AUTH_SALT',        'V>o&_Y+dI2ayQ!P`(<0iL IS@Aw%bqkwhQ!wBXc;_`KYR_Oxu@x!3wwr6U>BtQ-?');
+define('SECURE_AUTH_SALT', 'd6::Ym$|XSy?$-X~HT7K2}Q 4%?U Xe+gwY2V7FO;kNvnTG5//YZW4:*kfVA5eWw');
+define('LOGGED_IN_SALT',   '-ONc3g-<Pm@M-&6;R2JIDX=/~`1 GXaDewKRlAmr2.->k0=hV1!xr8l=j![XDl28');
+define('NONCE_SALT',       'vi/{40CMK^mNYWMYv<>+Gi)>g.!S=!h@^^)]*.|Gf>5=JN7(lI1~cB-@>88,mhB1');
+
+$table_prefix  = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/dockerfiles/frameworks/wordpress.yml
+++ b/dockerfiles/frameworks/wordpress.yml
@@ -1,0 +1,28 @@
+version: "3.6"
+
+services:
+  wordpress:
+    depends_on: ['mysql', 'nginx_file_server']
+    build:
+      context: src
+      target: wordpress
+    image: 'docker.pkg.github.com/datadog/dd-trace-php/framwork-ci-wordpress:4.8-php-5.6'
+    ulimits:
+      core: 99999999999
+    cap_add:
+      - SYS_PTRACE
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_ROOT_HOST: "%"
+    expose: ["3306"]
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+  nginx_file_server:
+    build: nginx_file_server
+    expose: ["80"]


### PR DESCRIPTION
### Description

This PR adds WordPress 4.8.10 core tests (running on PHP 5.6) to the framework tests in preparation for the WordPress integration.

### Readiness checklist
- ~~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~~
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- ~~[ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~~
