### PR TITLE
Handle out-of-sync spans

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -174,6 +174,7 @@
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
                         <file name="safe_to_string_properties.phpt" role="test" />
+                        <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-regression">

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -164,6 +164,11 @@ static BOOL_T ddtrace_execute_tracing_closure(zval *callable, zval *span_data, z
     }
     zval *this = ddtrace_this(call);
 
+    if (!callable || !span_data || !user_args || !user_retval) {
+        ddtrace_log_debug("Tracing closure could not be run because it is in an invalid state");
+        return FALSE;
+    }
+
     if (zend_fcall_info_init(callable, 0, &fci, &fcc, NULL, NULL) == FAILURE) {
         ddtrace_log_debug("Could not init tracing closure");
         return FALSE;
@@ -306,8 +311,11 @@ static void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *
     zend_fcall_info fci = {0};
     zend_fcall_info_cache fcc = {0};
     ddtrace_forward_call(EX(call), fbc, user_retval, &fci, &fcc);
-
-    _end_span(span, user_retval);
+    if (span == DDTRACE_G(open_spans_top)) {
+        _end_span(span, user_retval);
+    } else {
+        ddtrace_log_debug("Cannot run tracing closure; spans out of sync");
+    }
 
     zend_fcall_info_args_clear(&fci, 0);
     zval_dtor(&rv);

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -25,9 +25,13 @@ static void _free_span(ddtrace_span_t *span) {
         return;
     }
 #if PHP_VERSION_ID < 70000
-    zval_ptr_dtor(&span->span_data);
+    if (span->span_data) {
+        zval_ptr_dtor(&span->span_data);
+        span->span_data = NULL;
+    }
     if (span->exception) {
         zval_ptr_dtor(&span->exception);
+        span->exception = NULL;
     }
 #else
     if (span->span_data) {

--- a/tests/ext/sandbox/spans_out_of_sync.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Gracefully handle out-of-sync spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+dd_trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'dd_trace_serialize_closed_spans';
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure; spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync.phpt
@@ -18,7 +18,7 @@ var_dump(dd_trace_serialize_closed_spans());
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
-Cannot run tracing closure; spans out of sync
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
 array(0) {
 }
 Done.


### PR DESCRIPTION
### Description

This PR fixes an edge case where spans can get out of sync if the open spans are cleared after the original call but before the tracing closure is run.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
