### PR TITLE
Fix distributed trace ID handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,6 +393,9 @@ jobs:
           name: Run auto-instrumentation tests
           command: composer test-auto-instrumentation -- --log-junit test-results/php-auto-instrumentation/results.xml
       - run:
+          name: Run distributed-tracing tests
+          command: DD_TRACE_AGENT_TIMEOUT=2000 composer test-distributed-tracing -- --log-junit test-results/php-distributed-tracing/results.xml
+      - run:
           name: Run integration tests
           command: composer test-integration -- --log-junit test-results/php-integration/results.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,11 @@ aliases:
       command: |
         echo "export $(cat .env.circleci | xargs)" >> $HOME/.profile
 
+  - &STEP_DISABLE_XDEBUG
+    run:
+      name: Disable Xdebug for built-in web tests
+      command: test -e /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && sudo rm -f $_ || true
+
   - &STEP_WAIT_AGENT
     run:
       name: Waiting for Dockerized agent
@@ -386,6 +391,7 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
+      - <<: *STEP_DISABLE_XDEBUG
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "test-all-54": [
             "@test-unit",
             "@test-auto-instrumentation",
+            "@test-distributed-tracing",
             "@test-integration",
             "@test-integrations-54",
             "@test-web-54"
@@ -67,6 +68,7 @@
         "test-all-56": [
             "@test-unit",
             "@test-auto-instrumentation",
+            "@test-distributed-tracing",
             "@test-integration",
             "@test-integrations-56",
             "@test-web-56"
@@ -74,6 +76,7 @@
         "test-all-70": [
             "@test-unit",
             "@test-auto-instrumentation",
+            "@test-distributed-tracing",
             "@test-integration",
             "@test-integrations-70",
             "@test-web-70"
@@ -81,6 +84,7 @@
         "test-all-71": [
             "@test-unit",
             "@test-auto-instrumentation",
+            "@test-distributed-tracing",
             "@test-integration",
             "@test-integrations-71",
             "@test-web-71"
@@ -88,6 +92,7 @@
         "test-all-72": [
             "@test-unit",
             "@test-auto-instrumentation",
+            "@test-distributed-tracing",
             "@test-integration",
             "@test-integrations-72",
             "@test-web-72"
@@ -328,6 +333,8 @@
         "test-unit": "phpunit --colors=always --configuration=phpunit.xml --testsuite=unit",
 
         "test-auto-instrumentation": "phpunit --colors=always --configuration=phpunit.xml --testsuite=auto-instrumentation",
+
+        "test-distributed-tracing": "phpunit --colors=always --configuration=phpunit.xml --testsuite=distributed-tracing",
 
         "cakephp-28-update": "@composer --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
         "cakephp-28-test": "@composer test -- --testsuite=cakephp-28-test",

--- a/package.xml
+++ b/package.xml
@@ -140,6 +140,7 @@
                         <file name="dd_trace_method_binds_called_object.phpt" role="test" />
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />
+                        <file name="dd_trace_set_trace_id.phpt" role="test" />
                         <file name="drop_spans.phpt" role="test" />
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -128,6 +128,7 @@
                     <file name="dd_trace_forward_call_from_include.phpt" role="test" />
                     <file name="dd_trace_forward_call_with_inheritance.phpt" role="test" />
                     <file name="dd_trace_forward_call_with_private_callback.phpt" role="test" />
+                    <file name="dd_trace_push_span_id_from_userland.phpt" role="test" />
                     <file name="dd_trace_tracer_is_limited_hard.phpt" role="test" />
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,9 @@
         <testsuite name="auto-instrumentation">
             <directory>tests/AutoInstrumentation/</directory>
         </testsuite>
+        <testsuite name="distributed-tracing">
+            <directory>tests/DistributedTracing/</directory>
+        </testsuite>
         <testsuite name="integration">
             <directory>tests/Integration/</directory>
         </testsuite>

--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -49,8 +49,8 @@ final class TextMap implements Propagator
      */
     public function extract($carrier)
     {
-        $traceId = null;
-        $spanId = null;
+        $traceId = '';
+        $spanId = '';
         $prioritySampling = null;
         $baggageItems = [];
 
@@ -64,7 +64,10 @@ final class TextMap implements Propagator
             }
         }
 
-        if ($traceId === null || $spanId === null) {
+        if (
+            preg_match('/^\d+$/', $traceId) !== 1 ||
+            preg_match('/^\d+$/', $spanId) !== 1
+        ) {
             return null;
         }
 

--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -17,7 +17,7 @@ final class SpanContext extends SpanContextData
     ) {
         $this->traceId = $traceId;
         $this->spanId = $spanId;
-        $this->parentId = $parentId;
+        $this->parentId = $parentId ?: null;
         $this->baggageItems = $baggageItems;
         $this->isDistributedTracingActivationContext = $isDistributedTracingActivationContext;
     }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -461,8 +461,10 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        $this->prioritySampling = $span->getContext()->getPropagatedPrioritySampling()
-            ?: $this->sampler->getPrioritySampling($span);
+        $this->prioritySampling = $span->getContext()->getPropagatedPrioritySampling();
+        if (null === $this->prioritySampling) {
+            $this->prioritySampling = $this->sampler->getPrioritySampling($span);
+        }
     }
 
     /**

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -189,7 +189,7 @@ final class Tracer implements TracerInterface
         }
 
         $tags = $options->getTags() + $this->config['global_tags'];
-        if ($reference === null) {
+        if ($context->getParentId() === null) {
             $tags[Tag::PID] = getmypid();
         }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -72,6 +72,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_env_config, 0, 0, 1)
 ZEND_ARG_INFO(0, env_name)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_push_span_id, 0, 0, 0)
+ZEND_ARG_INFO(0, existing_id)
+ZEND_END_ARG_INFO()
+
 static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, sizeof(zend_ddtrace_globals)); }
 
 /* DDTrace\SpanData */
@@ -640,41 +644,44 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
 #endif
 }
 
+static inline void return_span_id(zval *return_value, uint64_t id) {
+    char buf[DD_TRACE_MAX_ID_LEN + 1];
+    snprintf(buf, sizeof(buf), "%" PRIu64, id);
 #if PHP_VERSION_ID >= 70000
-#define RETURN_SPAN_ID(id_fn)                             \
-    do {                                                  \
-        char buf[20];                                     \
-        snprintf(buf, 20, "%" PRIu64, (id_fn)(TSRMLS_C)); \
-        RETURN_STRING(buf);                               \
-    } while (0);
+    RETURN_STRING(buf);
 #else
-#define RETURN_SPAN_ID(id_fn)                             \
-    do {                                                  \
-        char buf[20];                                     \
-        snprintf(buf, 20, "%" PRIu64, (id_fn)(TSRMLS_C)); \
-        RETURN_STRING(buf, 1);                            \
-    } while (0);
+    RETURN_STRING(buf, 1);
 #endif
+}
 
 /* {{{ proto string dd_trace_push_span_id() */
 static PHP_FUNCTION(dd_trace_push_span_id) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
-    RETURN_SPAN_ID(ddtrace_push_span_id);
+
+    zval *existing_id = NULL;
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &existing_id) == SUCCESS) {
+        if (ddtrace_push_userland_span_id(existing_id TSRMLS_CC) == TRUE) {
+            return_span_id(return_value, ddtrace_peek_span_id(TSRMLS_C));
+            return;
+        }
+    }
+
+    return_span_id(return_value, ddtrace_push_span_id(0 TSRMLS_CC));
 }
 
 /* {{{ proto string dd_trace_pop_span_id() */
 static PHP_FUNCTION(dd_trace_pop_span_id) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
-    RETURN_SPAN_ID(ddtrace_pop_span_id);
+    return_span_id(return_value, ddtrace_pop_span_id(TSRMLS_C));
 }
 
 /* {{{ proto string dd_trace_peek_span_id() */
 static PHP_FUNCTION(dd_trace_peek_span_id) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
-    RETURN_SPAN_ID(ddtrace_peek_span_id);
+    return_span_id(return_value, ddtrace_peek_span_id(TSRMLS_C));
 }
 
 /* {{{ proto string dd_trace_closed_spans_count() */
@@ -692,24 +699,22 @@ static PHP_FUNCTION(dd_trace_tracer_is_limited) {
 }
 
 static const zend_function_entry ddtrace_functions[] = {
-    PHP_FE(dd_trace, NULL) PHP_FE(dd_trace_method, arginfo_dd_trace_method)
-        PHP_FE(dd_trace_function, arginfo_dd_trace_function) PHP_FE(dd_trace_serialize_closed_spans,
-                                                                    arginfo_dd_trace_serialize_closed_spans)
-            PHP_FE(dd_trace_forward_call, NULL) PHP_FE(dd_trace_reset, NULL) PHP_FE(dd_trace_noop, NULL) PHP_FE(
-                dd_untrace, NULL) PHP_FE(dd_trace_disable_in_request, NULL) PHP_FE(dd_trace_dd_get_memory_limit, NULL)
-                PHP_FE(dd_trace_check_memory_under_limit, NULL) PHP_FE(dd_tracer_circuit_breaker_register_error, NULL)
-                    PHP_FE(dd_tracer_circuit_breaker_register_success, NULL)
-                        PHP_FE(dd_tracer_circuit_breaker_can_try, NULL) PHP_FE(dd_tracer_circuit_breaker_info, NULL)
-                            PHP_FE(dd_trace_env_config, arginfo_dd_trace_env_config)
-                                PHP_FE(dd_trace_coms_trigger_writer_flush, NULL)
-                                    PHP_FE(dd_trace_buffer_span, arginfo_dd_trace_buffer_span)
-                                        PHP_FE(dd_trace_internal_fn, NULL)
-                                            PHP_FE(dd_trace_serialize_msgpack, arginfo_dd_trace_serialize_msgpack)
-                                                PHP_FE(dd_trace_push_span_id, NULL) PHP_FE(dd_trace_pop_span_id, NULL)
-                                                    PHP_FE(dd_trace_peek_span_id, NULL)
-                                                        PHP_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL)
-                                                            PHP_FE(dd_trace_closed_spans_count, NULL)
-                                                                PHP_FE(dd_trace_tracer_is_limited, NULL) ZEND_FE_END};
+    PHP_FE(dd_trace, NULL) PHP_FE(dd_trace_method, arginfo_dd_trace_method) PHP_FE(
+        dd_trace_function, arginfo_dd_trace_function) PHP_FE(dd_trace_serialize_closed_spans,
+                                                             arginfo_dd_trace_serialize_closed_spans)
+        PHP_FE(dd_trace_forward_call, NULL) PHP_FE(dd_trace_reset, NULL) PHP_FE(dd_trace_noop, NULL) PHP_FE(
+            dd_untrace, NULL) PHP_FE(dd_trace_disable_in_request, NULL) PHP_FE(dd_trace_dd_get_memory_limit, NULL)
+            PHP_FE(dd_trace_check_memory_under_limit, NULL) PHP_FE(
+                dd_tracer_circuit_breaker_register_error, NULL) PHP_FE(dd_tracer_circuit_breaker_register_success, NULL)
+                PHP_FE(dd_tracer_circuit_breaker_can_try, NULL) PHP_FE(dd_tracer_circuit_breaker_info, NULL) PHP_FE(
+                    dd_trace_env_config, arginfo_dd_trace_env_config) PHP_FE(dd_trace_coms_trigger_writer_flush, NULL)
+                    PHP_FE(dd_trace_buffer_span, arginfo_dd_trace_buffer_span) PHP_FE(dd_trace_internal_fn, NULL)
+                        PHP_FE(dd_trace_serialize_msgpack, arginfo_dd_trace_serialize_msgpack)
+                            PHP_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id)
+                                PHP_FE(dd_trace_pop_span_id, NULL) PHP_FE(dd_trace_peek_span_id, NULL)
+                                    PHP_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL)
+                                        PHP_FE(dd_trace_closed_spans_count, NULL)
+                                            PHP_FE(dd_trace_tracer_is_limited, NULL) ZEND_FE_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,    PHP_DDTRACE_EXTNAME,    ddtrace_functions,
                                           PHP_MINIT(ddtrace),        PHP_MSHUTDOWN(ddtrace), PHP_RINIT(ddtrace),

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -39,7 +39,7 @@ user_opcode_handler_t ddtrace_old_icall_handler;
 user_opcode_handler_t ddtrace_old_ucall_handler;
 user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
 
-uint64_t root_span_id;
+uint64_t trace_id;
 ddtrace_span_ids_t *span_ids_top;
 ddtrace_span_t *open_spans_top;
 ddtrace_span_t *closed_spans_top;

--- a/src/ext/random.c
+++ b/src/ext/random.c
@@ -49,8 +49,9 @@ static inline uint64_t zval_to_uint64(zval *zid) {
             return 0U;
         }
     }
+    errno = 0;
     uint64_t uid = (uint64_t)strtoull(id, NULL, 10);
-    return (uid && errno != ERANGE) ? uid : 0U;
+    return (uid && errno == 0) ? uid : 0U;
 }
 
 BOOL_T ddtrace_set_userland_trace_id(zval *zid TSRMLS_DC) {

--- a/src/ext/random.h
+++ b/src/ext/random.h
@@ -5,8 +5,10 @@
 #include <stdint.h>
 
 #include "compatibility.h"
+#include "env_config.h"
 
 #define DD_TRACE_DEBUG_PRNG_SEED "DD_TRACE_DEBUG_PRNG_SEED"
+#define DD_TRACE_MAX_ID_LEN 20  // uint64_t -> 2**64 = 20 chars max ID
 
 // We keep a separate stack for span ID generation since spans are
 // generated from userland as well
@@ -18,7 +20,8 @@ typedef struct _ddtrace_span_ids_t {
 void ddtrace_seed_prng(TSRMLS_D);
 void ddtrace_init_span_id_stack(TSRMLS_D);
 void ddtrace_free_span_id_stack(TSRMLS_D);
-uint64_t ddtrace_push_span_id(TSRMLS_D);
+uint64_t ddtrace_push_span_id(uint64_t id TSRMLS_DC);
+BOOL_T ddtrace_push_userland_span_id(zval *zid TSRMLS_DC);
 uint64_t ddtrace_pop_span_id(TSRMLS_D);
 uint64_t ddtrace_peek_span_id(TSRMLS_D);
 

--- a/src/ext/random.h
+++ b/src/ext/random.h
@@ -20,6 +20,7 @@ typedef struct _ddtrace_span_ids_t {
 void ddtrace_seed_prng(TSRMLS_D);
 void ddtrace_init_span_id_stack(TSRMLS_D);
 void ddtrace_free_span_id_stack(TSRMLS_D);
+BOOL_T ddtrace_set_userland_trace_id(zval *zid TSRMLS_DC);
 uint64_t ddtrace_push_span_id(uint64_t id TSRMLS_DC);
 BOOL_T ddtrace_push_userland_span_id(zval *zid TSRMLS_DC);
 uint64_t ddtrace_pop_span_id(TSRMLS_D);

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -77,7 +77,7 @@ ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
 
     // Peek at the active span ID before we push a new one onto the stack
     span->parent_id = ddtrace_peek_span_id(TSRMLS_C);
-    span->span_id = ddtrace_push_span_id(TSRMLS_C);
+    span->span_id = ddtrace_push_span_id(0 TSRMLS_CC);
     // Set the trace_id last so we have ID's on the stack
     span->trace_id = DDTRACE_G(root_span_id);
     span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -79,7 +79,7 @@ ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
     span->parent_id = ddtrace_peek_span_id(TSRMLS_C);
     span->span_id = ddtrace_push_span_id(0 TSRMLS_CC);
     // Set the trace_id last so we have ID's on the stack
-    span->trace_id = DDTRACE_G(root_span_id);
+    span->trace_id = DDTRACE_G(trace_id);
     span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);
     span->exception = NULL;
     span->pid = getpid();
@@ -130,4 +130,6 @@ void ddtrace_serialize_closed_spans(zval *serialized TSRMLS_DC) {
     }
     DDTRACE_G(closed_spans_top) = NULL;
     DDTRACE_G(closed_spans_count) = 0;
+    // Reset the span ID stack and trace ID
+    ddtrace_free_span_id_stack(TSRMLS_C);
 }

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -57,7 +57,7 @@ final class SpanAssertion
      * @param array $exactTags
      * @param null $parent
      * @param bool $error
-     * @param array $extactMetrics
+     * @param array|string $extactMetrics
      * @return SpanAssertion
      */
     public static function build(
@@ -68,7 +68,7 @@ final class SpanAssertion
         $exactTags = [],
         $parent = null,
         $error = false,
-        $extactMetrics = []
+        $extactMetrics = SpanAssertion::NOT_TESTED
     ) {
         return SpanAssertion::forOperation($name, $error)
             ->service($service)
@@ -147,10 +147,10 @@ final class SpanAssertion
     }
 
     /**
-     * @param array $metrics
+     * @param array|string $metrics
      * @return $this
      */
-    public function withExactMetrics(array $metrics)
+    public function withExactMetrics($metrics)
     {
         $this->exactMetrics = $metrics;
         return $this;
@@ -298,16 +298,5 @@ final class SpanAssertion
     public function getExactMetrics()
     {
         return $this->exactMetrics;
-    }
-
-    /**
-     * @return array
-     */
-    public function getNotTestedMetricNames()
-    {
-        return [
-            '_sampling_priority_v1',
-            '_dd1.sr.eausr',
-        ];
     }
 }

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -226,12 +226,8 @@ final class SpanChecker
         }
         if ($exp->getExactMetrics() !== SpanAssertion::NOT_TESTED) {
             TestCase::assertEquals(
-                self::filterArrayByKey($exp->getExactMetrics(), $exp->getNotTestedMetricNames(), false),
-                self::filterArrayByKey(
-                    isset($span['metrics']) ? $span['metrics'] : [],
-                    $exp->getNotTestedMetricNames(),
-                    false
-                ),
+                $exp->getExactMetrics(),
+                isset($span['metrics']) ? $span['metrics'] : [],
                 $namePrefix . "Wrong value for 'metrics'"
             );
         }
@@ -270,27 +266,6 @@ final class SpanChecker
             array_walk($trace, function (array $span) use (&$result) {
                 $result[] = $span;
             });
-        }
-
-        return $result;
-    }
-
-    /**
-     * PHP < 5.6 does not offer a way to filter only specific elements in an array by key.
-     *
-     * @param array $associative
-     * @param string[] $allowedKeys
-     * @param bool $include
-     * @return array
-     */
-    private static function filterArrayByKey($associative, $allowedKeys, $include = true)
-    {
-        $result = [];
-
-        foreach ($associative as $key => $value) {
-            if (($include && in_array($key, $allowedKeys)) || (!$include && !in_array($key, $allowedKeys))) {
-                $result[$key] = $value;
-            }
         }
 
         return $result;

--- a/tests/DistributedTracing/DistributedTraceTest.php
+++ b/tests/DistributedTracing/DistributedTraceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace DDTrace\Tests\DistributedTracing;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+class DistributedTraceTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../Frameworks/Custom/Version_Not_Autoloaded/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_DISTRIBUTED_TRACING' => 'true',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    public function testDistributedTrace()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-trace-id: 1042',
+                    'x-datadog-parent-id: 1000',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertSame(1042, $traces[0][0]['trace_id']);
+        // TODO Fix parent ID propagation
+        //$this->assertSame(1000, $traces[0][0]['parent_id']);
+    }
+
+    // Synthetics requests have "0" as the parent ID
+    public function testDistributedTraceWithNoParent()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-trace-id: 6017420907356617206',
+                    'x-datadog-parent-id: 0',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertSame(6017420907356617206, $traces[0][0]['trace_id']);
+        // TODO Fix parent ID propagation
+        //$this->assertArrayNotHasKey('parent_id', $traces[0][0]);
+    }
+
+    public function testInvalidTraceId()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-trace-id: this-is-not-valid',
+                    'x-datadog-parent-id: 42',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertNotSame('this-is-not-valid', $traces[0][0]['trace_id']);
+        $this->assertNotSame(0, $traces[0][0]['trace_id']);
+        $this->assertArrayNotHasKey('parent_id', $traces[0][0]);
+    }
+
+    public function testInvalidParentId()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-trace-id: 42',
+                    'x-datadog-parent-id: this-is-not-valid',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertNotSame(42, $traces[0][0]['trace_id']);
+        $this->assertArrayNotHasKey('parent_id', $traces[0][0]);
+    }
+}

--- a/tests/DistributedTracing/DistributedTraceTest.php
+++ b/tests/DistributedTracing/DistributedTraceTest.php
@@ -36,8 +36,7 @@ class DistributedTraceTest extends WebFrameworkTestCase
         });
 
         $this->assertSame(1042, $traces[0][0]['trace_id']);
-        // TODO Fix parent ID propagation
-        //$this->assertSame(1000, $traces[0][0]['parent_id']);
+        $this->assertSame(1000, $traces[0][0]['parent_id']);
     }
 
     // Synthetics requests have "0" as the parent ID
@@ -57,8 +56,7 @@ class DistributedTraceTest extends WebFrameworkTestCase
         });
 
         $this->assertSame(6017420907356617206, $traces[0][0]['trace_id']);
-        // TODO Fix parent ID propagation
-        //$this->assertArrayNotHasKey('parent_id', $traces[0][0]);
+        $this->assertArrayNotHasKey('parent_id', $traces[0][0]);
     }
 
     public function testInvalidTraceId()

--- a/tests/DistributedTracing/SamplingPriorityTest.php
+++ b/tests/DistributedTracing/SamplingPriorityTest.php
@@ -29,8 +29,8 @@ class SamplingPriorityTest extends WebFrameworkTestCase
                 'GET',
                 '/index.php',
                 [
-                    'x-datadog-parent-id: 0',
-                    'x-datadog-trace-id: 0',
+                    'x-datadog-trace-id: 100',
+                    'x-datadog-parent-id: 200',
                     'x-datadog-sampling-priority: 1',
                 ]
             );
@@ -59,8 +59,8 @@ class SamplingPriorityTest extends WebFrameworkTestCase
                 'GET',
                 '/index.php',
                 [
-                    'x-datadog-parent-id: 0',
-                    'x-datadog-trace-id: 0',
+                    'x-datadog-trace-id: 100',
+                    'x-datadog-parent-id: 200',
                     'x-datadog-sampling-priority: 0',
                 ]
             );

--- a/tests/DistributedTracing/SamplingPriorityTest.php
+++ b/tests/DistributedTracing/SamplingPriorityTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace DDTrace\Tests\DistributedTracing;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+class SamplingPriorityTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../Frameworks/Custom/Version_Not_Autoloaded/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_PRIORITY_SAMPLING' => 'true',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    public function testKeepPriority()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec  = new RequestSpec(
+                'Keep',
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-parent-id: 0',
+                    'x-datadog-trace-id: 0',
+                    'x-datadog-sampling-priority: 1',
+                ]
+            );
+            $this->call($spec);
+        });
+        $this->assertOneExpectedSpan(
+            $traces,
+            SpanAssertion::build(
+                'web.request',
+                'web.request',
+                'web',
+                'GET /index.php'
+            )->withExactTags(
+                SpanAssertion::NOT_TESTED
+            )->withExactMetrics([
+                '_sampling_priority_v1' => 1,
+            ])
+        );
+    }
+
+    public function testDropPriority()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec  = new RequestSpec(
+                'Drop',
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-parent-id: 0',
+                    'x-datadog-trace-id: 0',
+                    'x-datadog-sampling-priority: 0',
+                ]
+            );
+            $this->call($spec);
+        });
+        $this->assertOneExpectedSpan(
+            $traces,
+            SpanAssertion::build(
+                'web.request',
+                'web.request',
+                'web',
+                'GET /index.php'
+            )->withExactTags(
+                SpanAssertion::NOT_TESTED
+            )->withExactMetrics([
+                '_sampling_priority_v1' => 0,
+            ])
+        );
+    }
+}

--- a/tests/DistributedTracing/SandboxAndLegacyTest.php
+++ b/tests/DistributedTracing/SandboxAndLegacyTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DDTrace\Tests\DistributedTracing;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+class SandboxAndLegacyTest extends WebFrameworkTestCase
+{
+    const IS_SANDBOX = true;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../Frameworks/Custom/Version_Not_Autoloaded/sandbox.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_DISTRIBUTED_TRACING' => 'true',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    public function testDistributedTrace()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/',
+                [
+                    'x-datadog-trace-id: 1042',
+                    'x-datadog-parent-id: 1000',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertCount(1, $traces);
+        $this->assertCount(2, $traces[0]);
+        // Root span (userland)
+        $rootSpan = $traces[0][0];
+        $this->assertSame(1042, $rootSpan['trace_id']);
+        $this->assertSame(1000, $rootSpan['parent_id']);
+        // Child span (internal)
+        $childSpan = $traces[0][1];
+        $this->assertSame(1042, $childSpan['trace_id']);
+        $this->assertSame($rootSpan['span_id'], $childSpan['parent_id']);
+    }
+
+    // Synthetics requests have "0" as the parent ID
+    public function testDistributedTraceWithNoParent()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/',
+                [
+                    'x-datadog-trace-id: 6017420907356617206',
+                    'x-datadog-parent-id: 0',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        // Root span (userland)
+        $rootSpan = $traces[0][0];
+        $this->assertSame(6017420907356617206, $rootSpan['trace_id']);
+        $this->assertArrayNotHasKey('parent_id', $rootSpan);
+        // Child span (internal)
+        $childSpan = $traces[0][1];
+        $this->assertSame(6017420907356617206, $childSpan['trace_id']);
+        $this->assertSame($rootSpan['span_id'], $childSpan['parent_id']);
+    }
+
+    public function testNonDistributedTest()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(__FUNCTION__, 'GET', '/');
+            $this->call($spec);
+        });
+
+        // Root span (userland)
+        $rootSpan = $traces[0][0];
+        $this->assertArrayNotHasKey('parent_id', $rootSpan);
+        // Child span (internal)
+        $childSpan = $traces[0][1];
+        $this->assertSame($rootSpan['trace_id'], $childSpan['trace_id']);
+        $this->assertSame($rootSpan['span_id'], $childSpan['parent_id']);
+    }
+}

--- a/tests/DistributedTracing/SyntheticsTest.php
+++ b/tests/DistributedTracing/SyntheticsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DDTrace\Tests\DistributedTracing;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+class SyntheticsTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../Frameworks/Custom/Version_Not_Autoloaded/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            // Ensure that Synthetics requests do not get sampled
+            // even with a really low sampling rate
+            'DD_SAMPLING_RATE' => '0.0',
+            // Disabling priority sampling will break Synthetic requests
+            'DD_PRIORITY_SAMPLING' => 'true',
+            // Disabling distributed tracing will break Synthetic requests
+            'DD_DISTRIBUTED_TRACING' => 'true',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    public function testSyntheticsRequest()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = new RequestSpec(
+                'Synthetics Request',
+                'GET',
+                '/index.php',
+                [
+                    'x-datadog-trace-id: 123456',
+                    'x-datadog-parent-id: 0',
+                    'x-datadog-sampling-priority: 1',
+                    'x-datadog-origin: synthetics-browser',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertOneExpectedSpan(
+            $traces,
+            SpanAssertion::build(
+                'web.request',
+                'web.request',
+                'web',
+                'GET /index.php'
+            )->withExactTags([
+                'http.method' => 'GET',
+                'http.url' => '/index.php',
+                'http.status_code' => '200',
+                'integration.name' => 'web',
+                '_dd.origin' => 'synthetics-browser',
+            ])->withExactMetrics([
+                '_sampling_priority_v1' => 1,
+            ])
+        );
+        $this->assertSame(123456, $traces[0][0]['trace_id']);
+    }
+}

--- a/tests/Frameworks/Custom/Version_Not_Autoloaded/sandbox.php
+++ b/tests/Frameworks/Custom/Version_Not_Autoloaded/sandbox.php
@@ -1,0 +1,13 @@
+<?php
+
+dd_trace_function('myWebsite', function($span) {
+    $span->name = $span->resource = 'myWebsite';
+    $span->type = 'web';
+    $span->service = 'foo_service';
+});
+
+function myWebsite() {
+    echo 'Sandbox-enabled web page' . PHP_EOL;
+}
+
+myWebsite();

--- a/tests/Frameworks/Util/Request/GetSpec.php
+++ b/tests/Frameworks/Util/Request/GetSpec.php
@@ -8,7 +8,7 @@ class GetSpec extends RequestSpec
      * @param string $name
      * @param string $path
      */
-    protected function __construct($name, $path)
+    public function __construct($name, $path)
     {
         parent::__construct($name, 'GET', $path);
     }
@@ -20,6 +20,6 @@ class GetSpec extends RequestSpec
      */
     public static function create($name, $path)
     {
-        return new GetSpec($name, $path);
+        return new self($name, $path);
     }
 }

--- a/tests/Frameworks/Util/Request/RequestSpec.php
+++ b/tests/Frameworks/Util/Request/RequestSpec.php
@@ -2,7 +2,7 @@
 
 namespace DDTrace\Tests\Frameworks\Util\Request;
 
-abstract class RequestSpec
+class RequestSpec
 {
     /**
      * @var string
@@ -25,21 +25,22 @@ abstract class RequestSpec
     private $statusCode = 200;
 
     /**
-     * @param string $name
-     * @param string $path
+     * @var string[]
      */
-    // abstract public static function create($name, $path);
+    private $headers = [];
 
     /**
      * @param $name
      * @param string $method
      * @param string $path
+     * @param array $headers
      */
-    protected function __construct($name, $method, $path)
+    public function __construct($name, $method, $path, array $headers = [])
     {
         $this->name = $name;
         $this->method = $method;
         $this->path = $path;
+        $this->headers = $headers;
     }
 
     /**
@@ -82,5 +83,13 @@ abstract class RequestSpec
     public function getPath()
     {
         return $this->path;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
     }
 }

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -246,6 +246,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
         // parent is: curl_exec
         $this->assertSame($traces[0][1]['span_id'], (int) $found['headers']['X-Datadog-Parent-Id']);
         $this->assertSame('1', $found['headers']['X-Datadog-Sampling-Priority']);
+        $this->assertSame($traces[0][0]['metrics']['_sampling_priority_v1'], PrioritySampling::AUTO_KEEP);
         // existing headers are honored
         $this->assertSame('preserved_value', $found['headers']['Honored']);
     }

--- a/tests/ext/dd_trace_push_span_id_from_userland.phpt
+++ b/tests/ext/dd_trace_push_span_id_from_userland.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Push a span ID onto the stack from userland
+--ENV--
+DD_TRACE_DEBUG_PRNG_SEED=42
+--FILE--
+<?php
+echo dd_trace_push_span_id('42') . PHP_EOL;
+foreach (range(0, 2) as $i) {
+    echo dd_trace_push_span_id() . PHP_EOL;
+}
+echo dd_trace_push_span_id('invalid') . PHP_EOL;
+echo dd_trace_push_span_id('16142341506862590864') . PHP_EOL; // uint64
+echo dd_trace_push_span_id('99999999999999999999999999999') . PHP_EOL; // overflow
+echo dd_trace_push_span_id() . PHP_EOL;
+
+echo "\n";
+
+foreach (range(0, 7) as $i) {
+    echo dd_trace_pop_span_id() . PHP_EOL;
+}
+echo dd_trace_pop_span_id() . PHP_EOL;
+?>
+--EXPECT--
+42
+6965080426129060204
+5894024288751747413
+6937315012233870726
+1256893659602577832
+16142341506862590864
+8331185726714219691
+867627036267489215
+
+867627036267489215
+8331185726714219691
+16142341506862590864
+1256893659602577832
+6937315012233870726
+5894024288751747413
+6965080426129060204
+42
+0

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Set the trace ID from userland
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_DEBUG_PRNG_SEED=42
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'array_sum';
+});
+
+var_dump(dd_trace_set_trace_id('42'));
+echo dd_trace_push_span_id('100') . PHP_EOL;
+
+var_dump(array_sum([1, 1]));
+
+$printSpans = function($span) {
+    printf(
+        "Name: %s\nSpan ID: %s\nTrace ID: %s\nParent ID: %s\n",
+        $span['name'],
+        $span['span_id'],
+        $span['trace_id'],
+        isset($span['parent_id']) ? $span['parent_id'] : '(empty)'
+    );
+};
+array_map($printSpans, dd_trace_serialize_closed_spans());
+
+echo '*Flushed spans*' . PHP_EOL;
+var_dump(array_sum([1, 1]));
+
+array_map($printSpans, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(true)
+100
+int(2)
+Name: array_sum
+Span ID: 6965080426129060204
+Trace ID: 42
+Parent ID: 100
+*Flushed spans*
+int(2)
+Name: array_sum
+Span ID: 5894024288751747413
+Trace ID: 5894024288751747413
+Parent ID: (empty)


### PR DESCRIPTION
### Description

Distributed traces serialize over the wire using HTTP headers `x-datadog-trace-id` and `x-datadog-parent-id`.

Due to the way the tracer supports both internal and userland spans, neither of these propagated ID's were being synced between the sandbox and legacy API's properly and would thus break distributed traces. This issue wasn't caught by the tests since there wasn't a full integration test for distributed traces.

This PR:
- Adds integration tests for distributed traces including Synthetics requests
- Properly handles `x-datadog-trace-id` and `x-datadog-parent-id` for internal and userland spans
- Improves validation and handling of span ID's
- Fixes a small edge-case where the sampling priority would erroneously be set to the default value when the `x-datadog-sampling-priority` header was set to `0`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
