### PR TITLE
Fix Predis integration for clusters

### DIFF
--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -7,6 +7,7 @@ use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\GlobalTracer;
 use Predis\Configuration\OptionsInterface;
+use Predis\Connection\AbstractConnection;
 use Predis\Pipeline\Pipeline;
 
 const VALUE_PLACEHOLDER = "?";
@@ -221,12 +222,13 @@ class PredisIntegration extends Integration
     {
         $tags = [];
 
-        try {
-            $identifier = (string)$predis->getConnection();
-            list($host, $port) = explode(':', $identifier);
-            $tags[Tag::TARGET_HOST] = $host;
-            $tags[Tag::TARGET_PORT] = $port;
-        } catch (\Exception $e) {
+        $connection = $predis->getConnection();
+
+        if ($connection instanceof AbstractConnection) {
+            $connectionParameters = $connection->getParameters();
+
+            $tags[Tag::TARGET_HOST] = $connectionParameters->host;
+            $tags[Tag::TARGET_PORT] = $connectionParameters->port;
         }
 
         if (isset($args[1])) {

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -83,6 +83,22 @@ final class PredisTest extends IntegrationTestCase
         ]);
     }
 
+    public function testPredisClusterConnect()
+    {
+        $connectionString = "tcp://{$this->host}";
+
+        $traces = $this->isolateTracer(function () use ($connectionString) {
+            $client = new \Predis\Client([ $connectionString, $connectionString, $connectionString ]);
+            $client->connect();
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::exists('Predis.Client.__construct'),
+            SpanAssertion::build('Predis.Client.connect', 'redis', 'cache', 'Predis.Client.connect')
+                ->withExactTags([]),
+        ]);
+    }
+
     public function testPredisSetCommand()
     {
         $traces = $this->isolateTracer(function () {


### PR DESCRIPTION
### Description

Currently, the Predis integration makes our application crash when enabling APM (see issue #315). Because the interface that Predis provides doesn't allow getting the connection details for a cluster, in this PR I've removed the host and port tags for clusters. This also makes the retrieving of host and port a bit cleaner.

### Readiness checklist
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
