### PR TITLE
Fix static keyword handling

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -184,6 +184,7 @@
                     <file name="method_returning_array.phpt" role="test" />
                     <file name="multiple_instrumentations.phpt" role="test" />
                     <file name="namespaces.phpt" role="test" />
+                    <file name="new_static.phpt" role="test" />
                     <file name="overriding_construct.phpt" role="test" />
                     <file name="overriding_method_defined_in_parent.phpt" role="test" />
                     <file name="private_method_hook.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -137,6 +137,7 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
+                        <file name="new_static.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-regression">

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -301,7 +301,11 @@ int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zv
     fcc.function_handler = fbc;
     fcc.object_ptr = ddtrace_this(execute_data);
     fcc.calling_scope = fbc->common.scope;  // EG(scope);
-    fcc.called_scope = fcc.object_ptr ? Z_OBJCE_P(fcc.object_ptr) : fbc->common.scope;
+#if PHP_VERSION_ID < 50500
+    fcc.called_scope = EX(called_scope);
+#else
+    fcc.called_scope = EX(call) ? EX(call)->called_scope : NULL;
+#endif
 
     ddtrace_setup_fcall(execute_data, &fci, &retval_ptr TSRMLS_CC);
     fci.size = sizeof(fci);
@@ -383,7 +387,11 @@ BOOL_T ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_exe
 
     fcc.initialized = 1;
     fcc.object_ptr = this;
-    fcc.called_scope = fcc.object_ptr ? Z_OBJCE_P(fcc.object_ptr) : NULL;
+#if PHP_VERSION_ID < 50500
+    fcc.called_scope = EX(called_scope);
+#else
+    fcc.called_scope = EX(call) ? EX(call)->called_scope : NULL;
+#endif
     // Give the tracing closure access to private & protected class members
     fcc.function_handler->common.scope = fcc.called_scope;
 

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -209,7 +209,13 @@ void ddtrace_wrapper_forward_call_from_userland(zend_execute_data *execute_data,
     fcc.function_handler = DDTRACE_G(original_context).fbc;
     fcc.object_ptr = DDTRACE_G(original_context).this;
     fcc.calling_scope = DDTRACE_G(original_context).calling_ce;
-    fcc.called_scope = fcc.object_ptr ? Z_OBJCE_P(fcc.object_ptr) : DDTRACE_G(original_context).fbc->common.scope;
+#if PHP_VERSION_ID < 50500
+    fcc.called_scope = DDTRACE_G(original_context).execute_data->called_scope;
+#else
+    fcc.called_scope = DDTRACE_G(original_context).execute_data->call
+                           ? DDTRACE_G(original_context).execute_data->call->called_scope
+                           : NULL;
+#endif
 
     fci.size = sizeof(fci);
     fci.function_table = EG(function_table);

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -170,7 +170,7 @@ int ddtrace_forward_call(zend_execute_data *execute_data, zend_function *fbc, zv
     fcc->function_handler = fbc;
     fcc->object = Z_TYPE(EX(This)) == IS_OBJECT ? Z_OBJ(EX(This)) : NULL;
     fcc->calling_scope = fbc->common.scope;  // EG(scope);
-    fcc->called_scope = fcc->object ? fcc->object->ce : fbc->common.scope;
+    fcc->called_scope = zend_get_called_scope(execute_data);
 
     fci->size = sizeof(zend_fcall_info);
     fci->no_separation = 1;
@@ -274,7 +274,7 @@ BOOL_T ddtrace_execute_tracing_closure(zval *callable, zval *span_data, zend_exe
     fcc.initialized = 1;
 #endif
     fcc.object = this ? Z_OBJ_P(this) : NULL;
-    fcc.called_scope = fcc.object ? fcc.object->ce : NULL;
+    fcc.called_scope = zend_get_called_scope(EX(call));
     // Give the tracing closure access to private & protected class members
     fcc.function_handler->common.scope = fcc.called_scope;
 

--- a/src/ext/dispatch_compat_php7.c
+++ b/src/ext/dispatch_compat_php7.c
@@ -112,7 +112,7 @@ void ddtrace_wrapper_forward_call_from_userland(zend_execute_data *execute_data,
 #endif
     fcc.function_handler = DDTRACE_G(original_context).execute_data->func;
     fcc.calling_scope = DDTRACE_G(original_context).calling_ce;
-    fcc.called_scope = fci.object ? fci.object->ce : DDTRACE_G(original_context).fbc->common.scope;
+    fcc.called_scope = zend_get_called_scope(DDTRACE_G(original_context).execute_data);
     fcc.object = fci.object;
 
     if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {

--- a/tests/ext/new_static.phpt
+++ b/tests/ext/new_static.phpt
@@ -1,0 +1,23 @@
+--TEST--
+New static instantiates from expected class
+--FILE--
+<?php
+abstract class Foo {
+    public static function get() {
+        return new static();
+    }
+}
+
+class Bar extends Foo {
+    // Empty
+}
+
+dd_trace('Foo', 'get', function () {
+    return dd_trace_forward_call();
+});
+
+$bar = Bar::get();
+var_dump($bar instanceof Bar);
+?>
+--EXPECT--
+bool(true)

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Errors from userland will be flagged on span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/new_static.phpt
+++ b/tests/ext/sandbox/new_static.phpt
@@ -1,0 +1,32 @@
+--TEST--
+New static instantiates from expected class
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+abstract class Foo {
+    public static function get() {
+        return new static();
+    }
+}
+
+class Bar extends Foo {
+    // Empty
+}
+
+dd_trace_method('Foo', 'get', function (SpanData $span) {
+    $span->name = get_called_class();
+});
+
+$bar = Bar::get();
+var_dump($bar instanceof Bar);
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(true)
+Bar


### PR DESCRIPTION
### Description

This PR fixes an edge case the breaks usage of `new static()` for traced methods in both the sandbox and original API's.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
