### PR TITLE
Move Mysqli integration to sandboxed api

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -15,6 +15,9 @@
     <rule ref="Generic.Commenting.DocComment.MissingShort">
         <severity>0</severity>
     </rule>
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>tests/Integrations/*</exclude-pattern>
+    </rule>
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>

--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -74,6 +74,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedIntegration.p
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Curl/CurlIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoClientIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoDBIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php';

--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -73,6 +73,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegr
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Curl/CurlIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliCommon.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoClientIntegration.php';

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -184,4 +184,17 @@ abstract class Integration
 
         return true;
     }
+
+    /**
+     * Merge an associative array of span metadata into a span.
+     *
+     * @param Span $span
+     * @param array $meta
+     */
+    public static function mergeMetaLegacyApi(Span $span, $meta)
+    {
+        foreach ($meta as $tagName => $value) {
+            $span->setTag($tagName, $value);
+        }
+    }
 }

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -191,7 +191,7 @@ abstract class Integration
      * @param Span $span
      * @param array $meta
      */
-    public static function mergeMetaLegacyApi(Span $span, $meta)
+    public static function mergeTagsLegacyApi(Span $span, $meta)
     {
         foreach ($meta as $tagName => $value) {
             $span->setTag($tagName, $value);

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -17,6 +17,7 @@ use DDTrace\Integrations\Memcached\MemcachedIntegration;
 use DDTrace\Integrations\Memcached\MemcachedSandboxedIntegration;
 use DDTrace\Integrations\Mongo\MongoIntegration;
 use DDTrace\Integrations\Mysqli\MysqliIntegration;
+use DDTrace\Integrations\Mysqli\MysqliSandboxedIntegration;
 use DDTrace\Integrations\PDO\PDOIntegration;
 use DDTrace\Integrations\PDO\PDOSandboxedIntegration;
 use DDTrace\Integrations\Predis\PredisIntegration;
@@ -88,6 +89,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Eloquent\EloquentSandboxedIntegration';
             $this->integrations[MemcachedSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Memcached\MemcachedSandboxedIntegration';
+            $this->integrations[MysqliSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Mysqli\MysqliSandboxedIntegration';
             $this->integrations[PDOSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
             $this->integrations[WordPressSandboxedIntegration::NAME] =

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -54,7 +54,6 @@ class MemcachedIntegration extends Integration
     public static function load()
     {
         if (!extension_loaded('memcached')) {
-            // Memcached is provided through an extension and not through a class loader.
             return Integration::NOT_AVAILABLE;
         }
 

--- a/src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php
@@ -53,7 +53,6 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
     public function init()
     {
         if (!extension_loaded('memcached')) {
-            // Memcached is provided through an extension and not through a class loader.
             return Integration::NOT_AVAILABLE;
         }
         $integration = $this;

--- a/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
@@ -15,7 +15,22 @@ class MysqliCommon
     public static function extractHostInfo($mysqli)
     {
         $host_info = $mysqli->host_info;
-        $parts = explode(':', substr($host_info, 0, strpos($host_info, ' ')));
+        return self::parseHostInfo(substr($host_info, 0, strpos($host_info, ' ')));
+    }
+
+    /**
+     * Given a host definition string, it extract an array containing host info.
+     *
+     * @param string $hostString
+     * @return array
+     */
+    public static function parseHostInfo($hostString)
+    {
+        if (empty($hostString) || !is_string($hostString)) {
+            return [];
+        }
+
+        $parts = explode(':', $hostString);
         $host = $parts[0];
         $port = isset($parts[1]) ? $parts[1] : '3306';
         return [

--- a/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace DDTrace\Integrations\Mysqli;
+
+use DDTrace\Util\ObjectKVStore;
+
+class MysqliCommon
+{
+    /**
+     * Given a mysqli instance, it extract an array containing host info.
+     *
+     * @param $mysqli
+     * @return array
+     */
+    public static function extractHostInfo($mysqli)
+    {
+        $host_info = $mysqli->host_info;
+        $parts = explode(':', substr($host_info, 0, strpos($host_info, ' ')));
+        $host = $parts[0];
+        $port = isset($parts[1]) ? $parts[1] : '3306';
+        return [
+            'db.type' => 'mysql',
+            'out.host' => $host,
+            'out.port' => $port,
+        ];
+    }
+
+    /**
+     * Store a query into a mysqli or statement instance.
+     *
+     * @param mixed $instance
+     * @param string $query
+     */
+    public static function storeQuery($instance, $query)
+    {
+        ObjectKVStore::put($instance, 'query', $query);
+    }
+
+    /**
+     * Retrieves a query from a mysqli or statement instance.
+     *
+     * @param mixed $instance
+     * @param string $fallbackValue
+     * @return string|null
+     */
+    public static function retrieveQuery($instance, $fallbackValue)
+    {
+        return ObjectKVStore::get($instance, 'query', $fallbackValue);
+    }
+}

--- a/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
@@ -14,7 +14,10 @@ class MysqliCommon
      */
     public static function extractHostInfo($mysqli)
     {
-        $host_info = $mysqli->host_info;
+        if (!isset($mysqli->host_info) || !is_string($mysqli->host_info)) {
+            return [];
+        }
+        $hostInfo = $mysqli->host_info;
         return self::parseHostInfo(substr($host_info, 0, strpos($host_info, ' ')));
     }
 

--- a/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliCommon.php
@@ -18,7 +18,7 @@ class MysqliCommon
             return [];
         }
         $hostInfo = $mysqli->host_info;
-        return self::parseHostInfo(substr($host_info, 0, strpos($host_info, ' ')));
+        return self::parseHostInfo(substr($hostInfo, 0, strpos($hostInfo, ' ')));
     }
 
     /**

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -57,16 +57,18 @@ class MysqliIntegration extends Integration
 
             $scope = MysqliIntegration::initScope('mysqli_connect', 'mysqli_connect');
             $span = $scope->getSpan();
+            list($host) = func_get_args();
 
             $thrown = null;
             $result = null;
             try {
+                MysqliIntegration::mergeMetaLegacyApi($span, MysqliCommon::parseHostInfo($host));
+
                 // Depending on configuration, connections errors can both cause an exception and return false
                 $result = dd_trace_forward_call();
+
                 if ($result === false) {
                     $span->setError(new \Exception(mysqli_connect_error(), mysqli_connect_errno()));
-                } else {
-                    MysqliIntegration::setConnectionInfo($span, $result);
                 }
             } catch (\Exception $ex) {
                 $span->setError($ex);

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -62,7 +62,7 @@ class MysqliIntegration extends Integration
             $thrown = null;
             $result = null;
             try {
-                MysqliIntegration::mergeMetaLegacyApi($span, MysqliCommon::parseHostInfo($host));
+                MysqliIntegration::mergeTagsLegacyApi($span, MysqliCommon::parseHostInfo($host));
 
                 // Depending on configuration, connections errors can both cause an exception and return false
                 $result = dd_trace_forward_call();

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -39,7 +39,6 @@ class MysqliIntegration extends Integration
     public static function load()
     {
         if (!extension_loaded('mysqli')) {
-            // Memcached is provided through an extension and not through a class loader.
             return Integration::NOT_AVAILABLE;
         }
 

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -4,6 +4,7 @@ namespace DDTrace\Integrations\Mysqli;
 
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\Util\ObjectKVStore;
@@ -33,339 +34,225 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             return Integration::NOT_AVAILABLE;
         }
 
-        return Integration::LOADED;
-    }
+        $integration = $this;
 
-    public static function load()
-    {
-
-        // mysqli mysqli_connect ([ string $host = ini_get("mysqli.default_host")
-        //      [, string $username = ini_get("mysqli.default_user")
-        //      [, string $passwd = ini_get("mysqli.default_pw")
-        //      [, string $dbname = ""
-        //      [, int $port = ini_get("mysqli.default_port")
-        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
-        dd_trace('mysqli_connect', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_function('mysqli_connect', function (SpanData $span, $args, $result) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $scope = MysqliIntegration::initScope('mysqli_connect', 'mysqli_connect');
-            $span = $scope->getSpan();
+            $integration->setDefaultAttributes($span, 'mysqli_connect', 'mysqli_connect');
 
-            $thrown = null;
-            $result = null;
-            try {
-                // Depending on configuration, connections errors can both cause an exception and return false
-                $result = dd_trace_forward_call();
-                if ($result === false) {
-                    $span->setError(new \Exception(mysqli_connect_error(), mysqli_connect_errno()));
-                } else {
-                    MysqliIntegration::setConnectionInfo($span, $result);
-                }
-                $scope->close();
-            } catch (\Exception $ex) {
-                $span->setError($ex);
-                $thrown = $ex;
+            if ($result !== false) {
+                $integration->setConnectionInfo($span, $result);
+            } else {
+                $integration->trackPotentialError($span);
             }
-
-            $scope->close();
-            if ($thrown) {
-                throw $thrown;
-            }
-
-            return $result;
         });
 
-        // public mysqli mysqli::__construct ([ string $host = ini_get("mysqli.default_host")
-        //      [, string $username = ini_get("mysqli.default_user")
-        //      [, string $passwd = ini_get("mysqli.default_pw")
-        //      [, string $dbname = ""
-        //      [, int $port = ini_get("mysqli.default_port")
-        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
         $mysqli_constructor = PHP_MAJOR_VERSION > 5 ? '__construct' : 'mysqli';
-        dd_trace('mysqli', $mysqli_constructor, function () use ($mysqli_constructor) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli', $mysqli_constructor, function (SpanData $span, $args) use ($mysqli_constructor, $integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $scope = MysqliIntegration::initScope('mysqli.__construct', 'mysqli.__construct');
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
+            $integration->setDefaultAttributes($span, 'mysqli.__construct', 'mysqli.__construct');
+            $integration->trackPotentialError($span);
 
-            // PHP 5.4 compatible try-catch-finally
-            $thrown = null;
             try {
-                dd_trace_forward_call();
-                //Mysqli::storeConnectionParams($this, $args);
-                if (mysqli_connect_errno()) {
-                    $span->setError(new \Exception(mysqli_connect_error(), mysqli_connect_errno()));
-                } else {
-                    MysqliIntegration::setConnectionInfo($span, $this);
-                }
-            } catch (\Exception $ex) {
-                $thrown = $ex;
-                $span->setError($ex);
-            }
-
-            $scope->close();
-            if ($thrown) {
-                throw $thrown;
-            }
-
-            return $this;
+                // Host can either be provided as constructor arg or after
+                // through ->real_connect(...). In this latter case an error
+                // `Property access is not allowed yet` would be thrown when
+                // accessing host info.
+                $integration->setConnectionInfo($span, $this);
+            } catch (\Exception $ex) {}
         });
 
-        // mixed mysqli_query ( mysqli $link , string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
-        dd_trace('mysqli_query', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_function('mysqli_real_connect', function (SpanData $span, $args) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            list($mysqli, $query) = func_get_args();
+            $integration->setDefaultAttributes($span, 'mysqli_real_connect', 'mysqli_real_connect');
+            $integration->trackPotentialError($span);
 
-            $scope = MysqliIntegration::initScope('mysqli_query', $query);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            $span->setTraceAnalyticsCandidate();
-            MysqliIntegration::setConnectionInfo($span, $mysqli);
-            MysqliIntegration::storeQuery($mysqli, $query);
-
-            $result = dd_trace_forward_call();
-            MysqliIntegration::storeQuery($result, $query);
-            ObjectKVStore::put($result, 'host_info', MysqliIntegration::extractHostInfo($mysqli));
-
-            $scope->close();
-
-            return $result;
+            if (count($args) > 0) {
+                $integration->setConnectionInfo($span, $args[0]);
+            }
         });
 
-        // mysqli_stmt mysqli_prepare ( mysqli $link , string $query )
-        dd_trace('mysqli_prepare', function ($mysqli, $query) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli', 'real_connect', function (SpanData $span) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $scope = MysqliIntegration::initScope('mysqli_prepare', $query);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            MysqliIntegration::setConnectionInfo($span, $mysqli);
-
-            $statement = dd_trace_forward_call();
-            MysqliIntegration::storeQuery($statement, $query);
-            $host_info = MysqliIntegration::extractHostInfo($mysqli);
-            ObjectKVStore::put($statement, 'host_info', $host_info);
-
-            $scope->close();
-
-            return $statement;
+            $integration->setDefaultAttributes($span, 'mysqli.real_connect', 'mysqli.real_connect');
+            $integration->trackPotentialError($span);
+            $integration->setConnectionInfo($span, $this);
         });
 
-        // bool mysqli_commit ( mysqli $link [, int $flags [, string $name ]] )
-        dd_trace('mysqli_commit', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+
+        dd_trace_function('mysqli_query', function (SpanData $span, $args, $result) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $args = func_get_args();
+            list($mysqli, $query) = $args;
+            $integration->setDefaultAttributes($span, 'mysqli_query', $query);
+            $integration->addTraceAnalyticsIfEnabled($span);
+            $integration->setConnectionInfo($span, $mysqli);
+
+            MysqliCommon::storeQuery($mysqli, $query);
+            MysqliCommon::storeQuery($result, $query);
+            ObjectKVStore::put($result, 'host_info', MysqliCommon::extractHostInfo($mysqli));
+        });
+
+        dd_trace_function('mysqli_prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
+
+            list($mysqli, $query) = $args;
+            $integration->setDefaultAttributes($span, 'mysqli_prepare', $query);
+            $integration->setConnectionInfo($span, $mysqli);
+
+            $host_info = MysqliCommon::extractHostInfo($mysqli);
+            MysqliCommon::storeQuery($returnedStatement, $query);
+            ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
+        });
+
+        dd_trace_function('mysqli_commit', function (SpandData $span, $args) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
+            }
+
             list($mysqli) = $args;
-            $resource = MysqliIntegration::retrieveQuery($mysqli, 'mysqli_commit');
-            $scope = MysqliIntegration::initScope('mysqli_commit', $resource);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            MysqliIntegration::setConnectionInfo($span, $mysqli);
+            $resource = MysqliCommon::retrieveQuery($mysqli, 'mysqli_commit');
+            $integration->setDefaultAttributes($span, 'mysqli_commit', $resource);
+            $integration->setConnectionInfo($span, $mysqli);
 
             if (isset($args[2])) {
-                $span->setTag('db.transaction_name', $args[2]);
+                $span->meta['db.transaction_name'] =$args[2];
             }
-
-            $result = dd_trace_forward_call();
-
-            $scope->close();
-
-            return $result;
         });
 
-        // bool mysqli_stmt_execute ( mysqli_stmt $stmt )
-        dd_trace('mysqli_stmt_execute', function ($stmt) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_function('mysqli_stmt_execute', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_execute');
-            $scope = MysqliIntegration::initScope('mysqli_stmt_execute', $resource);
-
-            $result = dd_trace_forward_call();
-
-            $scope->close();
-
-            return $result;
+            $resource = MysqliCommon::retrieveQuery($returnedStatement, 'mysqli_stmt_execute');
+            $integration->setDefaultAttributes($span, 'mysqli_stmt_execute', $resource);
         });
 
-        // bool mysqli_stmt_get_result ( mysqli_stmt $stmt )
-        dd_trace('mysqli_stmt_get_result', function ($stmt) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_function('mysqli_stmt_get_result', function (SpanData $span, $args, $result) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_get_result');
-            $result = dd_trace_forward_call();
-
+            list($statement) = $args;
+            $resource = MysqliCommon::retrieveQuery($statement, 'mysqli_stmt_get_result');
             MysqliIntegration::storeQuery($result, $resource);
-            ObjectKVStore::propagate($stmt, $result, 'host_info');
+            ObjectKVStore::propagate($statement, $result, 'host_info');
 
-            return $result;
+            return false;
         });
 
-        // mixed mysqli::query ( string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
-        dd_trace('mysqli', 'query', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli', 'query', function (SpanData $span, $args, $result) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            list($query) = func_get_args();
-            $scope = MysqliIntegration::initScope('mysqli.query', $query);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            $span->setTraceAnalyticsCandidate();
-            MysqliIntegration::setConnectionInfo($span, $this);
-            MysqliIntegration::storeQuery($this, $query);
-
-            $afterResult = function ($result) use ($query) {
-                $host_info = MysqliIntegration::extractHostInfo($this);
-                ObjectKVStore::put($result, 'host_info', $host_info);
-                ObjectKVStore::put($result, 'query', $query);
-            };
-            return include __DIR__ . '/../../try_catch_finally.php';
+            list($query) = $args;
+            $integration->setDefaultAttributes($span, 'mysqli.query', $query);
+            $integration->addTraceAnalyticsIfEnabled($span);
+            $integration->setConnectionInfo($span, $this);
+            MysqliCommon::storeQuery($this, $query);
+            ObjectKVStore::put($result, 'query', $query);
+            $host_info = MysqliCommon::extractHostInfo($this);
+            ObjectKVStore::put($result, 'host_info', $host_info);
+            ObjectKVStore::put($result, 'query', $query);
         });
 
-        // mysqli_stmt mysqli::prepare ( string $query )
-        dd_trace('mysqli', 'prepare', function ($query) {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli', 'prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $scope = MysqliIntegration::initScope('mysqli.prepare', $query);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            MysqliIntegration::setConnectionInfo($span, $this);
-            $afterResult = function ($statement) use ($query) {
-                $host_info = MysqliIntegration::extractHostInfo($this);
-                ObjectKVStore::put($statement, 'host_info', $host_info);
-                MysqliIntegration::storeQuery($statement, $query);
-            };
-            return include __DIR__ . '/../../try_catch_finally.php';
+            list($query) = $args;
+            $integration->setDefaultAttributes($span, 'mysqli.prepare', $query);
+            $integration->setConnectionInfo($span, $this);
+            $host_info = MysqliCommon::extractHostInfo($this);
+            ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
+            MysqliIntegration::storeQuery($returnedStatement, $query);
         });
 
-        // bool mysqli::commit ([ int $flags [, string $name ]] )
-        dd_trace('mysqli', 'commit', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli', 'commit', function (SpanData $span, $args) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $args = func_get_args();
-            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli.commit');
-            $scope = MysqliIntegration::initScope('mysqli.commit', $resource);
-            /** @var \DDTrace\Span $span */
-            $span = $scope->getSpan();
-            MysqliIntegration::setConnectionInfo($span, $this);
+            $resource = MysqliCommon::retrieveQuery($this, 'mysqli.commit');
+            $integration->setDefaultAttributes($span, 'mysqli.commit', $resource);
+            $integration->setConnectionInfo($span, $this);
 
             if (isset($args[1])) {
                 $span->setTag('db.transaction_name', $args[1]);
             }
-
-            return include __DIR__ . '/../../try_catch_finally.php';
         });
 
-        // bool mysqli_stmt::execute ( void )
-        dd_trace('mysqli_stmt', 'execute', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli_stmt', 'execute', function (SpanData $span) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.execute');
-            $scope = MysqliIntegration::initScope('mysqli_stmt.execute', $resource);
-            $scope->getSpan()->setTraceAnalyticsCandidate();
-            return include __DIR__ . '/../../try_catch_finally.php';
+            $resource = MysqliCommon::retrieveQuery($this, 'mysqli_stmt.execute');
+            $integration->setDefaultAttributes($span, 'mysqli_stmt.execute', $resource);
+            $integration->addTraceAnalyticsIfEnabled($span);
         });
 
-        // bool mysqli_stmt::execute ( void )
-        dd_trace('mysqli_stmt', 'get_result', function () {
-            $tracer = GlobalTracer::get();
-            if ($tracer->limited()) {
-                return dd_trace_forward_call();
+        dd_trace_method('mysqli_stmt', 'get_result', function (SpanData $span, $args, $result) use ($integration) {
+            if (dd_trace_tracer_is_limited()) {
+                return false;
             }
 
-            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.get_result');
-            $scope = MysqliIntegration::initScope('mysqli_stmt.get_result', $resource);
-            $afterResult = function ($result) use ($resource) {
-                ObjectKVStore::propagate($this, $result, 'host_info');
-                ObjectKVStore::put($result, 'query', $resource);
-            };
-            return include __DIR__ . '/../../try_catch_finally.php';
+            $resource = MysqliCommon::retrieveQuery($this, 'mysqli_stmt.get_result');
+            $integration->setDefaultAttributes($span, 'mysqli_stmt.get_result', $resource);
+            $integration->setConnectionInfo($span, $this);
+
+            ObjectKVStore::propagate($this, $result, 'host_info');
+            ObjectKVStore::put($result, 'query', $resource);
         });
+
         return Integration::LOADED;
     }
 
     /**
-     * Given a mysqli instance, it extract an array containing host info.
+     * Initialize a span with the common attributes.
      *
-     * @param $mysqli
-     * @return array
-     */
-    public static function extractHostInfo($mysqli)
-    {
-        $host_info = $mysqli->host_info;
-        $parts = explode(':', substr($host_info, 0, strpos($host_info, ' ')));
-        $host = $parts[0];
-        $port = isset($parts[1]) ? $parts[1] : '3306';
-        return [
-            'db.type' => 'mysql',
-            'out.host' => $host,
-            'out.port' => $port,
-        ];
-    }
-
-    /**
-     * Initialize a scope setting basic tags to identify the mysqli service.
-     *
-     * @param string $operationName
+     * @param SpanData $span
+     * @param string $name
      * @param string $resource
-     * @return \DDTrace\Contracts\Scope
      */
-    public static function initScope($operationName, $resource)
+    public function setDefaultAttributes(SpanData $span, $name, $resource)
     {
-        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MysqliIntegration::getInstance(), $operationName);
-        /** @var \DDTrace\Span $span */
-        $span = $scope->getSpan();
-        $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-        $span->setTag(Tag::SERVICE_NAME, 'mysqli');
-        $span->setTag(Tag::RESOURCE_NAME, $resource);
-        return $scope;
+        $span->name = $name;
+        $span->resource = $resource;
+        $span->type = Type::SQL;
+        $span->service = 'mysqli';
     }
 
     /**
      * Set connection info into an existing span.
      *
-     * @param \DDTrace\Contracts\Span $span
+     * @param SpanData $span
      * @param $mysqli
      */
-    public static function setConnectionInfo($span, $mysqli)
+    public function setConnectionInfo(SpanData $span, $mysqli)
     {
-        $hostInfo = self::extractHostInfo($mysqli);
+        $hostInfo = MysqliCommon::extractHostInfo($mysqli);
         foreach ($hostInfo as $tagName => $value) {
-            $span->setTag($tagName, $value);
+            $span->meta[$tagName] = $value;
         }
     }
 
@@ -390,5 +277,19 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
     public static function retrieveQuery($instance, $fallbackValue)
     {
         return ObjectKVStore::get($instance, 'query', $fallbackValue);
+    }
+
+    /**
+     * Extracts and sets the proper error info on the span if one is detected.
+     *
+     * @param SpanData $span
+     */
+    public function trackPotentialError(SpanData $span)
+    {
+        $errorCode = mysqli_connect_errno();
+        if ($errorCode > 0) {
+            $message = sprintf("%s [code: %d]", mysqli_connect_error(), $errorCode);
+            $this->setError($span, $message);
+        }
     }
 }

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace DDTrace\Integrations\Mysqli;
+
+use DDTrace\Integrations\Integration;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\Tag;
+use DDTrace\Type;
+use DDTrace\Util\ObjectKVStore;
+use DDTrace\GlobalTracer;
+
+class MysqliSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'mysqli';
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Load the integration
+     *
+     * @return int
+     */
+    public function init()
+    {
+        if (!extension_loaded('mysqli')) {
+            // Memcached is provided through an extension and not through a class loader.
+            return Integration::NOT_AVAILABLE;
+        }
+
+        return Integration::LOADED;
+    }
+
+    public static function load()
+    {
+
+        // mysqli mysqli_connect ([ string $host = ini_get("mysqli.default_host")
+        //      [, string $username = ini_get("mysqli.default_user")
+        //      [, string $passwd = ini_get("mysqli.default_pw")
+        //      [, string $dbname = ""
+        //      [, int $port = ini_get("mysqli.default_port")
+        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
+        dd_trace('mysqli_connect', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = MysqliIntegration::initScope('mysqli_connect', 'mysqli_connect');
+            $span = $scope->getSpan();
+
+            $thrown = null;
+            $result = null;
+            try {
+                // Depending on configuration, connections errors can both cause an exception and return false
+                $result = dd_trace_forward_call();
+                if ($result === false) {
+                    $span->setError(new \Exception(mysqli_connect_error(), mysqli_connect_errno()));
+                } else {
+                    MysqliIntegration::setConnectionInfo($span, $result);
+                }
+                $scope->close();
+            } catch (\Exception $ex) {
+                $span->setError($ex);
+                $thrown = $ex;
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $result;
+        });
+
+        // public mysqli mysqli::__construct ([ string $host = ini_get("mysqli.default_host")
+        //      [, string $username = ini_get("mysqli.default_user")
+        //      [, string $passwd = ini_get("mysqli.default_pw")
+        //      [, string $dbname = ""
+        //      [, int $port = ini_get("mysqli.default_port")
+        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
+        $mysqli_constructor = PHP_MAJOR_VERSION > 5 ? '__construct' : 'mysqli';
+        dd_trace('mysqli', $mysqli_constructor, function () use ($mysqli_constructor) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = MysqliIntegration::initScope('mysqli.__construct', 'mysqli.__construct');
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+
+            // PHP 5.4 compatible try-catch-finally
+            $thrown = null;
+            try {
+                dd_trace_forward_call();
+                //Mysqli::storeConnectionParams($this, $args);
+                if (mysqli_connect_errno()) {
+                    $span->setError(new \Exception(mysqli_connect_error(), mysqli_connect_errno()));
+                } else {
+                    MysqliIntegration::setConnectionInfo($span, $this);
+                }
+            } catch (\Exception $ex) {
+                $thrown = $ex;
+                $span->setError($ex);
+            }
+
+            $scope->close();
+            if ($thrown) {
+                throw $thrown;
+            }
+
+            return $this;
+        });
+
+        // mixed mysqli_query ( mysqli $link , string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
+        dd_trace('mysqli_query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            list($mysqli, $query) = func_get_args();
+
+            $scope = MysqliIntegration::initScope('mysqli_query', $query);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            $span->setTraceAnalyticsCandidate();
+            MysqliIntegration::setConnectionInfo($span, $mysqli);
+            MysqliIntegration::storeQuery($mysqli, $query);
+
+            $result = dd_trace_forward_call();
+            MysqliIntegration::storeQuery($result, $query);
+            ObjectKVStore::put($result, 'host_info', MysqliIntegration::extractHostInfo($mysqli));
+
+            $scope->close();
+
+            return $result;
+        });
+
+        // mysqli_stmt mysqli_prepare ( mysqli $link , string $query )
+        dd_trace('mysqli_prepare', function ($mysqli, $query) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = MysqliIntegration::initScope('mysqli_prepare', $query);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            MysqliIntegration::setConnectionInfo($span, $mysqli);
+
+            $statement = dd_trace_forward_call();
+            MysqliIntegration::storeQuery($statement, $query);
+            $host_info = MysqliIntegration::extractHostInfo($mysqli);
+            ObjectKVStore::put($statement, 'host_info', $host_info);
+
+            $scope->close();
+
+            return $statement;
+        });
+
+        // bool mysqli_commit ( mysqli $link [, int $flags [, string $name ]] )
+        dd_trace('mysqli_commit', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $args = func_get_args();
+            list($mysqli) = $args;
+            $resource = MysqliIntegration::retrieveQuery($mysqli, 'mysqli_commit');
+            $scope = MysqliIntegration::initScope('mysqli_commit', $resource);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            MysqliIntegration::setConnectionInfo($span, $mysqli);
+
+            if (isset($args[2])) {
+                $span->setTag('db.transaction_name', $args[2]);
+            }
+
+            $result = dd_trace_forward_call();
+
+            $scope->close();
+
+            return $result;
+        });
+
+        // bool mysqli_stmt_execute ( mysqli_stmt $stmt )
+        dd_trace('mysqli_stmt_execute', function ($stmt) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_execute');
+            $scope = MysqliIntegration::initScope('mysqli_stmt_execute', $resource);
+
+            $result = dd_trace_forward_call();
+
+            $scope->close();
+
+            return $result;
+        });
+
+        // bool mysqli_stmt_get_result ( mysqli_stmt $stmt )
+        dd_trace('mysqli_stmt_get_result', function ($stmt) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $resource = MysqliIntegration::retrieveQuery($stmt, 'mysqli_stmt_get_result');
+            $result = dd_trace_forward_call();
+
+            MysqliIntegration::storeQuery($result, $resource);
+            ObjectKVStore::propagate($stmt, $result, 'host_info');
+
+            return $result;
+        });
+
+        // mixed mysqli::query ( string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
+        dd_trace('mysqli', 'query', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            list($query) = func_get_args();
+            $scope = MysqliIntegration::initScope('mysqli.query', $query);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            $span->setTraceAnalyticsCandidate();
+            MysqliIntegration::setConnectionInfo($span, $this);
+            MysqliIntegration::storeQuery($this, $query);
+
+            $afterResult = function ($result) use ($query) {
+                $host_info = MysqliIntegration::extractHostInfo($this);
+                ObjectKVStore::put($result, 'host_info', $host_info);
+                ObjectKVStore::put($result, 'query', $query);
+            };
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        // mysqli_stmt mysqli::prepare ( string $query )
+        dd_trace('mysqli', 'prepare', function ($query) {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $scope = MysqliIntegration::initScope('mysqli.prepare', $query);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            MysqliIntegration::setConnectionInfo($span, $this);
+            $afterResult = function ($statement) use ($query) {
+                $host_info = MysqliIntegration::extractHostInfo($this);
+                ObjectKVStore::put($statement, 'host_info', $host_info);
+                MysqliIntegration::storeQuery($statement, $query);
+            };
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        // bool mysqli::commit ([ int $flags [, string $name ]] )
+        dd_trace('mysqli', 'commit', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $args = func_get_args();
+            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli.commit');
+            $scope = MysqliIntegration::initScope('mysqli.commit', $resource);
+            /** @var \DDTrace\Span $span */
+            $span = $scope->getSpan();
+            MysqliIntegration::setConnectionInfo($span, $this);
+
+            if (isset($args[1])) {
+                $span->setTag('db.transaction_name', $args[1]);
+            }
+
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        // bool mysqli_stmt::execute ( void )
+        dd_trace('mysqli_stmt', 'execute', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.execute');
+            $scope = MysqliIntegration::initScope('mysqli_stmt.execute', $resource);
+            $scope->getSpan()->setTraceAnalyticsCandidate();
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+
+        // bool mysqli_stmt::execute ( void )
+        dd_trace('mysqli_stmt', 'get_result', function () {
+            $tracer = GlobalTracer::get();
+            if ($tracer->limited()) {
+                return dd_trace_forward_call();
+            }
+
+            $resource = MysqliIntegration::retrieveQuery($this, 'mysqli_stmt.get_result');
+            $scope = MysqliIntegration::initScope('mysqli_stmt.get_result', $resource);
+            $afterResult = function ($result) use ($resource) {
+                ObjectKVStore::propagate($this, $result, 'host_info');
+                ObjectKVStore::put($result, 'query', $resource);
+            };
+            return include __DIR__ . '/../../try_catch_finally.php';
+        });
+        return Integration::LOADED;
+    }
+
+    /**
+     * Given a mysqli instance, it extract an array containing host info.
+     *
+     * @param $mysqli
+     * @return array
+     */
+    public static function extractHostInfo($mysqli)
+    {
+        $host_info = $mysqli->host_info;
+        $parts = explode(':', substr($host_info, 0, strpos($host_info, ' ')));
+        $host = $parts[0];
+        $port = isset($parts[1]) ? $parts[1] : '3306';
+        return [
+            'db.type' => 'mysql',
+            'out.host' => $host,
+            'out.port' => $port,
+        ];
+    }
+
+    /**
+     * Initialize a scope setting basic tags to identify the mysqli service.
+     *
+     * @param string $operationName
+     * @param string $resource
+     * @return \DDTrace\Contracts\Scope
+     */
+    public static function initScope($operationName, $resource)
+    {
+        $scope = GlobalTracer::get()->startIntegrationScopeAndSpan(MysqliIntegration::getInstance(), $operationName);
+        /** @var \DDTrace\Span $span */
+        $span = $scope->getSpan();
+        $span->setTag(Tag::SPAN_TYPE, Type::SQL);
+        $span->setTag(Tag::SERVICE_NAME, 'mysqli');
+        $span->setTag(Tag::RESOURCE_NAME, $resource);
+        return $scope;
+    }
+
+    /**
+     * Set connection info into an existing span.
+     *
+     * @param \DDTrace\Contracts\Span $span
+     * @param $mysqli
+     */
+    public static function setConnectionInfo($span, $mysqli)
+    {
+        $hostInfo = self::extractHostInfo($mysqli);
+        foreach ($hostInfo as $tagName => $value) {
+            $span->setTag($tagName, $value);
+        }
+    }
+
+    /**
+     * Store a query into a mysqli or statement instance.
+     *
+     * @param mixed $instance
+     * @param string $query
+     */
+    public static function storeQuery($instance, $query)
+    {
+        ObjectKVStore::put($instance, 'query', $query);
+    }
+
+    /**
+     * Retrieves a query from a mysqli or statement instance.
+     *
+     * @param mixed $instance
+     * @param string $fallbackValue
+     * @return string|null
+     */
+    public static function retrieveQuery($instance, $fallbackValue)
+    {
+        return ObjectKVStore::get($instance, 'query', $fallbackValue);
+    }
+}

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -259,29 +259,6 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
     }
 
     /**
-     * Store a query into a mysqli or statement instance.
-     *
-     * @param mixed $instance
-     * @param string $query
-     */
-    public static function storeQuery($instance, $query)
-    {
-        ObjectKVStore::put($instance, 'query', $query);
-    }
-
-    /**
-     * Retrieves a query from a mysqli or statement instance.
-     *
-     * @param mixed $instance
-     * @param string $fallbackValue
-     * @return string|null
-     */
-    public static function retrieveQuery($instance, $fallbackValue)
-    {
-        return ObjectKVStore::get($instance, 'query', $fallbackValue);
-    }
-
-    /**
      * Extracts and sets the proper error info on the span if one is detected.
      *
      * @param SpanData $span

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -31,7 +31,6 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
     public function init()
     {
         if (!extension_loaded('mysqli')) {
-            // Memcached is provided through an extension and not through a class loader.
             return Integration::NOT_AVAILABLE;
         }
 
@@ -55,7 +54,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
         dd_trace_method(
             'mysqli',
             $mysqli_constructor,
-            function (SpanData $span, $args) use ($mysqli_constructor, $integration) {
+            function (SpanData $span) use ($integration) {
                 if (dd_trace_tracer_is_limited()) {
                     return false;
                 }
@@ -152,11 +151,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setDefaultAttributes($span, 'mysqli_stmt_execute', $resource);
         });
 
-        dd_trace_function('mysqli_stmt_get_result', function (SpanData $span, $args, $result) use ($integration) {
-            if (dd_trace_tracer_is_limited()) {
-                return false;
-            }
-
+        dd_trace_function('mysqli_stmt_get_result', function (SpanData $span, $args, $result) {
             list($statement) = $args;
             $resource = MysqliCommon::retrieveQuery($statement, 'mysqli_stmt_get_result');
             MysqliCommon::storeQuery($result, $resource);

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -159,7 +159,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
 
             list($statement) = $args;
             $resource = MysqliCommon::retrieveQuery($statement, 'mysqli_stmt_get_result');
-            MysqliIntegration::storeQuery($result, $resource);
+            MysqliCommon::storeQuery($result, $resource);
             ObjectKVStore::propagate($statement, $result, 'host_info');
 
             return false;
@@ -204,7 +204,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setConnectionInfo($span, $this);
 
             if (isset($args[1])) {
-                $span->setTag('db.transaction_name', $args[1]);
+                $span->meta['db.transaction_name'] = $args[1];
             }
         });
 

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -66,7 +66,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
                 // `Property access is not allowed yet` would be thrown when
                 // accessing host info.
                 $integration->setConnectionInfo($span, $this);
-            } catch (\Exception $ex) {}
+            } catch (\Exception $ex) { }
         });
 
         dd_trace_function('mysqli_real_connect', function (SpanData $span, $args) use ($integration) {
@@ -122,7 +122,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
         });
 
-        dd_trace_function('mysqli_commit', function (SpandData $span, $args) use ($integration) {
+        dd_trace_function('mysqli_commit', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -133,7 +133,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setConnectionInfo($span, $mysqli);
 
             if (isset($args[2])) {
-                $span->meta['db.transaction_name'] =$args[2];
+                $span->meta['db.transaction_name'] = $args[2];
             }
         });
 

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -26,11 +26,25 @@ abstract class SandboxedIntegration extends Integration
      * Sets common error tags for an exception.
      *
      * @param SpanData $span
-     * @param string $message
+     * @param \Throwable $throwable
      */
-    public function setError(SpanData $span, $message)
+    public function setError(SpanData $span, \Throwable $throwable)
     {
-        $span->meta[Tag::ERROR_MSG] = $message;
-        $span->error = 1;
+        $span->meta[Tag::ERROR_MSG] = $throwable->getMessage();
+        $span->meta[Tag::ERROR_TYPE] = get_class($throwable);
+        $span->meta[Tag::ERROR_STACK] = $throwable->getTraceAsString();
+    }
+
+    /**
+     * Merge an associative array of span metadata into a span.
+     *
+     * @param SpanData $span
+     * @param array $meta
+     */
+    public function mergeMeta(SpanData $span, $meta)
+    {
+        foreach ($meta as $tagName => $value) {
+            $span->meta[$tagName] = $value;
+        }
     }
 }

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -21,4 +21,16 @@ abstract class SandboxedIntegration extends Integration
         }
         $span->metrics[Tag::ANALYTICS_KEY] = $this->configuration->getTraceAnalyticsSampleRate();
     }
+
+    /**
+     * Sets common error tags for an exception.
+     *
+     * @param SpanData $span
+     * @param string $message
+     */
+    public function setError(SpanData $span, $message)
+    {
+        $span->meta[Tag::ERROR_MSG] = $message;
+        $span->error = 1;
+    }
 }

--- a/src/DDTrace/Integrations/SandboxedIntegration.php
+++ b/src/DDTrace/Integrations/SandboxedIntegration.php
@@ -26,13 +26,13 @@ abstract class SandboxedIntegration extends Integration
      * Sets common error tags for an exception.
      *
      * @param SpanData $span
-     * @param \Throwable $throwable
+     * @param \Exception $exception
      */
-    public function setError(SpanData $span, \Throwable $throwable)
+    public function setError(SpanData $span, \Exception $exception)
     {
-        $span->meta[Tag::ERROR_MSG] = $throwable->getMessage();
-        $span->meta[Tag::ERROR_TYPE] = get_class($throwable);
-        $span->meta[Tag::ERROR_STACK] = $throwable->getTraceAsString();
+        $span->meta[Tag::ERROR_MSG] = $exception->getMessage();
+        $span->meta[Tag::ERROR_TYPE] = get_class($exception);
+        $span->meta[Tag::ERROR_STACK] = $exception->getTraceAsString();
     }
 
     /**

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -14,6 +14,8 @@ abstract class IntegrationTestCase extends TestCase
     use TracerTestTrait;
     use SpanAssertionTrait;
 
+    private $errorReportingBefore;
+
     const IS_SANDBOX = false;
 
     public static function setUpBeforeClass()
@@ -38,10 +40,24 @@ abstract class IntegrationTestCase extends TestCase
 
     protected function setUp()
     {
+        $this->errorReportingBefore = error_reporting();
         parent::setUp();
         if (Versions::phpVersionMatches('5.4') && self::isSandboxed()) {
             $this->markTestSkipped('Sandboxed tests are skipped on PHP 5.4.');
         }
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        error_reporting($this->errorReportingBefore);
+        \PHPUnit_Framework_Error_Warning::$enabled = true;
+    }
+
+    protected function disableTranslateWarningsIntoErrors()
+    {
+        \PHPUnit_Framework_Error_Warning::$enabled = false;
+        error_reporting(E_ERROR | E_PARSE);
     }
 
     /**

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -120,6 +120,18 @@ final class SpanAssertion
     }
 
     /**
+     * Marks a span as expected error and sets only the message.
+     *
+     * @return $this
+     */
+    public function setErrorMessage()
+    {
+        $this->hasError = true;
+        $this->existingTags[] = Tag::ERROR_MSG;
+        return $this;
+    }
+
+    /**
      * @param SpanAssertion|SpanAssertion[] $children
      * @return $this
      */

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -120,18 +120,6 @@ final class SpanAssertion
     }
 
     /**
-     * Marks a span as expected error and sets only the message.
-     *
-     * @return $this
-     */
-    public function setErrorMessage()
-    {
-        $this->hasError = true;
-        $this->existingTags[] = Tag::ERROR_MSG;
-        return $this;
-    }
-
-    /**
      * @param SpanAssertion|SpanAssertion[] $children
      * @return $this
      */

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -300,17 +300,6 @@ final class SpanAssertion
         return $this->exactMetrics;
     }
 
-    /**
-     * @return array
-     */
-    public function getNotTestedMetricNames()
-    {
-        return [
-            '_sampling_priority_v1',
-            '_dd1.sr.eausr',
-        ];
-    }
-
     public function __toString()
     {
         return sprintf(

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -299,4 +299,24 @@ final class SpanAssertion
     {
         return $this->exactMetrics;
     }
+
+    /**
+     * @return array
+     */
+    public function getNotTestedMetricNames()
+    {
+        return [
+            '_sampling_priority_v1',
+            '_dd1.sr.eausr',
+        ];
+    }
+
+    public function __toString()
+    {
+        return sprintf(
+            "{name:'%s' resource:'%s'}",
+            $this->getOperationName(),
+            $this->getResource()
+        );
+    }
 }

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -28,9 +28,9 @@ final class SpanChecker
      * @param array $graph
      * @param SpanAssertion $expectedNodeRoot
      */
-    private function assertNode(array $graph, SpanAssertion $expectedNodeRoot, $parentName, $parenResource)
+    private function assertNode(array $graph, SpanAssertion $expectedNodeRoot, $parentName, $parentResource)
     {
-        $node = $this->findOne($graph, $expectedNodeRoot, $parentName, $parenResource);
+        $node = $this->findOne($graph, $expectedNodeRoot, $parentName, $parentResource);
         $this->assertSpan($node['span'], $expectedNodeRoot);
 
         $actualChildrenCount = count($node['children']);

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -20,7 +20,7 @@ final class SpanChecker
         $flattenTraces = $this->flattenTraces($traces);
         $actualGraph = $this->buildSpansGraph($flattenTraces);
         foreach ($expectedFlameGraph as $oneTrace) {
-            $this->assertNode($actualGraph, $oneTrace);
+            $this->assertNode($actualGraph, $oneTrace, 'root', 'root');
         }
     }
 
@@ -28,47 +28,122 @@ final class SpanChecker
      * @param array $graph
      * @param SpanAssertion $expectedNodeRoot
      */
-    private function assertNode($graph, SpanAssertion $expectedNodeRoot)
+    private function assertNode(array $graph, SpanAssertion $expectedNodeRoot, $parentName, $parenResource)
     {
-        $found = array_values(array_filter($graph, function (array $node) use ($expectedNodeRoot) {
-            return $node['span']['name'] === $expectedNodeRoot->getOperationName()
-                && $node['span']['resource'] === $expectedNodeRoot->getResource();
-        }));
-
-        if (count($found) > 1) {
-            TestCase::fail(
-                'Edge case not handled, more than one span with same name and resource at the same level: '
-                . $expectedNodeRoot->getOperationName() . '/' . $expectedNodeRoot->getResource()
-            );
-            return;
-        } elseif (count($found) === 0) {
-            TestCase::fail(
-                'Cannot find at the current level name/resource: '
-                . $expectedNodeRoot->getOperationName() . '/' . $expectedNodeRoot->getResource()
-            );
-            return;
-        }
-
-        $node = $found[0];
+        $node = $this->findOne($graph, $expectedNodeRoot, $parentName, $parenResource);
         $this->assertSpan($node['span'], $expectedNodeRoot);
 
         $actualChildrenCount = count($node['children']);
         $expectedChildrenCount = count($expectedNodeRoot->getChildren());
 
         if ($actualChildrenCount !== $expectedChildrenCount) {
+            $expectedNames = array_map(function (SpanAssertion $spanAssertion) {
+                return $spanAssertion->getOperationName();
+            }, $expectedNodeRoot->getChildren());
+            sort($expectedNames);
+            $actualNames = array_map(function (array $child) {
+                return $child['span']['name'];
+            }, $node['children']);
+            sort($actualNames);
             TestCase::fail(sprintf(
-                'Wrong number of children (actual %d, expected %d) for operation/resource: %s/%s',
+                "Wrong number of children (actual %d, expected %d) for operation/resource: %s/%s."
+                    . "\n\nExpected:\n%s\n\nActual:\n%s\n",
                 $actualChildrenCount,
                 $expectedChildrenCount,
                 $expectedNodeRoot->getOperationName(),
-                $expectedNodeRoot->getResource()
+                $expectedNodeRoot->getResource(),
+                implode("\n", $expectedNames),
+                implode("\n", $actualNames)
             ));
             return;
         }
 
         foreach ($expectedNodeRoot->getChildren() as $child) {
-            $this->assertNode($node['children'], $child);
+            $this->assertNode(
+                $node['children'],
+                $child,
+                $expectedNodeRoot->getOperationName(),
+                $expectedNodeRoot->getResource()
+            );
         }
+    }
+
+    private function findOne(array $graph, SpanAssertion $expectedNodeRoot, $parentName, $parenResource)
+    {
+        if ($expectedNodeRoot->getResource()) {
+            // If the resource is specified, then we use it
+            $found = array_values(array_filter($graph, function (array $node) use ($expectedNodeRoot) {
+                return empty($node['__visited'])
+                    && $this->matches($node['span']['name'], $expectedNodeRoot->getOperationName())
+                    && $this->matches($node['span']['resource'], $expectedNodeRoot->getResource(), $wildcards = true);
+            }));
+        } else {
+            // If the resource is NOT specified, then we use only the operation name
+            $found = array_values(array_filter($graph, function (array $node) use ($expectedNodeRoot) {
+                return empty($node['__visited'])
+                    && $this->matches($node['span']['name'], $expectedNodeRoot->getOperationName());
+            }));
+        }
+
+        if (count($found) > 1) {
+            // Not using a TestCase::markTestAsIncomplete() because it exits immediately,
+            // while with an error log we are still able to proceed with tests.
+            error_log(sprintf(
+                "WARNING: More then one candidate found for '%s' at the same level. "
+                . "Proceeding in the order they appears. "
+                . "This might not work if this span is not a leaf span.",
+                $expectedNodeRoot
+            ));
+        } elseif (count($found) === 0) {
+            TestCase::fail(
+                sprintf(
+                    "Cannot find span\n  - Current level: %s\n  - Span not found: %s",
+                    $parentName . '/' . $parenResource,
+                    $expectedNodeRoot->getOperationName() . '/' . $expectedNodeRoot->getResource()
+                )
+            );
+            return;
+        }
+
+        $found[0]['__visited'] = true;
+        return $found[0];
+    }
+
+    /**
+     * Normalize a raw string removing white spaces when possible
+     */
+    private function normalizeString($raw)
+    {
+        if (null === $raw) {
+            return null;
+        }
+        return trim(preg_replace('/\s+/', ' ', $raw));
+    }
+
+    /**
+     * Given an actual and an expected span, it tells if the two matches
+     * normalizing resource names.
+     */
+    private function matches($actual, $expectation, $wildcards = false)
+    {
+        if ($actual === null && $expectation === null) {
+            return true;
+        }
+
+        if (!is_string($actual) || !is_string($expectation)) {
+            return false;
+        }
+
+        $normalizedActual = $this->normalizeString($actual);
+        $normalizedExpectation = $this->normalizeString($expectation);
+
+        if ($wildcards && substr($normalizedExpectation, -1) === '*') {
+            // Ends with *
+            $length = strlen($normalizedExpectation) - 1;
+            return substr($normalizedActual, 0, $length) === substr($normalizedExpectation, 0, $length);
+        }
+
+        return $normalizedExpectation === $normalizedActual;
     }
 
     /**
@@ -147,7 +222,7 @@ final class SpanChecker
             $expectedSpansReferences,
             $tracesReferences,
             'Missing or additional spans. Expected: ' . print_r($expectedOperationsAndResources, true) .
-            "\n Found: " . print_r($actualOperationsAndResources, true)
+                "\n Found: " . print_r($actualOperationsAndResources, true)
         );
 
         // Then we assert content on each individual received span
@@ -164,7 +239,7 @@ final class SpanChecker
      */
     public function assertSpan($span, SpanAssertion $exp)
     {
-        TestCase::assertNotNull($span, 'Expected span was not \'' . $exp->getOperationName() . '\' found.');
+        TestCase::assertNotNull($span, 'Expected span was not found \'' . $exp->getOperationName() . '\'.');
 
         $spanMeta = isset($span['meta']) ? $span['meta'] : [];
 

--- a/tests/Frameworks/WordPress/Version_4_8/wp-config.php
+++ b/tests/Frameworks/WordPress/Version_4_8/wp-config.php
@@ -80,7 +80,7 @@ $table_prefix  = 'wp_';
  */
 define('WP_DEBUG', false);
 
-/** Disabilita la funzione interna Wp-Cron **/
+/** Disable internal Wp-Cron feature **/
 define('DISABLE_WP_CRON', true);
 
 /* That's all, stop editing! Happy blogging. */

--- a/tests/Frameworks/WordPress/Version_4_8/wp-config.php
+++ b/tests/Frameworks/WordPress/Version_4_8/wp-config.php
@@ -80,6 +80,9 @@ $table_prefix  = 'wp_';
  */
 define('WP_DEBUG', false);
 
+/** Disabilita la funzione interna Wp-Cron **/
+define('DISABLE_WP_CRON', true);
+
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */

--- a/tests/Frameworks/WordPress/Version_4_8/wp-load.php
+++ b/tests/Frameworks/WordPress/Version_4_8/wp-load.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Bootstrap file for setting the ABSPATH constant
  * and loading the wp-config.php file. The wp-config.php

--- a/tests/Integrations/Mysqli/MysqliSandboxedTest.php
+++ b/tests/Integrations/Mysqli/MysqliSandboxedTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Mysqli;
+
+class MysqliSandboxedTest extends MysqliTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integrations/Mysqli/MysqliTest.php
@@ -6,8 +6,10 @@ use DDTrace\Integrations\IntegrationsLoader;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 
-final class MysqliTest extends IntegrationTestCase
+class MysqliTest extends IntegrationTestCase
 {
+    const IS_SANDBOX = false;
+
     private static $host = 'mysql_integration';
     private static $db = 'test';
     private static $port = '3306';

--- a/tests/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integrations/Mysqli/MysqliTest.php
@@ -46,7 +46,7 @@ class MysqliTest extends IntegrationTestCase
     {
         $traces = $this->isolateTracer(function () {
             try {
-                $mysqli = \mysqli_connect(self::$host, 'wrong');
+                \mysqli_connect(self::$host, 'wrong');
                 $this->fail('should not be possible to connect to wrong host');
             } catch (\Exception $ex) {
             }

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -60,32 +60,19 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         'integration.name' => 'wordpress',
                     ])->withChildren([
-                        SpanAssertion::exists('curl_exec'),
                         SpanAssertion::exists(
                             'wpdb.query',
                             "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1"
                         )->withChildren([
                             SpanAssertion::exists('mysqli_query'),
                         ]),
-                        SpanAssertion::exists('WP.init'),
-                        SpanAssertion::exists(
-                            'wpdb.query',
-                            "SHOW FULL COLUMNS FROM `wp_options`"
-                        )->withChildren([
-                            SpanAssertion::exists('mysqli_query'),
-                            ]),
                         SpanAssertion::exists(
                             'wpdb.query',
                             "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1"
                         )->withChildren([
                             SpanAssertion::exists('mysqli_query'),
                         ]),
-                        SpanAssertion::exists(
-                            'wpdb.query',
-                            "UPDATE `wp_options` SET `option_value` = *"
-                        )->withChildren([
-                            SpanAssertion::exists('mysqli_query'),
-                        ]),
+                        SpanAssertion::exists('WP.init'),
                         SpanAssertion::exists('WP_Widget_Factory._register_widgets'),
                         SpanAssertion::exists('create_initial_taxonomies'),
                         SpanAssertion::exists('create_initial_post_types'),
@@ -158,7 +145,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('create_initial_post_types'),
                         SpanAssertion::exists('create_initial_post_types'),
                         SpanAssertion::exists('create_initial_taxonomies'),
-                        SpanAssertion::exists('curl_exec'),
                         SpanAssertion::exists('get_footer')
                             ->withChildren([
                                 SpanAssertion::exists('load_template')
@@ -211,14 +197,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             ->withChildren([
                                 SpanAssertion::exists('mysqli_query'),
                             ]),
-                        SpanAssertion::exists('wpdb.query')
-                            ->withChildren([
-                                SpanAssertion::exists('mysqli_query'),
-                            ]),
-                        SpanAssertion::exists('wpdb.query')
-                            ->withChildren([
-                                SpanAssertion::exists('mysqli_query'),
-                            ]),
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -255,19 +233,10 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             ->withChildren([
                                 SpanAssertion::exists('mysqli_query'),
                             ]),
-                        SpanAssertion::exists('wpdb.query')
-                            ->withChildren([
-                                SpanAssertion::exists('mysqli_query'),
-                            ]),
-                        SpanAssertion::exists('wpdb.query')
-                            ->withChildren([
-                                SpanAssertion::exists('mysqli_query'),
-                            ]),
                         SpanAssertion::exists('WP_Widget_Factory._register_widgets'),
                         SpanAssertion::exists('create_initial_taxonomies'),
                         SpanAssertion::exists('create_initial_post_types'),
                         SpanAssertion::exists('WP.init'),
-                        SpanAssertion::exists('curl_exec'),
                         SpanAssertion::exists('_wp_customize_include'),
                         SpanAssertion::exists('wp_maybe_load_embeds'),
                         SpanAssertion::exists('wp_maybe_load_widgets'),

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -82,7 +82,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('create_initial_post_types'),
                         SpanAssertion::exists('create_initial_taxonomies'),
                         // WARNING: something not properly working with the tracing of WP.main
-                        // causes these spans to exists but not having the proper parent. This is
+                        // causes these spans to exist but not having the proper parent. This is
                         // prossible due to an exit/die in WP code. To be investigated. Once fixed this
                         // test will fail.
                         // SpanAssertion::exists('WP.init'),

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -155,29 +155,27 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('load_template'),
                         SpanAssertion::exists('get_header')
                             ->withChildren([
-                                SpanAssertion::exists(
-                                    'load_template',
-                                    '/home/circleci/app/tests/Frameworks/WordPress/Version_4_8/wp-content/themes/twentyseventeen/header.php'
-                                )->withChildren([
-                                    SpanAssertion::exists('the_custom_header_markup'),
-                                    SpanAssertion::exists('body_class')
-                                        ->withChildren([
-                                            SpanAssertion::exists('wpdb.query')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('mysqli_query'),
-                                                ]),
-                                        ]),
-                                    SpanAssertion::exists('wp_head')
-                                        ->withChildren([
-                                            SpanAssertion::exists('wp_print_head_scripts')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('wpdb.query')
-                                                        ->withChildren([
-                                                            SpanAssertion::exists('mysqli_query'),
-                                                        ]),
-                                                ]),
-                                        ]),
-                                ]),
+                                SpanAssertion::exists('load_template')
+                                    ->withChildren([
+                                        SpanAssertion::exists('the_custom_header_markup'),
+                                        SpanAssertion::exists('body_class')
+                                            ->withChildren([
+                                                SpanAssertion::exists('wpdb.query')
+                                                    ->withChildren([
+                                                        SpanAssertion::exists('mysqli_query'),
+                                                    ]),
+                                            ]),
+                                        SpanAssertion::exists('wp_head')
+                                            ->withChildren([
+                                                SpanAssertion::exists('wp_print_head_scripts')
+                                                    ->withChildren([
+                                                        SpanAssertion::exists('wpdb.query')
+                                                            ->withChildren([
+                                                                SpanAssertion::exists('mysqli_query'),
+                                                            ]),
+                                                    ]),
+                                            ]),
+                                    ]),
                             ]),
                         SpanAssertion::exists('wp_maybe_load_embeds'),
                         SpanAssertion::exists('wp_maybe_load_widgets'),


### PR DESCRIPTION
### Description

Move Mysqli integration to sandboxed api. Along the way a few issues (mostly with testing) came out that forced me to add more changes to this PR than I would have wanted. I am sorry for the CR that has to look at quite a few things. Specifically:

- Wordpress tests had to be migrated to the new assertFlamegraph api. A minor bug in our integration was found and a card was created to keep track of it.
- SpanChecker had to be added the possibility to support multi-spans at the same level of a grph with the same name and resource. This has been done in a very quick and dirty way. We might want to provide a more sophisticated approach in the future, but this works for now in our use case.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
