### PR TITLE
Target a specific PHP version during install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,25 @@ jobs:
           name: Running phpstan
           command: PATH=$PATH:~/.composer/vendor/bin composer static-analyze
 
+  "Post-Install Hook":
+    working_directory: ~/datadog
+    docker:
+      - image: docker.pkg.github.com/datadog/dd-trace-ci/php-nginx-apache2
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Start Supervisor
+          command: supervisord
+          background: true
+      - run:
+          name: Copy post-install script
+          command: |
+              mkdir -p /src/ddtrace-scripts
+              cp package/post-install.sh /src/ddtrace-scripts
+      - run:
+          name: Test post-install hook
+          command: bash tests/PostInstallHook/run-tests.sh
+
   unit_tests:
     parameters:
       docker_image:
@@ -897,4 +916,6 @@ workflows:
       - "Lint files":
           requires: [ 'Code Checkout' ]
       - "Static Analysis":
+          requires: [ 'Code Checkout' ]
+      - "Post-Install Hook":
           requires: [ 'Code Checkout' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
   "Post-Install Hook":
     working_directory: ~/datadog
     docker:
-      - image: docker.pkg.github.com/datadog/dd-trace-ci/php-nginx-apache2
+      - image: datadog/dd-trace-ci:php-nginx-apache2
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - run:

--- a/tests/PostInstallHook/README.md
+++ b/tests/PostInstallHook/README.md
@@ -1,0 +1,30 @@
+# Post-Install Hook Tests
+
+These tests ensure proper functionality of the post-install script that is executed after installing ddtrace from a package.
+
+The post-install script is expected to be at the following location to run the tests:
+
+```
+/src/ddtrace-scripts/post-install.sh
+```
+
+To run the tests from this directory:
+
+```bash
+$ docker-compose run --rm php bash
+# In the container...
+$ cd ~/datadog \
+    && (supervisord) \
+    && bash tests/PostInstallHook/run-tests.sh
+```
+
+## Adding new PHP versions
+
+1. Add the version number to the `CliInput::VALID_PHP_VERSIONS` array in **bootstrap.php**.
+2. Add the new port number `80<PHP VERSION>` to **docker-compose.yml**.
+3. Head over to [the Docker set up for `datadog/dd-trace-ci:php-nginx-apache2`](https://github.com/DataDog/dd-trace-ci/tree/master/php/nginx-apache2).
+4. Add the new version to the `apt-get install` line in the **Dockerfile**. _Note: there should only be one version that installs mod_php (`libapache2-mod-php<version>`). If you update it, make sure to also update **apache-ports.conf**._
+5. Add a new `server` context for the new version in **nginx-default-site**. 
+6. Finally, add the new process config to **supervisord.conf**.
+
+> **Note:** `mod_php` only supports one PHP version at a time. If the Apache PHP version is updated, make sure to update the `apachePhpVersion` variable in the **run-tests.sh** script and edit the port in the **docker-compose.yml** file.

--- a/tests/PostInstallHook/README.md
+++ b/tests/PostInstallHook/README.md
@@ -20,7 +20,7 @@ $ cd ~/datadog \
 
 ## Adding new PHP versions
 
-1. Add the version number to the `CliInput::VALID_PHP_VERSIONS` array in **bootstrap.php**.
+1. Add the version number to the `CliInput::VALID_PHP_VERSIONS` array in **tests/PostInstallHook/classes.php**.
 2. Add the new port number `80<PHP VERSION>` to **docker-compose.yml**.
 3. Head over to [the Docker set up for `datadog/dd-trace-ci:php-nginx-apache2`](https://github.com/DataDog/dd-trace-ci/tree/master/php/nginx-apache2).
 4. Add the new version to the `apt-get install` line in the **Dockerfile**. _Note: there should only be one version that installs mod_php (`libapache2-mod-php<version>`). If you update it, make sure to also update **apache-ports.conf**._

--- a/tests/PostInstallHook/bootstrap.php
+++ b/tests/PostInstallHook/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+use DDTrace\Tests\PostInstallHook\CliInput;
+use DDTrace\Tests\PostInstallHook\Request;
+
+if ('cli' !== PHP_SAPI) {
+    die('Cannot run CLI script from web SAPI');
+}
+
+require __DIR__ . '/classes.php';
+
+$request = new Request(new CliInput());
+return $request->send();

--- a/tests/PostInstallHook/classes.php
+++ b/tests/PostInstallHook/classes.php
@@ -15,7 +15,7 @@ class CliInput
         $options = getopt('', ['php-version:', 'sapi:']);
         if (false === $options || !isset($options['php-version'], $options['sapi'])) {
             printf(
-                'Usage: php %s --php-version PHP VERSION --sapi SAPI NAME%s',
+                'Usage: php %s --php-version [PHP VERSION] --sapi [SAPI NAME]%s',
                 $_SERVER['PHP_SELF'],
                 PHP_EOL
             );

--- a/tests/PostInstallHook/classes.php
+++ b/tests/PostInstallHook/classes.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace DDTrace\Tests\PostInstallHook;
+
+class CliInput
+{
+    private const VALID_PHP_VERSIONS = ['5.6', '7.0', '7.1', '7.2', '7.3'/*, '7.4'*/];
+    private const VALID_SAPIS = ['apache2handler', 'fpm-fcgi'];
+
+    private $phpVersion;
+    private $sapi;
+
+    public function __construct()
+    {
+        $options = getopt('', ['php-version:', 'sapi:']);
+        if (false === $options || !isset($options['php-version'], $options['sapi'])) {
+            printf(
+                'Usage: php %s --php-version PHP VERSION --sapi SAPI NAME%s',
+                $_SERVER['PHP_SELF'],
+                PHP_EOL
+            );
+            printf(
+                '  --php-version    %s%s',
+                implode(', ', self::VALID_PHP_VERSIONS),
+                PHP_EOL
+            );
+            printf(
+                '  --sapi           %s%s',
+                implode(', ', self::VALID_SAPIS),
+                PHP_EOL
+            );
+            exit(1);
+        }
+        $this->phpVersion = $options['php-version'];
+        $this->sapi = $options['sapi'];
+
+        if (!in_array($this->phpVersion, self::VALID_PHP_VERSIONS, true)) {
+            printf(
+                'Please specify a valid target PHP version: %s%s',
+                implode(', ', self::VALID_PHP_VERSIONS),
+                PHP_EOL
+            );
+            exit(1);
+        }
+        if (!in_array($this->sapi, self::VALID_SAPIS, true)) {
+            printf(
+                'Please specify a valid target SAPI: %s%s',
+                implode(', ', self::VALID_SAPIS),
+                PHP_EOL
+            );
+            exit(1);
+        }
+    }
+
+    public function phpVersion(): string
+    {
+        return $this->phpVersion;
+    }
+
+    public function sapi(): string
+    {
+        return $this->sapi;
+    }
+}
+
+class Request
+{
+    private $input;
+    private $url;
+
+    public function __construct(CliInput $input)
+    {
+        $this->input = $input;
+
+        $host = getenv('TARGET_HOST') ?: 'localhost';
+        $port = 'fpm-fcgi' === $this->input->sapi() ? '80' : '81';
+        $port .= str_replace('.', '', $this->input->phpVersion());
+        $this->url = 'http://' . $host . ':' . $port;
+    }
+
+    public function url(): string
+    {
+        return $this->url;
+    }
+
+    public function send(): Response
+    {
+        return new Response($this->input, $this);
+    }
+}
+
+class Response
+{
+    private $status;
+    private $input;
+
+    public function __construct(CliInput $input, Request $request)
+    {
+        $this->input = $input;
+
+        $verbose = fopen('php://temp', 'w+b');
+        $ch = curl_init($request->url());
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+        curl_setopt($ch, CURLOPT_VERBOSE, true);
+        curl_setopt($ch, CURLOPT_STDERR, $verbose);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+        $response = curl_exec($ch);
+        if (!$response) {
+            $errorCode = curl_errno($ch);
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            rewind($verbose);
+            printf(
+                '[%s; %s] Unexpected response from "%s": (%d) %s {%s}%s',
+                $this->input->phpVersion(),
+                $this->input->sapi(),
+                $request->url(),
+                $errorCode,
+                $error,
+                stream_get_contents($verbose),
+                PHP_EOL
+            );
+            exit(1);
+        }
+        curl_close($ch);
+        $this->status = json_decode($response, true);
+        if (
+            !$this->status
+            || !isset($this->status['sapi'], $this->status['php_version'], $this->status['ddtrace_installed'])
+        ) {
+            printf(
+                '[%s; %s] Unexpected payload from "%s": %s%s',
+                $this->input->phpVersion(),
+                $this->input->sapi(),
+                $request->url(),
+                var_export($response, true),
+                PHP_EOL
+            );
+            exit(1);
+        }
+        $this->assertSameFromKey('sapi', $input->sapi());
+        $this->assertSameFromKey('php_version', $input->phpVersion());
+    }
+
+    public function assertSameFromKey($key, $expected): void
+    {
+        if ($expected !== $this->status[$key]) {
+            printf(
+                '[%s; %s] Unexpected response for "%s"; expected "%s"; actual "%s"%s',
+                $this->input->phpVersion(),
+                $this->input->sapi(),
+                $key,
+                var_export($expected, true),
+                var_export($this->status[$key], true),
+                PHP_EOL
+            );
+            exit(1);
+        }
+    }
+}

--- a/tests/PostInstallHook/docker-compose.yml
+++ b/tests/PostInstallHook/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.6"
+
+services:
+  php:
+    image: "datadog/dd-trace-ci:php-nginx-apache2"
+    volumes:
+      - ../..:/root/datadog
+      - ../../package:/src/ddtrace-scripts
+    ports:
+      # nginx
+      - "8056:8056"
+      - "8070:8070"
+      - "8071:8071"
+      - "8072:8072"
+      - "8073:8073"
+      - "8074:8074"
+      # Apache2
+      - "8173:8173"

--- a/tests/PostInstallHook/run-tests.sh
+++ b/tests/PostInstallHook/run-tests.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+IFS=", "
+exitCode=0
+pwd=$(dirname "$0")
+
+# The version that installed libapache2-mod-php* in the Dockerfile
+apachePhpVersion=7.3
+
+pv=$(php "$pwd/bootstrap.php" | grep "  --php-version")
+if [ -z "$pv" ]; then
+    printf "No supported PHP versions found\n"
+    exit 1
+fi
+phpVersions=${pv#"  --php-version    "}
+
+defaultPhpVersion=$(php-config --version | cut -d . -f -2)
+
+function restartService() {
+    supervisorctl restart "$1" > /dev/null 2>&1
+    # Apache needs ~~a little~~ a lot of extra time to get its act together after restart
+    if [ "apache2" = "$1" ]; then
+        sleep 6
+    fi
+}
+
+function reset() {
+    for v in $phpVersions; do
+        rm -f /etc/php/"$v"/cli/conf.d/*-ddtrace*.ini
+        rm -f /etc/php/"$v"/fpm/conf.d/*-ddtrace*.ini
+        restartService "php-fpm$v"
+    done
+    rm -f /opt/datadog-php/etc/ddtrace*.ini
+    restartService "apache2"
+}
+
+function showStatus() {
+    if [ "$1" -eq 0 ]; then
+        printf "[OK]\n"
+    else
+        printf "[FAIL]\n"
+        exitCode=1
+    fi
+}
+
+function testInstalled() {
+    printf "  %s; %s ddtrace installed " "$1" "$2"
+    php "$pwd/test-installed.php" --php-version "$1" --sapi "$2"
+    showStatus $?
+}
+
+function testNotInstalled() {
+    printf "  %s; %s ddtrace NOT installed " "$1" "$2"
+    php "$pwd/test-not-installed.php" --php-version "$1" --sapi "$2"
+    showStatus $?
+}
+
+function checkIsInstalledCli() {
+    if [ $# -eq 1 ]; then
+        bin="/usr/bin/php$1"
+    else
+        bin="/usr/bin/php$defaultPhpVersion"
+    fi
+    printf "  %s; cli " "$bin"
+    $bin --ri=ddtrace > /dev/null 2>&1
+}
+
+function testInstalledCli() {
+    if [ $# -eq 1 ]; then
+        checkIsInstalledCli "$1"
+    else
+        checkIsInstalledCli
+    fi
+    showStatus $?
+}
+
+function testNotInstalledCli() {
+    if [ $# -eq 1 ]; then
+        checkIsInstalledCli "$1"
+    else
+        checkIsInstalledCli
+    fi
+    case $? in
+        0) showStatus 1;;
+        *) showStatus 0;;
+    esac
+}
+
+function enableExtension() {
+    if [ $# -eq 1 ]; then
+        (export DD_TRACE_PHP_BIN="$(command -v $1)"; /src/ddtrace-scripts/post-install.sh > /dev/null 2>&1)
+    else
+        /src/ddtrace-scripts/post-install.sh > /dev/null 2>&1
+    fi
+}
+
+printf "> Test ddtrace is not installed yet...\n"
+reset
+for v in $phpVersions; do
+    testNotInstalled "$v" fpm-fcgi
+    testNotInstalledCli "$v"
+done
+testNotInstalled $apachePhpVersion apache2handler
+
+printf "\n> Test ddtrace is installed for default PHP version only...\n"
+enableExtension # Empty params enables default PHP version
+restartService "php-fpm$defaultPhpVersion"
+for v in $phpVersions; do
+    if [ "$v" != "$defaultPhpVersion" ]; then
+        testNotInstalled "$v" fpm-fcgi
+        testNotInstalledCli "$v"
+    else
+        testInstalled "$v" fpm-fcgi
+        testInstalledCli "$v"
+    fi
+done
+restartService "apache2"
+if [ "$apachePhpVersion" != "$defaultPhpVersion" ]; then
+    testNotInstalled $apachePhpVersion apache2handler
+else
+    testInstalled $apachePhpVersion apache2handler
+fi
+
+printf "\n> Test ddtrace is installed for specific PHP-FPM versions...\n"
+reset
+for v in $phpVersions; do
+    enableExtension "php-fpm$v"
+    restartService "php-fpm$v"
+    testInstalled "$v" fpm-fcgi
+    testInstalledCli "$v"
+    if [ "$v" = "$apachePhpVersion" ]; then
+        restartService "apache2"
+        testInstalled $apachePhpVersion apache2handler
+    fi
+done
+
+printf "\n> Test ddtrace is installed for specific PHP-CLI versions...\n"
+reset
+for v in $phpVersions; do
+    enableExtension "php$v"
+    restartService "php-fpm$v"
+    testInstalled "$v" fpm-fcgi
+    testInstalledCli "$v"
+    if [ "$v" = "$apachePhpVersion" ]; then
+        restartService "apache2"
+        testInstalled $apachePhpVersion apache2handler
+    fi
+done
+
+# Not running reset here to leave in unclean state for debugging
+
+if [ $exitCode -eq 1 ]; then
+    exit 1
+fi

--- a/tests/PostInstallHook/run-tests.sh
+++ b/tests/PostInstallHook/run-tests.sh
@@ -7,12 +7,12 @@ pwd=$(dirname "$0")
 # The version that installed libapache2-mod-php* in the Dockerfile
 apachePhpVersion=7.3
 
-pv=$(php "$pwd/bootstrap.php" | grep "  --php-version")
-if [ -z "$pv" ]; then
+phpVersion=$(php "$pwd/bootstrap.php" | grep "  --php-version")
+if [ -z "$phpVersion" ]; then
     printf "No supported PHP versions found\n"
     exit 1
 fi
-phpVersions=${pv#"  --php-version    "}
+phpVersions=${phpVersion#"  --php-version    "}
 
 defaultPhpVersion=$(php-config --version | cut -d . -f -2)
 

--- a/tests/PostInstallHook/test-installed.php
+++ b/tests/PostInstallHook/test-installed.php
@@ -1,0 +1,7 @@
+<?php
+
+$response = require __DIR__ . '/bootstrap.php';
+
+$response->assertSameFromKey('ddtrace_installed', true);
+
+// No news is good news

--- a/tests/PostInstallHook/test-not-installed.php
+++ b/tests/PostInstallHook/test-not-installed.php
@@ -1,0 +1,7 @@
+<?php
+
+$response = require __DIR__ . '/bootstrap.php';
+
+$response->assertSameFromKey('ddtrace_installed', false);
+
+// No news is good news


### PR DESCRIPTION
### Description

When installing from a package, the post-install script will install ddtrace for the default PHP version located at `$ which php`. This PR enables a user to target a specific PHP binary using `DD_TRACE_PHP_BIN` on hosts that have multiple versions of PHP installed.

For example, if I wanted to target `php-fpm7`, I could set the path to the binary using `DD_TRACE_PHP_BIN`.

```bash
$ export DD_TRACE_PHP_BIN=$(which php-fpm7)
$ #... install the extension ...
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
