### PR TITLE
Ensure the request init hook is bound by the open_basedir INI directive

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -67,6 +67,7 @@
                     <file name="random.h" role="src" />
                     <file name="request_hooks.c" role="src" />
                     <file name="request_hooks.h" role="src" />
+                    <file name="sandbox.h" role="src" />
                     <file name="serializer.c" role="src" />
                     <file name="serializer.h" role="src" />
                     <file name="version.h" role="src" />

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -9,6 +9,7 @@
 #include "ddtrace.h"
 #include "env_config.h"
 #include "logging.h"
+#include "sandbox.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
@@ -81,10 +82,10 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
     int ret;
 
     BOOL_T rv = FALSE;
-    char *original_open_basedir = PG(open_basedir);
-    PG(open_basedir) = NULL;
 
+    DD_TRACE_SANDBOX_OPEN
     ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE TSRMLS_CC);
+    DD_TRACE_SANDBOX_CLOSE
 
     if (ret == SUCCESS) {
         if (!file_handle.opened_path) {
@@ -105,7 +106,10 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
                 zend_rebuild_symbol_table(TSRMLS_C);
             }
 
-            zend_execute(new_op_array TSRMLS_CC);
+            DD_TRACE_SANDBOX_OPEN
+            zend_try { zend_execute(new_op_array TSRMLS_CC); }
+            zend_end_try();
+            DD_TRACE_SANDBOX_CLOSE
 
             destroy_op_array(new_op_array TSRMLS_CC);
             efree(new_op_array);
@@ -118,7 +122,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         }
     }
 
-    PG(open_basedir) = original_open_basedir;
     return rv;
 }
 #else
@@ -133,9 +136,9 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
     zend_op_array *new_op_array;
     zval result;
     int ret, rv = FALSE;
-    char *original_open_basedir = PG(open_basedir);
-    PG(open_basedir) = NULL;
+    DD_TRACE_SANDBOX_OPEN
     ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE);
+    DD_TRACE_SANDBOX_CLOSE
 
     if (ret == SUCCESS) {
         zend_string *opened_path;
@@ -154,7 +157,9 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         zend_string_release(opened_path);
         if (new_op_array) {
             ZVAL_UNDEF(&result);
+            DD_TRACE_SANDBOX_OPEN
             zend_execute(new_op_array, &result);
+            DD_TRACE_SANDBOX_CLOSE
 
             destroy_op_array(new_op_array);
             efree(new_op_array);
@@ -165,7 +170,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         }
     }
 
-    PG(open_basedir) = original_open_basedir;
     return rv;
 }
 #endif

--- a/src/ext/sandbox.h
+++ b/src/ext/sandbox.h
@@ -1,0 +1,37 @@
+#ifndef DDTRACE_SANDBOX_H
+#define DDTRACE_SANDBOX_H
+#include <Zend/zend_exceptions.h>
+#include <php.h>
+
+#if PHP_VERSION_ID < 70000
+#define DD_TRACE_SANDBOX_OPEN                                                  \
+    zend_error_handling error_handling;                                        \
+    int orig_error_reporting = EG(error_reporting);                            \
+    EG(error_reporting) = 0;                                                   \
+    zend_replace_error_handling(EH_SUPPRESS, NULL, &error_handling TSRMLS_CC); \
+    {
+#define DD_TRACE_SANDBOX_CLOSE                              \
+    }                                                       \
+    zend_restore_error_handling(&error_handling TSRMLS_CC); \
+    EG(error_reporting) = orig_error_reporting;             \
+    if (EG(exception)) {                                    \
+        if (!DDTRACE_G(strict_mode)) {                      \
+            zend_clear_exception(TSRMLS_C);                 \
+        }                                                   \
+    }
+#else
+#define DD_TRACE_SANDBOX_OPEN                       \
+    int orig_error_reporting = EG(error_reporting); \
+    EG(error_reporting) = 0;                        \
+    {
+#define DD_TRACE_SANDBOX_CLOSE                  \
+    }                                           \
+    EG(error_reporting) = orig_error_reporting; \
+    if (EG(exception)) {                        \
+        if (!DDTRACE_G(strict_mode)) {          \
+            zend_clear_exception(TSRMLS_C);     \
+        }                                       \
+    }
+#endif
+
+#endif  // DDTRACE_SANDBOX_H


### PR DESCRIPTION
### Description

This PR ensures that the `ddtrace.request_init_hook` is still bound by the `open_basedir` INI directive. It also sandboxes the request init hook so that errors or exceptions within the request init hook do not affect the main script execution.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- ~~[ ] Tests added for this feature/bug.~~ The master build tests are expected to fail for this PR; this will be addressed ASAP

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
