### PR TITLE
Let curl calculate Content-Length header value when sending requests to the agent

### DIFF
--- a/playground/start-server.sh
+++ b/playground/start-server.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR=$(realpath $(dirname "$0"))
+set -e
+
+SCRIPT_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
 REQUEST_INIT_HOOK="$PROJECT_ROOT/bridge/dd_wrap_autoloader.php"
 WEB_ENTRY_POINT="${SCRIPT_DIR}/index.php"
 
+echo "Script directory: ${SCRIPT_DIR}"
+echo "Project root: ${PROJECT_ROOT}"
 echo "Serving with request init hook: ${REQUEST_INIT_HOOK}"
 echo "Web server entry point: ${WEB_ENTRY_POINT}"
 

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -176,7 +176,6 @@ final class Http implements Transport
             $curlHeaders,
             [
                 'Content-Type: ' . $this->encoder->getContentType(),
-                'Content-Length: ' . $bodySize,
                 'X-Datadog-Trace-Count: ' . $tracesCount,
             ]
         );

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -154,6 +154,23 @@ final class HttpTest extends BaseTestCase
         $this->assertEquals('1', $traceRequest['headers']['X-Datadog-Trace-Count']);
     }
 
+    public function testContentLengthAutomaticallyAddedByCurl()
+    {
+        $httpTransport = new Http(new Json(), [
+            'endpoint' => $this->getAgentReplayerEndpoint(),
+        ]);
+        $tracer = new Tracer($httpTransport);
+        GlobalTracer::set($tracer);
+
+        $span = $tracer->startSpan('test');
+        $span->finish();
+
+        $httpTransport->send($tracer);
+        $traceRequest = $this->getLastAgentRequest();
+
+        $this->assertArrayHasKey('Content-Length', $traceRequest['headers']);
+    }
+
     private static function recordContainsPrefixAndSuffix($record, $prefix, $suffix)
     {
         if ($record[0] !== 'error') {


### PR DESCRIPTION
### Description

We were calculating and setting the content-length header when not using the background sender.

This was probably the source of errors `unexpected EOF` in the trace agents logs.

While we were not able to deterministically assert this, here are a few facts:
- Literature seems to relegate that error to Content-Length > actualy payload size
- I was able to recreate from curl
- I was able to recreate after hours-long random spans/trace generation using msgpack
- In long runs, I was never able to recreate this error using json
- If Content-Length is not provided, it is automatically added by the underlying curl lib
- I assume curl is better at calculating the payload compared to us using PHP's strlen on a binary var
- That explixit Content-Length header was there from forever (one of the first commits) and there is no memory or documentation on why it was there
- It works perfectly without it

### Readiness checklist
- [*] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [*] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
