### PR TITLE
Add more information to tracing closure exceptions

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -153,6 +153,7 @@
                         <file name="dd_trace_set_trace_id.phpt" role="test" />
                         <file name="drop_spans.phpt" role="test" />
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
+                        <file name="exception_error_log.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
                         <file name="exception_is_defined.phpt" role="test" />

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -566,11 +566,7 @@ static void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *
                 const char *msg = message && Z_TYPE_P(message) == IS_STRING
                                       ? Z_STRVAL_P(message)
                                       : "(internal error reading exception message)";
-
                 ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
-                if (message) {
-                    zval_ptr_dtor(&message);
-                }
             }
             if (!DDTRACE_G(strict_mode)) {
                 zend_clear_exception(TSRMLS_C);

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -266,7 +266,9 @@ static void _end_span(ddtrace_span_t *span, zval *user_retval) {
                 const char *msg = Z_TYPE_P(message) == IS_STRING ? Z_STR_P(message)->val
                                                                  : "(internal error reading exception message)";
                 ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
-                zval_ptr_dtor(message);
+                if (message == &rv) {
+                    zval_dtor(message);
+                }
             }
             if (!DDTRACE_G(strict_mode)) {
                 zend_clear_exception();

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+dd_trace_function('array_sum', function () {
+    throw new RuntimeException("This exception is expected");
+});
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in tracing closure for array_sum: This exception is expected
+int(9)


### PR DESCRIPTION
### Description

This adds more information to the error log when an exception is thrown in a tracing closure. This should speed up debugging in such cases.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
