### PR TITLE
Sandbox the Guzzle integration

### DIFF
--- a/bridge/dd_require_all.php
+++ b/bridge/dd_require_all.php
@@ -92,6 +92,7 @@ require __DIR__ . '/../src/DDTrace/Integrations/Laravel/V4/LaravelIntegration.ph
 require __DIR__ . '/../src/DDTrace/Integrations/Lumen/LumenIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php';
+require __DIR__ . '/../src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php';
 require __DIR__ . '/../src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php';
 require __DIR__ . '/../src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php';

--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DDTrace\Integrations\Guzzle;
+
+use DDTrace\Configuration;
+use DDTrace\GlobalTracer;
+use DDTrace\Http\Urls;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+
+class GuzzleSandboxedIntegration extends SandboxedIntegration
+{
+
+    const NAME = 'guzzle';
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function init()
+    {
+        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
+            return SandboxedIntegration::NOT_LOADED;
+        }
+
+        $tracer = GlobalTracer::get();
+        $rootScope = $tracer->getRootScope();
+        if (!$rootScope) {
+            return SandboxedIntegration::NOT_LOADED;
+        }
+
+        $integration = $this;
+        $service = Configuration::get()->appName(self::NAME);
+
+        /* Until we support both pre- and post- hooks on the same function, do
+         * not send distributed tracing headers; curl will almost guaranteed do
+         * it for us anyway. Just do a post-hook to get the response.
+         */
+        \dd_trace_method(
+            'GuzzleHttp\Client',
+            'send',
+            function (SpanData $span, $args, $retval) use ($integration, $service) {
+                $span->resource = 'send';
+                $span->name = 'GuzzleHttp\Client.send';
+                $span->service = $service;
+                $span->type = Type::HTTP_CLIENT;
+
+                if (isset($args[0])) {
+                    $integration->addRequestInfo($span, $args[0]);
+                }
+
+                if (isset($retval)) {
+                    $response = $retval;
+                    if (\is_a($response, 'GuzzleHttp\Message\ResponseInterface')) {
+                        /** @var \GuzzleHttp\Message\ResponseInterface $response */
+                        $span->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
+                    } elseif (\is_a($response, 'Psr\Http\Message\ResponseInterface')) {
+                        /** @var \Psr\Http\Message\ResponseInterface $response */
+                        $span->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
+                    } elseif (\is_a($response, 'GuzzleHttp\Promise\PromiseInterface')) {
+                        /** @var \GuzzleHttp\Promise\PromiseInterface $response */
+                        $response->then(function (\Psr\Http\Message\ResponseInterface $response) use ($span) {
+                            $span->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
+                        });
+                    }
+                }
+            }
+        );
+
+        \dd_trace_method(
+            'GuzzleHttp\Client',
+            'transfer',
+            function (SpanData $span, $args, $retval) use ($integration, $service) {
+                $span->resource = 'transfer';
+                $span->name = 'GuzzleHttp\Client.transfer';
+                $span->service = $service;
+                $span->type = Type::HTTP_CLIENT;
+
+                if (isset($args[0])) {
+                    $integration->addRequestInfo($span, $args[0]);
+                }
+                if (isset($retval)) {
+                    $response = $retval;
+                    if (\is_a($response, 'GuzzleHttp\Promise\PromiseInterface')) {
+                        /** @var \GuzzleHttp\Promise\PromiseInterface $response */
+                        $response->then(function (\Psr\Http\Message\ResponseInterface $response) use ($span) {
+                            $span->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
+                        });
+                    }
+                }
+            }
+        );
+    }
+
+    public function addRequestInfo(SpanData $span, $request)
+    {
+        if (\is_a($request, 'Psr\Http\Message\RequestInterface')) {
+            /** @var \Psr\Http\Message\RequestInterface $request */
+            $url = $request->getUri();
+            if (Configuration::get()->isHttpClientSplitByDomain()) {
+                $span->service = Urls::hostnameForTag($url);
+            }
+            $span->meta[Tag::HTTP_METHOD] = $request->getMethod();
+            $span->meta[Tag::HTTP_URL] = Urls::sanitize($url);
+        } elseif (\is_a($request, 'GuzzleHttp\Message\RequestInterface')) {
+            /** @var \GuzzleHttp\Message\RequestInterface $request */
+            $url = $request->getUrl();
+            if (Configuration::get()->isHttpClientSplitByDomain()) {
+                $span->service = Urls::hostnameForTag($url);
+            }
+            $span->meta[Tag::HTTP_METHOD] = $request->getMethod();
+            $span->meta[Tag::HTTP_URL] = Urls::sanitize($url);
+        }
+    }
+}

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -11,6 +11,7 @@ use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration;
 use DDTrace\Integrations\Eloquent\EloquentIntegration;
 use DDTrace\Integrations\Eloquent\EloquentSandboxedIntegration;
 use DDTrace\Integrations\Guzzle\GuzzleIntegration;
+use DDTrace\Integrations\Guzzle\GuzzleSandboxedIntegration;
 use DDTrace\Integrations\Laravel\LaravelIntegration;
 use DDTrace\Integrations\Laravel\LaravelSandboxedIntegration;
 use DDTrace\Integrations\Lumen\LumenIntegration;
@@ -91,6 +92,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration';
             $this->integrations[EloquentSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Eloquent\EloquentSandboxedIntegration';
+            $this->integrations[GuzzleSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Guzzle\GuzzleSandboxedIntegration';
             $this->integrations[LaravelSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Laravel\LaravelSandboxedIntegration';
             $this->integrations[MemcachedSandboxedIntegration::NAME] =

--- a/tests/Integrations/Guzzle/V5/GuzzleSandboxedIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleSandboxedIntegrationTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Guzzle\V5;
+
+final class GuzzleSandboxedIntegrationTest extends GuzzleIntegrationTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/Guzzle/V6/GuzzleSandboxedIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleSandboxedIntegrationTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Guzzle\V6;
+
+final class GuzzleSandboxedIntegrationTest extends GuzzleIntegrationTest
+{
+    const IS_SANDBOX = true ;
+}


### PR DESCRIPTION
### Description

This adds sandboxing to the Guzzle integration using a posthook.

Note that the Guzzle 6 distributed tracing did not work, but curl adds the distributed headers anyway, so in practice everything is fine. I am still verifying if Guzzle 5 has the same issue.

I mention this because the current iteration does not attempt to send these in Guzzle anymore because we can't use a pre- and post- hook simultaneously -- not yet, anyway. Since we have to use a post-hook to get the HTTP response status and curl already adds the distributed tracing headers, this may be okay even on Guzzle 5.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
