### PR TITLE
Request init hook edge cases tests

### DIFF
--- a/.circleci/valgrind/valgrind_7_3_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_7_3_musl_suppressions.lib
@@ -70,3 +70,10 @@
     obj:*
     obj:*
 }
+{
+    <insert_a_suppression_name_here>
+    Memcheck:Cond
+    fun:strlcpy
+    obj:*
+    obj:*
+}

--- a/package.xml
+++ b/package.xml
@@ -64,6 +64,7 @@
                     <file name="random.h" role="src" />
                     <file name="request_hooks.c" role="src" />
                     <file name="request_hooks.h" role="src" />
+                    <file name="sandbox.h" role="src" />
                     <file name="serializer.c" role="src" />
                     <file name="serializer.h" role="src" />
                     <file name="span.c" role="src" />

--- a/package.xml
+++ b/package.xml
@@ -90,7 +90,18 @@
             <dir name="tests">
                 <dir name="ext">
                     <dir name="includes">
+                        <file name="sanity_check.php" role="test" />
                         <file name="try_catch_finally.php" role="test" />
+                    </dir>
+                    <dir name="request-init-hook">
+                        <file name="raises_fatal_error.php" role="test" />
+                        <file name="request_init_hook_check_blacklisted_modules.phpt" role="test" />
+                        <file name="request_init_hook_confined_to_open_basedir.phpt" role="test" />
+                        <file name="request_init_hook_file_not_found.phpt" role="test" />
+                        <file name="request_init_hook_ignores_exceptions.phpt" role="test" />
+                        <file name="request_init_hook_ignores_fatal_errors.phpt" role="test" />
+                        <file name="run_file_before_request_handling.phpt" role="test" />
+                        <file name="throws_exception.php" role="test" />
                     </dir>
                     <file name="access_modifier_method_access_hook.phpt" role="test" />
                     <file name="access_modifier_property_access_hook.phpt" role="test" />
@@ -192,13 +203,10 @@
                     <file name="private_self_access.phpt" role="test" />
                     <file name="protected_method_hook.phpt" role="test" />
                     <file name="recursion.phpt" role="test" />
-                    <file name="request_init_hook_check_blacklisted_modules.phpt" role="test" />
-                    <file name="request_init_hook_file_not_found.phpt" role="test" />
                     <file name="read_c_configuration.phpt" role="test" />
                     <file name="reset_configured_overrides.phpt" role="test" />
                     <file name="reset_function_tracing.phpt" role="test" />
                     <file name="return_value_passed.phpt" role="test" />
-                    <file name="run_file_before_request_handling.phpt" role="test" />
                     <file name="segfault_backtrace_disabled.phpt" role="test" />
                     <file name="segfault_backtrace_enabled.phpt" role="test" />
                     <file name="get_memory_limit_set_by_percentage.phpt" role="test" />
@@ -217,7 +225,6 @@
                     <file name="get_memory_limit_0_percent.phpt" role="test" />
                     <file name="simple_function_hook.phpt" role="test" />
                     <file name="simple_method_hook.phpt" role="test" />
-                    <file name="simple_sanity_check.phpt" role="test" />
                     <file name="throw_exception.phpt" role="test" />
                     <file name="trace_method_or_function_that_will_exist_later.phpt" role="test" />
                     <file name="trace_static_method.phpt" role="test" />

--- a/src/ext/dispatch_compat_php5.c
+++ b/src/ext/dispatch_compat_php5.c
@@ -227,7 +227,7 @@ void ddtrace_wrapper_forward_call_from_userland(zend_execute_data *execute_data,
     fci.no_separation = 1;
     fci.symbol_table = NULL;
 
-    zval args;
+    zval args = {0};
     if (0 == get_args(&args, prev_ex)) {
         zval_dtor(&args);
         zend_throw_exception_ex(spl_ce_RuntimeException, 0 TSRMLS_CC, "Cannot forward original function arguments");

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -114,10 +114,11 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
             destroy_op_array(new_op_array TSRMLS_CC);
             efree(new_op_array);
             if (!EG(exception)) {
-                if (EG(return_value_ptr_ptr)) {
+                if (EG(return_value_ptr_ptr) && *EG(return_value_ptr_ptr)) {
                     zval_ptr_dtor(EG(return_value_ptr_ptr));
                 }
             }
+            DD_TRACE_MAYBE_CLEAR_EXCEPTION
             rv = TRUE;
         }
     }
@@ -166,6 +167,7 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
             if (!EG(exception)) {
                 zval_ptr_dtor(&result);
             }
+            DD_TRACE_MAYBE_CLEAR_EXCEPTION
             rv = TRUE;
         }
     }

--- a/src/ext/request_hooks.c
+++ b/src/ext/request_hooks.c
@@ -9,6 +9,7 @@
 #include "ddtrace.h"
 #include "env_config.h"
 #include "logging.h"
+#include "sandbox.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
@@ -81,10 +82,10 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
     int ret;
 
     BOOL_T rv = FALSE;
-    char *original_open_basedir = PG(open_basedir);
-    PG(open_basedir) = NULL;
 
+    DD_TRACE_SANDBOX_OPEN
     ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE TSRMLS_CC);
+    DD_TRACE_SANDBOX_CLOSE
 
     if (ret == SUCCESS) {
         if (!file_handle.opened_path) {
@@ -105,7 +106,10 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
                 zend_rebuild_symbol_table(TSRMLS_C);
             }
 
-            zend_execute(new_op_array TSRMLS_CC);
+            DD_TRACE_SANDBOX_OPEN
+            zend_try { zend_execute(new_op_array TSRMLS_CC); }
+            zend_end_try();
+            DD_TRACE_SANDBOX_CLOSE
 
             destroy_op_array(new_op_array TSRMLS_CC);
             efree(new_op_array);
@@ -118,7 +122,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         }
     }
 
-    PG(open_basedir) = original_open_basedir;
     return rv;
 }
 #else
@@ -133,9 +136,9 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
     zend_op_array *new_op_array;
     zval result;
     int ret, rv = FALSE;
-    char *original_open_basedir = PG(open_basedir);
-    PG(open_basedir) = NULL;
+    DD_TRACE_SANDBOX_OPEN
     ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE);
+    DD_TRACE_SANDBOX_CLOSE
 
     if (ret == SUCCESS) {
         zend_string *opened_path;
@@ -154,7 +157,9 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         zend_string_release(opened_path);
         if (new_op_array) {
             ZVAL_UNDEF(&result);
+            DD_TRACE_SANDBOX_OPEN
             zend_execute(new_op_array, &result);
+            DD_TRACE_SANDBOX_CLOSE
 
             destroy_op_array(new_op_array);
             efree(new_op_array);
@@ -165,7 +170,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
         }
     }
 
-    PG(open_basedir) = original_open_basedir;
     return rv;
 }
 #endif

--- a/src/ext/sandbox.h
+++ b/src/ext/sandbox.h
@@ -13,24 +13,37 @@
 #define DD_TRACE_SANDBOX_CLOSE                              \
     }                                                       \
     zend_restore_error_handling(&error_handling TSRMLS_CC); \
-    EG(error_reporting) = orig_error_reporting;             \
-    if (EG(exception)) {                                    \
-        if (!DDTRACE_G(strict_mode)) {                      \
-            zend_clear_exception(TSRMLS_C);                 \
-        }                                                   \
+    EG(error_reporting) = orig_error_reporting;
+
+// Cannot use zend_clear_exception() in PHP 5 since there is no NULL check on the opline
+#define DD_TRACE_MAYBE_CLEAR_EXCEPTION                                          \
+    if (EG(exception)) {                                                        \
+        if (!DDTRACE_G(strict_mode)) {                                          \
+            zval_ptr_dtor(&EG(exception));                                      \
+            EG(exception) = NULL;                                               \
+            if (EG(prev_exception)) {                                           \
+                zval_ptr_dtor(&EG(prev_exception));                             \
+                EG(prev_exception) = NULL;                                      \
+            }                                                                   \
+            if (EG(current_execute_data)) {                                     \
+                EG(current_execute_data)->opline = EG(opline_before_exception); \
+            }                                                                   \
+        }                                                                       \
     }
 #else
 #define DD_TRACE_SANDBOX_OPEN                       \
     int orig_error_reporting = EG(error_reporting); \
     EG(error_reporting) = 0;                        \
     {
-#define DD_TRACE_SANDBOX_CLOSE                  \
-    }                                           \
-    EG(error_reporting) = orig_error_reporting; \
-    if (EG(exception)) {                        \
-        if (!DDTRACE_G(strict_mode)) {          \
-            zend_clear_exception(TSRMLS_C);     \
-        }                                       \
+#define DD_TRACE_SANDBOX_CLOSE \
+    }                          \
+    EG(error_reporting) = orig_error_reporting;
+
+#define DD_TRACE_MAYBE_CLEAR_EXCEPTION \
+    if (EG(exception)) {               \
+        if (!DDTRACE_G(strict_mode)) { \
+            zend_clear_exception();    \
+        }                              \
     }
 #endif
 

--- a/src/ext/sandbox.h
+++ b/src/ext/sandbox.h
@@ -1,0 +1,37 @@
+#ifndef DDTRACE_SANDBOX_H
+#define DDTRACE_SANDBOX_H
+#include <Zend/zend_exceptions.h>
+#include <php.h>
+
+#if PHP_VERSION_ID < 70000
+#define DD_TRACE_SANDBOX_OPEN                                                  \
+    zend_error_handling error_handling;                                        \
+    int orig_error_reporting = EG(error_reporting);                            \
+    EG(error_reporting) = 0;                                                   \
+    zend_replace_error_handling(EH_SUPPRESS, NULL, &error_handling TSRMLS_CC); \
+    {
+#define DD_TRACE_SANDBOX_CLOSE                              \
+    }                                                       \
+    zend_restore_error_handling(&error_handling TSRMLS_CC); \
+    EG(error_reporting) = orig_error_reporting;             \
+    if (EG(exception)) {                                    \
+        if (!DDTRACE_G(strict_mode)) {                      \
+            zend_clear_exception(TSRMLS_C);                 \
+        }                                                   \
+    }
+#else
+#define DD_TRACE_SANDBOX_OPEN                       \
+    int orig_error_reporting = EG(error_reporting); \
+    EG(error_reporting) = 0;                        \
+    {
+#define DD_TRACE_SANDBOX_CLOSE                  \
+    }                                           \
+    EG(error_reporting) = orig_error_reporting; \
+    if (EG(exception)) {                        \
+        if (!DDTRACE_G(strict_mode)) {          \
+            zend_clear_exception(TSRMLS_C);     \
+        }                                       \
+    }
+#endif
+
+#endif  // DDTRACE_SANDBOX_H

--- a/tests/ext/includes/sanity_check.php
+++ b/tests/ext/includes/sanity_check.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "Sanity check\n";

--- a/tests/ext/request-init-hook/raises_fatal_error.php
+++ b/tests/ext/request-init-hook/raises_fatal_error.php
@@ -1,0 +1,5 @@
+<?php
+
+echo "Calling a function that does not exist...\n";
+this_function_does_not_exist();
+echo "You should not see this line.\n";

--- a/tests/ext/request-init-hook/request_init_hook_check_blacklisted_modules.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_check_blacklisted_modules.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Do not prepend request hook if offending module has been detected
 --INI--
-ddtrace.request_init_hook=tests/ext/simple_sanity_check.phpt
+ddtrace.request_init_hook=tests/ext/includes/sanity_check.php
 ddtrace.internal_blacklisted_modules_list=ddtrace,some_other_module
 --FILE--
 <?php

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Request init hook is confined to open_basedir
+--INI--
+open_basedir=tests/ext/request-init-hook
+ddtrace.request_init_hook=tests/ext/includes/sanity_check.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -1,11 +1,11 @@
 --TEST--
 Do not fail when PHP code couldn't be loaded
 --INI--
-ddtrace.request_init_hook=tests/ext/this_file_doesnt_exist.phpt
+ddtrace.request_init_hook=tests/ext/request-init-hook/this_file_doesnt_exist.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;
 
 ?>
---EXPECTREGEX--
+--EXPECT--
 Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Request init hook ignores exceptions
+--INI--
+ddtrace.request_init_hook=tests/ext/request-init-hook/throws_exception.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Throwing an exception...
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Request init hook ignores fatal errors
+--INI--
+ddtrace.request_init_hook=tests/ext/request-init-hook/raises_fatal_error.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Calling a function that does not exist...
+Request start

--- a/tests/ext/request-init-hook/run_file_before_request_handling.phpt
+++ b/tests/ext/request-init-hook/run_file_before_request_handling.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Prepend PHP code before the processing takes place and do not blacklist functionality on partial match
 --INI--
-ddtrace.request_init_hook=tests/ext/simple_sanity_check.phpt
+ddtrace.request_init_hook=tests/ext/includes/sanity_check.php
 ddtrace.internal_blacklisted_modules_list=ddtrace_its_not,some_other_module
 
 --FILE--
@@ -9,11 +9,6 @@ ddtrace.internal_blacklisted_modules_list=ddtrace_its_not,some_other_module
 echo "Request start" . PHP_EOL;
 
 ?>
---EXPECTREGEX--
-.-TEST--
-Simple sanity check, used in run_file_before_request_handling.phpt test
-.-FILE--
-Check
-.-EXPECT--
-Check
+--EXPECT--
+Sanity check
 Request start

--- a/tests/ext/request-init-hook/throws_exception.php
+++ b/tests/ext/request-init-hook/throws_exception.php
@@ -1,0 +1,5 @@
+<?php
+
+echo "Throwing an exception...\n";
+throw new Exception('Oops!');
+echo "You should not see this line.\n";

--- a/tests/ext/simple_sanity_check.phpt
+++ b/tests/ext/simple_sanity_check.phpt
@@ -1,9 +1,0 @@
---TEST--
-Simple sanity check, used in run_file_before_request_handling.phpt test
---FILE--
-<?php
-echo "Check" . PHP_EOL;
-
-?>
---EXPECT--
-Check


### PR DESCRIPTION
### Description

* This PR pulls #579 into master.
* It also adds more tests to the request init hook and specifically tests that the request init hook is properly sandboxed such that errors raised and exceptions thrown in the hook do not crash the app.
* It also includes a tweak to **dd-doctor.php** to better accommodate environments jailed with `open_basedir` and more debug info.
* It also includes a small fix for a compiler warning that was making the master build fail.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
