### PR TITLE
Log background sender messages to error_log

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -40,8 +40,11 @@
             <directory>tests/Integrations/Slim/V3_12</directory>
         </testsuite>
         <testsuite name="custom-framework-autoloaded-test">
+            <file>tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php</file>
             <file>tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php</file>
             <file>tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php</file>
+            <file>tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php</file>
+            <file>tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php</file>
             <directory>tests/Integrations/CLI/Custom/Autoloaded</directory>
         </testsuite>
         <testsuite name="unit">

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -13,6 +13,7 @@
 
 #include "compatibility.h"
 #include "configuration.h"
+#include "logging.h"
 #include "mpack.h"
 
 extern inline bool ddtrace_coms_is_stack_unused(ddtrace_coms_stack_t *stack);
@@ -672,9 +673,7 @@ static struct timespec _dd_deadline_in_ms(uint32_t ms) {
 static size_t _dd_dummy_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata) {
     UNUSED(userdata);
     size_t data_length = size * nmemb;
-    if (get_dd_trace_debug_curl_output()) {
-        printf("%s", ptr);
-    }
+    ddtrace_bgs_logf("%s", ptr);
     return data_length;
 }
 
@@ -728,17 +727,11 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         res = curl_easy_perform(writer->curl);
 
         if (res != CURLE_OK) {
-            if (get_dd_trace_debug_curl_output()) {
-                printf("curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-                fflush(stdout);
-            }
-        } else {
-            if (get_dd_trace_debug_curl_output()) {
-                double uploaded;
-                curl_easy_getinfo(writer->curl, CURLINFO_SIZE_UPLOAD, &uploaded);
-                printf("UPLOADED %.0f bytes\n", uploaded);
-                fflush(stdout);
-            }
+            ddtrace_bgs_logf("[bgs] curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        } else if (get_dd_trace_debug_curl_output()) {
+            double uploaded;
+            curl_easy_getinfo(writer->curl, CURLINFO_SIZE_UPLOAD, &uploaded);
+            ddtrace_bgs_logf("[bgs] uploaded %.0f bytes\n", uploaded);
         }
 
         _dd_deinit_read_userdata(read_data);

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -134,6 +134,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_bgs_log_minit(PG(error_log));
+
     ddtrace_dogstatsd_client_minit(TSRMLS_C);
     ddtrace_signals_minit(TSRMLS_C);
 
@@ -164,6 +166,8 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
         ddtrace_coms_curl_shutdown();
         // if writer is ensured to be shutdown we can free up config resources safely
         ddtrace_config_shutdown();
+
+        ddtrace_bgs_log_mshutdown();
     }
 
     ddtrace_engine_hooks_mshutdown();

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -26,22 +26,20 @@ void ddtrace_bgs_log_minit(char *error_log) {
 
 void ddtrace_bgs_log_mshutdown(void) { free(php_ini_error_log); }
 
+#undef ddtrace_bgs_logf
 int ddtrace_bgs_logf(const char *fmt, ...) {
-    if (php_ini_error_log && get_dd_trace_debug_curl_output()) {
-        int ret = 0;
-        va_list args;
-        FILE *fh = fopen(php_ini_error_log, "a");
+    int ret = 0;
+    va_list args;
+    FILE *fh = fopen(php_ini_error_log, "a");
 
-        if (fh) {
-            va_start(args, fmt);
-            ret = vfprintf(fh, fmt, args);
-            va_end(args);
-            fclose(fh);
-        }
-
-        return ret;
+    if (fh) {
+        va_start(args, fmt);
+        ret = vfprintf(fh, fmt, args);
+        va_end(args);
+        fclose(fh);
     }
-    return 0;
+
+    return ret;
 }
 
 extern inline void ddtrace_log_err(char *message);

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -1,5 +1,49 @@
 #include "logging.h"
 
+#include <stdio.h>
+#include <string.h>
+
+#include "configuration.h"
+
+char *php_ini_error_log = NULL;
+
+void ddtrace_bgs_log_minit(char *error_log) {
+    if (!error_log || strcasecmp(error_log, "syslog") == 0 || strlen(error_log) == 0) {
+        return;
+    }
+
+    /* Check if we can open the file for appending; if not we'll abandon logging.
+     * Note that we do not keep the file open; if a log rotate happened then we
+     * would be writing to the old log file. I believe there is a way to detect
+     * this using fstat, but I'm going for a simple solution for now.
+     */
+    FILE *fh = fopen(error_log, "a");
+    if (fh) {
+        fclose(fh);
+        php_ini_error_log = strdup(error_log);
+    }
+}
+
+void ddtrace_bgs_log_mshutdown(void) { free(php_ini_error_log); }
+
+int ddtrace_bgs_logf(const char *fmt, ...) {
+    if (php_ini_error_log && get_dd_trace_debug_curl_output()) {
+        int ret = 0;
+        va_list args;
+        FILE *fh = fopen(php_ini_error_log, "a");
+
+        if (fh) {
+            va_start(args, fmt);
+            ret = vfprintf(fh, fmt, args);
+            va_end(args);
+            fclose(fh);
+        }
+
+        return ret;
+    }
+    return 0;
+}
+
 extern inline void ddtrace_log_err(char *message);
 
 void ddtrace_log_errf(const char *format, ...) {

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -25,7 +25,12 @@ void ddtrace_log_errf(const char *format, ...);
 extern char *php_ini_error_log;
 void ddtrace_bgs_log_minit(char *error_log);
 void ddtrace_bgs_log_mshutdown(void);
+
 int ddtrace_bgs_logf(const char *fmt, ...);
+/* variadic functions cannot be inlined; we use a macro to essentially inline
+ * the part we care about: the early return */
+#define ddtrace_bgs_logf(fmt, ...) \
+    ((php_ini_error_log && get_dd_trace_debug_curl_output()) ? ddtrace_bgs_logf(fmt, __VA_ARGS__) : 0)
 /* }}} */
 
 #endif  // DD_LOGGING_H

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -20,4 +20,12 @@ inline void ddtrace_log_err(char *message) {
 
 void ddtrace_log_errf(const char *format, ...);
 
+/* These are used by the background sender; use other functions from PHP thread.
+ * {{{ */
+extern char *php_ini_error_log;
+void ddtrace_bgs_log_minit(char *error_log);
+void ddtrace_bgs_log_mshutdown(void);
+int ddtrace_bgs_logf(const char *fmt, ...);
+/* }}} */
+
 #endif  // DD_LOGGING_H

--- a/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
+++ b/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class BackgroundSenderLogTest extends WebFrameworkTestCase
+{
+    const BGS_FLUSH_INTERVAL_MS = 1000;
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    private static function getAppErrorLog()
+    {
+        $index = static::getAppIndexScript();
+        $log = \dirname($index) . '/error.log';
+        return $log;
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_BGS_ENABLED' => true,
+            'DD_TRACE_DEBUG_CURL_OUTPUT' => true,
+            'DD_TRACE_ENCODER' => 'msgpack',
+            'DD_TRACE_AGENT_FLUSH_INTERVAL' => self::BGS_FLUSH_INTERVAL_MS,
+        ]);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // clear out any previous logs
+        $log = self::getAppErrorLog();
+        @\unlink($log);
+        \touch($log);
+    }
+
+    protected static function getInis()
+    {
+        return array_merge(parent::getInis(), [
+            'error_log' => self::getAppErrorLog(),
+        ]);
+    }
+
+    public function testScenario()
+    {
+        $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('BGS logs test', '/simple');
+            $response = $this->call($spec);
+
+            self::assertEquals('This is a string', $response);
+
+            // Endpoint seemed to work; allow for flush interval to trigger
+            \usleep(self::BGS_FLUSH_INTERVAL_MS * 1000);
+        });
+
+        $log = self::getAppErrorLog();
+        $contents = \file_get_contents($log);
+        self::assertContains('[bgs] uploaded', $contents);
+
+        // if this fails, our test may not be reliably clearing the log file
+        self::assertNotContains('[bgs] curl_easy_perform() failed', $contents);
+    }
+}


### PR DESCRIPTION
### Description

This changes the background sender to log to a file instead of stdout.

Also enables some missing tests on CI.

### Readiness checklist
- [x] Writes to error_log.
- [x] Uses PHP's timestamp format.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.