### PR TITLE
Auto flush with userland root span

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -151,6 +151,7 @@
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">
                         <file name="auto_flush.phpt" role="test" />
+                        <file name="auto_flush_disables_tracing.phpt" role="test" />
                         <file name="close-on-exit.phpt" role="test" />
                         <file name="close-on-exit-retval.phpt" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -152,6 +152,7 @@
                     <dir name="sandbox">
                         <file name="auto_flush.phpt" role="test" />
                         <file name="auto_flush_disables_tracing.phpt" role="test" />
+                        <file name="auto_flush_userland_root_span.phpt" role="test" />
                         <file name="close-on-exit.phpt" role="test" />
                         <file name="close-on-exit-retval.phpt" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -36,7 +36,9 @@ final class Bootstrap
             $tracer = GlobalTracer::get();
             $scopeManager = $tracer->getScopeManager();
             $scopeManager->close();
-            $tracer->flush();
+            if (!\dd_trace_env_config('DD_TRACE_AUTO_FLUSH_ENABLED')) {
+                $tracer->flush();
+            }
         };
         // Sandbox API is not supported on PHP 5.4
         if (PHP_VERSION_ID < 50500) {

--- a/src/ext/span.c
+++ b/src/ext/span.c
@@ -140,7 +140,8 @@ void ddtrace_close_span(TSRMLS_D) {
         span->dispatch = NULL;
     }
 
-    if (DDTRACE_G(open_spans_top) == NULL && get_dd_trace_auto_flush_enabled()) {
+    // A userland span might still be open so we check the span ID stack instead of the internal span stack
+    if (DDTRACE_G(span_ids_top) == NULL && get_dd_trace_auto_flush_enabled()) {
         if (ddtrace_flush_tracer() == FAILURE) {
             ddtrace_log_debug("Unable to auto flush the tracer");
         }

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Auto-flushing will not instrument while flushing
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require 'fake_tracer.inc';
+
+// This is called from the flush() method of the fake tracer
+dd_trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
+    $span->name = 'fake_curl_exec';
+});
+
+dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+dd_trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Userland root spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require 'fake_tracer.inc';
+
+dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+function main($max) {
+    // Emulate opening a userland span
+    dd_trace_push_span_id();
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+    echo 'Has not flushed yet.' . PHP_EOL;
+    // Emulate closing a userland span
+    dd_trace_pop_span_id();
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Has not flushed yet.
+Flushing tracer...
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Has not flushed yet.
+Flushing tracer...
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Has not flushed yet.
+Flushing tracer...
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/fake_tracer.inc
+++ b/tests/ext/sandbox/fake_tracer.inc
@@ -27,6 +27,9 @@ class Tracer
             }
             echo PHP_EOL;
         }, dd_trace_serialize_closed_spans());
+
+        // To test curl_exec calls are not instrumented in a flush
+        fake_curl_exec();
     }
 
     public function reset()
@@ -51,4 +54,8 @@ class GlobalTracer
         }
         return self::$instance = new Tracer();
     }
+}
+
+function fake_curl_exec() {
+    return true;
 }


### PR DESCRIPTION
### Description

This followup PR to #819 enables auto flushing when the root span is created in userland. Before this, only internal root spans would trigger auto flushing.

This also includes a fix to disable instrumentation during auto flushing to prevent infinite recursion.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
