### PR TITLE
Fix copying function args for forwarding and clean up tests

### DIFF
--- a/.circleci/valgrind/valgrind_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_musl_suppressions.lib
@@ -66,3 +66,10 @@
     obj:*
     obj:*
 }
+{
+    <insert_a_suppression_name_here>
+    Memcheck:Cond
+    fun:strlcpy
+    obj:*
+    obj:*
+}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ test_extension_ci: $(SO_FILE)
 	$(MAKE) -C $(BUILD_DIR) test  TESTS="-q --show-all $(TESTS)" && grep -e 'errors="0"' $$TEST_PHP_JUNIT; \
 	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/valgrind-extension-test.xml; \
-	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean test  TESTS="-q -m --show-all $(TESTS)" && grep -e 'errors="0"' $$TEST_PHP_JUNIT; \
+	export TEST_PHP_OUTPUT=$(JUNIT_RESULTS_DIR)/valgrind-run-tests.out; \
+	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean test  TESTS="-q -m -s $$TEST_PHP_OUTPUT --show-all $(TESTS)" && grep -e 'errors="0"' $$TEST_PHP_JUNIT  && ! grep -e 'LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
 	)
 
 test_integration: install_ini

--- a/tests/ext/from_php_7_3_test_user_streams_consumed_bug.phpt
+++ b/tests/ext/from_php_7_3_test_user_streams_consumed_bug.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Testing user filter on streams
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70300) die('skip: Requires PHP 7.3 or greater'); ?>
 --FILE--
 <?php
 class Intercept extends php_user_filter

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
@@ -39,20 +39,20 @@ dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args
 });
 
 testExceptionIsNull();
-testExceptionIsPassed();
-echo "This line should not be run\n";
+/* Uncaught exceptions in PHP 5 leak the exception object
+ * so tests catch the exception */
+try {
+    testExceptionIsPassed();
+    echo "This line should not be run\n";
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
 ?>
---EXPECTF--
+--EXPECT--
 testExceptionIsNull()
 bool(true)
 testExceptionIsPassed()
 bool(true)
-
-Fatal error: Uncaught %sOops!%sin %s:%d
-Stack trace:
-#0 %s(%d): testExceptionIsPassed()
-#1 %s(%d): unknown()
-#2 {main}
-  thrown in %s on line %d
+Oops!
 TestEx with exception: Oops!
 TestNull

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
@@ -25,16 +25,16 @@ dd_trace_function('a', function($s, $args, $r, $ex) {
     throw $ex;
 });
 
-a();
-echo "This line should not be run\n";
+/* Uncaught exceptions in PHP 5 leak the exception object
+ * so tests catch the exception */
+try {
+    a();
+    echo "This line should not be run\n";
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
 ?>
---EXPECTF--
+--EXPECT--
 a()
-
-Fatal error: Uncaught %sOops!%sin %s:%d
-Stack trace:
-#0 %s(%d): a()
-#1 %s(%d): unknown()
-#2 {main}
-  thrown in %s on line %d
+Oops!
 a with exception: Oops!


### PR DESCRIPTION
This PR fixes a memory issue with copying the function arguments when being passed to the tracing closure. It also cleans up some other testing issues, such as having memory leaks fail the build so we detect these issues sooner, and skipping a PHP 7.3 test that was still running on PHP 5.

These issues are isolated to the sandboxing API, which hasn't been released yet.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] ~Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
