### PR TITLE
Disable container info check if not allowed by open_basedir directive

### DIFF
--- a/src/DDTrace/Util/ContainerInfo.php
+++ b/src/DDTrace/Util/ContainerInfo.php
@@ -33,8 +33,11 @@ class ContainerInfo
      */
     public function getContainerId()
     {
-        // We do not want to emit a warning if user application uses ini setting 'open_basedir'
-        // and '/proc/self' is not included in the ini setting.
+        // We check open_basedir because even if we use @file_exists an annoying error message is printed.
+        if (!Runtime::openBaseDirAllowsFile($this->cgroupProcFile)) {
+            return null;
+        }
+
         if (!@file_exists($this->cgroupProcFile)) {
             return null;
         }

--- a/src/DDTrace/Util/Runtime.php
+++ b/src/DDTrace/Util/Runtime.php
@@ -8,6 +8,29 @@ namespace DDTrace\Util;
 final class Runtime
 {
     /**
+     * Tells whether or not open_basedir ini param allows access to a specific file.
+     *
+     * @param string $absFilePath The absolute file path
+     * @return bool
+     */
+    public static function openBaseDirAllowsFile($absFilePath)
+    {
+        $openBaseDir = ini_get('open_basedir');
+        if (empty($openBaseDir)) {
+            return true;
+        }
+
+        $fragments = \explode(':', $openBaseDir);
+        foreach ($fragments as $fragment) {
+            if (substr($absFilePath, 0, strlen($fragment)) === $fragment) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Tells whether or not a given autoloader is registered.
      *
      * @param string $class


### PR DESCRIPTION
### Description

We check for container info while serving a request in order to properly add relevant tags from container to the span. When `open_basedir` directive prevents access to that file an error log is dumped by the PHP runtime which is annoying.

This PR ensures that that error message is not printed.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
