### PR TITLE
Add a few more predis integration tests with different connection types

### DIFF
--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -7,7 +7,7 @@ use DDTrace\Tag;
 use DDTrace\Type;
 use DDTrace\GlobalTracer;
 use Predis\Configuration\OptionsInterface;
-use Predis\Connection\AbstractConnection;
+use Predis\Connection\NodeConnectionInterface;
 use Predis\Pipeline\Pipeline;
 
 const VALUE_PLACEHOLDER = "?";
@@ -224,7 +224,7 @@ class PredisIntegration extends Integration
 
         $connection = $predis->getConnection();
 
-        if ($connection instanceof AbstractConnection) {
+        if ($connection instanceof NodeConnectionInterface) {
             $connectionParameters = $connection->getParameters();
 
             $tags[Tag::TARGET_HOST] = $connectionParameters->host;


### PR DESCRIPTION
### Description

Closes #315 (original issue) .
Closes #479 (attempted fix, which was already fixed by #574)

This was previously fixed by #574. As I explored #315 and the fix, noticed the current fix leaves out a few rarely used connection types without host and port tags information, as they do not use the AbstractConnection, while still being single node configurations.
Not the end of the world, but fix was simple.

Also added tests for many other connection types that do not need extra integrations (live connections into a Redis instance) to initialize.

--- 
**More detail:**

This moves from checking on extending the abstract class, into checking on implementing thise single node connection interface. [All but one one core connection (Webdis)](https://github.com/nrk/predis/blob/v1.1/src/Connection/WebdisConnection.php#L46) uses the interface without extending the abstract class. Any custom connection a user can define could also fall under this, though this is again, a rare case.


This change focused on the original intent of #574. Avoids trying to get a connection's host and port from a Redis cluster, since these cluster might have more than one connections configured. These connection types all [implement the AggregateConnectionInterface](https://github.com/nrk/predis/blob/v1.1/src/Connection/AggregateConnectionInterface.php).

On the other hand, single server connections implement the [NodeConnectionInterface](https://github.com/nrk/predis/blob/v1.1/src/Connection/NodeConnectionInterface.php), which is also [implemented by the AbstractConnection](https://github.com/nrk/predis/blob/111d100ee389d624036b46b35ed0c9ac59c71313/src/Connection/AbstractConnection.php#L24).

The `NodeConnectionInterface` guarantees the `getParameter` method, which returns a `ParameterInterface` implementing object, which in turn guarantees for any getter methods that:
-  at least an string empty value for the host and port value, if they don't exist.
- the actual host and port configured for the Redis node.

See:
https://github.com/nrk/predis/blob/v1.1/src/Connection/ParametersInterface.php#L21-L32
and
https://github.com/nrk/predis/blob/v1.1/src/Connection/Parameters.php#L146-L151

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
