### PR TITLE
avoid `X-Datadog-Trace-Count` error in agent during dd-doctor.php requests

### DIFF
--- a/src/dd-doctor.php
+++ b/src/dd-doctor.php
@@ -125,7 +125,14 @@ function check_agent_connectivity()
     curl_setopt($ch, CURLOPT_POSTFIELDS, "[]");
     curl_setopt($ch, CURLOPT_VERBOSE, true);
     curl_setopt($ch, CURLOPT_STDERR, $verbose);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+    curl_setopt(
+        $ch,
+        CURLOPT_HTTPHEADER,
+        array(
+            'Content-Type: application/json',
+            'X-Datadog-Trace-Count: 0',
+        )
+    );
     curl_exec($ch);
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $success = $httpcode >= 200 && $httpcode < 300;


### PR DESCRIPTION
### Description

When we ask customers to enable dd-doctor.php, then we find in the agent
logs the following error which is misleading:

```
2019-12-23 10:00:16 PST | TRACE | WARN | (pkg/trace/api/api.go:358 in handleTraces) | Error getting trace count: "HTTP header \"X-Datadog-Trace-Count\" not found". Functionality may be limited.
```

The reason for that is that dd-doctor.php sends an empty array of traces to
the agent to check connectivity. This request this not provide the header above
(it is created manually).

This PR adds the above header to all requests with a value of `X-Datadog-Trace-Count: 0`.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
- ~[ ] Tests added for this feature/bug.~ Manual testing was successfully done.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
