### PR TITLE
Increase available memory for PHP 5.6 Web Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,6 +886,7 @@ workflows:
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 56 Web integration tests"
+          resource_class: medium+
           integration_testsuite: "test-web-56"
           # docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug" composer goes over memory if run with debug
           docker_image: "datadog/docker-library:ddtrace_php_5_6"

--- a/composer.json
+++ b/composer.json
@@ -384,7 +384,7 @@
             "@opentracing-10-test"
         ],
 
-        "inrease-memory-limit": "export COMPOSER_MEMORY_LIMIT=-1",
+        "increase-memory-limit": "export COMPOSER_MEMORY_LIMIT=-1",
         "memory_test": "echo $COMPOSER_MEMORY_LIMIT",
 
         "opentracing-10-test": [
@@ -460,7 +460,7 @@
         "symfony-34-suite": [ "@symfony-34-update", "@symfony-34-test" ],
 
         "symfony-40-update": [
-            "@inrease-memory-limit",
+            "@increase-memory-limit",
             "@memory_test",
             "@composer --working-dir=tests/Frameworks/Symfony/Version_4_0 update",
             "@php tests/Frameworks/Symfony/Version_4_0/bin/console cache:clear --no-warmup --env=prod"
@@ -468,7 +468,7 @@
         "symfony-40-test": "@composer test -- tests/Integrations/Symfony/V4_0",
         "symfony-40-suite": [ "@symfony-40-update", "@symfony-40-test" ],
         "symfony-42-update": [
-            "@inrease-memory-limit",
+            "@increase-memory-limit",
             "@composer --working-dir=tests/Frameworks/Symfony/Version_4_2 update",
             "php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod"
         ],


### PR DESCRIPTION
### Description
Composer was running out of memory when updating Symfony 2.8 and was getting killed by CircleCi. Seeing if running with a larger node will clear it up.
Also fixes a mis-spelling in the name "increase-memory-limit."

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.