### PR TITLE
Consolidate internal monotonic and realtime clocks

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -29,6 +29,7 @@ if test "$PHP_DDTRACE" != "no"; then
     src/dogstatsd/client.c \
     src/ext/arrays.c \
     src/ext/circuit_breaker.c \
+    src/ext/clocks.c \
     src/ext/comms_php.c \
     src/ext/compat_string.c \
     src/ext/coms.c \

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,8 @@
                     <file name="arrays.c" role="src" />
                     <file name="arrays.h" role="src" />
                     <file name="auto_flush.h" role="src" />
+                    <file name="clocks.c" role="src" />
+                    <file name="clocks.h" role="src" />
                     <file name="comms_php.c" role="src" />
                     <file name="comms_php.h" role="src" />
                     <file name="compat_string.c" role="src" />

--- a/src/ext/clocks.c
+++ b/src/ext/clocks.c
@@ -1,0 +1,44 @@
+#include "clocks.h"
+
+#include <php_config.h>   // for HAVE_CLOCK_GETTIME
+#include <php_version.h>  // for PHP_VERSION_ID
+
+// UNEXPECTED is in different places in PHP 5 and 7
+#if PHP_VERSION_ID < 70000
+#include <Zend/zend.h>
+#else
+#include <Zend/zend_portability.h>
+#endif
+
+#if HAVE_CLOCK_GETTIME
+
+#include <time.h>  // for clock_gettime, CLOCK_MONOTONIC
+
+ddtrace_monotonic_nsec_t ddtrace_monotonic_nsec(void) {
+    struct timespec timespec;
+    if (UNEXPECTED(clock_gettime(CLOCK_MONOTONIC, &timespec))) {
+        return 0;
+    }
+    return ((uint64_t)timespec.tv_sec) * UINT64_C(1000000000) + ((uint64_t)timespec.tv_nsec);
+}
+
+ddtrace_monotonic_usec_t ddtrace_monotonic_usec(void) {
+    struct timespec timespec;
+    if (UNEXPECTED(clock_gettime(CLOCK_MONOTONIC, &timespec))) {
+        return 0;
+    }
+    return ((uint64_t)timespec.tv_sec) * UINT64_C(1000000) + ((uint64_t)timespec.tv_nsec / UINT64_C(1000));
+}
+
+ddtrace_realtime_nsec_t ddtrace_realtime_nsec(void) {
+    struct timespec timespec;
+    if (UNEXPECTED(clock_gettime(CLOCK_REALTIME, &timespec))) {
+        return 0;
+    }
+    return ((uint64_t)timespec.tv_sec) * UINT64_C(1000000000) + ((uint64_t)timespec.tv_nsec);
+}
+#else
+ddtrace_monotonic_nsec_t ddtrace_monotonic_nsec(void) { return 0; }
+ddtrace_monotonic_usec_t ddtrace_monotonic_usec(void) { return 0; }
+ddtrace_realtime_nsec_t ddtrace_realtime_nsec(void) { return 0; }
+#endif

--- a/src/ext/clocks.h
+++ b/src/ext/clocks.h
@@ -1,0 +1,14 @@
+#ifndef DDTRACE_CLOCKS_H
+#define DDTRACE_CLOCKS_H
+
+#include <stdint.h>
+
+typedef uint64_t ddtrace_monotonic_nsec_t;
+typedef uint64_t ddtrace_monotonic_usec_t;
+typedef uint64_t ddtrace_realtime_nsec_t;
+
+ddtrace_monotonic_nsec_t ddtrace_monotonic_nsec(void);
+ddtrace_monotonic_usec_t ddtrace_monotonic_usec(void);
+ddtrace_realtime_nsec_t ddtrace_realtime_nsec(void);
+
+#endif  // DDTRACE_CLOCKS_H

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -17,6 +17,7 @@
 
 #include "auto_flush.h"
 #include "circuit_breaker.h"
+#include "clocks.h"
 #include "comms_php.h"
 #include "compat_string.h"
 #include "compatibility.h"

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -1,8 +1,8 @@
 #include "engine_hooks.h"
 
 #include <php.h>
-#include <time.h>
 
+#include "clocks.h"
 #include "configuration.h"
 #include "ddtrace.h"
 
@@ -31,19 +31,11 @@ void ddtrace_engine_hooks_mshutdown(void) {
     ddtrace_execute_internal_mshutdown();
 }
 
-static uint64_t _get_microseconds() {
-    struct timespec time;
-    if (clock_gettime(CLOCK_MONOTONIC, &time) == 0) {
-        return time.tv_sec * 1000000U + time.tv_nsec / 1000U;
-    }
-    return 0U;
-}
-
 static zend_op_array *_dd_compile_file(zend_file_handle *file_handle, int type TSRMLS_DC) {
     zend_op_array *res;
-    uint64_t start = _get_microseconds();
+    ddtrace_monotonic_usec_t start = ddtrace_monotonic_usec();
     res = _prev_compile_file(file_handle, type TSRMLS_CC);
-    DDTRACE_G(compile_time_microseconds) += (int64_t)(_get_microseconds() - start);
+    DDTRACE_G(compile_time_microseconds) += (int64_t)(ddtrace_monotonic_usec() - start);
     return res;
 }
 

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -1,7 +1,6 @@
 #include "span.h"
 
 #include <php.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "auto_flush.h"
@@ -11,9 +10,6 @@
 #include "logging.h"
 #include "random.h"
 #include "serializer.h"
-
-#define USE_REALTIME_CLOCK 0
-#define USE_MONOTONIC_CLOCK 1
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
@@ -79,14 +75,6 @@ void ddtrace_free_span_stacks(TSRMLS_D) {
     DDTRACE_G(closed_spans_count) = 0;
 }
 
-static uint64_t _get_nanoseconds(BOOL_T monotonic_clock) {
-    struct timespec time;
-    if (clock_gettime(monotonic_clock ? CLOCK_MONOTONIC : CLOCK_REALTIME, &time) == 0) {
-        return time.tv_sec * 1000000000L + time.tv_nsec;
-    }
-    return 0;
-}
-
 ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispatch_t *dispatch TSRMLS_DC) {
     ddtrace_span_t *span = ecalloc(1, sizeof(ddtrace_span_t));
     span->next = DDTRACE_G(open_spans_top);
@@ -105,21 +93,19 @@ ddtrace_span_t *ddtrace_open_span(zend_execute_data *call, struct ddtrace_dispat
     span->span_id = ddtrace_push_span_id(0 TSRMLS_CC);
     // Set the trace_id last so we have ID's on the stack
     span->trace_id = DDTRACE_G(trace_id);
-    span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);
+    span->duration_start = ddtrace_monotonic_nsec();
     span->exception = NULL;
     span->pid = getpid();
     // Start time is nanoseconds from unix epoch
     // @see https://docs.datadoghq.com/api/?lang=python#send-traces
-    span->start = _get_nanoseconds(USE_REALTIME_CLOCK);
+    span->start = ddtrace_realtime_nsec();
 
     span->call = call;
     span->dispatch = dispatch;
     return span;
 }
 
-void dd_trace_stop_span_time(ddtrace_span_t *span) {
-    span->duration = _get_nanoseconds(USE_MONOTONIC_CLOCK) - span->duration_start;
-}
+void dd_trace_stop_span_time(ddtrace_span_t *span) { span->duration = ddtrace_monotonic_nsec() - span->duration_start; }
 
 void ddtrace_close_span(TSRMLS_D) {
     ddtrace_span_t *span = DDTRACE_G(open_spans_top);

--- a/src/ext/span.h
+++ b/src/ext/span.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include "clocks.h"
 #include "compatibility.h"
 
 struct ddtrace_dispatch_t;
@@ -15,10 +16,10 @@ typedef struct ddtrace_span_t {
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;
-    uint64_t start;
+    ddtrace_realtime_nsec_t start;
     union {
-        uint64_t duration_start;
-        uint64_t duration;
+        ddtrace_monotonic_nsec_t duration_start;
+        ddtrace_monotonic_nsec_t duration;
     };
     pid_t pid;
     struct ddtrace_span_t *next;


### PR DESCRIPTION
### Description

This adds three clock functions at ~both the C and PHP levels~ the C level:
  - ddtrace_monotonic_nsec
  - ddtrace_monotonic_usec
  - ddtrace_realtime_nsec

The first two are monontonic clock ticks in nanoseconds and
microseconds respectively. The latter is a system clock time
in nanoseconds.

It consolidates the existing clock functions found in span.c and
engine_hooks.c.

It also adds three typedefs, one for each clock type+unit:
  - ddtrace_monotonic_nsec_t
  - ddtrace_monotonic_usec_t
  - ddtrace_realtime_nsec_t

This helps convey the semantics of the result, such as in
ddtrace_span_t where they were previously just uint64_t.

This does not change the `DDTrace\Time::now()` call. It
appears that it is doing microseconds, but then multiplies
it by the wrong multipliers, and the encoder appends extra
zeros. In other words, I want to leave it for another PR.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
