### PR TITLE
Pass return value as null to tracing closure when value IS_UNDEF

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -176,6 +176,7 @@
                         <file name="keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
                         <file name="memory_limit_graceful_bailout.phpt" role="test" />
                         <file name="new_static.phpt" role="test" />
+                        <file name="retval_is_null_with_exception.phpt" role="test" />
                         <file name="safe_to_string_metadata.phpt" role="test" />
                         <file name="safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
                         <file name="safe_to_string_properties.phpt" role="test" />

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -192,8 +192,11 @@ static bool _dd_execute_tracing_closure(zval *callable, zval *span_data, zend_ex
     // Arg 1: array $args
     ZVAL_COPY(&args[1], user_args);
 
-    // Arg 2: mixed|null $retval
-    ZVAL_COPY(&args[2], user_retval ?: &EG(uninitialized_zval));
+    // Arg 2: mixed $retval
+    if (!user_retval || Z_TYPE_INFO_P(user_retval) == IS_UNDEF) {
+        user_retval = &EG(uninitialized_zval);
+    }
+    ZVAL_COPY(&args[2], user_retval);
 
     // Arg 3: Exception|null $exception
     ZVAL_COPY(&args[3], &exception_arg);

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The return value is null when an exception is thrown in the original call
+--DESCRIPTION--
+We enable debug mode to ensure this does not raise an "Undefined variable" E_NOTICE in the tracing closure
+https://github.com/DataDog/dd-trace-php/issues/788
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function foo()
+{
+    throw new Exception('Oops!');
+    return 42;
+}
+
+dd_trace_function('foo', function (SpanData $span, array $args, $retval, $ex) {
+    var_dump($ex instanceof Exception);
+    var_dump($retval);
+});
+
+try {
+    foo();
+} catch (Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+bool(true)
+NULL
+Oops!


### PR DESCRIPTION
### Description

This PR ensures that if a return value is of type `IS_UNDEF`, it will be passed to the tracing closure as null.

Fixes #788.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
