### PR TITLE
Generate output on test controllers

### DIFF
--- a/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/EloquentTestController.php
+++ b/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/EloquentTestController.php
@@ -5,12 +5,15 @@ namespace App\Http\Controllers;
 use App\User;
 use Illuminate\Routing\Controller as BaseController;
 
-
+/* PLEASE NOTE: all tests must return output of some kind due to what we think
+ * is a bug in the built-in PHP Web SAPI. If you do not generate output, under
+ * certain situations it will leak memory, and even sometimes segfault! */
 class EloquentTestController extends BaseController
 {
     public function get()
     {
         User::get();
+        return __METHOD__;
     }
 
     public function insert()
@@ -19,6 +22,7 @@ class EloquentTestController extends BaseController
             'email' => 'test-user-created@email.com',
         ]);
         $user->save();
+        return __METHOD__;
     }
 
     public function update()
@@ -26,22 +30,26 @@ class EloquentTestController extends BaseController
         $user = User::where('email', '=', 'test-user-updated@email.com')->firstOrFail();
         $user->name = 'updated';
         $user->save();
+        return __METHOD__;
     }
 
     public function delete()
     {
         $user = User::where('email', '=', 'test-user-deleted@email.com')->firstOrFail();
         $user->delete();
+        return __METHOD__;
     }
 
     public function destroy()
     {
         User::destroy(1);
+        return __METHOD__;
     }
 
     public function refresh()
     {
         $user = User::find(1);
         $user->refresh();
+        return __METHOD__;
     }
 }


### PR DESCRIPTION
### Description

The testing infrastructure uses the builtin PHP web SAPI. If this SAPI does not generate output, it will sometimes leak memory and sometimes even segfault.

All tests should generate output. For now, I've added output to the Eloquent tests, which are the tests which helped us find this issue.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] ~Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
