### PR TITLE
Make PHP API check more specific

### DIFF
--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -133,7 +133,7 @@ println
 
 php -i > "$EXTENSION_LOGS_DIR/php-info.log"
 
-PHP_VERSION=$(php -i | grep 'PHP API' | awk '{print $NF}')
+PHP_VERSION=$(php -i | grep '^PHP[[:space:]]\+API[[:space:]]\+=>' | awk '{print $NF}')
 PHP_CFG_DIR=$(php --ini | grep 'Scan for additional .ini files in:' | sed -e 's/Scan for additional .ini files in://g' | head -n 1 | awk '{print $1}')
 
 PHP_THREAD_SAFETY=$(php -i | grep 'Thread Safety' | awk '{print $NF}' | grep -i enabled)


### PR DESCRIPTION
### Description

As described in issue [586](https://github.com/DataDog/dd-trace-php/issues/586) the PHP API check is not specific enough and catches other `php -i` lines that look like `PHP API`.

I have revised the regex adding in the capability for varying whitespace characters and repetition and checked this going back to GNU Grep 2.0 to ensure maximum compatibility:

```
[dsapala@DansMacBookProIE grep-2.0]$ ./grep -V
GNU grep version 2.0
usage: grep [-[[AB] ]<num>] [-[CEFGVchilnqsvwx]] [-[ef]] <expr> [<files...>]
```

current regex:
```
[dsapala@DansMacBookProIE grep-2.0]$ echo "PHP API => 20131106" | ./grep 'PHP API' | awk '{print $NF}'
20131106
[dsapala@DansMacBookProIE grep-2.0]$ echo "ChartDirector PHP API" | ./grep 'PHP API' | awk '{print $NF}'
API
```

revised regex:
```
[dsapala@DansMacBookProIE grep-2.0]$ echo "PHP API => 20131106" | ./grep '^PHP[[:space:]]\+API[[:space:]]\+=>' | awk '{print $NF}'
20131106
[dsapala@DansMacBookProIE grep-2.0]$ echo "ChartDirector PHP API" | ./grep '^PHP[[:space:]]\+API[[:space:]]\+=>' | awk '{print $NF}'
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
