### PR TITLE
Close open sandboxed spans on exit (PHP 5)

### DIFF
--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -73,11 +73,7 @@ static uint64_t _get_nanoseconds(BOOL_T monotonic_clock) {
     return 0;
 }
 
-#if PHP_VERSION_ID < 70000
-ddtrace_span_t *ddtrace_open_span(TSRMLS_D) {
-#else
 ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC) {
-#endif
     ddtrace_span_t *span = ecalloc(1, sizeof(ddtrace_span_t));
     span->next = DDTRACE_G(open_spans_top);
     DDTRACE_G(open_spans_top) = span;
@@ -102,10 +98,8 @@ ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispat
     // @see https://docs.datadoghq.com/api/?lang=python#send-traces
     span->start = _get_nanoseconds(USE_REALTIME_CLOCK);
 
-#if PHP_VERSION_ID >= 70000
     span->call = call;
     span->dispatch = dispatch;
-#endif
     return span;
 }
 

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -23,20 +23,14 @@ typedef struct ddtrace_span_t {
     pid_t pid;
     struct ddtrace_span_t *next;
 
-#if PHP_VERSION_ID >= 70000
     zend_execute_data *call;
     struct ddtrace_dispatch_t *dispatch;
-#endif
 } ddtrace_span_t;
 
 void ddtrace_init_span_stacks(TSRMLS_D);
 void ddtrace_free_span_stacks(TSRMLS_D);
 
-#if PHP_VERSION_ID < 70000
-ddtrace_span_t *ddtrace_open_span(TSRMLS_D);
-#else
 ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC);
-#endif
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 void ddtrace_close_span(TSRMLS_D);
 void ddtrace_drop_span(TSRMLS_D);

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -25,6 +25,9 @@ typedef struct ddtrace_span_t {
 
     zend_execute_data *call;
     struct ddtrace_dispatch_t *dispatch;
+#if PHP_VERSION_ID < 70000
+    zval *retval;
+#endif
 } ddtrace_span_t;
 
 void ddtrace_init_span_stacks(TSRMLS_D);

--- a/tests/ext/sandbox/close-on-exit-retval.phpt
+++ b/tests/ext/sandbox/close-on-exit-retval.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Ensure tracing closure's $retval arg is null if invoked due to exit()
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -30,7 +30,7 @@ function outer() {
     inner();
     exit();
 
-    // ensure we did not break something    
+    // ensure we did not break something
     return 1;
 }
 

--- a/tests/ext/sandbox/close-on-exit.phpt
+++ b/tests/ext/sandbox/close-on-exit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Run sandbox closures for open spans on exit
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/exit_and_drop_span.phpt
+++ b/tests/ext/sandbox/exit_and_drop_span.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Exit gracefully handles a dropped span
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('skip PHP < 7 not supported'); ?>
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 dd_trace_function('foo', function () {


### PR DESCRIPTION
### Description

This PR adds support for closing sandbox spans when `exit` is used on PHP 5. This feature was already available in PHP 7 via #679.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
