### PR TITLE
Avoid strdup

### DIFF
--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -144,23 +144,12 @@ char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRML
     }
 }
 
-#if !defined(__clang__) && (__GNUC__ >= 7)
-// disable checks since some GCC trigger false positives
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif  // !defined(__clang__) && (__GNUC__ >= 7)
-
 // Do not use regular strdup! On some platforms it segfaults with C11.
-char *ddtrace_strdup(const char *c) {
-    size_t len = strlen(c);
-    char *dup = malloc(len + 1);
-
-    if (dup != NULL) {
-        strncpy(dup, c, len + 1);
+char *ddtrace_strdup(const char *source) {
+    size_t size = strlen(source) + 1;
+    char *dest = malloc(size);
+    if (dest) {
+        memcpy(dest, source, size);
     }
-    return dup;
+    return dest;
 }
-
-#if !defined(__clang__) && __GNUC__ >= 7
-#pragma GCC diagnostic pop
-#endif  //! defined(__clang__) && __GNUC__ >= 7

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -150,6 +150,7 @@ char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRML
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif  // !defined(__clang__) && (__GNUC__ >= 7)
 
+// Do not use regular strdup! On some platforms it segfaults with C11.
 char *ddtrace_strdup(const char *c) {
     size_t len = strlen(c);
     char *dup = malloc(len + 1);

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -14,6 +14,6 @@ int64_t ddtrace_get_int_config(char *name, int64_t def TSRMLS_DC);
 uint32_t ddtrace_get_uint32_config(char *name, uint32_t def TSRMLS_DC);
 double ddtrace_get_double_config(char *name, double def TSRMLS_DC);
 char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRMLS_DC);
-char *ddtrace_strdup(const char *c);
+char *ddtrace_strdup(const char *source);
 
 #endif  // DD_ENV_CONFIG_H

--- a/src/ext/logging.c
+++ b/src/ext/logging.c
@@ -16,7 +16,7 @@ void ddtrace_bgs_log_rinit(char *error_log) {
         return;
     }
 
-    uintptr_t desired = (uintptr_t)strdup(error_log);
+    uintptr_t desired = (uintptr_t)ddtrace_strdup(error_log);
     uintptr_t expected = (uintptr_t)NULL;
     if (!atomic_compare_exchange_strong(&php_ini_error_log, &expected, desired)) {
         // if it didn't exchange, then we need to free our duplicated string


### PR DESCRIPTION
### Description

With C11 on Alpine under libc6-compat, the strdup function will segfault on some inputs such as `php://stderr`. This makes no sense, but it is reality; see #797.

Use `ddtrace_strdup` instead. The fact this function exists kind of makes me think we've hit this case before. I've better documented it to hopefully help us find it, but I wonder if there's a tool we can use to forbid the use of certain functions?

Aside from this, we should probably work towards packaging Alpine with musl directly instead of using libc6-compat.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
