### PR TITLE
Always return unaltered VM dispatch (PHP 7)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -166,6 +166,7 @@
                         <file name="drop_spans.phpt" role="test" />
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
                         <file name="exception_error_log.phpt" role="test" />
+                        <file name="exception_from_user_error_handler_internal.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
                         <file name="exception_is_defined.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -185,6 +185,11 @@
                         <file name="fake_tracer.inc" role="test" />
                         <file name="fatal_errors_ignored_in_shutdown.phpt" role="test" />
                         <file name="fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
+                        <file name="generator.phpt" role="test" />
+                        <file name="generator_not_supported.phpt" role="test" />
+                        <file name="generator_with_exception.phpt" role="test" />
+                        <file name="generator_with_return.phpt" role="test" />
+                        <file name="generator_yield_from.phpt" role="test" />
                         <file name="get_last_error.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_internal_functions.phpt" role="test" />
                         <file name="keep_spans_in_limited_tracing_internal_methods.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -200,6 +200,7 @@
                         <file name="sandbox_api_not_available_on_unsupported_versions.phpt" role="test" />
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
+                        <file name="variadic_args_internal.phpt" role="test" />
                         <file name="vm_var_types_return.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-prehook">
@@ -225,6 +226,7 @@
                         <file name="php5_unsupported.phpt" role="test" />
                         <file name="trace_static_method.phpt" role="test" />
                         <file name="variable_length_parameter_list.phpt" role="test" />
+                        <file name="variadic_args_internal.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-regression">
                         <file name="access_modifier_method_access_hook.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -165,8 +165,13 @@
                         <file name="dd_trace_set_trace_id.phpt" role="test" />
                         <file name="drop_spans.phpt" role="test" />
                         <file name="errors_are_flagged_from_userland.phpt" role="test" />
+                        <file name="exception_does_not_close_span_that_catches.phpt" role="test" />
                         <file name="exception_error_log.phpt" role="test" />
                         <file name="exception_from_user_error_handler_internal.phpt" role="test" />
+                        <file name="exception_handled_for_correct_catch_block.phpt" role="test" />
+                        <file name="exception_handled_in_correct_catch_frame.phpt" role="test" />
+                        <file name="exception_handled_in_multicatch.phpt" role="test" />
+                        <file name="exception_handled_with_finally.phpt" role="test" />
                         <file name="exception_handling_php5.phpt" role="test" />
                         <file name="exception_handling.phpt" role="test" />
                         <file name="exception_is_defined.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -187,6 +187,7 @@
                         <file name="keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
                         <file name="memory_limit_graceful_bailout.phpt" role="test" />
                         <file name="new_static.phpt" role="test" />
+                        <file name="return_by_ref.phpt" role="test" />
                         <file name="retval_is_null_with_exception.phpt" role="test" />
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
@@ -194,6 +195,7 @@
                         <file name="sandbox_api_not_available_on_unsupported_versions.phpt" role="test" />
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
+                        <file name="vm_var_types_return.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-prehook">
                         <file name="access_modifier_method_access_hook.phpt" role="test" />

--- a/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
@@ -38,14 +38,14 @@ class YiiIntegrationLoader
         );
 
         // We assume the first controller is the one to assign to app.endpoint
-        $first_controller = null;
+        $firstController = null;
         \dd_trace_method(
             'yii\web\Application',
             'createController',
-            function (SpanData $span, $args, $retval, $ex) use (&$first_controller) {
+            function (SpanData $span, $args, $retval, $ex) use (&$firstController) {
                 if (!$ex && isset($args[0], $retval) && \is_array($retval) && !empty($retval)) {
-                    if ($this->requestedRoute === $args[0]) {
-                        $first_controller = $retval[0];
+                    if ($firstController === null) {
+                        $firstController = $retval[0];
                     }
                 }
                 return false;
@@ -70,14 +70,14 @@ class YiiIntegrationLoader
         \dd_trace_method(
             'yii\base\Controller',
             'runAction',
-            function (SpanData $span, $args) use (&$first_controller, $service, $root) {
+            function (SpanData $span, $args) use (&$firstController, $service, $root) {
                 $span->name = \get_class($this) . '.runAction';
                 $span->type = Type::WEB_SERVLET;
                 $span->service = $service;
                 $span->resource = isset($args[0]) && \is_string($args[0]) ? $args[0] : $span->name;
 
                 if (
-                    $first_controller === $this
+                    $firstController === $this
                     && $root->getTag('app.endpoint') === null
                     && isset($this->action->actionMethod)
                 ) {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -6,6 +6,7 @@
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
+#include <Zend/zend_vm.h>
 #include <inttypes.h>
 #include <php.h>
 #include <php_ini.h>
@@ -246,6 +247,10 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     if (DDTRACE_G(internal_blacklisted_modules_list) && !dd_no_blacklisted_modules(TSRMLS_C)) {
         return SUCCESS;
     }
+
+    // This allows us to hook the ZEND_HANDLE_EXCEPTION pseudo opcode
+    ZEND_VM_SET_OPCODE_HANDLER(EG(exception_op));
+    EG(exception_op)->opcode = ZEND_HANDLE_EXCEPTION;
 
     ddtrace_dogstatsd_client_rinit(TSRMLS_C);
 

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -21,7 +21,6 @@ typedef struct ddtrace_dispatch_t {
 
 ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC);
 zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, uint32_t options TSRMLS_DC);
-int ddtrace_wrap_fcall(zend_execute_data *TSRMLS_DC);
 void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);
 void ddtrace_class_lookup_release(ddtrace_dispatch_t *);
 zend_class_entry *ddtrace_target_class_entry(zval *, zval *TSRMLS_DC);

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -21,8 +21,18 @@ typedef struct ddtrace_dispatch_t {
 
 ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC);
 zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, uint32_t options TSRMLS_DC);
-void ddtrace_class_lookup_acquire(ddtrace_dispatch_t *);
-void ddtrace_class_lookup_release(ddtrace_dispatch_t *);
+
+void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch);
+
+inline void ddtrace_dispatch_copy(ddtrace_dispatch_t *dispatch) { dispatch->acquired++; }
+
+inline void ddtrace_dispatch_release(ddtrace_dispatch_t *dispatch) {
+    if (--dispatch->acquired == 0) {
+        ddtrace_dispatch_dtor(dispatch);
+        efree(dispatch);
+    }
+}
+
 zend_class_entry *ddtrace_target_class_entry(zval *, zval *TSRMLS_DC);
 int ddtrace_find_function(HashTable *table, zval *name, zend_function **function);
 void ddtrace_dispatch_init(TSRMLS_D);
@@ -70,7 +80,6 @@ void ddtrace_class_lookup_release_compat(zval *zv);
 #endif
 
 zend_function *ddtrace_function_get(const HashTable *table, zval *name);
-void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch);
 HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);
 void ddtrace_wrapper_forward_call_from_userland(zend_execute_data *execute_data, zval *return_value TSRMLS_DC);

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -120,7 +120,7 @@ zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, u
     if (ddtrace_dispatch_store(overridable_lookup, &dispatch)) {
         return 1;
     } else {
-        ddtrace_dispatch_free_owned_data(&dispatch);
+        ddtrace_dispatch_dtor(&dispatch);
         return 0;
     }
 }

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -10,6 +10,9 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 static zend_op_array *(*_prev_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
 
+void ddtrace_execute_internal_minit(void);
+void ddtrace_execute_internal_mshutdown(void);
+
 static void _compile_minit(void);
 static void _compile_mshutdown(void);
 
@@ -17,12 +20,15 @@ void ddtrace_opcode_minit(void);
 void ddtrace_opcode_mshutdown(void);
 
 void ddtrace_engine_hooks_minit(void) {
+    ddtrace_execute_internal_minit();
     ddtrace_opcode_minit();
     _compile_minit();
 }
+
 void ddtrace_engine_hooks_mshutdown(void) {
     _compile_mshutdown();
     ddtrace_opcode_mshutdown();
+    ddtrace_execute_internal_mshutdown();
 }
 
 static uint64_t _get_microseconds() {

--- a/src/ext/php5/dispatch.c
+++ b/src/ext/php5/dispatch.c
@@ -37,14 +37,14 @@ zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     return fptr;
 }
 
-void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
+void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
     zval_dtor(&dispatch->function_name);
     zval_dtor(&dispatch->callable);
 }
 
 void ddtrace_class_lookup_release_compat(void *zv) {
     ddtrace_dispatch_t *dispatch = *(ddtrace_dispatch_t **)zv;
-    ddtrace_class_lookup_release(dispatch);
+    ddtrace_dispatch_release(dispatch);
 }
 
 HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
@@ -62,7 +62,7 @@ zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch
 
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
 
-    ddtrace_class_lookup_acquire(dispatch);
+    ddtrace_dispatch_copy(dispatch);
     return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -663,7 +663,7 @@ static int _dd_opcode_default_dispatch(zend_execute_data *execute_data TSRMLS_DC
     return ZEND_USER_OPCODE_DISPATCH;
 }
 
-int ddtrace_wrap_fcall(zend_execute_data *execute_data TSRMLS_DC) {
+static int _dd_begin_fcall_handler(zend_execute_data *execute_data TSRMLS_DC) {
     zend_function *current_fbc = NULL;
     ddtrace_dispatch_t *dispatch = NULL;
     if (!_dd_should_trace_call(execute_data, &current_fbc, &dispatch TSRMLS_CC)) {
@@ -739,8 +739,8 @@ static int _dd_exit_handler(zend_execute_data *execute_data TSRMLS_DC) {
 void ddtrace_opcode_minit(void) {
     _prev_fcall_handler = zend_get_user_opcode_handler(ZEND_DO_FCALL);
     _prev_fcall_by_name_handler = zend_get_user_opcode_handler(ZEND_DO_FCALL_BY_NAME);
-    zend_set_user_opcode_handler(ZEND_DO_FCALL, ddtrace_wrap_fcall);
-    zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, ddtrace_wrap_fcall);
+    zend_set_user_opcode_handler(ZEND_DO_FCALL, _dd_begin_fcall_handler);
+    zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, _dd_begin_fcall_handler);
 
     _prev_exit_handler = zend_get_user_opcode_handler(ZEND_EXIT);
     zend_set_user_opcode_handler(ZEND_EXIT, _dd_exit_handler);
@@ -751,4 +751,12 @@ void ddtrace_opcode_mshutdown(void) {
     zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, NULL);
 
     zend_set_user_opcode_handler(ZEND_EXIT, NULL);
+}
+
+void ddtrace_execute_internal_minit(void) {
+    // TODO
+}
+
+void ddtrace_execute_internal_mshutdown(void) {
+    // TODO
 }

--- a/src/ext/php7/dispatch.c
+++ b/src/ext/php7/dispatch.c
@@ -48,7 +48,7 @@ zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     return ptr;
 }
 
-void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
+void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
     zval_ptr_dtor(&dispatch->function_name);
     zval_ptr_dtor(&dispatch->callable);
 }
@@ -56,7 +56,7 @@ void ddtrace_dispatch_free_owned_data(ddtrace_dispatch_t *dispatch) {
 void ddtrace_class_lookup_release_compat(zval *zv) {
     DD_PRINTF("freeing %p", (void *)zv);
     ddtrace_dispatch_t *dispatch = Z_PTR_P(zv);
-    ddtrace_class_lookup_release(dispatch);
+    ddtrace_dispatch_release(dispatch);
 }
 
 HashTable *ddtrace_new_class_lookup(zval *class_name) {
@@ -79,7 +79,7 @@ zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch
     ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & DDTRACE_IS_ARRAY_PERSISTENT);
 
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
-    ddtrace_class_lookup_acquire(dispatch);
+    ddtrace_dispatch_copy(dispatch);
     return zend_hash_update_ptr(lookup, Z_STR(dispatch->function_name), dispatch) != NULL;
 }
 

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -318,7 +318,7 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
     if (keep_span) {
         ddtrace_close_span();
     } else {
-        ddtrace_drop_span();
+        ddtrace_drop_top_open_span();
     }
 }
 
@@ -468,16 +468,14 @@ static int _dd_begin_fcall_handler(zend_execute_data *execute_data) {
         dispatch->options & (DDTRACE_DISPATCH_POSTHOOK | DDTRACE_DISPATCH_PREHOOK)) {
         return vm_retval;
     }
-    ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
-    dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
+    ddtrace_dispatch_copy(dispatch);  // protecting against dispatch being freed during php code execution
+    dispatch->busy = 1;               // guard against recursion, catching only topmost execution
 
     if (dispatch->options & (DDTRACE_DISPATCH_POSTHOOK | DDTRACE_DISPATCH_PREHOOK)) {
         ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
 
         if ((dispatch->options & DDTRACE_DISPATCH_PREHOOK) && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
-            ddtrace_drop_span();
-            dispatch->busy = 0;
-            ddtrace_class_lookup_release(dispatch);
+            ddtrace_drop_top_open_span();
         }
 
         return ZEND_USER_OPCODE_DISPATCH;
@@ -515,7 +513,7 @@ static int _dd_begin_fcall_handler(zend_execute_data *execute_data) {
     _dd_update_opcode_leave(execute_data);
 
     dispatch->busy = 0;
-    ddtrace_class_lookup_release(dispatch);
+    ddtrace_dispatch_release(dispatch);
 
     EX(opline)++;
 
@@ -546,13 +544,7 @@ static void _dd_do_return_handler(zend_execute_data *execute_data) {
             ZVAL_NULL(&rv);
             retval = &rv;
         }
-        // Save pointer to dispatch since span can be dropped from _dd_end_span()
-        ddtrace_dispatch_t *dispatch = span->dispatch;
         _dd_end_span(span, retval);
-        if (dispatch) {
-            dispatch->busy = 0;
-            ddtrace_class_lookup_release(dispatch);
-        }
     }
 }
 
@@ -671,18 +663,12 @@ static int _dd_handle_exception_handler(zend_execute_data *execute_data) {
     if (span && span->call == execute_data) {
         zval retval;
         ZVAL_NULL(&retval);
-        // Save pointer to dispatch since span can be dropped from _dd_end_span()
-        ddtrace_dispatch_t *dispatch = span->dispatch;
         // The catching frame's span will get closed by the return handler so we leave it open
         if (_dd_is_catching_frame(execute_data) == false) {
             if (EG(exception)) {
                 _dd_span_attach_exception(span, EG(exception));
             }
             _dd_end_span(span, &retval);
-            if (dispatch) {
-                dispatch->busy = 0;
-                ddtrace_class_lookup_release(dispatch);
-            }
         }
     }
 
@@ -694,13 +680,7 @@ static int _dd_exit_handler(zend_execute_data *execute_data) {
     while ((span = DDTRACE_G(open_spans_top))) {
         zval retval;
         ZVAL_NULL(&retval);
-        // Save pointer to dispatch since span can be dropped from _dd_end_span()
-        ddtrace_dispatch_t *dispatch = span->dispatch;
         _dd_end_span(span, &retval);
-        if (dispatch) {
-            dispatch->busy = 0;
-            ddtrace_class_lookup_release(dispatch);
-        }
     }
 
     return _prev_exit_handler ? _prev_exit_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;
@@ -764,14 +744,12 @@ static void _dd_execute_internal(zend_execute_data *execute_data, zval *return_v
         return;
     }
 
-    ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
-    dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
+    ddtrace_dispatch_copy(dispatch);  // protecting against dispatch being freed during php code execution
+    dispatch->busy = 1;               // guard against recursion, catching only topmost execution
 
     ddtrace_span_t *span = ddtrace_open_span(execute_data, dispatch);
     if ((dispatch->options & DDTRACE_DISPATCH_PREHOOK) && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
-        ddtrace_drop_span();
-        dispatch->busy = 0;
-        ddtrace_class_lookup_release(dispatch);
+        ddtrace_drop_top_open_span();
 
         _prev_execute_internal(execute_data, return_value);
         return;
@@ -782,11 +760,11 @@ static void _dd_execute_internal(zend_execute_data *execute_data, zval *return_v
             _dd_span_attach_exception(span, EG(exception));
         }
         _dd_end_span(span, return_value);
-    } else if (get_dd_trace_debug()) {
+        return;
+    }
+    if (get_dd_trace_debug()) {
         ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync",
                          ZSTR_VAL(current_fbc->common.function_name));
     }
-
     dispatch->busy = 0;
-    ddtrace_class_lookup_release(dispatch);
 }

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -1,6 +1,7 @@
 #include "engine_hooks.h"
 
 #include <Zend/zend_closures.h>
+#include <Zend/zend_compile.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_interfaces.h>
 #include <stdbool.h>
@@ -24,6 +25,8 @@ static user_opcode_handler_t _prev_icall_handler;
 static user_opcode_handler_t _prev_ucall_handler;
 static user_opcode_handler_t _prev_fcall_handler;
 static user_opcode_handler_t _prev_fcall_by_name_handler;
+static user_opcode_handler_t _prev_return_handler;
+static user_opcode_handler_t _prev_return_by_ref_handler;
 static user_opcode_handler_t _prev_exit_handler;
 
 #if PHP_VERSION_ID < 70100
@@ -114,38 +117,6 @@ static void _dd_setup_fcall(zend_execute_data *execute_data, zend_fcall_info *fc
     fci->param_count = ZEND_CALL_NUM_ARGS(execute_data);
     fci->params = fci->param_count ? ZEND_CALL_ARG(execute_data, 1) : NULL;
     fci->retval = *result;
-}
-
-static int _dd_forward_call(zend_execute_data *execute_data, zend_function *fbc, zval *return_value,
-                            zend_fcall_info *fci, zend_fcall_info_cache *fcc) {
-    int fcall_status;
-
-#if PHP_VERSION_ID < 70300
-    fcc->initialized = 1;
-#endif
-    fcc->function_handler = fbc;
-    fcc->object = Z_TYPE(EX(This)) == IS_OBJECT ? Z_OBJ(EX(This)) : NULL;
-    fcc->calling_scope = fbc->common.scope;  // EG(scope);
-    fcc->called_scope = zend_get_called_scope(execute_data);
-
-    fci->size = sizeof(zend_fcall_info);
-    fci->no_separation = 1;
-    fci->object = fcc->object;
-
-    _dd_setup_fcall(execute_data, fci, &return_value);
-
-    fcall_status = zend_call_function(fci, fcc);
-    if (fcall_status == SUCCESS && Z_TYPE_P(return_value) != IS_UNDEF) {
-#if PHP_VERSION_ID >= 70100
-        if (Z_ISREF_P(return_value)) {
-            zend_unwrap_reference(return_value);
-        }
-#endif
-    }
-
-    // We don't want to clear the args with zend_fcall_info_args_clear() yet
-    // since our tracing closure might need them
-    return fcall_status;
 }
 
 static bool _dd_execute_tracing_closure(zval *callable, zval *span_data, zend_execute_data *call, zval *user_args,
@@ -316,47 +287,6 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
     }
 }
 
-static bool _dd_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc, zend_execute_data *execute_data) {
-    ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
-
-    if ((dispatch->options & DDTRACE_DISPATCH_PREHOOK) && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
-        ddtrace_drop_span();
-        return false;
-    }
-
-    const zend_op *opline = EX(opline);
-
-    zval rv, *user_retval;
-    ZVAL_NULL(&rv);
-    user_retval = (RETURN_VALUE_USED(opline) ? EX_VAR(opline->result.var) : &rv);
-
-    zend_fcall_info fci = {0};
-    zend_fcall_info_cache fcc = {0};
-    _dd_forward_call(EX(call), fbc, user_retval, &fci, &fcc);
-    if (span == DDTRACE_G(open_spans_top)) {
-        if (EG(exception)) {
-            _dd_span_attach_exception(span, EG(exception));
-        }
-        _dd_end_span(span, user_retval);
-    } else if (get_dd_trace_debug()) {
-        const char *fname = Z_STRVAL(dispatch->function_name);
-        ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync", fname);
-    }
-
-    zend_fcall_info_args_clear(&fci, 0);
-    zval_dtor(&rv);
-
-    // Since zend_leave_helper isn't run we have to dtor $this here
-    // https://lxr.room11.org/xref/php-src%407.4/Zend/zend_vm_def.h#2888
-    if (ZEND_CALL_INFO(EX(call)) & ZEND_CALL_RELEASE_THIS) {
-        OBJ_RELEASE(Z_OBJ(EX(call)->This));
-    }
-    // Restore call for internal functions
-    EX(call) = EX(call)->prev_execute_data;
-
-    return true;
-}
-
 static void _dd_update_opcode_leave(zend_execute_data *execute_data) {
     DD_PRINTF("Update opcode leave");
     EX(call) = EX(call)->prev_execute_data;
@@ -507,43 +437,47 @@ static int _dd_begin_fcall_handler(zend_execute_data *execute_data) {
     dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
     if (dispatch->options & (DDTRACE_DISPATCH_POSTHOOK | DDTRACE_DISPATCH_PREHOOK)) {
-        if (_dd_trace_dispatch(dispatch, current_fbc, execute_data) == false) {
+        ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
+
+        if ((dispatch->options & DDTRACE_DISPATCH_PREHOOK) && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
+            ddtrace_drop_span();
             dispatch->busy = 0;
             ddtrace_class_lookup_release(dispatch);
-            return vm_retval;
-        }
-    } else {
-        // Store original context for forwarding the call from userland
-        zend_function *previous_fbc = DDTRACE_G(original_context).fbc;
-        DDTRACE_G(original_context).fbc = current_fbc;
-        zend_function *previous_calling_fbc = DDTRACE_G(original_context).calling_fbc;
-
-        DDTRACE_G(original_context).calling_fbc = current_fbc->common.scope ? current_fbc : execute_data->func;
-
-        zval *this = _dd_this(EX(call));
-
-        zend_object *previous_this = DDTRACE_G(original_context).this;
-        DDTRACE_G(original_context).this = this ? Z_OBJ_P(this) : NULL;
-        zend_class_entry *previous_calling_ce = DDTRACE_G(original_context).calling_ce;
-
-        if (DDTRACE_G(original_context).this) {
-            GC_ADDREF(DDTRACE_G(original_context).this);
-        }
-        DDTRACE_G(original_context).calling_ce = Z_OBJ(execute_data->This) ? Z_OBJ(execute_data->This)->ce : NULL;
-
-        _dd_wrap_and_run(execute_data, dispatch);
-        if (DDTRACE_G(original_context).this) {
-            GC_DELREF(DDTRACE_G(original_context).this);
         }
 
-        // Restore original context
-        DDTRACE_G(original_context).calling_ce = previous_calling_ce;
-        DDTRACE_G(original_context).this = previous_this;
-        DDTRACE_G(original_context).calling_fbc = previous_calling_fbc;
-        DDTRACE_G(original_context).fbc = previous_fbc;
-
-        _dd_update_opcode_leave(execute_data);
+        return ZEND_USER_OPCODE_DISPATCH;
     }
+
+    // Store original context for forwarding the call from userland
+    zend_function *previous_fbc = DDTRACE_G(original_context).fbc;
+    DDTRACE_G(original_context).fbc = current_fbc;
+    zend_function *previous_calling_fbc = DDTRACE_G(original_context).calling_fbc;
+
+    DDTRACE_G(original_context).calling_fbc = current_fbc->common.scope ? current_fbc : execute_data->func;
+
+    zval *this = _dd_this(EX(call));
+
+    zend_object *previous_this = DDTRACE_G(original_context).this;
+    DDTRACE_G(original_context).this = this ? Z_OBJ_P(this) : NULL;
+    zend_class_entry *previous_calling_ce = DDTRACE_G(original_context).calling_ce;
+
+    if (DDTRACE_G(original_context).this) {
+        GC_ADDREF(DDTRACE_G(original_context).this);
+    }
+    DDTRACE_G(original_context).calling_ce = Z_OBJ(execute_data->This) ? Z_OBJ(execute_data->This)->ce : NULL;
+
+    _dd_wrap_and_run(execute_data, dispatch);
+    if (DDTRACE_G(original_context).this) {
+        GC_DELREF(DDTRACE_G(original_context).this);
+    }
+
+    // Restore original context
+    DDTRACE_G(original_context).calling_ce = previous_calling_ce;
+    DDTRACE_G(original_context).this = previous_this;
+    DDTRACE_G(original_context).calling_fbc = previous_calling_fbc;
+    DDTRACE_G(original_context).fbc = previous_fbc;
+
+    _dd_update_opcode_leave(execute_data);
 
     dispatch->busy = 0;
     ddtrace_class_lookup_release(dispatch);
@@ -551,6 +485,50 @@ static int _dd_begin_fcall_handler(zend_execute_data *execute_data) {
     EX(opline)++;
 
     return ZEND_USER_OPCODE_LEAVE;
+}
+
+static void _dd_do_return_handler(zend_execute_data *execute_data) {
+    ddtrace_span_t *span = DDTRACE_G(open_spans_top);
+    if (span && span->call == execute_data) {
+        zval rv;
+        zval *retval = NULL;
+        switch (EX(opline)->op1_type) {
+            case IS_CONST:
+#if PHP_VERSION_ID >= 70300
+                retval = RT_CONSTANT(EX(opline), EX(opline)->op1);
+#else
+                retval = EX_CONSTANT(EX(opline)->op1);
+#endif
+                break;
+            case IS_TMP_VAR:
+            case IS_VAR:
+            case IS_CV:
+                retval = EX_VAR(EX(opline)->op1.var);
+                break;
+                /* IS_UNUSED is NULL */
+        }
+        if (!retval || Z_TYPE_INFO_P(retval) == IS_UNDEF) {
+            ZVAL_NULL(&rv);
+            retval = &rv;
+        }
+        // Save pointer to dispatch since span can be dropped from _dd_end_span()
+        ddtrace_dispatch_t *dispatch = span->dispatch;
+        _dd_end_span(span, retval);
+        if (dispatch) {
+            dispatch->busy = 0;
+            ddtrace_class_lookup_release(dispatch);
+        }
+    }
+}
+
+static int _dd_return_handler(zend_execute_data *execute_data) {
+    _dd_do_return_handler(execute_data);
+    return _prev_return_handler ? _prev_return_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;
+}
+
+static int _dd_return_by_ref_handler(zend_execute_data *execute_data) {
+    _dd_do_return_handler(execute_data);
+    return _prev_return_by_ref_handler ? _prev_return_by_ref_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;
 }
 
 static int _dd_exit_handler(zend_execute_data *execute_data) {
@@ -580,6 +558,10 @@ void ddtrace_opcode_minit(void) {
     zend_set_user_opcode_handler(ZEND_DO_FCALL, _dd_begin_fcall_handler);
     zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, _dd_begin_fcall_handler);
 
+    _prev_return_handler = zend_get_user_opcode_handler(ZEND_RETURN);
+    zend_set_user_opcode_handler(ZEND_RETURN, _dd_return_handler);
+    _prev_return_by_ref_handler = zend_get_user_opcode_handler(ZEND_RETURN_BY_REF);
+    zend_set_user_opcode_handler(ZEND_RETURN_BY_REF, _dd_return_by_ref_handler);
     _prev_exit_handler = zend_get_user_opcode_handler(ZEND_EXIT);
     zend_set_user_opcode_handler(ZEND_EXIT, _dd_exit_handler);
 }
@@ -590,6 +572,8 @@ void ddtrace_opcode_mshutdown(void) {
     zend_set_user_opcode_handler(ZEND_DO_FCALL, NULL);
     zend_set_user_opcode_handler(ZEND_DO_FCALL_BY_NAME, NULL);
 
+    zend_set_user_opcode_handler(ZEND_RETURN, NULL);
+    zend_set_user_opcode_handler(ZEND_RETURN_BY_REF, NULL);
     zend_set_user_opcode_handler(ZEND_EXIT, NULL);
 }
 

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -7,6 +7,7 @@
 #include "auto_flush.h"
 #include "configuration.h"
 #include "ddtrace.h"
+#include "dispatch.h"
 #include "logging.h"
 #include "random.h"
 #include "serializer.h"
@@ -51,11 +52,21 @@ static void _free_span(ddtrace_span_t *span) {
     efree(span);
 }
 
+static void ddtrace_drop_span(ddtrace_span_t *span) {
+    if (span->dispatch) {
+        span->dispatch->busy = 0;
+        ddtrace_dispatch_release(span->dispatch);
+        span->dispatch = NULL;
+    }
+
+    _free_span(span);
+}
+
 static void _free_span_stack(ddtrace_span_t *span) {
     while (span != NULL) {
         ddtrace_span_t *tmp = span;
         span = tmp->next;
-        _free_span(tmp);
+        ddtrace_drop_span(tmp);
     }
 }
 
@@ -123,6 +134,12 @@ void ddtrace_close_span(TSRMLS_D) {
     span->next = DDTRACE_G(closed_spans_top);
     DDTRACE_G(closed_spans_top) = span;
 
+    if (span->dispatch) {
+        span->dispatch->busy = 0;
+        ddtrace_dispatch_release(span->dispatch);
+        span->dispatch = NULL;
+    }
+
     if (DDTRACE_G(open_spans_top) == NULL && get_dd_trace_auto_flush_enabled()) {
         if (ddtrace_flush_tracer() == FAILURE) {
             ddtrace_log_debug("Unable to auto flush the tracer");
@@ -130,7 +147,7 @@ void ddtrace_close_span(TSRMLS_D) {
     }
 }
 
-void ddtrace_drop_span(TSRMLS_D) {
+void ddtrace_drop_top_open_span(TSRMLS_D) {
     ddtrace_span_t *span = DDTRACE_G(open_spans_top);
     if (span == NULL) {
         return;
@@ -138,8 +155,7 @@ void ddtrace_drop_span(TSRMLS_D) {
     DDTRACE_G(open_spans_top) = span->next;
     // Sync with span ID stack
     ddtrace_pop_span_id(TSRMLS_C);
-
-    _free_span(span);
+    ddtrace_drop_span(span);
 }
 
 void ddtrace_serialize_closed_spans(zval *serialized TSRMLS_DC) {

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -36,7 +36,7 @@ void ddtrace_free_span_stacks(TSRMLS_D);
 ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC);
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 void ddtrace_close_span(TSRMLS_D);
-void ddtrace_drop_span(TSRMLS_D);
+void ddtrace_drop_top_open_span(TSRMLS_D);
 void ddtrace_serialize_closed_spans(zval *serialized TSRMLS_DC);
 
 #endif  // DD_SPAN_H

--- a/tests/ext/sandbox-prehook/variadic_args_internal.phpt
+++ b/tests/ext/sandbox-prehook/variadic_args_internal.phpt
@@ -1,0 +1,42 @@
+--TEST--
+[Prehook] Variadic arguments are passed to tracing closure for internal functions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+dd_trace_function('array_unshift', ['prehook' => function (DDTrace\SpanData $s, array $args) {
+    var_dump($args);
+}]);
+
+$queue = ['Foo', 'Bar'];
+array_unshift($queue, 'Baz', 42, true);
+var_dump($queue);
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(3) "Foo"
+    [1]=>
+    string(3) "Bar"
+  }
+  [1]=>
+  string(3) "Baz"
+  [2]=>
+  int(42)
+  [3]=>
+  bool(true)
+}
+array(5) {
+  [0]=>
+  string(3) "Baz"
+  [1]=>
+  int(42)
+  [2]=>
+  bool(true)
+  [3]=>
+  string(3) "Foo"
+  [4]=>
+  string(3) "Bar"
+}

--- a/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
+++ b/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Exceptions do not close the span that catches it
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function main() {
+    return handle();
+}
+
+function handle() {
+    try {
+        return doException();
+    } catch (Exception $e) {
+        return handleException($e);
+    }
+}
+
+function handleException(Exception $e) {
+    echo 'Exception was handled: ' . $e->getMessage() . PHP_EOL;
+    return '-HANDLED';
+}
+
+function doException() {
+    try {
+        throw new Exception('Oops!');
+    } catch (RuntimeException $e) {
+        echo 'You should not see this';
+    }
+    return 'You should not see this either';
+}
+
+dd_trace_function('main', function(SpanData $s, $a, $retval) {
+    $s->name = 'main';
+    $s->resource = $retval;
+});
+
+dd_trace_function('handle', function(SpanData $s, $a, $retval) {
+    $s->name = 'handle';
+    $s->resource = $retval;
+});
+
+dd_trace_function('handleException', function(SpanData $s, $a, $retval) {
+    $s->name = 'handleException';
+    $s->resource = $retval;
+});
+
+echo main() . PHP_EOL;
+
+list($mainSpan, $handleSpan, $handleExceptionSpan) = dd_trace_serialize_closed_spans();
+
+echo $mainSpan['name'] . $mainSpan['resource'] . PHP_EOL;
+var_dump(!isset($mainSpan['parent_id']));
+
+echo $handleSpan['name'] . $handleSpan['resource'] . PHP_EOL;
+var_dump($handleSpan['parent_id'] === $mainSpan['span_id']);
+
+echo $handleExceptionSpan['name'] . $handleExceptionSpan['resource'] . PHP_EOL;
+var_dump($handleExceptionSpan['parent_id'] === $handleSpan['span_id']);
+?>
+--EXPECT--
+Exception was handled: Oops!
+-HANDLED
+main-HANDLED
+bool(true)
+handle-HANDLED
+bool(true)
+handleException-HANDLED
+bool(true)

--- a/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
+++ b/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Exceptions from user error handler are tracked for instrumented internal functions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+class FooErrorHandler
+{
+    public static function handleError($errno, $errstr, $errfile, $errline)
+    {
+        throw new Exception($errstr);
+    }
+}
+
+set_error_handler('FooErrorHandler::handleError');
+
+dd_trace_function('scandir', function() {});
+
+try {
+    var_dump(scandir(''));
+} catch (Exception $e) {
+    $spans = dd_trace_serialize_closed_spans();
+    echo 'Spans count: ' . count($spans) . PHP_EOL;
+
+    $span = $spans[0];
+    echo 'error: ' . $span['error'] . PHP_EOL;
+    echo 'error.type: ' . $span['meta']['error.type'] . PHP_EOL;
+    echo 'error.msg: ' . $span['meta']['error.msg'] . PHP_EOL;
+    echo 'Has error.stack: ' . isset($span['meta']['error.stack']) . PHP_EOL;
+}
+?>
+--EXPECT--
+Spans count: 1
+error: 1
+error.type: Exception
+error.msg: scandir(): Directory name cannot be empty
+Has error.stack: 1

--- a/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
+++ b/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
@@ -2,6 +2,7 @@
 Exceptions from user error handler are tracked for instrumented internal functions
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for handling return value on PHP 5'); ?>
 --FILE--
 <?php
 class FooErrorHandler

--- a/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
+++ b/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Exceptions are handled for the correct catch block
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class FooException extends Exception {}
+class BarException extends FooException {}
+
+function throwException() {
+    throw new BarException('Oops!');
+}
+
+function multiCatch() {
+    try {
+        throwException();
+        return 'You should not see this';
+    } catch (DomainException $e) {
+        return get_class($e) . ' caught';
+    } catch (RuntimeException $e) {
+        return get_class($e) . ' caught';
+    } catch (FooException $e) {
+        return get_class($e) . ' caught';
+    } catch (LogicException $e) {
+        return get_class($e) . ' caught';
+    }
+}
+
+function embeddedCatch() {
+    try {
+        try {
+            try {
+                throwException();
+                return 'You should not see this';
+            } catch (LogicException $e) {
+                return get_class($e) . ' caught';
+            }
+        } catch (FooException $e) {
+            return get_class($e) . ' caught';
+        }
+    } catch (DomainException $e) {
+        return get_class($e) . ' caught';
+    }
+}
+
+dd_trace_function('throwException', function(SpanData $s) {
+    $s->name = 'throwException';
+});
+
+dd_trace_function('multiCatch', function(SpanData $s, $a, $retval) {
+    $s->name = 'multiCatch';
+    $s->resource = $retval;
+});
+
+dd_trace_function('embeddedCatch', function(SpanData $s, $a, $retval) {
+    $s->name = 'embeddedCatch';
+    $s->resource = $retval;
+});
+
+echo multiCatch() . PHP_EOL;
+echo embeddedCatch() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo isset($span['meta']['error.msg']) ? ', ' . $span['meta']['error.msg'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+BarException caught
+BarException caught
+embeddedCatch, BarException caught
+throwException, Oops!
+multiCatch, BarException caught
+throwException, Oops!

--- a/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
+++ b/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Exceptions are handled in the correct catch frame
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for handling return value on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function handleException(Exception $e, $function) {
+    echo 'Exception was handled by '. $function . '(): ';
+    echo $e->getMessage() . PHP_EOL;
+    return 'HANDLED';
+}
+
+function level0() {
+    try {
+        return level1();
+    } catch (Exception $e) {
+        return handleException($e, __FUNCTION__);
+    }
+}
+
+function level1() {
+    try {
+        return level2();
+    } catch (Exception $e) {
+        return handleException($e, __FUNCTION__);
+    }
+}
+
+function level2() {
+    try {
+        return level3();
+    } catch (RuntimeException $e) {
+        echo 'You should not see this ' . __FUNCTION__;
+        return 'RuntimeException caught';
+    }
+}
+
+function level3() {
+    throw new Exception('Oops!');
+    return 'You should not see this ' . __FUNCTION__;
+}
+
+dd_trace_function('level0', function(SpanData $s, $a, $retval) {
+    $s->name = 'level0';
+    $s->resource = $retval;
+});
+
+dd_trace_function('level1', function(SpanData $s, $a, $retval) {
+    $s->name = 'level1';
+    $s->resource = $retval;
+});
+
+dd_trace_function('level2', function(SpanData $s, $a, $retval) {
+    $s->name = 'level2';
+    $s->resource = $retval;
+});
+
+dd_trace_function('level3', function(SpanData $s, $a, $retval) {
+    $s->name = 'level3';
+    $s->resource = $retval;
+});
+
+echo level0() . PHP_EOL;
+
+array_map(function($span) {
+    echo 'Span: ' . $span['name'];
+    if (isset($span['resource'])) {
+        echo '-' . $span['resource'];
+    }
+    if (isset($span['meta']['error.msg'])) {
+        echo ' (' . $span['meta']['error.msg'] . ')';
+    }
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+Exception was handled by level1(): Oops!
+HANDLED
+Span: level0-HANDLED
+Span: level1-HANDLED
+Span: level2 (Oops!)
+Span: level3 (Oops!)

--- a/tests/ext/sandbox/exception_handled_in_multicatch.phpt
+++ b/tests/ext/sandbox/exception_handled_in_multicatch.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Exceptions are handled with multi-catch syntax
+--DESCRIPTION--
+Even though multi-catch syntax is equivalent to using multiple catch blocks from
+the VM perspective, this test exists in case that changes in the future.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: Multi-catch was added in PHP 7.1'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class FooException extends Exception {}
+
+function throwException() {
+    throw new FooException('Oops!');
+}
+
+function multiCatch() {
+    try {
+        throwException();
+        return 'You should not see this';
+    } catch (DomainException | RuntimeException | FooException | LogicException $e) {
+        return get_class($e) . ' caught';
+    }
+}
+
+dd_trace_function('throwException', function(SpanData $s) {
+    $s->name = 'throwException';
+});
+
+dd_trace_function('multiCatch', function(SpanData $s, $a, $retval) {
+    $s->name = 'multiCatch';
+    $s->resource = $retval;
+});
+
+echo multiCatch() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo isset($span['meta']['error.msg']) ? ', ' . $span['meta']['error.msg'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+FooException caught
+multiCatch, FooException caught
+throwException, Oops!

--- a/tests/ext/sandbox/exception_handled_with_finally.phpt
+++ b/tests/ext/sandbox/exception_handled_with_finally.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Return value from finally block is passed to tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: This causes an unpatched memory leak from php-src on PHP 5.6 and 7.0'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class FooException extends Exception {}
+
+function throwException() {
+    throw new FooException('Oops!');
+}
+
+function doCatchWithFinally() {
+    try {
+        throwException();
+        return 'You should not see this';
+    } catch (FooException $e) {
+        return get_class($e) . ' caught';
+    } finally {
+        return 'Finally retval';
+    }
+}
+
+dd_trace_function('throwException', function(SpanData $s) {
+    $s->name = 'throwException';
+});
+
+dd_trace_function('doCatchWithFinally', function(SpanData $s, $a, $retval) {
+    $s->name = 'doCatchWithFinally';
+    $s->resource = $retval;
+});
+
+echo doCatchWithFinally() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo isset($span['meta']['error.msg']) ? ', ' . $span['meta']['error.msg'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+Finally retval
+doCatchWithFinally, Finally retval
+throwException, Oops!

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
@@ -6,10 +6,6 @@ Exceptions from original call are passed to tracing closure (PHP 7)
 <?php
 use DDTrace\SpanData;
 
-register_shutdown_function(function () {
-
-});
-
 function testExceptionIsNull()
 {
     echo "testExceptionIsNull()\n";
@@ -46,7 +42,7 @@ array_map(function($span) {
     echo PHP_EOL;
 }, dd_trace_serialize_closed_spans());
 ?>
---EXPECTF--
+--EXPECT--
 testExceptionIsNull()
 bool(true)
 testExceptionIsPassed()

--- a/tests/ext/sandbox/generator.phpt
+++ b/tests/ext/sandbox/generator.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Functions that return generators are instrumented
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: Generators are supported for PHP 7.1 and greater'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function getResults() {
+    for ($i = 10; $i < 13; $i++) {
+        yield $i;
+    }
+}
+
+function doSomething() {
+    $generator = getResults();
+    foreach ($generator as $value) {
+        echo $value . PHP_EOL;
+    }
+
+    return 'Done';
+}
+
+dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+    $s->name = 'getResults';
+    $s->resource = $retval;
+});
+
+dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+10
+11
+12
+Done
+doSomething, Done
+getResults, 10

--- a/tests/ext/sandbox/generator_not_supported.phpt
+++ b/tests/ext/sandbox/generator_not_supported.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Generators are not supported on PHP versions < 7.1
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: Generators were added in PHP 5.5'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Requires unaltered VM dispatch'); /* Remove when unaltered VM dispatch added in PHP 5 */ ?>
+<?php if (PHP_VERSION_ID >= 70100) die('skip: Test is for PHP versions less than 7.1'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function getResults() {
+    for ($i = 0; $i < 3; $i++) {
+        yield $i;
+    }
+}
+
+function doSomething() {
+    $generator = getResults();
+    foreach ($generator as $value) {
+        echo $value . PHP_EOL;
+    }
+
+    return 'Done';
+}
+
+dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+    $s->name = 'getResults';
+    $s->resource = $retval;
+});
+
+dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+Cannot instrument generators for PHP versions < 7.1
+0
+1
+2
+Done
+doSomething, Done

--- a/tests/ext/sandbox/generator_with_exception.phpt
+++ b/tests/ext/sandbox/generator_with_exception.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Exceptions are handled from a generator context
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: Generators are supported for PHP 7.1 and greater'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class FooException extends Exception {}
+
+function maybeThrowException() {
+    for ($i = 0; $i <= 3; $i++) {
+        if ($i === 3) {
+            // TODO Figure out this black hole
+            // The span closes on the first yield so there
+            // is no span to attach the exception to
+            throw new FooException('Oops!');
+        }
+        yield $i;
+    }
+}
+
+function doSomething() {
+    try {
+        $generator = maybeThrowException();
+        foreach ($generator as $value) {
+            echo $value . PHP_EOL;
+        }
+        return 'You should not see this';
+    } catch (FooException $e) {
+        return get_class($e) . ' caught';
+    }
+}
+
+dd_trace_function('maybeThrowException', function(SpanData $s, $a, $retval) {
+    $s->name = 'maybeThrowException';
+    $s->resource = $retval;
+});
+
+dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo isset($span['meta']['error.msg']) ? ', ' . $span['meta']['error.msg'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+0
+1
+2
+FooException caught
+doSomething, FooException caught
+maybeThrowException, 0

--- a/tests/ext/sandbox/generator_with_return.phpt
+++ b/tests/ext/sandbox/generator_with_return.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Functions that use return with yield are instrumented
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: Generators are supported for PHP 7.1 and greater'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function getResultsWithReturn() {
+    for ($i = 20; $i < 23; $i++) {
+        yield $i;
+    }
+    return 1337;
+}
+
+function doSomething() {
+    $generatorRet = getResultsWithReturn();
+    foreach ($generatorRet as $value) {
+        echo $value . PHP_EOL;
+    }
+    echo $generatorRet->getReturn() . PHP_EOL;
+
+    return 'Done';
+}
+
+dd_trace_function('getResultsWithReturn', function(SpanData $s, $a, $retval) {
+    $s->name = 'getResultsWithReturn';
+    $s->resource = $retval;
+});
+
+dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+20
+21
+22
+1337
+Done
+doSomething, Done
+getResultsWithReturn, 20

--- a/tests/ext/sandbox/generator_yield_from.phpt
+++ b/tests/ext/sandbox/generator_yield_from.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Functions that return generators with 'yield from' are instrumented
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) die('skip: Generators are supported for PHP 7.1 and greater'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function getResults() {
+    yield from [1337, 42, 0];
+}
+
+function doSomething() {
+    $generator = getResults();
+    foreach ($generator as $value) {
+        echo $value . PHP_EOL;
+    }
+
+    return 'Done';
+}
+
+dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+    $s->name = 'getResults';
+    $s->resource = $retval[0];
+});
+
+dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+1337
+42
+0
+Done
+doSomething, Done
+getResults, 1337

--- a/tests/ext/sandbox/return_by_ref.phpt
+++ b/tests/ext/sandbox/return_by_ref.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Functions that return by reference are instrumented
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for return by ref on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('foo', function (SpanData $span, array $args, $retval) {
+    $span->name = 'foo';
+    var_dump($retval);
+});
+
+function &foo() {
+    static $data = [];
+    $data[] = 42;
+    return $data;
+}
+
+$data = &foo();
+$data[] = 1337;
+foo();
+var_dump($data);
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(42)
+}
+array(3) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(1337)
+  [2]=>
+  int(42)
+}
+array(3) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(1337)
+  [2]=>
+  int(42)
+}
+foo
+foo

--- a/tests/ext/sandbox/variadic_args_internal.phpt
+++ b/tests/ext/sandbox/variadic_args_internal.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Variadic arguments are passed to tracing closure for internal functions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+dd_trace_function('sscanf', function (DDTrace\SpanData $s, array $args) {
+    var_dump($args);
+});
+
+$ret = sscanf("42\tFoo Bar", "%d\t%s %s", $id, $first, $last);
+var_dump($ret);
+?>
+--EXPECT--
+array(5) {
+  [0]=>
+  string(10) "42	Foo Bar"
+  [1]=>
+  string(8) "%d	%s %s"
+  [2]=>
+  int(42)
+  [3]=>
+  string(3) "Foo"
+  [4]=>
+  string(3) "Bar"
+}
+int(3)

--- a/tests/ext/sandbox/vm_var_types_return.phpt
+++ b/tests/ext/sandbox/vm_var_types_return.phpt
@@ -1,0 +1,73 @@
+--TEST--
+VM variable types are handled properly for return
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('retval_IS_CONST', function (SpanData $span, array $args, $retval) {
+    $span->name = 'retval_IS_CONST';
+    $span->resource = $retval;
+    var_dump($retval);
+});
+
+dd_trace_function('retval_IS_CV', function (SpanData $span, array $args, $retval) {
+    $span->name = 'retval_IS_CV';
+    $span->resource = $retval;
+    var_dump($retval);
+});
+
+dd_trace_function('retval_IS_VAR', function (SpanData $span, array $args, $retval) {
+    $span->name = 'retval_IS_VAR';
+    $span->resource = $retval;
+    var_dump($retval);
+});
+
+dd_trace_function('retval_IS_TMP_VAR', function (SpanData $span, array $args, $retval) {
+    $span->name = 'retval_IS_TMP_VAR';
+    $span->resource = $retval;
+    var_dump($retval);
+});
+
+function retval_IS_CONST() {
+    return 42;
+}
+
+function retval_IS_CV() {
+    $a = 'IS_CV';
+    return $a;
+}
+
+function retval_IS_VAR() {
+    return array_sum([50, 50]);
+}
+
+function retval_IS_TMP_VAR() {
+    return 100 + array_sum([50, 50]);
+}
+
+echo retval_IS_CONST() . PHP_EOL;
+echo retval_IS_CV() . PHP_EOL;
+echo retval_IS_VAR() . PHP_EOL;
+echo retval_IS_TMP_VAR() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+int(42)
+42
+string(5) "IS_CV"
+IS_CV
+int(100)
+100
+int(200)
+200
+retval_IS_TMP_VAR, 200
+retval_IS_VAR, 100
+retval_IS_CV, IS_CV
+retval_IS_CONST, 42


### PR DESCRIPTION
### Description

This PR addresses part two of a two-part refactor of the opcode handlers. The the first part was merged in #754. This PR changes the way the tracer hooks into the engine for instrumented calls for PHP 7. PHP 5 will be addressed in a separate PR.

Before this PR, instrumented calls would be forwarded from within the custom handlers for `ZEND_DO_FCALL` and friends. This required the handlers to return `ZEND_USER_OPCODE_LEAVE` to the VM which would prevent any downstream neighboring extensions from reliably hooking the function call opcodes.

This PR will start the span and run any prehook tracking closures in the function-call handlers and immediately return `ZEND_USER_OPCODE_DISPATCH` to the VM to resume normal execution. The span is stopped by hooking return opcodes. Exceptions are tracked via the `ZEND_HANDLE_EXCEPTION` pseudo opcode. Since all the opcode handlers allow the VM to continue its expected path unaltered, downstream neighboring extensions can reliably hook the function call opcodes for every call.

### Nice-Neighbor Framework Results

This change was tested on the nice-neighbor framework to ensure that the new design allowed neighboring extensions to function without adverse effects from the tracer.

#### dd_fcall_dump

The fake `dd_fcall_dump` extension prints all function-call related opcodes. This is a nice neighbor that runs any upstream neighboring handlers before running its own. If it detects a change in the VM state (if the upstream handlers return anything other than `ZEND_USER_OPCODE_DISPATCH`) it will not run its own handler.

Before this change, when `dd_fcall_dump` is loaded _after_ `ddtrace`, the following output is produced when running [drop_spans.phpt](https://github.com/DataDog/dd-trace-php/blob/383e70e/tests/ext/sandbox/drop_spans.phpt):

```
OPCODE (ZEND_DO_ICALL -> date_default_timezone_set)
OPCODE (ZEND_DO_ICALL -> dd_trace_function)
OPCODE (ZEND_DO_ICALL -> dd_trace_method)
Traced array_sum
OPCODE (ZEND_RETURN)
VM state change detected. Cannot handle OPCODE (ZEND_INIT_FCALL)
Traced array_sum
OPCODE (ZEND_RETURN)
VM state change detected. Cannot handle OPCODE (ZEND_NEW)
Traced DateTime
OPCODE (ZEND_DO_FCALL -> DateTime::format)
OPCODE (ZEND_RETURN)
VM state change detected. Cannot handle OPCODE (ZEND_FREE)
Traced DateTime
OPCODE (ZEND_DO_FCALL -> DateTime::format)
OPCODE (ZEND_RETURN)
VM state change detected. Cannot handle OPCODE (ZEND_FREE)
OPCODE (ZEND_DO_ICALL -> dd_trace_serialize_closed_spans)
OPCODE (ZEND_DO_ICALL -> array_map)
DateTime: 2000-01-01
OPCODE (ZEND_RETURN)
ArraySum: 6
OPCODE (ZEND_RETURN)
```

The "**VM state change detected**" messages are from `dd_fcall_dump`. This reveals two fundamental issues.

1. For instrumented calls, `ddtrace` is altering the VM state (returning `ZEND_USER_OPCODE_LEAVE` from the opcode handler), and `dd_fcall_dump` is unable to reliably hook those opcodes.
2. By design, extensions that alter the VM state and return `ZEND_USER_OPCODE_LEAVE` must manually increment the opline `EX(opline)++`. However, neighboring extension's opcode handlers are still run for the original opcode with the `execute_data` mutated. For example, in the message above "**VM state change detected. Cannot handle OPCODE (ZEND_INIT_FCALL)**", that message was generated by the `ZEND_DO_ICALL` opcode handler. The `dd_fcall_dump` extension does not hook `ZEND_INIT_FCALL`, but since `ddtrace` mutated the VM state, the `ZEND_INIT_FCALL` was being passed to its `ZEND_DO_ICALL` opcode handler.

After this change, the output reflects `ddtrace` being a nice neighbor by not altering the VM state and allowing `dd_fcall_dump` to successfully hook the intended opcodes with the proper handlers.

```
OPCODE (ZEND_DO_FCALL -> date_default_timezone_set)
OPCODE (ZEND_DO_FCALL -> dd_trace_function)
OPCODE (ZEND_DO_FCALL -> dd_trace_method)
OPCODE (ZEND_DO_FCALL -> array_sum)
Traced array_sum
OPCODE (ZEND_RETURN)
OPCODE (ZEND_DO_FCALL -> array_sum)
Traced array_sum
OPCODE (ZEND_RETURN)
OPCODE (ZEND_DO_FCALL -> DateTime::__construct)
Traced DateTime
OPCODE (ZEND_DO_FCALL -> DateTime::format)
OPCODE (ZEND_RETURN)
OPCODE (ZEND_DO_FCALL -> DateTime::__construct)
Traced DateTime
OPCODE (ZEND_DO_FCALL -> DateTime::format)
OPCODE (ZEND_RETURN)
OPCODE (ZEND_DO_FCALL -> dd_trace_serialize_closed_spans)
OPCODE (ZEND_DO_FCALL -> array_map)
DateTime: 2000-01-01
OPCODE (ZEND_RETURN)
ArraySum: 6
OPCODE (ZEND_RETURN)
```

You might also have noticed that all the `ZEND_DO_ICALL` opcodes are now being emitted as `ZEND_DO_FCALL`. This is a direct result of the new design overriding `zend_execute_internal` which [changes the opcode that the compiler emits](https://github.com/php/php-src/blob/c5159b3/Zend/zend_compile.c#L3100-L3123).

This design does not hook `zend_execute_ex` in order to avoid the stack limitations that that override introduces. This means userland functions will continue to emit `ZEND_DO_UCALL` as illustrated by running [exit_and_drop_span.phpt](https://github.com/DataDog/dd-trace-php/blob/31b7251/tests/ext/sandbox/exit_and_drop_span.phpt).

```
OPCODE (ZEND_DO_FCALL -> dd_trace_function)
OPCODE (ZEND_DO_UCALL -> foo)
foo()
Dropping span
OPCODE (ZEND_RETURN)
OPCODE (ZEND_EXIT)
```

### Side Effects

#### Argument Mutation

The primary side effect of this new design relates to the mutability of arguments within an instrumented call. With this change, the tracing closure has access to the same arguments passed to the original call. If the original call mutates an argument, the posthook tracing closure will receive the mutated argument. This is the expected behavior of arguments in PHP 7.

The best way to illustrate this is with an example:

```php
function foo($a) {
    var_dump(func_get_args());
    $a = 'Dogs';
    var_dump(func_get_args());
}

foo('Cats');
```

On PHP 7, this outputs: 

```
array(1) {
  [0]=>
  string(4) "Cats"
}
array(1) {
  [0]=>
  string(4) "Dogs"
}
```

This illustrates that arguments in PHP 7 are mutable in a sense. If a posthook tracing closure were to access argument `$a`, it would be set to "Dogs". Before this change, the tracing closure would receive `$a` in its state before mutation and would be set to "Cats". If an argument needs to be accessed before mutation, the tracing closure can be run as a prehook to access the arguments before the original call.

So given:

```php
function foo($a) {
    $a = 'Dogs';
}
```

Posthook example:

```php
dd_trace_function('foo', function ($span, array $args) {
    var_dump($args[0]);
});

foo('Cats');

// string(4) "Dogs"
```

Prehook example:

```php
dd_trace_function('foo', [
    'prehook' => function ($span, array $args) {
        var_dump($args[0]);
    }
]);

foo('Cats');

// string(4) "Cats"
```

A few integrations have been changed to prehooks on PHP 7 to circumvent argument mutation. The Symfony integration was changed preceding this PR: #786.

#### Generators

Another side effect of the new design impacts function calls that return a generator with `yield` and `yield from`. A current limitation of the existing design is that generators are only traced until the first `yield`. Subsequent `yield`'s in an iteration are not instrumented. The following code illustrates this limitation:

```php
function getResults() {
    yield 1;
    yield 2;
    yield 3;
}

dd_trace_function('getResults', function() {});

$generator = getResults();
foreach ($generator as $value) {
    echo $value . PHP_EOL;
}

// Instruments getResults() one time, not three times
```

The same limitation exists in this new design, but now the return value is passed to the tracing closure differently. Before this change, the return value is provided to the tracing closure as an instance of `Generator`. With the new design, the return values are passed to the tracing closure directly from the opline (before the `ZEND_YIELD` opcode has run.) Therefore the return value provided to the tracing closure is now the _actual value_ provided by the `yield` statement, not an instance of `Generator`. The following code demonstrates this behavior change:

```php
function getResults() {
    yield 1;
    yield 2;
    yield 3;
}

dd_trace_function('getResults', function($s, $a, $retval) {
    var_dump($retval);
});

$generator = getResults();
foreach ($generator as $value) {
    echo $value . PHP_EOL;
}
```

Existing behavior output:

```
object(Generator)#3 (0) {
}
1
2
3
```

New behavior output:

```
int(1)
1
2
3
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
