### PR TITLE
Add test cases similar to CakePHP on PHP 5.4

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -117,6 +117,8 @@
                     <file name="access_modifier_method_access_hook.phpt" role="test" />
                     <file name="access_modifier_property_access_hook.phpt" role="test" />
                     <file name="allow_overriding_before_overrided_methods_functions_are_defined.phpt" role="test" />
+                    <file name="cake_01.phpt" role="test" />
+                    <file name="cake_02.phpt" role="test" />
                     <file name="case_insensitive_class_hook.phpt" role="test" />
                     <file name="case_insensitive_method_hook.phpt" role="test" />
                     <file name="closure_accessing_outside_variables.phpt" role="test" />

--- a/tests/ext/cake_01.phpt
+++ b/tests/ext/cake_01.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test that we don't have a sigsegv in a set-up similar to CakePHP
+--FILE--
+<?php
+
+dd_trace('DatadogDispatcher', 'dispatch', function () {
+    return dd_trace_forward_call();
+});
+
+class DatadogDispatcher
+{
+    // if I add a constructor I get a leak, but no segfault
+    // public function __construct() {}
+
+    public function dispatch() {}
+    public function _stop() {}
+}
+
+function run() {
+    $dispatcher = new DatadogDispatcher();
+    $dispatcher->_stop($dispatcher->dispatch());
+}
+
+run();
+echo "Done.\n";
+?>
+--EXPECT--
+Done.
+

--- a/tests/ext/cake_02.phpt
+++ b/tests/ext/cake_02.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test that we don't leak in a set-up similar to CakePHP
+--FILE--
+<?php
+
+dd_trace('DatadogDispatcher', 'dispatch', function () {
+    return dd_trace_forward_call();
+});
+
+class DatadogDispatcher
+{
+    public function __construct() {}
+
+    public function dispatch() {}
+    public function _stop() {}
+}
+
+function run() {
+    $dispatcher = new DatadogDispatcher();
+    $dispatcher->_stop($dispatcher->dispatch());
+}
+
+run();
+echo "Done.\n";
+?>
+--EXPECT--
+Done.
+


### PR DESCRIPTION
### Description
This PR uncovers issues with the PHP 5.4 tracer, one behavior issue and one sigsegv. I am hopeful that these issues are the same ones that plague the PHP 5.4 tests on CircleCI. 

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
