### PR TITLE
Fix background sender logging for ZTS

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -134,7 +134,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
-    ddtrace_bgs_log_minit(PG(error_log));
+    ddtrace_bgs_log_minit();
 
     ddtrace_dogstatsd_client_minit(TSRMLS_C);
     ddtrace_signals_minit(TSRMLS_C);
@@ -186,6 +186,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_bgs_log_rinit(PG(error_log));
     ddtrace_dispatch_init(TSRMLS_C);
     DDTRACE_G(disable_in_current_request) = 0;
 

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -5,58 +5,64 @@
 #include <time.h>
 
 #include "configuration.h"
+#include "vendor_stdatomic.h"
 
-char *php_ini_error_log = NULL;
+atomic_uintptr_t php_ini_error_log;
 
-void ddtrace_bgs_log_minit(char *error_log) {
+void ddtrace_bgs_log_minit(void) { atomic_store(&php_ini_error_log, (uintptr_t)NULL); }
+
+void ddtrace_bgs_log_rinit(char *error_log) {
     if (!error_log || strcasecmp(error_log, "syslog") == 0 || strlen(error_log) == 0) {
         return;
     }
 
-    /* Check if we can open the file for appending; if not we'll abandon logging.
-     * Note that we do not keep the file open; if a log rotate happened then we
-     * would be writing to the old log file. I believe there is a way to detect
-     * this using fstat, but I'm going for a simple solution for now.
-     */
-    FILE *fh = fopen(error_log, "a");
-    if (fh) {
-        fclose(fh);
-        php_ini_error_log = strdup(error_log);
+    uintptr_t desired = (uintptr_t)strdup(error_log);
+    uintptr_t expected = (uintptr_t)NULL;
+    if (!atomic_compare_exchange_strong(&php_ini_error_log, &expected, desired)) {
+        // if it didn't exchange, then we need to free our duplicated string
+        free((char *)desired);
     }
 }
 
-void ddtrace_bgs_log_mshutdown(void) { free(php_ini_error_log); }
+void ddtrace_bgs_log_mshutdown(void) {
+    char *error_log = (char *)atomic_load(&php_ini_error_log);
+    atomic_store(&php_ini_error_log, (uintptr_t)NULL);
+    free(error_log);
+}
 
 #undef ddtrace_bgs_logf
 int ddtrace_bgs_logf(const char *fmt, ...) {
     int ret = 0;
-    FILE *fh = fopen(php_ini_error_log, "a");
+    char *error_log = (char *)atomic_load(&php_ini_error_log);
+    if (error_log) {
+        FILE *fh = fopen(error_log, "a");
 
-    if (fh) {
-        va_list args, args_copy;
-        va_start(args, fmt);
+        if (fh) {
+            va_list args, args_copy;
+            va_start(args, fmt);
 
-        va_copy(args_copy, args);
-        int needed_len = vsnprintf(NULL, 0, fmt, args_copy);
-        va_end(args_copy);
+            va_copy(args_copy, args);
+            int needed_len = vsnprintf(NULL, 0, fmt, args_copy);
+            va_end(args_copy);
 
-        char *msgbuf = malloc(needed_len);
-        vsnprintf(msgbuf, needed_len, fmt, args);
-        va_end(args);
+            char *msgbuf = malloc(needed_len);
+            vsnprintf(msgbuf, needed_len, fmt, args);
+            va_end(args);
 
-        time_t now;
-        time(&now);
-        struct tm *now_local = localtime(&now);
-        // todo: we only need 20-ish for the main part, but how much for the timezone?
-        // Wish PHP printed -hhmm or +hhmm instead of the name
-        char timebuf[64];
-        int time_len = strftime(timebuf, sizeof timebuf, "%d-%m-%Y %H:%m:%S %Z", now_local);
-        if (time_len > 0) {
-            ret = fprintf(fh, "[%s] %s\n", timebuf, msgbuf);
+            time_t now;
+            time(&now);
+            struct tm *now_local = localtime(&now);
+            // todo: we only need 20-ish for the main part, but how much for the timezone?
+            // Wish PHP printed -hhmm or +hhmm instead of the name
+            char timebuf[64];
+            int time_len = strftime(timebuf, sizeof timebuf, "%d-%m-%Y %H:%m:%S %Z", now_local);
+            if (time_len > 0) {
+                ret = fprintf(fh, "[%s] %s\n", timebuf, msgbuf);
+            }
+
+            free(msgbuf);
+            fclose(fh);
         }
-
-        free(msgbuf);
-        fclose(fh);
     }
 
     return ret;

--- a/src/ext/logging.h
+++ b/src/ext/logging.h
@@ -22,15 +22,14 @@ void ddtrace_log_errf(const char *format, ...);
 
 /* These are used by the background sender; use other functions from PHP thread.
  * {{{ */
-extern char *php_ini_error_log;
-void ddtrace_bgs_log_minit(char *error_log);
+void ddtrace_bgs_log_minit(void);
+void ddtrace_bgs_log_rinit(char *error_log);
 void ddtrace_bgs_log_mshutdown(void);
 
 int ddtrace_bgs_logf(const char *fmt, ...);
 /* variadic functions cannot be inlined; we use a macro to essentially inline
  * the part we care about: the early return */
-#define ddtrace_bgs_logf(fmt, ...) \
-    ((php_ini_error_log && get_dd_trace_debug_curl_output()) ? ddtrace_bgs_logf(fmt, __VA_ARGS__) : 0)
+#define ddtrace_bgs_logf(fmt, ...) (get_dd_trace_debug_curl_output() ? ddtrace_bgs_logf(fmt, __VA_ARGS__) : 0)
 /* }}} */
 
 #endif  // DD_LOGGING_H


### PR DESCRIPTION
### Description
Delay saving the `error_log` until RINIT. As a consequence, nothing can be logged until the first request is served. I don't think we can log anything at the moment without any requests, so this doesn't matter.

Reported in #782.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
