### PR TITLE
Fix execinfo on builds from source in Alpine containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ $(PACKAGES_BUILD_DIR):
 .rpm: $(PACKAGES_BUILD_DIR)
 	fpm -p $(PACKAGES_BUILD_DIR) -t rpm $(FPM_OPTS) $(FPM_FILES)
 .apk: $(PACKAGES_BUILD_DIR)
-	fpm -p $(PACKAGES_BUILD_DIR) -t apk $(FPM_OPTS) --depends=libc6-compat --depends=bash $(FPM_FILES)
+	fpm -p $(PACKAGES_BUILD_DIR) -t apk $(FPM_OPTS) --depends=libc6-compat --depends=bash --depends=libexecinfo $(FPM_FILES)
 .tar.gz: $(PACKAGES_BUILD_DIR)
 	fpm -p $(PACKAGES_BUILD_DIR)/$(PACKAGE_NAME)-$(VERSION).x86_64.tar.gz -t tar $(FPM_OPTS) $(FPM_FILES)
 

--- a/config.m4
+++ b/config.m4
@@ -8,10 +8,16 @@ if test "$PHP_DDTRACE" != "no"; then
 
   AX_EXECINFO
 
+  AS_IF([test x"$ac_cv_header_execinfo_h" = xyes],
+    dnl This duplicates some of AX_EXECINFO's work, but AX_EXECINFO puts the
+    dnl library into LIBS, which we don't use anywhere else and am worried that
+    dnl it may contain things we are not expecting aside from execinfo
+    PHP_CHECK_LIBRARY(execinfo, backtrace, [EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lexecinfo"]))
+
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     EXTRA_LDFLAGS="-lasan"
-	  EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-	  PHP_SUBST(EXTRA_LDFLAGS)
+    EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+    PHP_SUBST(EXTRA_LDFLAGS)
     PHP_SUBST(EXTRA_CFLAGS)
   fi
 


### PR DESCRIPTION
### Description

This `-lexecinfo` check is needed for Alpine containers where execinfo is a separate library from the libc. Relates to #381.

Also fixes some mixed tabs and spaces.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. 