### PR TITLE
Move dogstatsd client init to rinit

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -27,6 +27,7 @@ if test "$PHP_DDTRACE" != "no"; then
     src/ext/configuration_php_iface.c \
     src/ext/dispatch.c \
     src/ext/dispatch_setup.c \
+    src/ext/dogstatsd_client.c \
     src/ext/engine_hooks.c \
     src/ext/env_config.c \
     src/ext/logging.c \

--- a/package.xml
+++ b/package.xml
@@ -54,6 +54,8 @@
                     <file name="dispatch.c" role="src" />
                     <file name="dispatch.h" role="src" />
                     <file name="dispatch_setup.c" role="src" />
+                    <file name="dogstatsd_client.c" role="src" />
+                    <file name="dogstatsd_client.h" role="src" />
                     <file name="engine_hooks.c" role="src" />
                     <file name="engine_hooks.h" role="src" />
                     <file name="env_config.c" role="src" />

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -5,36 +5,14 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-dogstatsd_client dogstatsd_client_default_ctor() {
-  dogstatsd_client client = {
-      .socket = -1,
-      .address = NULL,
-      .addresslist = NULL,
-      .msg_buffer = NULL,
-      .msg_buffer_len = 0,
-      .const_tags = NULL,
-      .const_tags_len = 0,
-  };
-  return client;
-}
-
-/* This function is inline, but it needs to go in a translation unit somewhere
- * to avoid certain linker errors. This line instructs the tooling it should
- * go here.
+/* These functions are inline, but it needs to go in a translation unit
+ * somewhere to avoid certain linker errors. The extern inline handles this.
  */
-extern inline int dogstatsd_client_is_default_client(dogstatsd_client *);
+extern inline dogstatsd_client dogstatsd_client_default_ctor();
+extern inline _Bool dogstatsd_client_is_default_client(dogstatsd_client client);
 
-dogstatsd_client dogstatsd_client_ctor(const char *host, const char *port,
-                                       char *buffer, int buffer_len,
-                                       const char *const_tags) {
-  if (!host || !port || !buffer || buffer_len < 0) {
-    return dogstatsd_client_default_ctor();
-  }
-
-  struct addrinfo *result;
-  struct addrinfo *res;
-  int error;
-
+int dogstatsd_client_getaddrinfo(struct addrinfo **result, const char *host,
+                                 const char *port) {
   struct addrinfo hints;
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_DGRAM;
@@ -42,42 +20,40 @@ dogstatsd_client dogstatsd_client_ctor(const char *host, const char *port,
   hints.ai_flags = AI_NUMERICSERV;
 
   /* resolve the domain name into a list of addresses */
-  error = getaddrinfo(host, port, &hints, &result);
-  if (error != 0) {
-    if (error == EAI_SYSTEM) {
-      perror("getaddrinfo");
-    } else {
-      fprintf(stderr, "error in getaddrinfo: %s\n", gai_strerror(error));
-    }
-    return dogstatsd_client_default_ctor();
+  return getaddrinfo(host, port, &hints, result);
+}
+
+dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
+                                       int buffer_len, const char *const_tags) {
+  dogstatsd_client client = dogstatsd_client_default_ctor();
+
+  if (!addrs) {
+    return client;
+  }
+  client.addresslist = addrs;
+
+  struct addrinfo *addr = NULL;
+  if (!buffer || buffer_len < 0) {
+    return client;
   }
 
-  int fd = -1;
   /* loop over all returned results and do inverse lookup */
-  for (res = result; res != NULL; res = res->ai_next) {
-    if ((fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) !=
-        -1) {
+  for (addr = client.addresslist; addr != NULL; addr = addr->ai_next) {
+    if ((client.socket = socket(addr->ai_family, addr->ai_socktype,
+                                addr->ai_protocol)) != -1) {
       break;
     }
-  }
-
-  if (res == NULL || fd == -1) {
-    return dogstatsd_client_default_ctor();
   }
 
   if (!const_tags) {
     const_tags = "";
   }
 
-  dogstatsd_client client = {
-      .socket = fd,
-      .addresslist = result,
-      .address = res,
-      .msg_buffer = buffer,
-      .msg_buffer_len = buffer_len,
-      .const_tags = const_tags,
-      .const_tags_len = strlen(const_tags),
-  };
+  client.const_tags = const_tags;
+  client.const_tags_len = strlen(const_tags);
+  client.address = addr;
+  client.msg_buffer = buffer;
+  client.msg_buffer_len = buffer_len;
 
   return client;
 }
@@ -88,9 +64,11 @@ void dogstatsd_client_dtor(dogstatsd_client *client) {
   }
   if (client->socket != -1) {
     close(client->socket);
+    client->socket = -1;
   }
   if (client->addresslist) {
     freeaddrinfo(client->addresslist);
+    client->addresslist = NULL;
   }
 }
 
@@ -101,7 +79,7 @@ void dogstatsd_client_dtor(dogstatsd_client *client) {
 static dogstatsd_client_status _dogstatsd_client_send(
     dogstatsd_client *client, const char *name, const char *value,
     const char *type, float sample_rate, const char *tags) {
-  if (dogstatsd_client_is_default_client(client)) {
+  if (dogstatsd_client_is_default_client(*client)) {
     return DOGSTATSD_CLIENT_E_NO_CLIENT;
   }
 
@@ -136,7 +114,7 @@ static dogstatsd_client_status _dogstatsd_client_send(
   /* snprintf does not report the null byte in the length, so if it is size or
    * more then it is an error
    */
-  if (((size_t)size) >= client->msg_buffer_len) {
+  if (size >= client->msg_buffer_len) {
     return DOGSTATSD_CLIENT_E_TOO_LONG;
   }
 

--- a/src/dogstatsd/dogstatsd_client/client.h
+++ b/src/dogstatsd/dogstatsd_client/client.h
@@ -56,15 +56,7 @@ typedef enum {
 
 // Creates a client whose operations will fail with E_NO_CLIENT
 inline dogstatsd_client dogstatsd_client_default_ctor() {
-  dogstatsd_client client = {
-      .socket = -1,
-      .address = NULL,
-      .addresslist = NULL,
-      .msg_buffer = NULL,
-      .msg_buffer_len = 0,
-      .const_tags = NULL,
-      .const_tags_len = 0,
-  };
+  dogstatsd_client client = {-1, NULL, NULL, NULL, 0, NULL, 0};
   return client;
 }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -24,6 +24,7 @@
 #include "ddtrace.h"
 #include "debug.h"
 #include "dispatch.h"
+#include "dogstatsd_client.h"
 #include "engine_hooks.h"
 #include "logging.h"
 #include "memory_limit.h"
@@ -115,6 +116,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 
     // config initialization needs to be at the top
     ddtrace_initialize_config(TSRMLS_C);
+    ddtrace_dogstatsd_client_minit(TSRMLS_C);
     ddtrace_signals_minit(TSRMLS_C);
 
     register_span_data_ce(TSRMLS_C);
@@ -169,6 +171,8 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_dogstatsd_client_rinit(TSRMLS_C);
+
     ddtrace_seed_prng(TSRMLS_C);
     ddtrace_init_span_id_stack(TSRMLS_C);
     ddtrace_init_span_stacks(TSRMLS_C);
@@ -193,6 +197,8 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     if (DDTRACE_G(disable)) {
         return SUCCESS;
     }
+
+    ddtrace_dogstatsd_client_rshutdown(TSRMLS_C);
 
     ddtrace_dispatch_destroy(TSRMLS_C);
     ddtrace_free_span_id_stack(TSRMLS_C);

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -1,5 +1,6 @@
 #ifndef DDTRACE_H
 #define DDTRACE_H
+#include <dogstatsd_client/client.h>
 #include <stdint.h>
 
 #include "env_config.h"
@@ -37,6 +38,10 @@ HashTable *class_lookup;
 HashTable *function_lookup;
 zend_bool log_backtrace;
 zend_bool backtrace_handler_already_run;
+dogstatsd_client dogstatsd_client;
+char *dogstatsd_host;
+char *dogstatsd_port;
+char *dogstatsd_buffer;
 ddtrace_original_context original_context;
 
 uint64_t trace_id;

--- a/src/ext/dogstatsd_client.c
+++ b/src/ext/dogstatsd_client.c
@@ -1,0 +1,46 @@
+#include "dogstatsd_client.h"
+
+#include <dogstatsd_client/client.h>
+
+#include "configuration.h"
+#include "ddtrace.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+#define METRICS_CONST_TAGS "lang:php,lang_version:" PHP_VERSION ",tracer_version:" PHP_DDTRACE_VERSION
+
+void ddtrace_dogstatsd_client_minit(TSRMLS_D) { DDTRACE_G(dogstatsd_client) = dogstatsd_client_default_ctor(); }
+
+static void _set_dogstatsd_client_globals(dogstatsd_client client, char *host, char *port, char *buffer TSRMLS_DC) {
+    DDTRACE_G(dogstatsd_client) = client;
+    DDTRACE_G(dogstatsd_host) = host;
+    DDTRACE_G(dogstatsd_port) = port;
+    DDTRACE_G(dogstatsd_buffer) = buffer;
+}
+
+void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
+    BOOL_T health_metrics_enabled = get_dd_trace_heath_metrics_enabled();
+    dogstatsd_client client = dogstatsd_client_default_ctor();
+    char *host = NULL;
+    char *port = NULL;
+    char *buffer = NULL;
+
+    if (health_metrics_enabled) {
+        host = get_dd_agent_host();
+        port = get_dd_dogstatsd_port();
+        buffer = malloc(DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE);
+        size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
+
+        client = dogstatsd_client_ctor(host, port, buffer, len, METRICS_CONST_TAGS);
+    }
+    _set_dogstatsd_client_globals(client, host, port, buffer TSRMLS_CC);
+}
+
+void ddtrace_dogstatsd_client_rshutdown(TSRMLS_D) {
+    dogstatsd_client_dtor(&DDTRACE_G(dogstatsd_client));
+    free(DDTRACE_G(dogstatsd_host));
+    free(DDTRACE_G(dogstatsd_port));
+    free(DDTRACE_G(dogstatsd_buffer));
+
+    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor(), NULL, NULL, NULL TSRMLS_CC);
+}

--- a/src/ext/dogstatsd_client.h
+++ b/src/ext/dogstatsd_client.h
@@ -1,0 +1,10 @@
+#ifndef DDTRACE_DOGSTATSD_CLIENT_H
+#define DDTRACE_DOGSTATSD_CLIENT_H
+
+#include "compatibility.h"
+
+void ddtrace_dogstatsd_client_minit(TSRMLS_D);
+void ddtrace_dogstatsd_client_rinit(TSRMLS_D);
+void ddtrace_dogstatsd_client_rshutdown(TSRMLS_D);
+
+#endif  // DDTRACE_DOGSTATSD_CLIENT_H

--- a/tests/ext/segfault_backtrace_enabled.phpt
+++ b/tests/ext/segfault_backtrace_enabled.phpt
@@ -13,6 +13,7 @@ posix_kill(posix_getpid(), 11); // boom
 
 ?>
 --EXPECTREGEX--
+Segmentation fault
 Datadog PHP Trace extension \(DEBUG MODE\)
 Received Signal 11
 Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime


### PR DESCRIPTION
### Description

This moves the client init to rinit and shutdown to rshutdown. This is in preparation for using the client in more places than only the sigsegv health metric, such as a heartbeat metric or tracking tracing closure exceptions.

It also does some minor cleanup, such as always emitting "Segmentation fault" (it was accidentally only emitting that message if health metrics are enabled) and allowing the caller of the dogstatsd client to control error messages.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
