### PR TITLE
Enable Sandboxed Symfony Integration

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -98,10 +98,10 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Mysqli\MysqliSandboxedIntegration';
             $this->integrations[PDOSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
-            // Symfony integration sandboxing is disabled until we support spans auto-closing on
-            // exit
-            // $this->integrations[SymfonySandboxedIntegration::NAME] =
-            //     '\DDTrace\Integrations\Symfony\SymfonySandboxedIntegration';
+            if (\PHP_MAJOR_VERSION > 5) {
+                $this->integrations[SymfonySandboxedIntegration::NAME] =
+                    '\DDTrace\Integrations\Symfony\SymfonySandboxedIntegration';
+            }
             $this->integrations[WordPressSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\WordPress\WordPressSandboxedIntegration';
             $this->integrations[YiiSandboxedIntegration::NAME] =

--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -97,7 +97,9 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
 
                 $symfonyRequestSpan->setTag(Tag::HTTP_METHOD, $request->getMethod());
                 $symfonyRequestSpan->setTag(Tag::HTTP_URL, $request->getUriForPath($request->getPathInfo()));
-                $symfonyRequestSpan->setTag(Tag::HTTP_STATUS_CODE, $response->getStatusCode());
+                if (isset($response)) {
+                    $symfonyRequestSpan->setTag(Tag::HTTP_STATUS_CODE, $response->getStatusCode());
+                }
 
                 $route = $request->get('_route');
                 if (null !== $route && null !== $request) {

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -66,14 +66,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            // This will be required with sandboxed integration, that
-                            // instead put this span in the correct place in the gerarchy
-                            // SpanAssertion::exists('symfony.kernel.terminate')
-                            //     ->skipIf(!static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // 'symfony.kernel.terminate' Terminate has the wrong parent span in legacy api.
-                    // This test will fail as we enable the symfony sandboxed api.
-                    // SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -108,14 +103,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            // This will be required with sandboxed integration, that
-                            // instead put this span in the correct place in the gerarchy
-                            // SpanAssertion::exists('symfony.kernel.terminate')
-                            //     ->skipIf(!static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // 'symfony.kernel.terminate' Terminate has the wrong parent span in legacy api.
-                    // This test will fail as we enable the symfony sandboxed api.
-                    // SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -150,14 +140,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                             SpanAssertion::exists('symfony.kernel.finish_request'),
                                         ]),
                                 ]),
-                            // This will be required with sandboxed integration, that
-                            // instead put this span in the correct place in the gerarchy
-                            // SpanAssertion::exists('symfony.kernel.terminate')
-                            //     ->skipIf(!static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // 'symfony.kernel.terminate' Terminate has the wrong parent span in legacy api.
-                    // This test will fail as we enable the symfony sandboxed api.
-                    // SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -62,10 +62,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                        // 'symfony.kernel.terminate' Terminate has the wrong parent span in legacy api.
-                        // This test will fail as we enable the symfony sandboxed api.
-                        // SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                     ]),
+                SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -66,15 +66,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            // Remove 'true' once sandboxed api is enabled for symfony
-                            SpanAssertion::exists('symfony.kernel.terminate')
-                                ->skipIf(true || !static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // This should be fixed for legacy api as this should be a child
-                    // of the root span while here it is a lone trace.
-                    // Remove 'false' once sandboxed api is enabled for symfony
-                    SpanAssertion::exists('symfony.kernel.terminate')
-                        ->skipIf(false && static::IS_SANDBOX),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -109,15 +103,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            // Remove 'true' once sandboxed api is enabled for symfony
-                            SpanAssertion::exists('symfony.kernel.terminate')
-                                ->skipIf(true || !static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // This should be fixed for legacy api as this should be a child
-                    // of the root span while here it is a lone trace.
-                    // Remove 'false' once sandboxed api is enabled for symfony
-                    SpanAssertion::exists('symfony.kernel.terminate')
-                        ->skipIf(false && static::IS_SANDBOX),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -152,15 +140,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                             SpanAssertion::exists('symfony.kernel.finish_request'),
                                         ]),
                                 ]),
-                            // Remove 'true' once sandboxed api is enabled for symfony
-                            SpanAssertion::exists('symfony.kernel.terminate')
-                                ->skipIf(true || !static::IS_SANDBOX),
+                            SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                         ]),
-                    // This should be fixed for legacy api as this should be a child
-                    // of the root span while here it is a lone trace.
-                    // Remove 'false' once sandboxed api is enabled for symfony
-                    SpanAssertion::exists('symfony.kernel.terminate')
-                        ->skipIf(false && static::IS_SANDBOX),
+                    SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -62,15 +62,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
-                        // Remove 'true' once sandboxed api is enabled for symfony
-                        SpanAssertion::exists('symfony.kernel.terminate')
-                            ->skipIf(true || !static::IS_SANDBOX),
+                        SpanAssertion::exists('symfony.kernel.terminate')->skipIf(!static::IS_SANDBOX),
                     ]),
-                // This should be fixed for legacy api as this should be a child
-                // of the root span while here it is a lone trace.
-                // Remove 'false' once sandboxed api is enabled for symfony
-                SpanAssertion::exists('symfony.kernel.terminate')
-                    ->skipIf(false && static::IS_SANDBOX),
+                SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
             ]
         );
     }


### PR DESCRIPTION
### Description
Enable the sandboxed integration for Symfony now that sandboxed spans will close on exit.

Includes a minor fix for if the HttpKernel `$response` arg is null.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
