### PR TITLE
Separate background sender timeout env vars from userland

### DIFF
--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -29,6 +29,8 @@ final class Http implements Transport
     const DEFAULT_TRACE_AGENT_PORT = '8126';
     const DEFAULT_TRACE_AGENT_PATH = '/v0.3/traces';
     const PRIORITY_SAMPLING_TRACE_AGENT_PATH = '/v0.4/traces';
+
+    /* Keep these in sync with configuration.h's values */
     const DEFAULT_AGENT_CONNECT_TIMEOUT = 100;
     const DEFAULT_AGENT_TIMEOUT = 500;
 
@@ -149,7 +151,10 @@ final class Http implements Transport
         }
 
         if (
-            \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
+            (
+                \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
+                || \dd_trace_env_config('DD_TRACE_BGS_ENABLED')
+            )
             && $this->encoder->getContentType() === 'application/msgpack'
             && \dd_trace_send_traces_via_thread($tracesCount, $curlHeaders, $body)
         ) {

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -619,12 +619,16 @@ void ddtrace_coms_curl_shutdown(void) {
     }
 }
 
+static long _dd_max_long(long a, long b) { return a >= b ? a : b; }
+
 static void _dd_curl_set_timeout(CURL *curl) {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, get_dd_trace_agent_timeout());
+    long timeout = _dd_max_long(get_dd_trace_bgs_timeout(), get_dd_trace_agent_timeout());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout);
 }
 
 static void _dd_curl_set_connect_timeout(CURL *curl) {
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, get_dd_trace_agent_connect_timeout());
+    long timeout = _dd_max_long(get_dd_trace_bgs_connect_timeout(), get_dd_trace_agent_connect_timeout());
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout);
 }
 
 static void _dd_curl_set_hostname(CURL *curl) {

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -17,9 +17,16 @@ void ddtrace_config_shutdown(void);
  * The default is 0, which means to wait indefinitely. Even in the background
  * we don't want to wait forever, but I'm not sure what to set the connect
  * timeout to.
- * A user hit an issue with the previous time of 100.
+ * A user hit an issue with the userland time of 100.
  */
-#define DD_TRACE_AGENT_CONNECT_TIMEOUT 1000L
+#define DD_TRACE_AGENT_CONNECT_TIMEOUT 100L
+#define DD_TRACE_BGS_CONNECT_TIMEOUT 2000L
+
+/* Default for the PHP sender; should be kept in sync with DDTrace\Transport\Http::DEFAULT_AGENT_TIMEOUT */
+#define DD_TRACE_AGENT_TIMEOUT 500L
+
+/* This should be at least an order of magnitude higher than the userland HTTP Transport default. */
+#define DD_TRACE_BGS_TIMEOUT 5000L
 
 #define DD_CONFIGURATION                                                                                             \
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
@@ -27,21 +34,25 @@ void ddtrace_config_shutdown(void);
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
     BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", TRUE)                                   \
     BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", FALSE)                                                                \
-    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
-    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \
     BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", FALSE)                               \
     DOUBLE(get_dd_trace_heath_metrics_heartbeat_sample_rate, "DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE", 0.001) \
     CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                                   \
-    INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
-    INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \
-    INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", 500)                                                   \
+    INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", DD_TRACE_AGENT_TIMEOUT)                                \
     INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", DD_TRACE_AGENT_CONNECT_TIMEOUT)        \
     INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
     BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", FALSE)                                                            \
-    INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                            \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
     BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", FALSE,                         \
          "use background thread to send traces to the agent")                                                        \
+    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", FALSE,                                                    \
+         "use background sender (BGS) to send traces to the agent")                                                  \
+    INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
+    INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \
+    INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
+    INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \
+    INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                            \
+    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
+    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \
     INT(get_dd_trace_beta_high_memory_pressure_percent, "DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT", 80,            \
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")


### PR DESCRIPTION
### Description

Separate background sender timeout env vars from userland. This allows them to be controlled independently, which is important because they both be in use at the same time. The background sender has higher default values than the PHP components.

Also create `DD_TRACE_BGS_ENABLED` to replace `DD_TRACE_BETA_SEND_TRACES_VIA_THREAD`
for when the feature goes into GA.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
