### PR TITLE
Return that the sandboxed Guzzle integration loaded

### DIFF
--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -93,6 +93,8 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
                 }
             }
         );
+
+        return SandboxedIntegration::LOADED;
     }
 
     public function addRequestInfo(SpanData $span, $request)


### PR DESCRIPTION
### Description
This is a tiny bugfix to #809; I forgot to return `Integration::LOADED` which causes entries like this to show up in the debug log:

> [2020-04-10T20:29:07+00:00] [ddtrace] [error] - Invalid value returning by integration loader for guzzle:

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft.