### PR TITLE
Add new license files to package.xml

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -369,3 +369,8 @@ ext/standard/tests/serialize/__serialize_004.phpt
 ext/standard/tests/serialize/__serialize_005.phpt
 ext/standard/tests/serialize/bug45706.phpt
 ext/standard/tests/serialize/typed_property_refs.phpt
+Zend/tests/bug73816.phpt
+Zend/tests/bug78999.phpt
+Zend/tests/overloaded_assign_prop_return_value.phpt
+ext/session/tests/bug79031.phpt
+ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt

--- a/package.xml
+++ b/package.xml
@@ -279,6 +279,9 @@
                 <file name="polyfill.m4" role="src" />
             </dir>
             <file name="LICENSE" role="doc" />
+            <file name="LICENSE.Apache" role="doc" />
+            <file name="LICENSE.BSD3" role="doc" />
+            <file name="NOTICE" role="doc" />
             <file name="README.md" role="doc" />
             <file name="UPGRADE-0.10.md" role="doc" />
         </dir>


### PR DESCRIPTION
### Description

A cherry pick from #731 as a follow-up to #727.

This PR also adds some PHP 7.4 tests to the xfail list since the `datadog/dd-trace-ci:php-7.4-debug-buster` container was updated to the latest patch version of PHP 7.4.