### PR TITLE
Convert pid from long to string for internal spans

### DIFF
--- a/src/ext/serializer.c
+++ b/src/ext/serializer.c
@@ -365,7 +365,9 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span TSRMLS_DC) {
         add_assoc_long(el, "error", 1);
     }
     if (span->parent_id == 0) {
-        add_assoc_long(meta, "system.pid", (uint)span->pid);
+        char pid[MAX_LENGTH_OF_LONG + 1];
+        snprintf(pid, sizeof(pid), "%ld", (long)span->pid);
+        add_assoc_string(meta, "system.pid", pid, 1);
     }
 
     // Add meta only if it has elements
@@ -542,7 +544,9 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span) {
         }
     }
     if (span->parent_id == 0) {
-        add_assoc_long(meta, "system.pid", (zend_long)span->pid);
+        char pid[MAX_LENGTH_OF_LONG + 1];
+        snprintf(pid, sizeof(pid), "%ld", (long)span->pid);
+        add_assoc_string(meta, "system.pid", pid);
     }
 
     if (zend_array_count(Z_ARRVAL_P(meta))) {

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -113,7 +113,7 @@ array(3) {
       ["args.0"]=>
       string(18) "tracing is awesome"
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
     ["metrics"]=>
     array(2) {
@@ -158,7 +158,7 @@ array(3) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
@@ -116,7 +116,7 @@ array(1) {
       ["args.1.0"]=>
       string(4) "pink"
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -120,7 +120,7 @@ array(5) {
       ["retval.rand"]=>
       string(%d) "%d"
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
     ["metrics"]=>
     array(2) {
@@ -175,7 +175,7 @@ array(5) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
   [4]=>
@@ -193,7 +193,7 @@ array(5) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -37,7 +37,7 @@ array(1) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -54,7 +54,7 @@ array(1) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -128,7 +128,7 @@ array(3) {
       ["retval.rand"]=>
       string(%d) "%d"
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
     ["metrics"]=>
     array(2) {
@@ -175,7 +175,7 @@ array(3) {
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
@@ -121,7 +121,7 @@ array(1) {
       string(48) "New fav num is 42 with 3 colors and pink on top
 "
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -42,7 +42,7 @@ array(1) {
       ["error.msg"]=>
       string(9) "Foo error"
       ["system.pid"]=>
-      int(%d)
+      string(%d) "%d"
     }
   }
 }


### PR DESCRIPTION
### Description

The Agent only supports string values in the `meta` array. This PR ensures that when a pid is added to a root internal span, it is added as a string instead of a long.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
