### PR TITLE
Auto flushing (PHP 7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION_WITHOUT_SUFFIX:=$(shell cat src/DDTrace/version.php | grep return | awk 
 INI_FILE := /usr/local/etc/php/conf.d/ddtrace.ini
 
 C_FILES := $(shell find src/{dogstatsd,ext} -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
-TEST_FILES := $(shell find tests/ext -name '*.php*' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
+TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 M4_FILES := $(shell find m4 -name '*.m4*' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 
 ALL_FILES := $(C_FILES) $(TEST_FILES) $(BUILD_DIR)/config.m4 $(M4_FILES)

--- a/config.m4
+++ b/config.m4
@@ -54,12 +54,14 @@ if test "$PHP_DDTRACE" != "no"; then
 
   if test $PHP_VERSION -lt 70000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
+      src/ext/php5/auto_flush.c \
       src/ext/php5/dispatch.c \
       src/ext/php5/engine_hooks.c \
       src/ext/php5/handlers_curl.c \
     "
   elif test $PHP_VERSION -lt 80000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
+      src/ext/php7/auto_flush.c \
       src/ext/php7/dispatch.c \
       src/ext/php7/engine_api.c \
       src/ext/php7/engine_hooks.c \

--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,7 @@
                 <dir name="ext">
                     <file name="arrays.c" role="src" />
                     <file name="arrays.h" role="src" />
+                    <file name="auto_flush.h" role="src" />
                     <file name="comms_php.c" role="src" />
                     <file name="comms_php.h" role="src" />
                     <file name="compat_string.c" role="src" />
@@ -84,11 +85,13 @@
                         <file name="mpack.h" role="src" />
                     </dir>
                     <dir name="php5">
+                        <file name="auto_flush.c" role="src" />
                         <file name="dispatch.c" role="src" />
                         <file name="engine_hooks.c" role="src" />
                         <file name="handlers_curl.c" role="src" />
                     </dir>
                     <dir name="php7">
+                        <file name="auto_flush.c" role="src" />
                         <file name="dispatch.c" role="src" />
                         <file name="engine_api.c" role="src" />
                         <file name="engine_api.h" role="src" />
@@ -147,6 +150,7 @@
                     <file name="dd_trace_tracer_is_limited_hard.phpt" role="test" />
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">
+                        <file name="auto_flush.phpt" role="test" />
                         <file name="close-on-exit.phpt" role="test" />
                         <file name="close-on-exit-retval.phpt" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />
@@ -172,6 +176,7 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
                         <file name="exit_and_drop_span.phpt" role="test" />
+                        <file name="fake_tracer.inc" role="test" />
                         <file name="fatal_errors_ignored_in_shutdown.phpt" role="test" />
                         <file name="fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
                         <file name="get_last_error.phpt" role="test" />

--- a/src/ext/auto_flush.h
+++ b/src/ext/auto_flush.h
@@ -1,10 +1,12 @@
 #ifndef DDTRACE_AUTO_FLUSH_H
 #define DDTRACE_AUTO_FLUSH_H
 
-#include <stdbool.h>
+#include <php.h>
 
-#include "compatibility.h"
-
-bool ddtrace_flush_tracer(void);
+#if PHP_VERSION_ID < 50500
+int ddtrace_flush_tracer(void);
+#else
+ZEND_RESULT_CODE ddtrace_flush_tracer(void);
+#endif
 
 #endif  // DDTRACE_AUTO_FLUSH_H

--- a/src/ext/auto_flush.h
+++ b/src/ext/auto_flush.h
@@ -1,0 +1,10 @@
+#ifndef DDTRACE_AUTO_FLUSH_H
+#define DDTRACE_AUTO_FLUSH_H
+
+#include <stdbool.h>
+
+#include "compatibility.h"
+
+bool ddtrace_flush_tracer(void);
+
+#endif  // DDTRACE_AUTO_FLUSH_H

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -48,6 +48,7 @@ void ddtrace_config_shutdown(void);
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
+    BOOL(get_dd_trace_auto_flush_enabled, "DD_TRACE_AUTO_FLUSH_ENABLED", false)                                      \
     BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", true)                                   \
     BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", false)                                                                \
     BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", false)                               \

--- a/src/ext/php5/auto_flush.c
+++ b/src/ext/php5/auto_flush.c
@@ -1,0 +1,3 @@
+#include "auto_flush.h"
+
+bool ddtrace_flush_tracer(void) { return true; }

--- a/src/ext/php5/auto_flush.c
+++ b/src/ext/php5/auto_flush.c
@@ -1,3 +1,9 @@
 #include "auto_flush.h"
 
-bool ddtrace_flush_tracer(void) { return true; }
+#include <php.h>
+
+#if PHP_VERSION_ID < 50500
+int ddtrace_flush_tracer(void) { return SUCCESS; }
+#else
+ZEND_RESULT_CODE ddtrace_flush_tracer(void) { return SUCCESS; }
+#endif

--- a/src/ext/php7/auto_flush.c
+++ b/src/ext/php7/auto_flush.c
@@ -6,9 +6,8 @@
 #include "engine_api.h"
 #include "engine_hooks.h"  // for ddtrace_backup_error_handling
 
-bool ddtrace_flush_tracer() {
+ZEND_RESULT_CODE ddtrace_flush_tracer() {
     zval tracer, retval;
-    zend_function *Configuration_get_fe = NULL;
     zend_class_entry *GlobalTracer_ce = ddtrace_lookup_ce(ZEND_STRL("DDTrace\\GlobalTracer"));
     bool success = true;
 
@@ -16,25 +15,18 @@ bool ddtrace_flush_tracer() {
     ddtrace_backup_error_handling(&eh, EH_THROW);
 
     // $tracer = \DDTrace\GlobalTracer::get();
-    if (!GlobalTracer_ce || ddtrace_call_method(NULL, GlobalTracer_ce, &Configuration_get_fe, ZEND_STRL("get"), &tracer,
-                                                0, NULL) == FAILURE) {
+    if (!GlobalTracer_ce ||
+        ddtrace_call_method(NULL, GlobalTracer_ce, NULL, ZEND_STRL("get"), &tracer, 0, NULL) == FAILURE) {
         ddtrace_restore_error_handling(&eh);
         ddtrace_maybe_clear_exception();
-        return false;
+        return FAILURE;
     }
 
     if (Z_TYPE(tracer) == IS_OBJECT) {
-        // $tracer->flush();
-        if (ddtrace_call_method(Z_OBJ(tracer), Z_OBJ(tracer)->ce, NULL, ZEND_STRL("flush"), &retval, 0, NULL) ==
-            FAILURE) {
-            success = false;
-        }
-
-        // $tracer->reset();
-        if (success && ddtrace_call_method(Z_OBJ(tracer), Z_OBJ(tracer)->ce, NULL, ZEND_STRL("reset"), &retval, 0,
-                                           NULL) == FAILURE) {
-            success = false;
-        }
+        zend_object *obj = Z_OBJ(tracer);
+        zend_class_entry *ce = obj->ce;
+        success = ddtrace_call_method(obj, ce, NULL, ZEND_STRL("flush"), &retval, 0, NULL) == SUCCESS &&
+                  ddtrace_call_method(obj, ce, NULL, ZEND_STRL("reset"), &retval, 0, NULL) == SUCCESS;
     }
 
     ddtrace_restore_error_handling(&eh);
@@ -43,5 +35,5 @@ bool ddtrace_flush_tracer() {
     zval_dtor(&tracer);
     zval_dtor(&retval);
 
-    return success;
+    return success ? SUCCESS : FAILURE;
 }

--- a/src/ext/php7/auto_flush.c
+++ b/src/ext/php7/auto_flush.c
@@ -1,0 +1,47 @@
+#include "auto_flush.h"
+
+#include <php.h>
+
+#include "configuration.h"
+#include "engine_api.h"
+#include "engine_hooks.h"  // for ddtrace_backup_error_handling
+
+bool ddtrace_flush_tracer() {
+    zval tracer, retval;
+    zend_function *Configuration_get_fe = NULL;
+    zend_class_entry *GlobalTracer_ce = ddtrace_lookup_ce(ZEND_STRL("DDTrace\\GlobalTracer"));
+    bool success = true;
+
+    ddtrace_error_handling eh;
+    ddtrace_backup_error_handling(&eh, EH_THROW);
+
+    // $tracer = \DDTrace\GlobalTracer::get();
+    if (!GlobalTracer_ce || ddtrace_call_method(NULL, GlobalTracer_ce, &Configuration_get_fe, ZEND_STRL("get"), &tracer,
+                                                0, NULL) == FAILURE) {
+        ddtrace_restore_error_handling(&eh);
+        ddtrace_maybe_clear_exception();
+        return false;
+    }
+
+    if (Z_TYPE(tracer) == IS_OBJECT) {
+        // $tracer->flush();
+        if (ddtrace_call_method(Z_OBJ(tracer), Z_OBJ(tracer)->ce, NULL, ZEND_STRL("flush"), &retval, 0, NULL) ==
+            FAILURE) {
+            success = false;
+        }
+
+        // $tracer->reset();
+        if (success && ddtrace_call_method(Z_OBJ(tracer), Z_OBJ(tracer)->ce, NULL, ZEND_STRL("reset"), &retval, 0,
+                                           NULL) == FAILURE) {
+            success = false;
+        }
+    }
+
+    ddtrace_restore_error_handling(&eh);
+    ddtrace_maybe_clear_exception();
+
+    zval_dtor(&tracer);
+    zval_dtor(&retval);
+
+    return success;
+}

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -4,7 +4,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "auto_flush.h"
+#include "configuration.h"
 #include "ddtrace.h"
+#include "logging.h"
 #include "random.h"
 #include "serializer.h"
 
@@ -119,6 +122,12 @@ void ddtrace_close_span(TSRMLS_D) {
     // ddtrace_coms_buffer_data() and free the span
     span->next = DDTRACE_G(closed_spans_top);
     DDTRACE_G(closed_spans_top) = span;
+
+    if (DDTRACE_G(open_spans_top) == NULL && get_dd_trace_auto_flush_enabled()) {
+        if (!ddtrace_flush_tracer()) {
+            ddtrace_log_debug("Unable to auto flush the tracer");
+        }
+    }
 }
 
 void ddtrace_drop_span(TSRMLS_D) {

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -124,7 +124,7 @@ void ddtrace_close_span(TSRMLS_D) {
     DDTRACE_G(closed_spans_top) = span;
 
     if (DDTRACE_G(open_spans_top) == NULL && get_dd_trace_auto_flush_enabled()) {
-        if (!ddtrace_flush_tracer()) {
+        if (ddtrace_flush_tracer() == FAILURE) {
             ddtrace_log_debug("Unable to auto flush the tracer");
         }
     }

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -9,7 +9,7 @@ DD_TRACE_AUTO_FLUSH_ENABLED=1
 <?php
 use DDTrace\SpanData;
 
-include 'fake_tracer.inc';
+require 'fake_tracer.inc';
 
 dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+include 'fake_tracer.inc';
+
+dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+dd_trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/fake_tracer.inc
+++ b/tests/ext/sandbox/fake_tracer.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace DDTrace;
+
+class Tracer
+{
+    public function flush()
+    {
+        echo 'Flushing tracer...' . PHP_EOL;
+        array_map(function($span) {
+            $values = [];
+            if (isset($span['service'])) {
+                $values[] = $span['service'];
+            }
+            if (isset($span['resource'])) {
+                $values[] = $span['resource'];
+            }
+            if (isset($span['type'])) {
+                $values[] = $span['type'];
+            }
+
+            if (isset($span['name'])) {
+                echo $span['name'];
+            }
+            if (!empty($values)) {
+                echo ' (' . implode(', ', $values) . ')';
+            }
+            echo PHP_EOL;
+        }, dd_trace_serialize_closed_spans());
+    }
+
+    public function reset()
+    {
+        echo 'Tracer reset' . PHP_EOL;
+    }
+}
+
+class GlobalTracer
+{
+    private static $instance;
+
+    public static function set(Tracer $tracer)
+    {
+        self::$instance = $tracer;
+    }
+
+    public static function get()
+    {
+        if (null !== self::$instance) {
+            return self::$instance;
+        }
+        return self::$instance = new Tracer();
+    }
+}


### PR DESCRIPTION
### Description

This change add a feature to auto-flush spans when the internal open span count reaches zero. The feature is enabled by setting `DD_TRACE_AUTO_FLUSH_ENABLED=1`. This change allows flushing multiple traces within the same request.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
