### PR TITLE
Add Yii 2 integration

### DIFF
--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -88,6 +88,8 @@ require __DIR__ . '/../src/DDTrace/Integrations/Laravel/V4/LaravelIntegration.ph
 require __DIR__ . '/../src/DDTrace/Integrations/Lumen/LumenIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php';
 

--- a/composer.json
+++ b/composer.json
@@ -205,6 +205,7 @@
             "@cakephp-28-test",
             "@laravel-42-update",
             "@laravel-42-test",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],
@@ -220,6 +221,7 @@
             "@symfony-30-suite",
             "@symfony-33-suite",
             "@symfony-34-suite",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],

--- a/composer.json
+++ b/composer.json
@@ -235,6 +235,7 @@
             "@symfony-33-suite",
             "@symfony-34-suite",
             "@wordpress-48-test",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],
@@ -262,6 +263,7 @@
             "@symfony-40-suite",
             "@symfony-42-suite",
             "@wordpress-48-test",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],
@@ -292,6 +294,7 @@
             "@symfony-40-suite",
             "@symfony-42-suite",
             "@wordpress-48-test",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],
@@ -312,6 +315,7 @@
             "@symfony-40-suite",
             "@symfony-42-suite",
             "@wordpress-48-test",
+            "@yii-2-suite",
             "@zend-framework-1-test",
             "@custom-framework-autoloaded-suite"
         ],
@@ -398,6 +402,10 @@
         "symfony-42-suite": [ "@symfony-42-update", "@symfony-42-test" ],
 
         "wordpress-48-test": "@composer test -- tests/Integrations/WordPress/V4_8",
+
+        "yii-2-update": "@composer --working-dir=tests/Frameworks/Yii/Version_2_0_26 update",
+        "yii-2-test": "@composer test -- tests/Integrations/Yii/V2_0_26",
+        "yii-2-suite": [ "@yii-2-update", "@yii-2-test"],
 
         "zend-framework-1-test": "@composer test -- tests/Integrations/ZendFramework/V1",
 

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -24,6 +24,7 @@ use DDTrace\Integrations\Slim\SlimIntegration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration;
 use DDTrace\Integrations\Web\WebIntegration;
 use DDTrace\Integrations\WordPress\WordPressSandboxedIntegration;
+use DDTrace\Integrations\Yii\YiiSandboxedIntegration;
 use DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration;
 use DDTrace\Log\LoggingTrait;
 
@@ -91,6 +92,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
             $this->integrations[WordPressSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\WordPress\WordPressSandboxedIntegration';
+            $this->integrations[YiiSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Yii\YiiSandboxedIntegration';
         }
     }
 

--- a/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace DDTrace\Integrations\Yii\V2;
+
+use DDTrace\Configuration;
+use DDTrace\Contracts\Scope;
+use DDTrace\GlobalTracer;
+use DDTrace\Http\Urls;
+use DDTrace\Integrations\Yii\YiiSandboxedIntegration;
+use DDTrace\Integrations\Integration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+use yii\helpers\Url;
+
+class YiiIntegrationLoader
+{
+
+    public function load(YiiSandboxedIntegration $integration)
+    {
+        $scope = GlobalTracer::get()->getRootScope();
+        if (!$scope instanceof Scope) {
+            return Integration::NOT_LOADED;
+        }
+        $root = $scope->getSpan();
+        // Overwrite the default web integration
+        $root->setIntegration($integration);
+        $root->setTraceAnalyticsCandidate();
+        $service = Configuration::get()->appName(YiiSandboxedIntegration::NAME);
+
+        // This will also attach app.endpoint info to the root span
+        \dd_trace_method(
+            'yii\web\Application',
+            'run',
+            function (SpanData $span) use ($root, $service) {
+                $span->name = $span->resource = \get_class($this) . '.run';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $service;
+
+                if (isset($this->controller->action->actionMethod)) {
+                    $controller = \get_class($this->controller);
+                    $endpoint = "{$controller}::{$this->controller->action->actionMethod}";
+                    $root->setTag("app.endpoint", $endpoint);
+                    $root->setTag(Tag::HTTP_URL, Url::base(true) . Url::current());
+                }
+            }
+        );
+
+        /* Note that Applications are Modules, so this will also trace Application::runAction, but
+         * modules are worth tracing independently, as multiple modules can trigger per
+         * application, such as in the event of an unhandled exception.
+         */
+        \dd_trace_method(
+            'yii\base\Module',
+            'runAction',
+            function (SpanData $span, $args) use ($service) {
+                $span->name = \get_class($this) . '.runAction';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $service;
+                $span->resource = isset($args[0]) && \is_string($args[0]) ? $args[0] : $span->name;
+            }
+        );
+
+        \dd_trace_method(
+            'yii\base\Controller',
+            'runAction',
+            function (SpanData $span, $args) use ($service) {
+                $span->name = \get_class($this) . '.runAction';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $service;
+                $span->resource = isset($args[0]) && \is_string($args[0]) ? $args[0] : $span->name;
+            }
+        );
+
+        \dd_trace_method(
+            'yii\base\View',
+            'renderFile',
+            function (SpanData $span, $args) use ($service) {
+                $span->name = \get_class($this) . '.renderFile';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $service;
+                $span->resource = isset($args[0]) && \is_string($args[0]) ? $args[0] : $span->name;
+            }
+        );
+
+        /* I'm hoping to be able to get app.route.path and proper root resource name out of this somehow:
+        \dd_trace_method('yii\web\Request', 'resolve', function (SpanData $span, $args, $retval, $ex) use ($service) {
+            $span->name = $span->resource = \get_class($this) . '.resolve';
+            $span->type = Type::WEB_SERVLET;
+            $span->service = $service;
+
+            $pathInfo = $this->getPathInfo();
+
+            if (!$ex) {
+                list($route, $params) = $retval;
+            }
+            return false;
+        });
+        */
+
+        $root->setTag(Tag::SERVICE_NAME, $service);
+        if ('cli' !== PHP_SAPI) {
+            $normalizer = new Urls(explode(',', getenv('DD_TRACE_RESOURCE_URI_MAPPING')));
+            $root->setTag(
+                Tag::RESOURCE_NAME,
+                $_SERVER['REQUEST_METHOD'] . ' ' . $normalizer->normalize($_SERVER['REQUEST_URI']),
+                true
+            );
+        }
+
+        return Integration::LOADED;
+    }
+}

--- a/src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DDTrace\Integrations\Yii;
+
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\Util\Versions;
+
+class YiiSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'yii';
+
+    /**
+     * @var self
+     */
+    private static $instance;
+
+    /**
+     * @return self
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresExplicitTraceAnalyticsEnabling()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        $integration = self::getInstance();
+
+        // This happens somewhat early in the setup, though there may be a better candidate
+        \dd_trace_method('yii\di\Container', '__construct', function () use ($integration) {
+            if (Versions::versionMatches('2.0', \Yii::getVersion())) {
+                $loader = new V2\YiiIntegrationLoader();
+                $loader->load($integration);
+            }
+            return false; // Drop this span to reduce noise
+        });
+
+        return self::LOADED;
+    }
+}

--- a/tests/Frameworks/Yii/Version_2_0_26/config/db.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/config/db.php
@@ -2,9 +2,9 @@
 
 return [
     'class' => 'yii\db\Connection',
-    'dsn' => 'mysql:host=localhost;dbname=yii2basic',
-    'username' => 'root',
-    'password' => '',
+    'dsn' => 'mysql:host=test;dbname=test',
+    'username' => 'test',
+    'password' => 'test',
     'charset' => 'utf8',
 
     // Schema cache options (for production environment)

--- a/tests/Frameworks/Yii/Version_2_0_26/config/test_db.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/config/test_db.php
@@ -1,6 +1,6 @@
 <?php
 $db = require __DIR__ . '/db.php';
 // test database! Important not to run tests on production or development databases
-$db['dsn'] = 'mysql:host=localhost;dbname=yii2_basic_tests';
+$db['dsn'] = 'mysql:host=test;dbname=test';
 
 return $db;

--- a/tests/Frameworks/Yii/Version_2_0_26/config/web.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/config/web.php
@@ -43,14 +43,17 @@ $config = [
             ],
         ],
         'db' => $db,
-        /*
+
         'urlManager' => [
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'rules' => [
+                'simple' => 'simple/index',
+                'simple_view' => 'simple/view',
+                'error' => 'simple/error',
             ],
         ],
-        */
+
     ],
     'params' => $params,
 ];

--- a/tests/Frameworks/Yii/Version_2_0_26/config/web.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/config/web.php
@@ -51,6 +51,7 @@ $config = [
                 'simple' => 'simple/index',
                 'simple_view' => 'simple/view',
                 'error' => 'simple/error',
+                'homes/<state>/<city>/<neighborhood>' => 'homes/view',
             ],
         ],
 

--- a/tests/Frameworks/Yii/Version_2_0_26/controllers/HomesController.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/controllers/HomesController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace app\controllers;
+
+use yii\web\Controller;
+
+class HomesController extends Controller
+{
+
+    /**
+     * @return string
+     */
+    public function actionView($state, $city, $neighborhood)
+    {
+        return "Hit {$state}/{$city}/{$neighborhood}";
+    }
+}

--- a/tests/Frameworks/Yii/Version_2_0_26/controllers/SimpleController.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/controllers/SimpleController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace app\controllers;
+
+use yii\web\Controller;
+
+class SimpleController extends Controller
+{
+
+    /**
+     * @return string
+     */
+    public function actionIndex()
+    {
+        return 'Hello world';
+    }
+
+    /**
+     * @return string
+     */
+    public function actionView()
+    {
+        return $this->render('index');
+    }
+
+    /**
+     * @return string
+     */
+    public function actionError()
+    {
+        throw new \Exception('datadog');
+    }
+}

--- a/tests/Frameworks/Yii/Version_2_0_26/views/simple/index.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/views/simple/index.php
@@ -1,0 +1,18 @@
+<?php
+
+/* @var $this yii\web\View */
+
+use yii\helpers\Html;
+
+$this->title = 'Simple View';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+<div class="site-about">
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <p>
+        This is the Simple View page. You may modify the following file to customize its content:
+    </p>
+
+    <code><?= __FILE__ ?></code>
+</div>

--- a/tests/Frameworks/Yii/Version_2_0_26/web/index.php
+++ b/tests/Frameworks/Yii/Version_2_0_26/web/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // comment out the following two lines when deployed to production
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
+//defined('YII_DEBUG') or define('YII_DEBUG', true);
+//defined('YII_ENV') or define('YII_ENV', 'dev');
 
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';

--- a/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
+++ b/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Yii\V2_0_26;
+
+use DDTrace\Tag;
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+use DDTrace\Type;
+
+final class CommonScenariosTest extends WebFrameworkTestCase
+{
+    const IS_SANDBOX = true;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Yii/Version_2_0_26/web/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE_NAME' => 'yii2_test_app',
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSpecs
+     * @param RequestSpec $spec
+     * @param array $spanExpectations
+     * @throws \Exception
+     */
+    public function testScenario(RequestSpec $spec, array $spanExpectations)
+    {
+        $traces = $this->tracesFromWebRequest(function () use ($spec) {
+            $this->call($spec);
+        });
+
+        $this->assertExpectedSpans($traces, $spanExpectations);
+    }
+
+    public function provideSpecs()
+    {
+            return $this->buildDataProvider(
+                [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'yii2_test_app',
+                        'web',
+                        'GET /simple'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/simple',
+                        Tag::HTTP_STATUS_CODE => '200',
+                        'integration.name' => 'yii',
+                        'app.endpoint' => 'app\controllers\SimpleController::actionIndex',
+                    ]),
+                    SpanAssertion::build(
+                        'yii\web\Application.run',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'yii\web\Application.run'
+                    ),
+                    SpanAssertion::build(
+                        'yii\web\Application.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'simple/index'
+                    ),
+                    SpanAssertion::build(
+                        'app\controllers\SimpleController.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'index'
+                    ),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'yii2_test_app',
+                        'web',
+                        'GET /simple_view'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/simple_view',
+                        Tag::HTTP_STATUS_CODE => '200',
+                        'integration.name' => 'yii',
+                        'app.endpoint' => 'app\controllers\SimpleController::actionView',
+                    ]),
+                    SpanAssertion::build(
+                        'yii\web\Application.run',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'yii\web\Application.run'
+                    ),
+                    SpanAssertion::build(
+                        'yii\web\Application.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'simple/view'
+                    ),
+                    SpanAssertion::build(
+                        'app\controllers\SimpleController.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'view'
+                    ),
+                    SpanAssertion::exists('yii\web\View.renderFile'),
+                    SpanAssertion::exists('yii\web\View.renderFile'),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'yii2_test_app',
+                        'web',
+                        'GET /error'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/error',
+                        Tag::HTTP_STATUS_CODE => '500',
+                        'integration.name' => 'yii',
+                        'app.endpoint' => 'app\controllers\SimpleController::actionError',
+                    ])->setError(),
+                    SpanAssertion::build(
+                        'yii\web\Application.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'site/error'
+                    ),
+                    SpanAssertion::build(
+                        'app\controllers\SiteController.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'error'
+                    ),
+                    SpanAssertion::exists('yii\web\View.renderFile'),
+                    SpanAssertion::exists('yii\web\View.renderFile'),
+                    SpanAssertion::build(
+                        'yii\web\Application.run',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'yii\web\Application.run'
+                    )->setError('Exception', 'datadog', true),
+                    SpanAssertion::build(
+                        'yii\web\Application.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'simple/error'
+                    )->setError('Exception', 'datadog', true),
+                    SpanAssertion::build(
+                        'app\controllers\SimpleController.runAction',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'error'
+                    )->setError('Exception', 'datadog', true),
+                ],
+                ]
+            );
+    }
+}

--- a/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
+++ b/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
@@ -55,6 +55,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '200',
                         'integration.name' => 'yii',
                         'app.endpoint' => 'app\controllers\SimpleController::actionIndex',
+                        'app.route.path' => '/simple',
                     ]),
                     SpanAssertion::build(
                         'yii\web\Application.run',
@@ -87,6 +88,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '200',
                         'integration.name' => 'yii',
                         'app.endpoint' => 'app\controllers\SimpleController::actionView',
+                        'app.route.path' => '/simple_view',
                     ]),
                     SpanAssertion::build(
                         'yii\web\Application.run',
@@ -121,6 +123,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '500',
                         'integration.name' => 'yii',
                         'app.endpoint' => 'app\controllers\SimpleController::actionError',
+                        'app.route.path' => '/error',
                     ])->setError(),
                     SpanAssertion::build(
                         'yii\web\Application.runAction',

--- a/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Yii\V2_0_26;
+
+use DDTrace\Tag;
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\SpanAssertionTrait;
+use DDTrace\Tests\Common\TracerTestTrait;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use DDTrace\Type;
+
+class ParameterizedRouteTest extends WebFrameworkTestCase
+{
+    use TracerTestTrait;
+    use SpanAssertionTrait;
+
+    const IS_SANDBOX = true;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Yii/Version_2_0_26/web/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE_NAME' => 'yii2_test_app',
+        ]);
+    }
+
+    public function testGet()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec  = GetSpec::create('homes get', '/homes/new-york/new-york/manhattan');
+            $this->call($spec);
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'web.request',
+                    'yii2_test_app',
+                    Type::WEB_SERVLET,
+                    'GET /homes/?/?/?'
+                )->withExactTags([
+                    Tag::HTTP_METHOD => 'GET',
+                    Tag::HTTP_URL => 'http://localhost:9999/homes/new-york/new-york/manhattan',
+                    Tag::HTTP_STATUS_CODE => '200',
+                    'integration.name' => 'yii',
+                    'app.route.path' => '/homes/:state/:city/:neighborhood',
+                    'app.endpoint' => 'app\controllers\HomesController::actionView',
+                ])->withChildren([
+                    SpanAssertion::build(
+                        'yii\web\Application.run',
+                        'yii2_test_app',
+                        Type::WEB_SERVLET,
+                        'yii\web\Application.run'
+                    )->withChildren([
+                        SpanAssertion::build(
+                            'yii\web\Application.runAction',
+                            'yii2_test_app',
+                            Type::WEB_SERVLET,
+                            'homes/view'
+                        )->withChildren([
+                            SpanAssertion::build(
+                                'app\controllers\HomesController.runAction',
+                                'yii2_test_app',
+                                Type::WEB_SERVLET,
+                                'view'
+                            )
+                        ])
+                    ])
+                ])
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Description

Adds support for Module and Controller runAction, View::renderFile, and adds some metadata to the root span.

Tests are for PHP 5.4, 5.6, and 7.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
