### PR TITLE
Prevent mysqli_connect span from closing twice

### DIFF
--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -68,7 +68,6 @@ class MysqliIntegration extends Integration
                 } else {
                     MysqliIntegration::setConnectionInfo($span, $result);
                 }
-                $scope->close();
             } catch (\Exception $ex) {
                 $span->setError($ex);
                 $thrown = $ex;


### PR DESCRIPTION
### Description

The `mysqli_connect()` span gets closed twice which can cause the span ID's to get out of sync between userland and internal spans. This PR fixes that. :)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
