### PR TITLE
Backup and restore last error

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -162,6 +162,7 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
+                        <file name="get_last_error.phpt" role="test" />
                         <file name="new_static.phpt" role="test" />
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -155,6 +155,7 @@
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
+                        <file name="exception_is_defined.phpt" role="test" />
                         <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_are_passed_to_the_tracing_closure.phpt" role="test" />
                         <file name="exceptions_are_passed_to_the_tracing_closure_php5.phpt" role="test" />

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -54,3 +54,6 @@ static void _compile_mshutdown(void) {
 void ddtrace_compile_time_reset(TSRMLS_D) { DDTRACE_G(compile_time_microseconds) = 0; }
 
 int64_t ddtrace_compile_time_get(TSRMLS_D) { return DDTRACE_G(compile_time_microseconds); }
+
+extern inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC);
+extern inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC);

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -10,4 +10,46 @@ void ddtrace_engine_hooks_mshutdown(void);
 void ddtrace_compile_time_reset(TSRMLS_D);
 int64_t ddtrace_compile_time_get(TSRMLS_D);
 
+struct ddtrace_error_handling {
+    int type;
+    int lineno;
+    char *message;
+    char *file;
+    int error_reporting;
+    zend_error_handling error_handling;
+};
+typedef struct ddtrace_error_handling ddtrace_error_handling;
+
+inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC) {
+    eh->type = PG(last_error_type);
+    eh->lineno = PG(last_error_lineno);
+    eh->message = PG(last_error_message);
+    eh->file = PG(last_error_file);
+
+    // Need to null these so that if another error comes along that they don't get double-freed
+    PG(last_error_message) = NULL;
+    PG(last_error_file) = NULL;
+
+    eh->error_reporting = EG(error_reporting);
+    EG(error_reporting) = 0;
+    zend_replace_error_handling(mode, NULL, &eh->error_handling TSRMLS_CC);
+}
+
+inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC) {
+    if (PG(last_error_message)) {
+        if (PG(last_error_message) != eh->message) {
+            free(PG(last_error_message));
+        }
+        if (PG(last_error_file) != eh->file) {
+            free(PG(last_error_file));
+        }
+    }
+    zend_restore_error_handling(&eh->error_handling TSRMLS_CC);
+    PG(last_error_type) = eh->type;
+    PG(last_error_message) = eh->message;
+    PG(last_error_file) = eh->file;
+    PG(last_error_lineno) = eh->lineno;
+    EG(error_reporting) = eh->error_reporting;
+}
+
 #endif  // DD_ENGINE_HOOKS_H

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -154,7 +154,7 @@ static BOOL_T ddtrace_execute_tracing_closure(zval *callable, zval *span_data, z
     INIT_ZVAL(rv);
     zval args[4];
     zval exception_arg = {.value = {0}};
-    ZVAL_UNDEF(&exception_arg);
+    ZVAL_NULL(&exception_arg);
     if (exception) {
         ZVAL_OBJ(&exception_arg, exception);
     }

--- a/tests/ext/sandbox/exception_is_defined.phpt
+++ b/tests/ext/sandbox/exception_is_defined.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Exceptions in the tracing closure callback are always defined
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+
+var_dump(error_get_last());
+dd_trace_function('array_sum', function ($span, $args, $retval, $ex) {
+    var_dump(\is_null($ex));
+    var_dump(error_get_last());
+});
+array_sum([]);
+?>
+--EXPECTF--
+NULL
+bool(true)
+NULL

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -43,6 +43,7 @@ $test->testFoo();
 echo "---\n";
 
 var_dump(dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
 ?>
 --EXPECTF--
 bool(true)
@@ -100,3 +101,4 @@ array(3) {
     string(6) "MTSeed"
   }
 }
+NULL

--- a/tests/ext/sandbox/get_last_error.phpt
+++ b/tests/ext/sandbox/get_last_error.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Existing errors are kept
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+
+@$i = $i_do_not_exist;
+$last_error = error_get_last();
+if (
+    is_array($last_error)
+    && $last_error['type'] == E_NOTICE
+    && strpos($last_error['message'], 'Undefined variable') === 0
+) {
+    dd_trace_function('array_sum', function () {
+        echo $i_also_do_not_exist;
+    });
+    array_sum([]);
+    $current_error = error_get_last();
+    var_dump($current_error === $last_error);
+} else {
+    echo "Test setup was not as expected\n";
+}
+
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
### Description

This fixes two issues, both part of #693:

1. On PHP 7 the exception argument to the tracing closure was previously set to undef, when it should have been null. This causes an undefined variable access warning if it's accessed when there isn't an exception. The sandbox catches it, but due to another bug it can leak out.
2. Don't leak the error out of the sandbox. It does this by backing up the previous error and restoring it.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
