### PR TITLE
Refactor curl handlers

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -253,7 +253,6 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
-    ddtrace_curl_handlers_rinit();
     ddtrace_bgs_log_rinit(PG(error_log));
     ddtrace_dispatch_init(TSRMLS_C);
     DDTRACE_G(disable_in_current_request) = 0;

--- a/src/ext/handlers_curl.h
+++ b/src/ext/handlers_curl.h
@@ -4,7 +4,6 @@
 #include "compatibility.h"
 
 void ddtrace_curl_handlers_startup(void);
-void ddtrace_curl_handlers_rinit(void);
 void ddtrace_curl_handlers_rshutdown(void);
 
 #endif  // DDTRACE_HANDLERS_CURL_H

--- a/src/ext/php5/handlers_curl.c
+++ b/src/ext/php5/handlers_curl.c
@@ -1,5 +1,4 @@
 #include "handlers_curl.h"
 
 void ddtrace_curl_handlers_startup(void) {}
-void ddtrace_curl_handlers_rinit(void) {}
 void ddtrace_curl_handlers_rshutdown(void) {}


### PR DESCRIPTION
### Description

This provides two main changes:
- Removes the curl rinit hook that found the `le_curl` resource id. Instead we install a handler for `curl_init` that fetches this same value. This removes upfront cost but slightly increases it at usage site.
- Cleans up how the handlers are installed. Previously this was duplicated for every handler; now it is consolidated into a single array and function.

Targeting ddtrace v0.43.0, which will need to cherry-pick this change if merged.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
