### PR TITLE
Implement service mapping

### DIFF
--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -165,6 +165,14 @@ class Configuration extends AbstractConfiguration
     }
 
     /**
+     * Returns the service mapping.
+     */
+    public function getServiceMapping()
+    {
+        return $this->associativeStringArrayValue('trace.service.mapping');
+    }
+
+    /**
      * Append hostname as a root span tag
      *
      * @return bool

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -170,7 +170,7 @@ class Configuration extends AbstractConfiguration
     public function getServiceMapping()
     {
         // We use the format 'service.mapping' instead of 'trace.service.mapping' for consistency
-        // with java naming pattern for this very same config: DD_SERVICE_MAPING
+        // with java naming pattern for this very same config: DD_SERVICE_MAPPING
         return $this->associativeStringArrayValue('service.mapping');
     }
 

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -169,7 +169,9 @@ class Configuration extends AbstractConfiguration
      */
     public function getServiceMapping()
     {
-        return $this->associativeStringArrayValue('trace.service.mapping');
+        // We use the format 'service.mapping' instead of 'trace.service.mapping' for consistency
+        // with java naming pattern for this very same config: DD_SERVICE_MAPING
+        return $this->associativeStringArrayValue('service.mapping');
     }
 
     /**

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -358,6 +358,13 @@ final class Tracer implements TracerInterface
                 if ($span->getResource() === null) {
                     $span->setResource($span->getOperationName());
                 }
+
+                // Doing service mapping here to avoid an external call, one more part to be refactored in the future
+                $serviceName = $span->getService();
+                if ($serviceName && !empty($serviceMappings[$serviceName])) {
+                    $span->setTag(Tag::SERVICE_NAME, $serviceMappings[$serviceName], true);
+                }
+
                 if ($span->duration === null) { // is span not finished
                     if (!$autoFinishSpans) {
                         $traceToBeSent = null;
@@ -369,12 +376,6 @@ final class Tracer implements TracerInterface
                 // the internal (hard-coded) processors programmatically.
 
                 $this->traceAnalyticsProcessor->process($span);
-
-                // Doing service mapping here to avoid an external call, one more part to be refactored in the future
-                $serviceName = $span->getService();
-                if ($serviceName && !empty($serviceMappings[$serviceName])) {
-                    $span->setTag(Tag::SERVICE_NAME, $serviceMappings[$serviceName]);
-                }
 
                 $encodedSpan = SpanEncoder::encode($span);
                 $traceToBeSent[] = $encodedSpan;

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -359,7 +359,8 @@ final class Tracer implements TracerInterface
                     $span->setResource($span->getOperationName());
                 }
 
-                // Doing service mapping here to avoid an external call, one more part to be refactored in the future
+                // Doing service mapping here to avoid an external call. This will be refactored once
+                // we completely move to internal span API.
                 $serviceName = $span->getService();
                 if ($serviceName && !empty($serviceMappings[$serviceName])) {
                     $span->setTag(Tag::SERVICE_NAME, $serviceMappings[$serviceName], true);
@@ -408,7 +409,8 @@ final class Tracer implements TracerInterface
                     $internalSpan['meta'][$globalTagName] = $globalTagValue;
                 }
 
-                // Doing service mapping here to avoid an external call, one more part to be refactored in the future
+                // Doing service mapping here to avoid an external call. This will be refactored once
+                // we completely move to internal span API.
                 if (!empty($internalSpan['service']) && !empty($serviceMappings[$internalSpan['service']])) {
                     $internalSpan['service'] = $serviceMappings[$internalSpan['service']];
                 }

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Tests\Integration;
 
-use DDTrace\Configuration;
 use DDTrace\Tests\Unit\BaseTestCase;
 use DDTrace\Tracer;
 use DDTrace\Tests\Common\TracerTestTrait;
@@ -299,6 +298,40 @@ final class TracerTest extends BaseTestCase
         });
 
         $this->assertSame('changed_service', $traces[0][0]['service']);
+    }
+
+    public function testServiceMappingHttpClientsSplitByDomainHost()
+    {
+        $traces = $this->inWebServer(
+            function ($execute) {
+                $execute(GetSpec::create('split by domain', '/curl-host'));
+            },
+            __DIR__ . '/TracerTest_files/index.php',
+            [
+                'DD_TRACE_SERVICE_MAPPING' => 'host-httpbin_integration:changed_service',
+                'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
+                'DD_TRACE_NO_AUTOLOADER' => true,
+            ]
+        );
+
+        $this->assertSame('changed_service', $traces[0][1]['service']);
+    }
+
+    public function testServiceMappingHttpClientsSplitByDomainIp()
+    {
+        $traces = $this->inWebServer(
+            function ($execute) {
+                $execute(GetSpec::create('split by domain', '/curl-ip'));
+            },
+            __DIR__ . '/TracerTest_files/index.php',
+            [
+                'DD_TRACE_SERVICE_MAPPING' => 'host-127.0.0.1:changed_service',
+                'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
+                'DD_TRACE_NO_AUTOLOADER' => true,
+            ]
+        );
+
+        $this->assertSame('changed_service', $traces[0][1]['service']);
     }
 
     public function dummyMethodGlobalTags()

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -24,7 +24,7 @@ final class TracerTest extends BaseTestCase
     {
         \putenv('DD_TRACE_GLOBAL_TAGS');
         \putenv('DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED');
-        \putenv('DD_TRACE_SERVICE_MAPPING');
+        \putenv('DD_SERVICE_MAPPING');
         parent::tearDown();
     }
 
@@ -247,7 +247,7 @@ final class TracerTest extends BaseTestCase
 
     public function testServiceMappingRootSpan()
     {
-        putenv('DD_TRACE_SERVICE_MAPPING=original_service:changed_service');
+        putenv('DD_SERVICE_MAPPING=original_service:changed_service');
         $traces = $this->isolateTracer(function (Tracer $tracer) {
             $scope = $tracer->startActiveSpan('custom.root');
             $scope->getSpan()->setTag(Tag::SERVICE_NAME, 'original_service');
@@ -259,7 +259,7 @@ final class TracerTest extends BaseTestCase
 
     public function testServiceMappingNestedSpanLegacyApi()
     {
-        putenv('DD_TRACE_SERVICE_MAPPING=original_service:changed_service');
+        putenv('DD_SERVICE_MAPPING=original_service:changed_service');
         $traces = $this->isolateTracer(function (Tracer $tracer) {
             $scope = $tracer->startActiveSpan('custom.root');
             $scope->getSpan()->setTag(Tag::SERVICE_NAME, 'root_service');
@@ -275,7 +275,7 @@ final class TracerTest extends BaseTestCase
 
     public function testServiceMappingInternalApi()
     {
-        putenv('DD_TRACE_SERVICE_MAPPING=original_service:changed_service');
+        putenv('DD_SERVICE_MAPPING=original_service:changed_service');
 
         if (Versions::phpVersionMatches('5.4')) {
             $this->markTestSkipped('Internal spans are not enabled yet on PHP 5.4');
@@ -308,7 +308,7 @@ final class TracerTest extends BaseTestCase
             },
             __DIR__ . '/TracerTest_files/index.php',
             [
-                'DD_TRACE_SERVICE_MAPPING' => 'host-httpbin_integration:changed_service',
+                'DD_SERVICE_MAPPING' => 'host-httpbin_integration:changed_service',
                 'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
                 'DD_TRACE_NO_AUTOLOADER' => true,
             ]
@@ -325,7 +325,7 @@ final class TracerTest extends BaseTestCase
             },
             __DIR__ . '/TracerTest_files/index.php',
             [
-                'DD_TRACE_SERVICE_MAPPING' => 'host-127.0.0.1:changed_service',
+                'DD_SERVICE_MAPPING' => 'host-127.0.0.1:changed_service',
                 'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
                 'DD_TRACE_NO_AUTOLOADER' => true,
             ]

--- a/tests/Integration/TracerTest_files/index.php
+++ b/tests/Integration/TracerTest_files/index.php
@@ -2,9 +2,25 @@
 
 use DDTrace\GlobalTracer;
 
-if ('/override-resource' === $_SERVER['REQUEST_URI']) {
+$uriPath = $_SERVER['REQUEST_URI'];
+error_log("Received request for uri path: '$uriPath'");
+
+if ('/override-resource' === $uriPath) {
     $tracer = GlobalTracer::get();
     $tracer->getSafeRootSpan()->setResource('custom-resource');
+    error_log('/override-resource completed');
+}
+
+if ('/curl-host' === $uriPath) {
+    $ch = curl_init("http://httpbin_integration/status/200");
+    curl_exec($ch);
+    error_log('/curl-host completed');
+}
+
+if ('/curl-ip' === $uriPath) {
+    $ch = curl_init("http://127.0.0.1");
+    curl_exec($ch);
+    error_log('/curl-ip completed');
 }
 
 return "OK\n";

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -29,6 +29,7 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_TRACE_ENABLED');
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
+        putenv('DD_TRACE_SERVICE_MAPPING');
     }
 
     public function testTracerEnabledByDefault()
@@ -304,6 +305,46 @@ final class ConfigurationTest extends BaseTestCase
                     'DD_TRACE_SAMPLE_RATE=0.7',
                 ],
                 0.7,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestServiceMapping
+     * @param mixed $envs
+     * @param array $expected
+     */
+    public function testTraceServiceMapping($env, $expected)
+    {
+        if (false !== $env) {
+            putenv("DD_TRACE_SERVICE_MAPPING=$env");
+        }
+
+        $this->assertSame($expected, Configuration::get()->getServiceMapping());
+    }
+
+    public function dataProviderTestServiceMapping()
+    {
+        return [
+            'not set' => [
+                false,
+                [],
+            ],
+            'empty' => [
+                false,
+                [],
+            ],
+            'one service mapping' => [
+                'service1:service2',
+                [ 'service1' => 'service2' ],
+            ],
+            'multiple service mappings' => [
+                'service1:service2,service3:service4',
+                [ 'service1' => 'service2', 'service3' => 'service4' ],
+            ],
+            'tolerant to extra whitespace' => [
+                'service1 :    service2 ,         service3 : service4                    ',
+                [ 'service1' => 'service2', 'service3' => 'service4' ],
             ],
         ];
     }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -29,7 +29,7 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_TRACE_ENABLED');
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
-        putenv('DD_TRACE_SERVICE_MAPPING');
+        putenv('DD_SERVICE_MAPPING');
     }
 
     public function testTracerEnabledByDefault()
@@ -317,7 +317,7 @@ final class ConfigurationTest extends BaseTestCase
     public function testTraceServiceMapping($env, $expected)
     {
         if (false !== $env) {
-            putenv("DD_TRACE_SERVICE_MAPPING=$env");
+            putenv("DD_SERVICE_MAPPING=$env");
         }
 
         $this->assertSame($expected, Configuration::get()->getServiceMapping());


### PR DESCRIPTION
### Description

This PR adds the possibility to implement service mapping via env variables:

Examples:
- Simple service renaming:

```DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db```
- Together with split by domain:
```
DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=true
DD_SERVICE_MAPPING=host-api.example.com:example-api,host-api.internal.com:internal-api
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
