### PR TITLE
Add pointer on SpanData objects to go back to ddtrace_span_t

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -85,10 +85,14 @@
                     <dir name="php5">
                         <file name="dispatch.c" role="src" />
                         <file name="engine_hooks.c" role="src" />
+                        <file name="spandata.c" role="src" />
+                        <file name="spandata.h" role="src" />
                     </dir>
                     <dir name="php7">
                         <file name="dispatch.c" role="src" />
                         <file name="engine_hooks.c" role="src" />
+                        <file name="spandata.c" role="src" />
+                        <file name="spandata.h" role="src" />
                     </dir>
                     <dir name="third-party">
                         <file name="mt19937-64.c" role="src" />
@@ -184,6 +188,7 @@
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
                         <file name="safe_to_string_properties.phpt" role="test" />
                         <file name="sandbox_api_not_available_on_unsupported_versions.phpt" role="test" />
+                        <file name="spandata_is_top.phpt" role="test" />
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                     </dir>

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -9,7 +9,6 @@
 #include "version.h"
 
 extern zend_module_entry ddtrace_module_entry;
-extern zend_class_entry *ddtrace_ce_span_data;
 
 BOOL_T ddtrace_tracer_is_limited(TSRMLS_D);
 

--- a/src/ext/php5/spandata.c
+++ b/src/ext/php5/spandata.c
@@ -1,0 +1,21 @@
+#include "spandata.h"
+
+#include <php.h>
+
+zend_class_entry *ddtrace_spandata_ce;
+
+void ddtrace_spandata_register_ce(TSRMLS_D) {
+    zend_class_entry ce;
+    INIT_NS_CLASS_ENTRY(ce, "DDTrace", "SpanData", NULL);
+    ddtrace_spandata_ce = zend_register_internal_class(&ce TSRMLS_CC);
+
+    /* trace_id, span_id, parent_id, start & duration are stored directly on
+     * ddtrace_span_t so we don't need to make them properties on DDTrace\SpanData
+     */
+    zend_declare_property_null(ddtrace_spandata_ce, "name", sizeof("name") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "resource", sizeof("resource") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "service", sizeof("service") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "type", sizeof("type") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+}

--- a/src/ext/php5/spandata.h
+++ b/src/ext/php5/spandata.h
@@ -1,0 +1,12 @@
+#ifndef DDTRACE_SPANDATA_HH
+#define DDTRACE_SPANDATA_HH
+
+#include "compatibility.h"
+
+extern zend_class_entry *ddtrace_spandata_ce;
+
+// todo: fully implement this on PHP 5 if the feature proves valuable
+
+void ddtrace_spandata_register_ce(TSRMLS_D);
+
+#endif  // DDTRACE_SPANDATA_HH

--- a/src/ext/php7/spandata.c
+++ b/src/ext/php7/spandata.c
@@ -1,0 +1,71 @@
+#include "spandata.h"
+
+#include "ddtrace.h"
+#include "span.h"
+
+zend_class_entry *ddtrace_spandata_ce;
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+extern inline ddtrace_spandata *ddtrace_spandata_from_obj(zend_object *object);
+extern inline ddtrace_spandata *ddtrace_spandata_from_zval(zval *zv);
+
+bool ddtrace_spandata_is_top(zval *obj) {
+    ddtrace_spandata *span = ddtrace_spandata_from_zval(obj);
+    return DDTRACE_G(open_spans_top) == span->backptr;
+}
+
+/* {{{ PHP objects have a two-part destruction: dtor and free.
+ * You can run PHP code in dtor but not free.
+ * The dtor is not always called.
+ */
+static void _ddtrace_spandata_dtor_obj(zend_object *object) { zend_objects_destroy_object(object); }
+static void _ddtrace_spandata_free_obj(zend_object *object) { zend_object_std_dtor(object); }
+/* }}} */
+
+/* PHP does not expose the individual std_object_handlers until PHP 7.3, so we
+ * cannot make this a const object; instead initialize it at registration.
+ */
+static zend_object_handlers ddtrace_spandata_handlers;
+
+/* Note that creating a spandata object through this API is incomplete; the
+ * backptr will not be assigned.
+ */
+zend_object *ddtrace_spandata_create_obj(zend_class_entry *ce) {
+    ddtrace_spandata *spandata = ecalloc(1, sizeof(ddtrace_spandata) + zend_object_properties_size(ce));
+    zend_object *object = &spandata->std;
+    zend_object_std_init(object, ce);
+    object_properties_init(object, ce);
+    object->handlers = &ddtrace_spandata_handlers;
+    return object;
+}
+
+void ddtrace_spandata_register_ce(void) {
+    /* Initialize the handlers at registration time since PHP does not expose
+     * the individual handlers by name until 7.3, and accessing
+     * std_object_handlers members is not a compile-time constant: {{{ */
+    memcpy(&ddtrace_spandata_handlers, &std_object_handlers, sizeof ddtrace_spandata_handlers);
+    ddtrace_spandata_handlers.offset = XtOffsetOf(ddtrace_spandata, std);
+    ddtrace_spandata_handlers.free_obj = _ddtrace_spandata_free_obj;
+    ddtrace_spandata_handlers.dtor_obj = _ddtrace_spandata_dtor_obj;
+
+    // Delete the clone handler which in effect forbids cloning the obj
+    ddtrace_spandata_handlers.clone_obj = NULL;
+    /* }}} */
+
+    zend_class_entry ce;
+    INIT_NS_CLASS_ENTRY(ce, "DDTrace", "SpanData", NULL);
+    ddtrace_spandata_ce = zend_register_internal_class(&ce);
+
+    /* trace_id, span_id, parent_id, start & duration are stored directly on
+     * ddtrace_span_t so we don't need to make them properties on DDTrace\SpanData
+     */
+    zend_declare_property_null(ddtrace_spandata_ce, "name", sizeof("name") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "resource", sizeof("resource") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "service", sizeof("service") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "type", sizeof("type") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_spandata_ce, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+
+    ddtrace_spandata_ce->create_object = ddtrace_spandata_create_obj;
+}

--- a/src/ext/php7/spandata.h
+++ b/src/ext/php7/spandata.h
@@ -1,0 +1,33 @@
+#ifndef DDTRACE_SPANDATA_HH
+#define DDTRACE_SPANDATA_HH
+
+#include <Zend/zend.h>
+#include <stdbool.h>
+
+extern zend_class_entry *ddtrace_spandata_ce;
+
+void ddtrace_spandata_register_ce(void);
+
+struct ddtrace_spandata {
+    struct ddtrace_span_t *backptr;
+
+    /* In PHP 7, the standard PHP object is placed last and named `std`.
+     * This is because of a memory optimization that places the common
+     * properties directly after this struct. The struct becomes variable sized,
+     * so be cautious about stack allocating it or storing it directly in an
+     * array (use an array of pointers instead).
+     */
+    zend_object std;
+};
+typedef struct ddtrace_spandata ddtrace_spandata;
+
+// Converts pointer to ddtrace_spandata's std member to a pointer of span itself.
+inline ddtrace_spandata *ddtrace_spandata_from_obj(zend_object *object) {
+    return (ddtrace_spandata *)((char *)(object)-XtOffsetOf(ddtrace_spandata, std));
+}
+
+inline ddtrace_spandata *ddtrace_spandata_from_zval(zval *zv) { return ddtrace_spandata_from_obj(Z_OBJ_P(zv)); }
+
+bool ddtrace_spandata_is_top(zval *obj);
+
+#endif  // DDTRACE_SPANDATA_HH

--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -13,6 +13,7 @@
 #include "ddtrace.h"
 #include "logging.h"
 #include "mpack/mpack.h"
+#include "spandata.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
@@ -183,7 +184,7 @@ int ddtrace_serialize_simple_array(zval *trace, zval *retval TSRMLS_DC) {
 
 #if PHP_VERSION_ID < 70000
 static zval *_read_span_property(zval *span_data, const char *name, size_t name_len TSRMLS_DC) {
-    return zend_read_property(ddtrace_ce_span_data, span_data, name, name_len, 1 TSRMLS_CC);
+    return zend_read_property(ddtrace_spandata_ce, span_data, name, name_len, 1 TSRMLS_CC);
 }
 
 static void _add_assoc_zval_copy(zval *el, const char *name, zval *prop) {
@@ -391,7 +392,7 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span TSRMLS_DC) {
 #else
 static zval *_read_span_property(zval *span_data, const char *name, size_t name_len) {
     zval rv;
-    return zend_read_property(ddtrace_ce_span_data, span_data, name, name_len, 1, &rv);
+    return zend_read_property(ddtrace_spandata_ce, span_data, name, name_len, 1, &rv);
 }
 
 static void _add_assoc_zval_copy(zval *el, const char *name, zval *prop) {

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -7,6 +7,7 @@
 #include "ddtrace.h"
 #include "random.h"
 #include "serializer.h"
+#include "spandata.h"
 
 #define USE_REALTIME_CLOCK 0
 #define USE_MONOTONIC_CLOCK 1
@@ -84,7 +85,13 @@ ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispat
 #else
     span->span_data = (zval *)ecalloc(1, sizeof(zval));
 #endif
-    object_init_ex(span->span_data, ddtrace_ce_span_data);
+
+    object_init_ex(span->span_data, ddtrace_spandata_ce);
+
+#if PHP_VERSION_ID >= 70000
+    ddtrace_spandata *spandata = ddtrace_spandata_from_zval(span->span_data);
+    spandata->backptr = span;
+#endif
 
     // Peek at the active span ID before we push a new one onto the stack
     span->parent_id = ddtrace_peek_span_id(TSRMLS_C);

--- a/tests/ext/sandbox/drop_spans.phpt
+++ b/tests/ext/sandbox/drop_spans.phpt
@@ -29,9 +29,12 @@ array_sum([42, 0, 1]); // Should drop
 new DateTime('2000-01-01');
 new DateTime('2019-09-10'); // Should drop
 
-array_map(function($span) {
-    echo $span['name'] . PHP_EOL;
-}, dd_trace_serialize_closed_spans());
+array_map(
+    function($span) {
+        echo $span['name'] . PHP_EOL;
+    },
+    dd_trace_serialize_closed_spans()
+);
 ?>
 --EXPECT--
 Traced array_sum

--- a/tests/ext/sandbox/spandata_is_top.phpt
+++ b/tests/ext/sandbox/spandata_is_top.phpt
@@ -1,0 +1,17 @@
+--TEST--
+test that the spandata object is on top
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION < 7) die("skip: test works on PHP 7+"); ?>
+--FILE--
+<?php
+dd_trace_function('foo', function (DDTrace\SpanData $span) {
+    var_dump(dd_trace_internal_fn('spandata_is_top', $span));
+});
+
+function foo() {}
+
+foo();
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
### Description

Add a pointer on SpanData objects to go back to the ddtrace_span_t they are associated with. Also separate the spandata object and handlers into new files and fix the asan configure flags.

The key motivation is to allow us to pass SpanData objects around in userland without losing the data on the ddtrace_span_t struct they are associated with, such as trace_id and span_id. It also lays the foundation for various things:

- For moving properties from `ddtrace_span_t` to the SpanData object, and then we can reduce our allocations per span by one.
- It may also enable creating spans directly in userland e.g. `new SpanData(...)` which is not currently supported.

### Readiness checklist
- [ ] PHP 5 support
- [x] PHP 7 support
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
