### PR TITLE
Add gauge, histogram, and generic metric helpers

### DIFF
--- a/src/dogstatsd/CMakeLists.txt
+++ b/src/dogstatsd/CMakeLists.txt
@@ -2,20 +2,20 @@
  We need to be able to set the C version in a standard way, which was not
  added until CMake 3.1 with the C_STANDARD property.
 
- The feature c_std_99 was added to CMake 3.8. The feature is more desriable
+ The feature c_std_99 was added to CMake 3.8. The feature is more desirable
  than C_STANDARD because it's a minimum rather than an exact. This way if a
  compiler prefers a newer version it is free to do so, and most compilers on
  the latest releases do prefer a newer C standard.
 
               Operating System Matrix
  OS      OS_VERSION  OS_CODENAME   CMAKE_VERSION
- Debian              Jessie        3.0.2
- Debian              Stretch       3.7.2
- Debian              Buster        3.13
+ Debian  8           Jessie        3.0.2
+ Debian  9           Stretch       3.7.2
+ Debian  10          Buster        3.13
  CentOS  6                         2.8.12
  CentOS  7                         2.8.12
  CentOS  8                         3.11
- Ubuntu  14.04       Xenial        2.8.12
+ Ubuntu  14.04       Trusty        2.8.12
  Ubuntu  16.04       Xenial        3.5
  Ubuntu  18.04       Bionic        3.10
 

--- a/src/dogstatsd/dogstatsd_client/client.h
+++ b/src/dogstatsd/dogstatsd_client/client.h
@@ -2,6 +2,7 @@
 #define DOGSTATSD_CLIENT_H
 
 #include <netdb.h>
+#include <stdbool.h>
 #include <stddef.h>
 
 /* This describes a simple interface to communicate with dogstatsd. It only
@@ -14,7 +15,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+struct dogstatsd_client {
   int socket;                    // closed on dtor
   struct addrinfo *address;      // freed on dtor as part of addresslist
   struct addrinfo *addresslist;  // freed on dtor
@@ -22,9 +23,10 @@ typedef struct {
   int msg_buffer_len;
   const char *const_tags;  // NOT freed on dtor
   size_t const_tags_len;
-} dogstatsd_client;
+};
+typedef struct dogstatsd_client dogstatsd_client;
 
-typedef enum {
+enum dogstatsd_client_status {
   // This doesn't mean delivered; just that nothing went visibly wrong.
   DOGSTATSD_CLIENT_OK = 0,
 
@@ -34,7 +36,8 @@ typedef enum {
   DOGSTATSD_CLIENT_E_TOO_LONG,
   DOGSTATSD_CLIENT_E_FORMATTING,
   DOGSTATSD_CLIENT_EWRITE,
-} dogstatsd_client_status;
+};
+typedef enum dogstatsd_client_status dogstatsd_client_status;
 
 /* A typical IPv4 header is 20 bytes, but can be up to 60 bytes.
  * The UDP header is 8 bytes.
@@ -54,15 +57,38 @@ typedef enum {
  */
 #define DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE 1024
 
+enum dogstatsd_metric_t {
+  DOGSTATSD_METRIC_COUNT,
+  DOGSTATSD_METRIC_GAUGE,
+  DOGSTATSD_METRIC_HISTOGRAM,
+};
+typedef enum dogstatsd_metric_t dogstatsd_metric_t;
+
+// Returns NULL on bad enum values
+inline const char *dogstatsd_metric_type_to_str(dogstatsd_metric_t type) {
+  switch (type) {
+    case DOGSTATSD_METRIC_COUNT:
+      return "c";
+    case DOGSTATSD_METRIC_GAUGE:
+      return "g";
+    case DOGSTATSD_METRIC_HISTOGRAM:
+      return "h";
+    default:
+      return NULL;
+  }
+}
+
 // Creates a client whose operations will fail with E_NO_CLIENT
 inline dogstatsd_client dogstatsd_client_default_ctor() {
   dogstatsd_client client = {-1, NULL, NULL, NULL, 0, NULL, 0};
   return client;
 }
 
-inline _Bool dogstatsd_client_is_default_client(dogstatsd_client client) {
+inline bool dogstatsd_client_is_default_client(dogstatsd_client client) {
   return client.socket == -1;
 }
+
+void dogstatsd_client_dtor(dogstatsd_client *client);
 
 /* Wrapper around getaddrinfo to connect using UDP.
  * Returns the result of getaddrinfo.
@@ -74,13 +100,36 @@ int dogstatsd_client_getaddrinfo(struct addrinfo **result, const char *host,
 dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
                                        int buffer_len, const char *const_tags);
 
-// Uses sample_rate of 1.0
-dogstatsd_client_status dogstatsd_client_count(dogstatsd_client *client,
-                                               const char *metric,
-                                               const char *value,
-                                               const char *tags);
+/* Most generic way to send a metric. If the input is malformed the metric will
+ * not be sent, and an error code will be returned.
+ * The sample_rate must be between 0.0 and 1.0 inclusive.
+ */
+dogstatsd_client_status dogstatsd_client_metric_send(
+    dogstatsd_client *client, const char *metric, const char *value,
+    dogstatsd_metric_t type, double sample_rate, const char *tags);
 
-void dogstatsd_client_dtor(dogstatsd_client *client);
+inline dogstatsd_client_status dogstatsd_client_count(dogstatsd_client *client,
+                                                      const char *metric,
+                                                      const char *value,
+                                                      const char *tags) {
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
+  return dogstatsd_client_metric_send(client, metric, value, type, 1.0, tags);
+}
+
+inline dogstatsd_client_status dogstatsd_client_gauge(dogstatsd_client *client,
+                                                      const char *metric,
+                                                      const char *value,
+                                                      const char *tags) {
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_GAUGE;
+  return dogstatsd_client_metric_send(client, metric, value, type, 1.0, tags);
+}
+
+inline dogstatsd_client_status dogstatsd_client_histogram(
+    dogstatsd_client *client, const char *metric, const char *value,
+    const char *tags) {
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_HISTOGRAM;
+  return dogstatsd_client_metric_send(client, metric, value, type, 1.0, tags);
+}
 
 #if __cplusplus
 }

--- a/src/dogstatsd/test/client.cc
+++ b/src/dogstatsd/test/client.cc
@@ -1,6 +1,7 @@
 #include <dogstatsd_client/client.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
 #include <catch2/catch.hpp>
 #include <thread>
 
@@ -55,7 +56,10 @@ void dogstatsd_server_listen(dogstatsd_server *server, dogstatsd_client *client,
   free(buffer);
 }
 
-void _test_tags(const char *tags, const char *const_tags, const char *expect) {
+template <class Method>
+static void _test_method(const char *expect, const char *metric,
+                         const char *value, const char *tags,
+                         const char *const_tags, Method method) {
   dogstatsd_server server = dogstatsd_server_make();
 
   char buf[DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE];
@@ -74,8 +78,7 @@ void _test_tags(const char *tags, const char *const_tags, const char *expect) {
   // start a thread for the server
   std::thread server_thread{dogstatsd_server_listen, &server, &client, expect};
 
-  dogstatsd_client_status status =
-      dogstatsd_client_count(&client, "metric.hello", "1", tags);
+  dogstatsd_client_status status = method(&client, metric, value, tags);
   REQUIRE(status == DOGSTATSD_CLIENT_OK);
 
   server_thread.join();
@@ -83,22 +86,114 @@ void _test_tags(const char *tags, const char *const_tags, const char *expect) {
   dogstatsd_client_dtor(&client);
 }
 
-TEST_CASE("count with no tags, no const_tags", "[dogstatsd_client]") {
-  _test_tags(nullptr, nullptr, "metric.hello:1|c|@1.000000");
+void _test_count(const char *expect, const char *metric, const char *value,
+                 const char *tags, const char *const_tags) {
+  _test_method(expect, metric, value, tags, const_tags,
+               [](dogstatsd_client *client, const char *metric,
+                  const char *value, const char *tags) {
+                 return dogstatsd_client_count(client, metric, value, tags);
+               });
 }
 
-TEST_CASE("count with no tags, with const_tags", "[dogstatsd_client]") {
-  _test_tags(nullptr, "lang:c", "metric.hello:1|c|@1.000000|#lang:c");
+void _test_gauge(const char *expect, const char *metric, const char *value,
+                 const char *tags, const char *const_tags) {
+  _test_method(expect, metric, value, tags, const_tags,
+               [](dogstatsd_client *client, const char *metric,
+                  const char *value, const char *tags) {
+                 return dogstatsd_client_gauge(client, metric, value, tags);
+               });
 }
 
-TEST_CASE("count with with tags, no const_tags", "[dogstatsd_client]") {
-  _test_tags("lang:c", nullptr, "metric.hello:1|c|@1.000000|#lang:c");
+void _test_histogram(const char *expect, const char *metric, const char *value,
+                     const char *tags, const char *const_tags) {
+  _test_method(expect, metric, value, tags, const_tags,
+               [](dogstatsd_client *client, const char *metric,
+                  const char *value, const char *tags) {
+                 return dogstatsd_client_histogram(client, metric, value, tags);
+               });
 }
 
-TEST_CASE("count with with tags, with const_tags", "[dogstatsd_client]") {
-  _test_tags("lang:c", "hello:world",
-             "metric.hello:1|c|@1.000000|#lang:c,hello:world");
+void _test_metric(const char *expect, const char *metric, const char *value,
+                  dogstatsd_metric_t type, double sample_rate, const char *tags,
+                  const char *const_tags) {
+  auto closure = [type, sample_rate](dogstatsd_client *client,
+                                     const char *metric, const char *value,
+                                     const char *tags) {
+    return dogstatsd_client_metric_send(client, metric, value, type,
+                                        sample_rate, tags);
+  };
+  _test_method(expect, metric, value, tags, const_tags, closure);
+}
+
+TEST_CASE("count -tags -const_tags", "[dogstatsd_client]") {
+  const char *expect = "page.views:1|c|@1.000000";
+  const char *metric = "page.views";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
+
+  _test_count(expect, metric, "1", nullptr, nullptr);
+  _test_metric(expect, metric, "1", type, 1.0, nullptr, nullptr);
+}
+
+TEST_CASE("count -tags +const_tags", "[dogstatsd_client]") {
+  const char *expect = "page.views:1|c|@1.000000|#hello:world";
+  const char *metric = "page.views";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
+  const char *const_tags = "hello:world";
+
+  _test_count(expect, metric, "1", nullptr, const_tags);
+  _test_metric(expect, metric, "1", type, 1.0, nullptr, const_tags);
+}
+
+TEST_CASE("count +tags -const_tags", "[dogstatsd_client]") {
+  const char *expect = "page.views:1|c|@1.000000|#lang:c";
+  const char *metric = "page.views";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
+  const char *tags = "lang:c";
+
+  _test_count(expect, metric, "1", tags, nullptr);
+  _test_metric(expect, metric, "1", type, 1.0, tags, nullptr);
+}
+
+TEST_CASE("count +tags +const_tags", "[dogstatsd_client]") {
+  const char *expect = "page.views:1|c|@1.000000|#lang:c,hello:world";
+  const char *metric = "page.views";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
+  const char *tags = "lang:c";
+  const char *const_tags = "hello:world";
+
+  _test_count(expect, metric, "1", tags, const_tags);
+  _test_metric(expect, metric, "1", type, 1.0, tags, const_tags);
+}
+
+TEST_CASE("gauge +tags +const_tags", "[dogstatsd_client]") {
+  const char *expect = "fuel.level:0.5|g|@1.000000|#lang:c,hello:world";
+  const char *metric = "fuel.level";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_GAUGE;
+  const char *tags = "lang:c";
+  const char *const_tags = "hello:world";
+
+  _test_gauge(expect, metric, "0.5", tags, const_tags);
+  _test_metric(expect, metric, "0.5", type, 1.0, tags, const_tags);
+}
+
+TEST_CASE("histogram +tags +const_tags", "[dogstatsd_client]") {
+  const char *expect = "song.length:240|h|@1.000000|#lang:c,hello:world";
+  const char *metric = "song.length";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_HISTOGRAM;
+  const char *tags = "lang:c";
+  const char *const_tags = "hello:world";
+
+  _test_histogram(expect, metric, "240", tags, const_tags);
+  _test_metric(expect, metric, "240", type, 1.0, tags, const_tags);
+}
+
+TEST_CASE("sample_rate -tags -const_tags", "[dogstatsd_client]") {
+  const char *expect = "song.length:240|h|@0.500000";
+  const char *metric = "song.length";
+  dogstatsd_metric_t type = DOGSTATSD_METRIC_HISTOGRAM;
+  _test_metric(expect, metric, "240", type, 0.5, nullptr, nullptr);
 }
 
 // todo: test sending message that's too large
 // todo: test configuring client with lens of 0 and < 0.
+// todo: test an out of range sample rate returns DOGSTATSD_CLIENT_E_VALUE


### PR DESCRIPTION
### Description

This adds support for gauges, histograms, and the ability to send metrics in a generic way. This also completely revamps the tests and fixes some C++ incompatibilities that I accidentally introduced recently.

At this point, the new features aren't used in the tracer anywhere yet because I'm still trying to figure out the best way to do that. I anticipate usage like:

```c
const char *metric = "datadog.tracer.heartbeat";
dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
dogstatsd_client_metric_send(&client, metric, "1", type, 0.01, NULL);
```

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
