### PR TITLE
Fix error reporting in case of fatal errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!tests/Integration/ErrorReportingTest.php' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' || touch .failure
       - run:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure

--- a/composer.json
+++ b/composer.json
@@ -208,8 +208,6 @@
         ],
         "test-web-54": [
             "@test-metrics",
-            "@cakephp-28-update",
-            "@cakephp-28-test",
             "@laravel-42-update",
             "@laravel-42-test",
             "@yii-2-suite",
@@ -344,7 +342,7 @@
 
         "test-distributed-tracing": "phpunit --colors=always --configuration=phpunit.xml --testsuite=distributed-tracing",
 
-        "cakephp-28-update": "@composer --working-dir=tests/Frameworks/CakePHP/Version_2_8 update",
+        "cakephp-28-update": "@composer --working-dir=tests/Frameworks/CakePHP/Version_2_8/app update",
         "cakephp-28-test": "@composer test -- --testsuite=cakephp-28-test",
 
         "codeigniter-22-test": "@composer test -- --testsuite=codeigniter-22-test",

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -48,7 +48,7 @@ final class Bootstrap
                     return;
                 }
                 $span->setTag(Tag::ERROR, true);
-                $span->setTag(Tag::ERROR_TYPE, 'fatal');
+                $span->setTag(Tag::ERROR_TYPE, 'fatal/uncaught exception');
                 $span->setTag(Tag::HTTP_STATUS_CODE, '500');
                 if (isset($error['message'])) {
                     $span->setTag(Tag::ERROR_MSG, $error['message']);

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -48,12 +48,16 @@ final class Bootstrap
                     return;
                 }
                 $span->setTag(Tag::ERROR, true);
-                $span->setTag(Tag::ERROR_TYPE, 'fatal/uncaught exception');
-                $span->setTag(Tag::HTTP_STATUS_CODE, '500');
-                if (isset($error['message'])) {
+                $existingTags = $span->getAllTags();
+                if (empty($existingTags[Tag::ERROR_TYPE])) {
+                    $span->setTag(Tag::ERROR_TYPE, 'fatal/uncaught exception');
+                }
+                if (isset($error['message']) && empty($existingTags[Tag::ERROR_MSG])) {
                     $span->setTag(Tag::ERROR_MSG, $error['message']);
                 }
-                if (isset($error['file']) && isset($error['line'])) {
+                $span->setTag(Tag::HTTP_STATUS_CODE, '500');
+
+                if (empty($existingTags[Tag::ERROR_STACK]) && isset($error['file']) && isset($error['line'])) {
                     $span->setTag(Tag::ERROR_STACK, $error['file'] . '(' . $error['line'] . ')');
                 }
             }

--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -5,6 +5,7 @@ namespace DDTrace\Integrations\CakePHP;
 use DDTrace\Configuration;
 use DDTrace\Integrations\CakePHP\V2\CakePHPIntegrationLoader;
 use DDTrace\Integrations\Integration;
+use DDTrace\Util\Versions;
 
 /**
  * The base Laravel integration which delegates loading to the appropriate integration version.
@@ -53,6 +54,10 @@ class CakePHPIntegration extends Integration
     public static function load()
     {
         if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        if (Versions::phpVersionMatches(5.4)) {
             return self::NOT_AVAILABLE;
         }
 

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -257,6 +257,7 @@ final class SpanChecker
             isset($span['name']) ? $span['name'] : '',
             $namePrefix . "Wrong value for 'operation name'"
         );
+
         TestCase::assertSame(
             $exp->hasError(),
             isset($span['error']) && 1 === $span['error'],

--- a/tests/Frameworks/CakePHP/Version_2_8/app/composer.json
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",
-		"cakephp/cakephp": "~2.8"
+		"cakephp/cakephp": "2.8.*"
 	},
 	"suggest": {
 		"cakephp/cakephp-codesniffer": "Easily check code formatting against the CakePHP coding standards."

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DDTrace\Tests\Integration;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class ErrorReportingTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/fatalError.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    public function testFatalErrorsReportedAsError()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Testing a fatal error', '/'));
+        });
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build('web.request', 'web.request', 'web', 'GET /')
+                ->setError()
+                ->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/',
+                    'http.status_code' => '500',
+                    'integration.name' => 'web',
+                    // .... error related tags ...
+                ]),
+        ]);
+    }
+}

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -71,10 +71,13 @@ Stack trace:
             $this->call(GetSpec::create('Testing an exceptin not handled by the framework', '/unhandled-exception'));
         });
 
+        // phpcs:disable
         $message = "Uncaught Exception: Exception not hanlded by the framework! in " . __DIR__ . "/fatalError.php:8
 Stack trace:
 #0 {main}
   thrown";
+        // phpcs:enable
+
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /unhandled-exception')
                 ->setError('fatal', $message)

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -28,13 +28,13 @@ final class ErrorReportingTest extends WebFrameworkTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /')
-                ->setError()
+                ->setError('fatal', 'Manually triggered fatal error')
                 ->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => '/',
                     'http.status_code' => '500',
                     'integration.name' => 'web',
-                    // .... error related tags ...
+                    'error.stack' => __DIR__ . '/fatalError.php(3)',
                 ]),
         ]);
     }

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -47,10 +47,10 @@ final class ErrorReportingTest extends WebFrameworkTestCase
 
         // phpcs:disable
         $message = "Uncaught LogicException: Function 'doesnt_exist' not found (function 'doesnt_exist' not found or invalid function name) in " . __DIR__ . "/fatalError.php:6
-        Stack trace:
-        #0 " . __DIR__ . "/fatalError.php(6): spl_autoload_register('doesnt_exist')
-        #1 {main}
-        thrown";
+Stack trace:
+#0 " . __DIR__ . "/fatalError.php(6): spl_autoload_register('doesnt_exist')
+#1 {main}
+  thrown";
         // phpcs:enable
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /core-fatal')

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -28,7 +28,7 @@ final class ErrorReportingTest extends WebFrameworkTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /user-fatal')
-                ->setError('fatal', 'Manually triggered user fatal error')
+                ->setError('fatal/uncaught exception', 'Manually triggered user fatal error')
                 ->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => '/user-fatal',
@@ -45,19 +45,10 @@ final class ErrorReportingTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing a core fatal error', '/core-fatal'));
         });
 
-        /* phpcs:disable */
-        /* eslint-disable */
-        $message = "Uncaught LogicException: Function 'doesnt_exist' not found (function 'doesnt_exist' not found or invalid function name) in " . __DIR__ . "/fatalError.php:6
-Stack trace:
-#0 " . __DIR__ . "/fatalError.php(6): spl_autoload_register('doesnt_exist')
-#1 {main}
-  thrown";
-        /* eslint-enable */
-        /* phpcs:enable */
-
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /core-fatal')
-                ->setError('fatal', $message)
+                ->setError('fatal/uncaught exception')
+                ->withExistingTagsNames(['error.msg'])
                 ->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => '/core-fatal',
@@ -74,22 +65,33 @@ Stack trace:
             $this->call(GetSpec::create('Testing an exceptin not handled by the framework', '/unhandled-exception'));
         });
 
-        /* eslint-disable */
-        $message = "Uncaught Exception: Exception not hanlded by the framework! in " . __DIR__ . "/fatalError.php:8
-Stack trace:
-#0 {main}
-  thrown";
-        /* eslint-enable */
-
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /unhandled-exception')
-                ->setError('fatal', $message)
+                ->setError('fatal/uncaught exception')
+                ->withExistingTagsNames(['error.msg'])
                 ->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => '/unhandled-exception',
                     'http.status_code' => '500',
                     'integration.name' => 'web',
                     'error.stack' => __DIR__ . '/fatalError.php(8)',
+                ]),
+        ]);
+    }
+
+    public function testExceptionThatHasBeenCaught()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Testing an exceptin not handled by the framework', '/caught-exception'));
+        });
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build('web.request', 'web.request', 'web', 'GET /caught-exception')
+                ->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/caught-exception',
+                    'http.status_code' => '200',
+                    'integration.name' => 'web',
                 ]),
         ]);
     }

--- a/tests/Integration/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReportingTest.php
@@ -45,13 +45,16 @@ final class ErrorReportingTest extends WebFrameworkTestCase
             $this->call(GetSpec::create('Testing a core fatal error', '/core-fatal'));
         });
 
-        // phpcs:disable
+        /* phpcs:disable */
+        /* eslint-disable */
         $message = "Uncaught LogicException: Function 'doesnt_exist' not found (function 'doesnt_exist' not found or invalid function name) in " . __DIR__ . "/fatalError.php:6
 Stack trace:
 #0 " . __DIR__ . "/fatalError.php(6): spl_autoload_register('doesnt_exist')
 #1 {main}
   thrown";
-        // phpcs:enable
+        /* eslint-enable */
+        /* phpcs:enable */
+
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /core-fatal')
                 ->setError('fatal', $message)
@@ -71,12 +74,12 @@ Stack trace:
             $this->call(GetSpec::create('Testing an exceptin not handled by the framework', '/unhandled-exception'));
         });
 
-        // phpcs:disable
+        /* eslint-disable */
         $message = "Uncaught Exception: Exception not hanlded by the framework! in " . __DIR__ . "/fatalError.php:8
 Stack trace:
 #0 {main}
   thrown";
-        // phpcs:enable
+        /* eslint-enable */
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /unhandled-exception')

--- a/tests/Integration/fatalError.php
+++ b/tests/Integration/fatalError.php
@@ -1,3 +1,9 @@
 <?php
 
-trigger_error("Manually triggered fatal error", E_USER_ERROR);
+if ($_SERVER['REQUEST_URI'] === '/user-fatal') {
+    trigger_error("Manually triggered user fatal error", E_USER_ERROR);
+} elseif ($_SERVER['REQUEST_URI'] === '/core-fatal') {
+    spl_autoload_register('doesnt_exist');
+} elseif ($_SERVER['REQUEST_URI'] === '/unhandled-exception') {
+    throw new \Exception('Exception not hanlded by the framework!');
+}

--- a/tests/Integration/fatalError.php
+++ b/tests/Integration/fatalError.php
@@ -6,4 +6,10 @@ if ($_SERVER['REQUEST_URI'] === '/user-fatal') {
     spl_autoload_register('doesnt_exist');
 } elseif ($_SERVER['REQUEST_URI'] === '/unhandled-exception') {
     throw new \Exception('Exception not hanlded by the framework!');
+} elseif ($_SERVER['REQUEST_URI'] === '/caught-exception') {
+    try {
+        throw new \Exception('Exception hanlded by the framework!');
+    } catch (\Exception $e) {
+        // handling somehow
+    }
 }

--- a/tests/Integration/fatalError.php
+++ b/tests/Integration/fatalError.php
@@ -1,0 +1,3 @@
+<?php
+
+trigger_error("Manually triggered fatal error", E_USER_ERROR);

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -90,7 +90,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'cakephp.route.action' => 'index',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
-                        'http.status_code' => '500',
+                        'http.status_code' => '200',
                         'integration.name' => 'cakephp',
                     ])->withExistingTagsNames([
                         'error.stack'

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -67,15 +67,16 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
                         'integration.name' => 'cakephp',
-                    ]),
-                    SpanAssertion::build(
-                        'cakephp.view',
-                        'cakephp_test_app',
-                        'web',
-                        'SimpleView/index.ctp'
-                    )->withExactTags([
-                        'cakephp.view' => 'SimpleView/index.ctp',
-                        'integration.name' => 'cakephp',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'cakephp.view',
+                            'cakephp_test_app',
+                            'web',
+                            'SimpleView/index.ctp'
+                        )->withExactTags([
+                            'cakephp.view' => 'SimpleView/index.ctp',
+                            'integration.name' => 'cakephp',
+                        ]),
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -89,20 +90,23 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'cakephp.route.action' => 'index',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
-                        // CakePHP doesn't appear to set the proper error code
-                        'http.status_code' => '200',
+                        'http.status_code' => '500',
                         'integration.name' => 'cakephp',
                     ])->withExistingTagsNames([
                         'error.stack'
-                    ])->setError(null, 'Foo error'),
-                    SpanAssertion::build(
-                        'cakephp.view',
-                        'cakephp_test_app',
-                        'web',
-                        'Errors/index.ctp'
-                    )->withExactTags([
-                        'cakephp.view' => 'Errors/index.ctp',
-                        'integration.name' => 'cakephp',
+                    ])->setError(
+                        null,
+                        'Foo error'
+                    )->withChildren([
+                        SpanAssertion::build(
+                            'cakephp.view',
+                            'cakephp_test_app',
+                            'web',
+                            'Errors/index.ctp'
+                        )->withExactTags([
+                            'cakephp.view' => 'Errors/index.ctp',
+                            'integration.name' => 'cakephp',
+                        ]),
                     ]),
                 ],
             ]

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -98,11 +98,12 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         Tag::HTTP_METHOD => 'GET',
                         Tag::HTTP_URL => 'http://localhost:9999/error',
-                        // CodeIgniter's error handler does not adjust the status code
-                        Tag::HTTP_STATUS_CODE => '200',
+                        Tag::HTTP_STATUS_CODE => '500',
                         'integration.name' => 'codeigniter',
                         'app.endpoint' => 'Error_::index',
-                    ]),
+                    ])
+                        ->setError('fatal/uncaught exception', null, true)
+                        ->withExistingTagsNames(['error.msg']),
                     SpanAssertion::build(
                         'Error_.index',
                         'codeigniter_test_app',


### PR DESCRIPTION
### Description

This PR improves error reporting marking a trace as error (and reporting a 500) in cases when a framework does not handle errors are such and in case of but `E_ERROR` and `E_USER_ERROR` fatal errors.

_Notes_
Reported stack traces are not changed in case of frameworks that handle exceptions, e.g. Symfony and Laravel. While in case of frameworks not handling exception on their own, we try to fill in the proper metadata based on the info we can obtain from `error_get_last()`

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
