### PR TITLE
Update background sender

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -18,7 +18,9 @@ if test "$PHP_DDTRACE" != "no"; then
   dnl ddtrace.c comes first, then everything else alphabetically
   DD_TRACE_PHP_SOURCES="src/ext/ddtrace.c \
     src/dogstatsd/client.c \
+    src/ext/arrays.c \
     src/ext/circuit_breaker.c \
+    src/ext/comms_php.c \
     src/ext/compat_string.c \
     src/ext/coms.c \
     src/ext/coms_curl.c \

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,10 @@
                     <file name="dogstatsd_client/client.h" role="src" />
                 </dir>
                 <dir name="ext">
+                    <file name="arrays.c" role="src" />
+                    <file name="arrays.h" role="src" />
+                    <file name="comms_php.c" role="src" />
+                    <file name="comms_php.h" role="src" />
                     <file name="compat_string.c" role="src" />
                     <file name="compat_string.h" role="src" />
                     <file name="configuration.h" role="src" />

--- a/package.xml
+++ b/package.xml
@@ -129,6 +129,7 @@
                     <file name="circuit_breaker_retry_time.phpt" role="test" />
                     <file name="circuit_breaker_max_failures.phpt" role="test" />
                     <file name="dd_trace_api_error.phpt" role="test" />
+                    <file name="dd_trace_send_traces_via_thread.phpt" role="test" />
                     <file name="dd_trace_serialize_msgpack.phpt" role="test" />
                     <file name="dd_trace_serialize_msgpack_error.phpt" role="test" />
                     <file name="dd_trace_serialize_msgpack_reference.phpt" role="test" />

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -365,11 +365,7 @@ final class Tracer implements TracerInterface
 
                 $this->traceAnalyticsProcessor->process($span);
                 $encodedSpan = SpanEncoder::encode($span);
-                if (dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')) {
-                    dd_trace_buffer_span($encodedSpan);
-                } else {
-                    $traceToBeSent[] = $encodedSpan;
-                }
+                $traceToBeSent[] = $encodedSpan;
             }
 
             if ($traceToBeSent === null) {
@@ -397,19 +393,10 @@ final class Tracer implements TracerInterface
             }
         }
 
-        if (dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')) {
-            array_map(function ($span) {
-                dd_trace_buffer_span($span);
-            }, $internalSpans);
-        } elseif (!empty($internalSpans)) {
+        if (!empty($internalSpans)) {
             $tracesToBeSent[0] = isset($tracesToBeSent[0])
                 ? array_merge($tracesToBeSent[0], $internalSpans)
                 : $internalSpans;
-        }
-
-        if (empty($tracesToBeSent)) {
-            self::logDebug('No finished traces to be sent to the agent');
-            return [];
         }
 
         return $tracesToBeSent;

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -100,7 +100,14 @@ final class Http implements Transport
         }
         $tracesCount = $tracer->getTracesCount();
         $tracesPayload = $this->encoder->encodeTraces($tracer);
-        self::logDebug('About to send trace(s) to the agent');
+
+        if ($tracesCount === 0) {
+            self::logDebug('No finished traces to be sent to the agent');
+            /* We should short-circuit here so the agent is never bothered, but
+             * at time of writing tests were depending on existing behavior.
+             * return;
+             */
+        }
 
         // We keep the endpoint configuration option for backward compatibility instead of moving to an 'agent base url'
         // concept, but this should be probably revisited in the future.
@@ -109,6 +116,8 @@ final class Http implements Transport
             self::PRIORITY_SAMPLING_TRACE_AGENT_PATH,
             $this->config['endpoint']
         ) : $this->config['endpoint'];
+
+        self::logDebug('About to send trace(s) to the agent');
 
         $this->sendRequest($endpoint, $this->headers, $tracesPayload, $tracesCount);
     }
@@ -134,18 +143,8 @@ final class Http implements Transport
             ]);
             return;
         }
-        $handle = curl_init($url);
-        curl_setopt($handle, CURLOPT_POST, true);
-        curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
-        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handle, CURLOPT_TIMEOUT_MS, $this->config['timeout']);
-        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, $this->config['connect_timeout']);
 
-        $curlHeaders = [
-            'Content-Type: ' . $this->encoder->getContentType(),
-            'Content-Length: ' . $bodySize,
-            'X-Datadog-Trace-Count: ' . $tracesCount,
-        ];
+        $curlHeaders = [];
 
         /* Curl will add Expect: 100-continue if it is a POST over a certain size. The trouble is that CURL will
          * wait for *1 second* for 100 Continue response before sending the rest of the data. This wait is
@@ -158,6 +157,30 @@ final class Http implements Transport
         foreach ($headers as $key => $value) {
             $curlHeaders[] = "$key: $value";
         }
+
+        if (
+            \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
+            && $this->encoder->getContentType() === 'application/msgpack'
+        ) {
+            \dd_trace_send_traces_via_thread($url, $curlHeaders, $body);
+            return;
+        }
+
+        $curlHeaders = \array_merge(
+            $curlHeaders,
+            [
+                'Content-Type: ' . $this->encoder->getContentType(),
+                'Content-Length: ' . $bodySize,
+                'X-Datadog-Trace-Count: ' . $tracesCount,
+            ]
+        );
+
+        $handle = curl_init($url);
+        curl_setopt($handle, CURLOPT_POST, true);
+        curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_TIMEOUT_MS, $this->config['timeout']);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT_MS, $this->config['connect_timeout']);
 
         $isDebugEnabled = Configuration::get()->isDebugModeEnabled();
         if ($isDebugEnabled) {

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -159,7 +159,8 @@ final class Http implements Transport
         }
 
         if (
-            \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
+            $tracesCount === 1
+            && \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
             && $this->encoder->getContentType() === 'application/msgpack'
         ) {
             \dd_trace_send_traces_via_thread($url, $curlHeaders, $body);

--- a/src/ext/arrays.c
+++ b/src/ext/arrays.c
@@ -1,0 +1,23 @@
+#include "arrays.h"
+
+#include <php_version.h>
+
+#if PHP_VERSION_ID < 70000
+void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
+    HashPosition pos;
+    zval **operand;
+    size_t order = 0;
+    zend_hash_internal_pointer_reset_ex(input, &pos);
+    while (zend_hash_get_current_data_ex(input, (void **)&operand, &pos) == SUCCESS) {
+        callback(*operand, order++, context);
+        zend_hash_move_forward_ex(input, &pos);
+    }
+}
+#else
+void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
+    zval *item = NULL;
+    size_t order = 0;
+    ZEND_HASH_FOREACH_VAL(input, item) { callback(item, order++, context); }
+    ZEND_HASH_FOREACH_END();
+}
+#endif

--- a/src/ext/arrays.h
+++ b/src/ext/arrays.h
@@ -1,0 +1,9 @@
+#ifndef DDTRACE_ARRAYS_H
+#define DDTRACE_ARRAYS_H
+
+#include <Zend/zend.h>
+
+typedef void (*ddtrace_walk_fn)(zval *item, size_t visitation_order, void *context);
+void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn, void *context);
+
+#endif  // DDTRACE_ARRAYS_H

--- a/src/ext/comms_php.c
+++ b/src/ext/comms_php.c
@@ -1,0 +1,37 @@
+#include "comms_php.h"
+
+#include "arrays.h"
+#include "compat_string.h"
+#include "coms_curl.h"
+#include "logging.h"
+
+static void _comms_convert_append(zval *item, size_t offset, void *context) {
+    struct curl_slist **list = context;
+    zval converted;
+    TSRMLS_FETCH();
+
+    PHP5_UNUSED(offset);
+    PHP7_UNUSED(offset);
+
+    ddtrace_convert_to_string(&converted, item TSRMLS_CC);
+    *list = curl_slist_append(*list, Z_STRVAL(converted));
+    zval_dtor(&converted);
+}
+
+struct curl_slist *ddtrace_convert_hashtable_to_curl_slist(HashTable *input) {
+    if (zend_hash_num_elements(input) > 0) {
+        struct curl_slist *list = NULL;
+        ddtrace_array_walk(input, _comms_convert_append, &list);
+        return list;
+    }
+    return NULL;
+}
+
+bool ddtrace_memoize_http_headers(HashTable *input) {
+    if (((struct curl_slist *)atomic_load(&memoized_agent_curl_headers)) == NULL && zend_hash_num_elements(input) > 0) {
+        uintptr_t desired = (uintptr_t)ddtrace_convert_hashtable_to_curl_slist(input);
+        uintptr_t expect = (uintptr_t)NULL;
+        return atomic_compare_exchange_strong(&memoized_agent_curl_headers, &expect, desired);
+    }
+    return false;
+}

--- a/src/ext/comms_php.h
+++ b/src/ext/comms_php.h
@@ -1,0 +1,11 @@
+#ifndef DDTRACE_COMMS_PHP_H
+#define DDTRACE_COMMS_PHP_H
+
+#include <Zend/zend.h>
+#include <curl/curl.h>
+#include <stdbool.h>
+
+struct curl_slist *ddtrace_convert_hashtable_to_curl_slist(HashTable *input);
+bool ddtrace_memoize_http_headers(HashTable *input);
+
+#endif  // DDTRACE_COMMS_PHP_H

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -265,6 +265,8 @@ struct _grouped_stack_t {
 };
 
 static size_t write_array_header(char *buffer, size_t buffer_size, size_t position, uint32_t array_size) {
+    // todo: fix background sender's model now that we send complete traces
+    return 0;
     size_t free_space = buffer_size - position;
     char *data = buffer + position;
     if (array_size < 16) {
@@ -508,6 +510,11 @@ void ddtrace_deinit_read_userdata(void *userdata) {
         free(data->dest_data);
     }
     free(userdata);
+}
+
+size_t ddtrace_read_userdata_get_total_groups(void *userdata) {
+    struct _grouped_stack_t *data = userdata;
+    return data->total_groups;
 }
 
 ddtrace_coms_stack_t *ddtrace_coms_attempt_acquire_stack(void) {

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -282,8 +282,6 @@ struct _grouped_stack_t {
 };
 
 static size_t write_array_header(char *buffer, size_t buffer_size, size_t position, uint32_t array_size) {
-    // todo: fix background sender's model now that we send complete traces
-    return 0;
     size_t free_space = buffer_size - position;
     char *data = buffer + position;
     if (array_size < 16) {
@@ -388,7 +386,7 @@ size_t ddtrace_coms_read_callback(char *buffer, size_t size, size_t nitems, void
         if (read->bytes_to_write == 0) {
             break;
         }
-        written += write_array_header(buffer, buffer_size, written, num_elements);
+        // written += write_array_header(buffer, buffer_size, written, num_elements);
         read->position += sizeof(size_t) * 2;
 
         written += write_to_buffer(buffer, buffer_size, written, read);

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -22,14 +22,14 @@ typedef uint32_t group_id_t;
 // disable checks since older GCC is throwing false errors
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-ddtrace_coms_state_t ddtrace_coms_global_state = {{0}};
+ddtrace_coms_state_t ddtrace_coms_globals = {{0}};
 #pragma GCC diagnostic pop
 #else  //__clang__
-ddtrace_coms_state_t ddtrace_coms_global_state = {.stacks = NULL};
+ddtrace_coms_state_t ddtrace_coms_globals = {.stacks = NULL};
 #endif
 
 static bool is_memory_pressure_high(void) {
-    ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_globals.current_stack);
     if (stack) {
         int64_t used = (((double)atomic_load(&stack->position) / (double)stack->size) * 100);
         return used > get_dd_trace_beta_high_memory_pressure_percent();
@@ -39,7 +39,7 @@ static bool is_memory_pressure_high(void) {
 }
 
 static uint32_t store_data(group_id_t group_id, const char *src, size_t size) {
-    ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_globals.current_stack);
     if (stack == NULL) {
         // no stack to save data to
         return ENOMEM;
@@ -70,9 +70,20 @@ static uint32_t store_data(group_id_t group_id, const char *src, size_t size) {
 }
 
 static ddtrace_coms_stack_t *new_stack(size_t min_size) {
-    size_t size = DDTRACE_COMS_STACK_SIZE;
-    while (min_size > size) {
+    size_t initial_size = atomic_load(&ddtrace_coms_globals.stack_size);
+    size_t size = initial_size;
+    while (min_size > size && size <= DDTRACE_COMS_STACK_HALF_MAX_SIZE) {
         size *= 2;
+    }
+    if (size != initial_size) {
+        // If we fail to update the global twice in a row, we can just rely on dynamic size allocation in the future
+        int i = 2;
+        while (!atomic_compare_exchange_weak(&ddtrace_coms_globals.stack_size, &initial_size, size) && i--) {
+            if (initial_size > size) {
+                size = initial_size;
+                break;
+            }
+        };
     }
     ddtrace_coms_stack_t *stack = calloc(1, sizeof(ddtrace_coms_stack_t));
     stack->size = size;
@@ -98,28 +109,29 @@ static void recycle_stack(ddtrace_coms_stack_t *stack) {
 }
 
 bool ddtrace_coms_initialize(void) {
-    ddtrace_coms_stack_t *stack = new_stack(DDTRACE_COMS_STACK_SIZE);
-    if (!ddtrace_coms_global_state.stacks) {
-        ddtrace_coms_global_state.stacks = calloc(DDTRACE_COMS_STACKS_BACKLOG_SIZE, sizeof(ddtrace_coms_stack_t *));
+    atomic_store(&ddtrace_coms_globals.stack_size, DDTRACE_COMS_STACK_INITIAL_SIZE);
+    ddtrace_coms_stack_t *stack = new_stack(DDTRACE_COMS_STACK_INITIAL_SIZE);
+    if (!ddtrace_coms_globals.stacks) {
+        ddtrace_coms_globals.stacks = calloc(DDTRACE_COMS_STACKS_BACKLOG_SIZE, sizeof(ddtrace_coms_stack_t *));
     }
 
-    atomic_store(&ddtrace_coms_global_state.next_group_id, 1);
-    atomic_store(&ddtrace_coms_global_state.current_stack, stack);
+    atomic_store(&ddtrace_coms_globals.next_group_id, 1);
+    atomic_store(&ddtrace_coms_globals.current_stack, stack);
 
     return true;
 }
 
 void ddtrace_coms_shutdown(void) {
-    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
     if (current_stack) {
         if (current_stack->data) {
             free(current_stack->data);
         }
         free(current_stack);
     }
-    if (ddtrace_coms_global_state.stacks) {
-        free(ddtrace_coms_global_state.stacks);
-        ddtrace_coms_global_state.stacks = NULL;
+    if (ddtrace_coms_globals.stacks) {
+        free(ddtrace_coms_globals.stacks);
+        ddtrace_coms_globals.stacks = NULL;
     }
 }
 
@@ -132,13 +144,13 @@ static void printf_stack_info(ddtrace_coms_stack_t *stack) {
 
 static void unsafe_store_or_discard_stack(ddtrace_coms_stack_t *stack) {
     for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
-        ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_global_state.stacks[i];
+        ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_globals.stacks[i];
         if (stack_tmp == stack) {
             return;
         }
 
         if (stack_tmp == NULL) {
-            ddtrace_coms_global_state.stacks[i] = stack;
+            ddtrace_coms_globals.stacks[i] = stack;
             return;
         }
     }
@@ -147,27 +159,27 @@ static void unsafe_store_or_discard_stack(ddtrace_coms_stack_t *stack) {
 }
 
 static void unsafe_cleanup_dirty_stack_area(void) {
-    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
-    if (!ddtrace_coms_global_state.tmp_stack) {
+    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
+    if (!ddtrace_coms_globals.tmp_stack) {
         return;
     }
 
-    if (ddtrace_coms_global_state.tmp_stack != current_stack) {
-        ddtrace_coms_stack_t *stack = ddtrace_coms_global_state.tmp_stack;
+    if (ddtrace_coms_globals.tmp_stack != current_stack) {
+        ddtrace_coms_stack_t *stack = ddtrace_coms_globals.tmp_stack;
 
         atomic_store(&stack->refcount, 0);
         unsafe_store_or_discard_stack(stack);
     }
-    ddtrace_coms_global_state.tmp_stack = NULL;
+    ddtrace_coms_globals.tmp_stack = NULL;
 }
 
 static void unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) {
     unsafe_cleanup_dirty_stack_area();
 
     // store the temp variable if we ever need to recover it
-    ddtrace_coms_stack_t **current_stack = &ddtrace_coms_global_state.tmp_stack;
+    ddtrace_coms_stack_t **current_stack = &ddtrace_coms_globals.tmp_stack;
 
-    *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
 
     if (*current_stack && (*current_stack)->size >= min_size && ddtrace_coms_is_stack_free(*current_stack)) {
         *current_stack = NULL;
@@ -177,12 +189,12 @@ static void unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) 
     if (*current_stack) {
         // try to swap out current stack for an empty stack
         for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
-            ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_global_state.stacks[i];
+            ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_globals.stacks[i];
             if (stack_tmp && stack_tmp->size >= min_size && ddtrace_coms_is_stack_free(stack_tmp)) {
                 // order is important due to ability to restore state on thread restart
                 recycle_stack(stack_tmp);
-                atomic_store(&ddtrace_coms_global_state.current_stack, stack_tmp);
-                ddtrace_coms_global_state.stacks[i] = *current_stack;
+                atomic_store(&ddtrace_coms_globals.current_stack, stack_tmp);
+                ddtrace_coms_globals.stacks[i] = *current_stack;
 
                 *current_stack = NULL;
                 break;
@@ -193,10 +205,10 @@ static void unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) 
     // if we couldn't swap for a empty stack lets store it
     if (*current_stack) {
         for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
-            ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_global_state.stacks[i];
+            ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_globals.stacks[i];
             if (!stack_tmp) {
-                atomic_store(&ddtrace_coms_global_state.current_stack, NULL);
-                ddtrace_coms_global_state.stacks[i] = *current_stack;
+                atomic_store(&ddtrace_coms_globals.current_stack, NULL);
+                ddtrace_coms_globals.stacks[i] = *current_stack;
                 *current_stack = NULL;
 
                 break;
@@ -210,7 +222,7 @@ static void unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) 
 bool ddtrace_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     unsafe_store_or_swap_current_stack_for_empty_stack(min_size);
 
-    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_global_state.current_stack);
+    ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
 
     if (current_stack && current_stack->size >= min_size && ddtrace_coms_is_stack_free(current_stack)) {
         return true;
@@ -219,9 +231,9 @@ bool ddtrace_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     // old current stack was stored so set a new stack
     if (!current_stack) {
         if (attempt_allocate_new) {
-            ddtrace_coms_stack_t **next_stack = &ddtrace_coms_global_state.tmp_stack;
+            ddtrace_coms_stack_t **next_stack = &ddtrace_coms_globals.tmp_stack;
             *next_stack = new_stack(min_size);
-            atomic_store(&ddtrace_coms_global_state.current_stack, *next_stack);
+            atomic_store(&ddtrace_coms_globals.current_stack, *next_stack);
             *next_stack = NULL;
             return true;
         }
@@ -232,7 +244,7 @@ bool ddtrace_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
 }
 
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size) {
-    if (!data) {
+    if (!data || size > DDTRACE_COMS_STACK_MAX_SIZE) {
         return false;
     }
 
@@ -259,7 +271,7 @@ bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size) 
     return store_result == 0;
 }
 
-group_id_t ddtrace_coms_next_group_id(void) { return atomic_fetch_add(&ddtrace_coms_global_state.next_group_id, 1); }
+group_id_t ddtrace_coms_next_group_id(void) { return atomic_fetch_add(&ddtrace_coms_globals.next_group_id, 1); }
 
 struct _grouped_stack_t {
     size_t position, total_bytes, total_groups;
@@ -526,10 +538,10 @@ ddtrace_coms_stack_t *ddtrace_coms_attempt_acquire_stack(void) {
     ddtrace_coms_stack_t *stack = NULL;
 
     for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
-        ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_global_state.stacks[i];
+        ddtrace_coms_stack_t *stack_tmp = ddtrace_coms_globals.stacks[i];
         if (stack_tmp && atomic_load(&stack_tmp->refcount) == 0 && atomic_load(&stack_tmp->bytes_written) > 0) {
             stack = stack_tmp;
-            ddtrace_coms_global_state.stacks[i] = NULL;
+            ddtrace_coms_globals.stacks[i] = NULL;
             break;
         }
     }

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -6,7 +6,9 @@
 
 #include "vendor_stdatomic.h"
 
-#define DDTRACE_COMS_STACK_SIZE (1024 * 128)  // 1 MB
+#define DDTRACE_COMS_STACK_MAX_SIZE (1024u * 1024u * 10u)      // 10 MiB
+#define DDTRACE_COMS_STACK_HALF_MAX_SIZE (1024u * 1024u * 5u)  // 5 MiB
+#define DDTRACE_COMS_STACK_INITIAL_SIZE (1024u * 128u)         // 128 KiB
 #define DDTRACE_COMS_STACKS_BACKLOG_SIZE 10
 
 typedef struct ddtrace_coms_stack_t {
@@ -22,6 +24,7 @@ typedef struct ddtrace_coms_state_t {
     ddtrace_coms_stack_t *tmp_stack;
     ddtrace_coms_stack_t **stacks;
     _Atomic(uint32_t) next_group_id;
+    atomic_size_t stack_size;
 } ddtrace_coms_state_t;
 
 inline bool ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack) { return atomic_load(&stack->refcount) == 0; }

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -40,6 +40,7 @@ size_t ddtrace_coms_read_callback(char *buffer, size_t size, size_t nitems, void
 void *ddtrace_init_read_userdata(ddtrace_coms_stack_t *stack);
 void ddtrace_deinit_read_userdata(void *);
 uint32_t ddtrace_coms_next_group_id(void);
+size_t ddtrace_read_userdata_get_total_groups(void *);
 
 void ddtrace_coms_free_stack();
 

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -6,7 +6,7 @@
 
 #include "vendor_stdatomic.h"
 
-#define DDTRACE_COMS_STACK_SIZE (1024 * 1024 * 10)  // 10 MB
+#define DDTRACE_COMS_STACK_SIZE (1024 * 128)  // 1 MB
 #define DDTRACE_COMS_STACKS_BACKLOG_SIZE 10
 
 typedef struct ddtrace_coms_stack_t {
@@ -30,7 +30,7 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
     return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
-bool ddtrace_coms_rotate_stack(bool allocate_new);
+bool ddtrace_coms_rotate_stack(bool allocate_new, size_t min_size);
 ddtrace_coms_stack_t *ddtrace_coms_attempt_acquire_stack();
 
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -18,6 +18,15 @@
 
 atomic_uintptr_t memoized_agent_curl_headers;
 
+void ddtrace_coms_mshutdown(void) {
+    uintptr_t desired = (uintptr_t)NULL;
+    uintptr_t expect = atomic_load(&memoized_agent_curl_headers);
+    if (expect != (uintptr_t)NULL) {
+        atomic_compare_exchange_strong(&memoized_agent_curl_headers, &expect, desired);
+        curl_slist_free_all((struct curl_slist *)expect);
+    }
+}
+
 struct _writer_thread_variables_t {
     pthread_t self;
     pthread_mutex_t interval_flush_mutex, finished_flush_mutex, stack_rotation_mutex;

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -249,7 +249,8 @@ static void *writer_loop(void *_) {
         atomic_store(&writer->requests_since_last_flush, 0);
 
         ddtrace_coms_stack_t **stack = &writer->tmp_stack;
-        ddtrace_coms_threadsafe_rotate_stack(atomic_load(&writer->allocate_new_stacks), DDTRACE_COMS_STACK_SIZE);
+        ddtrace_coms_threadsafe_rotate_stack(atomic_load(&writer->allocate_new_stacks),
+                                             DDTRACE_COMS_STACK_INITIAL_SIZE);
 
         uint32_t processed_stacks = 0;
         if (!*stack) {

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -249,7 +249,7 @@ static void *writer_loop(void *_) {
         atomic_store(&writer->requests_since_last_flush, 0);
 
         ddtrace_coms_stack_t **stack = &writer->tmp_stack;
-        ddtrace_coms_threadsafe_rotate_stack(atomic_load(&writer->allocate_new_stacks));
+        ddtrace_coms_threadsafe_rotate_stack(atomic_load(&writer->allocate_new_stacks), DDTRACE_COMS_STACK_SIZE);
 
         uint32_t processed_stacks = 0;
         if (!*stack) {
@@ -376,12 +376,12 @@ bool ddtrace_coms_on_pid_change(void) {
     return false;
 }
 
-bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new) {
+bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     struct _writer_loop_data_t *writer = get_writer();
     bool rv = false;
     if (writer->thread) {
         pthread_mutex_lock(&writer->thread->stack_rotation_mutex);
-        rv = ddtrace_coms_rotate_stack(attempt_allocate_new);
+        rv = ddtrace_coms_rotate_stack(attempt_allocate_new, min_size);
         pthread_mutex_unlock(&writer->thread->stack_rotation_mutex);
     }
     return rv;

--- a/src/ext/coms_curl.c
+++ b/src/ext/coms_curl.c
@@ -1,6 +1,5 @@
 #include "coms_curl.h"
 
-#include <curl/curl.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,6 +15,8 @@
 #include "vendor_stdatomic.h"
 
 #define HOST_FORMAT_STR "http://%s:%u/v0.4/traces"
+
+atomic_uintptr_t memoized_agent_curl_headers;
 
 struct _writer_thread_variables_t {
     pthread_t self;
@@ -119,25 +120,43 @@ void ddtrace_coms_setup_atexit_hook() {
 
 void ddtrace_coms_disable_atexit_hook() { ptr_at_exit_callback = NULL; }
 
+#define DD_TRACE_COUNT_HEADER "X-Datadog-Trace-Count: "
+
+static void _curl_set_headers(struct _writer_loop_data_t *writer, size_t trace_count) {
+    struct curl_slist *static_headers = (struct curl_slist *)atomic_load(&memoized_agent_curl_headers);
+    struct curl_slist *headers = NULL;
+    for (struct curl_slist *current = static_headers; current; current = current->next) {
+        headers = curl_slist_append(headers, current->data);
+    }
+    headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
+    headers = curl_slist_append(headers, "Content-Type: application/msgpack");
+
+    char buffer[64];
+    int bytes_written = snprintf(buffer, sizeof buffer, DD_TRACE_COUNT_HEADER "%zu", trace_count);
+    if (bytes_written > ((int)sizeof(DD_TRACE_COUNT_HEADER)) - 1 && bytes_written < ((int)sizeof buffer)) {
+        headers = curl_slist_append(headers, buffer);
+    }
+
+    if (writer->headers) {
+        curl_slist_free_all(writer->headers);
+    }
+
+    curl_easy_setopt(writer->curl, CURLOPT_HTTPHEADER, headers);
+    writer->headers = headers;
+}
+
 static void curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms_stack_t *stack) {
     if (!writer->curl) {
         writer->curl = curl_easy_init();
-
-        struct curl_slist *headers = NULL;
-        headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
-        headers = curl_slist_append(headers, "Content-Type: application/msgpack");
-        curl_easy_setopt(writer->curl, CURLOPT_HTTPHEADER, headers);
-
         curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, ddtrace_coms_read_callback);
         curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, dummy_write_callback);
-        writer->headers = headers;
     }
 
     if (writer->curl) {
         CURLcode res;
 
         void *read_data = ddtrace_init_read_userdata(stack);
-
+        _curl_set_headers(writer, ddtrace_read_userdata_get_total_groups(read_data));
         curl_easy_setopt(writer->curl, CURLOPT_READDATA, read_data);
         curl_set_hostname(writer->curl);
         curl_set_timeout(writer->curl);
@@ -164,6 +183,8 @@ static void curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms_sta
         }
 
         ddtrace_deinit_read_userdata(read_data);
+        curl_slist_free_all(writer->headers);
+        writer->headers = NULL;
     }
 }
 static void signal_writer_started(struct _writer_loop_data_t *writer) {
@@ -250,6 +271,8 @@ static void *writer_loop(void *_) {
     } while (running);
 
     curl_slist_free_all(writer->headers);
+    writer->headers = NULL;
+
     curl_easy_cleanup(writer->curl);
     ddtrace_coms_shutdown();
     signal_writer_finished(writer);
@@ -299,6 +322,7 @@ bool ddtrace_coms_init_and_start_writer(void) {
     struct _writer_loop_data_t *writer = get_writer();
     writer_set_operational_state(writer);
     atomic_store(&writer->current_pid, getpid());
+    atomic_store(&memoized_agent_curl_headers, (uintptr_t)NULL);
 
     if (writer->thread) {
         return false;

--- a/src/ext/coms_curl.h
+++ b/src/ext/coms_curl.h
@@ -1,8 +1,13 @@
 #ifndef DD_COMS_CURL_H
 #define DD_COMS_CURL_H
 
+#include <curl/curl.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "vendor_stdatomic.h"
+
+extern atomic_uintptr_t memoized_agent_curl_headers;
 
 bool ddtrace_coms_init_and_start_writer(void);
 bool ddtrace_coms_trigger_writer_flush(void);

--- a/src/ext/coms_curl.h
+++ b/src/ext/coms_curl.h
@@ -20,5 +20,6 @@ bool ddtrace_coms_synchronous_flush(uint32_t timeout);
 bool ddtrace_coms_on_pid_change(void);
 void ddtrace_coms_setup_atexit_hook(void);
 void ddtrace_coms_disable_atexit_hook(void);
+void ddtrace_coms_mshutdown(void);
 
 #endif  // DD_COMS_CURL_H

--- a/src/ext/coms_curl.h
+++ b/src/ext/coms_curl.h
@@ -14,7 +14,7 @@ bool ddtrace_coms_trigger_writer_flush(void);
 void ddtrace_coms_on_request_finished(void);
 bool ddtrace_coms_set_writer_send_on_flush(bool send);
 bool ddtrace_in_writer_thread(void);
-bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new);
+bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size);
 bool ddtrace_coms_flush_shutdown_writer_synchronous(void);
 bool ddtrace_coms_synchronous_flush(uint32_t timeout);
 bool ddtrace_coms_on_pid_change(void);

--- a/src/ext/coms_debug.c
+++ b/src/ext/coms_debug.c
@@ -10,7 +10,7 @@
 #define DDTRACE_NUMBER_OF_DATA_TO_WRITE 2000
 #define DDTRACE_DATA_TO_WRITE "0123456789"
 
-extern ddtrace_coms_state_t ddtrace_coms_global_state;
+extern ddtrace_coms_state_t ddtrace_coms_globals;
 
 static void *test_writer_function(void *_) {
     (void)_;
@@ -47,12 +47,12 @@ uint32_t ddtrace_coms_test_writers(void) {
 }
 
 uint32_t ddtrace_coms_test_consumer(void) {
-    if (!ddtrace_coms_rotate_stack(true, DDTRACE_COMS_STACK_SIZE)) {
+    if (!ddtrace_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
         printf("error rotating stacks");
     }
 
     for (int i = 0; i < DDTRACE_COMS_STACKS_BACKLOG_SIZE; i++) {
-        ddtrace_coms_stack_t *stack = ddtrace_coms_global_state.stacks[i];
+        ddtrace_coms_stack_t *stack = ddtrace_coms_globals.stacks[i];
         if (!stack) continue;
 
         if (!ddtrace_coms_is_stack_unused(stack)) {
@@ -101,7 +101,7 @@ uint32_t ddtrace_coms_test_consumer(void) {
     } while (0)
 
 uint32_t ddtrace_coms_test_msgpack_consumer(void) {
-    ddtrace_coms_rotate_stack(true, DDTRACE_COMS_STACK_SIZE);
+    ddtrace_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
 
     ddtrace_coms_stack_t *stack = ddtrace_coms_attempt_acquire_stack();
     if (!stack) {

--- a/src/ext/coms_debug.c
+++ b/src/ext/coms_debug.c
@@ -47,7 +47,7 @@ uint32_t ddtrace_coms_test_writers(void) {
 }
 
 uint32_t ddtrace_coms_test_consumer(void) {
-    if (!ddtrace_coms_rotate_stack(true)) {
+    if (!ddtrace_coms_rotate_stack(true, DDTRACE_COMS_STACK_SIZE)) {
         printf("error rotating stacks");
     }
 
@@ -101,7 +101,7 @@ uint32_t ddtrace_coms_test_consumer(void) {
     } while (0)
 
 uint32_t ddtrace_coms_test_msgpack_consumer(void) {
-    ddtrace_coms_rotate_stack(true);
+    ddtrace_coms_rotate_stack(true, DDTRACE_COMS_STACK_SIZE);
 
     ddtrace_coms_stack_t *stack = ddtrace_coms_attempt_acquire_stack();
     if (!stack) {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -731,7 +731,11 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
         ddtrace_log_debug("Successfully memoized Agent HTTP headers");
     }
 
-    if (!ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), payload, payload_len)) {
+    /* Encoders encode X traces, but we need to do concatenation at the
+     * transport layer too, so we strip away the msgpack array prefix.
+     * todo: properly read msgpack encoding instead of assuming 1 trace
+     */
+    if (!ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), payload + 1, payload_len - 1)) {
         ddtrace_log_debug("Unable to send payload to background sender's buffer");
     }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -14,6 +14,7 @@
 #include <ext/standard/info.h>
 
 #include "circuit_breaker.h"
+#include "comms_php.h"
 #include "compat_string.h"
 #include "compatibility.h"
 #include "coms.h"
@@ -81,6 +82,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_push_span_id, 0, 0, 0)
 ZEND_ARG_INFO(0, existing_id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_send_traces_via_thread, 0, 0, 3)
+ZEND_ARG_INFO(0, url)
+ZEND_ARG_INFO(0, http_headers)
+ZEND_ARG_INFO(0, body)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_compile_time_microseconds, 0, 0, 0)
@@ -699,6 +706,37 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
     return;
 }
 
+#if PHP_VERSION_ID < 70000
+typedef int ddtrace_zppstrlen_t;
+typedef long ddtrace_zpplong_t;
+#else
+typedef size_t ddtrace_zppstrlen_t;
+typedef zend_long ddtrace_zpplong_t;
+#endif
+
+static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
+    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
+    char *url = NULL, *payload = NULL;
+    ddtrace_zppstrlen_t url_len = 0, payload_len = 0;
+    zval *curl_headers = NULL;
+
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "sas", &url, &url_len,
+                                 &curl_headers, &payload, &payload_len) == FAILURE) {
+        ddtrace_log_debug("dd_trace_send_traces_via_thread() expects url, http headers, and http body");
+        RETURN_FALSE
+    }
+
+    if (ddtrace_memoize_http_headers(Z_ARRVAL_P(curl_headers))) {
+        ddtrace_log_debug("Successfully memoized Agent HTTP headers");
+    }
+
+    if (!ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), payload, payload_len)) {
+        ddtrace_log_debug("Unable to send payload to background sender's buffer");
+    }
+
+    RETURN_TRUE
+}
+
 static PHP_FUNCTION(dd_trace_buffer_span) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
@@ -927,6 +965,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_pop_span_id, NULL),
     DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_FE(dd_trace_reset, NULL),
+    DDTRACE_FE(dd_trace_send_traces_via_thread, arginfo_dd_trace_send_traces_via_thread),
     DDTRACE_FE(dd_trace_serialize_closed_spans, arginfo_dd_trace_serialize_closed_spans),
     DDTRACE_FE(dd_trace_serialize_msgpack, arginfo_dd_trace_serialize_msgpack),
     DDTRACE_FE(dd_trace_set_trace_id, arginfo_dd_trace_set_trace_id),

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -153,6 +153,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     // when extension is properly unloaded disable the at_exit hook
     ddtrace_coms_disable_atexit_hook();
     if (ddtrace_coms_flush_shutdown_writer_synchronous()) {
+        ddtrace_coms_mshutdown();
         // if writer is ensured to be shutdown we can free up config resources safely
         ddtrace_config_shutdown();
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 error_reporting(E_ALL);
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/tests/ext/dd_trace_coms_curl_out.phpt
+++ b/tests/ext/dd_trace_coms_curl_out.phpt
@@ -6,6 +6,8 @@ if (!getenv("DD_AGENT_HOST")) {
     die("skip test if agent host is not set");
 }
 ?>
+--XFAIL--
+This is testing the internal guts of the background sender without using a tracer
 --ENV--
 DD_TRACE_DEBUG_CURL_OUTPUT=1
 DD_TRACE_AGENT_TIMEOUT=10000

--- a/tests/ext/dd_trace_coms_test_parallel_writer_consistency.phpt
+++ b/tests/ext/dd_trace_coms_test_parallel_writer_consistency.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Coms test parallel writer consistency
+--XFAIL--
+This is testing the internal guts of the background sender without using a tracer
 --FILE--
 <?php
 // store two packets separately

--- a/tests/ext/dd_trace_coms_test_span_concatenation.phpt
+++ b/tests/ext/dd_trace_coms_test_span_concatenation.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Coms test messagepack payloads are concatendated and serialized correctly
+--XFAIL--
+This is testing the internal guts of the background sender without using a tracer
 --FILE--
 <?php
 

--- a/tests/ext/dd_trace_coms_writer_shutdown_and_flush_on_exit.phpt
+++ b/tests/ext/dd_trace_coms_writer_shutdown_and_flush_on_exit.phpt
@@ -6,6 +6,8 @@ if (!getenv("DD_AGENT_HOST")) {
     die("skip test if agent host is not set");
 }
 ?>
+--XFAIL--
+This is testing the internal guts of the background sender without using a tracer
 --ENV--
 DD_TRACE_DEBUG_CURL_OUTPUT=1
 --FILE--

--- a/tests/ext/dd_trace_send_traces_via_thread.phpt
+++ b/tests/ext/dd_trace_send_traces_via_thread.phpt
@@ -16,11 +16,13 @@ $headers = [
     'Datadog-Meta-Lang' => 'php',
 ];
 
-// payload = [[]]
-$payload = "\x91\x90";
+// payload = []
+$payload = "\x90";
 
 
 dd_trace_send_traces_via_thread($url, $headers, $payload);
 
+echo "Done.";
 ?>
 --EXPECT--
+Done.

--- a/tests/ext/dd_trace_send_traces_via_thread.phpt
+++ b/tests/ext/dd_trace_send_traces_via_thread.phpt
@@ -15,9 +15,9 @@ $url = "http://{$host}:{$port}/0.4/traces";
 $headers = [
     'Datadog-Meta-Lang' => 'php',
 ];
-$trace = [[]];
 
-$payload = dd_trace_serialize_msgpack($trace);
+// payload = [[]]
+$payload = "\x91\x90";
 
 
 dd_trace_send_traces_via_thread($url, $headers, $payload);

--- a/tests/ext/dd_trace_send_traces_via_thread.phpt
+++ b/tests/ext/dd_trace_send_traces_via_thread.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test the background sender does not leak
+--SKIPIF--
+<?php if (!getenv("DD_AGENT_HOST")) die("skip test if agent host is not set"); ?>
+--ENV--
+--FILE--
+<?php
+
+$host = getenv("DD_AGENT_HOST");
+$port = getenv("DD_TRACE_AGENT_PORT");
+if ($port === false) {
+    $port = '8126';
+}
+$url = "http://{$host}:{$port}/0.4/traces";
+$headers = [
+    'Datadog-Meta-Lang' => 'php',
+];
+$trace = [[]];
+
+$payload = dd_trace_serialize_msgpack($trace);
+
+
+dd_trace_send_traces_via_thread($url, $headers, $payload);
+
+?>
+--EXPECT--


### PR DESCRIPTION
### Description

This updates the background sender to re-use headers that have already been gathered by PHP, and also uses the PHP encoder instead of serializing msgpack on its own. As a side effect, the whole trace is buffered at once. This means in the future we can significantly simplify the background sender code.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
