### PR TITLE
Add minimal Dogstatsd client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!config.*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!config.*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' || touch .failure
       - run:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure

--- a/src/dogstatsd/.clang-format
+++ b/src/dogstatsd/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Google
+---
+Language: Cpp
+---

--- a/src/dogstatsd/.editorconfig
+++ b/src/dogstatsd/.editorconfig
@@ -1,0 +1,38 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+# C-style doc comments
+block_comment_start = /*
+block_comment = *
+block_comment_end = */
+
+[*.{c,cc,h}]
+indent_size = none
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Dockerfile]
+indent_size = 2
+
+[*.php]
+block_comment_start = /*
+block_comment = *
+block_comment_end = */
+
+[*Makefile]
+indent_style = tab
+
+[CMakeLists.txt]
+indent_size = 2
+block_comment_start = #[[
+block_comment_end = #]]

--- a/src/dogstatsd/.gitignore
+++ b/src/dogstatsd/.gitignore
@@ -1,0 +1,2 @@
+cmake-build-*/
+.idea/

--- a/src/dogstatsd/CMakeLists.txt
+++ b/src/dogstatsd/CMakeLists.txt
@@ -1,0 +1,103 @@
+#[[
+ We need to be able to set the C version in a standard way, which was not
+ added until CMake 3.1 with the C_STANDARD property.
+
+ The feature c_std_99 was added to CMake 3.8. The feature is more desriable
+ than C_STANDARD because it's a minimum rather than an exact. This way if a
+ compiler prefers a newer version it is free to do so, and most compilers on
+ the latest releases do prefer a newer C standard.
+
+              Operating System Matrix
+ OS      OS_VERSION  OS_CODENAME   CMAKE_VERSION
+ Debian              Jessie        3.0.2
+ Debian              Stretch       3.7.2
+ Debian              Buster        3.13
+ CentOS  6                         2.8.12
+ CentOS  7                         2.8.12
+ CentOS  8                         3.11
+ Ubuntu  14.04       Xenial        2.8.12
+ Ubuntu  16.04       Xenial        3.5
+ Ubuntu  18.04       Bionic        3.10
+
+ I decided to pick the next lowest version after 3.8 that is supported by a
+ major operating system: 3.10.
+#]]
+cmake_minimum_required(VERSION 3.10)
+project(DogstatsdClient
+  VERSION 0.1.0
+  LANGUAGES C
+)
+
+add_library(DogstatsdClient client.c)
+target_include_directories(DogstatsdClient PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(DogstatsdClient PRIVATE c_std_99)
+
+set_target_properties(DogstatsdClient PROPERTIES
+  OUTPUT_NAME dogstatsd_client # It should be named libdogstatsd_client.{a,so}, not libDogstatsdClient.{a,so}
+  PUBLIC_HEADER dogstatsd_client/client.h
+  VERSION ${PROJECT_VERSION}
+)
+
+#[[
+ We want to be able to use the namespaced name everywhere, including in this project's tests;
+ this is a pattern described in the talk Effective CMake that allows that
+#]]
+add_library(DogstatsdClient::DogstatsdClient ALIAS DogstatsdClient)
+
+# Add infrastructure for enabling tests
+option(BUILD_TESTING "Enable tests" OFF)
+include(CTest)
+if (${BUILD_TESTING})
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
+# Everything below this line is for usage in other projects via CMake or pkg-config
+
+install(
+  TARGETS DogstatsdClient
+  EXPORT DogstatsdClientTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include/dogstatsd_client
+  INCLUDES DESTINATION include/dogstatsd_client
+)
+
+install(
+  EXPORT DogstatsdClientTargets
+  NAMESPACE DogstatsdClient::
+  DESTINATION share/cmake/DogstatsdClient
+)
+
+# This allows the exports to be used from the build tree, instead of only after installing
+export(
+  TARGETS DogstatsdClient
+  FILE DogstatsdClientExports.cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+# When the library is more stable, change ExactVersion to SameMajorVersion
+write_basic_package_version_file("DogstatsdClientVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/DogstatsdClientVersion.cmake"
+  DESTINATION share/cmake/DogstatsdClient
+)
+
+# pkg-config support
+configure_file(${PROJECT_SOURCE_DIR}/dogstatsd_client.pc.in
+  ${PROJECT_BINARY_DIR}/share/pkgconfig/dogstatsd_client.pc @ONLY
+)
+
+install(
+  FILES ${PROJECT_BINARY_DIR}/share/pkgconfig/dogstatsd_client.pc
+  DESTINATION share/pkgconfig
+)

--- a/src/dogstatsd/README.md
+++ b/src/dogstatsd/README.md
@@ -1,0 +1,85 @@
+# A dogstatsd client written in C
+
+This is a [dogstatsd](https://docs.datadoghq.com/developers/dogstatsd/) client written in C. It's used by the
+[PHP tracer](https://github.com/DataDog/dd-trace-php), and right now only implements the pieces needed for its metrics
+logging. If there is demand, it can be split into its own project.
+
+Requirements:
+  - POSIX OS
+  - C99 compatible compiler and standard library, notably `snprintf`.
+
+Optional, but recommended:
+  - CMake 3.10 or newer.
+
+The build has been tested on recent Mac OS and Linux operating systems.
+
+## Compiling
+
+This project intentionally uses a simple layout, with just `client.c` and `dogstatsd_client/client.h`. You can build,
+compile, and install these however you want as long as you use a C99 compiler; they do not require any configuring.
+Building with CMake does provide pkg-config and CMake project integration, though.
+
+### Compiling and installing with CMake
+
+This project has CMake support, which will generate files for `pkg-config` and cmake imported targets. It should use an
+out of tree build, meaning don't build it from the directory that contains CMakeLists.txt.
+
+Here are some common commands that will probably get it built and installed on your platform, where `$prefix` is the
+path CMake will install to and `$srcdir` is the directory that contains this project's `CMakeLists.txt`:
+```
+mkdir /tmp/build-dogstatsd_client
+cd /tmp/build-dogstatsd_client
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$prefix" $srcdir
+cmake --build . --config RelWithDebInfo
+cmake --build . --target install
+```
+
+To build the dogstatsd_client tests, add `-DBUILD_TESTING=ON` to the cmake flags and use the `test` target.
+
+## Integrating from other projects
+If dogstatsd_client was installed via CMake then there is support for `pkg-config` and CMake.
+
+The header is named `dogstatsd_client/client.h`. The [API](#API) is described below.
+
+### Integrating with pkg-config
+
+The path `$prefix/share/pkgconfig` will contain the `dogstatsd_client.pc` file. If it is added to `PKG_CONFIG_PATH`,
+then commands like `pkg-config --libs dogstatsd_client` should work.
+
+### Integrating with CMake
+As long as `$prefix` is in the environment variable `CMAKE_PREFIX_PATH`, e.g.
+`export CMAKE_PREFIX_PATH="$prefix:$CMAKE_PREFIX_PATH"` in bash, then `find_package(dogstatsd_client)` should find it.
+The target `DogstatsdClient::DogstatsdClient` can then be linked. As an example, this will add the client to the
+`example` target:
+
+```
+find_package(dogstatsd_client REQUIRED)
+target_link_libraries(example DogstatsdClient::DogstatsdClient)
+```
+
+## API
+
+Create a client with `dogstatsd_client_ctor`. Note that the `const_tags` parameter will be attached to all metrics
+automatically. This example uses localhost and the default port.
+```c
+char buf[DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE];
+size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
+dogstatsd_client client;
+if (dogstatsd_client_ctor(&client, "localhost", "8125", buf, len, "lang:php") == 0) {
+  // success
+}
+```
+
+To increment a metric with the default sampling rate of 1.0, use `dogstatsd_client_count`. This example increments the
+metric `datadog.tracer.uncaught_exceptions` by 1, using the tag `class:sigsegv`:
+```c
+dogstatsd_client_count(&client, "datadog.tracer.uncaught_exceptions", "1", "class:sigsegv");
+```
+The tags parameter can be NULL or an empty string if you do not need to set any tags specific to this metric.
+
+Use the `dogstatsd_client_dtor` function to clean up. Note that it will _not_ free any arguments it has been passed;
+it will clean up only its own data.
+```c
+dogstatsd_client_dtor(&dtor);
+````
+The dtor function does not need to be called if the ctor fails.

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -1,0 +1,159 @@
+#include "dogstatsd_client/client.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+dogstatsd_client dogstatsd_client_default_ctor() {
+  dogstatsd_client client = {
+      .socket = -1,
+      .address = NULL,
+      .addresslist = NULL,
+      .msg_buffer = NULL,
+      .msg_buffer_len = 0,
+      .const_tags = NULL,
+      .const_tags_len = 0,
+  };
+  return client;
+}
+
+/* This function is inline, but it needs to go in a translation unit somewhere
+ * to avoid certain linker errors. This line instructs the tooling it should
+ * go here.
+ */
+extern inline int dogstatsd_client_is_default_client(dogstatsd_client *);
+
+dogstatsd_client dogstatsd_client_ctor(const char *host, const char *port,
+                                       char *buffer, int buffer_len,
+                                       const char *const_tags) {
+  if (!host || !port || !buffer || buffer_len < 0) {
+    return dogstatsd_client_default_ctor();
+  }
+
+  struct addrinfo *result;
+  struct addrinfo *res;
+  int error;
+
+  struct addrinfo hints;
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_protocol = IPPROTO_UDP;
+  hints.ai_flags = AI_NUMERICSERV;
+
+  /* resolve the domain name into a list of addresses */
+  error = getaddrinfo(host, port, &hints, &result);
+  if (error != 0) {
+    if (error == EAI_SYSTEM) {
+      perror("getaddrinfo");
+    } else {
+      fprintf(stderr, "error in getaddrinfo: %s\n", gai_strerror(error));
+    }
+    return dogstatsd_client_default_ctor();
+  }
+
+  int fd = -1;
+  /* loop over all returned results and do inverse lookup */
+  for (res = result; res != NULL; res = res->ai_next) {
+    if ((fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) !=
+        -1) {
+      break;
+    }
+  }
+
+  if (res == NULL || fd == -1) {
+    return dogstatsd_client_default_ctor();
+  }
+
+  if (!const_tags) {
+    const_tags = "";
+  }
+
+  dogstatsd_client client = {
+      .socket = fd,
+      .addresslist = result,
+      .address = res,
+      .msg_buffer = buffer,
+      .msg_buffer_len = buffer_len,
+      .const_tags = const_tags,
+      .const_tags_len = strlen(const_tags),
+  };
+
+  return client;
+}
+
+void dogstatsd_client_dtor(dogstatsd_client *client) {
+  if (!client) {
+    return;
+  }
+  if (client->socket != -1) {
+    close(client->socket);
+  }
+  if (client->addresslist) {
+    freeaddrinfo(client->addresslist);
+  }
+}
+
+/* allowed metric types: c, g, ms, h, and s.
+ * sample_rate must be between 0.0 and 1.0 (inclusive); if you are unsure then
+ * specify 1.0.
+ */
+static dogstatsd_client_status _dogstatsd_client_send(
+    dogstatsd_client *client, const char *name, const char *value,
+    const char *type, float sample_rate, const char *tags) {
+  if (dogstatsd_client_is_default_client(client)) {
+    return DOGSTATSD_CLIENT_E_NO_CLIENT;
+  }
+
+  if (!name || !value || !type) {
+    return DOGSTATSD_CLIENT_E_VALUE;
+  }
+
+  /* We need to concatenate all the strings together (without spaces, they
+   * are there just to show how the format maps):
+   *     metric : value | type |@ sample_rate |# tags ,  const_tags
+   *     %s     : %s    | %s   |@ %f          %s %s   %s %s
+   */
+
+  if (!tags) {
+    tags = "";
+  }
+
+  size_t tags_len = strlen(tags);
+  size_t const_tags_len = client->const_tags_len;
+  const char *tags_prefix = (tags_len + const_tags_len > 0) ? "|#" : "";
+  const char *tags_separator = (tags_len > 0 && const_tags_len > 0) ? "," : "";
+
+  const char *format = "%s:%s|%s|@%f%s%s%s%s";
+  int size = snprintf(client->msg_buffer, client->msg_buffer_len, format, name,
+                      value, type, sample_rate, tags_prefix, tags,
+                      tags_separator, client->const_tags);
+
+  if (size < 0) {
+    return DOGSTATSD_CLIENT_E_FORMATTING;
+  }
+
+  /* snprintf does not report the null byte in the length, so if it is size or
+   * more then it is an error
+   */
+  if (((size_t)size) >= client->msg_buffer_len) {
+    return DOGSTATSD_CLIENT_E_TOO_LONG;
+  }
+
+  ssize_t send_status =
+      sendto(client->socket, client->msg_buffer, size, MSG_DONTWAIT,
+             client->address->ai_addr, client->address->ai_addrlen);
+
+  if (send_status > -1) {
+    return DOGSTATSD_CLIENT_OK;
+  }
+
+  return DOGSTATSD_CLIENT_EWRITE;
+}
+
+dogstatsd_client_status dogstatsd_client_count(dogstatsd_client *client,
+                                               const char *metric,
+                                               const char *value,
+                                               const char *tags) {
+  return _dogstatsd_client_send(client, metric, value, "c", 1.0f, tags);
+}

--- a/src/dogstatsd/dogstatsd_client.pc.in
+++ b/src/dogstatsd/dogstatsd_client.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: dogstatsd_client
+Description: dogstatsd client written in C
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -ldogstatsd_client
+Cflags: -I${includedir}

--- a/src/dogstatsd/dogstatsd_client/client.h
+++ b/src/dogstatsd/dogstatsd_client/client.h
@@ -1,0 +1,82 @@
+#ifndef DOGSTATSD_CLIENT_H
+#define DOGSTATSD_CLIENT_H
+
+#include <netdb.h>
+
+/* This describes a simple interface to communicate with dogstatsd. It only
+ * implements the portions of the interface that the PHP tracer needs. If it
+ * gets enough features and there is interest from another project, we could
+ * pull it out and release it as its own project.
+ */
+
+#if __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  int socket;                    // closed on dtor
+  struct addrinfo *address;      // freed on dtor as part of addresslist
+  struct addrinfo *addresslist;  // freed on dtor
+  char *msg_buffer;              // NOT freed on dtor
+  size_t msg_buffer_len;
+  const char *const_tags;  // NOT freed on dtor
+  size_t const_tags_len;
+} dogstatsd_client;
+
+typedef enum {
+  // This doesn't mean delivered; just that nothing went visibly wrong.
+  DOGSTATSD_CLIENT_OK = 0,
+
+  // errors:
+  DOGSTATSD_CLIENT_E_NO_CLIENT,
+  DOGSTATSD_CLIENT_E_VALUE,
+  DOGSTATSD_CLIENT_E_TOO_LONG,
+  DOGSTATSD_CLIENT_E_FORMATTING,
+  DOGSTATSD_CLIENT_EWRITE,
+} dogstatsd_client_status;
+
+/* A typical IPv4 header is 20 bytes, but can be up to 60 bytes.
+ * The UDP header is 8 bytes.
+ * The minimum maximum reassembly buffer size required by RFC 1122 is 576.
+ * 576 - 60 - 8 = 508.
+ *
+ * If we consider IPv6, the situation is different. IPv6 packets cannot be
+ * fragmented, and the minimum MTU is 1280. Most implementations seem to use
+ * 1024 for the IPv6 buffer.
+ *
+ * Ethernet has an MTU 1500.
+ *
+ * The official Java dogstatsd client uses 1400. Given this, I am presuming
+ * that most hardware in use today is capable of supporting IPv6, and out of
+ * implementation simplicity they support the IPv6 sizes on IPv4 too, and
+ * chose the IPv6 numbers.
+ */
+#define DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE 1024
+
+// Creates a client whose operations will fail with E_NO_CLIENT
+dogstatsd_client dogstatsd_client_default_ctor();
+
+inline int dogstatsd_client_is_default_client(dogstatsd_client *client) {
+  return !client || client->socket == -1;
+}
+
+/* If the client fails to open a socket to the host and port, it will
+ * create a default client.
+ */
+dogstatsd_client dogstatsd_client_ctor(const char *host, const char *port,
+                                       char *buffer, int buffer_len,
+                                       const char *const_tags);
+
+// Uses sample_rate of 1.0
+dogstatsd_client_status dogstatsd_client_count(dogstatsd_client *client,
+                                               const char *metric,
+                                               const char *value,
+                                               const char *tags);
+
+void dogstatsd_client_dtor(dogstatsd_client *client);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // DOGSTATSD_CLIENT_H

--- a/src/dogstatsd/test/CMakeLists.txt
+++ b/src/dogstatsd/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+enable_language(CXX)
+
+# The Catch2::Catch2 target has been available since 2.1.2
+# dd-trace-cpp uses Catch2 2.4 at this time, so we can require at least 2.4
+find_package(Catch2 2.4 REQUIRED)
+
+include(Catch)
+
+add_library(catch2main main.cc)
+target_link_libraries(catch2main PUBLIC Catch2::Catch2)
+set_target_properties(catch2main PROPERTIES
+  CXX_STANDARD 11
+)
+
+add_executable(client client.cc)
+target_link_libraries(client PUBLIC catch2main DogstatsdClient::DogstatsdClient)
+
+catch_discover_tests(client)

--- a/src/dogstatsd/test/client.cc
+++ b/src/dogstatsd/test/client.cc
@@ -1,0 +1,103 @@
+#include <dogstatsd_client/client.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <catch2/catch.hpp>
+#include <thread>
+
+// dummy server
+struct dogstatsd_server {
+  int sock;
+  struct sockaddr_in addr;
+
+  ~dogstatsd_server() { close(sock); }
+};
+
+dogstatsd_server dogstatsd_server_make() {
+  int sock = -1;
+  REQUIRE((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) >= 0);
+
+  struct sockaddr_in server = {0};
+  socklen_t len = sizeof server;
+  memset(&server, 0, sizeof server);
+  server.sin_family = AF_INET;
+  server.sin_addr.s_addr = INADDR_ANY;
+  server.sin_port = 0;  // pick any open port
+
+  REQUIRE(bind(sock, (struct sockaddr *)&server, len) > -1);
+
+  // find out which port we were given
+  REQUIRE(getsockname(sock, (struct sockaddr *)&server, &len) > -1);
+
+  return dogstatsd_server{sock, server};
+}
+
+void dogstatsd_server_listen(dogstatsd_server *server, dogstatsd_client *client,
+                             const char *expected_string) {
+  socklen_t client_addr_size = sizeof(client->address);
+  // 60 bytes for the IP header
+  // 8 bytes for the UDP overhead
+  int buffer_len = client->msg_buffer_len + 60 + 8;
+  char *buffer = (char *)malloc(buffer_len);
+
+  ssize_t bytes_received =
+      recvfrom(server->sock, buffer, buffer_len, 0,
+               (struct sockaddr *)&client->address, &client_addr_size);
+
+  REQUIRE(bytes_received > -1);
+  REQUIRE(bytes_received < buffer_len);
+
+  buffer[bytes_received] = '\0';
+
+  // this may be too brittle; if so, may need to parse the full string
+  std::string actual_string = buffer;
+  REQUIRE(actual_string == expected_string);
+
+  free(buffer);
+}
+
+void _test_tags(const char *tags, const char *const_tags, const char *expect) {
+  dogstatsd_server server = dogstatsd_server_make();
+
+  char buf[DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE];
+  size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
+  char host[NI_MAXHOST];
+  char port[NI_MAXSERV];
+
+  getnameinfo((sockaddr *)&server.addr, server.addr.sin_len, host, NI_MAXHOST,
+              port, NI_MAXSERV, NI_NUMERICHOST | NI_NUMERICSERV);
+
+  dogstatsd_client client =
+      dogstatsd_client_ctor(host, port, buf, len, const_tags);
+  REQUIRE(!dogstatsd_client_is_default_client(&client));
+
+  // start a thread for the server
+  std::thread server_thread{dogstatsd_server_listen, &server, &client, expect};
+
+  dogstatsd_client_status status =
+      dogstatsd_client_count(&client, "metric.hello", "1", tags);
+  REQUIRE(status == DOGSTATSD_CLIENT_OK);
+
+  server_thread.join();
+
+  dogstatsd_client_dtor(&client);
+}
+
+TEST_CASE("count with no tags, no const_tags", "[dogstatsd_client]") {
+  _test_tags(nullptr, nullptr, "metric.hello:1|c|@1.000000");
+}
+
+TEST_CASE("count with no tags, with const_tags", "[dogstatsd_client]") {
+  _test_tags(nullptr, "lang:c", "metric.hello:1|c|@1.000000|#lang:c");
+}
+
+TEST_CASE("count with with tags, no const_tags", "[dogstatsd_client]") {
+  _test_tags("lang:c", nullptr, "metric.hello:1|c|@1.000000|#lang:c");
+}
+
+TEST_CASE("count with with tags, with const_tags", "[dogstatsd_client]") {
+  _test_tags("lang:c", "hello:world",
+             "metric.hello:1|c|@1.000000|#lang:c,hello:world");
+}
+
+// todo: test sending message that's too large
+// todo: test configuring client with lens of 0 and < 0.

--- a/src/dogstatsd/test/main.cc
+++ b/src/dogstatsd/test/main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
### Description

The Dogstatsd client will be used to log health metrics in the PHP extension. It has a minimal API that is directly suited to our needs. Care has been taken so that it can eventually move to its own repository and project once it is more mature and there is demand.

### Readiness checklist
- [x] Tests added for this feature/bug.
- [ ] Continuous integration runs the above tests.
- [ ] Multiple CMake versions including the minimum are tested.
- [ ] Project license is decided.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
