### PR TITLE
Refactor opcode hooks

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -120,8 +120,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 
     register_span_data_ce(TSRMLS_C);
 
-    ddtrace_opcode_minit();
-    ddtrace_compile_minit();
+    ddtrace_engine_hooks_minit();
 
     ddtrace_coms_initialize();
     ddtrace_coms_setup_atexit_hook();
@@ -148,8 +147,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
         ddtrace_config_shutdown();
     }
 
-    ddtrace_compile_mshutdown();
-    ddtrace_opcode_mshutdown();
+    ddtrace_engine_hooks_mshutdown();
 
     return SUCCESS;
 }

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -120,7 +120,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 
     register_span_data_ce(TSRMLS_C);
 
-    ddtrace_dispatch_inject(TSRMLS_C);
+    ddtrace_opcode_minit();
     ddtrace_compile_minit();
 
     ddtrace_coms_initialize();
@@ -149,6 +149,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     }
 
     ddtrace_compile_mshutdown();
+    ddtrace_opcode_mshutdown();
 
     return SUCCESS;
 }

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -35,11 +35,6 @@ zend_bool log_backtrace;
 zend_bool backtrace_handler_already_run;
 ddtrace_original_context original_context;
 
-user_opcode_handler_t ddtrace_old_fcall_handler;
-user_opcode_handler_t ddtrace_old_icall_handler;
-user_opcode_handler_t ddtrace_old_ucall_handler;
-user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
-
 uint64_t trace_id;
 ddtrace_span_ids_t *span_ids_top;
 ddtrace_span_t *open_spans_top;

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -22,7 +22,6 @@ void ddtrace_class_lookup_release(ddtrace_dispatch_t *);
 zend_class_entry *ddtrace_target_class_entry(zval *, zval *TSRMLS_DC);
 int ddtrace_find_function(HashTable *table, zval *name, zend_function **function);
 void ddtrace_dispatch_init(TSRMLS_D);
-void ddtrace_dispatch_inject(TSRMLS_D);
 void ddtrace_dispatch_destroy(TSRMLS_D);
 void ddtrace_dispatch_reset(TSRMLS_D);
 

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -14,11 +14,6 @@
 #include "dispatch_compat.h"
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
-user_opcode_handler_t ddtrace_old_fcall_handler;
-user_opcode_handler_t ddtrace_old_icall_handler;
-user_opcode_handler_t ddtrace_old_ucall_handler;
-user_opcode_handler_t ddtrace_old_fcall_by_name_handler;
-
 #if PHP_VERSION_ID >= 70000
 static inline void dispatch_table_dtor(zval *zv) {
     zend_hash_destroy(Z_PTR_P(zv));
@@ -65,28 +60,6 @@ void ddtrace_dispatch_reset(TSRMLS_D) {
     if (DDTRACE_G(function_lookup)) {
         zend_hash_clean(DDTRACE_G(function_lookup));
     }
-}
-
-void ddtrace_dispatch_inject(TSRMLS_D) {
-/**
- * Replacing zend_execute_ex with anything other than original
- * changes some of the bevavior in PHP compilation and execution
- *
- * e.g. it changes compilation of function calls to produce ZEND_DO_FCALL
- * opcode instead of ZEND_DO_UCALL for user defined functions
- */
-#if PHP_VERSION_ID >= 70000
-    DDTRACE_G(ddtrace_old_icall_handler) = zend_get_user_opcode_handler(ZEND_DO_ICALL);
-    zend_set_user_opcode_handler(ZEND_DO_ICALL, ddtrace_wrap_fcall);
-
-    DDTRACE_G(ddtrace_old_ucall_handler) = zend_get_user_opcode_handler(ZEND_DO_UCALL);
-    zend_set_user_opcode_handler(ZEND_DO_UCALL, ddtrace_wrap_fcall);
-#endif
-    DDTRACE_G(ddtrace_old_fcall_handler) = zend_get_user_opcode_handler(ZEND_DO_FCALL);
-    zend_set_user_opcode_handler(ZEND_DO_FCALL, ddtrace_wrap_fcall);
-
-    DDTRACE_G(ddtrace_old_fcall_by_name_handler) = zend_get_user_opcode_handler(ZEND_DO_FCALL_BY_NAME);
-    zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, ddtrace_wrap_fcall);
 }
 
 zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, zend_bool run_as_postprocess TSRMLS_DC) {

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -5,10 +5,78 @@
 #include <time.h>
 
 #include "ddtrace.h"
+#include "dispatch.h"
+#if PHP_VERSION_ID < 70000
+#include "dispatch_compat_php5.h"
+#endif
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
+// True gloals that need not worry about thread safety
+#if PHP_VERSION_ID >= 70000
+static user_opcode_handler_t _prev_icall_handler;
+static user_opcode_handler_t _prev_ucall_handler;
+#endif
+static user_opcode_handler_t _prev_fcall_handler;
+static user_opcode_handler_t _prev_fcall_by_name_handler;
+
 static zend_op_array *(*_prev_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
+
+void ddtrace_opcode_minit(void) {
+#if PHP_VERSION_ID >= 70000
+    _prev_icall_handler = zend_get_user_opcode_handler(ZEND_DO_ICALL);
+    _prev_ucall_handler = zend_get_user_opcode_handler(ZEND_DO_UCALL);
+    zend_set_user_opcode_handler(ZEND_DO_ICALL, ddtrace_wrap_fcall);
+    zend_set_user_opcode_handler(ZEND_DO_UCALL, ddtrace_wrap_fcall);
+#endif
+
+    _prev_fcall_handler = zend_get_user_opcode_handler(ZEND_DO_FCALL);
+    _prev_fcall_by_name_handler = zend_get_user_opcode_handler(ZEND_DO_FCALL_BY_NAME);
+    zend_set_user_opcode_handler(ZEND_DO_FCALL, ddtrace_wrap_fcall);
+    zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, ddtrace_wrap_fcall);
+}
+
+void ddtrace_opcode_mshutdown(void) {
+#if PHP_VERSION_ID >= 70000
+    zend_set_user_opcode_handler(ZEND_DO_ICALL, NULL);
+    zend_set_user_opcode_handler(ZEND_DO_UCALL, NULL);
+#endif
+    zend_set_user_opcode_handler(ZEND_DO_FCALL, NULL);
+    zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, NULL);
+}
+
+int ddtrace_opcode_default_dispatch(zend_execute_data *execute_data TSRMLS_DC) {
+    if (!EX(opline)->opcode) {
+        return ZEND_USER_OPCODE_DISPATCH;
+    }
+    switch (EX(opline)->opcode) {
+#if PHP_VERSION_ID >= 70000
+        case ZEND_DO_ICALL:
+            if (_prev_icall_handler) {
+                return _prev_icall_handler(execute_data TSRMLS_CC);
+            }
+            break;
+
+        case ZEND_DO_UCALL:
+            if (_prev_ucall_handler) {
+                return _prev_ucall_handler(execute_data TSRMLS_CC);
+            }
+            break;
+#endif
+        case ZEND_DO_FCALL:
+            if (_prev_fcall_handler) {
+                return _prev_fcall_handler(execute_data TSRMLS_CC);
+            }
+            break;
+
+        case ZEND_DO_FCALL_BY_NAME:
+            if (_prev_fcall_by_name_handler) {
+                return _prev_fcall_by_name_handler(execute_data TSRMLS_CC);
+            }
+            break;
+    }
+    return ZEND_USER_OPCODE_DISPATCH;
+}
 
 static uint64_t _get_microseconds() {
     struct timespec time;

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -22,7 +22,21 @@ static user_opcode_handler_t _prev_fcall_by_name_handler;
 
 static zend_op_array *(*_prev_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
 
-void ddtrace_opcode_minit(void) {
+static void _opcode_minit(void);
+static void _opcode_mshutdown(void);
+static void _compile_minit(void);
+static void _compile_mshutdown(void);
+
+void ddtrace_engine_hooks_minit(void) {
+    _opcode_minit();
+    _compile_minit();
+}
+void ddtrace_engine_hooks_mshutdown(void) {
+    _compile_mshutdown();
+    _opcode_mshutdown();
+}
+
+static void _opcode_minit(void) {
 #if PHP_VERSION_ID >= 70000
     _prev_icall_handler = zend_get_user_opcode_handler(ZEND_DO_ICALL);
     _prev_ucall_handler = zend_get_user_opcode_handler(ZEND_DO_UCALL);
@@ -36,7 +50,7 @@ void ddtrace_opcode_minit(void) {
     zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, ddtrace_wrap_fcall);
 }
 
-void ddtrace_opcode_mshutdown(void) {
+static void _opcode_mshutdown(void) {
 #if PHP_VERSION_ID >= 70000
     zend_set_user_opcode_handler(ZEND_DO_ICALL, NULL);
     zend_set_user_opcode_handler(ZEND_DO_UCALL, NULL);
@@ -86,7 +100,7 @@ static uint64_t _get_microseconds() {
     return 0U;
 }
 
-static zend_op_array *ddtrace_compile_file(zend_file_handle *file_handle, int type TSRMLS_DC) {
+static zend_op_array *_dd_compile_file(zend_file_handle *file_handle, int type TSRMLS_DC) {
     zend_op_array *res;
     uint64_t start = _get_microseconds();
     res = _prev_compile_file(file_handle, type TSRMLS_CC);
@@ -94,13 +108,13 @@ static zend_op_array *ddtrace_compile_file(zend_file_handle *file_handle, int ty
     return res;
 }
 
-void ddtrace_compile_minit(void) {
+static void _compile_minit(void) {
     _prev_compile_file = zend_compile_file;
-    zend_compile_file = ddtrace_compile_file;
+    zend_compile_file = _dd_compile_file;
 }
 
-void ddtrace_compile_mshutdown(void) {
-    if (zend_compile_file == ddtrace_compile_file) {
+static void _compile_mshutdown(void) {
+    if (zend_compile_file == _dd_compile_file) {
         zend_compile_file = _prev_compile_file;
     }
 }

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -4,12 +4,11 @@
 #include <php.h>
 #include <stdint.h>
 
-void ddtrace_opcode_minit(void);
-void ddtrace_opcode_mshutdown(void);
+void ddtrace_engine_hooks_minit(void);
+void ddtrace_engine_hooks_mshutdown(void);
+
 int ddtrace_opcode_default_dispatch(zend_execute_data *execute_data TSRMLS_DC);
 
-void ddtrace_compile_minit(void);
-void ddtrace_compile_mshutdown(void);
 void ddtrace_compile_time_reset(TSRMLS_D);
 int64_t ddtrace_compile_time_get(TSRMLS_D);
 

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -4,6 +4,10 @@
 #include <php.h>
 #include <stdint.h>
 
+void ddtrace_opcode_minit(void);
+void ddtrace_opcode_mshutdown(void);
+int ddtrace_opcode_default_dispatch(zend_execute_data *execute_data TSRMLS_DC);
+
 void ddtrace_compile_minit(void);
 void ddtrace_compile_mshutdown(void);
 void ddtrace_compile_time_reset(TSRMLS_D);


### PR DESCRIPTION
### Description

Ticket: https://datadoghq.atlassian.net/browse/APMPHP-42

This PR moves the opcode hooks to the new **engine_hooks.c** file and removes the previous handlers out of the extension globals and into true globals since they do not need to be thread safe in this context. It also includes a fix for forwarding the `ZEND_DO_ICALL` and `ZEND_DO_UCALL` handlers to the proper previous opcode handlers on PHP 7.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
