### PR TITLE
Move some Configuration methods to functions written at the C level

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -34,6 +34,7 @@ if test "$PHP_DDTRACE" != "no"; then
     src/ext/coms.c \
     src/ext/configuration.c \
     src/ext/configuration_php_iface.c \
+    src/ext/ddtrace_string.c \
     src/ext/dispatch.c \
     src/ext/dispatch_setup.c \
     src/ext/dogstatsd_client.c \

--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,8 @@
                     <file name="macros.h" role="src" />
                     <file name="ddtrace.c" role="src" />
                     <file name="ddtrace.h" role="src" />
+                    <file name="ddtrace_string.c" role="src" />
+                    <file name="ddtrace_string.h" role="src" />
                     <file name="debug.h" role="src" />
                     <file name="memory_limit.c" role="src" />
                     <file name="memory_limit.h" role="src" />

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -150,10 +150,7 @@ final class Bootstrap
         }
         $span->setIntegration(WebIntegration::getInstance());
         $span->setTraceAnalyticsCandidate();
-        $span->setTag(
-            Tag::SERVICE_NAME,
-            Configuration::get()->appName($operationName)
-        );
+        $span->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name($operationName));
 
         dd_trace('header', function () use ($span) {
             $args = func_get_args();

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -153,7 +153,7 @@ class Configuration extends AbstractConfiguration
      */
     public function isIntegrationEnabled($name)
     {
-        return \ddtrace_config_trace_enabled() && !$this->inArray('integrations.disabled', $name);
+        return \ddtrace_config_integration_enabled($name);
     }
 
     /**

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -26,7 +26,7 @@ class Configuration extends AbstractConfiguration
      */
     public function isEnabled()
     {
-        return $this->boolValue('trace.enabled', true);
+        return \ddtrace_config_trace_enabled();
     }
 
     /**
@@ -153,7 +153,7 @@ class Configuration extends AbstractConfiguration
      */
     public function isIntegrationEnabled($name)
     {
-        return $this->isEnabled() && !$this->inArray('integrations.disabled', $name);
+        return \ddtrace_config_trace_enabled() && !$this->inArray('integrations.disabled', $name);
     }
 
     /**

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -222,30 +222,6 @@ class Configuration extends AbstractConfiguration
      */
     public function appName($default = '')
     {
-        // Using the env `DD_SERVICE_NAME` for consistency with other tracers.
-        $appName = $this->stringValue('service.name');
-        if ($appName) {
-            return $appName;
-        }
-
-        // This is deprecated and will be removed in a future release
-        $appName = $this->stringValue('trace.app.name');
-        if ($appName) {
-            self::logDebug(
-                'Env variable \'DD_TRACE_APP_NAME\' is deprecated and will be removed soon. ' .
-                'Use \'DD_SERVICE_NAME\' instead'
-            );
-            return $appName;
-        }
-
-        $appName = getenv('ddtrace_app_name');
-        if (false !== $appName) {
-            self::logDebug(
-                'Env variable \'ddtrace_app_name\' is deprecated and will be removed soon. ' .
-                'Use \'DD_SERVICE_NAME\' instead'
-            );
-            return trim($appName);
-        }
-        return $default;
+        return \ddtrace_config_app_name($default);
     }
 }

--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -78,13 +78,4 @@ class CakePHPIntegration extends Integration
 
         return self::LOADED;
     }
-
-    public static function getAppName()
-    {
-        $name = Configuration::get()->appName();
-        if ($name) {
-            return $name;
-        }
-        return self::NAME;
-    }
 }

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -32,7 +32,7 @@ class CakePHPIntegrationLoader
         $this->rootSpan->setIntegration($integration);
         $this->rootSpan->setTraceAnalyticsCandidate();
         $this->rootSpan->overwriteOperationName('cakephp.request');
-        $this->rootSpan->setTag(Tag::SERVICE_NAME, CakePHPIntegration::getAppName());
+        $this->rootSpan->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name(CakePHPIntegration::NAME));
 
         $loader = $this;
 

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
@@ -36,7 +36,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
         if (!$rootScope) {
             return SandboxedIntegration::NOT_LOADED;
         }
-        $service = Configuration::get()->appName(self::NAME);
+        $service = \ddtrace_config_app_name(self::NAME);
 
         \dd_trace_method(
             'CI_Router',

--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -5,6 +5,7 @@ namespace DDTrace\Integrations\Curl;
 use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
 use DDTrace\Http\Urls;
+use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\SandboxedIntegration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
@@ -40,7 +41,7 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
             return SandboxedIntegration::NOT_AVAILABLE;
         }
 
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
+        if (!Integration::shouldLoad(self::NAME)) {
             return SandboxedIntegration::NOT_LOADED;
         }
 

--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -50,7 +50,7 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
             return SandboxedIntegration::NOT_LOADED;
         }
 
-        $service = Configuration::get()->appName(self::NAME);
+        $service = \ddtrace_config_app_name(self::NAME);
 
         \dd_trace_function('curl_exec', [
             // the ddtrace extension will handle distributed headers

--- a/src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php
@@ -119,7 +119,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             return $this->appName;
         }
 
-        $name = Configuration::get()->appName();
+        $name = \ddtrace_config_app_name();
         if (empty($name) && is_callable('config')) {
             $name = config('app.name');
         }

--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -22,7 +22,7 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
 
     public function init()
     {
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
+        if (!self::shouldLoad(self::NAME)) {
             return SandboxedIntegration::NOT_LOADED;
         }
 

--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -33,7 +33,7 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
         }
 
         $integration = $this;
-        $service = Configuration::get()->appName(self::NAME);
+        $service = \ddtrace_config_app_name(self::NAME);
 
         /* Until we support both pre- and post- hooks on the same function, do
          * not send distributed tracing headers; curl will almost guaranteed do

--- a/src/DDTrace/Integrations/Integration.php
+++ b/src/DDTrace/Integrations/Integration.php
@@ -167,22 +167,19 @@ abstract class Integration
     }
 
     /**
-     * Tells whether or not the provided application should be loaded.
+     * Tells whether or not the provided integration should be loaded.
      *
      * @param string $name
      * @return bool
      */
-    protected static function shouldLoad($name)
+    public static function shouldLoad($name)
     {
-        if (!Configuration::get()->isIntegrationEnabled($name)) {
-            return false;
-        }
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load integration.', E_USER_WARNING);
+        if (!\extension_loaded('ddtrace')) {
+            \trigger_error('ddtrace extension required to load integration.', \E_USER_WARNING);
             return false;
         }
 
-        return true;
+        return \ddtrace_config_integration_enabled($name);
     }
 
     /**

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -144,11 +144,6 @@ class IntegrationsLoader
      */
     public function loadAll()
     {
-        $globalConfig = Configuration::get();
-        if (!$globalConfig->isEnabled()) {
-            return;
-        }
-
         if (!extension_loaded('ddtrace')) {
             trigger_error(
                 'Missing ddtrace extension. To disable tracing set env variable DD_TRACE_ENABLED=false',
@@ -157,8 +152,13 @@ class IntegrationsLoader
             return;
         }
 
+        if (!\ddtrace_config_trace_enabled()) {
+            return;
+        }
+
         self::logDebug('Attempting integrations load');
 
+        $globalConfig = Configuration::get();
         foreach ($this->integrations as $name => $class) {
             if (!$globalConfig->isIntegrationEnabled($name)) {
                 self::logDebug('Integration {name} is disabled', ['name' => $name]);

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -158,9 +158,8 @@ class IntegrationsLoader
 
         self::logDebug('Attempting integrations load');
 
-        $globalConfig = Configuration::get();
         foreach ($this->integrations as $name => $class) {
-            if (!$globalConfig->isIntegrationEnabled($name)) {
+            if (!\ddtrace_config_integration_enabled($name)) {
                 self::logDebug('Integration {name} is disabled', ['name' => $name]);
                 continue;
             }

--- a/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Laravel;
 
-use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
 use DDTrace\SpanData;
 use DDTrace\Integrations\SandboxedIntegration;
@@ -42,7 +41,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
      */
     public function init()
     {
-        if (!Configuration::get()->isIntegrationEnabled(LaravelSandboxedIntegration::NAME)) {
+        if (!self::shouldLoad(self::NAME)) {
             return SandboxedIntegration::NOT_LOADED;
         }
 

--- a/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
@@ -198,7 +198,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
         if (!empty($this->serviceName)) {
             return $this->serviceName;
         }
-        $this->serviceName = Configuration::get()->appName();
+        $this->serviceName = \ddtrace_config_app_name();
         if (empty($this->serviceName) && is_callable('config')) {
             $this->serviceName = config('app.name');
         }

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -141,7 +141,7 @@ class LaravelProvider extends ServiceProvider
      */
     private static function getAppName()
     {
-        $name = Configuration::get()->appName();
+        $name = \ddtrace_config_app_name();
         if ($name) {
             return $name;
         }

--- a/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
+++ b/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php
@@ -2,8 +2,8 @@
 
 namespace DDTrace\Integrations\Laravel\V4;
 
-use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
+use DDTrace\Integrations\Integration;
 use DDTrace\Span;
 use DDTrace\Tag;
 use DDTrace\Type;
@@ -26,7 +26,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function register()
     {
-        if (!$this->shouldLoad()) {
+        if (!Integration::shouldLoad(self::NAME)) {
             return;
         }
 
@@ -56,7 +56,7 @@ class LaravelProvider extends ServiceProvider
     /** @inheritdoc */
     public function boot()
     {
-        if (!$this->shouldLoad()) {
+        if (!Integration::shouldLoad(self::NAME)) {
             return;
         }
 
@@ -116,22 +116,6 @@ class LaravelProvider extends ServiceProvider
         $span->setTag(Tag::RESOURCE_NAME, $resource);
 
         return $scope;
-    }
-
-    /**
-     * @return bool
-     */
-    private function shouldLoad()
-    {
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
-            return false;
-        }
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Laravel\V5;
 
-use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\Laravel\LaravelIntegration;
@@ -23,7 +22,7 @@ class LaravelIntegrationLoader
 
     public function load()
     {
-        if (!$this->shouldLoad()) {
+        if (!Integration::shouldLoad(LaravelIntegration::NAME)) {
             return Integration::NOT_AVAILABLE;
         }
 
@@ -168,22 +167,6 @@ class LaravelIntegrationLoader
             $self->rootScope->getSpan()->setTag(Tag::HTTP_STATUS_CODE, $args[0]);
             return dd_trace_forward_call();
         });
-    }
-
-    /**
-     * @return bool
-     */
-    private function shouldLoad()
-    {
-        if (!Configuration::get()->isIntegrationEnabled(LaravelIntegration::NAME)) {
-            return false;
-        }
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Laravel integration.', E_USER_WARNING);
-            return false;
-        }
-
-        return true;
     }
 
     private function getAppName()

--- a/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php
@@ -188,7 +188,7 @@ class LaravelIntegrationLoader
 
     private function getAppName()
     {
-        $name = Configuration::get()->appName();
+        $name = \ddtrace_config_app_name();
         if ($name) {
             return $name;
         }

--- a/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
@@ -123,6 +123,6 @@ final class LumenIntegrationLoader
 
     private function getAppName()
     {
-        return Configuration::get()->appName() ?: LumenIntegration::NAME;
+        return \ddtrace_config_app_name(LumenIntegration::NAME);
     }
 }

--- a/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Lumen\V5;
 
-use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\Lumen\LumenIntegration;
@@ -14,13 +13,13 @@ final class LumenIntegrationLoader
 {
     public function load()
     {
-        if (!$this->shouldLoad()) {
+        if (!Integration::shouldLoad(LumenIntegration::NAME)) {
             return Integration::NOT_AVAILABLE;
         }
 
         $span = GlobalTracer::get()->getRootScope()->getSpan();
         $span->overwriteOperationName('lumen.request');
-        $span->setTag(Tag::SERVICE_NAME, $this->getAppName());
+        $span->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name(LumenIntegration::NAME));
         $span->setIntegration(LumenIntegration::getInstance());
         $span->setTraceAnalyticsCandidate();
 
@@ -104,25 +103,5 @@ final class LumenIntegrationLoader
         dd_trace('Laravel\Lumen\Application', 'routeMiddleware', $traceMiddleware);
 
         return Integration::LOADED;
-    }
-
-    /**
-     * @return bool
-     */
-    private function shouldLoad()
-    {
-        if (!Configuration::get()->isIntegrationEnabled(LumenIntegration::NAME)) {
-            return false;
-        }
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Lumen integration.', E_USER_WARNING);
-            return false;
-        }
-        return true;
-    }
-
-    private function getAppName()
-    {
-        return \ddtrace_config_app_name(LumenIntegration::NAME);
     }
 }

--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -81,10 +81,6 @@ class SlimIntegration extends Integration
 
     public static function getAppName()
     {
-        $name = Configuration::get()->appName();
-        if ($name) {
-            return $name;
-        }
-        return self::NAME;
+        return \ddtrace_config_app_name(self::NAME);
     }
 }

--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -73,7 +73,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
 
     public function loadSymfony($integration)
     {
-        $integration->appName = Configuration::get()->appName('symfony');
+        $integration->appName = \ddtrace_config_app_name('symfony');
         $integration->symfonyRequestSpan->overwriteOperationName('symfony.request');
         $integration->symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $integration->appName);
         $integration->symfonyRequestSpan->setIntegration($integration);

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -2,9 +2,9 @@
 
 namespace DDTrace\Integrations\Symfony\V3;
 
-use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
 use DDTrace\GlobalTracer;
+use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration as DDSymfonyIntegration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration;
 use DDTrace\Tag;
@@ -30,12 +30,7 @@ class SymfonyBundle extends Bundle
     {
         parent::boot();
 
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
-            return;
-        }
-
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Symfony integration.', E_USER_WARNING);
+        if (!Integration::shouldLoad(self::NAME)) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php
@@ -43,7 +43,7 @@ class SymfonyBundle extends Bundle
 
         // Create a span that starts from when Symfony first boots
         $scope = $tracer->getRootScope();
-        $appName = $this->getAppName();
+        $appName = \ddtrace_config_app_name('symfony');
         $symfonyRequestSpan = $scope->getSpan();
         $symfonyRequestSpan->overwriteOperationName('symfony.request');
         // Overwriting the default web integration
@@ -218,10 +218,5 @@ class SymfonyBundle extends Bundle
             $rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
             $rootSpan->setResource($route);
         }
-    }
-
-    private function getAppName()
-    {
-        return Configuration::get()->appName('symfony');
     }
 }

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -40,7 +40,7 @@ class SymfonyBundle extends Bundle
         }
 
         $tracer = GlobalTracer::get();
-        $appName = $this->getAppName();
+        $appName = \ddtrace_config_app_name('symfony');
 
         // Retrieve the web root span for the current host
         $symfonyRequestScope = $tracer->getRootScope();
@@ -205,10 +205,5 @@ class SymfonyBundle extends Bundle
         $action = get_class($controllerAndAction[0]) . '@' . $controllerAndAction[1];
         $requestSpan->setTag('symfony.route.action', $action);
         $requestSpan->setTag('symfony.route.name', $request->get('_route'));
-    }
-
-    private function getAppName()
-    {
-        return Configuration::get()->appName('symfony');
     }
 }

--- a/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
+++ b/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php
@@ -2,9 +2,9 @@
 
 namespace DDTrace\Integrations\Symfony\V4;
 
-use DDTrace\Configuration;
 use DDTrace\Contracts\Span;
 use DDTrace\GlobalTracer;
+use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration as DDSymfonyIntegration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration;
 use DDTrace\Tag;
@@ -30,12 +30,7 @@ class SymfonyBundle extends Bundle
     {
         parent::boot();
 
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
-            return;
-        }
-
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Symfony integration.', E_USER_WARNING);
+        if (!Integration::shouldLoad(self::NAME)) {
             return;
         }
 

--- a/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
@@ -31,7 +31,7 @@ class WordPressIntegrationLoader
         $this->rootSpan->setIntegration($integration);
         $this->rootSpan->setTraceAnalyticsCandidate();
         $this->rootSpan->overwriteOperationName('wordpress.request');
-        $service = Configuration::get()->appName(WordPressSandboxedIntegration::NAME);
+        $service = \ddtrace_config_app_name(WordPressSandboxedIntegration::NAME);
         $this->rootSpan->setTag(Tag::SERVICE_NAME, $service);
         if ('cli' !== PHP_SAPI) {
             $normalizer = new Urls(explode(',', getenv('DD_TRACE_RESOURCE_URI_MAPPING')));

--- a/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
@@ -25,7 +25,7 @@ class YiiIntegrationLoader
         // Overwrite the default web integration
         $root->setIntegration($integration);
         $root->setTraceAnalyticsCandidate();
-        $service = Configuration::get()->appName(YiiSandboxedIntegration::NAME);
+        $service = \ddtrace_config_app_name(YiiSandboxedIntegration::NAME);
 
         \dd_trace_method(
             'yii\web\Application',

--- a/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
@@ -28,7 +28,7 @@ class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
         $tracer = GlobalTracer::get();
         $span = $tracer->getRootScope()->getSpan();
         $span->overwriteOperationName(self::getOperationName());
-        $span->setTag(Tag::SERVICE_NAME, $this->getAppName());
+        $span->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name(self::NAME));
 
         return $this->tracer;
     }
@@ -55,13 +55,5 @@ class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
     {
         $contextName = 'cli' === PHP_SAPI ? 'command' : 'request';
         return self::NAME . '.' . $contextName;
-    }
-
-    /**
-     * @return string
-     */
-    private function getAppName()
-    {
-        return Configuration::get()->appName(self::NAME);
     }
 }

--- a/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
@@ -2,8 +2,8 @@
 
 require __DIR__ . '/../../../autoload.php';
 
-use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
+use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\ZendFramework\V1\TraceRequest;
 use DDTrace\Tag;
 use DDTrace\Tracer;
@@ -19,7 +19,7 @@ class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
 
     public function init()
     {
-        if (!$this->shouldLoad()) {
+        if (!Integration::shouldLoad(self::NAME)) {
             return false;
         }
         $front = Zend_Controller_Front::getInstance();
@@ -31,21 +31,6 @@ class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
         $span->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name(self::NAME));
 
         return $this->tracer;
-    }
-
-    /**
-     * @return bool
-     */
-    private function shouldLoad()
-    {
-        if (!Configuration::get()->isIntegrationEnabled(self::NAME)) {
-            return false;
-        }
-        if (!extension_loaded('ddtrace')) {
-            trigger_error('ddtrace extension required to load Zend Framework 1 integration.', E_USER_WARNING);
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
@@ -54,7 +54,7 @@ class ZendFrameworkSandboxedIntegration extends SandboxedIntegration
         $integration = $this;
         // For backward compatibility with the legacy API we are not using the integration
         // name 'zendframework', we are instead using the 'zf1' prefix.
-        $appName = Configuration::get()->appName('zf1');
+        $appName = \ddtrace_config_app_name('zf1');
 
         dd_trace_method(
             'Zend_Controller_Plugin_Broker',

--- a/src/ext/ddtrace_string.c
+++ b/src/ext/ddtrace_string.c
@@ -4,3 +4,4 @@ extern inline bool ddtrace_isspace(unsigned char c);
 extern inline char *ddtrace_ltrim(char *restrict begin, char *restrict end);
 extern inline char *ddtrace_rtrim(char *restrict begin, char *restrict end);
 extern inline ddtrace_string ddtrace_trim(ddtrace_string src);
+extern inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b);

--- a/src/ext/ddtrace_string.c
+++ b/src/ext/ddtrace_string.c
@@ -1,7 +1,38 @@
 #include "ddtrace_string.h"
 
+#include <Zend/zend_operators.h>
+
+extern inline ddtrace_string ddtrace_string_cstring_ctor(char *ptr);
 extern inline bool ddtrace_isspace(unsigned char c);
 extern inline char *ddtrace_ltrim(char *restrict begin, char *restrict end);
 extern inline char *ddtrace_rtrim(char *restrict begin, char *restrict end);
 extern inline ddtrace_string ddtrace_trim(ddtrace_string src);
 extern inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b);
+
+/* Annoyingly, zend_memnstr changed from char* to const char* in PHP 5.6, but
+ * not for `end`! That happened in 7.
+ * We aren't modifying anything, so we'll use const and just cast inside.
+ */
+static const char *_dd_memnstr(const char *haystack, const char *needle, int needle_len, const char *end) {
+#if PHP_VERSION_ID < 50600
+    return zend_memnstr((char *)haystack, (char *)needle, needle_len, (char *)end);
+#elif PHP_VERSION_ID < 70000
+    return zend_memnstr((const char *)haystack, (const char *)needle, needle_len, (char *)end);
+#else
+    return zend_memnstr((const char *)haystack, (const char *)needle, needle_len, (const char *)end);
+#endif
+}
+
+bool ddtrace_string_contains_in_csv(ddtrace_string haystack, ddtrace_string needle) {
+    const char *match, *begin, *end;
+    begin = haystack.ptr;
+    end = begin + haystack.len;
+    while ((match = _dd_memnstr(begin, needle.ptr, needle.len, end))) {
+        const char *match_end = match + needle.len;
+        if ((match == begin || *(match - 1) == ',') && (match_end == end || *match_end == ',')) {
+            return true;
+        }
+        begin = match + 1;
+    }
+    return false;
+}

--- a/src/ext/ddtrace_string.c
+++ b/src/ext/ddtrace_string.c
@@ -1,0 +1,6 @@
+#include "ddtrace_string.h"
+
+extern inline bool ddtrace_isspace(unsigned char c);
+extern inline char *ddtrace_ltrim(char *restrict begin, char *restrict end);
+extern inline char *ddtrace_rtrim(char *restrict begin, char *restrict end);
+extern inline ddtrace_string ddtrace_trim(ddtrace_string src);

--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -1,0 +1,52 @@
+#ifndef DDTRACE_STRING_H
+#define DDTRACE_STRING_H
+
+#include <php_version.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#if PHP_VERSION_ID < 70000
+typedef int ddtrace_zppstrlen_t;
+#else
+typedef size_t ddtrace_zppstrlen_t;
+#endif
+
+struct ddtrace_string {
+    char *ptr;
+    ddtrace_zppstrlen_t len;
+};
+typedef struct ddtrace_string ddtrace_string;
+
+// this is the same set of character's that PHP's trim treats as whitespace
+inline bool ddtrace_isspace(unsigned char c) {
+    return (c <= ' ' && (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '\v' || c == '\0'));
+}
+
+inline char *ddtrace_ltrim(char *restrict begin, char *restrict end) {
+    while (begin != end && ddtrace_isspace((unsigned char)*(begin))) {
+        ++begin;
+    }
+    return begin;
+}
+
+inline char *ddtrace_rtrim(char *restrict begin, char *restrict end) {
+    while (end != begin && ddtrace_isspace((unsigned char)*(end - 1))) {
+        --end;
+    }
+    return end;
+}
+
+// str.ptr must be non-null and src.len >= 0; does not copy!
+inline ddtrace_string ddtrace_trim(ddtrace_string src) {
+    char *begin = src.ptr;
+    char *end = begin + src.len;
+    begin = ddtrace_ltrim(begin, end);
+    end = ddtrace_rtrim(begin, end);
+    ddtrace_string result = {
+        .ptr = begin,
+        .len = end - begin,
+    };
+    return result;
+}
+
+#endif  // DDTRACE_STRING_H

--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -4,6 +4,7 @@
 #include <php_version.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 
 #if PHP_VERSION_ID < 70000
 typedef int ddtrace_zppstrlen_t;
@@ -47,6 +48,10 @@ inline ddtrace_string ddtrace_trim(ddtrace_string src) {
         .len = end - begin,
     };
     return result;
+}
+
+inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b) {
+    return a.len == b.len && (a.ptr == b.ptr || !memcmp(a.ptr, b.ptr, a.len));
 }
 
 #endif  // DDTRACE_STRING_H

--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -18,6 +18,14 @@ struct ddtrace_string {
 };
 typedef struct ddtrace_string ddtrace_string;
 
+inline ddtrace_string ddtrace_string_cstring_ctor(char *ptr) {
+    ddtrace_string string = {
+        .ptr = ptr,
+        .len = ptr ? strlen(ptr) : 0,
+    };
+    return string;
+}
+
 // this is the same set of character's that PHP's trim treats as whitespace
 inline bool ddtrace_isspace(unsigned char c) {
     return (c <= ' ' && (c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '\v' || c == '\0'));
@@ -53,5 +61,10 @@ inline ddtrace_string ddtrace_trim(ddtrace_string src) {
 inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b) {
     return a.len == b.len && (a.ptr == b.ptr || !memcmp(a.ptr, b.ptr, a.len));
 }
+
+/* This function is _case sensitive_.
+ * Only call if haystack and needle have len > 0.
+ */
+bool ddtrace_string_contains_in_csv(ddtrace_string haystack, ddtrace_string needle);
 
 #endif  // DDTRACE_STRING_H

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -15,7 +15,7 @@ final class CommonScenariosTest extends CLITestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_APP_NAME' => 'console_test_app',
+            'DD_SERVICE_NAME' => 'console_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -16,7 +16,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_APP_NAME' => 'lumen_test_app',
+            'DD_SERVICE_NAME' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -16,7 +16,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_APP_NAME' => 'lumen_test_app',
+            'DD_SERVICE_NAME' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
@@ -16,7 +16,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_APP_NAME' => 'lumen_test_app',
+            'DD_SERVICE_NAME' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -99,6 +99,7 @@ final class ConfigurationTest extends BaseTestCase
 
     public function testAppNameFallbackPriorities()
     {
+        // we do not support these fallbacks anymore; testing that we ignore them
         putenv('ddtrace_app_name');
         putenv('DD_TRACE_APP_NAME');
         $this->assertSame(
@@ -107,12 +108,12 @@ final class ConfigurationTest extends BaseTestCase
         );
 
         putenv('ddtrace_app_name=foo_app');
-        $this->assertSame('foo_app', Configuration::get()->appName());
+        $this->assertSame('fallback_name', Configuration::get()->appName('fallback_name'));
 
         Configuration::clear();
         putenv('ddtrace_app_name=foo_app');
         putenv('DD_TRACE_APP_NAME=bar_app');
-        $this->assertSame('bar_app', Configuration::get()->appName());
+        $this->assertSame('fallback_name', Configuration::get()->appName('fallback_name'));
     }
 
     public function testServiceName()

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -27,8 +27,8 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testGlobalConfigCanDisableLoading()
     {
+        putenv('DD_TRACE_ENABLED=0');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => false,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
         ]));
@@ -36,14 +36,15 @@ final class IntegrationsLoaderTest extends BaseTestCase
         DummyIntegration1::$value = Integration::LOADED;
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
 
         $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('integration_1'));
     }
 
     public function testSingleIntegrationLoadingCanBeDisabled()
     {
+        putenv('DD_TRACE_ENABLED=1');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => true,
             'isIntegrationEnabled' => false,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -52,14 +53,15 @@ final class IntegrationsLoaderTest extends BaseTestCase
         DummyIntegration1::$value = Integration::LOADED;
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
 
         $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('integration_1'));
     }
 
     public function testIntegrationsAreLoaded()
     {
+        putenv('DD_TRACE_ENABLED=true');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -69,6 +71,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         DummyIntegration1::$value = Integration::LOADED;
         DummyIntegration2::$value = Integration::NOT_AVAILABLE;
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
 
         $this->assertSame(Integration::LOADED, $loader->getLoadingStatus('integration_1'));
         $this->assertSame(Integration::NOT_AVAILABLE, $loader->getLoadingStatus('integration_2'));
@@ -76,8 +79,8 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testIntegrationAlreadyLoadedIsNotReloaded()
     {
+        putenv('DD_TRACE_ENABLED=1');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -90,6 +93,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         // We load it
         DummyIntegration1::$value = Integration::LOADED;
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
         $this->assertSame(Integration::LOADED, $loader->getLoadingStatus('integration_1'));
 
         // If now we change the returned value, it won't be reflected in the loadings statuses as it is not reloaded
@@ -100,8 +104,8 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testIntegrationNotAvailableIsNotReloaded()
     {
+        putenv('DD_TRACE_ENABLED=1');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -114,6 +118,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         // We load it
         DummyIntegration1::$value = Integration::NOT_AVAILABLE;
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
         $this->assertSame(Integration::NOT_AVAILABLE, $loader->getLoadingStatus('integration_1'));
 
         // If now we change the returned value, it won't be reflected in the loadings statuses as it is not reloaded
@@ -124,8 +129,8 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testIntegrationNotLoadedIsReloaded()
     {
+        putenv('DD_TRACE_ENABLED=1');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isEnabled' => true,
             'isIntegrationEnabled' => true,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -138,6 +143,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         // We load it, but the integration returned Integration::NOT_LOADED
         DummyIntegration1::$value = Integration::NOT_LOADED;
         $loader->loadAll();
+        putenv('DD_TRACE_ENABLED');
         $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('integration_1'));
 
         // If now we change the returned value, it won't be reflected in the loadings statuses as it is not reloaded

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -44,8 +44,8 @@ final class IntegrationsLoaderTest extends BaseTestCase
     public function testSingleIntegrationLoadingCanBeDisabled()
     {
         putenv('DD_TRACE_ENABLED=1');
+        putenv('DD_INTEGRATIONS_DISABLED=integration_1');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isIntegrationEnabled' => false,
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
         ]));
@@ -53,6 +53,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         DummyIntegration1::$value = Integration::LOADED;
         $loader = new IntegrationsLoader(self::$dummyIntegrations);
         $loader->loadAll();
+        putenv('DD_INTEGRATIONS_DISABLED');
         putenv('DD_TRACE_ENABLED');
 
         $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('integration_1'));


### PR DESCRIPTION
### Description
This moves the implementations of these `DDTrace\Configuration` methods to the C level:

- `appName` -> `ddtrace_config_app_name`
- `isIntegrationEnabled` -> `ddtrace_config_integration_enabled`
- `isEnabled` -> `ddtrace_config_trace_enabled`

It moves the callers of these methods to directly call the new functions. This is because `Configuration` shows up as hotspots in our recent performance testing; avoiding the `Configuration::get()` is important, and speeding up the call by moving it to C are both important. We can continue moving functions from Configuration, but this is a good stopping place as the latter two were among the top hotspots for integration loading.

It also consolidates the `shouldLoad($integration)` checks into `Integration::shouldLoad($integration)`, as this code was duplicated across the codebase.

**Importantly**, it also removes previously deprecated environment variable support for `ddtrace_app_name` and `DD_TRACE_APP_NAME`. We need to be sure to highlight this in release notes.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.