### PR TITLE
Move dev images to new dd-trace-ci repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,14 +830,14 @@ workflows:
           requires: [ 'Code Checkout' ]
           name: "PHP 70 Web integration tests"
           integration_testsuite: "test-web-70"
-          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.0"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-7.0-debug"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 71 Web integration tests"
           resource_class: medium+
           integration_testsuite: "test-web-71"
-          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.1"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-7.1-debug"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
+      - <<: *DD_TRACE_CI_DOCKER_CREDENTIALS
       - <<: *IMAGE_DOCKER_DD_AGENT
       - <<: *IMAGE_DOCKER_ELASTICSEARCH2
       - <<: *IMAGE_DOCKER_HTTPBIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,6 +845,8 @@ workflows:
           resource_class: medium+
           integration_testsuite: "test-web-72"
           docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.2"
+          # Temporary workaround while we migrate all images to new versions
+          lib_curl_command: ":"
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 73 Web integration tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -824,7 +824,7 @@ workflows:
           name: "PHP 56 Web integration tests"
           integration_testsuite: "test-web-56"
           # docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debug
-          docker_image: "datadog/docker-library:ddtrace_php_5_6"
+          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:5.6"
           lib_curl_command: sudo apt update ; sudo apt-get -y install libcurl4-nss-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
@@ -844,8 +844,7 @@ workflows:
           name: "PHP 72 Web integration tests"
           resource_class: medium+
           integration_testsuite: "test-web-72"
-          docker_image: "datadog/docker-library:ddtrace_php_7_2"
-          lib_curl_command: sudo apt update ; sudo apt-get -y install libcurl4-nss-dev
+          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.2"
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 73 Web integration tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
-      - <<: *DD_TRACE_CI_DOCKER_CREDENTIALS
+        <<: *DD_TRACE_CI_DOCKER_CREDENTIALS
       - <<: *IMAGE_DOCKER_DD_AGENT
       - <<: *IMAGE_DOCKER_ELASTICSEARCH2
       - <<: *IMAGE_DOCKER_HTTPBIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,6 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
-        <<: *DD_TRACE_CI_DOCKER_CREDENTIALS
       - <<: *IMAGE_DOCKER_DD_AGENT
       - <<: *IMAGE_DOCKER_ELASTICSEARCH2
       - <<: *IMAGE_DOCKER_HTTPBIN
@@ -825,29 +824,28 @@ workflows:
           name: "PHP 56 Web integration tests"
           integration_testsuite: "test-web-56"
           # docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debug
-          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:5.6"
+          docker_image: "datadog/docker-library:ddtrace_php_5_6"
           lib_curl_command: sudo apt update ; sudo apt-get -y install libcurl4-nss-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 70 Web integration tests"
           integration_testsuite: "test-web-70"
-          docker_image: "datadog/docker-library:ddtrace_alpine_php-7.0-debug"
+          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.0"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 71 Web integration tests"
           resource_class: medium+
           integration_testsuite: "test-web-71"
-          docker_image: "datadog/docker-library:ddtrace_alpine_php-7.1-debug"
+          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.1"
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 72 Web integration tests"
           resource_class: medium+
           integration_testsuite: "test-web-72"
-          docker_image: "docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.2"
-          # Temporary workaround while we migrate all images to new versions
-          lib_curl_command: ":"
+          docker_image: "datadog/docker-library:ddtrace_php_7_2"
+          lib_curl_command: sudo apt update ; sudo apt-get -y install libcurl4-nss-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 73 Web integration tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,27 +43,27 @@ x-aliases:
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
 
 services:
-  '5.4': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_5_4' }
+  '5.4': { <<: *base_php_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:5.4' }
   '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
   '5.5': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5' }
   '5.5-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5-debug' }
-  '5.6': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_php_5_6' }
+  '5.6': { <<: *base_56_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:5.6' }
   '5.6-original': { <<: *base_56_service, image: 'circleci/php:5.6-zts' }
   '5.6-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-debug' }
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }
-  '7.0': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_0' }
+  '7.0': { <<: *base_php_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.0' }
   '7.0-centos': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_centos_6_php_7_0' }
   '7.0-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-debug' }
   '7.0-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-zts' }
-  '7.1': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_1' }
+  '7.1': { <<: *base_php_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.1' }
   '7.1-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-debug' }
   '7.1-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-zts' }
   '7.1-centos6': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_centos_6_php_7_1' }
   '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
-  '7.2': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_php_7_2' }
+  '7.2': { <<: *base_php_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.2' }
   '7.2-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-debug' }
   '7.2-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-zts' }
-  '7.3': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3' }
+  '7.3': { <<: *base_php_service, image: 'docker.pkg.github.com/datadog/dd-trace-ci/php-dev:7.3' }
   '7.3-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-debug' }
   '7.3-zts-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts-debug' }
   '7.3-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts' }


### PR DESCRIPTION
### Description

Images used for testing (specifically `5.4`,`5.6`,`7.0`,`7.1`,`7.2`,`7.3`) were moved to new repo `dd-trace-ci` and some utilities were added to the images.

This PR updates image versions in the `docker-compose.yml` file so development images are up to date with the latests tools.

In order to run a dev environment for a specificic version, e.g. `7.2`:

```
docker-composer run --rm 7.2
```

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- ~[ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
