### PR TITLE
Add polyfill.m4 to support autoconf < 2.64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,14 +666,16 @@ workflows:
           requires: [ "Framework tests" ]
           framework_target: laravel_no_ddtrace
           name: "Laravel baseline testsuite"
-      - framework_tests:
-          requires: [ "Framework tests" ]
-          framework_target: symfony
-          name: "Symfony testsuite"
-      - framework_tests:
-          requires: [ "Framework tests" ]
-          framework_target: symfony_no_ddtrace
-          name: "Symfony baseline testsuite"
+      # Symfony path needs to be updated as symfony/contracts 2.0 has been released and it changes
+      # test files where the patch is applied.
+      # - framework_tests:
+      #     requires: [ "Framework tests" ]
+      #     framework_target: symfony
+      #     name: "Symfony testsuite"
+      # - framework_tests:
+      #     requires: [ "Framework tests" ]
+      #     framework_target: symfony_no_ddtrace
+      #     name: "Symfony baseline testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
           framework_target: wordpress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,14 +650,14 @@ workflows:
       - placeholder:
           requires: [ 'package extension' ]
           name: Framework tests
-      # - framework_tests:
-      #     requires: [ "Framework tests" ]
-      #     framework_target: flow
-      #     name: "Flow testsuite"
-      # - framework_tests:
-      #     requires: [ "Framework tests" ]
-      #     framework_target: flow_no_ddtrace
-      #     name: "Flow baseline testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
+          framework_target: flow
+          name: "Flow testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
+          framework_target: flow_no_ddtrace
+          name: "Flow baseline testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
           framework_target: laravel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,14 +650,14 @@ workflows:
       - placeholder:
           requires: [ 'package extension' ]
           name: Framework tests
-      - framework_tests:
-          requires: [ "Framework tests" ]
-          framework_target: flow
-          name: "Flow testsuite"
-      - framework_tests:
-          requires: [ "Framework tests" ]
-          framework_target: flow_no_ddtrace
-          name: "Flow baseline testsuite"
+      # - framework_tests:
+      #     requires: [ "Framework tests" ]
+      #     framework_target: flow
+      #     name: "Flow testsuite"
+      # - framework_tests:
+      #     requires: [ "Framework tests" ]
+      #     framework_target: flow_no_ddtrace
+      #     name: "Flow baseline testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
           framework_target: laravel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,6 @@ jobs:
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_remote_docker
-      - run: docker login docker.pkg.github.com --username $GITHUB_REGISTRY_USERNAME --password $GITHUB_REGISTRY_PASSWORD
       - run: make -f dockerfiles/frameworks/Makefile << parameters.framework_target >>
 
   verify_package:

--- a/config.m4
+++ b/config.m4
@@ -3,6 +3,7 @@ PHP_ARG_ENABLE(ddtrace, whether to enable Datadog tracing support,[  --enable-dd
 PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,[  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
 if test "$PHP_DDTRACE" != "no"; then
+  m4_include([m4/polyfill.m4])
   m4_include([m4/ax_execinfo.m4])
 
   AX_EXECINFO

--- a/dockerfiles/frameworks/src/Dockerfile
+++ b/dockerfiles/frameworks/src/Dockerfile
@@ -75,27 +75,27 @@ ADD flow/20-redis.ini /etc/php/7.0/cli/conf.d/20-redis.ini
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 CMD [ "bash" ]
 
-FROM base AS symfony
-ENV COMPOSER_MEMORY_LIMIT -1
-ARG SYMFONY_VERSION_TAG=v4.3.4
+# FROM base AS symfony
+# ENV COMPOSER_MEMORY_LIMIT -1
+# ARG SYMFONY_VERSION_TAG=v4.3.4
 
-RUN set -xe; \
-    git clone --depth 1 --branch ${SYMFONY_VERSION_TAG} https://github.com/symfony/symfony /home/symfony; \
-    cd /home/symfony; \
-    composer update --prefer-dist; \
-    php ./phpunit install
+# RUN set -xe; \
+#     git clone --depth 1 --branch ${SYMFONY_VERSION_TAG} https://github.com/symfony/symfony /home/symfony; \
+#     cd /home/symfony; \
+#     composer update --prefer-dist; \
+#     php ./phpunit install
 
-WORKDIR /home/symfony/
-ADD symfony/${SYMFONY_VERSION_TAG}.patch ./
-RUN set -xe; \
-    # add vendor to git to allow easy patching of vendor files too
-    git add -f vendor; \
-    git commit -m "vendor"; \
-    git apply *.patch
+# WORKDIR /home/symfony/
+# ADD symfony/${SYMFONY_VERSION_TAG}.patch ./
+# RUN set -xe; \
+#     # add vendor to git to allow easy patching of vendor files too
+#     git add -f vendor; \
+#     git commit -m "vendor"; \
+#     git apply *.patch
 
-ENV SYMFONY_DEPRECATIONS_HELPER=disabled=1
-ADD symfony/run.sh ./
-CMD [ "./run.sh" ]
+# ENV SYMFONY_DEPRECATIONS_HELPER=disabled=1
+# ADD symfony/run.sh ./
+# CMD [ "./run.sh" ]
 
 FROM base AS laravel
 ARG LARAVEL_VERSION_TAG=v5.8.17

--- a/m4/polyfill.m4
+++ b/m4/polyfill.m4
@@ -1,0 +1,27 @@
+dnl If needed, define the m4_ifblank and m4_ifnblank macros from autoconf 2.64
+dnl This allows us to run with earlier Autoconfs as well.
+dnl
+dnl m4_ifblank(COND, [IF-BLANK], [IF-TEXT])
+dnl m4_ifnblank(COND, [IF-TEXT], [IF-BLANK])
+dnl ----------------------------------------
+dnl If COND is empty, or consists only of blanks (space, tab, newline),
+dnl then expand IF-BLANK, otherwise expand IF-TEXT.  This differs from
+dnl m4_ifval only if COND has just whitespace, but it helps optimize in
+dnl spite of users who mistakenly leave trailing space after what they
+dnl thought was an empty argument:
+dnl   macro(
+dnl         []
+dnl        )
+dnl
+dnl Writing one macro in terms of the other causes extra overhead, so
+dnl we inline both definitions.
+ifdef([m4_ifblank],[],[
+m4_define([m4_ifblank],
+[m4_if(m4_translit([[$1]],  [ ][	][
+]), [], [$2], [$3])])])
+
+ifdef([m4_ifnblank],[],[
+m4_define([m4_ifnblank],
+[m4_if(m4_translit([[$1]],  [ ][	][
+]), [], [$3], [$2])])])
+

--- a/package.xml
+++ b/package.xml
@@ -248,7 +248,10 @@
             </dir>
             <file name="CHANGELOG.md" role="doc" />
             <file name="config.m4" role="src" />
-            <file name="m4/ax_execinfo.m4" role="src" />
+            <dir name="m4">
+                <file name="ax_execinfo.m4" role="src" />
+                <file name="polyfill.m4" role="src" />
+            </dir>
             <file name="LICENSE" role="doc" />
             <file name="README.md" role="doc" />
             <file name="UPGRADE-0.10.md" role="doc" />


### PR DESCRIPTION
### Description

With the recent addition of `ax_execinfo` for detecting support for `<execinfo.h>` support, this caused our builds to fail on CentOS 6. The version of autoconf on CentOS 6 is 2.63, and the `ax_execinfo` macro uses `m4_ifnblank` which was added in 2.64.

This adds a polyfill for `m4_inblank` so that it will work with autoconf < 2.64, such as CentOS 6.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.