### PR TITLE
Add Empty Expect Header to Avoid Curl 100-Continue

### DIFF
--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -141,10 +141,12 @@ final class Http implements Transport
         curl_setopt($handle, CURLOPT_TIMEOUT_MS, $this->config['timeout']);
         curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, $this->config['connect_timeout']);
 
+        // Empty Expect header to avoid curl auto-adding 100-Continue back and forth
         $curlHeaders = [
             'Content-Type: ' . $this->encoder->getContentType(),
             'Content-Length: ' . $bodySize,
             'X-Datadog-Trace-Count: ' . $tracesCount,
+            'Expect:',
         ];
         foreach ($headers as $key => $value) {
             $curlHeaders[] = "$key: $value";

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -149,7 +149,7 @@ final class Http implements Transport
 
         // Empty Expect header to avoid curl auto-adding 100-Continue back and forth
         if (!isset($headers['Expect'])) {
-          $curlHeaders[] = "Expect:";
+            $curlHeaders[] = "Expect:";
         }
 
         foreach ($headers as $key => $value) {

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -141,13 +141,17 @@ final class Http implements Transport
         curl_setopt($handle, CURLOPT_TIMEOUT_MS, $this->config['timeout']);
         curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, $this->config['connect_timeout']);
 
-        // Empty Expect header to avoid curl auto-adding 100-Continue back and forth
         $curlHeaders = [
             'Content-Type: ' . $this->encoder->getContentType(),
             'Content-Length: ' . $bodySize,
             'X-Datadog-Trace-Count: ' . $tracesCount,
-            'Expect:',
         ];
+
+        // Empty Expect header to avoid curl auto-adding 100-Continue back and forth
+        if (!isset($headers['Expect'])) {
+          $curlHeaders[] = "Expect:";
+        }
+
         foreach ($headers as $key => $value) {
             $curlHeaders[] = "$key: $value";
         }

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -147,7 +147,10 @@ final class Http implements Transport
             'X-Datadog-Trace-Count: ' . $tracesCount,
         ];
 
-        // Empty Expect header to avoid curl auto-adding 100-Continue back and forth
+        /* Curl will add Expect: 100-continue if it is a POST over a certain size. The trouble is that CURL will
+         * wait for *1 second* for 100 Continue response before sending the rest of the data. This wait is
+         * configurable, but requires a newer curl than we have on CentOS 6. So instead we send an empty Expect.
+         */
         if (!isset($headers['Expect'])) {
             $curlHeaders[] = "Expect:";
         }

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -177,7 +177,7 @@ final class HttpTest extends BaseTestCase
 
         // This helps it timeout more reliably
         $httpTransport->setHeader('Expect', '100-continue');
-        
+
         $tracer = new Tracer($httpTransport);
         GlobalTracer::set($tracer);
         $logger = $this->withDebugLogger();

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -174,6 +174,10 @@ final class HttpTest extends BaseTestCase
             'connect_timeout' => $curlTimeout,
             'timeout' => $timeout,
         ]);
+
+        // This helps it timeout more reliably
+        $httpTransport->setHeader('Expect', '100-continue');
+        
         $tracer = new Tracer($httpTransport);
         GlobalTracer::set($tracer);
         $logger = $this->withDebugLogger();


### PR DESCRIPTION
### Description

Add the Empty Expect header to prevent Curl from auto adding 100-Continue workflow. 
This is a fix for https://github.com/DataDog/dd-trace-php/issues/651

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
