### PR TITLE
Prehook: run tracing closures before the original call (PHP 7)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' '!LICENSE.*' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!tests/ext/sandbox/*' '!tests/ext/sandbox-prehook/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**/*.patch' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' '!LICENSE.*' || touch .failure
       - run:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure

--- a/package.xml
+++ b/package.xml
@@ -188,11 +188,28 @@
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-prehook">
+                        <file name="access_modifier_method_access_hook.phpt" role="test" />
+                        <file name="access_modifier_property_access_hook.phpt" role="test" />
                         <file name="args_copy_before_mutation.phpt" role="test" />
+                        <file name="close_on_exit.phpt" role="test" />
                         <file name="closure_arg_exception.phpt" role="test" />
                         <file name="closure_arg_retval.phpt" role="test" />
                         <file name="dd_trace_api_error.phpt" role="test" />
+                        <file name="dd_trace_function_internal.phpt" role="test" />
+                        <file name="dd_trace_function_userland.phpt" role="test" />
+                        <file name="dd_trace_method.phpt" role="test" />
+                        <file name="dd_trace_method_binds_called_object.phpt" role="test" />
+                        <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
+                        <file name="drop_spans.phpt" role="test" />
+                        <file name="exception_error_log.phpt" role="test" />
+                        <file name="exception_handling.phpt" role="test" />
+                        <file name="exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
+                        <file name="exit_and_drop_span.phpt" role="test" />
+                        <file name="keep_spans_in_limited_tracing_userland_functions.phpt" role="test" />
+                        <file name="new_static.phpt" role="test" />
                         <file name="php5_unsupported.phpt" role="test" />
+                        <file name="trace_static_method.phpt" role="test" />
+                        <file name="variable_length_parameter_list.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-regression">
                         <file name="access_modifier_method_access_hook.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -187,6 +187,13 @@
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>
+                    <dir name="sandbox-prehook">
+                        <file name="args_copy_before_mutation.phpt" role="test" />
+                        <file name="closure_arg_exception.phpt" role="test" />
+                        <file name="closure_arg_retval.phpt" role="test" />
+                        <file name="dd_trace_api_error.phpt" role="test" />
+                        <file name="php5_unsupported.phpt" role="test" />
+                    </dir>
                     <dir name="sandbox-regression">
                         <file name="access_modifier_method_access_hook.phpt" role="test" />
                         <file name="access_modifier_property_access_hook.phpt" role="test" />

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -10,6 +10,7 @@
 #define DDTRACE_DISPATCH_INNERHOOK (1 << 0)
 #define DDTRACE_DISPATCH_INSTRUMENT_WHEN_LIMITED (1 << 1)
 #define DDTRACE_DISPATCH_POSTHOOK (1 << 2)
+#define DDTRACE_DISPATCH_PREHOOK (1 << 3)
 
 typedef struct ddtrace_dispatch_t {
     uint32_t options;

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -317,7 +317,7 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
 static bool _dd_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc, zend_execute_data *execute_data) {
     ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
 
-    if (dispatch->options & DDTRACE_DISPATCH_PREHOOK && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
+    if ((dispatch->options & DDTRACE_DISPATCH_PREHOOK) && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
         ddtrace_drop_span();
         return false;
     }

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -164,7 +164,7 @@ static bool _dd_execute_tracing_closure(zval *callable, zval *span_data, zend_ex
     }
     zval *this = _dd_this(call);
 
-    if (!callable || !span_data || !user_args || !user_retval) {
+    if (!callable || !span_data || !user_args) {
         if (get_dd_trace_debug()) {
             const char *fname = ZSTR_VAL(call->func->common.function_name);
             ddtrace_log_errf("Tracing closure could not be run for %s() because it is in an invalid state", fname);
@@ -192,8 +192,8 @@ static bool _dd_execute_tracing_closure(zval *callable, zval *span_data, zend_ex
     // Arg 1: array $args
     ZVAL_COPY(&args[1], user_args);
 
-    // Arg 2: mixed $retval
-    ZVAL_COPY(&args[2], user_retval);
+    // Arg 2: mixed|null $retval
+    ZVAL_COPY(&args[2], user_retval ?: &EG(uninitialized_zval));
 
     // Arg 3: Exception|null $exception
     ZVAL_COPY(&args[3], &exception_arg);
@@ -236,13 +236,15 @@ static zend_class_entry *_dd_get_exception_base(zval *object) {
 #define GET_PROPERTY(object, id) zend_read_property_ex(_dd_get_exception_base(object), (object), ZSTR_KNOWN(id), 1, &rv)
 #endif
 
-static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
+static bool _dd_call_sandboxed_tracing_closure(ddtrace_span_t *span, zval *user_retval) {
     zend_execute_data *call = span->call;
     ddtrace_dispatch_t *dispatch = span->dispatch;
     zend_object *exception = NULL, *prev_exception = NULL;
     zval user_args;
 
-    dd_trace_stop_span_time(span);
+    if (Z_TYPE(dispatch->callable) != IS_OBJECT) {
+        return true;
+    }
 
     _dd_copy_function_args(call, &user_args);
     if (EG(exception)) {
@@ -250,48 +252,39 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
         EG(exception) = NULL;
         prev_exception = EG(prev_exception);
         EG(prev_exception) = NULL;
-        _dd_span_attach_exception(span, exception);
         zend_clear_exception();
     }
 
     bool keep_span = true;
-    if (Z_TYPE(dispatch->callable) == IS_OBJECT) {
-        ddtrace_error_handling eh;
-        ddtrace_backup_error_handling(&eh, EH_THROW);
+    ddtrace_error_handling eh;
+    ddtrace_backup_error_handling(&eh, EH_THROW);
 
-        keep_span =
-            _dd_execute_tracing_closure(&dispatch->callable, span->span_data, call, &user_args, user_retval, exception);
+    keep_span =
+        _dd_execute_tracing_closure(&dispatch->callable, span->span_data, call, &user_args, user_retval, exception);
 
-        if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
-            const char *fname = Z_STRVAL(dispatch->function_name);
-            ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname,
-                             PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
-        }
-
-        ddtrace_restore_error_handling(&eh);
-        // If the tracing closure threw an exception, ignore it to not impact the original call
-        if (get_dd_trace_debug() && EG(exception)) {
-            zend_object *ex = EG(exception);
-            const char *name = Z_STR(dispatch->function_name)->val;
-            const char *type = ex->ce->name->val;
-            zval rv, obj;
-            ZVAL_OBJ(&obj, ex);
-            zval *message = GET_PROPERTY(&obj, ZEND_STR_MESSAGE);
-            const char *msg =
-                Z_TYPE_P(message) == IS_STRING ? Z_STR_P(message)->val : "(internal error reading exception message)";
-            ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
-            if (message == &rv) {
-                zval_dtor(message);
-            }
-        }
-        ddtrace_maybe_clear_exception();
+    if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+        const char *fname = Z_STRVAL(dispatch->function_name);
+        ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname, PG(last_error_message),
+                         PG(last_error_file), PG(last_error_lineno));
     }
 
-    if (keep_span) {
-        ddtrace_close_span();
-    } else {
-        ddtrace_drop_span();
+    ddtrace_restore_error_handling(&eh);
+    // If the tracing closure threw an exception, ignore it to not impact the original call
+    if (get_dd_trace_debug() && EG(exception)) {
+        zend_object *ex = EG(exception);
+        const char *name = Z_STR(dispatch->function_name)->val;
+        const char *type = ex->ce->name->val;
+        zval rv, obj;
+        ZVAL_OBJ(&obj, ex);
+        zval *message = GET_PROPERTY(&obj, ZEND_STR_MESSAGE);
+        const char *msg =
+            Z_TYPE_P(message) == IS_STRING ? Z_STR_P(message)->val : "(internal error reading exception message)";
+        ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
+        if (message == &rv) {
+            zval_dtor(message);
+        }
     }
+    ddtrace_maybe_clear_exception();
 
     zval_dtor(&user_args);
 
@@ -301,20 +294,47 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
 
         zend_throw_exception_internal(NULL);
     }
+
+    return keep_span;
 }
 
-static void _dd_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc, zend_execute_data *execute_data) {
+static void _dd_end_span(ddtrace_span_t *span, zval *user_retval) {
+    ddtrace_dispatch_t *dispatch = span->dispatch;
+    dd_trace_stop_span_time(span);
+
+    bool keep_span = true;
+    if (dispatch->options & DDTRACE_DISPATCH_POSTHOOK) {
+        keep_span = _dd_call_sandboxed_tracing_closure(span, user_retval);
+    }
+
+    if (keep_span) {
+        ddtrace_close_span();
+    } else {
+        ddtrace_drop_span();
+    }
+}
+
+static bool _dd_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc, zend_execute_data *execute_data) {
+    ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
+
+    if (dispatch->options & DDTRACE_DISPATCH_PREHOOK && _dd_call_sandboxed_tracing_closure(span, NULL) == false) {
+        ddtrace_drop_span();
+        return false;
+    }
+
     const zend_op *opline = EX(opline);
 
     zval rv, *user_retval;
     ZVAL_NULL(&rv);
     user_retval = (RETURN_VALUE_USED(opline) ? EX_VAR(opline->result.var) : &rv);
 
-    ddtrace_span_t *span = ddtrace_open_span(EX(call), dispatch);
     zend_fcall_info fci = {0};
     zend_fcall_info_cache fcc = {0};
     _dd_forward_call(EX(call), fbc, user_retval, &fci, &fcc);
     if (span == DDTRACE_G(open_spans_top)) {
+        if (EG(exception)) {
+            _dd_span_attach_exception(span, EG(exception));
+        }
         _dd_end_span(span, user_retval);
     } else if (get_dd_trace_debug()) {
         const char *fname = Z_STRVAL(dispatch->function_name);
@@ -331,6 +351,8 @@ static void _dd_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc,
     }
     // Restore call for internal functions
     EX(call) = EX(call)->prev_execute_data;
+
+    return true;
 }
 
 static void _dd_update_opcode_leave(zend_execute_data *execute_data) {
@@ -469,8 +491,12 @@ int ddtrace_wrap_fcall(zend_execute_data *execute_data) {
     ddtrace_class_lookup_acquire(dispatch);  // protecting against dispatch being freed during php code execution
     dispatch->busy = 1;                      // guard against recursion, catching only topmost execution
 
-    if (dispatch->options & DDTRACE_DISPATCH_POSTHOOK) {
-        _dd_trace_dispatch(dispatch, current_fbc, execute_data);
+    if (dispatch->options & (DDTRACE_DISPATCH_POSTHOOK | DDTRACE_DISPATCH_PREHOOK)) {
+        if (_dd_trace_dispatch(dispatch, current_fbc, execute_data) == false) {
+            dispatch->busy = 0;
+            ddtrace_class_lookup_release(dispatch);
+            return vm_retval;
+        }
     } else {
         // Store original context for forwarding the call from userland
         zend_function *previous_fbc = DDTRACE_G(original_context).fbc;

--- a/tests/ext/dd_trace_api_error.phpt
+++ b/tests/ext/dd_trace_api_error.phpt
@@ -59,7 +59,7 @@ Expected 'innerhook' to be an instance of Closure
 bool(false)
 Legacy API does not support 'posthook'
 bool(false)
-Required key 'posthook' or 'innerhook' not found in config_array
+Required key 'posthook', 'prehook' or 'innerhook' not found in config_array
 bool(false)
 
 bool(false)
@@ -75,5 +75,5 @@ Expected 'innerhook' to be an instance of Closure
 bool(false)
 Legacy API does not support 'posthook'
 bool(false)
-Required key 'posthook' or 'innerhook' not found in config_array
+Required key 'posthook', 'prehook' or 'innerhook' not found in config_array
 bool(false)

--- a/tests/ext/sandbox-prehook/access_modifier_method_access_hook.phpt
+++ b/tests/ext/sandbox-prehook/access_modifier_method_access_hook.phpt
@@ -1,0 +1,67 @@
+--TEST--
+[Prehook regression] Private and protected methods are called from a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+class Foo
+{
+    public function getBar()
+    {
+        return new Bar();
+    }
+
+    public function aPublic()
+    {
+        echo 'Foo PUBLIC' . PHP_EOL;
+    }
+
+    protected function bProtected()
+    {
+        return 'Foo PROTECTED';
+    }
+
+    private function cPrivate()
+    {
+        return 'Foo PRIVATE';
+    }
+}
+
+class Bar
+{
+    public function dPublic()
+    {
+        echo 'Bar PUBLIC' . PHP_EOL;
+    }
+
+    protected function eProtected()
+    {
+        return 'Bar PROTECTED';
+    }
+
+    private function fPrivate()
+    {
+        return 'Bar PRIVATE';
+    }
+}
+
+dd_trace_method('Foo', 'aPublic', ['prehook' => function() {
+    $this->getBar()->dPublic();
+    var_dump($this->bProtected());
+    var_dump($this->cPrivate());
+}]);
+
+dd_trace_method('Bar', 'dPublic', ['prehook' => function() {
+    var_dump($this->eProtected());
+    var_dump($this->fPrivate());
+}]);
+
+(new Foo())->aPublic();
+?>
+--EXPECT--
+string(13) "Bar PROTECTED"
+string(11) "Bar PRIVATE"
+Bar PUBLIC
+string(13) "Foo PROTECTED"
+string(11) "Foo PRIVATE"
+Foo PUBLIC

--- a/tests/ext/sandbox-prehook/access_modifier_property_access_hook.phpt
+++ b/tests/ext/sandbox-prehook/access_modifier_property_access_hook.phpt
@@ -1,0 +1,28 @@
+--TEST--
+[Prehook regression] Private and protected properties are accessed from a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+class Test
+{
+    private $value_private = '__value__private__';
+    protected $value_protected = '__value__protected__';
+
+    public function m()
+    {
+        echo "METHOD" . PHP_EOL;
+    }
+}
+
+dd_trace_method("Test", "m", ['prehook' => function() {
+    echo "PRIVATE PROPERTY IN HOOK " . $this->value_private . PHP_EOL;
+    echo "PROTECTED PROPERTY IN HOOK " . $this->value_protected . PHP_EOL;
+}]);
+
+(new Test())->m();
+?>
+--EXPECT--
+PRIVATE PROPERTY IN HOOK __value__private__
+PROTECTED PROPERTY IN HOOK __value__protected__
+METHOD

--- a/tests/ext/sandbox-prehook/args_copy_before_mutation.phpt
+++ b/tests/ext/sandbox-prehook/args_copy_before_mutation.phpt
@@ -1,0 +1,37 @@
+--TEST--
+[Prehook] Arguments are copied before mutation can occur
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('foo', [
+    'prehook' => function (SpanData $span, array $args) {
+        echo 'foo() prehook' . PHP_EOL;
+        var_dump($args);
+    }
+]);
+
+function foo($a) {
+    var_dump(func_get_args());
+    $a = 'Dogs';
+    var_dump(func_get_args());
+}
+
+foo('Cats');
+?>
+--EXPECT--
+foo() prehook
+array(1) {
+  [0]=>
+  string(4) "Cats"
+}
+array(1) {
+  [0]=>
+  string(4) "Cats"
+}
+array(1) {
+  [0]=>
+  string(4) "Dogs"
+}

--- a/tests/ext/sandbox-prehook/close_on_exit.phpt
+++ b/tests/ext/sandbox-prehook/close_on_exit.phpt
@@ -1,0 +1,45 @@
+--TEST--
+[Prehook Regression] Run sandbox closures for open spans on exit
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+register_shutdown_function(function () {
+    $spans = dd_trace_serialize_closed_spans();
+    array_map(
+        function($span) {
+            echo @$span['name'], PHP_EOL;
+        },
+        $spans
+    );
+});
+
+dd_trace_function('outer', ['prehook' => function (SpanData $span) {
+    $span->name = 'outer';
+    $span->resource = $span->name;
+    $span->service = 'test';
+    $span->type = 'custom';
+}]);
+
+dd_trace_function('inner', ['prehook' => function (SpanData $span) {
+    $span->name = 'inner';
+    $span->resource = $span->name;
+    $span->service = 'test';
+    $span->type = 'custom';
+}]);
+
+function inner() {}
+
+function outer() {
+    inner();
+    exit();
+}
+
+outer();
+
+?>
+--EXPECT--
+outer
+inner

--- a/tests/ext/sandbox-prehook/close_on_exit.phpt
+++ b/tests/ext/sandbox-prehook/close_on_exit.phpt
@@ -10,7 +10,7 @@ register_shutdown_function(function () {
     $spans = dd_trace_serialize_closed_spans();
     array_map(
         function($span) {
-            echo @$span['name'], PHP_EOL;
+            echo $span['name'], PHP_EOL;
         },
         $spans
     );

--- a/tests/ext/sandbox-prehook/closure_arg_exception.phpt
+++ b/tests/ext/sandbox-prehook/closure_arg_exception.phpt
@@ -1,0 +1,28 @@
+--TEST--
+[Prehook] Tracing closure does not have access to thrown exception
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('foo', [
+    'prehook' => function (SpanData $span, array $args, $retval, $ex) {
+        var_dump($ex);
+    }
+]);
+
+function foo($a) {
+    throw new Exception('foo error');
+    return 'foo(' . $a . ')';
+}
+
+try {
+    echo foo('bar') . PHP_EOL;
+} catch (Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+NULL
+foo error

--- a/tests/ext/sandbox-prehook/closure_arg_retval.phpt
+++ b/tests/ext/sandbox-prehook/closure_arg_retval.phpt
@@ -1,0 +1,23 @@
+--TEST--
+[Prehook] Tracing closure does not have access to return value
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('foo', [
+    'prehook' => function (SpanData $span, array $args, $retval) {
+        var_dump($retval);
+    }
+]);
+
+function foo($a) {
+    return 'foo(' . $a . ')';
+}
+
+echo foo('bar') . PHP_EOL;
+?>
+--EXPECT--
+NULL
+foo(bar)

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -1,0 +1,35 @@
+--TEST--
+[Prehook] API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+# Functions
+var_dump(dd_trace_function('foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace_function('foo', [
+    'prehook' => new stdClass(),
+]));
+
+# Methods
+echo PHP_EOL;
+var_dump(dd_trace_method('foo', 'foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace_method('foo', 'foo', [
+    'prehook' => new stdClass(),
+]));
+?>
+--EXPECT--
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)
+
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)

--- a/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
@@ -1,0 +1,22 @@
+--TEST--
+[Prehook Regression] dd_trace_function() can trace internal functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(dd_trace_function('array_sum', ['prehook' => function (SpanData $span) {
+    $span->name = 'ArraySum';
+}]));
+
+var_dump(array_sum([1, 3, 5]));
+
+array_map(function($span) {
+    echo $span['name'], PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(true)
+int(9)
+ArraySum

--- a/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
@@ -13,7 +13,7 @@ var_dump(dd_trace_function('filter_to_array', ['prehook' => function (SpanData $
 function filter_to_array($fn, $input) {
     $output = array();
     foreach ($input as $x) {
-        if (call_user_func($fn, $x)) {
+        if ($fn($x)) {
             $output[] = $x;
         }
     }

--- a/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
@@ -1,0 +1,41 @@
+--TEST--
+[Prehook Regression] dd_trace_function() can trace userland functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(dd_trace_function('filter_to_array', ['prehook' => function (SpanData $span) {
+    $span->name = 'filter_to_array';
+}]));
+
+function filter_to_array($fn, $input) {
+    $output = array();
+    foreach ($input as $x) {
+        if (call_user_func($fn, $x)) {
+            $output[] = $x;
+        }
+    }
+    return $output;
+}
+
+$is_odd = function ($x) {
+    return $x % 2 == 1;
+};
+
+var_export(filter_to_array($is_odd, array(1, 2, 3)));
+
+echo PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'], PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(true)
+array (
+  0 => 1,
+  1 => 3,
+)
+filter_to_array

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -1,0 +1,166 @@
+--TEST--
+[Prehook Regression] dd_trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        echo "Test::testFoo()\n";
+    }
+}
+
+class TestService
+{
+    public function testServiceFoo()
+    {
+        echo "TestService::testServiceFoo()\n";
+    }
+}
+
+class Foo
+{
+    public function bar($thoughts, array $bar = [])
+    {
+        echo "Foo::bar()\n";
+        return [
+            'thoughts' => $thoughts,
+            'first' => isset($bar[0]) ? $bar[0] : '(none)',
+            'rand' => mt_rand(42, 999)
+        ];
+    }
+}
+
+dd_trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+}]);
+dd_trace_method(
+    'Foo', 'bar',
+    ['prehook' => function (SpanData $span, $args) {
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }]
+);
+dd_trace_function('mt_rand', ['prehook' => function (SpanData $span, $args) {
+    $span->name = 'MT';
+    $span->meta = [
+        'rand.range' => $args[0] . ' - ' . $args[1],
+    ];
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+$testService = new TestService();
+$testService->testServiceFoo();
+
+$foo = new Foo();
+$ret = $foo->bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+Test::testFoo()
+TestService::testServiceFoo()
+Foo::bar()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(3) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    int(%d)
+    ["span_id"]=>
+    int(%d)
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(2) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["system.pid"]=>
+      int(%d)
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      string(7) "foo-red"
+      ["bar"]=>
+      string(9) "bar-green"
+    }
+  }
+  [1]=>
+  array(7) {
+    ["trace_id"]=>
+    int(%d)
+    ["span_id"]=>
+    int(%d)
+    ["parent_id"]=>
+    int(%d)
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(2) "MT"
+    ["meta"]=>
+    array(1) {
+      ["rand.range"]=>
+      string(8) "42 - 999"
+    }
+  }
+  [2]=>
+  array(6) {
+    ["trace_id"]=>
+    int(%d)
+    ["span_id"]=>
+    int(%d)
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      int(%d)
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
@@ -1,0 +1,39 @@
+--TEST--
+[Prehook Regression] dd_trace_method() binds the called object to the tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+date_default_timezone_set('UTC');
+
+class Foo
+{
+    public function testBinding()
+    {
+        echo "Foo::testBinding()\n";
+    }
+}
+
+dd_trace_method('Foo', 'testBinding', ['prehook' => function () {
+    echo "Traced testBinding\n";
+    var_dump($this);
+}]);
+
+dd_trace_method('DatePeriod', 'getStartDate', ['prehook' => function () {
+    echo "Traced getStartDate\n";
+    var_dump($this instanceof DatePeriod);
+}]);
+
+$foo = new Foo();
+$foo->testBinding();
+
+$period = new DatePeriod('R7/2019-08-21T00:00:00Z/P1D');
+$period->getStartDate();
+?>
+--EXPECTF--
+Traced testBinding
+object(Foo)#%d (0) {
+}
+Foo::testBinding()
+Traced getStartDate
+bool(true)

--- a/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
@@ -1,0 +1,124 @@
+--TEST--
+[Prehook Regression] dd_trace_method() works alongside dd_trace()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function oldWay($favNumber, array $colors = [])
+    {
+        echo "Foo::oldWay($favNumber, [...])\n";
+        return sprintf(
+            "Old fav num is %d with %d colors and %s on top\n",
+            $favNumber,
+            count($colors),
+            $colors[0]
+        );
+    }
+
+    public function newWay($favNumber, array $colors = [])
+    {
+        echo "Foo::newWay($favNumber, [...])\n";
+        return sprintf(
+            "New fav num is %d with %d colors and %s on top\n",
+            $favNumber,
+            count($colors),
+            $colors[0]
+        );
+    }
+}
+
+dd_trace('Foo', 'oldWay', function () {
+    echo "TRACED Test::oldWay()\n";
+    var_dump(func_get_args());
+    $retval = dd_trace_forward_call();
+    var_dump($retval);
+    return $retval;
+});
+
+dd_trace_method(
+    'Foo', 'newWay',
+    ['prehook' => function (SpanData $span, $args) {
+        echo "TRACED Test::newWay()\n";
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+            'args.1.0' => isset($args[1][0]) ? $args[1][0] : '',
+        ];
+    }]
+);
+
+$foo = new Foo();
+$old = $foo->oldWay(70, ['green', 'red', 'blue']);
+var_dump($old);
+$new = $foo->newWay(42, ['pink', 'blue', 'grey']);
+var_dump($new);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+TRACED Test::oldWay()
+array(2) {
+  [0]=>
+  int(70)
+  [1]=>
+  array(3) {
+    [0]=>
+    string(5) "green"
+    [1]=>
+    string(3) "red"
+    [2]=>
+    string(4) "blue"
+  }
+}
+Foo::oldWay(70, [...])
+string(49) "Old fav num is 70 with 3 colors and green on top
+"
+string(49) "Old fav num is 70 with 3 colors and green on top
+"
+TRACED Test::newWay()
+Foo::newWay(42, [...])
+string(48) "New fav num is 42 with 3 colors and pink on top
+"
+---
+array(1) {
+  [0]=>
+  array(9) {
+    ["trace_id"]=>
+    int(%d)
+    ["span_id"]=>
+    int(%d)
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(3) {
+      ["args.0"]=>
+      string(%d) "%d"
+      ["args.1.0"]=>
+      string(4) "pink"
+      ["system.pid"]=>
+      int(%d)
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox-prehook/drop_spans.phpt
+++ b/tests/ext/sandbox-prehook/drop_spans.phpt
@@ -1,0 +1,42 @@
+--TEST--
+[Prehook Regression] Span is dropped when tracing closure returns false
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+date_default_timezone_set('UTC');
+
+dd_trace_function('array_sum', ['prehook' => function (SpanData $span, array $args) {
+    echo 'Traced array_sum' . PHP_EOL;
+    $span->name = 'ArraySum';
+    if ($args[0][0] === 42) {
+        return false;
+    }
+}]);
+
+dd_trace_method('DateTime', '__construct', ['prehook' => function (SpanData $span, array $args) {
+    echo 'Traced DateTime' . PHP_EOL;
+    $span->name = 'DateTime: ' . $args[0];
+    if ($args[0] === '2019-09-10') {
+        return false;
+    }
+}]);
+
+array_sum([1, 2, 3]);
+array_sum([42, 0, 1]); // Should drop
+new DateTime('2000-01-01');
+new DateTime('2019-09-10'); // Should drop
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+Traced array_sum
+Traced array_sum
+Traced DateTime
+Traced DateTime
+DateTime: 2000-01-01
+ArraySum

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -1,0 +1,17 @@
+--TEST--
+[Prehook Regression] Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+dd_trace_function('array_sum', ['prehook' => function () {
+    throw new RuntimeException("This exception is expected");
+}]);
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in tracing closure for array_sum: This exception is expected
+int(9)

--- a/tests/ext/sandbox-prehook/exception_handling.phpt
+++ b/tests/ext/sandbox-prehook/exception_handling.phpt
@@ -1,0 +1,53 @@
+--TEST--
+[Prehook Regression] Exceptions get attached to spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+
+function outer() {
+    inner('datadog');
+}
+function inner($message) {
+    throw new Exception($message);
+}
+
+dd_trace_function("outer", ['prehook' => function() {}]);
+dd_trace_function("inner", ['prehook' => function() {}]);
+
+try {
+    outer();
+} catch (Exception $e) {
+    $stack = dd_trace_serialize_closed_spans();
+    echo "Stack size: ", count($stack), "\n";
+
+    $span = $stack[0];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+
+    $span = $stack[1];
+    echo "error: ", $span['error'], "\n";
+    echo "Exception type: ", $span['meta']['error.type'], "\n";
+    echo "Exception msg: ", $span['meta']['error.msg'], "\n";
+    echo "Exception stack:\n", $span['meta']['error.stack'], "\n";
+}
+
+?>
+--EXPECTF--
+Stack size: 2
+error: 1
+Exception type: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner(...)
+#1 %s: outer()
+#2 {main}
+error: 1
+Exception type: Exception
+Exception msg: datadog
+Exception stack:
+#0 %s: inner(...)
+#1 %s: outer()
+#2 {main}

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -1,0 +1,56 @@
+--TEST--
+[Prehook Regression] Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        mt_srand(42);
+        printf(
+            "Test::testFoo() fav num: %d\n",
+            mt_rand()
+        );
+    }
+}
+
+dd_trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+    $span->service = $this_normally_raises_a_notice; // E_NOTICE
+}]);
+
+dd_trace_function('mt_srand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTSeed';
+    throw new Exception('This should be ignored');
+}]);
+
+dd_trace_function('mt_rand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTRand';
+    htmlentities('<b>', 0, 'BIG5'); // E_STRICT
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECTF--
+Error raised in tracing closure for testfoo(): Undefined variable: this_normally_raises_a_notice in %s on line %d
+Exception thrown in tracing closure for mt_srand: This should be ignored
+Error raised in tracing closure for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+Test::testFoo() fav num: %d
+TestFoo
+MTRand
+MTSeed
+NULL

--- a/tests/ext/sandbox-prehook/exit_and_drop_span.phpt
+++ b/tests/ext/sandbox-prehook/exit_and_drop_span.phpt
@@ -1,0 +1,23 @@
+--TEST--
+[Prehook Regression] Exit gracefully handles a dropped span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+dd_trace_function('foo', ['prehook' => function () {
+    echo 'Dropping span' . PHP_EOL;
+    return false;
+}]);
+
+function foo() {
+    echo 'foo()' . PHP_EOL;
+    exit;
+}
+
+foo();
+
+echo 'You should not see this.' . PHP_EOL;
+?>
+--EXPECT--
+Dropping span
+foo()

--- a/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -1,0 +1,50 @@
+--TEST--
+[Prehook Regression] Keep spans in limited mode (userland functions)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_SPANS_LIMIT=5
+--FILE--
+<?php
+function myFunc1($foo) {
+    return $foo;
+}
+
+function myFunc2($bar) {
+    return $bar;
+}
+
+dd_trace_function('myFunc1', ['prehook' => function (\DDTrace\SpanData $span) {
+    $span->name = 'myFunc1';
+}]);
+
+dd_trace_function('myFunc2', [
+    'instrument_when_limited' => 1,
+    'prehook' => function (\DDTrace\SpanData $span) {
+        $span->name = 'myFunc2';
+    }
+]);
+
+var_dump(dd_trace_tracer_is_limited());
+myFunc2('foo');
+for ($i = 0; $i < 100; $i++) {
+    myFunc1([]);
+}
+var_dump(dd_trace_tracer_is_limited());
+myFunc2(42);
+myFunc2(true);
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(false)
+bool(true)
+myFunc2
+myFunc2
+myFunc1
+myFunc1
+myFunc1
+myFunc1
+myFunc2

--- a/tests/ext/sandbox-prehook/new_static.phpt
+++ b/tests/ext/sandbox-prehook/new_static.phpt
@@ -1,0 +1,32 @@
+--TEST--
+[Prehook Regression] New static instantiates from expected class
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+abstract class Foo {
+    public static function get() {
+        return new static();
+    }
+}
+
+class Bar extends Foo {
+    // Empty
+}
+
+dd_trace_method('Foo', 'get', ['prehook' => function (SpanData $span) {
+    $span->name = get_called_class();
+}]);
+
+$bar = Bar::get();
+var_dump($bar instanceof Bar);
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+bool(true)
+Bar

--- a/tests/ext/sandbox-prehook/php5_unsupported.phpt
+++ b/tests/ext/sandbox-prehook/php5_unsupported.phpt
@@ -1,0 +1,37 @@
+--TEST--
+[Prehook] Not supported on PHP 5
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID >= 70000) die('skip: PHP 5 only test'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(dd_trace_function('foo', [
+    'prehook' => function (SpanData $span, array $args) {
+        echo 'foo() prehook' . PHP_EOL;
+        var_dump($args);
+    }
+]));
+
+function foo($a) {
+    var_dump(func_get_args());
+    $a = 'Dogs';
+    var_dump(func_get_args());
+}
+
+foo('Cats');
+?>
+--EXPECT--
+'prehook' not supported on PHP 5
+bool(false)
+array(1) {
+  [0]=>
+  string(4) "Cats"
+}
+array(1) {
+  [0]=>
+  string(4) "Cats"
+}

--- a/tests/ext/sandbox-prehook/trace_static_method.phpt
+++ b/tests/ext/sandbox-prehook/trace_static_method.phpt
@@ -1,0 +1,24 @@
+--TEST--
+[Prehook regression] Trace public static method
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+class Test
+{
+    public static function public_static_method()
+    {
+        echo "PUBLIC STATIC METHOD" . PHP_EOL;
+    }
+
+}
+
+dd_trace_method("Test", "public_static_method", ['prehook' => function(){
+    echo "test_access hook" . PHP_EOL;
+}]);
+
+Test::public_static_method();
+?>
+--EXPECT--
+test_access hook
+PUBLIC STATIC METHOD

--- a/tests/ext/sandbox-prehook/variable_length_parameter_list.phpt
+++ b/tests/ext/sandbox-prehook/variable_length_parameter_list.phpt
@@ -1,0 +1,52 @@
+--TEST--
+[Prehook regression] Trace variadic functions and methods
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--FILE--
+<?php
+function test($a, $b, $c){
+    echo "FUNCTION " . $a ." ". $b . " " . $c . " " . implode(" ", array_slice(func_get_args(), 3)) .  PHP_EOL;
+}
+
+class Test {
+    public function m($a, $b, $c){
+        echo "METHOD " . $a ." ". $b . " " . $c . " " . implode(" ", array_slice(func_get_args(), 3)) .  PHP_EOL;
+    }
+}
+
+dd_trace_function("test", ['prehook' => function($s, array $args){
+    echo "HOOK " . implode(" ", $args) . PHP_EOL;
+}]);
+
+dd_trace_method("Test", "m", ['prehook' => function($s, array $args){
+    echo "HOOK " . implode(" ", $args) . PHP_EOL;
+}]);
+
+
+test("a", "b", "c", "d", "e", "f", "g", "h");
+test("a1", "b", "c", "d", "e", "f", "g", "h");
+test("a2", "b", "c", "d", "e", "f", "g", "h");
+test("a3", "b", "c", "d", "e", "f", "g", "h");
+(new Test())->m("a", "b", "c", "d", "e", "f", "g", "h");
+(new Test())->m("a1", "b", "c", "d", "e", "f", "g", "h");
+(new Test())->m("a2", "b", "c", "d", "e", "f", "g", "h");
+(new Test())->m("a3", "b", "c", "d", "e", "f", "g", "h");
+
+?>
+--EXPECT--
+HOOK a b c d e f g h
+FUNCTION a b c d e f g h
+HOOK a1 b c d e f g h
+FUNCTION a1 b c d e f g h
+HOOK a2 b c d e f g h
+FUNCTION a2 b c d e f g h
+HOOK a3 b c d e f g h
+FUNCTION a3 b c d e f g h
+HOOK a b c d e f g h
+METHOD a b c d e f g h
+HOOK a1 b c d e f g h
+METHOD a1 b c d e f g h
+HOOK a2 b c d e f g h
+METHOD a2 b c d e f g h
+HOOK a3 b c d e f g h
+METHOD a3 b c d e f g h

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -61,7 +61,7 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 Sandbox API does not support 'innerhook'
 bool(false)
-Required key 'posthook' or 'innerhook' not found in config_array
+Required key 'posthook', 'prehook' or 'innerhook' not found in config_array
 bool(false)
 
 bool(false)
@@ -77,5 +77,5 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 Sandbox API does not support 'innerhook'
 bool(false)
-Required key 'posthook' or 'innerhook' not found in config_array
+Required key 'posthook', 'prehook' or 'innerhook' not found in config_array
 bool(false)


### PR DESCRIPTION
### Description

This PR allows tracing closures to be run _before_ the original call by using the `prehook` option.

```php
dd_trace_function('foo', [
    'prehook' => function (\DDTrace\SpanData $span, array $args) {
        // ...
    }
]);
```

This feature is only supported on PHP 7.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
