### PR TITLE
Revert "Stop running PHP 5.4 integration tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,12 +836,12 @@ workflows:
           name: "PHP 54 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/5.4.list
           docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
-#      - integration_tests:
-#          requires: [ 'Code Checkout' ]
-#          name: "PHP 54 Integration tests"
-#          docker_image: "datadog/docker-library:ddtrace_alpine_php-5.4-debug"
-#          integration_testsuite: "test-integrations-54"
-#          lib_curl_command: sudo apk update ; sudo apk add curl-dev
+      - integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 54 Integration tests"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-5.4-debug"
+          integration_testsuite: "test-integrations-54"
+          lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 56 Integration tests"


### PR DESCRIPTION
### Description

This reverts commit c473a42324389bf559e7748d9c06910ca5362373.

Yesterday, this was done because nobody was around to force-push some bugfixes which definitely did not cause those tests to fail, and were blocking other work. However, they were not supposed to block a merge anyway, so I'm opening this PR to get that worked out.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
