### PR TITLE
Fix CodeIgniter namespace definition

### DIFF
--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Integrations\CodeIgniter\V2_2;
+namespace DDTrace\Integrations\CodeIgniter\V2;
 
 use DDTrace\Configuration;
 use DDTrace\Contracts\Span;

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -4,7 +4,7 @@ namespace DDTrace\Integrations;
 
 use DDTrace\Configuration;
 use DDTrace\Integrations\CakePHP\CakePHPIntegration;
-use DDTrace\Integrations\CodeIgniter\V2_2\CodeIgniterSandboxedIntegration;
+use DDTrace\Integrations\CodeIgniter\V2\CodeIgniterSandboxedIntegration;
 use DDTrace\Integrations\Curl\CurlIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration;
@@ -81,7 +81,7 @@ class IntegrationsLoader
         // Sandboxed integrations get loaded with a feature flag
         if (Configuration::get()->isSandboxEnabled()) {
             $this->integrations[CodeIgniterSandboxedIntegration::NAME] =
-                '\DDTrace\Integrations\CodeIgniter\V2_2\CodeIgniterSandboxedIntegration';
+                '\DDTrace\Integrations\CodeIgniter\V2\CodeIgniterSandboxedIntegration';
             $this->integrations[ElasticSearchSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration';
             $this->integrations[EloquentSandboxedIntegration::NAME] =

--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -33,7 +33,7 @@ class AutoInstrumentationTest extends BaseTestCase
 
             // We want to make sure that the version declared in composer.json is picked up instead of the installed
             // version.
-            ['composer_with_ddtrace_dependency', '0.30.0', true],
+            ['composer_with_ddtrace_dependency', '0.31.0', true],
 
             // We want to make sure that users can safely declare a dependency in the latest version of our
             // tracer in composer even if not required.

--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -33,7 +33,11 @@ class AutoInstrumentationTest extends BaseTestCase
 
             // We want to make sure that the version declared in composer.json is picked up instead of the installed
             // version.
-            ['composer_with_ddtrace_dependency', '0.11.0-beta', true],
+            ['composer_with_ddtrace_dependency', '0.30.0', true],
+
+            // We want to make sure that users can safely declare a dependency in the latest version of our
+            // tracer in composer even if not required.
+            ['composer_with_local_code_dependency', $currentTracerVersion, true],
 
             // Symfony 3.3 has a loader Symfony\Component\Config\Resource\ClassExistenceResource which registers a
             // private method as the actual class loader. Because of https://github.com/DataDog/dd-trace-php/issues/224

--- a/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "datadog/dd-trace": "0.30.0"
+        "datadog/dd-trace": "0.31.0"
     }
 }

--- a/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "datadog/dd-trace": "0.11.0"
+        "datadog/dd-trace": "0.30.0"
     }
 }

--- a/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "DDTrace\\": "../../../../src/DDTrace"
+        }
+    }
+}

--- a/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/index.php
+++ b/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/index.php
@@ -1,0 +1,5 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+echo DDTrace\Tracer::VERSION;


### PR DESCRIPTION
### Description

This PR fixes a bug in the namespace definition of the CodeIgniter integrations.

An application is impacted by this bug is all the following conditions apply:
- the application uses composer.
- ddtrace manual tracing is used (if your application only uses automatic instrumentation is not impacted).
- the application explicitly declare a dependency in composer instead of using classes provided by our extension.

What happens is that the when declaring a dependency our library in `composer.json` composer register an autoloader that place itself before our `OptionalDepsAutoloader` and `RequiredDepsAutoloader`, as it uses the `$prepend = true` flag when invoking `spl_autoload_register`.

As a result we have the following chain of autoloaders, that are attempted in this order:

1. `\Composer\Autoload\ClassLoader`
2. `\DDTrace\Bridge\OptionalDepsAutoloader`
3. `\DDTrace\Bridge\RequiredDepsAutoloader`

Now assume we are in the phase of request init hook execution, the class `\DDTrace\Bootstrap` is loaded, composer's autoloader has a definition for it and it loads the class, so step 2 and 3 are not executed. While loading `Bootstrap` a number of other classes get loaded, e.g. `DDTrace\Log\LoggingTrait`. Let me say again that so far autoloaders in position 1. and 2. have not been used.

Now assume that a request for `DDTrace\Integrations\CodeIgniter\V2_2\CodeIgniterSandboxedIntegration` class gets in. Because the folder `src/...../V2_2/` does not exist (the name was `.../V2/...`) the composer's autoloader cannot load it and will delegate the task to autoloader in position 2. Our autoloaders load ALL the files assigned to them by a brute force `require` so it happens that a class, e.g. `DDTrace\Log\LoggingTrait` is loaded twice (now and before by the composer's autoloader), causing a class redefinition fatal error.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
