### PR TITLE
Modernize configuration

### DIFF
--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -118,3 +118,16 @@ void ddtrace_config_shutdown(void) {
 #undef INT
 #undef DOUBLE
 }
+
+// define configuration getters macros
+#define CHAR(getter_name, ...) extern inline char* getter_name(void);
+#define BOOL(getter_name, ...) extern inline bool getter_name(void);
+#define INT(getter_name, ...) extern inline int64_t getter_name(void);
+#define DOUBLE(getter_name, ...) extern inline double getter_name(void);
+
+DD_CONFIGURATION
+
+#undef CHAR
+#undef BOOL
+#undef INT
+#undef DOUBLE

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -1,6 +1,8 @@
 #ifndef DD_CONFIGURATION_H
 #define DD_CONFIGURATION_H
 
+#include <stdbool.h>
+
 #include "compatibility.h"
 
 struct ddtrace_memoized_configuration_t;
@@ -32,27 +34,27 @@ void ddtrace_config_shutdown(void);
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
-    BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", TRUE)                                   \
-    BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", FALSE)                                                                \
-    BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", FALSE)                               \
+    BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", true)                                   \
+    BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", false)                                                                \
+    BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", false)                               \
     DOUBLE(get_dd_trace_heath_metrics_heartbeat_sample_rate, "DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE", 0.001) \
     CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                                   \
     INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", DD_TRACE_AGENT_TIMEOUT)                                \
     INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", DD_TRACE_AGENT_CONNECT_TIMEOUT)        \
     INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
-    BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", FALSE)                                                            \
+    BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", false)                                                            \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", FALSE,                         \
+    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", false,                         \
          "use background thread to send traces to the agent")                                                        \
-    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", FALSE,                                                    \
+    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", false,                                                    \
          "use background sender (BGS) to send traces to the agent")                                                  \
     INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
     INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \
     INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
     INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \
     INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                            \
-    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", FALSE)                          \
-    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", FALSE)                                        \
+    BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", false)                          \
+    BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", false)                                        \
     INT(get_dd_trace_beta_high_memory_pressure_percent, "DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT", 80,            \
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")

--- a/src/ext/configuration_render.h
+++ b/src/ext/configuration_render.h
@@ -11,13 +11,13 @@
 struct ddtrace_memoized_configuration_t {
 #define CHAR(getter_name, env_name, default, ...) \
     char* getter_name;                            \
-    BOOL_T __is_set_##getter_name;
+    bool __is_set_##getter_name;
 #define BOOL(getter_name, env_name, default, ...) \
-    BOOL_T getter_name;                           \
-    BOOL_T __is_set_##getter_name;
+    bool getter_name;                             \
+    bool __is_set_##getter_name;
 #define INT(getter_name, env_name, default, ...) \
     int64_t getter_name;                         \
-    BOOL_T __is_set_##getter_name;
+    bool __is_set_##getter_name;
 #define DOUBLE(getter_name, env_name, default, ...) \
     double getter_name;                             \
     double __is_set_##getter_name;
@@ -36,7 +36,7 @@ struct ddtrace_memoized_configuration_t {
 
 // define configuration getters macros
 #define CHAR(getter_name, env_name, default, ...)                                      \
-    inline static char* getter_name() {                                                \
+    inline char* getter_name(void) {                                                   \
         if (ddtrace_memoized_configuration.__is_set_##getter_name) {                   \
             if (ddtrace_memoized_configuration.getter_name) {                          \
                 pthread_mutex_lock(&ddtrace_memoized_configuration.mutex);             \
@@ -56,16 +56,16 @@ struct ddtrace_memoized_configuration_t {
     }
 
 #define BOOL(getter_name, env_name, default, ...)                    \
-    inline static BOOL_T getter_name() {                             \
+    inline bool getter_name(void) {                                  \
         if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
             return ddtrace_memoized_configuration.getter_name;       \
         } else {                                                     \
-            return 1;                                                \
+            return true;                                             \
         }                                                            \
     }
 
 #define INT(getter_name, env_name, default, ...)                     \
-    inline static int64_t getter_name() {                            \
+    inline int64_t getter_name(void) {                               \
         if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
             return ddtrace_memoized_configuration.getter_name;       \
         } else {                                                     \
@@ -74,7 +74,7 @@ struct ddtrace_memoized_configuration_t {
     }
 
 #define DOUBLE(getter_name, env_name, default, ...)                  \
-    inline static double getter_name() {                             \
+    inline double getter_name(void) {                                \
         if (ddtrace_memoized_configuration.__is_set_##getter_name) { \
             return ddtrace_memoized_configuration.getter_name;       \
         } else {                                                     \

--- a/src/ext/dogstatsd_client.c
+++ b/src/ext/dogstatsd_client.c
@@ -20,7 +20,7 @@ static void _set_dogstatsd_client_globals(dogstatsd_client client, char *host, c
 }
 
 void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
-    BOOL_T health_metrics_enabled = get_dd_trace_heath_metrics_enabled();
+    bool health_metrics_enabled = get_dd_trace_heath_metrics_enabled();
     dogstatsd_client client = dogstatsd_client_default_ctor();
     char *host = NULL;
     char *port = NULL;

--- a/src/ext/signals.c
+++ b/src/ext/signals.c
@@ -39,7 +39,7 @@ static void ddtrace_sigsegv_handler(int sig) {
         ddtrace_log_errf("Segmentation fault");
 
 #if HAVE_SIGACTION
-        BOOL_T health_metrics_enabled = get_dd_trace_heath_metrics_enabled();
+        bool health_metrics_enabled = get_dd_trace_heath_metrics_enabled();
         if (health_metrics_enabled) {
             dogstatsd_client *client = &DDTRACE_G(dogstatsd_client);
             const char *metric = "datadog.tracer.uncaught_exceptions";
@@ -78,7 +78,7 @@ static void ddtrace_sigsegv_handler(int sig) {
 }
 
 void ddtrace_signals_minit(TSRMLS_D) {
-    BOOL_T install_handler = get_dd_trace_heath_metrics_enabled();
+    bool install_handler = get_dd_trace_heath_metrics_enabled();
 
 #if DDTRACE_HAVE_BACKTRACE
     install_handler |= get_dd_log_backtrace();


### PR DESCRIPTION
### Description

This PR changes the `configuration.h` family of files to use more modern C standard features. 

- Convert static inline functions to inline only
- Convert BOOL_T to bool
- Add (void) to 0-arg functions

There should not be any functional changes in this PR.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
