### PR TITLE
Add basic playground to live test changes to the code base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-aliases:
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
       tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec' ]
       depends_on:
+        - agent
         - ddagent_integration
         - request-replayer
         - elasticsearch2_integration

--- a/playground/index.php
+++ b/playground/index.php
@@ -1,0 +1,4 @@
+<?php
+
+error_log("Printed to the error log");
+echo "This is the playground!\n";

--- a/playground/start-server.sh
+++ b/playground/start-server.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(realpath $(dirname "$0"))
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
+REQUEST_INIT_HOOK="$PROJECT_ROOT/bridge/dd_wrap_autoloader.php"
+WEB_ENTRY_POINT="${SCRIPT_DIR}/index.php"
+
+echo "Serving with request init hook: ${REQUEST_INIT_HOOK}"
+echo "Web server entry point: ${WEB_ENTRY_POINT}"
+
+echo "Installing the latest extension"
+composer --working-dir="${PROJECT_ROOT}" install-ext
+echo "Done installing the extension"
+
+DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=true \
+    DD_TRACE_NO_AUTOLOADER=true \
+    DD_AGENT_HOST=agent \
+    DD_TRACE_DEBUG=true \
+    php \
+    -d error_log=/dev/stderr \
+    -d ddtrace.request_init_hook=${REQUEST_INIT_HOOK} \
+    -S 0.0.0.0:8000 \
+    "${WEB_ENTRY_POINT}"


### PR DESCRIPTION
### Description

A super simple playground that can be used to test basic changes to the tracer and send spans to the our real backend.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- ~[ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
