### PR TITLE
Set global tags in internal spans

### DIFF
--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -389,6 +389,9 @@ final class Tracer implements TracerInterface
         if ($globalTags) {
             foreach ($internalSpans as &$internalSpan) {
                 foreach ($globalTags as $globalTagName => $globalTagValue) {
+                    if (isset($internalSpan['meta'][$globalTagName])) {
+                        continue;
+                    }
                     $internalSpan['meta'][$globalTagName] = $globalTagValue;
                 }
             }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -384,7 +384,7 @@ final class Tracer implements TracerInterface
 
         $internalSpans = dd_trace_serialize_closed_spans();
 
-        // Setting global tags on internal tags, if any
+        // Setting global tags on internal spans, if any
         $globalTags = $this->globalConfig->getGlobalTags();
         if ($globalTags) {
             foreach ($internalSpans as &$internalSpan) {

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -383,6 +383,17 @@ final class Tracer implements TracerInterface
         }
 
         $internalSpans = dd_trace_serialize_closed_spans();
+
+        // Setting global tags on internal tags, if any
+        $globalTags = $this->globalConfig->getGlobalTags();
+        if ($globalTags) {
+            foreach ($internalSpans as &$internalSpan) {
+                foreach ($globalTags as $globalTagName => $globalTagValue) {
+                    $internalSpan['meta'][$globalTagName] = $globalTagValue;
+                }
+            }
+        }
+
         if (dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')) {
             array_map(function ($span) {
                 dd_trace_buffer_span($span);

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DDTrace\Tests\Integration;
+
+use DDTrace\Tests\Unit\BaseTestCase;
+use DDTrace\Tracer;
+use DDTrace\Tests\Common\TracerTestTrait;
+use DDTrace\SpanData;
+
+final class TracerTest extends BaseTestCase
+{
+    use TracerTestTrait;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        \putenv('DD_TRACE_GLOBAL_TAGS=global_tag:global');
+    }
+
+    protected function tearUp()
+    {
+        \putenv('DD_TRACE_GLOBAL_TAGS');
+        parent::tearDown();
+    }
+
+    public function testGlobalTagsArePresentOnLegacySpansByFlushTime()
+    {
+        $traces = $this->isolateTracer(function (Tracer $tracer) {
+            $scope = $tracer->startRootSpan('custom.name', [
+                'tags' => [
+                    'local_tag' => 'local',
+                ],
+            ]);
+            $scope->getSpan()->finish();
+        });
+
+        $this->assertSame('custom.name', $traces[0][0]['name']);
+        $this->assertSame('local', $traces[0][0]['meta']['local_tag']);
+        $this->assertSame('global', $traces[0][0]['meta']['global_tag']);
+    }
+
+    public function testGlobalTagsArePresentOnInternalSpansByFlushTime()
+    {
+        \dd_trace_method('DDTrace\Tests\Integration\TracerTest', 'dummyMethod', function (SpanData $span) {
+            $span->service = 'custom.service';
+            $span->name = 'custom.name';
+            $span->resource = 'custom.resource';
+            $span->type = 'custom';
+            $span->meta['local_tag'] = 'local';
+        });
+
+        $test = $this;
+        $traces = $this->isolateTracer(function (Tracer $tracer) use ($test) {
+            $test->dummyMethod();
+        });
+
+        $this->assertSame('custom.name', $traces[0][0]['name']);
+        $this->assertSame('local', $traces[0][0]['meta']['local_tag']);
+        $this->assertSame('global', $traces[0][0]['meta']['global_tag']);
+    }
+
+    public function dummyMethod()
+    {
+    }
+}


### PR DESCRIPTION
### Description

Global tags were not set on internal spans generated by the sandboxed API. This PR adds such tags when the final traces is generated for serialization.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
