### PR TITLE
Bump version to 0.43.0

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -374,3 +374,7 @@ Zend/tests/bug78999.phpt
 Zend/tests/overloaded_assign_prop_return_value.phpt
 ext/session/tests/bug79031.phpt
 ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
+Zend/tests/bug79155.phpt
+ext/simplexml/tests/bug51615.phpt
+ext/standard/tests/array/arsort_object1.phpt
+ext/standard/tests/array/arsort_object2.phpt

--- a/package.xml
+++ b/package.xml
@@ -10,17 +10,35 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>${date}</date>
+    <date>2020-04-22</date>
     <version>
-        <release>${version}</release>
-        <api>${version}</api>
+        <release>0.43.0</release>
+        <api>0.43.0</api>
     </version>
     <stability>
         <release>stable</release>
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+        **Note: This release comes with minor behavior changes for tracing closures on PHP 7. Please see [the PR for details](https://github.com/DataDog/dd-trace-php/pull/762).**
+
+        ### Added
+
+        - Service mapping with `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db` #801, #817
+        - Auto flushing with `DD_TRACE_AUTO_FLUSH_ENABLED=1` (PHP 7) #819, #826
+        - Disable automatic root-span creation with `DD_TRACE_GENERATE_ROOT_SPAN=0` #834
+
+        ### Changed
+
+        - Always return unaltered VM dispatch (PHP 7) #762
+        - Uri to resource name ON by default #798
+        - Sandbox Guzzle #809, #816
+        - Sandbox predis integration #813
+        - Sandbox curl (PHP 7) #814, #817, #831
+        - Convert pid from long to string for internal spans #825
+        - Move some Configuration methods to functions written at the C level #829
+    </notes>
     <contents>
         <dir name="/">
             <dir name="src">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '1.0.0-nightly'; // Update ./version.php too
+    const VERSION = '0.43.0'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '1.0.0-nightly'; // Update Tracer::VERSION too
+return '0.43.0'; // Update Tracer::VERSION too

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.43.0"
 #endif


### PR DESCRIPTION
### Description

Version bump to `0.43.0`. Also contains a cherry-pick from #835 because the Buster container was updated for the PHP 7.4 language tests.
