### PR TITLE
Cherry-pick #831 into 0.43.0

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -238,7 +238,6 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
-    ddtrace_curl_handlers_rinit();
     ddtrace_bgs_log_rinit(PG(error_log));
     ddtrace_dispatch_init(TSRMLS_C);
     DDTRACE_G(disable_in_current_request) = 0;

--- a/src/ext/handlers_curl.h
+++ b/src/ext/handlers_curl.h
@@ -4,7 +4,6 @@
 #include "compatibility.h"
 
 void ddtrace_curl_handlers_startup(void);
-void ddtrace_curl_handlers_rinit(void);
 void ddtrace_curl_handlers_rshutdown(void);
 
 #endif  // DDTRACE_HANDLERS_CURL_H

--- a/src/ext/php5/handlers_curl.c
+++ b/src/ext/php5/handlers_curl.c
@@ -1,5 +1,4 @@
 #include "handlers_curl.h"
 
 void ddtrace_curl_handlers_startup(void) {}
-void ddtrace_curl_handlers_rinit(void) {}
 void ddtrace_curl_handlers_rshutdown(void) {}


### PR DESCRIPTION
This picks up some curl refactoring for the 0.43.0, which moves some of the cost for the curl integration out of rinit into `curl_init`.