### PR TITLE
Circuit breaker should not prevent background sender

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -40,6 +40,7 @@
             <directory>tests/Integrations/Slim/V3_12</directory>
         </testsuite>
         <testsuite name="custom-framework-autoloaded-test">
+            <file>tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php</file>
             <file>tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php</file>
             <directory>tests/Integrations/CLI/Custom/Autoloaded</directory>
         </testsuite>

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -88,16 +88,6 @@ final class Http implements Transport
      */
     public function send(Tracer $tracer)
     {
-        if ($this->isLogDebugActive() && function_exists('dd_tracer_circuit_breaker_info')) {
-            self::logDebug('circuit breaker status: closed => {closed}, total_failures => {total_failures},'
-            . 'consecutive_failures => {consecutive_failures}, opened_timestamp => {opened_timestamp}, '
-            . 'last_failure_timestamp=> {last_failure_timestamp}', dd_tracer_circuit_breaker_info());
-        }
-
-        if (function_exists('dd_tracer_circuit_breaker_can_try') && !dd_tracer_circuit_breaker_can_try()) {
-            self::logError('Reporting of spans skipped due to open circuit breaker');
-            return;
-        }
         $tracesCount = $tracer->getTracesCount();
         $tracesPayload = $this->encoder->encodeTraces($tracer);
 
@@ -163,6 +153,17 @@ final class Http implements Transport
             && $this->encoder->getContentType() === 'application/msgpack'
             && \dd_trace_send_traces_via_thread($tracesCount, $curlHeaders, $body)
         ) {
+            return;
+        }
+
+        if ($this->isLogDebugActive() && function_exists('dd_tracer_circuit_breaker_info')) {
+            self::logDebug('circuit breaker status: closed => {closed}, total_failures => {total_failures},'
+            . 'consecutive_failures => {consecutive_failures}, opened_timestamp => {opened_timestamp}, '
+            . 'last_failure_timestamp=> {last_failure_timestamp}', dd_tracer_circuit_breaker_info());
+        }
+
+        if (function_exists('dd_tracer_circuit_breaker_can_try') && !dd_tracer_circuit_breaker_can_try()) {
+            self::logError('Reporting of spans skipped due to open circuit breaker');
             return;
         }
 

--- a/tests/Frameworks/Custom/Version_Autoloaded/src/CircuitBreakerController.php
+++ b/tests/Frameworks/Custom/Version_Autoloaded/src/CircuitBreakerController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+class CircuitBreakerController
+{
+    public function render()
+    {
+        for ($i = 0; $i < getenv('DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES') + 1; ++$i) {
+            \dd_tracer_circuit_breaker_register_error();
+        }
+        header('Content-type: text/html; charset=utf-8');
+        echo '<h1>Circuit Breaker</h1>';
+        echo '<p>This endpoint will register circuit breaker errors before rendering the page.</p>';
+    }
+}

--- a/tests/Frameworks/Custom/Version_Autoloaded/src/routes.php
+++ b/tests/Frameworks/Custom/Version_Autoloaded/src/routes.php
@@ -4,4 +4,6 @@ return function(FastRoute\RouteCollector $r) {
     $r->addRoute('GET', '/simple', '\App\SimpleController');
     $r->addRoute('GET', '/simple_view', '\App\SimpleViewController');
     $r->addRoute('GET', '/error', '\App\ErrorController');
+
+    $r->addRoute('GET', '/circuit_breaker', '\App\CircuitBreakerController');
 };

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class CircuitBreakerTest extends WebFrameworkTestCase
+{
+    const FLUSH_INTERVAL_MS = 1500;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_BETA_SEND_TRACES_VIA_THREAD' => '1',
+            'DD_TRACE_ENCODER' => 'msgpack',
+            'DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES' => 2,
+            'DD_TRACE_AGENT_FLUSH_INTERVAL' => self::FLUSH_INTERVAL_MS,
+        ]);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        \dd_tracer_circuit_breaker_register_success();
+    }
+
+    public function testScenario()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('Failed circuit breaker', '/circuit_breaker');
+            $this->call($spec);
+
+            // allow time for background sender to trigger
+            usleep(self::FLUSH_INTERVAL_MS * 1000);
+        });
+
+        $this->assertExpectedSpans(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'web.request',
+                    'web.request',
+                    'web',
+                    'GET /circuit_breaker'
+                )->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/circuit_breaker',
+                    'http.status_code' => '200',
+                    'integration.name' => 'web',
+                ]),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Description

The background sender can fall back to the PHP Transport\HTTP sender if certain conditions are met,  so the open circuit-breaker code was left in place for these situations. This PR fixes a bug where even if the background sender is used the open circuit breaker would prevent traces being sent, instead of only applying if the PHP fallback is used. 

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
