### PR TITLE
Add test for HTTP headers being overridden

### DIFF
--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -414,4 +414,23 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ]),
         ]);
     }
+
+    public function testHttpHeadersIsCorrectlySetAgain()
+    {
+        $found = [];
+
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => self::URL . '/headers',
+            CURLOPT_HTTPHEADER => ['Accept: application/json', 'Host: test.invalid'],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FAILONERROR => false,
+            CURLOPT_HEADER => false,
+        ]);
+        $found = json_decode(curl_exec($ch), 1);
+
+        $this->assertSame('test.invalid', $found['headers']['Host']);
+        $this->assertSame('application/json', $found['headers']['Accept']);
+        $this->assertSame('1', $found['headers']['X-Datadog-Sampling-Priority']);
+    }
 }


### PR DESCRIPTION
### Description

This updates PR #405 to the latest master. However, I wasn't sure what the Ubuntu tests were for -- issue 405 did not seem specific to Ubuntu -- so this only updates the test case.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
