### PR TITLE
Re-enable PDO integration for Drupal

### DIFF
--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -55,15 +55,6 @@ class PDOIntegration extends Integration
             return Integration::NOT_AVAILABLE;
         }
 
-        /**
-         * Workaround for the Drupal DBAL bug.
-         * Delete this `if` block once the bug is fixed.
-         * @see https://github.com/DataDog/dd-trace-php/pull/284
-         */
-        if (defined('DRUPAL_CORE_COMPATIBILITY')) {
-            return Integration::NOT_AVAILABLE;
-        }
-
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
         dd_trace('PDO', '__construct', function () {
             $tracer = GlobalTracer::get();


### PR DESCRIPTION
### Description

Closes #539 (already fixed by #284).
Reverts #285. 

Confirming #539 is fixed with a local copy test of Drupal 7.

Setup a couple of local drupal 7 images based on the official drupal 7 dockerhub image.

Removed the code from #285 (same change as this PR)

1. **Error:** Tried to unsuccessfully reproduce the error using the 0.20.0 version of the tracer. The [fix was introduced on 0.21.0](https://github.com/DataDog/dd-trace-php/releases/tag/0.21.0) .
Was not successful in reproducing an issue based on #284. I was expecting some kind of error. Nothing shown with errors turned on. However, the traces weren't being sent.

2. **Fix:** Successfully reproduced the fix on the latest version of the tracer (0.41.1):
![](https://i.imgur.com/xUw9a0u.png)


#### Reproducing steps

Created a docker file based on Drupal 7 [dockerfile](https://github.com/docker-library/drupal/blob/bee08efba505b740a14d68254d6e51af7ab2f3ea/7/Dockerfile) fron [Drupal's dockerhub](https://hub.docker.com/_/drupal/), but modified it to use php 5.6 (since that docker uses 5.5 which DataDog doesn't support).


To use them:
1. Clone gist. **All the work for reproducing locally is here:**
https://gist.github.com/ajessu/4e27b13c3b1db180b1a29a695f8f40b0

2. Run:

```
DD_API_KEY=<insert_your_dd_api_key_here> docker-compose up -d
```

Both containers are connecting to the same db and are sharing the same volume, for drupal files, so the project only needs to be setup once for both:

3. For Drupal 7 without #284 fix present (0.20.0), open:
```
localhost:8080
```

4. For Drupal 7 with latest tracer (0.41.0)
```
localhost:8081
```

5. To test the fix, bash into each container and comment out the #285 fix (line 63)
```
docker-compose exec reproduce_error bash
vim /opt/datadog-php/dd-trace-sources/src/DDTrace/Integrations/PDO/PDOIntegration.php
```


```
docker-compose exec reproduce_fix bash
vim /opt/datadog-php/dd-trace-sources/src/DDTrace/Integrations/PDO/PDOIntegration.php
```

6. Create new drupal project in either of the containers (see docker-compose file for db credentials and host) and create a dummy article.

Project is setup and traces should be sent to the APM UI.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug. **Did not add any tests, as Drupal is not supported, so there's not integration setup yet**.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
