### PR TITLE
Correctly treat class names as case insensitive

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -94,6 +94,7 @@
                     <file name="access_modifier_method_access_hook.phpt" role="test" />
                     <file name="access_modifier_property_access_hook.phpt" role="test" />
                     <file name="allow_overriding_before_overrided_methods_functions_are_defined.phpt" role="test" />
+                    <file name="case_insensitive_class_hook.phpt" role="test" />
                     <file name="case_insensitive_method_hook.phpt" role="test" />
                     <file name="closure_accessing_outside_variables.phpt" role="test" />
                     <file name="closure_set_inside_object_methods.phpt" role="test" />

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -43,14 +43,16 @@ static ddtrace_dispatch_t *find_method_dispatch(const zend_class_entry *class, z
     }
     HashTable *class_lookup = NULL;
 
+    // downcase the class name as they are case insensitive
 #if PHP_VERSION_ID < 70000
-    const char *class_name = NULL;
-    size_t class_name_length = 0;
-    class_name = class->name;
-    class_name_length = class->name_length;
+    size_t class_name_length = class->name_length;
+    char *class_name = zend_str_tolower_dup(class->name, class_name_length);
     class_lookup = zend_hash_str_find_ptr(DDTRACE_G(class_lookup), class_name, class_name_length);
+    efree(class_name);
 #else
-    class_lookup = zend_hash_find_ptr(DDTRACE_G(class_lookup), class->name);
+    zend_string *class_name = zend_string_tolower(class->name);
+    class_lookup = zend_hash_find_ptr(DDTRACE_G(class_lookup), class_name);
+    zend_string_release(class_name);
 #endif
 
     ddtrace_dispatch_t *dispatch = NULL;

--- a/tests/ext/case_insensitive_class_hook.phpt
+++ b/tests/ext/case_insensitive_class_hook.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Check if for case insensitive class name support
+--FILE--
+<?php
+class Base {
+    public function method(){
+        echo __METHOD__ . PHP_EOL;
+    }
+}
+
+dd_trace("base", "method", function () {
+    echo "HOOK ";
+    return dd_trace_forward_call();
+});
+
+(new Base())->method();
+(new base())->method();
+
+?>
+--EXPECT--
+HOOK Base::method
+HOOK Base::method


### PR DESCRIPTION
### Description

In PHP, class and method names are case insensitive. We already handled method names correctly. This PR adds support for case insensitive class names too.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
