### PR TITLE
Bring CONTRIBUTING.md up to date with current dev process

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -24,6 +24,7 @@
 
     <!-- PHP compatibility checks -->
     <config name="testVersion" value="5.4-7.3"/>
+    <exclude-pattern>dockerfiles/*</exclude-pattern>
     <exclude-pattern>playground*.php</exclude-pattern>
     <exclude-pattern>run-tests.php</exclude-pattern>
     <exclude-pattern>src/dd-doctor.php</exclude-pattern>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,29 +4,35 @@ As an open-source project we welcome contributions of many forms, but due to the
 
 ## Getting set up with Docker
 
-The easiest way to get the development environment set up is to install [Docker](https://www.docker.com/) and run the following [Docker Compose](https://docs.docker.com/compose/) command from the project root to start the containers.
+The easiest way to get the development environment set up is to install [Docker](https://www.docker.com/) and
+[Docker Compose](https://docs.docker.com/compose/).
+
+## Developing and testing locally
+
+While tests in CI run on all php versions, you typically develop on one version locally. Currently the latest local
+dev environment we support is `7.3`.
+
+Execute one the following commands from your command line, this will bring up all required services:
 
 ```bash
-$ docker-compose up -d
+# For 5.4
+$ docker-compose run --rm 5.4
+# For 5.6
+$ docker-compose run --rm 5.6
+# For 7.0
+$ docker-compose run --rm 7.0
+# For 7.1
+$ docker-compose run --rm 7.1
+# For 7.2
+$ docker-compose run --rm 7.2
+# For 7.3
+$ docker-compose run --rm 7.3
 ```
 
-This will run the [preconfigured docker images](https://hub.docker.com/r/datadog/docker-library/) that we provide for the different PHP versions.
-
-- PHP 5.6: `datadog/docker-library:ddtrace_php_5_6`
-- PHP 7.0: `datadog/docker-library:ddtrace_php_7_0`
-- PHP 7.1: `datadog/docker-library:ddtrace_php_7_1`
-- PHP 7.2: `datadog/docker-library:ddtrace_php_7_2`
-
-To access a `bash` from the PHP 7.2 container, run the following:
+Once inside the container, update dependencies with Composer.
 
 ```bash
-$ docker-compose run --rm 7.2 bash
-```
-
-Once inside the container, install the dependencies with Composer.
-
-```bash
-$ composer install
+$ composer update
 ```
 
 Then install the `ddtrace` extension.
@@ -50,22 +56,31 @@ ddtrace
 
 
 Datadog PHP tracer extension
-For help, check out the documentation at https://github.com/DataDog/dd-trace-php/blob/master/README.md#getting-started
-(c) Datadog 2018
+For help, check out the documentation at https://docs.datadoghq.com/tracing/languages/php/
+(c) Datadog 2019
 
 Datadog tracing support => enabled
-Version => 0.7.0-beta
+Version => 1.0.0-nightly
+
+Directive => Local Value => Master Value
+ddtrace.disable => Off => Off
+ddtrace.internal_blacklisted_modules_list => ... => ...,
+ddtrace.request_init_hook => no value => no value
+ddtrace.strict_mode => Off => Off
 ```
 
 When you're done with development, you can stop and remove the containers with the following:
 
 ```bash
-$ docker-compose down
+$ docker-compose down -v
 ```
 
 ### Running the tests
 
 In order to run all the tracer tests:
+
+    # Run all tests for for php 5.4
+    $ composer test-all-54
 
     # Run all tests for for php 5.6
     $ composer test-all-56
@@ -78,6 +93,12 @@ In order to run all the tracer tests:
 
     # Run all tests for for php 7.2
     $ composer test-all-72
+
+    # Run all tests for for php 7.3
+    $ composer test-all-73
+
+    # Run all tests for for php 7.4
+    $ composer test-all-74
 
 > **Note:** The `composer test` command is a wrapper around `phpunit`, so you can use all the common [options](https://phpunit.de/manual/5.7/en/textui.html#textui.clioptions) that you would with `phpunit`. However you need to prepend the options list with the additional `--` dashes that `composer` requires:
 
@@ -98,6 +119,12 @@ In order to run all the tracer tests:
 
     # Run only library integrations tests for php 7.2
     $ composer test-integrations-72
+
+    # Run only library integrations tests for php 7.3
+    $ composer test-integrations-73
+
+    # Run only library integrations tests for php 7.3
+    $ composer test-integrations-73
 
 Testing individual integrations with libraries requires an additional step, as there are different scenarios where you want to test
 a specific integration. You can find available scenarios in `composer.json` at key `extras.scenarios`.
@@ -133,63 +160,10 @@ To try to automatically fix the code style, you can run:
 $ composer fix-lint
 ```
 
-### Static Analyzer
-
-The [PHPStan static analyzer](https://github.com/phpstan/phpstan) is part of the build checks when submitting a PR. To ensure your contribution passes the static analyzer, run the following:
-
-```bash
-$ composer static-analyze
-```
-
-> **Note:** The static analyzer only works on PHP 7.1 builds and greater.
-
 ## Sending a pull request (PR)
 
 There are a number of checks that are run automatically with [CircleCI](https://circleci.com/gh/DataDog/dd-trace-php/tree/master) when a PR is submitted. To ensure your PHP code changes pass the CircleCI checks, make sure to run all the same checks before submitting a PR.
 
 ```bash
-$ composer test && composer lint && composer static-analyze
-```
-
-## Changelog
-
-All notable changes to this project will be documented in `CHANGELOG.md` file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-### Changelog entry format
-
-Changelog entry should try to form a coherent sentence with the heading e.g,:
-
-```md
-### Added
-- integration
-```
-
-Changelog entry must link to relevant PR(s) via ```#reference``` e.g. ```new integration #124, #122```
-
-Changelog entry might mention PR author(s) via ```@mention```- especially when they are not a member of the DataDog team.
-
-Changelog entry should start with lowercase or preferably, a specific integration name it concerns e.g., Laravel.
-
-### Example Changelog
-
-```md
-## [Unreleased]
-### Added
-- Laravel integration #124 (@pr_author)
-### Fixed
-- Laravel integration breaking bug #123
-### Changed
-- Laravel integration documentation #111
-### Removed
-- support for PHP 5.3 #2
-
-## [0.0.1] - 2018-01-01
-### Added
-- support for PHP 5.3 #1
-
-[Unreleased]: https://github.com/DataDog/dd-trace-php/compare/0.0.1...HEAD
-[0.0.1]: https://github.com/DataDog/dd-trace-php/compare/0.0.0...0.0.1
+$ composer composer lint && test-all-<php-version>
 ```

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,22 @@
             "@test-integrations-72",
             "@test-web-72"
         ],
+        "test-all-73": [
+            "@test-unit",
+            "@test-auto-instrumentation",
+            "@test-distributed-tracing",
+            "@test-integration",
+            "@test-integrations-73",
+            "@test-web-73"
+        ],
+        "test-all-74": [
+            "@test-unit",
+            "@test-auto-instrumentation",
+            "@test-distributed-tracing",
+            "@test-integration",
+            "@test-integrations-74",
+            "@test-web-74"
+        ],
         "test-integration": [
             "echo \"Integration tests require the agent up and running. Use composer run-agent.\"",
             "@composer test -- --testsuite=integration"


### PR DESCRIPTION
### Description

Our contributing guidelines were left a little bit behind, with a few not yet up-to-date steps.

This PR applies the following changes:

- add testing scripts for php 7.3 and 7.4
- update instructions on how to setup a dev env for a specific version instead of bringing up all containers

It fixes #756 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
