### PR TITLE
Curl Integration: Add all available information from curl_getinfo as span tags

### DIFF
--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -98,7 +98,7 @@ class CurlIntegration extends Integration
             foreach ($info as $key => $val) {
                 // Datadog doesn't support arrays in tags
                 if (!is_array($val)) {
-                  // Datadog sets durations in nanoseconds - convert from seconds
+                    // Datadog sets durations in nanoseconds - convert from seconds
                     if (substr_compare($key, '_time', -5) === 0) {
                         $val = $val * 1000000000;
                     }

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -78,31 +78,31 @@ class CurlIntegration extends Integration
 
             $span->setTag(Tag::HTTP_URL, $sanitizedUrl);
 
-            tagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
+            CurlIntegration::tagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
 
             // Datadog sets durations in nanoseconds - convert from seconds
             $span->setTag('duration', $info['total_time'] * 1000000000);
             unset($info['duration']);
 
-            tagFromCurlInfo($span, $info, 'network.client.ip', 'local_ip');
-            tagFromCurlInfo($span, $info, 'network.client.port', 'local_port');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.client.ip', 'local_ip');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.client.port', 'local_port');
 
-            tagFromCurlInfo($span, $info, 'network.destination.ip', 'primary_ip');
-            tagFromCurlInfo($span, $info, 'network.destination.port', 'primary_port');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.destination.ip', 'primary_ip');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.destination.port', 'primary_port');
 
-            tagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
-            tagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
+            CurlIntegration::tagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
 
 
             // Add the rest to a 'curl.' object
             foreach ($info as $key => $val) {
-                // Datadog doesn't support arrays in tags 
-                if(!is_array($val)) {
+                // Datadog doesn't support arrays in tags
+                if (!is_array($val)) {
                   // Datadog sets durations in nanoseconds - convert from seconds
-                  if(substr_compare($key, '_time', -5) === 0) {
-                     $val = $val * 1000000000;
-                  }
-                  $span->setTag('curl.' . $key, $val);
+                    if (substr_compare($key, '_time', -5) === 0) {
+                        $val = $val * 1000000000;
+                    }
+                    $span->setTag('curl.' . $key, $val);
                 }
             }
 
@@ -181,17 +181,17 @@ class CurlIntegration extends Integration
             }
         }
     }
-}
 
-/**
- * @param span $span
- * @param tagName $tagName
- * @param info $info
- */
- function tagFromCurlInfo(&$span, &$info, $tagName, $curlInfoOpt)
- {
-     if (array_key_exists($curlInfoOpt, $info)) {
-        $span->setTag($tagName, $info[$curlInfoOpt]);
-        unset($info[$curlInfoOpt]);
-     }
- }
+    /**
+     * @param span $span
+     * @param tagName $tagName
+     * @param info $info
+     */
+    public static function tagFromCurlInfo($span, &$info, $tagName, $curlInfoOpt)
+    {
+        if (array_key_exists($curlInfoOpt, $info)) {
+            $span->setTag($tagName, $info[$curlInfoOpt]);
+            unset($info[$curlInfoOpt]);
+        }
+    }
+}

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -80,6 +80,7 @@ class CurlIntegration extends Integration
 
             tagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
 
+            // Datadog sets durations in nanoseconds - convert from seconds
             $span->setTag('duration', $info['total_time'] * 1000000000);
             unset($info['duration']);
 
@@ -89,13 +90,15 @@ class CurlIntegration extends Integration
             tagFromCurlInfo($span, $info, 'network.destination.ip', 'primary_ip');
             tagFromCurlInfo($span, $info, 'network.destination.port', 'primary_port');
 
-            //tagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
-            //tagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
+            tagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
+            tagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
 
 
-            // Add the rest to a curl. object
+            // Add the rest to a 'curl.' object
             foreach ($info as $key => $val) {
+                // Datadog doesn't support arrays in tags 
                 if(!is_array($val)) {
+                  // Datadog sets durations in nanoseconds - convert from seconds
                   if(substr_compare($key, '_time', -5) === 0) {
                      $val = $val * 1000000000;
                   }

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -15,6 +15,8 @@ final class SpanAssertion
     private $exactTags = SpanAssertion::NOT_TESTED;
     /** @var string[] Tags the MUST be present but with any value */
     private $existingTags = ['system.pid'];
+    /** @var string[] Ignore any tags that match these regexp patterns */
+    private $skipTagPatterns = [];
     /** @var array Exact metrics set on the span */
     private $exactMetrics = SpanAssertion::NOT_TESTED;
     private $service = SpanAssertion::NOT_TESTED;
@@ -172,6 +174,21 @@ final class SpanAssertion
     {
         $this->existingTags = $merge ? array_merge($tagNames, $this->existingTags) : $tagNames;
         return $this;
+    }
+
+    /**
+     * @param string $pattern regular expression
+     * @return $this
+     */
+    public function skipTagsLike($pattern)
+    {
+        $this->skipTagPatterns[] = $pattern;
+        return $this;
+    }
+
+    public function getSkippedTagPatterns()
+    {
+        return $this->skipTagPatterns;
     }
 
     /**

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -4,6 +4,17 @@ namespace DDTrace\Tests\Common;
 
 use PHPUnit\Framework\TestCase;
 
+function array_filter_by_key($fn, array $input)
+{
+    $output = [];
+    foreach ($input as $key => $value) {
+        if ($fn($key)) {
+            $output[$key] = $value;
+        }
+    }
+    return $output;
+}
+
 /**
  * @see https://phpunit.de/manual/5.7/en/extending-phpunit.html#extending-phpunit.custom-assertions
  */
@@ -284,6 +295,20 @@ final class SpanChecker
                     $filtered[$key] = $value;
                 }
             }
+
+            $skipPatterns = $exp->getSkippedTagPatterns();
+            $out = $filtered;
+            foreach ($skipPatterns as $pattern) {
+                $out = array_filter_by_key(
+                    function ($key) use ($pattern) {
+                        // keep if it *doesn't* match
+                        return !\preg_match($pattern, $key);
+                    },
+                    $out
+                );
+            }
+
+            $filtered = $out;
             $expectedTags = $exp->getExactTags();
             foreach ($expectedTags as $tagName => $tagValue) {
                 TestCase::assertArrayHasKey(

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -100,6 +100,12 @@ trait TracerTestTrait
         $this->resetRequestDumper();
 
         $transport = new Http(new Json(), ['endpoint' => self::$agentRequestDumperUrl]);
+
+        /* Disable Expect: 100-Continue that automatically gets added by curl,
+         * as it adds a 1s delay, causing tests to sometimes fail.
+         */
+        $transport->setHeader('Expect', '');
+
         $tracer = $tracer ?: new Tracer($transport);
         GlobalTracer::set($tracer);
 

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -48,6 +48,22 @@ final class CurlIntegrationTest extends IntegrationTestCase
         putenv('DD_CURL_ANALYTICS_ENABLED');
     }
 
+    private static function commonCurlInfoTags()
+    {
+        $tags = [
+            'duration',
+            'network.bytes_read',
+            'network.bytes_written',
+        ];
+        if (\version_compare(\PHP_VERSION, '5.4.7', '>=')) {
+            $tags += \array_merge(
+                $tags,
+                ['network.client.ip', 'network.client.port', 'network.destination.ip', 'network.destination.port']
+            );
+        }
+        return $tags;
+    }
+
     public function testLoad200UrlOnInit()
     {
         $traces = $this->isolateTracer(function () {
@@ -64,7 +80,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 
@@ -85,7 +103,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 
@@ -106,7 +126,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 
@@ -124,7 +146,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 
@@ -144,7 +168,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/404',
                     'http.status_code' => '404',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 
@@ -166,6 +192,8 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     'http.status_code' => '0',
                 ])
                 ->withExistingTagsNames(['error.msg'])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/')
                 ->setError('curl error'),
         ]);
     }
@@ -188,6 +216,8 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     'http.status_code' => '0',
                 ])
                 ->withExistingTagsNames(['error.msg'])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/')
                 ->setError('curl error'),
         ]);
     }
@@ -209,6 +239,8 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     'http.url' => 'http://__i_am_not_real__.invalid/',
                     'http.status_code' => '0',
                 ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/')
                 ->setError('curl error', 'Could not resolve host: __i_am_not_real__.invalid'),
         ]);
     }
@@ -411,7 +443,9 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
-                ]),
+                ])
+                ->withExistingTagsNames(self::commonCurlInfoTags())
+                ->skipTagsLike('/^curl\..*/'),
         ]);
     }
 


### PR DESCRIPTION
### Description

We're already calling curl_getinfo to get the URL and status code. Rather than throwing away the rest of the array, add it as tags to the span

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
