### PR TITLE
Replace function arguments with ellipsis in stack traces

### DIFF
--- a/tests/ext/sandbox/exception_handling.phpt
+++ b/tests/ext/sandbox/exception_handling.phpt
@@ -6,10 +6,10 @@ Exceptions get attached to spans
 <?php
 
 function outer() {
-    inner();
+    inner('datadog');
 }
-function inner() {
-    throw new Exception("datadog");
+function inner($message) {
+    throw new Exception($message);
 }
 
 dd_trace_function("outer", function() {});
@@ -41,14 +41,14 @@ error: 1
 Exception type: Exception
 Exception msg: datadog
 Exception stack:
-#0 %s: inner()
+#0 %s: inner(...)
 #1 %s: outer()
 #2 {main}
 error: 1
 Exception type: Exception
 Exception msg: datadog
 Exception stack:
-#0 %s: inner()
+#0 %s: inner(...)
 #1 %s: outer()
 #2 {main}
 

--- a/tests/ext/sandbox/exception_handling_php5.phpt
+++ b/tests/ext/sandbox/exception_handling_php5.phpt
@@ -7,10 +7,10 @@ Exceptions get attached to spans
 <?php
 
 function outer() {
-    inner();
+    inner('datadog');
 }
-function inner() {
-    throw new Exception("datadog");
+function inner($message) {
+    throw new Exception($message);
 }
 
 dd_trace_function("outer", function() {});
@@ -42,8 +42,8 @@ error: 1
 Exception type: Exception
 Exception msg: datadog
 Exception stack:
-#0 %s: inner()
-#1 %s: outer()
+#0 %s: inner(...)
+#1 %s: outer(...)
 #2 %s: outer()
 #3 %s: unknown()
 #4 {main}
@@ -51,8 +51,8 @@ error: 1
 Exception type: Exception
 Exception msg: datadog
 Exception stack:
-#0 %s: inner()
-#1 %s: outer()
+#0 %s: inner(...)
+#1 %s: outer(...)
 #2 %s: outer()
 #3 %s: unknown()
 #4 {main}


### PR DESCRIPTION
### Description

Function arguments can have sensitive information. Since we do not
have a comprehensive way to know which function arguments are sensitive
we will just hide all of them.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
