### PR TITLE
Make PHP API check more specific

### DIFF
--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -133,7 +133,7 @@ println
 
 php -i > "$EXTENSION_LOGS_DIR/php-info.log"
 
-PHP_VERSION=$(php -i | grep 'PHP API' | awk '{print $NF}')
+PHP_VERSION=$(php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $NF }')
 PHP_CFG_DIR=$(php --ini | grep 'Scan for additional .ini files in:' | sed -e 's/Scan for additional .ini files in://g' | head -n 1 | awk '{print $1}')
 
 PHP_THREAD_SAFETY=$(php -i | grep 'Thread Safety' | awk '{print $NF}' | grep -i enabled)


### PR DESCRIPTION
### Description

This fixes a post-install issue with determining the PHP version. Supersedes #587 and fixes #586. Thanks Dan Sapala!

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
