### PR TITLE
Enable background sender in tests

### DIFF
--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -151,10 +151,10 @@ final class Http implements Transport
         }
 
         // Now that bgs is enabled by default, allow disabling it by disabling either option
-        $bgs_enabled = \dd_trace_env_config('DD_TRACE_BGS_ENABLED')
+        $bgsEnabled = \dd_trace_env_config('DD_TRACE_BGS_ENABLED')
                     && \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD');
         if (
-            $bgs_enabled
+            $bgsEnabled
             && $this->encoder->getContentType() === 'application/msgpack'
             && \dd_trace_send_traces_via_thread($tracesCount, $curlHeaders, $body)
         ) {

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -150,11 +150,11 @@ final class Http implements Transport
             $curlHeaders[] = "$key: $value";
         }
 
+        // Now that bgs is enabled by default, allow disabling it by disabling either option
+        $bgs_enabled = \dd_trace_env_config('DD_TRACE_BGS_ENABLED')
+                    && \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD');
         if (
-            (
-                \dd_trace_env_config('DD_TRACE_BETA_SEND_TRACES_VIA_THREAD')
-                || \dd_trace_env_config('DD_TRACE_BGS_ENABLED')
-            )
+            $bgs_enabled
             && $this->encoder->getContentType() === 'application/msgpack'
             && \dd_trace_send_traces_via_thread($tracesCount, $curlHeaders, $body)
         ) {

--- a/src/ext/compatibility.h
+++ b/src/ext/compatibility.h
@@ -3,6 +3,7 @@
 
 #include <TSRM/TSRM.h>
 #include <Zend/zend.h>
+#include <php_version.h>
 
 #define UNUSED_1(x) (void)(x)
 #define UNUSED_2(x, y) \

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -935,7 +935,12 @@ void ddtrace_coms_rshutdown(void) {
     struct _writer_loop_data_t *writer = _dd_get_writer();
 
     atomic_fetch_add(&writer->request_counter, 1);
-    uint32_t requests_since_last_flush = atomic_fetch_add(&writer->requests_since_last_flush, 1);
+
+    /* atomic_fetch_add returns the old value, so +1 to get the current value;
+     * this allows DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1 act almost
+     * synchronously for our test suite
+     */
+    uint32_t requests_since_last_flush = atomic_fetch_add(&writer->requests_since_last_flush, 1) + 1;
 
     // simple heuristic to flush every n request to improve memory used
     if (requests_since_last_flush > get_dd_trace_agent_flush_after_n_requests()) {

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -30,6 +30,16 @@ void ddtrace_config_shutdown(void);
 /* This should be at least an order of magnitude higher than the userland HTTP Transport default. */
 #define DD_TRACE_BGS_TIMEOUT 5000L
 
+/* There is an issue on PHP 5.4 that has been around for a while that was
+ * exposed by the background sender getting enabled. We need to fix that, but
+ * until then let's not enable BGS by default on < 5.6
+ */
+#if PHP_VERSION_ID < 50600
+#define DD_TRACE_BGS_ENABLED false
+#else
+#define DD_TRACE_BGS_ENABLED true
+#endif
+
 #define DD_CONFIGURATION                                                                                             \
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
@@ -44,9 +54,9 @@ void ddtrace_config_shutdown(void);
     INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
     BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", false)                                                            \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", true,                          \
+    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", DD_TRACE_BGS_ENABLED,          \
          "use background thread to send traces to the agent")                                                        \
-    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", true,                                                     \
+    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", DD_TRACE_BGS_ENABLED,                                     \
          "use background sender (BGS) to send traces to the agent")                                                  \
     INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
     INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -13,6 +13,8 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
 {
     use CommonScenariosDataProviderTrait;
 
+    const FLUSH_INTERVAL_MS = 333;
+
     const PORT = 9999;
 
     /**
@@ -50,10 +52,10 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     {
         $envs = [
             'DD_TEST_INTEGRATION' => 'true',
-            'DD_TRACE_ENCODER' => 'json',
-            'DD_TRACE_AGENT_TIMEOUT' => '10000',
-            'DD_TRACE_AGENT_CONNECT_TIMEOUT' => '10000',
             'DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED' => 'true',
+            'DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS' => 1,
+            // Short flush interval by default or our tests will take all day
+            'DD_TRACE_AGENT_FLUSH_INTERVAL' => static::FLUSH_INTERVAL_MS,
         ];
 
         if (!self::isSandboxed()) {
@@ -112,11 +114,12 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected function call(RequestSpec $spec)
     {
-        return $this->sendRequest(
+        $response = $this->sendRequest(
             $spec->getMethod(),
             'http://localhost:' . self::PORT . $spec->getPath(),
             $spec->getHeaders()
         );
+        return $response;
     }
 
     /**
@@ -129,13 +132,22 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected function sendRequest($method, $url, $headers = [])
     {
-        $ch = curl_init($url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-        if ($headers) {
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        for ($i = 0; $i < 10; ++$i) {
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+            if ($headers) {
+                curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            }
+            $response = curl_exec($ch);
+            if ($response === false && $i < 9) {
+                \curl_close($ch);
+                // sleep for 100 milliseconds before trying again
+                \usleep(100 * 1000);
+            } else {
+                break;
+            }
         }
-        $response = curl_exec($ch);
 
         if ($response === false) {
             $message = sprintf(

--- a/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
+++ b/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
@@ -7,7 +7,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class BackgroundSenderLogTest extends WebFrameworkTestCase
 {
-    const BGS_FLUSH_INTERVAL_MS = 1000;
+    const BGS_FLUSH_INTERVAL_MS = 500;
 
     protected static function getAppIndexScript()
     {
@@ -24,7 +24,8 @@ final class BackgroundSenderLogTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_BGS_ENABLED' => true,
+            'DD_TRACE_BETA_SEND_TRACES_VIA_THREAD' => 'true',
+            'DD_TRACE_BGS_ENABLED' => 'true',
             'DD_TRACE_DEBUG_CURL_OUTPUT' => true,
             'DD_TRACE_ENCODER' => 'msgpack',
             'DD_TRACE_AGENT_FLUSH_INTERVAL' => self::BGS_FLUSH_INTERVAL_MS,

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class CircuitBreakerTest extends WebFrameworkTestCase
 {
-    const FLUSH_INTERVAL_MS = 1500;
+    const FLUSH_INTERVAL_MS = 500;
 
     protected static function getAppIndexScript()
     {
@@ -18,7 +18,8 @@ final class CircuitBreakerTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_BETA_SEND_TRACES_VIA_THREAD' => '1',
+            'DD_TRACE_BETA_SEND_TRACES_VIA_THREAD' => 'true',
+            'DD_TRACE_BGS_ENABLED' => 'true',
             'DD_TRACE_ENCODER' => 'msgpack',
             'DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES' => 2,
             'DD_TRACE_AGENT_FLUSH_INTERVAL' => self::FLUSH_INTERVAL_MS,
@@ -38,7 +39,7 @@ final class CircuitBreakerTest extends WebFrameworkTestCase
             $this->call($spec);
 
             // allow time for background sender to trigger
-            usleep(self::FLUSH_INTERVAL_MS * 1000);
+            usleep(self::FLUSH_INTERVAL_MS * 2 * 1000);
         });
 
         $this->assertExpectedSpans(

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -37,7 +37,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     'web.request',
                     'web.request',
                     'web',
-                    'web.request'
+                    'GET /simple'
                 )->withExactTags([
                     'http.method' => 'GET',
                     'http.url' => '/simple',

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -6,7 +6,7 @@ DD_TRACE_MEMORY_LIMIT=9999
 --FILE--
 
 <?php
-$bgs_should_be_enabled = PHP_VERSION_ID >= 50600;
+$bgsShouldBeEnabled = PHP_VERSION_ID >= 50600;
 echo dd_trace_env_config("DD_AGENT_HOST");
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_AGENT_PORT");
@@ -16,9 +16,9 @@ echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_DEBUG_CURL_OUTPUT") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=";
-echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
+echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_MEMORY_LIMIT");
 echo PHP_EOL;
@@ -35,7 +35,7 @@ echo PHP_EOL;
 echo dd_trace_env_config("trace.debug.curl.output") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "trace.beta.send.traces.via.thread=";
-echo dd_trace_env_config("trace.beta.send.traces.via.thread") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("trace.beta.send.traces.via.thread") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("trace.memory.limit");
 echo PHP_EOL;

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -6,6 +6,7 @@ DD_TRACE_MEMORY_LIMIT=9999
 --FILE--
 
 <?php
+$bgs_should_be_enabled = PHP_VERSION_ID >= 50600;
 echo dd_trace_env_config("DD_AGENT_HOST");
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_AGENT_PORT");
@@ -15,9 +16,9 @@ echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_DEBUG_CURL_OUTPUT") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=";
-echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") ? 'TRUE' : 'FALSE';
+echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_MEMORY_LIMIT");
 echo PHP_EOL;
@@ -34,7 +35,7 @@ echo PHP_EOL;
 echo dd_trace_env_config("trace.debug.curl.output") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "trace.beta.send.traces.via.thread=";
-echo dd_trace_env_config("trace.beta.send.traces.via.thread") ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("trace.beta.send.traces.via.thread") === $bgs_should_be_enabled ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("trace.memory.limit");
 echo PHP_EOL;


### PR DESCRIPTION
### Description

Building on PR #796, this enables the background sender (BGS) across the entire testsuite. Since the BGS works only with msgpack, we change the default encoding too.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.