### PR TITLE
Remove DoctrineCacheBundle

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_0/config/bundles.php
+++ b/tests/Frameworks/Symfony/Version_4_0/config/bundles.php
@@ -2,7 +2,6 @@
 
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
     Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],


### PR DESCRIPTION
Recently we have had some CI failures due to DoctrineCacheBundle, and we are not alone; see:

https://github.com/doctrine/DoctrineCacheBundle/issues/156#issuecomment-555900329

This should unblock our CI builds due to this failure.