### PR TITLE
Tag "env" in symfony integrations as env variable

### DIFF
--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -59,6 +59,7 @@ class SymfonyBundle extends Bundle
         $symfonyRequestSpan->setIntegration(SymfonyIntegration::getInstance());
         $symfonyRequestSpan->setTraceAnalyticsCandidate();
         $symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $appName);
+        $symfonyRequestSpan->setTag(Tag::ENV, $this->getAppEnv());
         $request = null;
 
         // public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
@@ -172,6 +173,7 @@ class SymfonyBundle extends Bundle
             );
             $span = $scope->getSpan();
             $span->setTag(Tag::SERVICE_NAME, $appName);
+            $span->setTag(Tag::ENV, $this->getAppEnv());
             $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
             $span->setTag(Tag::RESOURCE_NAME, get_class($this) . ' ' . $args[0]);
             return include __DIR__ . '/../../../try_catch_finally.php';
@@ -232,5 +234,14 @@ class SymfonyBundle extends Bundle
     private function getAppName()
     {
         return Configuration::get()->appName('symfony');
+    }
+
+    private function getAppEnv()
+    {
+        if ($appName = getenv('ddtrace_app_env')) {
+            return $appName;
+        } else {
+            return 'none';
+        }
     }
 }

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -55,6 +55,7 @@ class SymfonyBundle extends Bundle
         $symfonyRequestScope = $tracer->getRootScope();
         $symfonyRequestSpan = $symfonyRequestScope->getSpan();
         $symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $appName);
+        $symfonyRequestSpan->setTag(Tag::ENV, $this->getAppEnv());
         $symfonyRequestSpan->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
         $symfonyRequestSpan->overwriteOperationName('symfony.request');
         // Overwriting the default web integration
@@ -167,6 +168,7 @@ class SymfonyBundle extends Bundle
             );
             $span = $scope->getSpan();
             $span->setTag(Tag::SERVICE_NAME, $appName);
+            $span->setTag(Tag::ENV, $this->getAppEnv());
             $span->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
             $span->setTag(Tag::RESOURCE_NAME, get_class($this) . ' ' . $args[0]);
             return include __DIR__ . '/../../../try_catch_finally.php';
@@ -219,5 +221,14 @@ class SymfonyBundle extends Bundle
     private function getAppName()
     {
         return Configuration::get()->appName('symfony');
+    }
+
+    private function getAppEnv()
+    {
+        if ($appName = getenv('ddtrace_app_env')) {
+            return $appName;
+        } else {
+            return 'none';
+        }
     }
 }


### PR DESCRIPTION
### Description

It's now possible to pass the tag "env" in symfony integrations as environment variable
