### PR TITLE
Put compile_file hook behind a feature flag, default on

### DIFF
--- a/src/DDTrace/Encoders/SpanEncoder.php
+++ b/src/DDTrace/Encoders/SpanEncoder.php
@@ -64,8 +64,10 @@ final class SpanEncoder
             if ($prioritySampling !== PrioritySampling::UNKNOWN) {
                 $metrics['_sampling_priority_v1'] = $prioritySampling;
             }
-            // Metric expects milliseconds
-            $metrics['php.compilation.total_time_ms'] = (float) dd_trace_compile_time_microseconds() / 1000;
+            if (\dd_trace_env_config('DD_TRACE_MEASURE_COMPILE_TIME')) {
+                // Metric expects milliseconds
+                $metrics['php.compilation.total_time_ms'] = (float) dd_trace_compile_time_microseconds() / 1000;
+            }
         }
         if (!empty($metrics)) {
             $arraySpan['metrics'] = $metrics;

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -25,6 +25,7 @@ void ddtrace_config_shutdown(void);
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
+    BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", TRUE)                                   \
     BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", FALSE)                                                                \
     BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
     BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -3,6 +3,7 @@
 #include <php.h>
 #include <time.h>
 
+#include "configuration.h"
 #include "ddtrace.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
@@ -41,12 +42,14 @@ static zend_op_array *_dd_compile_file(zend_file_handle *file_handle, int type T
 }
 
 static void _compile_minit(void) {
-    _prev_compile_file = zend_compile_file;
-    zend_compile_file = _dd_compile_file;
+    if (get_dd_trace_measure_compile_time()) {
+        _prev_compile_file = zend_compile_file;
+        zend_compile_file = _dd_compile_file;
+    }
 }
 
 static void _compile_mshutdown(void) {
-    if (zend_compile_file == _dd_compile_file) {
+    if (get_dd_trace_measure_compile_time() && zend_compile_file == _dd_compile_file) {
         zend_compile_file = _prev_compile_file;
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class CompileTimeDisabledTest extends WebFrameworkTestCase
+{
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_MEASURE_COMPILE_TIME' => '0',
+        ]);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        /* The span encoder of this process gets used to convert the trace's spans into an array.
+         * For the compile-time metrics specifically, this goofs things up, so let's disable.
+         */
+        \putenv('DD_TRACE_MEASURE_COMPILE_TIME=0');
+        \dd_trace_internal_fn('ddtrace_reload_config');
+    }
+
+    protected function tearDown()
+    {
+        \putenv('DD_TRACE_MEASURE_COMPILE_TIME');
+        dd_trace_internal_fn('ddtrace_reload_config');
+        parent::tearDown();
+    }
+
+    public function testScenario()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('Compile time does not exist on root span', '/simple');
+            $this->call($spec);
+        });
+
+        self::assertFalse(isset($traces[0][0]['metrics']['php.compilation.total_time_ms']));
+    }
+}

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class CompileTimeEnabledTest extends WebFrameworkTestCase
+{
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_MEASURE_COMPILE_TIME' => '1',
+        ]);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        /* The span encoder of this process gets used to convert the trace's spans into an array.
+         * For the compile-time metrics specifically, this goofs things up, so let's disable.
+         */
+        \putenv('DD_TRACE_MEASURE_COMPILE_TIME=0');
+        \dd_trace_internal_fn('ddtrace_reload_config');
+    }
+
+    protected function tearDown()
+    {
+        \putenv('DD_TRACE_MEASURE_COMPILE_TIME');
+        dd_trace_internal_fn('ddtrace_reload_config');
+        parent::tearDown();
+    }
+
+    public function testScenario()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('Compile time exists on root span', '/simple');
+            $this->call($spec);
+        });
+
+        self::assertTrue(isset($traces[0][0]['metrics']['php.compilation.total_time_ms']));
+    }
+}


### PR DESCRIPTION
### Description

Our `compile_file` hook will delay compiling files a little bit by measuring how long it takes. If those files are prone to SIGBUS then this hook will exacerbate those issues by keeping them open slightly longer.

This flag defaults to on as most customers do not have this issue, but those who do have it can turn it off by setting `DD_TRACE_MEASURE_COMPILE_TIME=false` in their environment.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
