### PR TITLE
Add test to hit memory limit in a shutdown hook

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -173,6 +173,7 @@
                         <file name="keep_spans_in_limited_tracing_internal_methods.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_userland_functions.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
+                        <file name="memory_limit_graceful_bailout.phpt" role="test" />
                         <file name="new_static.phpt" role="test" />
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -1,0 +1,33 @@
+--TEST--
+The tracer bails out gracefully when memory_limit INI is reached in shutdown hook
+--DESCRIPTION--
+This test ensures that when the span stack is left in a "dirty" state from a zend_bailout() while serializing, they will be cleaned up properly in RSHUTDOWN.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
+--INI--
+memory_limit=2M
+--FILE--
+<?php
+register_shutdown_function(function () {
+    dd_trace_serialize_closed_spans();
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+dd_trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum' . str_repeat('.', 500);
+    $span->resource = 'array_sum' . str_repeat('-', 500);
+    $span->service = 'php';
+    $span->type = 'web';
+});
+
+for ($i = 0; $i < 900; $i++) {
+    array_sum([]);
+}
+
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+Done
+
+PHP Fatal error:  Allowed memory size of 2097152 bytes exhausted %s (tried to allocate %d bytes) in %s on line %d


### PR DESCRIPTION
### Description

There is an edge case where the span stack can be left in a "dirty" state when a `zend_bailout()` occurs while serializing the spans. Now that #689 is merged, the stack is cleaned up properly in RSHUTDOWN. This PR just adds a test to hit that specific edge case.