### PR TITLE
Add X-Datadog-Trace-Count header to background sender

### DIFF
--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -427,7 +427,7 @@ static inline size_t append_entry(struct _entry_t *entry, struct _grouped_stack_
     }
 }
 
-void ddtrace_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _grouped_stack_t *dest) {
+static void ddtrace_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _grouped_stack_t *dest) {
     // perform an insertion sort by group_id
     uint32_t current_group_id = 0;
     struct _entry_t first_entry = create_entry(stack, 0);
@@ -515,6 +515,11 @@ void ddtrace_deinit_read_userdata(void *userdata) {
         free(data->dest_data);
     }
     free(userdata);
+}
+
+size_t ddtrace_read_userdata_get_total_groups(void *userdata) {
+    struct _grouped_stack_t *data = userdata;
+    return data->total_groups;
 }
 
 ddtrace_coms_stack_t *ddtrace_coms_attempt_acquire_stack() {

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -40,6 +40,7 @@ void ddtrace_coms_shutdown();
 size_t ddtrace_coms_read_callback(char *buffer, size_t size, size_t nitems, void *userdata);
 void *ddtrace_init_read_userdata(ddtrace_coms_stack_t *stack);
 void ddtrace_deinit_read_userdata(void *);
+size_t ddtrace_read_userdata_get_total_groups(void *);
 uint32_t ddtrace_coms_next_group_id();
 
 void ddtrace_coms_free_stack();


### PR DESCRIPTION
### Description

This is a refresh of #522. 

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
