### PR TITLE
Pin phpstan to 0.11.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
       - prepare_extension_and_composer_with_cache
       - run:
           name: Install phpstan
-          command: composer global require phpstan/phpstan
+          command: composer global require phpstan/phpstan:0.11.*
       - run:
           name: Running phpstan
           command: PATH=$PATH:~/.composer/vendor/bin composer static-analyze


### PR DESCRIPTION
### Description

Version 0.12.0 has been released and brings some new issues we need to fix. Until we get around to that, let's pin this at 0.11.x.

Links:
  - [Failed master build](https://app.circleci.com/jobs/github/DataDog/dd-trace-php/92497)
  - [JIRA ticket to fix 0.12 issues](https://datadoghq.atlassian.net/browse/APMPHP-80?atlOrigin=eyJpIjoiNmQ5Y2FhZTEwMzQwNDRhZWEzYWI0YjU2NjJhYjlhN2YiLCJwIjoiaiJ9).

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
