### PR TITLE
Close open sandboxed spans on exit on PHP 7

### DIFF
--- a/.circleci/valgrind/valgrind_7_3_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_7_3_musl_suppressions.lib
@@ -77,3 +77,19 @@
     obj:*
     obj:*
 }
+{
+    <leaks on exit opcode>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:__zend_malloc
+    fun:_emalloc
+    fun:zend_compile
+    fun:compile_file
+    fun:phar_compile_file
+    fun:_dd_compile_file
+    fun:zend_execute_scripts
+    fun:php_execute_script
+    fun:do_cli
+    fun:main
+}

--- a/.circleci/valgrind/valgrind_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_musl_suppressions.lib
@@ -73,3 +73,34 @@
     obj:*
     obj:*
 }
+{
+    <leaks on exit opcode eq 70>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:__zend_malloc
+    fun:_emalloc
+    fun:compile_file
+    fun:phar_compile_file
+    fun:_dd_compile_file
+    fun:zend_execute_scripts
+    fun:php_execute_script
+    fun:do_cli
+    fun:main
+}
+{
+    <leaks on exit opcode gt 70>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:__zend_malloc
+    fun:_emalloc
+    fun:zend_compile
+    fun:compile_file
+    fun:phar_compile_file
+    fun:_dd_compile_file
+    fun:zend_execute_scripts
+    fun:php_execute_script
+    fun:do_cli
+    fun:main
+}

--- a/package.xml
+++ b/package.xml
@@ -140,6 +140,7 @@
                     <file name="dd_trace_tracer_is_limited_hard.phpt" role="test" />
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">
+                        <file name="close-on-exit.phpt" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />
                         <file name="dd_trace_function_complex.phpt" role="test" />
                         <file name="dd_trace_function_internal.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -141,6 +141,7 @@
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">
                         <file name="close-on-exit.phpt" role="test" />
+                        <file name="close-on-exit-retval.phpt" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />
                         <file name="dd_trace_function_complex.phpt" role="test" />
                         <file name="dd_trace_function_internal.phpt" role="test" />

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -7,7 +7,7 @@
 
 #include "compatibility.h"
 
-typedef struct _ddtrace_dispatch_t {
+typedef struct ddtrace_dispatch_t {
     zval callable, function_name;
     zend_bool run_as_postprocess;
     zend_bool busy;

--- a/src/ext/php7/dispatch.c
+++ b/src/ext/php7/dispatch.c
@@ -69,12 +69,14 @@ HashTable *ddtrace_new_class_lookup(zval *class_name) {
     return class_lookup;
 }
 
-zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
 #if PHP_VERSION_ID >= 70300
-    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & IS_ARRAY_PERSISTENT);
+#define DDTRACE_IS_ARRAY_PERSISTENT IS_ARRAY_PERSISTENT
 #else
-    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & HASH_FLAG_PERSISTENT);
+#define DDTRACE_IS_ARRAY_PERSISTENT HASH_FLAG_PERSISTENT
 #endif
+
+zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
+    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & DDTRACE_IS_ARRAY_PERSISTENT);
 
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
     ddtrace_class_lookup_acquire(dispatch);

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -61,7 +61,11 @@ static uint64_t _get_nanoseconds(BOOL_T monotonic_clock) {
     return 0;
 }
 
+#if PHP_VERSION_ID < 70000
 ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
+#else
+ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC) {
+#endif
     ddtrace_span_t *span = ecalloc(1, sizeof(ddtrace_span_t));
     span->next = DDTRACE_G(open_spans_top);
     DDTRACE_G(open_spans_top) = span;
@@ -85,6 +89,11 @@ ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
     // Start time is nanoseconds from unix epoch
     // @see https://docs.datadoghq.com/api/?lang=python#send-traces
     span->start = _get_nanoseconds(USE_REALTIME_CLOCK);
+
+#if PHP_VERSION_ID >= 70000
+    span->call = call;
+    span->dispatch = dispatch;
+#endif
     return span;
 }
 

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -7,6 +7,8 @@
 
 #include "compatibility.h"
 
+struct ddtrace_dispatch_t;
+
 typedef struct ddtrace_span_t {
     zval *span_data;
     ddtrace_exception_t *exception;
@@ -20,11 +22,21 @@ typedef struct ddtrace_span_t {
     };
     pid_t pid;
     struct ddtrace_span_t *next;
+
+#if PHP_VERSION_ID >= 70000
+    zend_execute_data *call;
+    struct ddtrace_dispatch_t *dispatch;
+#endif
 } ddtrace_span_t;
 
 void ddtrace_init_span_stacks(TSRMLS_D);
 void ddtrace_free_span_stacks(TSRMLS_D);
+
+#if PHP_VERSION_ID < 70000
 ddtrace_span_t *ddtrace_open_span(TSRMLS_D);
+#else
+ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC);
+#endif
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 void ddtrace_close_span(TSRMLS_D);
 void ddtrace_drop_span(TSRMLS_D);

--- a/tests/ext/sandbox/close-on-exit-retval.phpt
+++ b/tests/ext/sandbox/close-on-exit-retval.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Ensure tracing closure's $retval arg is null if invoked due to exit()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+register_shutdown_function(function () {
+    $spans = dd_trace_serialize_closed_spans();
+    array_map(
+        function($span) {
+            echo @$span['name'], PHP_EOL;
+        },
+        $spans
+    );
+});
+
+dd_trace_function('outer', function (SpanData $span, $args, $retval) {
+    $span->name =  'outer' . (isset($retval) ? ' was not null' : ' was null');
+});
+
+dd_trace_function('inner', function (SpanData $span, $args, $retval) {
+    $span->name =  'inner' . (isset($retval) ? ' was not null' : ' was null');
+});
+
+function inner() { return 1; }
+
+function outer() {
+    inner();
+    exit();
+
+    // ensure we did not break something    
+    return 1;
+}
+
+outer();
+
+?>
+--EXPECT--
+outer was null
+inner was not null

--- a/tests/ext/sandbox/close-on-exit.phpt
+++ b/tests/ext/sandbox/close-on-exit.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Run sandbox closures for open spans on exit
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+register_shutdown_function(function () {
+    $spans = dd_trace_serialize_closed_spans();
+    array_map(
+        function($span) {
+            echo @$span['name'], PHP_EOL;
+        },
+        $spans
+    );
+});
+
+dd_trace_function('outer', function (SpanData $span) {
+    $span->name = 'outer';
+    $span->resource = $span->name;
+    $span->service = 'test';
+    $span->type = 'custom';
+});
+
+dd_trace_function('inner', function (SpanData $span) {
+    $span->name = 'inner';
+    $span->resource = $span->name;
+    $span->service = 'test';
+    $span->type = 'custom';
+});
+
+function inner() {}
+
+function outer() {
+    inner();
+    exit();
+}
+
+outer();
+
+?>
+--EXPECT--
+outer
+inner


### PR DESCRIPTION
### Description
When a script calls `exit` the spans opened through the sandbox API will now get closed. This PR targets PHP 7 only.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
