### PR TITLE
Traces are flushed when in limited mode

### DIFF
--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -43,7 +43,11 @@ final class Bootstrap
             register_shutdown_function($flushTracer);
             return;
         }
-        dd_trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', $flushTracer);
+        dd_trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', [
+            'instrument_when_limited' => 1,
+            'posthook' => $flushTracer,
+        ]);
+
         register_shutdown_function(function () {
             /*
              * Register the shutdown handler during shutdown so that it is run after all the other shutdown handlers.

--- a/tests/Integration/BootstrapTest.php
+++ b/tests/Integration/BootstrapTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DDTrace\Tests\Integration;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use PHPUnit\Framework\TestCase;
+
+final class BootstrapTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/BootstrapTest_files/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_NO_AUTOLOADER' => '1',
+            'DD_TRACE_SPANS_LIMIT' => '1',
+        ]);
+    }
+
+    /**
+     * Testing that the tracer is still flushed even if the span limit `DD_TRACE_SPANS_LIMIT=1` is reached because of
+     * root span + custom span generated in index.php script.
+     */
+    public function testTracerFlushedWhenSpanLimitExceeded()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/'));
+            // We explicitly assert the configured value of 'DD_TRACE_SPANS_LIMIT' echoed by the web app
+            // because if we add tests to this test case that require a larger limit the current test would still pass
+            // but would not test the specific edge case.
+            TestCase::assertSame('1', $response);
+        });
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::exists('web.request')
+                ->withChildren([
+                    SpanAssertion::exists('my_span')
+                ]),
+        ]);
+    }
+}

--- a/tests/Integration/BootstrapTest_files/index.php
+++ b/tests/Integration/BootstrapTest_files/index.php
@@ -1,0 +1,14 @@
+<?php
+
+use DDTrace\GlobalTracer;
+use DDTrace\Tag;
+
+$tracer = GlobalTracer::get();
+$scope = $tracer->startActiveSpan('my_span');
+$span = $scope->getSpan();
+$span->setTag(Tag::SERVICE_NAME, 'my_service');
+$span->setTag(Tag::RESOURCE_NAME, 'my_resource');
+$span->setTag(Tag::SPAN_TYPE, 'custom');
+$scope->close();
+
+echo getenv('DD_TRACE_SPANS_LIMIT');


### PR DESCRIPTION
### Description

Release 0.37.0 introduced two changes that, together, prevent traces to be sent when the span limit is reached.

Specifically:
 - #689 prevents a callback registered through `dd_trace_(method|function)` to be called if we are in limited mode, AKA if the number of spans exceed the value DD_TRACE_SPANS_LIMIT which defaults to 1000.
 - #707 sandboxed the execution of the final flush of the tracer using, as a hook, a callback registered through `dd_trace_method()`.

As a consequence, when the limit of `DD_TRACE_SPANS_LIMIT` was reached (default is 1000) no more callbacks are invoked anymore, including the final one that would trigger sending traces to the agent.

This PR forces the execution of the callback used to flush through the parameter `'instrument_when_limited' => 1`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
