### PR TITLE
[Memcached] Prevent mutation of the result code

### DIFF
--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -706,6 +706,21 @@ class MemcachedTest extends IntegrationTestCase
         ]);
     }
 
+    // https://github.com/DataDog/dd-trace-php/issues/622
+    // https://github.com/DataDog/dd-trace-php/issues/656
+    public function testResultCodeIsError()
+    {
+        $this->isolateTracer(function () {
+            $m = new \Memcached();
+            $m->addServer('memcached_server_does_not_exist', 11211);
+            $m->get('foo');
+            $this->assertSame(
+                \Memcached::RES_HOST_LOOKUP_FAILURE,
+                $m->getResultCode()
+            );
+        });
+    }
+
     private static function baseTags()
     {
         return [


### PR DESCRIPTION
### Description

This PR fixes #622 and #656.

The Memcached integration was calling `Memcached::getServerByKey()` after the original traced call in order to append the server info to the span metadata. That method mutates the result code returned from `Memcached::getResultCode()` which was causing unexpected behavior when there was an error returned from the original call.

The Memcached integration now uses `Memcached::getServerList()` in order to append the server metadata which does not mutate the result code.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
