### PR TITLE
Add CodeIgniter v2 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ tests/ext/*.mem
 tmp-php.ini
 tmp/opcache*
 *.orig
-benchmark.php
 docker-compose.override.yml

--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -61,6 +61,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/DefaultIntegrationConfiguration.
 require __DIR__ . '/../src/DDTrace/Integrations/Integration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/SandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Predis/PredisIntegration.php';

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -89,6 +89,14 @@ function dd_wrap_autoloader()
 {
     dd_register_autoloader();
 
+    /* CodeIgniter v2 does not use an autoloader. Tracing the CI_Hooks
+     * constructor let's us set up the world because it is called very early
+     * in CodeIgniter's startup process before we need to trace anything. */
+    dd_trace_method('CI_Hooks', '__construct', function () {
+        require __DIR__ . '/dd_init.php';
+        return false;
+    });
+
     // Composer auto-generates a class loader with a varying name which follows the pattern
     // `ComposerAutoloaderInitaa9e6eaaeccc2dd24059c64bd3ff094c`. The name of this class varies and this variable is
     // used to keep track of the actual name.

--- a/composer.json
+++ b/composer.json
@@ -318,6 +318,8 @@
         "cakephp-28-update": "@composer --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
         "cakephp-28-test": "@composer test -- --testsuite=cakephp-28-test",
 
+        "codeigniter-22-test": "@composer test -- --testsuite=codeigniter-22-test",
+
         "laravel-42-update": "@composer --working-dir=tests/Frameworks/Laravel/Version_4_2 update",
         "laravel-42-optimize": "@php tests/Frameworks/Laravel/Version_4_2/artisan optimize",
         "laravel-42-test": "@composer test -- tests/Integrations/Laravel/V4",

--- a/composer.json
+++ b/composer.json
@@ -224,6 +224,7 @@
             "@custom-framework-autoloaded-suite"
         ],
         "test-web-70": [
+            "@codeigniter-22-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@slim-312-update",
@@ -237,6 +238,7 @@
             "@custom-framework-autoloaded-suite"
         ],
         "test-web-71": [
+            "@codeigniter-22-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@laravel-57-update",
@@ -262,6 +264,7 @@
             "@custom-framework-autoloaded-suite"
         ],
         "test-web-72": [
+            "@codeigniter-22-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@laravel-57-update",
@@ -290,6 +293,7 @@
             "@custom-framework-autoloaded-suite"
         ],
         "test-web-73": [
+            "@codeigniter-22-test",
             "@laravel-57-update",
             "@laravel-57-test",
             "@laravel-58-update",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,9 @@
             <directory>tests/Integrations/CakePHP/V2_8</directory>
             <directory>tests/Integrations/CLI/CakePHP/V2_8</directory>
         </testsuite>
+        <testsuite name="codeigniter-22-test">
+            <directory>tests/Integrations/CodeIgniter/V2_2</directory>
+        </testsuite>
         <testsuite name="laravel-58-test">
             <directory>tests/Integrations/Laravel/V5_8</directory>
             <directory>tests/Integrations/CLI/Laravel/V5_8</directory>

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace DDTrace\Integrations\CodeIgniter\V2_2;
+
+use DDTrace\Configuration;
+use DDTrace\Contracts\Span;
+use DDTrace\GlobalTracer;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+
+class CodeIgniterSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'codeigniter';
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Add instrumentation to CodeIgniter requests
+     */
+    public function init()
+    {
+
+        $tracer = GlobalTracer::get();
+
+        $integration = $this;
+        $rootScope = $tracer->getRootScope();
+        if (!$rootScope) {
+            return SandboxedIntegration::NOT_LOADED;
+        }
+        $service = Configuration::get()->appName(self::NAME);
+
+        \dd_trace_method(
+            'CI_Router',
+            '_set_routing',
+            function () use ($integration, $rootScope, $service) {
+
+                /* After _set_routing has been called the class and method are
+                 * known, so now we can set up tracing on CodeIgniter. */
+                $integration->registerIntegration($this, $rootScope->getSpan(), $service);
+                // at the time of this writing, dd_untrace does not work with methods
+                //\dd_untrace('CI_Router', '_set_routing');
+                return false;
+            }
+        );
+
+        return parent::LOADED;
+    }
+
+    public function registerIntegration(\CI_Router $router, Span $root, $service)
+    {
+        $root->setIntegration($this);
+        $root->setTraceAnalyticsCandidate();
+
+        $root->overwriteOperationName('codeigniter.request');
+        $root->setTag(Tag::SERVICE_NAME, $service);
+        $root->setTag(Tag::RESOURCE_NAME, "{$_SERVER['REQUEST_METHOD']} {$_SERVER['REQUEST_URI']}");
+        $root->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
+
+        $controller = $router->fetch_class();
+        $method = $router->fetch_method();
+
+        \dd_trace_method(
+            $controller,
+            $method,
+            function (SpanData $span) use ($root, $method, $service) {
+                $class = \get_class($this);
+                $span->name = $span->resource = "{$class}.{$method}";
+                $span->service = $service;
+                $span->type = Type::WEB_SERVLET;
+
+                $this->load->helper('url');
+                $root->setTag(Tag::HTTP_URL, base_url(uri_string()));
+                $root->setTag('app.endpoint', "{$class}::{$method}");
+            }
+        );
+
+        /* From https://codeigniter.com/userguide2/general/controllers.html:
+         * If your controller contains a function named _remap(), it will
+         * always get called regardless of what your URI contains. It
+         * overrides the normal behavior in which the URI determines which
+         * function is called, allowing you to define your own function
+         * routing rules.
+         */
+        \dd_trace_method(
+            $controller,
+            '_remap',
+            function (SpanData $span, $args, $retval, $ex) use ($root, $service) {
+                $class = \get_class($this);
+
+                $span->name = "{$class}._remap";
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+                $span->service = $service;
+                $span->type = Type::WEB_SERVLET;
+
+                $this->load->helper('url');
+                $root->setTag(Tag::HTTP_URL, base_url(uri_string()));
+                $root->setTag('app.endpoint', "{$class}::_remap");
+            }
+        );
+
+        \dd_trace_method(
+            'CI_Loader',
+            'view',
+            function (SpanData $span, $args, $retval, $ex) use ($service) {
+                $span->name = 'CI_Loader.view';
+                $span->service = $service;
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+                $span->type = Type::WEB_SERVLET;
+            }
+        );
+
+        /* I think tracing the CI_DB_driver's query method should catch usage
+         * from all drivers. All drivers extend CI_DB and I *think* that CI_DB
+         * extends either CI_DB_driver or CI_DB_active_rec which in turn
+         * extends CI_DB_driver. */
+        \dd_trace_method(
+            'CI_DB_driver',
+            'query',
+            function (SpanData $span, $args, $retval, $ex) use ($service) {
+                if (\dd_trace_tracer_is_limited()) {
+                    return false;
+                }
+                $class = \get_class($this);
+                $span->name = "{$class}.query";
+                $span->service = $service;
+                $span->type = Type::SQL;
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+            }
+        );
+
+        /* We can't just trace CI_Cache's methods, unfortunately. This
+         * pattern is provided in CodeIgniter's documentation:
+         *     $this->load->driver('cache')
+         *     $this->cache->memcached->save('foo', 'bar', 10);
+         * Which avoids get, save, delete, etc, on CI_Cache. But CI_Cache
+         * requires a driver, so we can intercept the driver at __get.
+         */
+        $registered_cache_adapters = array();
+        \dd_trace_method(
+            'CI_Cache',
+            '__get',
+            function (SpanData $span, $args, $retval, $ex) use ($service, &$registered_cache_adapters) {
+                if (!$ex && is_object($retval)) {
+                    $class = \get_class($retval);
+                    if (!isset($registered_cache_adapters[$class])) {
+                        CodeIgniterSandboxedIntegration::registerCacheAdapter($class, $service);
+                        $registered_cache_adapters[$class] = true;
+                    }
+                }
+                return false;
+            }
+        );
+    }
+
+    /**
+     * @param string $adapter
+     * @param string $service
+     */
+    public static function registerCacheAdapter($adapter, $service)
+    {
+        \dd_trace_method(
+            $adapter,
+            'get',
+            function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
+                $class = \get_class($this);
+                $span->name = "{$class}.get";
+                $span->service = $service;
+                $span->type = Type::CACHE;
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+            }
+        );
+
+        \dd_trace_method(
+            $adapter,
+            'save',
+            function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
+                $class = \get_class($this);
+                $span->name = "{$class}.save";
+                $span->service = $service;
+                $span->type = Type::CACHE;
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+            }
+        );
+
+        \dd_trace_method(
+            $adapter,
+            'delete',
+            function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
+                $class = \get_class($this);
+                $span->name = "{$class}.delete";
+                $span->service = $service;
+                $span->type = Type::CACHE;
+                $span->resource = !$ex && isset($args[0]) ? (string) $args[0] : $span->name;
+            }
+        );
+
+        \dd_trace_method(
+            $adapter,
+            'clean',
+            function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
+                $class = \get_class($this);
+                $span->name = "{$class}.clean";
+                $span->service = $service;
+                $span->type = Type::CACHE;
+                $span->resource = $span->name;
+            }
+        );
+    }
+}

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -4,6 +4,7 @@ namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
 use DDTrace\Integrations\CakePHP\CakePHPIntegration;
+use DDTrace\Integrations\CodeIgniter\V2_2\CodeIgniterSandboxedIntegration;
 use DDTrace\Integrations\Curl\CurlIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration;
@@ -85,6 +86,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Memcached\MemcachedSandboxedIntegration';
             $this->integrations[PDOSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
+            $this->integrations[CodeIgniterSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\CodeIgniter\V2_2\CodeIgniterSandboxedIntegration';
         }
     }
 

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/config/config.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/config/config.php
@@ -22,7 +22,7 @@
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] = '';
+$config['base_url'] = "http://{$_SERVER['HTTP_HOST']}";
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
@@ -40,6 +40,7 @@
 
 $route['default_controller'] = "welcome";
 $route['404_override'] = '';
+$route['error'] = 'error_';
 
 
 /* End of file routes.php */

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/error_.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/error_.php
@@ -1,0 +1,7 @@
+<?php
+
+class Error_ extends CI_Controller {
+    function index() {
+        throw new \Exception('datadog');
+    }
+}

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/simple.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/simple.php
@@ -1,0 +1,7 @@
+<?php
+
+class Simple extends CI_Controller {
+    function index() {
+        echo 'simple';
+    }
+}

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/simple_view.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/simple_view.php
@@ -1,0 +1,7 @@
+<?php
+
+class Simple_View extends CI_Controller {
+    function index() {
+        $this->load->view('simple_view', array('message' => 'Hi'));
+    }
+}

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/views/simple_view.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/views/simple_view.php
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <?= $message ?>
+  </body>
+</html>

--- a/tests/Frameworks/CodeIgniter/Version_2_2/ddshim.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/ddshim.php
@@ -1,0 +1,11 @@
+<?php
+
+// set up ddtrace integration (should be temporary)
+require dirname(dirname(ini_get('ddtrace.request_init_hook'))) . '/bridge/dd_init.php';
+
+/* CodeIgniter expects the CWD to be set to the root directory but the builtin
+ * CLI SAPI server will not do this:
+ * https://www.php.net/manual/en/features.commandline.differences.php */
+chdir(__DIR__);
+
+require 'index.php';

--- a/tests/Frameworks/CodeIgniter/Version_2_2/ddshim.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/ddshim.php
@@ -1,8 +1,5 @@
 <?php
 
-// set up ddtrace integration (should be temporary)
-require dirname(dirname(ini_get('ddtrace.request_init_hook'))) . '/bridge/dd_init.php';
-
 /* CodeIgniter expects the CWD to be set to the root directory but the builtin
  * CLI SAPI server will not do this:
  * https://www.php.net/manual/en/features.commandline.differences.php */

--- a/tests/Frameworks/CodeIgniter/Version_2_2/system/core/Benchmark.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/system/core/Benchmark.php
@@ -1,0 +1,119 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP 5.1.6 or newer
+ *
+ * @package		CodeIgniter
+ * @author		EllisLab Dev Team
+ * @copyright		Copyright (c) 2008 - 2014, EllisLab, Inc.
+ * @copyright		Copyright (c) 2014 - 2015, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license		http://codeigniter.com/user_guide/license.html
+ * @link		http://codeigniter.com
+ * @since		Version 1.0
+ * @filesource
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * CodeIgniter Benchmark Class
+ *
+ * This class enables you to mark points and calculate the time difference
+ * between them.  Memory consumption can also be displayed.
+ *
+ * @package		CodeIgniter
+ * @subpackage	Libraries
+ * @category	Libraries
+ * @author		EllisLab Dev Team
+ * @link		http://codeigniter.com/user_guide/libraries/benchmark.html
+ */
+class CI_Benchmark {
+
+	/**
+	 * List of all benchmark markers and when they were added
+	 *
+	 * @var array
+	 */
+	var $marker = array();
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Set a benchmark marker
+	 *
+	 * Multiple calls to this function can be made so that several
+	 * execution points can be timed
+	 *
+	 * @access	public
+	 * @param	string	$name	name of the marker
+	 * @return	void
+	 */
+	function mark($name)
+	{
+		$this->marker[$name] = microtime();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Calculates the time difference between two marked points.
+	 *
+	 * If the first parameter is empty this function instead returns the
+	 * {elapsed_time} pseudo-variable. This permits the full system
+	 * execution time to be shown in a template. The output class will
+	 * swap the real value for this variable.
+	 *
+	 * @access	public
+	 * @param	string	a particular marked point
+	 * @param	string	a particular marked point
+	 * @param	integer	the number of decimal places
+	 * @return	mixed
+	 */
+	function elapsed_time($point1 = '', $point2 = '', $decimals = 4)
+	{
+		if ($point1 == '')
+		{
+			return '{elapsed_time}';
+		}
+
+		if ( ! isset($this->marker[$point1]))
+		{
+			return '';
+		}
+
+		if ( ! isset($this->marker[$point2]))
+		{
+			$this->marker[$point2] = microtime();
+		}
+
+		list($sm, $ss) = explode(' ', $this->marker[$point1]);
+		list($em, $es) = explode(' ', $this->marker[$point2]);
+
+		return number_format(($em + $es) - ($sm + $ss), $decimals);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Memory Usage
+	 *
+	 * This function returns the {memory_usage} pseudo-variable.
+	 * This permits it to be put it anywhere in a template
+	 * without the memory being calculated until the end.
+	 * The output class will swap the real value for this variable.
+	 *
+	 * @access	public
+	 * @return	string
+	 */
+	function memory_usage()
+	{
+		return '{memory_usage}';
+	}
+
+}
+
+// END CI_Benchmark class
+
+/* End of file Benchmark.php */
+/* Location: ./system/core/Benchmark.php */

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CodeIgniter\V2_2;
+
+use DDTrace\Tag;
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+use DDTrace\Type;
+
+final class CommonScenariosTest extends WebFrameworkTestCase
+{
+    const IS_SANDBOX = true;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/CodeIgniter/Version_2_2/ddshim.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE_NAME' => 'codeigniter_test_app',
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSpecs
+     * @param RequestSpec $spec
+     * @param array $spanExpectations
+     * @throws \Exception
+     */
+    public function testScenario(RequestSpec $spec, array $spanExpectations)
+    {
+        $traces = $this->tracesFromWebRequest(function () use ($spec) {
+            $this->call($spec);
+        });
+
+        $this->assertExpectedSpans($traces, $spanExpectations);
+    }
+
+    public function provideSpecs()
+    {
+        return $this->buildDataProvider(
+            [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'codeigniter.request',
+                        'codeigniter_test_app',
+                        'web',
+                        'GET /simple'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/simple',
+                        Tag::HTTP_STATUS_CODE => '200',
+                        'integration.name' => 'codeigniter',
+                        'app.endpoint' => 'Simple::index',
+                    ]),
+                    SpanAssertion::build(
+                        'Simple.index',
+                        'codeigniter_test_app',
+                        Type::WEB_SERVLET,
+                        'Simple.index'
+                    ),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'codeigniter.request',
+                        'codeigniter_test_app',
+                        'web',
+                        'GET /simple_view'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/simple_view',
+                        Tag::HTTP_STATUS_CODE => '200',
+                        'integration.name' => 'codeigniter',
+                        'app.endpoint' => 'Simple_View::index',
+                    ]),
+                    SpanAssertion::build(
+                        'Simple_View.index',
+                        'codeigniter_test_app',
+                        Type::WEB_SERVLET,
+                        'Simple_View.index'
+                    ),
+                    SpanAssertion::build(
+                        'CI_Loader.view',
+                        'codeigniter_test_app',
+                        Type::WEB_SERVLET,
+                        'simple_view'
+                    ),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'codeigniter.request',
+                        'codeigniter_test_app',
+                        'web',
+                        'GET /error'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/error',
+                        // CodeIgniter's error handler does not adjust the status code
+                        Tag::HTTP_STATUS_CODE => '200',
+                        'integration.name' => 'codeigniter',
+                        'app.endpoint' => 'Error_::index',
+                    ]),
+                    SpanAssertion::build(
+                        'Error_.index',
+                        'codeigniter_test_app',
+                        Type::WEB_SERVLET,
+                        'Error_.index'
+                    )->setError('Exception', 'datadog', true),
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -6,6 +6,7 @@ use DDTrace\Configuration;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Unit\BaseTestCase;
+use DDTrace\Util\Versions;
 
 final class IntegrationsLoaderTest extends BaseTestCase
 {
@@ -147,6 +148,9 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testWeDidNotForgetToRegisterALibraryForAutoLoading()
     {
+        if (Versions::phpVersionMatches('5.4')) {
+            $this->markTestSkipped('Sandboxed tests are skipped on PHP 5.4 so we cannot check for all integrations.');
+        }
         $expected = $this->normalize(glob(__DIR__ . '/../../../src/DDTrace/Integrations/*', GLOB_ONLYDIR));
         \ksort($expected);
         $integrations = IntegrationsLoader::get()->getIntegrations();

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -14,26 +14,14 @@ final class IntegrationsLoaderTest extends BaseTestCase
         'integration_2' => 'DDTrace\Tests\Unit\Integrations\DummyIntegration2',
     ];
 
-    public static function setUpBeforeClass()
-    {
-        parent::setUpBeforeClass();
-        putenv('DD_TRACE_SANDBOX_ENABLED=false');
-    }
-
-    public function testGlobalLoaderDefaultsToOfficiallySupportedIntegrations()
-    {
-        $this->assertEquals(
-            IntegrationsLoader::$officiallySupportedIntegrations,
-            IntegrationsLoader::get()->getIntegrations()
-        );
-    }
-
     public function testIntegrationsCanBeProvidedToLoader()
     {
         $integration = [
             'name' => 'class',
         ];
-        $this->assertEquals($integration, (new IntegrationsLoader($integration))->getIntegrations());
+        $integrations = (new IntegrationsLoader($integration))->getIntegrations();
+        self::assertArrayHasKey('name', $integrations);
+        self::assertEquals('class', $integrations['name']);
     }
 
     public function testGlobalConfigCanDisableLoading()
@@ -160,7 +148,10 @@ final class IntegrationsLoaderTest extends BaseTestCase
     public function testWeDidNotForgetToRegisterALibraryForAutoLoading()
     {
         $expected = $this->normalize(glob(__DIR__ . '/../../../src/DDTrace/Integrations/*', GLOB_ONLYDIR));
-        $loaded = $this->normalize(array_keys(IntegrationsLoader::get()->getIntegrations()));
+        \ksort($expected);
+        $integrations = IntegrationsLoader::get()->getIntegrations();
+        \ksort($integrations);
+        $loaded = $this->normalize(array_keys($integrations));
 
         // If this test fails you need to add an entry to IntegrationsLoader::LIBRARIES array.
         $this->assertEquals(array_values($expected), array_values($loaded));


### PR DESCRIPTION
### Description

This adds an integration for CodeIgniter v2 , tested using v2.2.6. Support includes tracing views, `$this->db->query(...)`, caching, and controllers, including ones using `_remap`.

Note: on PHP 5 due to CodeIgniter's `call_user_func_array` usage the controller will not be traced. 

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
