### PR TITLE
Make code review of certain items easier

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -10,7 +10,33 @@ if test "$PHP_DDTRACE" != "no"; then
     PHP_SUBST(EXTRA_CFLAGS)
   fi
 
-  PHP_NEW_EXTENSION(ddtrace, src/ext/ddtrace.c src/ext/memory_limit.c src/ext/configuration.c src/ext/configuration_php_iface.c src/ext/circuit_breaker.c src/ext/dispatch_setup.c src/ext/dispatch.c src/ext/third-party/mt19937-64.c src/ext/random.c src/ext/coms.c src/ext/coms_curl.c src/ext/coms_debug.c src/ext/request_hooks.c src/ext/compat_string.c src/ext/dispatch_compat_php5.c src/ext/dispatch_compat_php7.c src/ext/backtrace.c src/ext/logging.c src/ext/env_config.c src/ext/serializer.c src/ext/span.c src/ext/trace.c src/ext/mpack/mpack.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
+  dnl ddtrace.c comes first, then everything else alphabetically
+  DD_TRACE_PHP_SOURCES="src/ext/ddtrace.c \
+    src/ext/backtrace.c \
+    src/ext/circuit_breaker.c \
+    src/ext/compat_string.c \
+    src/ext/coms.c \
+    src/ext/coms_curl.c \
+    src/ext/coms_debug.c \
+    src/ext/configuration.c \
+    src/ext/configuration_php_iface.c \
+    src/ext/dispatch.c \
+    src/ext/dispatch_compat_php5.c \
+    src/ext/dispatch_compat_php7.c \
+    src/ext/dispatch_setup.c \
+    src/ext/env_config.c \
+    src/ext/logging.c \
+    src/ext/memory_limit.c \
+    src/ext/mpack/mpack.c \
+    src/ext/random.c \
+    src/ext/request_hooks.c \
+    src/ext/serializer.c \
+    src/ext/span.c \
+    src/ext/third-party/mt19937-64.c \
+    src/ext/trace.c \
+  "
+
+  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
   PHP_ADD_BUILD_DIR($ext_builddir/src/ext, 1)
 
   PHP_CHECK_LIBRARY(rt, shm_open, [EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lrt"])

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -718,23 +718,34 @@ static PHP_FUNCTION(dd_trace_tracer_is_limited) {
 }
 
 static const zend_function_entry ddtrace_functions[] = {
-    PHP_FE(dd_trace, NULL) PHP_FE(dd_trace_method, arginfo_dd_trace_method) PHP_FE(
-        dd_trace_function, arginfo_dd_trace_function) PHP_FE(dd_trace_serialize_closed_spans,
-                                                             arginfo_dd_trace_serialize_closed_spans)
-        PHP_FE(dd_trace_forward_call, NULL) PHP_FE(dd_trace_reset, NULL) PHP_FE(dd_trace_noop, NULL) PHP_FE(
-            dd_untrace, NULL) PHP_FE(dd_trace_disable_in_request, NULL) PHP_FE(dd_trace_dd_get_memory_limit, NULL)
-            PHP_FE(dd_trace_check_memory_under_limit, NULL) PHP_FE(
-                dd_tracer_circuit_breaker_register_error, NULL) PHP_FE(dd_tracer_circuit_breaker_register_success, NULL)
-                PHP_FE(dd_tracer_circuit_breaker_can_try, NULL) PHP_FE(dd_tracer_circuit_breaker_info, NULL) PHP_FE(
-                    dd_trace_env_config, arginfo_dd_trace_env_config) PHP_FE(dd_trace_coms_trigger_writer_flush, NULL)
-                    PHP_FE(dd_trace_buffer_span, arginfo_dd_trace_buffer_span) PHP_FE(dd_trace_internal_fn, NULL)
-                        PHP_FE(dd_trace_serialize_msgpack, arginfo_dd_trace_serialize_msgpack)
-                            PHP_FE(dd_trace_set_trace_id, arginfo_dd_trace_set_trace_id)
-                                PHP_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id)
-                                    PHP_FE(dd_trace_pop_span_id, NULL) PHP_FE(dd_trace_peek_span_id, NULL)
-                                        PHP_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL)
-                                            PHP_FE(dd_trace_closed_spans_count, NULL)
-                                                PHP_FE(dd_trace_tracer_is_limited, NULL) ZEND_FE_END};
+    DDTRACE_FE(dd_trace, NULL),
+    DDTRACE_FE(dd_trace_buffer_span, arginfo_dd_trace_buffer_span),
+    DDTRACE_FE(dd_trace_check_memory_under_limit, NULL),
+    DDTRACE_FE(dd_trace_closed_spans_count, NULL),
+    DDTRACE_FE(dd_trace_coms_trigger_writer_flush, NULL),
+    DDTRACE_FE(dd_trace_dd_get_memory_limit, NULL),
+    DDTRACE_FE(dd_trace_disable_in_request, NULL),
+    DDTRACE_FE(dd_trace_env_config, arginfo_dd_trace_env_config),
+    DDTRACE_FE(dd_trace_forward_call, NULL),
+    DDTRACE_FE(dd_trace_function, arginfo_dd_trace_function),
+    DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL),
+    DDTRACE_FE(dd_trace_internal_fn, NULL),
+    DDTRACE_FE(dd_trace_method, arginfo_dd_trace_method),
+    DDTRACE_FE(dd_trace_noop, NULL),
+    DDTRACE_FE(dd_trace_peek_span_id, NULL),
+    DDTRACE_FE(dd_trace_pop_span_id, NULL),
+    DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
+    DDTRACE_FE(dd_trace_reset, NULL),
+    DDTRACE_FE(dd_trace_serialize_closed_spans, arginfo_dd_trace_serialize_closed_spans),
+    DDTRACE_FE(dd_trace_serialize_msgpack, arginfo_dd_trace_serialize_msgpack),
+    DDTRACE_FE(dd_trace_set_trace_id, arginfo_dd_trace_set_trace_id),
+    DDTRACE_FE(dd_trace_tracer_is_limited, NULL),
+    DDTRACE_FE(dd_tracer_circuit_breaker_can_try, NULL),
+    DDTRACE_FE(dd_tracer_circuit_breaker_info, NULL),
+    DDTRACE_FE(dd_tracer_circuit_breaker_register_error, NULL),
+    DDTRACE_FE(dd_tracer_circuit_breaker_register_success, NULL),
+    DDTRACE_FE(dd_untrace, NULL),
+    DDTRACE_FE_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,    PHP_DDTRACE_EXTNAME,    ddtrace_functions,
                                           PHP_MINIT(ddtrace),        PHP_MSHUTDOWN(ddtrace), PHP_RINIT(ddtrace),

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -60,4 +60,24 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
 
 #define DDTRACE_CALLBACK_NAME "dd_trace_callback"
 
+/* The clang formatter does not handle the ZEND macros these mirror, due to the
+ * missing comma in the usage site. It was making PRs unreviewable, so this
+ * defines these macros without the comma in the definition site, so that it
+ * exists at the usage site.
+ */
+#if PHP_VERSION_ID < 70000
+#define DDTRACE_ARG_INFO_SIZE(arg_info) ((zend_uint)(sizeof(arg_info) / sizeof(struct _zend_arg_info) - 1))
+#elif PHP_VERSION_ID < 80000
+#define DDTRACE_ARG_INFO_SIZE(arg_info) ((uint32_t)(sizeof(arg_info) / sizeof(struct _zend_internal_arg_info) - 1))
+#else
+#error Check if ZEND_FENTRY has changed in PHP 8 and if we need to update the macros
+#endif
+
+#define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
+    { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
+
+#define DDTRACE_FE(name, arg_info) DDTRACE_FENTRY(name, ZEND_FN(name), arg_info, 0)
+#define DDTRACE_FALIAS(name, alias, arg_info) DDTRACE_FENTRY(name, ZEND_FN(alias), arg_info, 0)
+#define DDTRACE_FE_END ZEND_FE_END
+
 #endif  // DDTRACE_H


### PR DESCRIPTION
### Description

This makes two changes aimed to make code review easier:

- Introduce DDTRACE_FE macros that mirror the PHP_FE/ZEND_FE macros _except_ that they do not have a trailing comma. This puts the comma in the usage site so that clang-format will do the Right Thing, instead of doing a very-long, unreviewable mess.
    - I also sorted the list.
- Introduce a sorted, multi-line sources list variable in config.m4. Now when we add/remove files it should be easy to see.

### Readiness checklist
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] ~Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.~
