### PR TITLE
Rename env DD_SAMPLING_RATE to DD_TRACE_SAMPLE_RATE

### DIFF
--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -91,7 +91,9 @@ class Configuration extends AbstractConfiguration
      */
     public function getSamplingRate()
     {
-        return $this->floatValue('sampling.rate', 1.0, 0.0, 1.0);
+        // DD_SAMPLING_RATE is deprecated and will be removed in in 0.40.0
+        $deprecatedValue = $this->floatValue('sampling.rate', 1.0, 0.0, 1.0);
+        return $this->floatValue('trace.sample.rate', $deprecatedValue, 0.0, 1.0);
     }
 
     /**

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -91,7 +91,7 @@ class Configuration extends AbstractConfiguration
      */
     public function getSamplingRate()
     {
-        // DD_SAMPLING_RATE is deprecated and will be removed in in 0.40.0
+        // DD_SAMPLING_RATE is deprecated and will be removed in 0.40.0
         $deprecatedValue = $this->floatValue('sampling.rate', 1.0, 0.0, 1.0);
         return $this->floatValue('trace.sample.rate', $deprecatedValue, 0.0, 1.0);
     }

--- a/tests/DistributedTracing/SyntheticsTest.php
+++ b/tests/DistributedTracing/SyntheticsTest.php
@@ -18,7 +18,7 @@ class SyntheticsTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             // Ensure that Synthetics requests do not get sampled
             // even with a really low sampling rate
-            'DD_SAMPLING_RATE' => '0.0',
+            'DD_TRACE_SAMPLE_RATE' => '0.0',
             // Disabling priority sampling will break Synthetic requests
             'DD_PRIORITY_SAMPLING' => 'true',
             // Disabling distributed tracing will break Synthetic requests

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -23,9 +23,11 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_DISTRIBUTED_TRACING');
         putenv('DD_INTEGRATIONS_DISABLED');
         putenv('DD_PRIORITY_SAMPLING');
+        putenv('DD_SAMPLING_RATE');
         putenv('DD_TRACE_ANALYTICS_ENABLED');
         putenv('DD_TRACE_DEBUG');
         putenv('DD_TRACE_ENABLED');
+        putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
     }
 
@@ -247,6 +249,61 @@ final class ConfigurationTest extends BaseTestCase
                         'sample_rate' => 0.3,
                     ],
                 ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestTraceSampleRate
+     * @param mixed $envs
+     * @param array $expected
+     */
+    public function testTraceSampleRate($envs, $expected)
+    {
+        foreach ($envs as $env) {
+            putenv($env);
+        }
+
+        $this->assertSame($expected, Configuration::get()->getSamplingRate());
+    }
+
+    public function dataProviderTestTraceSampleRate()
+    {
+        return [
+            'defaults to 1.0 when nothing is set' => [
+                [],
+                1.0,
+            ],
+            'DD_TRACE_SAMPLE_RATE can be set' => [
+                [
+                    'DD_TRACE_SAMPLE_RATE=0.7',
+                ],
+                0.7,
+            ],
+            'DD_TRACE_SAMPLE_RATE has a minimum of 0.0' => [
+                [
+                    'DD_TRACE_SAMPLE_RATE=-0.1',
+                ],
+                0.0,
+            ],
+            'DD_TRACE_SAMPLE_RATE has a maximum of 1.0' => [
+                [
+                    'DD_TRACE_SAMPLE_RATE=1.1',
+                ],
+                1.0,
+            ],
+            'deprecated DD_SAMPLING_RATE can still be used' => [
+                [
+                    'DD_SAMPLING_RATE=0.7',
+                ],
+                0.7,
+            ],
+            'DD_TRACE_SAMPLE_RATE wins over deprecated DD_SAMPLING_RATE' => [
+                [
+                    'DD_SAMPLING_RATE=0.3',
+                    'DD_TRACE_SAMPLE_RATE=0.7',
+                ],
+                0.7,
             ],
         ];
     }


### PR DESCRIPTION
### Description

We move to a naming more consistent with other tracers. We still support the deprecated name `DD_SAMPLING_RATE` at least until 0.40.0.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
