### PR TITLE
deprecate manual usage of legacy symfony bundles and laravel provider

### DIFF
--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -11,18 +11,8 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 /**
- * DataDog Laravel 4.2 tracing provider. Use by installing the dd-trace library:
- *
- * composer require datadog/dd-trace
- *
- * And then load the provider in config/app.php:
- *
- *     'providers' => array_merge(include(base_path('modules/system/providers.php')), [
- *        // 'Illuminate\Html\HtmlServiceProvider', // Example
- *
- *        'DDTrace\Integrations\Laravel\V4\LaravelProvider',
- *        'System\ServiceProvider',
- *   ]),
+ * @deprecated: this class is deprecated and should not be added to the list of providers. Automatic instrumentation
+ * does not require a provider anymore.
  */
 class LaravelProvider extends ServiceProvider
 {

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -14,17 +14,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * DataDog Symfony tracing bundle. Use by installing the dd-trace library:
- *
- * composer require datadog/dd-trace
- *
- * And then add the bundle in app/AppKernel.php:
- *
- *         $bundles = [
- *             // ...
- *             new DDTrace\Integrations\SymfonyBundle(),
- *             // ...
- *         ];
+ * @deprecated: this class is deprecated and should not be added to the list of bundles. Automatic instrumentation
+ * from a long time does not require adding any bundle as tracing is done automatically.
  */
 class SymfonyBundle extends Bundle
 {

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -14,17 +14,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * DataDog Symfony tracing bundle. Use by installing the dd-trace library:
- *
- * composer require datadog/dd-trace
- *
- * And then add the bundle in app/AppKernel.php:
- *
- *         $bundles = [
- *             // ...
- *             new DDTrace\Integrations\SymfonyBundle(),
- *             // ...
- *         ];
+ * @deprecated: this class is deprecated and should not be added to the list of bundles. Automatic instrumentation
+ * from a long time does not require adding any bundle as tracing is done automatically.
  */
 class SymfonyBundle extends Bundle
 {


### PR DESCRIPTION
### Description

This PR deprecates some legacy class docblocks that misleaded users into thinking that a bundle for Symfony had to be manually registered.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
