### PR TITLE
Fix PHP CodeSniffer v3.5.0 lints

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -6,6 +6,10 @@
 
     <rule ref="PSR12"/>
 
+    <rule ref="PSR12.Properties.ConstantVisibility.NotFound">
+        <severity>0</severity>
+    </rule>
+
     <rule ref="Generic.Commenting.Todo"/>
     <rule ref="Generic.Commenting.Fixme"/>
     <rule ref="Generic.Commenting.DocComment.MissingShort">

--- a/bridge/dd_optional_deps_autoloader.php
+++ b/bridge/dd_optional_deps_autoloader.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace DDTrace\Bridge;
+
 // phpcs:disable Generic.Files.LineLength.TooLong
 
 /**

--- a/bridge/dd_wrap_autoloader.php
+++ b/bridge/dd_wrap_autoloader.php
@@ -2,8 +2,10 @@
 
 namespace DDTrace\Bridge;
 
-if (!defined('DD_TRACE_VERSION')
-    || !file_exists(__DIR__ . '/../src/DDTrace/version.php')) {
+if (
+    !defined('DD_TRACE_VERSION')
+    || !file_exists(__DIR__ . '/../src/DDTrace/version.php')
+) {
     function_exists('dd_trace_disable_in_request') && dd_trace_disable_in_request();
     return;
 }

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -148,9 +148,10 @@ final class Bootstrap
      */
     public static function parseStatusCode($headersLine)
     {
-        if (empty($headersLine)
-                || !is_string($headersLine)
-                || substr(strtoupper($headersLine), 0, 5) !== 'HTTP/'
+        if (
+            empty($headersLine)
+            || !is_string($headersLine)
+            || substr(strtoupper($headersLine), 0, 5) !== 'HTTP/'
         ) {
             return null;
         }

--- a/src/DDTrace/Encoders/SpanEncoder.php
+++ b/src/DDTrace/Encoders/SpanEncoder.php
@@ -52,8 +52,10 @@ final class SpanEncoder
         foreach ($span->metrics as $metricName => $metricValue) {
             $metrics[$metricName] = $metricValue;
         }
-        if ($span->context->isHostRoot()
-                && ($prioritySampling = GlobalTracer::get()->getPrioritySampling()) !== PrioritySampling::UNKNOWN) {
+        if (
+            $span->context->isHostRoot()
+            && ($prioritySampling = GlobalTracer::get()->getPrioritySampling()) !== PrioritySampling::UNKNOWN
+        ) {
             $metrics['_sampling_priority_v1'] = $prioritySampling;
         }
         if (!empty($metrics)) {
@@ -62,9 +64,11 @@ final class SpanEncoder
 
         // This is only for testing purposes and possibly temporary as we may want to add integration name to the span's
         // metadata in a consistent way across various tracers.
-        if (null !== $span->integration
-                && false !== ($integrationTest = getenv('DD_TEST_INTEGRATION'))
-                && in_array($integrationTest, ['1', 'true'])) {
+        if (
+            null !== $span->integration
+            && false !== ($integrationTest = getenv('DD_TEST_INTEGRATION'))
+            && in_array($integrationTest, ['1', 'true'])
+        ) {
             $arraySpan['meta']['integration.name'] = $span->integration->getName();
         }
 

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -79,9 +79,10 @@ class CurlIntegration extends Integration
         dd_trace('curl_setopt', function ($ch, $option, $value) use ($globalConfig) {
             // Note that curl_setopt with option CURLOPT_HTTPHEADER overwrite data instead of appending it if called
             // multiple times on the same resource.
-            if ($option === CURLOPT_HTTPHEADER
-                    && $globalConfig->isDistributedTracingEnabled()
-                    && is_array($value)
+            if (
+                $option === CURLOPT_HTTPHEADER
+                && $globalConfig->isDistributedTracingEnabled()
+                && is_array($value)
             ) {
                 // Storing data to be used during exec as it cannot be retrieved at then.
                 ArrayKVStore::putForResource($ch, Format::CURL_HTTP_HEADERS, $value);
@@ -93,8 +94,9 @@ class CurlIntegration extends Integration
         dd_trace('curl_setopt_array', function ($ch, $options) use ($globalConfig) {
             // Note that curl_setopt with option CURLOPT_HTTPHEADER overwrite data instead of appending it if called
             // multiple times on the same resource.
-            if ($globalConfig->isDistributedTracingEnabled()
-                    && array_key_exists(CURLOPT_HTTPHEADER, $options)
+            if (
+                $globalConfig->isDistributedTracingEnabled()
+                && array_key_exists(CURLOPT_HTTPHEADER, $options)
             ) {
                 // Storing data to be used during exec as it cannot be retrieved at then.
                 ArrayKVStore::putForResource($ch, Format::CURL_HTTP_HEADERS, $options[CURLOPT_HTTPHEADER]);

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace DDTrace\Integrations\Guzzle;
 
 use DDTrace\Configuration;
@@ -199,8 +198,10 @@ final class GuzzleIntegration extends Integration
     {
         $headers = [];
 
-        if (is_a($request, '\GuzzleHttp\Message\MessageInterface')
-                || is_a($request, '\Psr\Http\Message\MessageInterface')) {
+        if (
+            is_a($request, '\GuzzleHttp\Message\MessageInterface')
+            || is_a($request, '\Psr\Http\Message\MessageInterface')
+        ) {
             // Associative array of header names to values
             $headers = $request->getHeaders();
         }

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -67,8 +67,11 @@ class SymfonyIntegration extends Integration
                 $version = \Symfony\Component\HttpKernel\Kernel::VERSION;
 
                 $bundle = null;
-                if (Versions::versionMatches('3.4', $version) || Versions::versionMatches('3.3', $version)
-                    || Versions::versionMatches('3.0', $version)) {
+                if (
+                    Versions::versionMatches('3.4', $version)
+                    || Versions::versionMatches('3.3', $version)
+                    || Versions::versionMatches('3.0', $version)
+                ) {
                     $bundle = new \DDTrace\Integrations\Symfony\V3\SymfonyBundle();
                 } elseif (Versions::versionMatches('4', $version)) {
                     $bundle = new \DDTrace\Integrations\Symfony\V4\SymfonyBundle();

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -211,7 +211,8 @@ class SymfonyBundle extends Bundle
         // Controller and action is provided in the form [$controllerInstance, <actionMethodName>]
         $controllerAndAction = $event->getController();
 
-        if (!is_array($controllerAndAction)
+        if (
+            !is_array($controllerAndAction)
             || count($controllerAndAction) !== 2
             || !is_object($controllerAndAction[0])
         ) {

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -203,7 +203,8 @@ class SymfonyBundle extends Bundle
         // Controller and action is provided in the form [$controllerInstance, <actionMethodName>]
         $controllerAndAction = $event->getController();
 
-        if (!is_array($controllerAndAction)
+        if (
+            !is_array($controllerAndAction)
             || count($controllerAndAction) !== 2
             || !is_object($controllerAndAction[0])
         ) {

--- a/src/DDTrace/Propagators/CurlHeadersMap.php
+++ b/src/DDTrace/Propagators/CurlHeadersMap.php
@@ -32,19 +32,23 @@ final class CurlHeadersMap implements Propagator
     public function inject(SpanContext $spanContext, &$carrier)
     {
         foreach ($carrier as $index => $value) {
-            if (substr($value, 0, strlen(Propagator::DEFAULT_TRACE_ID_HEADER))
-                    === Propagator::DEFAULT_TRACE_ID_HEADER
+            if (
+                substr($value, 0, strlen(Propagator::DEFAULT_TRACE_ID_HEADER))
+                === Propagator::DEFAULT_TRACE_ID_HEADER
             ) {
                 unset($carrier[$index]);
-            } elseif (substr($value, 0, strlen(Propagator::DEFAULT_PARENT_ID_HEADER))
-                    === Propagator::DEFAULT_PARENT_ID_HEADER
+            } elseif (
+                substr($value, 0, strlen(Propagator::DEFAULT_PARENT_ID_HEADER))
+                === Propagator::DEFAULT_PARENT_ID_HEADER
             ) {
                 unset($carrier[$index]);
-            } elseif (substr($value, 0, strlen(Propagator::DEFAULT_BAGGAGE_HEADER_PREFIX))
-                    === Propagator::DEFAULT_BAGGAGE_HEADER_PREFIX
+            } elseif (
+                substr($value, 0, strlen(Propagator::DEFAULT_BAGGAGE_HEADER_PREFIX))
+                === Propagator::DEFAULT_BAGGAGE_HEADER_PREFIX
             ) {
                 unset($carrier[$index]);
-            } elseif (substr($value, 0, strlen(Propagator::DEFAULT_SAMPLING_PRIORITY_HEADER))
+            } elseif (
+                substr($value, 0, strlen(Propagator::DEFAULT_SAMPLING_PRIORITY_HEADER))
                 === Propagator::DEFAULT_SAMPLING_PRIORITY_HEADER
             ) {
                 unset($carrier[$index]);

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -4,7 +4,6 @@ namespace DDTrace;
 
 use DDTrace\Integrations\Integration;
 use DDTrace\Data\Span as DataSpan;
-
 use DDTrace\Exceptions\InvalidSpanArgument;
 use DDTrace\SpanContext as SpanContext;
 use DDTrace\Http\Urls;

--- a/src/DDTrace/StartSpanOptionsFactory.php
+++ b/src/DDTrace/StartSpanOptionsFactory.php
@@ -22,8 +22,10 @@ class StartSpanOptionsFactory
     {
         $globalConfiguration = Configuration::get();
 
-        if ($globalConfiguration->isDistributedTracingEnabled()
-                && $spanContext = $tracer->extract(Format::HTTP_HEADERS, $headers)) {
+        if (
+            $globalConfiguration->isDistributedTracingEnabled()
+            && $spanContext = $tracer->extract(Format::HTTP_HEADERS, $headers)
+        ) {
             $options[Reference::CHILD_OF] = $spanContext;
         }
 

--- a/src/DDTrace/Util/ObjectKVStore.php
+++ b/src/DDTrace/Util/ObjectKVStore.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Util;
 
-
 /**
  * A key value store that stores metadata into object instances.
  *

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -11,7 +11,8 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class IntegrationTestCase extends TestCase
 {
-    use TracerTestTrait, SpanAssertionTrait;
+    use TracerTestTrait;
+    use SpanAssertionTrait;
 
     const IS_SANDBOX = false;
 

--- a/tests/Frameworks/TestScenarios.php
+++ b/tests/Frameworks/TestScenarios.php
@@ -4,7 +4,6 @@ namespace DDTrace\Tests\Frameworks;
 
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
-
 class TestScenarios
 {
     public static function all()

--- a/tests/Frameworks/Util/Request/GetSpec.php
+++ b/tests/Frameworks/Util/Request/GetSpec.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Frameworks\Util\Request;
 
-
 class GetSpec extends RequestSpec
 {
     /**

--- a/tests/Frameworks/Util/Request/RequestSpec.php
+++ b/tests/Frameworks/Util/Request/RequestSpec.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Frameworks\Util\Request;
 
-
 abstract class RequestSpec
 {
     /**

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -12,6 +12,7 @@ use DDTrace\GlobalTracer;
 final class HttpTest extends BaseTestCase
 {
     use AgentReplayerTrait;
+
     protected function tearDown()
     {
         // reset the circuit breker consecutive failures count and close it

--- a/tests/Integrations/Laravel/V4/EloquentTest.php
+++ b/tests/Integrations/Laravel/V4/EloquentTest.php
@@ -10,7 +10,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 class EloquentTest extends WebFrameworkTestCase
 {
-    use TracerTestTrait, SpanAssertionTrait;
+    use TracerTestTrait;
+    use SpanAssertionTrait;
 
     const IS_SANDBOX = false;
 

--- a/tests/Integrations/Laravel/V5_7/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_7/EloquentTest.php
@@ -10,8 +10,10 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 class EloquentTest extends WebFrameworkTestCase
 {
+    use TracerTestTrait;
+    use SpanAssertionTrait;
+
     const IS_SANDBOX = false;
-    use TracerTestTrait, SpanAssertionTrait;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Laravel/V5_7/PipelineTracingTest.php
+++ b/tests/Integrations/Laravel/V5_7/PipelineTracingTest.php
@@ -10,7 +10,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 class PipelineTracingTest extends WebFrameworkTestCase
 {
-    use TracerTestTrait, SpanAssertionTrait;
+    use TracerTestTrait;
+    use SpanAssertionTrait;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Laravel/V5_8/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_8/EloquentTest.php
@@ -10,8 +10,10 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 class EloquentTest extends WebFrameworkTestCase
 {
+    use TracerTestTrait;
+    use SpanAssertionTrait;
+
     const IS_SANDBOX = false;
-    use TracerTestTrait, SpanAssertionTrait;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -7,7 +7,6 @@ use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Util\Versions;
 
-
 class MemcachedTest extends IntegrationTestCase
 {
     const IS_SANDBOX = false;

--- a/tests/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integrations/Mysqli/MysqliTest.php
@@ -6,7 +6,6 @@ use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 
-
 final class MysqliTest extends IntegrationTestCase
 {
     private static $host = 'mysql_integration';

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -7,7 +7,6 @@ use DDTrace\Tests\DebugLogger;
 use DDTrace\Util\Versions;
 use PHPUnit\Framework;
 
-
 abstract class BaseTestCase extends Framework\TestCase
 {
     protected function tearDown()

--- a/tests/Unit/CleanEnvTrait.php
+++ b/tests/Unit/CleanEnvTrait.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Unit;
 
-
 /**
  * This trait provides to work in a clean environment for specific env variables. Env variables provided in the method
  * `getCleanEnvs()` are cleaned during setup and restored to their original value during tearDown.

--- a/tests/Unit/Util/TryCatchFinallyTest.php
+++ b/tests/Unit/Util/TryCatchFinallyTest.php
@@ -14,7 +14,6 @@ namespace {
         throw new CustomException('an exception');
     }
 }
-
 namespace DDTrace\Tests\Unit\Util {
 
     use DDTrace\Tests\DebugTransport;
@@ -197,6 +196,7 @@ namespace DDTrace\Tests\Unit\Util {
             );
         }
     }
+
     class CustomException extends \Exception
     {
     }

--- a/tests/Unit/Util/TryCatchFinallyTest.php
+++ b/tests/Unit/Util/TryCatchFinallyTest.php
@@ -14,6 +14,7 @@ namespace {
         throw new CustomException('an exception');
     }
 }
+// phpcs:disable PSR12.Files.FileHeader.SpacingAfterBlock
 namespace DDTrace\Tests\Unit\Util {
 
     use DDTrace\Tests\DebugTransport;

--- a/tests/bootstrap_utils.php
+++ b/tests/bootstrap_utils.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace DDTrace\Tests;
 
 function missing_ddtrace_class_fatal_autoloader($class)


### PR DESCRIPTION
### Description

Yesterday PHP CodeSniffer v3.5.0 was released, and they added a bunch of lints to enforce the PSR-12 coding style. This fixes these issues.

There is one issue I've been unable to fix thus far, and `composer fix-lint` can't fix it either. I think it may be a bug: squizlabs/PHP_CodeSniffer#2616. For now, I have disabled this lint in this file.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
