### PR TITLE
[POC] Drop spans without orphans

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -140,6 +140,7 @@
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />
                         <file name="drop_spans.phpt" role="test" />
+                        <file name="drop_spans_update_parent_ids.phpt" role="test" />
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -116,6 +116,15 @@ void ddtrace_drop_span(TSRMLS_D) {
     // Sync with span ID stack
     ddtrace_pop_span_id(TSRMLS_C);
 
+    // Replace child span's parent ID's with the dropped span's parent
+    ddtrace_span_t *next_closed_span = DDTRACE_G(closed_spans_top);
+    while (next_closed_span != NULL) {
+        if (next_closed_span->parent_id == span->span_id) {
+            next_closed_span->parent_id = span->parent_id;
+        }
+        next_closed_span = next_closed_span->next;
+    }
+
     _free_span(span);
 }
 

--- a/tests/ext/sandbox/drop_spans_update_parent_ids.phpt
+++ b/tests/ext/sandbox/drop_spans_update_parent_ids.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Update child span's parent ID's when span is dropped
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('main', function (SpanData $span) {
+    $span->name = 'Main';
+});
+dd_trace_function('dropMe', function (SpanData $span) {
+    $span->name = 'DropMe';
+    return false;
+});
+dd_trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'ArraySum';
+});
+
+function dropMe() {
+    return array_sum([1, 2]) + array_sum([3, 4]);
+}
+function main() {
+    dropMe();
+}
+main();
+
+$mainSpanId = 0;
+$droppedSpanId = 0; // Should not change
+$targetChildren = [];
+array_map(function($span) use (&$mainSpanId, &$targetChildren, &$droppedSpanId) {
+    switch ($span['name']) {
+        case 'Main':
+            $mainSpanId = $span['span_id'];
+            break;
+        case 'ArraySum':
+            $targetChildren[] = $span;
+            break;
+        case 'DropMe':
+            $droppedSpanId = $span['span_id'];
+            break;
+    }
+}, dd_trace_serialize_closed_spans());
+
+var_dump($mainSpanId === $targetChildren[0]['parent_id']);
+var_dump($mainSpanId === $targetChildren[1]['parent_id']);
+var_dump($droppedSpanId);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+int(0)


### PR DESCRIPTION
### Description

**DO NOT MERGE** :)

This is just a POC showing how to save child spans from becoming orphans when dropping a parent span from the sandbox API. This implementation would slow things down especially in limited-tracing mode. There are a number of ways to optimize this, but as @morrisonlevi pointed out, avoiding span dropping in the first place is a cleaner approach.

The two main areas where the tracer drops spans in the sandbox API are:

0. Call hooks that load integrations but do not need to create spans.
1. Dropping the span when the tracer is in limited tracing mode which has the potential to orphan a huge number of valid spans.

I'd love to have a discussion for figuring out an API for each of these requirements. :)