### PR TITLE
Move entire Symfony test suite to flame graph assertions

### DIFF
--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class RouteNameTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class RouteNameTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_3/web/app.php';
@@ -23,7 +25,7 @@ final class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, [
+        $this->assertFlameGraph($traces, [
             SpanAssertion::build(
                 'web.request',
                 'web.request',

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class RouteNameTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class RouteNameTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_2_8/web/app.php';
@@ -23,7 +25,7 @@ final class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, [
+        $this->assertFlameGraph($traces, [
             SpanAssertion::build(
                 'web.request',
                 'web.request',

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_0/web/app.php';
@@ -25,7 +27,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -46,13 +48,17 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -68,22 +74,26 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::build(
+                                        'symfony.templating.render',
+                                        'symfony',
+                                        'web',
+                                        'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
+                                    )
+                                        ->withExactTags([
+                                            'integration.name' => 'symfony',
+                                        ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'symfony',
-                        'web',
-                        'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                    )
-                        ->withExactTags([
-                            'integration.name' => 'symfony',
-                        ]),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -101,16 +111,24 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'integration.name' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.handleException'),
-                    SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                        ->withExistingTagsNames(['error.stack'])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.handleException')
+                                        ->withChildren([
+                                            SpanAssertion::exists('symfony.kernel.exception')
+                                                ->withChildren([
+                                                    SpanAssertion::exists('symfony.templating.render'),
+                                                ]),
+                                            SpanAssertion::exists('symfony.kernel.response'),
+                                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                                        ]),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                        ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_0/web/app.php';
@@ -30,7 +32,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
         });
 
-        $this->assertExpectedSpans(
+        $this->assertFlameGraph(
             $traces,
             [
                 SpanAssertion::build(
@@ -50,13 +52,17 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
-                SpanAssertion::exists('symfony.kernel.handle'),
-                SpanAssertion::exists('symfony.kernel.request'),
-                SpanAssertion::exists('symfony.kernel.controller'),
-                SpanAssertion::exists('symfony.kernel.response'),
-                SpanAssertion::exists('symfony.kernel.finish_request'),
-                SpanAssertion::exists('symfony.kernel.terminate'),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/app.php';
@@ -25,7 +27,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -46,14 +48,18 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -69,23 +75,27 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::build(
+                                        'symfony.templating.render',
+                                        'symfony',
+                                        'web',
+                                        'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
+                                    )
+                                        ->withExactTags([
+                                            'integration.name' => 'symfony',
+                                        ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'symfony',
-                        'web',
-                        'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                    )
-                        ->withExactTags([
-                            'integration.name' => 'symfony',
-                        ]),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -103,17 +113,25 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'integration.name' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.handleException'),
-                    SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                        ->withExistingTagsNames(['error.stack'])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.handleException')
+                                        ->withChildren([
+                                            SpanAssertion::exists('symfony.kernel.exception')
+                                                ->withChildren([
+                                                    SpanAssertion::exists('symfony.templating.render'),
+                                                ]),
+                                            SpanAssertion::exists('symfony.kernel.response'),
+                                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                                        ]),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                        ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/app.php';
@@ -30,7 +32,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
         });
 
-        $this->assertExpectedSpans(
+        $this->assertFlameGraph(
             $traces,
             [
                 SpanAssertion::build(
@@ -50,14 +52,18 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
-                SpanAssertion::exists('symfony.kernel.handle'),
-                SpanAssertion::exists('symfony.kernel.request'),
-                SpanAssertion::exists('symfony.kernel.controller'),
-                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                SpanAssertion::exists('symfony.kernel.response'),
-                SpanAssertion::exists('symfony.kernel.finish_request'),
-                SpanAssertion::exists('symfony.kernel.terminate'),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_4/web/app.php';
@@ -26,7 +28,7 @@ final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
             $this->call(GetSpec::create('Endpoint that invoke exit()', '/terminated_by_exit'));
         });
 
-        $this->assertSpans($traces, [
+        $this->assertFlameGraph($traces, [
             SpanAssertion::build(
                 'symfony.request',
                 'symfony',
@@ -40,11 +42,15 @@ final class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
                     'http.url' => 'http://localhost:9999/terminated_by_exit',
                     'http.status_code' => '200',
                     'integration.name' => 'symfony',
+                ])
+                ->withChildren([
+                    SpanAssertion::exists('symfony.kernel.handle')
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                        ]),
                 ]),
-            SpanAssertion::exists('symfony.kernel.handle'),
-            SpanAssertion::exists('symfony.kernel.request'),
-            SpanAssertion::exists('symfony.kernel.controller'),
-            SpanAssertion::exists('symfony.kernel.controller_arguments'),
         ]);
     }
 }

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_4/web/app.php';
@@ -32,7 +34,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -45,22 +47,24 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_34',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                            'integration.name' => 'symfony',
-                        ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                        'integration.name' => 'symfony',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -68,31 +72,32 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_34',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                            'integration.name' => 'symfony',
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                        'integration.name' => 'symfony',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                            SpanAssertion::build(
+                                'symfony.templating.render',
+                                'test_symfony_34',
+                                'web',
+                                'Twig\Environment twig_template.html.twig'
+                            )->withExactTags([
+                                'integration.name' => 'symfony',
+                            ]),
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'test_symfony_34',
-                        'web',
-                        'Twig\Environment twig_template.html.twig'
-                    )
-                        ->withExactTags([
-                            'integration.name' => 'symfony',
-                        ]),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -110,17 +115,25 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'integration.name' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.handleException'),
-                    SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                        ->withExistingTagsNames(['error.stack'])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.handleException')
+                                        ->withChildren([
+                                            SpanAssertion::exists('symfony.kernel.exception')
+                                                ->withChildren([
+                                                    SpanAssertion::exists('symfony.templating.render'),
+                                                ]),
+                                            SpanAssertion::exists('symfony.kernel.response'),
+                                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                                        ]),
+                                ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                        ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TemplateEnginesTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_4/web/app.php';
@@ -30,7 +32,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
         });
 
-        $this->assertExpectedSpans(
+        $this->assertFlameGraph(
             $traces,
             [
                 SpanAssertion::build(
@@ -50,14 +52,18 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
-                SpanAssertion::exists('symfony.kernel.handle'),
-                SpanAssertion::exists('symfony.kernel.request'),
-                SpanAssertion::exists('symfony.kernel.controller'),
-                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                SpanAssertion::exists('symfony.kernel.response'),
-                SpanAssertion::exists('symfony.kernel.finish_request'),
-                SpanAssertion::exists('symfony.kernel.terminate'),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_4_0/public/index.php';
@@ -30,7 +32,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
         });
 
-        $this->assertExpectedSpans(
+        $this->assertFlameGraph(
             $traces,
             [
                 SpanAssertion::build(
@@ -50,14 +52,19 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                        // This is an error. Terminate has the wrong  parent span and it should be fixed.
+                        // SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
-                SpanAssertion::exists('symfony.kernel.handle'),
-                SpanAssertion::exists('symfony.kernel.request'),
-                SpanAssertion::exists('symfony.kernel.controller'),
-                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                SpanAssertion::exists('symfony.kernel.response'),
-                SpanAssertion::exists('symfony.kernel.finish_request'),
-                SpanAssertion::exists('symfony.kernel.terminate'),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_4_2/public/index.php';
@@ -33,7 +35,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -54,13 +56,19 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                    // This should be fixed as this should be a child
+                    // of the root span while here it is a lone trace
                     SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A simple GET request with a view' => [
@@ -77,22 +85,28 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.url' => 'http://localhost:9999/simple_view',
                             'http.status_code' => '200',
                             'integration.name' => 'symfony',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::build(
+                                        'symfony.templating.render',
+                                        'test_symfony_42',
+                                        'web',
+                                        'Twig\Environment twig_template.html.twig'
+                                    )
+                                        ->withExactTags([
+                                            'integration.name' => 'symfony',
+                                        ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::build(
-                        'symfony.templating.render',
-                        'test_symfony_42',
-                        'web',
-                        'Twig\Environment twig_template.html.twig'
-                    )
-                        ->withExactTags([
-                            'integration.name' => 'symfony',
-                        ]),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                    // This should be fixed as this should be a child
+                    // of the root span while here it is a lone trace
                     SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
                 'A GET request with an exception' => [
@@ -111,16 +125,26 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'integration.name' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
-                    SpanAssertion::exists('symfony.kernel.handle'),
-                    SpanAssertion::exists('symfony.kernel.request'),
-                    SpanAssertion::exists('symfony.kernel.controller'),
-                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                    SpanAssertion::exists('symfony.kernel.handleException'),
-                    SpanAssertion::exists('symfony.kernel.exception'),
-                    SpanAssertion::exists('symfony.templating.render'),
-                    SpanAssertion::exists('symfony.kernel.response'),
-                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ->withExistingTagsNames(['error.stack'])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.handleException')
+                                        ->withChildren([
+                                            SpanAssertion::exists('symfony.kernel.exception')
+                                                ->withChildren([
+                                                    SpanAssertion::exists('symfony.templating.render'),
+                                                ]),
+                                            SpanAssertion::exists('symfony.kernel.response'),
+                                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                                        ]),
+                                ]),
+                        ]),
+                    // This should be fixed as this should be a child
+                    // of the root span while here it is a lone trace
                     SpanAssertion::exists('symfony.kernel.terminate'),
                 ],
             ]

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
-    const IS_SANDBOXED = false;
+    const IS_SANDBOX = false;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOXED = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_4_2/public/index.php';
@@ -30,7 +32,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
         });
 
-        $this->assertExpectedSpans(
+        $this->assertFlameGraph(
             $traces,
             [
                 SpanAssertion::build(
@@ -50,13 +52,19 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.handle')
+                            ->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                     ]),
-                SpanAssertion::exists('symfony.kernel.handle'),
-                SpanAssertion::exists('symfony.kernel.request'),
-                SpanAssertion::exists('symfony.kernel.controller'),
-                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                SpanAssertion::exists('symfony.kernel.response'),
-                SpanAssertion::exists('symfony.kernel.finish_request'),
+                // This should be fixed as this should be a child
+                // of the root span while here it is a lone trace
                 SpanAssertion::exists('symfony.kernel.terminate'),
             ]
         );


### PR DESCRIPTION
### Description

Move the entire Symfony test suite to flame graph assertion ahead of migrating Symfony to Sandboxed api.

### Readiness checklist
~- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
