### PR TITLE
Add filesystem integration

### DIFF
--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -72,6 +72,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegr
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Curl/CurlIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoClientIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoDBIntegration.php';

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace DDTrace\Integrations\Filesystem;
+
+use DDTrace\Integrations\Integration;
+use DDTrace\Span;
+use DDTrace\Tag;
+use DDTrace\Type;
+use DDTrace\GlobalTracer;
+
+/**
+ * Integration for native PHP filesystem functions.
+ */
+class FilesystemIntegration extends Integration
+{
+    const NAME = 'filesystem';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Loads the integration.
+     */
+    public static function load()
+    {
+        dd_trace('file_get_contents', function ($file) {
+            $tracer = GlobalTracer::get();
+
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                FilesystemIntegration::getInstance(),
+                'filesystem.file_get_contents'
+            );
+            $span = $scope->getSpan();
+
+            $span->setTag(Tag::SPAN_TYPE, Type::FILESYSTEM);
+            $span->setTag(Tag::SERVICE_NAME, 'filesystem');
+            $span->setTag(Tag::RESOURCE_NAME, $file);
+
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        dd_trace('file_put_contents', function ($file) {
+            $tracer = GlobalTracer::get();
+
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = $tracer->startIntegrationScopeAndSpan(
+                FilesystemIntegration::getInstance(),
+                'filesystem.file_put_contents'
+            );
+            $span = $scope->getSpan();
+
+            $span->setTag(Tag::SPAN_TYPE, Type::FILESYSTEM);
+            $span->setTag(Tag::SERVICE_NAME, 'filesystem');
+            $span->setTag(Tag::RESOURCE_NAME, $file);
+
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        return Integration::LOADED;
+    }
+}

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -9,6 +9,7 @@ use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration;
 use DDTrace\Integrations\Eloquent\EloquentIntegration;
 use DDTrace\Integrations\Eloquent\EloquentSandboxedIntegration;
+use DDTrace\Integrations\Filesystem\FilesystemIntegration;
 use DDTrace\Integrations\Guzzle\GuzzleIntegration;
 use DDTrace\Integrations\Laravel\LaravelIntegration;
 use DDTrace\Integrations\Lumen\LumenIntegration;
@@ -50,6 +51,7 @@ class IntegrationsLoader
         CurlIntegration::NAME => '\DDTrace\Integrations\Curl\CurlIntegration',
         ElasticSearchIntegration::NAME => '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
         EloquentIntegration::NAME => '\DDTrace\Integrations\Eloquent\EloquentIntegration',
+        FilesystemIntegration::NAME => '\DDTrace\Integrations\Filesystem\FilesystemIntegration',
         GuzzleIntegration::NAME => '\DDTrace\Integrations\Guzzle\GuzzleIntegration',
         LaravelIntegration::NAME => '\DDTrace\Integrations\Laravel\LaravelIntegration',
         LumenIntegration::NAME => '\DDTrace\Integrations\Lumen\LumenIntegration',

--- a/src/DDTrace/Type.php
+++ b/src/DDTrace/Type.php
@@ -4,6 +4,7 @@ namespace DDTrace;
 
 class Type
 {
+    const FILESYSTEM = 'filesystem';
     const CACHE = 'cache';
     const HTTP_CLIENT = 'http';
     const WEB_SERVLET = 'web';

--- a/tests/Common/SpanIntegrationChecker.php
+++ b/tests/Common/SpanIntegrationChecker.php
@@ -27,6 +27,7 @@ final class SpanIntegrationChecker
             // Officially supported integrations
             '/curl_.*/' => 'DDTrace\Integrations\Curl\CurlIntegration',
             '/Elasticsearch(.).*/' => 'DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration',
+            '/filesystem.*/' => 'DDTrace\Integrations\Filesystem\FilesystemIntegration',
             '/GuzzleHttp.*/' => 'DDTrace\Integrations\Guzzle\GuzzleIntegration',
             '/laravel.*/' => 'DDTrace\Integrations\Laravel\LaravelIntegration',
             '/Memcached.*/' => 'DDTrace\Integrations\Memcached\MemcachedIntegration',

--- a/tests/Integrations/Filesystem/FilesystemIntegrationTest.php
+++ b/tests/Integrations/Filesystem/FilesystemIntegrationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Filesystem;
+
+use DDTrace\Integrations\IntegrationsLoader;
+use DDTrace\Tests\Common\IntegrationTestCase;
+use DDTrace\Tests\Common\SpanAssertion;
+
+final class FilesystemIntegrationTest extends IntegrationTestCase
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        IntegrationsLoader::load();
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testFileGetAndPutContents()
+    {
+        $traces = $this->isolateTracer(function () {
+            file_put_contents('test_file', 'contents');
+            $this->assertEquals(file_get_contents('test_file'), 'contents');
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build('filesystem.file_put_contents', 'filesystem', 'filesystem', 'test_file'),
+            SpanAssertion::build('filesystem.file_get_contents', 'filesystem', 'filesystem', 'test_file'),
+        ]);
+    }
+}


### PR DESCRIPTION
### Description

This adds an integration for the native `file_get_contents` and `file_put_contents` functions. In a follow up, I want to also add spans to `fopen`/`fread`/`fwrite`/`fclose`. 

### Readiness checklist
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
