### PR TITLE
Fix pecl installs

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -77,8 +77,16 @@ if test "$PHP_DDTRACE" != "no"; then
   AC_CHECK_HEADER(time.h, [], [AC_MSG_ERROR([Cannot find or include time.h])])
   PHP_SUBST(EXTRA_LDFLAGS)
 
-  PHP_ADD_INCLUDE($ext_builddir)
-  PHP_ADD_INCLUDE($ext_builddir/src/ext)
-  PHP_ADD_INCLUDE($ext_builddir/src/ext/mpack)
-  PHP_ADD_INCLUDE($ext_builddir/src/dogstatsd)
+  PHP_ADD_INCLUDE([$ext_srcdir])
+  PHP_ADD_INCLUDE([$ext_srcdir/src/ext])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/src/ext/mpack])
+  PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/mpack])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/src/dogstatsd])
+  PHP_ADD_BUILD_DIR([$ext_builddir/src/dogstatsd])
+
+  PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/php5])
+  PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/php7])
+  PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/third-party])
 fi

--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,8 @@
-PHP_ARG_ENABLE(ddtrace,whether to enable Datadog tracing support,[  --enable-ddtrace   Enable Datadog tracing support])
+PHP_ARG_ENABLE(ddtrace, whether to enable Datadog tracing support,
+  [  --enable-ddtrace   Enable Datadog tracing support])
 
-PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,[  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
+PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
+  [  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
 if test "$PHP_DDTRACE" != "no"; then
   m4_include([m4/polyfill.m4])


### PR DESCRIPTION
### Description

As reported in #778, `pecl install datadog_trace` is not working. This PR fixes up the config.m4 file to support installation of the extension through this method.

Note for anyone reading this who installs via pecl: this only installs the extension. You still need to install the PHP sources (can be done with composer, but you need to keep extension and composer version in sync), and if you want automated tracing you still need to add ini settings such as `extension=ddtrace` and `ddtrace.request_init_hook=/path/to/vendor/datadog/dd-trace/bridge/dd_wrap_autoloader.php`.

### Readiness checklist
- [x] Has been manually tested.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.