### PR TITLE
PHP 5.4: Remove sandbox API

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -180,6 +180,7 @@
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
                         <file name="safe_to_string_properties.phpt" role="test" />
+                        <file name="sandbox_api_not_available_on_unsupported_versions.phpt" role="test" />
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -47,6 +47,7 @@ STD_PHP_INI_BOOLEAN("ddtrace.strict_mode", "0", PHP_INI_SYSTEM, OnUpdateBool, st
                     ddtrace_globals)
 PHP_INI_END()
 
+#if PHP_VERSION_ID >= 50600
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_method, 0, 0, 3)
 ZEND_ARG_INFO(0, class_name)
 ZEND_ARG_INFO(0, method_name)
@@ -57,6 +58,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_function, 0, 0, 2)
 ZEND_ARG_INFO(0, function_name)
 ZEND_ARG_INFO(0, tracing_closure)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_serialize_closed_spans, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -416,6 +418,7 @@ static PHP_FUNCTION(dd_trace) {
     RETURN_BOOL(rv);
 }
 
+#if PHP_VERSION_ID >= 50600
 static PHP_FUNCTION(dd_trace_method) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *class_name = NULL;
@@ -508,6 +511,7 @@ static PHP_FUNCTION(dd_trace_function) {
     zend_bool rv = ddtrace_trace(NULL, function, tracing_closure, options TSRMLS_CC);
     RETURN_BOOL(rv);
 }
+#endif
 
 static PHP_FUNCTION(dd_trace_serialize_closed_spans) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
@@ -912,10 +916,14 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_disable_in_request, NULL),
     DDTRACE_FE(dd_trace_env_config, arginfo_dd_trace_env_config),
     DDTRACE_FE(dd_trace_forward_call, NULL),
+#if PHP_VERSION_ID >= 50600
     DDTRACE_FE(dd_trace_function, arginfo_dd_trace_function),
+#endif
     DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL),
     DDTRACE_FE(dd_trace_internal_fn, NULL),
+#if PHP_VERSION_ID >= 50600
     DDTRACE_FE(dd_trace_method, arginfo_dd_trace_method),
+#endif
     DDTRACE_FE(dd_trace_noop, NULL),
     DDTRACE_FE(dd_trace_peek_span_id, NULL),
     DDTRACE_FE(dd_trace_pop_span_id, NULL),

--- a/tests/ext/sandbox/sandbox_api_not_available_on_unsupported_versions.phpt
+++ b/tests/ext/sandbox/sandbox_api_not_available_on_unsupported_versions.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Sandbox API is not available on unsupported versions
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 50600) die('skip Test is only for versions that do not support the sandbox API'); ?>
+--FILE--
+<?php
+var_dump(function_exists('dd_trace_function'));
+var_dump(function_exists('dd_trace_method'));
+?>
+--EXPECT--
+bool(false)
+bool(false)


### PR DESCRIPTION
### Description

Since the sandbox API is not supported on PHP 5.4, this PR removes the functions `dd_trace_function()` and `dd_trace_method()` on PHP 5.4 (and technically PHP 5.5 since that is not supported at all).

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
