### PR TITLE
Sandbox tracer flushing

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -165,6 +165,7 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
+                        <file name="fatal_errors_ignored_in_shutdown.phpt" role="test" />
                         <file name="get_last_error.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_internal_functions.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_internal_methods.phpt" role="test" />

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -558,6 +558,12 @@ static void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *
         keep_span = ddtrace_execute_tracing_closure(&dispatch->callable, span->span_data, execute_data, user_args,
                                                     user_retval, exception TSRMLS_CC);
 
+        if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+            const char *fname = Z_STRVAL(dispatch->function_name);
+            ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname,
+                             PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
+        }
+
         ddtrace_restore_error_handling(&eh TSRMLS_CC);
         // If the tracing closure threw an exception, ignore it to not impact the original call
         if (EG(exception)) {

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -256,6 +256,12 @@ static void _end_span(ddtrace_span_t *span, zval *user_retval) {
         keep_span = ddtrace_execute_tracing_closure(&dispatch->callable, span->span_data, call, &user_args, user_retval,
                                                     exception);
 
+        if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+            const char *fname = Z_STRVAL(dispatch->function_name);
+            ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname,
+                             PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
+        }
+
         ddtrace_restore_error_handling(&eh);
         // If the tracing closure threw an exception, ignore it to not impact the original call
         if (EG(exception)) {

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -18,87 +18,36 @@ class Test
     }
 }
 
-var_dump(dd_trace_method('Test', 'testFoo', function (SpanData $span) {
+dd_trace_method('Test', 'testFoo', function (SpanData $span) {
     $span->name = 'TestFoo';
     $span->service = $this_normally_raises_a_notice;
-}));
+});
 
-var_dump(dd_trace_function('mt_srand', function (SpanData $span) {
+dd_trace_function('mt_srand', function (SpanData $span) {
     $span->name = 'MTSeed';
     throw new Exception('This should be ignored');
-}));
+});
 
-var_dump(dd_trace_function('mt_rand', function (SpanData $span) {
+dd_trace_function('mt_rand', function (SpanData $span) {
     $span->name = 'MTRand';
     // TODO: Ignore fatals like this on PHP 5
     if (PHP_VERSION_ID >= 70000) {
         this_function_does_not_exist();
         //$foo = new ThisClassDoesNotExist();
     }
-}));
+});
 
 $test = new Test();
 $test->testFoo();
 
-echo "---\n";
-
-var_dump(dd_trace_serialize_closed_spans());
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
 var_dump(error_get_last());
 ?>
 --EXPECTF--
-bool(true)
-bool(true)
-bool(true)
 Test::testFoo() fav num: %d
----
-array(3) {
-  [0]=>
-  array(6) {
-    ["trace_id"]=>
-    int(%d)
-    ["span_id"]=>
-    int(%d)
-    ["start"]=>
-    int(%d)
-    ["duration"]=>
-    int(%d)
-    ["name"]=>
-    string(7) "TestFoo"
-    ["meta"]=>
-    array(1) {
-      ["system.pid"]=>
-      int(%d)
-    }
-  }
-  [1]=>
-  array(6) {
-    ["trace_id"]=>
-    int(%d)
-    ["span_id"]=>
-    int(%d)
-    ["parent_id"]=>
-    int(%d)
-    ["start"]=>
-    int(%d)
-    ["duration"]=>
-    int(%d)
-    ["name"]=>
-    string(6) "MTRand"
-  }
-  [2]=>
-  array(6) {
-    ["trace_id"]=>
-    int(%d)
-    ["span_id"]=>
-    int(%d)
-    ["parent_id"]=>
-    int(%d)
-    ["start"]=>
-    int(%d)
-    ["duration"]=>
-    int(%d)
-    ["name"]=>
-    string(6) "MTSeed"
-  }
-}
+TestFoo
+MTRand
+MTSeed
 NULL

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Fatal errors are ignored in shutdown handler
+--DESCRIPTION--
+This is how the tracer sandboxes the flushing functionality in userland
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+memory_limit=2M
+--FILE--
+<?php
+function flushTracer() {
+    // Flushing happens in sandboxed tracing closure after the call.
+    // Return a value from runtime to prevent Opcache from skipping the call.
+    return mt_rand();
+}
+
+register_shutdown_function(function () {
+    // Fatal errors will cause the same behavior as an "exit" (zend_bailout)
+    // which prevents the rest of the shutdown handlers from being run.
+    // We register the shutdown handler during shutdown to ensure this one is
+    // the last one to run.
+    // This will ensure that:
+    // 1) Code in shutdown hooks can be instrumented
+    // 2) If a fatal error occurs during flush, it will not affect the user's shutdown hooks
+    register_shutdown_function(function () {
+        // We wrap the call in a closure to prevent Opcache from skipping the call.
+        flushTracer();
+    });
+});
+
+register_shutdown_function(function () {
+    echo 'Some user\'s shutdown' . PHP_EOL;
+    var_dump(array_sum([10, 10, 10]));
+    var_dump(error_get_last());
+});
+
+dd_trace_function('flushTracer', function () {
+    echo 'Flushing...' . PHP_EOL;
+    array_map(function($span) {
+        echo $span['name'] . PHP_EOL;
+    }, dd_trace_serialize_closed_spans());
+    // Trigger a fatal error (hit the memory limit)
+    $a = str_repeat('.', 1024 * 1024 * 3); // 3MB
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+dd_trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum';
+});
+
+var_dump(array_sum([1, 2, 3]));
+var_dump(array_sum([4, 5, 6]));
+var_dump(array_sum([7, 8, 9]));
+?>
+--EXPECT--
+int(6)
+int(15)
+int(24)
+Some user's shutdown
+int(30)
+NULL
+Flushing...
+array_sum
+array_sum
+array_sum
+array_sum

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -4,8 +4,11 @@ Fatal errors are ignored in shutdown handler
 This is how the tracer sandboxes the flushing functionality in userland
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
 --INI--
 memory_limit=2M
+--ENV--
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 function flushTracer() {
@@ -42,6 +45,7 @@ dd_trace_function('flushTracer', function () {
     // Trigger a fatal error (hit the memory limit)
     $a = str_repeat('.', 1024 * 1024 * 3); // 3MB
     echo 'You should not see this.' . PHP_EOL;
+    var_dump(error_get_last());
 });
 
 dd_trace_function('array_sum', function (DDTrace\SpanData $span) {


### PR DESCRIPTION
### Description

This PR ensures that the tracer flushing is sandboxed and also attempts to push the flushing to the end of all of the user shutdown handlers.

There's also a bonus update that exposes errors raised in tracing closures when `DD_TRACE_DEBUG=1`.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
