### PR TITLE
Migrate Zend framework integration to sandboxed api

### DIFF
--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -62,7 +62,6 @@ require __DIR__ . '/../src/DDTrace/Integrations/Integration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/SandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php';
-require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Predis/PredisIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/IntegrationsLoader.php';
@@ -94,6 +93,8 @@ require __DIR__ . '/../src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php'
 require __DIR__ . '/../src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php';
+require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php';
 
 // Loggers
 require __DIR__ . '/../src/DDTrace/Log/Logger.php';

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -27,6 +27,7 @@ use DDTrace\Integrations\Web\WebIntegration;
 use DDTrace\Integrations\WordPress\WordPressSandboxedIntegration;
 use DDTrace\Integrations\Yii\YiiSandboxedIntegration;
 use DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration;
+use DDTrace\Integrations\ZendFramework\ZendFrameworkSandboxedIntegration;
 use DDTrace\Log\LoggingTrait;
 
 /**
@@ -97,6 +98,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\WordPress\WordPressSandboxedIntegration';
             $this->integrations[YiiSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Yii\YiiSandboxedIntegration';
+            $this->integrations[ZendFrameworkSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\ZendFramework\ZendFrameworkSandboxedIntegration';
         }
     }
 

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace DDTrace\Integrations\ZendFramework;
+
+use DDTrace\Configuration;
+use DDTrace\GlobalTracer;
+use DDTrace\Tag;
+use DDTrace\Integrations\Integration;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
+use DDTrace\Util\Runtime;
+use Zend_Controller_Front;
+
+/**
+ * Zend framework integration loader.
+ */
+class ZendFrameworkSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'zendframework';
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresExplicitTraceAnalyticsEnabling()
+    {
+        return false;
+    }
+
+    /**
+     * Loads the zend framework integration.
+     *
+     * @return int
+     */
+    public function init()
+    {
+        if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        // Some frameworks, e.g. Yii registers autoloaders that fails with non-psr4 classes. For this reason the
+        // Zend framework integration is not compatible with some of them
+        if (Runtime::isAutoloaderRegistered('YiiBase', 'autoload')) {
+            return self::NOT_AVAILABLE;
+        }
+
+        $integration = $this;
+        // For backward compatibility with the legacy API we are not using the integration
+        // name 'zendframework', we are instead using the 'zf1' prefix.
+        $appName = Configuration::get()->appName('zf1');
+
+        dd_trace_method(
+            'Zend_Controller_Plugin_Broker',
+            'preDispatch',
+            function (SpanData $spanData, $args) use ($integration, $appName) {
+                $rootScope = GlobalTracer::get()->getRootScope();
+                if (null === $rootScope) {
+                    return false;
+                }
+
+                $rootSpan = $rootScope->getSpan();
+                if (null === $rootSpan) {
+                    return false;
+                }
+
+                // We are enclosing this into a try-catch because we always have to return false,
+                // even at the cost of not setting specific metadata.
+                try {
+                    /** @var Zend_Controller_Request_Abstract $request */
+                    list($request) = $args;
+                    $rootSpan->setIntegration($integration);
+                    $rootSpan->setTraceAnalyticsCandidate();
+                    $rootSpan->overwriteOperationName($integration->getOperationName());
+                    $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
+                    $controller = $request->getControllerName();
+                    $action = $request->getActionName();
+                    $route = Zend_Controller_Front::getInstance()->getRouter()->getCurrentRouteName();
+                    $rootSpan->setTag('zf1.controller', $controller);
+                    $rootSpan->setTag('zf1.action', $action);
+                    $rootSpan->setTag('zf1.route_name', $route);
+                    $rootSpan->setResource($controller . '@' . $action . ' ' . $route);
+                    $rootSpan->setTag(Tag::HTTP_METHOD, $request->getMethod());
+                    $rootSpan->setTag(
+                        Tag::HTTP_URL,
+                        $request->getScheme() . '://' .
+                        $request->getHttpHost() .
+                        $request->getRequestUri()
+                    );
+                } catch (\Exception $e) {
+                }
+
+                return false;
+            }
+        );
+
+        dd_trace_method('Zend_Controller_Plugin_Broker', 'postDispatch', function () {
+            $rootScope = GlobalTracer::get()->getRootScope();
+            if (null === $rootScope || null === ($rootSpan = $rootScope->getSpan())) {
+                return false;
+            }
+
+            // We are enclosing this into a try-catch because we always have to return false,
+            // even at the cost of not setting specific metadata.
+            try {
+                $rootSpan->setTag(Tag::HTTP_STATUS_CODE, $this->getResponse()->getHttpResponseCode());
+            } catch (\Exception $e) {
+            }
+
+            return false;
+        });
+
+        return Integration::LOADED;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getOperationName()
+    {
+        $contextName = 'cli' === PHP_SAPI ? 'command' : 'request';
+        // For backward compatibility with the legacy API we are not using the integration
+        // name 'zendframework', we are instead using the 'zf1' prefix.
+        return 'zf1' . '.' . $contextName;
+    }
+}

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosSanboxedTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosSanboxedTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\ZendFramework\V1;
+
+class CommonScenariosSanboxedTest extends CommonScenariosTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -6,8 +6,10 @@ use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
-final class CommonScenariosTest extends WebFrameworkTestCase
+class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/ZendFramework/Version_1_12/public/index.php';
@@ -25,7 +27,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigSandboxedTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigSandboxedTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\ZendFramework\V1;
+
+class TraceSearchConfigSandboxedTest extends TraceSearchConfigTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -6,8 +6,10 @@ use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
-final class TraceSearchConfigTest extends WebFrameworkTestCase
+class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = false;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/ZendFramework/Version_1_12/public/index.php';


### PR DESCRIPTION
### Description

This PR implements a sandboxed integration for the Zend Framework and enables it by default.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
