### PR TITLE
Add heartbeat health metric

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,7 @@ services:
     environment:
     - DD_API_KEY=${DATADOG_API_KEY}
     - DD_APM_ENABLED=true
+    - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
 
   apache_56_server:
     build:

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -11,6 +11,8 @@
 extern inline dogstatsd_client dogstatsd_client_default_ctor();
 extern inline bool dogstatsd_client_is_default_client(dogstatsd_client client);
 extern inline const char *dogstatsd_metric_type_to_str(dogstatsd_metric_t type);
+extern inline const char *dogstatsd_client_status_to_str(
+    dogstatsd_client_status status);
 
 extern inline dogstatsd_client_status dogstatsd_client_count(
     dogstatsd_client *client, const char *metric, const char *value,

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -118,10 +118,22 @@ dogstatsd_client_status dogstatsd_client_metric_send(
   const char *tags_prefix = (tags_len + const_tags_len > 0) ? "|#" : "";
   const char *tags_separator = (tags_len > 0 && const_tags_len > 0) ? "," : "";
 
-  const char *format = "%s:%s|%s|@%.6f%s%s%s%s";
-  int size = snprintf(client->msg_buffer, client->msg_buffer_len, format, name,
-                      value, typestr, sample_rate, tags_prefix, tags,
-                      tags_separator, client->const_tags);
+  const char *format;
+  int size;
+  /* Omit the sample rate iff it is 1.0; a sample rate of 1.000000 causes issues
+   * for the agent, for some reason
+   */
+  if (sample_rate != 1.0) {
+    format = "%s:%s|%s|@%.6f%s%s%s%s";
+    size = snprintf(client->msg_buffer, client->msg_buffer_len, format, name,
+                    value, typestr, sample_rate, tags_prefix, tags,
+                    tags_separator, client->const_tags);
+  } else {
+    format = "%s:%s|%s%s%s%s%s";
+    size = snprintf(client->msg_buffer, client->msg_buffer_len, format, name,
+                    value, typestr, tags_prefix, tags, tags_separator,
+                    client->const_tags);
+  }
 
   if (size < 0) {
     return DOGSTATSD_CLIENT_E_FORMATTING;

--- a/src/dogstatsd/dogstatsd_client/client.h
+++ b/src/dogstatsd/dogstatsd_client/client.h
@@ -39,6 +39,26 @@ enum dogstatsd_client_status {
 };
 typedef enum dogstatsd_client_status dogstatsd_client_status;
 
+inline const char *dogstatsd_client_status_to_str(
+    dogstatsd_client_status status) {
+  switch (status) {
+    case DOGSTATSD_CLIENT_OK:
+      return "OK";
+    case DOGSTATSD_CLIENT_E_NO_CLIENT:
+      return "E_NO_CLIENT";
+    case DOGSTATSD_CLIENT_E_VALUE:
+      return "E_VALUE";
+    case DOGSTATSD_CLIENT_E_TOO_LONG:
+      return "E_TOO_LONG";
+    case DOGSTATSD_CLIENT_E_FORMATTING:
+      return "E_FORMATTING";
+    case DOGSTATSD_CLIENT_EWRITE:
+      return "E_WRITE";
+    default:
+      return NULL;
+  }
+}
+
 /* A typical IPv4 header is 20 bytes, but can be up to 60 bytes.
  * The UDP header is 8 bytes.
  * The minimum maximum reassembly buffer size required by RFC 1122 is 576.

--- a/src/dogstatsd/test/client.cc
+++ b/src/dogstatsd/test/client.cc
@@ -126,7 +126,7 @@ void _test_metric(const char *expect, const char *metric, const char *value,
 }
 
 TEST_CASE("count -tags -const_tags", "[dogstatsd_client]") {
-  const char *expect = "page.views:1|c|@1.000000";
+  const char *expect = "page.views:1|c";
   const char *metric = "page.views";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
 
@@ -135,7 +135,7 @@ TEST_CASE("count -tags -const_tags", "[dogstatsd_client]") {
 }
 
 TEST_CASE("count -tags +const_tags", "[dogstatsd_client]") {
-  const char *expect = "page.views:1|c|@1.000000|#hello:world";
+  const char *expect = "page.views:1|c|#hello:world";
   const char *metric = "page.views";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
   const char *const_tags = "hello:world";
@@ -145,7 +145,7 @@ TEST_CASE("count -tags +const_tags", "[dogstatsd_client]") {
 }
 
 TEST_CASE("count +tags -const_tags", "[dogstatsd_client]") {
-  const char *expect = "page.views:1|c|@1.000000|#lang:c";
+  const char *expect = "page.views:1|c|#lang:c";
   const char *metric = "page.views";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
   const char *tags = "lang:c";
@@ -155,7 +155,7 @@ TEST_CASE("count +tags -const_tags", "[dogstatsd_client]") {
 }
 
 TEST_CASE("count +tags +const_tags", "[dogstatsd_client]") {
-  const char *expect = "page.views:1|c|@1.000000|#lang:c,hello:world";
+  const char *expect = "page.views:1|c|#lang:c,hello:world";
   const char *metric = "page.views";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_COUNT;
   const char *tags = "lang:c";
@@ -166,7 +166,7 @@ TEST_CASE("count +tags +const_tags", "[dogstatsd_client]") {
 }
 
 TEST_CASE("gauge +tags +const_tags", "[dogstatsd_client]") {
-  const char *expect = "fuel.level:0.5|g|@1.000000|#lang:c,hello:world";
+  const char *expect = "fuel.level:0.5|g|#lang:c,hello:world";
   const char *metric = "fuel.level";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_GAUGE;
   const char *tags = "lang:c";
@@ -177,7 +177,7 @@ TEST_CASE("gauge +tags +const_tags", "[dogstatsd_client]") {
 }
 
 TEST_CASE("histogram +tags +const_tags", "[dogstatsd_client]") {
-  const char *expect = "song.length:240|h|@1.000000|#lang:c,hello:world";
+  const char *expect = "song.length:240|h|#lang:c,hello:world";
   const char *metric = "song.length";
   dogstatsd_metric_t type = DOGSTATSD_METRIC_HISTOGRAM;
   const char *tags = "lang:c";

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -8,10 +8,12 @@ struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {
 #define CHAR(...) NULL, FALSE,
 #define BOOL(...) FALSE, FALSE,
 #define INT(...) 0, FALSE,
+#define DOUBLE(...) 0.0, FALSE,
     DD_CONFIGURATION
 #undef CHAR
 #undef BOOL
 #undef INT
+#undef DOUBLE
         PTHREAD_MUTEX_INITIALIZER};
 
 void ddtrace_reload_config(TSRMLS_D) {
@@ -20,14 +22,16 @@ void ddtrace_reload_config(TSRMLS_D) {
         free(ddtrace_memoized_configuration.getter_name); \
     }                                                     \
     ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;
-#define INT(getter_name, ...) ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;
 #define BOOL(getter_name, ...) ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;
+#define INT(getter_name, ...) ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;
+#define DOUBLE(getter_name, ...) ddtrace_memoized_configuration.__is_set_##getter_name = FALSE;
 
     DD_CONFIGURATION
 
 #undef CHAR
-#undef INT
 #undef BOOL
+#undef INT
+#undef DOUBLE
     // repopulate config
     ddtrace_initialize_config(TSRMLS_C);
 }
@@ -44,13 +48,6 @@ void ddtrace_initialize_config(TSRMLS_D) {
         ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;              \
         pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);               \
     } while (0);
-#define INT(getter_name, env_name, default, ...)                                                          \
-    do {                                                                                                  \
-        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                        \
-        ddtrace_memoized_configuration.getter_name = ddtrace_get_int_config(env_name, default TSRMLS_CC); \
-        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                     \
-        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                      \
-    } while (0);
 #define BOOL(getter_name, env_name, default, ...)                                                          \
     do {                                                                                                   \
         pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                         \
@@ -58,12 +55,27 @@ void ddtrace_initialize_config(TSRMLS_D) {
         ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                      \
         pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                       \
     } while (0);
+#define INT(getter_name, env_name, default, ...)                                                          \
+    do {                                                                                                  \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                        \
+        ddtrace_memoized_configuration.getter_name = ddtrace_get_int_config(env_name, default TSRMLS_CC); \
+        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                     \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                      \
+    } while (0);
+#define DOUBLE(getter_name, env_name, default, ...)                                                          \
+    do {                                                                                                     \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);                                           \
+        ddtrace_memoized_configuration.getter_name = ddtrace_get_double_config(env_name, default TSRMLS_CC); \
+        ddtrace_memoized_configuration.__is_set_##getter_name = TRUE;                                        \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);                                         \
+    } while (0);
 
     DD_CONFIGURATION
 
 #undef CHAR
-#undef INT
 #undef BOOL
+#undef INT
+#undef DOUBLE
 }
 
 void ddtrace_config_shutdown(void) {
@@ -80,13 +92,19 @@ void ddtrace_config_shutdown(void) {
         ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
         pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
     } while (0);
+#define BOOL(getter_name, env_name, default, ...)                      \
+    do {                                                               \
+        pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
+        ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
+        pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
+    } while (0);
 #define INT(getter_name, env_name, default, ...)                       \
     do {                                                               \
         pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
         ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
         pthread_mutex_unlock(&ddtrace_memoized_configuration.mutex);   \
     } while (0);
-#define BOOL(getter_name, env_name, default, ...)                      \
+#define DOUBLE(getter_name, env_name, default, ...)                    \
     do {                                                               \
         pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);     \
         ddtrace_memoized_configuration.__is_set_##getter_name = FALSE; \
@@ -96,6 +114,7 @@ void ddtrace_config_shutdown(void) {
     DD_CONFIGURATION
 
 #undef CHAR
-#undef INT
 #undef BOOL
+#undef INT
+#undef DOUBLE
 }

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -10,27 +10,27 @@ void ddtrace_initialize_config(TSRMLS_D);
 void ddtrace_reload_config(TSRMLS_D);
 void ddtrace_config_shutdown(void);
 
-#define DD_CONFIGURATION                                                                                  \
-    CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                 \
-    CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                              \
-    INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                             \
-    BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", FALSE)                                                     \
-    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)               \
-    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                             \
-    BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", FALSE)                    \
-    CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                        \
-    INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                         \
-    INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)           \
-    INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", 500)                                        \
-    INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", 100)                        \
-    INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                     \
-    BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", FALSE)                                                 \
-    INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                 \
-    INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                           \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", FALSE,              \
-         "use background thread to send traces to the agent")                                             \
-    INT(get_dd_trace_beta_high_memory_pressure_percent, "DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT", 80, \
-        "reaching this percent threshold of a span buffer will trigger background thread "                \
+#define DD_CONFIGURATION                                                                                             \
+    CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
+    CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
+    INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
+    BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", FALSE)                                                                \
+    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
+    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \
+    BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", FALSE)                               \
+    CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                                   \
+    INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
+    INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \
+    INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", 500)                                                   \
+    INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", 100)                                   \
+    INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
+    BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", FALSE)                                                            \
+    INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                            \
+    INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
+    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", FALSE,                         \
+         "use background thread to send traces to the agent")                                                        \
+    INT(get_dd_trace_beta_high_memory_pressure_percent, "DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT", 80,            \
+        "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")
 
 // render all configuration getters and define memoization struct

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -18,6 +18,7 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
     BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \
     BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", FALSE)                               \
+    DOUBLE(get_dd_trace_heath_metrics_heartbeat_sample_rate, "DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE", 0.001) \
     CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                                   \
     INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
     INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \

--- a/src/ext/configuration_php_iface.c
+++ b/src/ext/configuration_php_iface.c
@@ -110,6 +110,14 @@ BOOL_T get_configuration(zval *return_value, char *env_name, size_t env_name_len
         }                                                    \
     } while (0);
 
+#define DOUBLE(getter, env, ...)                             \
+    do {                                                     \
+        if (ENV_NAME_MATCHES(env, env_name, env_name_len)) { \
+            RETVAL_DOUBLE(getter());                         \
+            return TRUE;                                     \
+        }                                                    \
+    } while (0);
+
     DD_CONFIGURATION
 
     // did not match any configuration getter

--- a/src/ext/configuration_render.h
+++ b/src/ext/configuration_render.h
@@ -1,5 +1,5 @@
-#ifndef DD_CONFIGURATION_REDER_H
-#define DD_CONFIGURATION_REDER_H
+#ifndef DD_CONFIGURATION_RENDER_H
+#define DD_CONFIGURATION_RENDER_H
 #include <pthread.h>
 #include <string.h>
 
@@ -12,20 +12,24 @@ struct ddtrace_memoized_configuration_t {
 #define CHAR(getter_name, env_name, default, ...) \
     char* getter_name;                            \
     BOOL_T __is_set_##getter_name;
-#define INT(getter_name, env_name, default, ...) \
-    int64_t getter_name;                         \
-    BOOL_T __is_set_##getter_name;
 #define BOOL(getter_name, env_name, default, ...) \
     BOOL_T getter_name;                           \
     BOOL_T __is_set_##getter_name;
+#define INT(getter_name, env_name, default, ...) \
+    int64_t getter_name;                         \
+    BOOL_T __is_set_##getter_name;
+#define DOUBLE(getter_name, env_name, default, ...) \
+    double getter_name;                             \
+    double __is_set_##getter_name;
 
     // render configuration struct
     DD_CONFIGURATION
 
 // cleanup macros
 #undef CHAR
-#undef INT
 #undef BOOL
+#undef INT
+#undef DOUBLE
     // configuration mutex
     pthread_mutex_t mutex;
 };
@@ -51,15 +55,6 @@ struct ddtrace_memoized_configuration_t {
         }                                                                              \
     }
 
-#define INT(getter_name, env_name, default, ...)                     \
-    inline static int64_t getter_name() {                            \
-        if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
-            return ddtrace_memoized_configuration.getter_name;       \
-        } else {                                                     \
-            return default;                                          \
-        }                                                            \
-    }
-
 #define BOOL(getter_name, env_name, default, ...)                    \
     inline static BOOL_T getter_name() {                             \
         if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
@@ -69,12 +64,31 @@ struct ddtrace_memoized_configuration_t {
         }                                                            \
     }
 
+#define INT(getter_name, env_name, default, ...)                     \
+    inline static int64_t getter_name() {                            \
+        if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
+            return ddtrace_memoized_configuration.getter_name;       \
+        } else {                                                     \
+            return default;                                          \
+        }                                                            \
+    }
+
+#define DOUBLE(getter_name, env_name, default, ...)                  \
+    inline static double getter_name() {                             \
+        if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
+            return ddtrace_memoized_configuration.getter_name;       \
+        } else {                                                     \
+            return default;                                          \
+        }                                                            \
+    }
+
 // render configuration getters
 DD_CONFIGURATION
 
 // cleanup configuration getter macros
 #undef CHAR
-#undef INT
 #undef BOOL
+#undef INT
+#undef DOUBLE
 
-#endif  // DD_CONFIGURATION_REDER_H
+#endif  // DD_CONFIGURATION_RENDER_H

--- a/src/ext/dogstatsd_client.c
+++ b/src/ext/dogstatsd_client.c
@@ -26,7 +26,7 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
     char *port = NULL;
     char *buffer = NULL;
 
-    if (health_metrics_enabled) {
+    while (health_metrics_enabled) {
         host = get_dd_agent_host();
         port = get_dd_dogstatsd_port();
         buffer = malloc(DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE);
@@ -37,12 +37,24 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
         if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
             ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
                                (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-        } else {
-            client = dogstatsd_client_ctor(addrs, buffer, len, METRICS_CONST_TAGS);
-            if (dogstatsd_client_is_default_client(client)) {
-                ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
-            }
+            break;
         }
+
+        client = dogstatsd_client_ctor(addrs, buffer, len, METRICS_CONST_TAGS);
+        if (dogstatsd_client_is_default_client(client)) {
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
+            break;
+        }
+
+        double sample_rate = get_dd_trace_heath_metrics_heartbeat_sample_rate();
+        const char *metric = "datadog.tracer.heartbeat";
+        dogstatsd_metric_t type = DOGSTATSD_METRIC_GAUGE;
+        dogstatsd_client_status status = dogstatsd_client_metric_send(&client, metric, "1", type, sample_rate, NULL);
+        if (status != DOGSTATSD_CLIENT_OK) {
+            const char *status_str = dogstatsd_client_status_to_str(status) ?: "(unknown dogstatsd_client_status)";
+            ddtrace_log_debugf("Health metric 'datadog.tracer.heartbeat' failed to send: %s", status_str);
+        }
+        break;
     }
     _set_dogstatsd_client_globals(client, host, port, buffer TSRMLS_CC);
 }

--- a/src/ext/dogstatsd_client.c
+++ b/src/ext/dogstatsd_client.c
@@ -50,9 +50,9 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
         const char *metric = "datadog.tracer.heartbeat";
         dogstatsd_metric_t type = DOGSTATSD_METRIC_GAUGE;
         dogstatsd_client_status status = dogstatsd_client_metric_send(&client, metric, "1", type, sample_rate, NULL);
-        if (status != DOGSTATSD_CLIENT_OK) {
+        if (status != DOGSTATSD_CLIENT_OK && get_dd_trace_debug()) {
             const char *status_str = dogstatsd_client_status_to_str(status) ?: "(unknown dogstatsd_client_status)";
-            ddtrace_log_debugf("Health metric 'datadog.tracer.heartbeat' failed to send: %s", status_str);
+            ddtrace_log_errf("Health metric '%s' failed to send: %s", metric, status_str);
         }
         break;
     }

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -92,6 +92,36 @@ uint32_t ddtrace_get_uint32_config(char *name, uint32_t def TSRMLS_DC) {
     return value;
 }
 
+double ddtrace_get_double_config(char *name, double def TSRMLS_DC) {
+    char *env = get_local_env_or_sapi_env(name TSRMLS_CC);
+    if (!env) {
+        return def;
+    }
+
+    char *endptr = env;
+
+    // The strtod function is a bit tricky, so I've quoted docs to explain code
+
+    /* Since 0 can legitimately be returned on both success and failure, the
+     * calling program should set errno to 0 before the call, and then
+     * determine if an error occurred by checking whether errno has a nonzero
+     * value after the call.
+     */
+    errno = 0;
+    double result = strtod(env, &endptr);
+
+    /* If endptr is not NULL, a pointer to the character after the last
+     * character used in the conversion is stored in the location referenced
+     * by endptr. If no conversion is performed, zero is returned and the value
+     * of nptr is stored in the location referenced by endptr.
+     */
+    int conversion_performed = endptr != env;
+
+    free(env);
+
+    return conversion_performed && errno == 0 ? result : def;
+}
+
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC) {
     char *env = get_local_env_or_sapi_env(name TSRMLS_CC);
     if (!env) {

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -115,11 +115,11 @@ double ddtrace_get_double_config(char *name, double def TSRMLS_DC) {
      * by endptr. If no conversion is performed, zero is returned and the value
      * of nptr is stored in the location referenced by endptr.
      */
-    int conversion_performed = endptr != env;
+    int conversion_performed = endptr != env && errno == 0;
 
     free(env);
 
-    return conversion_performed && errno == 0 ? result : def;
+    return conversion_performed ? result : def;
 }
 
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC) {

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -12,6 +12,7 @@ BOOL_T ddtrace_get_bool_config(char *name, BOOL_T def TSRMLS_DC);
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC);
 int64_t ddtrace_get_int_config(char *name, int64_t def TSRMLS_DC);
 uint32_t ddtrace_get_uint32_config(char *name, uint32_t def TSRMLS_DC);
+double ddtrace_get_double_config(char *name, double def TSRMLS_DC);
 char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRMLS_DC);
 char *ddtrace_strdup(const char *c);
 


### PR DESCRIPTION
### Description

This adds a gauge metric to each request called `datadog.tracer.heartbeat` with a default sample rate of 0.1%. The sample rate can be controlled via the `DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE` environment variable.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
