### PR TITLE
Add MySQLi multi_query support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "ext-mysqli": "*",
         "g1a/composer-test-scenarios": "~3.0",
         "mockery/mockery": "*",
         "phpunit/phpunit": "^4",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "ext-mysqli": "*",
         "g1a/composer-test-scenarios": "~3.0",
         "mockery/mockery": "*",
         "phpunit/phpunit": "^4",


### PR DESCRIPTION
### Description

[Ticket](https://datadoghq.atlassian.net/browse/APMPHP-60)

Add MySQLi multi_query support.

Add ext-mysqli to dev dependencies.
Fix bug in queryDatabaseAllAssociative test function.

-----

I added this while debugging a potential issue. No issue found, and it seemed like this would be useful to customers. 

### Readiness checklist
- [ ] Tests added for this feature/bug.
    - [x] Tests added for insert/update.
    - [ ] Tests added for multiple selects.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
