### PR TITLE
Update coms code style to C99

### DIFF
--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -1,12 +1,13 @@
 #ifndef DD_COMS_H
 #define DD_COMS_H
+
+#include <stdbool.h>
 #include <stdint.h>
 
-#include "env_config.h"
 #include "vendor_stdatomic.h"
 
-#define DD_TRACE_COMS_STACK_SIZE (1024 * 1024 * 10)  // 10 MB
-#define DD_TRACE_COMS_STACKS_BACKLOG_SIZE 10
+#define DDTRACE_COMS_STACK_SIZE (1024 * 1024 * 10)  // 10 MB
+#define DDTRACE_COMS_STACKS_BACKLOG_SIZE 10
 
 typedef struct ddtrace_coms_stack_t {
     size_t size;
@@ -23,24 +24,22 @@ typedef struct ddtrace_coms_state_t {
     _Atomic(uint32_t) next_group_id;
 } ddtrace_coms_state_t;
 
-inline static BOOL_T ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack) {
-    return atomic_load(&stack->refcount) == 0;
-}
+inline bool ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack) { return atomic_load(&stack->refcount) == 0; }
 
-inline static BOOL_T ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
+inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
     return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
-BOOL_T ddtrace_coms_rotate_stack(BOOL_T allocate_new);
+bool ddtrace_coms_rotate_stack(bool allocate_new);
 ddtrace_coms_stack_t *ddtrace_coms_attempt_acquire_stack();
 
-BOOL_T ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
-BOOL_T ddtrace_coms_initialize();
-void ddtrace_coms_shutdown();
+bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
+bool ddtrace_coms_initialize(void);
+void ddtrace_coms_shutdown(void);
 size_t ddtrace_coms_read_callback(char *buffer, size_t size, size_t nitems, void *userdata);
 void *ddtrace_init_read_userdata(ddtrace_coms_stack_t *stack);
 void ddtrace_deinit_read_userdata(void *);
-uint32_t ddtrace_coms_next_group_id();
+uint32_t ddtrace_coms_next_group_id(void);
 
 void ddtrace_coms_free_stack();
 

--- a/src/ext/coms_curl.h
+++ b/src/ext/coms_curl.h
@@ -1,17 +1,19 @@
 #ifndef DD_COMS_CURL_H
 #define DD_COMS_CURL_H
-#include "env_config.h"
 
-BOOL_T ddtrace_coms_init_and_start_writer();
-BOOL_T ddtrace_coms_trigger_writer_flush();
-BOOL_T ddtrace_coms_on_request_finished();
-BOOL_T ddtrace_coms_set_writer_send_on_flush(BOOL_T send);
-BOOL_T ddtrace_in_writer_thread();
-BOOL_T ddtrace_coms_threadsafe_rotate_stack(BOOL_T attempt_allocate_new);
-BOOL_T ddtrace_coms_flush_shutdown_writer_synchronous();
-BOOL_T ddtrace_coms_synchronous_flush(uint32_t timeout);
-BOOL_T ddtrace_coms_on_pid_change();
-void ddtrace_coms_setup_atexit_hook();
-void ddtrace_coms_disable_atexit_hook();
+#include <stdbool.h>
+#include <stdint.h>
+
+bool ddtrace_coms_init_and_start_writer(void);
+bool ddtrace_coms_trigger_writer_flush(void);
+void ddtrace_coms_on_request_finished(void);
+bool ddtrace_coms_set_writer_send_on_flush(bool send);
+bool ddtrace_in_writer_thread(void);
+bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new);
+bool ddtrace_coms_flush_shutdown_writer_synchronous(void);
+bool ddtrace_coms_synchronous_flush(uint32_t timeout);
+bool ddtrace_coms_on_pid_change(void);
+void ddtrace_coms_setup_atexit_hook(void);
+void ddtrace_coms_disable_atexit_hook(void);
 
 #endif  // DD_COMS_CURL_H

--- a/src/ext/coms_debug.c
+++ b/src/ext/coms_debug.c
@@ -21,7 +21,7 @@ static void *test_writer_function(void *_) {
     return NULL;
 }
 
-uint32_t ddtrace_coms_test_writers() {
+uint32_t ddtrace_coms_test_writers(void) {
     int threads = 100, ret = -1;
 
     pthread_t *thread = malloc(sizeof(pthread_t) * threads);
@@ -46,12 +46,12 @@ uint32_t ddtrace_coms_test_writers() {
     return 1;
 }
 
-uint32_t ddtrace_coms_test_consumer() {
-    if (!ddtrace_coms_rotate_stack(TRUE)) {
+uint32_t ddtrace_coms_test_consumer(void) {
+    if (!ddtrace_coms_rotate_stack(true)) {
         printf("error rotating stacks");
     }
 
-    for (int i = 0; i < DD_TRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
+    for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
         ddtrace_coms_stack_t *stack = ddtrace_coms_global_state.stacks[i];
         if (!stack) continue;
 
@@ -100,8 +100,8 @@ uint32_t ddtrace_coms_test_consumer() {
         }                                                       \
     } while (0)
 
-uint32_t ddtrace_coms_test_msgpack_consumer() {
-    ddtrace_coms_rotate_stack(TRUE);
+uint32_t ddtrace_coms_test_msgpack_consumer(void) {
+    ddtrace_coms_rotate_stack(true);
 
     ddtrace_coms_stack_t *stack = ddtrace_coms_attempt_acquire_stack();
     if (!stack) {

--- a/src/ext/coms_debug.h
+++ b/src/ext/coms_debug.h
@@ -1,9 +1,10 @@
-#ifndef DD_COMS_TEST_H
-#define DD_COMS_TEST_H
+#ifndef DD_COMS_DEBUG_H
+#define DD_COMS_DEBUG_H
+
 #include <stdint.h>
 
-uint32_t ddtrace_coms_test_writers();
-uint32_t ddtrace_coms_test_consumer();
-uint32_t ddtrace_coms_test_msgpack_consumer();
+uint32_t ddtrace_coms_test_writers(void);
+uint32_t ddtrace_coms_test_consumer(void);
+uint32_t ddtrace_coms_test_msgpack_consumer(void);
 
-#endif  // DD_COMS_TEST_H
+#endif  // DD_COMS_DEBUG_H


### PR DESCRIPTION
### Description

Update code style to C99 and fix small potential bug in `ddtrace_coms_buffer_data` with a return-type mismatch. This potential bug is unlikely to have any effect in practice, and would be isolated to 
 disabled-by-default BETA background sender.

Code style changes include:
- Add void parameters to functions that take no args
- Convert BOOL_T->bool, TRUE->true, FALSE->false. Note that C99's bool will do a conversion from integral types; the BOOL_T will not and be vulnerable to truncation issues (which is basically what the small potential bug was).
- Remove `inline` from static functions in source files
- Remove `static`  from inline functions in header files
- Rename a few macros to be consistent with the rest of the repo
- Refactor `ddtrace_coms_buffer_data` and `ddtrace_init_read_userdata`

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
