### PR TITLE
Cleanup finding dispatch and add cputime.d dtrace script

### DIFF
--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -22,7 +22,7 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 extern inline void ddtrace_dispatch_copy(ddtrace_dispatch_t *dispatch);
 extern inline void ddtrace_dispatch_release(ddtrace_dispatch_t *dispatch);
 
-static ddtrace_dispatch_t *find_function_dispatch(const HashTable *lookup, zval *fname) {
+static ddtrace_dispatch_t *_dd_find_function_dispatch(const HashTable *lookup, zval *fname) {
     char *key = zend_str_tolower_dup(Z_STRVAL_P(fname), Z_STRLEN_P(fname));
     ddtrace_dispatch_t *dispatch = NULL;
     dispatch = zend_hash_str_find_ptr(lookup, key, Z_STRLEN_P(fname));
@@ -31,7 +31,7 @@ static ddtrace_dispatch_t *find_function_dispatch(const HashTable *lookup, zval 
     return dispatch;
 }
 
-static ddtrace_dispatch_t *find_method_dispatch(const zend_class_entry *class, zval *fname TSRMLS_DC) {
+static ddtrace_dispatch_t *_dd_find_method_dispatch(const zend_class_entry *class, zval *fname TSRMLS_DC) {
     if (!fname || !Z_STRVAL_P(fname)) {
         return NULL;
     }
@@ -49,36 +49,19 @@ static ddtrace_dispatch_t *find_method_dispatch(const zend_class_entry *class, z
     zend_string_release(class_name);
 #endif
 
-    ddtrace_dispatch_t *dispatch = NULL;
     if (class_lookup) {
-        dispatch = find_function_dispatch(class_lookup, fname);
+        ddtrace_dispatch_t *dispatch = _dd_find_function_dispatch(class_lookup, fname);
+        if (dispatch) {
+            return dispatch;
+        }
     }
 
-    if (dispatch) {
-        return dispatch;
-    }
-
-    if (class->parent) {
-        return find_method_dispatch(class->parent, fname TSRMLS_CC);
-    } else {
-        return NULL;
-    }
+    return class->parent ? _dd_find_method_dispatch(class->parent, fname TSRMLS_CC) : NULL;
 }
 
-ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC) {
-    zend_class_entry *class = NULL;
-
-    if (this) {
-        class = Z_OBJCE_P(this);
-    } else if ((fbc->common.fn_flags & ZEND_ACC_STATIC) != 0) {
-        // Check for class on static method static
-        class = fbc->common.scope;
-    }
-
-    if (class) {
-        return find_method_dispatch(class, fname TSRMLS_CC);
-    }
-    return find_function_dispatch(DDTRACE_G(function_lookup), fname);
+ddtrace_dispatch_t *ddtrace_find_dispatch(zend_class_entry *scope, zval *fname TSRMLS_DC) {
+    return scope ? _dd_find_method_dispatch(scope, fname TSRMLS_CC)
+                 : _dd_find_function_dispatch(DDTRACE_G(function_lookup), fname);
 }
 
 static int _find_method(zend_class_entry *ce, zval *name, zend_function **function) {

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -19,7 +19,7 @@ typedef struct ddtrace_dispatch_t {
     uint32_t acquired;
 } ddtrace_dispatch_t;
 
-ddtrace_dispatch_t *ddtrace_find_dispatch(zval *this, zend_function *fbc, zval *fname TSRMLS_DC);
+ddtrace_dispatch_t *ddtrace_find_dispatch(zend_class_entry *scope, zval *fname TSRMLS_DC);
 zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, uint32_t options TSRMLS_DC);
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch);

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -172,7 +172,7 @@ static BOOL_T _dd_should_trace_call(zend_execute_data *execute_data, zend_functi
     }
 
     zval *this = ddtrace_this(execute_data);
-    *dispatch = ddtrace_find_dispatch(this, *fbc, fname TSRMLS_CC);
+    *dispatch = ddtrace_find_dispatch(this ? Z_OBJCE_P(this) : (*fbc)->common.scope, fname TSRMLS_CC);
     if (!*dispatch || (*dispatch)->busy) {
         return FALSE;
     }

--- a/tooling/bin/cputime.d
+++ b/tooling/bin/cputime.d
@@ -1,0 +1,59 @@
+#!/usr/sbin/dtrace -b 16m -Zs
+
+/*
+Launch with something like:
+    sudo ./cputime.d -p $pid
+Where $pid is the pid you want to trace.
+You can add `-o logfile` if you want to save the output to a file
+*/
+
+#pragma D option quiet
+
+dtrace:::BEGIN
+{
+    printf("Tracing... Hit Ctrl-C to end.\n");
+}
+
+pid$target:ddtrace:_dd_*:entry,pid$target:ddtrace:ddtrace_*:entry
+{
+    self->depth++;
+    self->exclude[self->depth] = 0;
+    self->function[self->depth] = vtimestamp;
+}
+
+pid$target:ddtrace:_dd_*:return,pid$target:ddtrace:ddtrace_*:return
+/self->function[self->depth]/
+{
+    this->oncpu_incl = vtimestamp - self->function[self->depth];
+    this->oncpu_excl = this->oncpu_incl - self->exclude[self->depth];
+    self->function[self->depth] = 0;
+    self->exclude[self->depth] = 0;
+    this->name = probefunc;
+
+    @num[this->name] = count();
+    @num["total"] = count();
+    @types_incl[this->name] = sum(this->oncpu_incl);
+    @types_excl[this->name] = sum(this->oncpu_excl);
+    @types_excl["total"] = sum(this->oncpu_excl);
+
+    self->depth--;
+    self->exclude[self->depth] += this->oncpu_incl;
+}
+
+
+dtrace:::END
+{
+    printf("\nCount,\n");
+    printf("   %-48s %8s\n", "NAME", "COUNT");
+    printa("   %-48s %@8d\n", @num);
+
+    normalize(@types_excl, 1000);
+    printf("\nExclusive function on-CPU times (us),\n");
+    printf("   %-48s %8s\n", "NAME", "TOTAL");
+    printa("   %-48s %@8d\n", @types_excl);
+
+    normalize(@types_incl, 1000);
+    printf("\nInclusive function on-CPU times (us),\n");
+    printf("   %-48s %8s\n", "NAME", "TOTAL");
+    printa("   %-48s %@8d\n", @types_incl);
+}

--- a/tooling/bin/cputime.d
+++ b/tooling/bin/cputime.d
@@ -14,14 +14,22 @@ dtrace:::BEGIN
     printf("Tracing... Hit Ctrl-C to end.\n");
 }
 
-pid$target:ddtrace:_dd_*:entry,pid$target:ddtrace:ddtrace_*:entry
+pid$target:ddtrace:_dd_*:entry,
+pid$target:ddtrace:ddtrace_*:entry,
+pid$target:ddtrace:zm_activate_ddtrace*:entry,
+pid$target:ddtrace:zif_dd_trace*:entry,
+pid$target:ddtrace:zif_ddtrace**:entry
 {
     self->depth++;
     self->exclude[self->depth] = 0;
     self->function[self->depth] = vtimestamp;
 }
 
-pid$target:ddtrace:_dd_*:return,pid$target:ddtrace:ddtrace_*:return
+pid$target:ddtrace:_dd_*:return,
+pid$target:ddtrace:ddtrace_*:return,
+pid$target:ddtrace:zm_activate_ddtrace*:return,
+pid$target:ddtrace:zif_dd_trace*:return,
+pid$target:ddtrace:zif_ddtrace*:return
 /self->function[self->depth]/
 {
     this->oncpu_incl = vtimestamp - self->function[self->depth];


### PR DESCRIPTION
### Description

The cputime.d dtrace script showed ddtrace_find_dispatch as a function of interest for performance.  This commit does not change performance very much; basically there is a addref/delref that is avoided. However, I think the code is better and the cputime.d script will probably be useful later.

### Readiness checklist
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
