### PR TITLE
Gracefully handle a dropped span on exit

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -170,6 +170,7 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
+                        <file name="exit_and_drop_span.phpt" role="test" />
                         <file name="fatal_errors_ignored_in_shutdown.phpt" role="test" />
                         <file name="fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
                         <file name="get_last_error.phpt" role="test" />

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -517,9 +517,13 @@ static int _dd_exit_handler(zend_execute_data *execute_data) {
     while ((span = DDTRACE_G(open_spans_top))) {
         zval retval;
         ZVAL_NULL(&retval);
+        // Save pointer to dispatch since span can be dropped from _dd_end_span()
+        ddtrace_dispatch_t *dispatch = span->dispatch;
         _dd_end_span(span, &retval);
-        span->dispatch->busy = 0;
-        ddtrace_class_lookup_release(span->dispatch);
+        if (dispatch) {
+            dispatch->busy = 0;
+            ddtrace_class_lookup_release(dispatch);
+        }
     }
 
     return _prev_exit_handler ? _prev_exit_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;

--- a/tests/ext/sandbox/exit_and_drop_span.phpt
+++ b/tests/ext/sandbox/exit_and_drop_span.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Exit gracefully handles a dropped span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+--FILE--
+<?php
+dd_trace_function('foo', function () {
+    echo 'Dropping span' . PHP_EOL;
+    return false;
+});
+
+function foo() {
+    echo 'foo()' . PHP_EOL;
+    exit;
+}
+
+foo();
+
+echo 'You should not see this.' . PHP_EOL;
+?>
+--EXPECT--
+foo()
+Dropping span


### PR DESCRIPTION
### Description

It is possible to cause a segmentation fault if a span is dropped from an instrumented call that uses `exit`. This PR ensures that this case is handled gracefully.

No customers have reported running into this issue.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
