### PR TITLE
Revert "Merge pull request #747 from DataDog/release-0.39.1"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,27 +10,17 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2020-02-10</date>
+    <date>${date}</date>
     <version>
-        <release>0.39.1</release>
-        <api>0.39.1</api>
+        <release>${version}</release>
+        <api>${version}</api>
     </version>
     <stability>
         <release>stable</release>
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>
-### Fixed
-
- - Traces are flushed when in limited mode #745
-
-### Changed:
-
-- Tracer will disable itself when an unsupported SAPI is detected #742
-- Move the "Found blacklisted module" message to the debug level #742
-- Increase connect timeout for background sender #744
-</notes>
+    <notes>${notes}</notes>
     <contents>
         <dir name="/">
             <dir name="src">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '0.39.1'; // Update ./version.php too
+    const VERSION = '1.0.0-nightly'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '0.39.1'; // Update Tracer::VERSION too
+return '1.0.0-nightly'; // Update Tracer::VERSION too

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "0.39.1"
+#define PHP_DDTRACE_VERSION "1.0.0-nightly"
 #endif


### PR DESCRIPTION
This reverts commit 55ef4a00bb2ca95ee316de77b48bf5a373bea2b1, reversing changes made to a074ef1bd22fd864f14c6823ad33f5990df79d4c.

The release PR was accidentally pulled into master instead of ddtrace-0.39.1.