### PR TITLE
Whitelist the cgi-fcgi SAPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,9 @@ jobs:
       resource_class:
         type: string
         default: medium
+      sapi:
+        type: string
+        default: cli-server
     resource_class: << parameters.resource_class >>
     executor:
       name: with_integrations
@@ -431,7 +434,14 @@ jobs:
           command: composer test-integration -- --log-junit test-results/php-integration/results.xml
       - run:
           name: Run << parameters.integration_testsuite >> integration test
-          command: DD_TRACE_AGENT_TIMEOUT=2000 composer << parameters.integration_testsuite >>
+          command: DD_TRACE_AGENT_TIMEOUT=2000 DD_TRACE_TEST_SAPI=<< parameters.sapi >> composer << parameters.integration_testsuite >>
+      - run:
+          command: |
+            mkdir -p /tmp/artifacts
+            find ~/datadog/tests -type f -name 'nginx_*.log' -o -name 'dd_php_error.log' -exec cp --parents '{}' /tmp/artifacts \;
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/artifacts/
       - save_cache:
           <<: *INTEGRATION_COMPOSER_CACHE_KEY
           paths:
@@ -741,6 +751,27 @@ workflows:
           name: "php:7.3"
           docker_image: php:7.3
           package_type: deb
+      - integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 72 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test-web-72"
+          docker_image: "datadog/dd-trace-ci:php-7.2-debug-buster"
+      - integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 73 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test-web-73"
+          docker_image: "datadog/dd-trace-ci:php-7.3-debug-buster"
+      - integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 74 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test-web-74"
+          docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
   build:
     jobs:
       - "Code Checkout"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,6 +388,45 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts/
 
+  base_integration_tests:
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+    resource_class: medium
+    executor:
+      name: with_integrations
+      docker_image: << parameters.docker_image >>
+    environment:
+      COMPOSER_PROCESS_TIMEOUT: 0
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - install_extension
+      - restore_cache: &INTEGRATION_COMPOSER_CACHE_KEY
+          key: 'betav1-composer-base-integration-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
+      - run: composer install --no-interaction --prefer-dist
+      - <<: *STEP_PREPARE_TEST_RESULTS_DIR
+      - <<: *STEP_EXPORT_CI_ENV
+      - <<: *STEP_WAIT_AGENT
+      - <<: *STEP_WAIT_MYSQL
+      - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - run:
+          name: Run auto-instrumentation tests
+          command: composer test-auto-instrumentation -- --log-junit test-results/php-auto-instrumentation/results.xml
+      - run:
+          name: Run distributed-tracing tests
+          command: DD_TRACE_AGENT_TIMEOUT=1000 composer test-distributed-tracing -- --log-junit test-results/php-distributed-tracing/results.xml
+      - run:
+          name: Run integration tests
+          command: composer test-integration -- --log-junit test-results/php-integration/results.xml
+      - save_cache:
+          <<: *INTEGRATION_COMPOSER_CACHE_KEY
+          paths:
+            - vendor/
+            - ~/.composer/cache
+      - <<: *STEP_PERSIST_TO_WORKSPACE
+      - <<: *STEP_STORE_TEST_RESULTS
+
   integration_tests:
     working_directory: ~/datadog
     parameters:
@@ -417,24 +456,14 @@ jobs:
       - restore_cache: &INTEGRATION_COMPOSER_CACHE_KEY
           key: 'betav1-composer-integration-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
       - run: composer install --no-interaction --prefer-dist
-      - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_DISABLE_XDEBUG
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - run:
-          name: Run auto-instrumentation tests
-          command: composer test-auto-instrumentation -- --log-junit test-results/php-auto-instrumentation/results.xml
-      - run:
-          name: Run distributed-tracing tests
-          command: DD_TRACE_AGENT_TIMEOUT=2000 composer test-distributed-tracing -- --log-junit test-results/php-distributed-tracing/results.xml
-      - run:
-          name: Run integration tests
-          command: composer test-integration -- --log-junit test-results/php-integration/results.xml
-      - run:
           name: Run << parameters.integration_testsuite >> integration test
-          command: DD_TRACE_AGENT_TIMEOUT=2000 DD_TRACE_TEST_SAPI=<< parameters.sapi >> composer << parameters.integration_testsuite >>
+          command: DD_TRACE_AGENT_TIMEOUT=1000 DD_TRACE_TEST_SAPI=<< parameters.sapi >> composer << parameters.integration_testsuite >>
       - run:
           command: |
             mkdir -p /tmp/artifacts
@@ -448,7 +477,6 @@ jobs:
             - vendor/
             - ~/.composer/cache
       - <<: *STEP_PERSIST_TO_WORKSPACE
-      - <<: *STEP_STORE_TEST_RESULTS
 
   hyperfine_tests:
     working_directory: ~/datadog
@@ -868,6 +896,34 @@ workflows:
           name: "PHP 54 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/5.4.list
           docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 54 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 56 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-5.6-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 70 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-7.0-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 71 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-7.1-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 72 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-7.2-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 73 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-7.3-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Code Checkout' ]
+          name: "PHP 74 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
       - integration_tests:
           requires: [ 'Code Checkout' ]
           name: "PHP 54 Integration tests"

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ configure
 *.so
 install-sh
 error.log
+dd_php_error.log
+nginx.pid
+nginx_*.log
 libtool
 ltmain.sh
 missing

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -175,7 +175,8 @@ static void register_span_data_ce(TSRMLS_D) {
 
 static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
     if (strcmp("fpm-fcgi", sapi_module.name) == 0 || strcmp("apache2handler", sapi_module.name) == 0 ||
-        strcmp("cli", sapi_module.name) == 0 || strcmp("cli-server", sapi_module.name) == 0) {
+        strcmp("cli", sapi_module.name) == 0 || strcmp("cli-server", sapi_module.name) == 0 ||
+        strcmp("cgi-fcgi", sapi_module.name) == 0) {
         return;
     }
     ddtrace_log_debugf("Incompatible SAPI detected '%s'; disabling ddtrace", sapi_module.name);

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -71,7 +71,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     protected static function getInis()
     {
         return [
-            'ddtrace.request_init_hook' => __DIR__ . '/../../bridge/dd_wrap_autoloader.php',
+            'ddtrace.request_init_hook' => realpath(__DIR__ . '/../../bridge/dd_wrap_autoloader.php'),
             // The following values should be made configurable from the outside. I could not get env XDEBUG_CONFIG
             // to work setting it both in docker-compose.yml and in `getEnvs()` above, but that should be the best
             // option.

--- a/tests/Metrics/SigSegV/SigSegVTest.php
+++ b/tests/Metrics/SigSegV/SigSegVTest.php
@@ -4,6 +4,7 @@ namespace DDTrace\Tests\Metrics\SigSegV;
 
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use DDTrace\Tests\WebServer;
 
 class SigSegVTest extends WebFrameworkTestCase
 {
@@ -26,12 +27,12 @@ class SigSegVTest extends WebFrameworkTestCase
             );
         }
         parent::setUp();
-        @unlink(__DIR__ . '/../../Frameworks/Custom/Version_Not_Autoloaded/error.log');
+        @unlink(__DIR__ . '/../../Frameworks/Custom/Version_Not_Autoloaded/' . WebServer::ERROR_LOG_NAME);
     }
 
     public function testGet()
     {
-        $log = __DIR__ . '/../../Frameworks/Custom/Version_Not_Autoloaded/error.log';
+        $log = __DIR__ . '/../../Frameworks/Custom/Version_Not_Autoloaded/' . WebServer::ERROR_LOG_NAME;
         self::assertFileNotExists($log);
 
         $spec = GetSpec::create('sigsegv', '/');

--- a/tests/Nginx/NginxServer.php
+++ b/tests/Nginx/NginxServer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DDTrace\Tests\Nginx;
+
+use Symfony\Component\Process\Process;
+
+final class NginxServer
+{
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var string
+     */
+    private $configFile;
+
+    /**
+     * @var string
+     */
+    private $rootPath;
+
+    /**
+     * @param string $indexFile
+     * @param string $serverHost
+     * @param string $hostPort
+     * @param string $fastCGIHost
+     * @param int $fastCGIPort
+     * @throws \Exception
+     */
+    public function __construct($indexFile, $serverHost, $hostPort, $fastCGIHost, $fastCGIPort)
+    {
+        $this->rootPath = dirname($indexFile);
+        $replacements = [
+            '{{root_path}}' => $this->rootPath,
+            '{{index_file}}' => basename($indexFile),
+            '{{server_host}}' => $serverHost,
+            '{{server_port}}' => $hostPort,
+            '{{fcgi_host}}' => $fastCGIHost,
+            '{{fcgi_port}}' => $fastCGIPort,
+        ];
+        $configContent = str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            file_get_contents(__DIR__ . '/nginx-default.conf')
+        );
+
+        $this->configFile = sys_get_temp_dir() . uniqid('/nginx-', true);
+        if (false === file_put_contents($this->configFile, $configContent)) {
+            throw new \Exception('Error creating temp nginx config file: ' . $this->configFile);
+        }
+    }
+
+    public function start()
+    {
+        $processCmd = sprintf(
+            'exec nginx -c %s -p %s',
+            $this->configFile,
+            $this->rootPath
+        );
+        $this->process = new Process($processCmd);
+        $this->process->start();
+    }
+
+    public function stop()
+    {
+        if ($this->process) {
+            $this->process->stop(0);
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($this->configFile) {
+            unlink($this->configFile);
+        }
+    }
+}

--- a/tests/Nginx/nginx-default.conf
+++ b/tests/Nginx/nginx-default.conf
@@ -1,0 +1,50 @@
+worker_processes 1;
+error_log stderr;
+daemon off;
+pid nginx.pid;
+
+events {
+    worker_connections 768;
+}
+
+http {
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log {{root_path}}/nginx_access.log;
+    error_log {{root_path}}/nginx_error.log;
+
+    gzip on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen {{server_port}};
+        server_name {{server_host}};
+        root {{root_path}};
+
+        index index.html index.htm {{index_file}};
+
+        charset utf-8;
+
+        location / {
+            try_files $uri $uri/ /{{index_file}}?$query_string;
+        }
+
+        error_page 404 /{{index_file}};
+
+        location ~ \.php$ {
+            fastcgi_pass {{fcgi_host}}:{{fcgi_port}};
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+
+            fastcgi_index {{index_file}};
+            include /etc/nginx/fastcgi_params;
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR whitelists the `cgi-fcgi` SAPI.

For build branches, the web integration tests will be run via nginx and FastCGI for PHP 7.2, 7.3 and 7.4. These tests only run on build branches since they take longer to run than the standard web integration tests (which use the built-in web server from the CLI SAPI). On non-build branches, the web integration tests will continue to run as before for all supported PHP versions.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
