### PR TITLE
[Yii 2] Remove duplicate trait usage in test

### DIFF
--- a/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
@@ -12,8 +12,6 @@ use DDTrace\Type;
 
 class ParameterizedRouteTest extends WebFrameworkTestCase
 {
-    use TracerTestTrait;
-    use SpanAssertionTrait;
 
     const IS_SANDBOX = true;
 


### PR DESCRIPTION
The duplicate trait usage is unnecessary and causes an E_STRICT warning on PHP 5.6.
