### PR TITLE
Add ddtrace_hash_find_ptr_lc and which stack-allocates small strings

### DIFF
--- a/src/ext/arrays.c
+++ b/src/ext/arrays.c
@@ -35,10 +35,24 @@ void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len) {
 
 void *ddtrace_hash_find_ptr_lc(HashTable *ht, const char *str, size_t len) {
     void *result;
+#if PHP_VERSION_ID < 70000
+    /* The code for the PHP 7 branch will also work on PHP 5, but if we do not
+     * call emalloc and free (even if we don't end up using it), then there is
+     * a memory leak reported by PHP 5.4 and 5.6:
+     *   - 5.4: https://app.circleci.com/jobs/github/DataDog/dd-trace-php/142159
+     *   - 5.6: https://app.circleci.com/jobs/github/DataDog/dd-trace-php/142298
+     * So we always use an emalloc path until this is resolved.
+     */
+    char *lc_str = zend_str_tolower_dup(str, len);
+    result = ddtrace_hash_find_ptr(ht, lc_str, len);
+    efree(lc_str);
+#else
+    // Stack allocate small strings to improve performance
     ALLOCA_FLAG(use_heap)
     // zend_str_tolower_copy will add a null terminator; leave room for it
     char *lc_str = zend_str_tolower_copy(do_alloca(len + 1, use_heap), str, len);
     result = ddtrace_hash_find_ptr(ht, lc_str, len);
     free_alloca(lc_str, use_heap);
+#endif
     return result;
 }

--- a/src/ext/arrays.c
+++ b/src/ext/arrays.c
@@ -21,3 +21,24 @@ void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *contex
     ZEND_HASH_FOREACH_END();
 }
 #endif
+
+void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len) {
+    void *result;
+#if PHP_VERSION_ID < 70000
+    void **rv = NULL;
+    result = zend_hash_find(ht, str, len, (void **)&rv) == SUCCESS ? *rv : NULL;
+#else
+    result = zend_hash_str_find_ptr(ht, str, len);
+#endif
+    return result;
+}
+
+void *ddtrace_hash_find_ptr_lc(HashTable *ht, const char *str, size_t len) {
+    void *result;
+    ALLOCA_FLAG(use_heap)
+    // zend_str_tolower_copy will add a null terminator; leave room for it
+    char *lc_str = zend_str_tolower_copy(do_alloca(len + 1, use_heap), str, len);
+    result = ddtrace_hash_find_ptr(ht, lc_str, len);
+    free_alloca(lc_str, use_heap);
+    return result;
+}

--- a/src/ext/arrays.h
+++ b/src/ext/arrays.h
@@ -6,4 +6,13 @@
 typedef void (*ddtrace_walk_fn)(zval *item, size_t visitation_order, void *context);
 void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn, void *context);
 
+/**
+ * Use ddtrace_hash_find_ptr_lc if you do not already have a lowercased string
+ * and do not need one for any reason other than to look up the string in the
+ * ht.
+ * If you already have a lowered string, use ddtrace_hash_find_ptr.
+ */
+void *ddtrace_hash_find_ptr_lc(HashTable *ht, const char *str, size_t len);
+void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len);
+
 #endif  // DDTRACE_ARRAYS_H

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -58,17 +58,6 @@ void ddtrace_dispatch_reset(TSRMLS_D);
 #define OBJECT() (EX(call) ? EX(call)->object : NULL)
 #endif
 
-inline void *zend_hash_str_find_ptr(const HashTable *ht, const char *key, size_t length) {
-    void **rv = NULL;
-    zend_hash_find(ht, key, length, (void **)&rv);
-
-    if (rv) {
-        return *rv;
-    } else {
-        return NULL;
-    }
-}
-
 void ddtrace_class_lookup_release_compat(void *zv);
 
 #define ddtrace_zval_ptr_dtor(x) zval_dtor(x)

--- a/src/ext/dispatch_setup.c
+++ b/src/ext/dispatch_setup.c
@@ -7,6 +7,7 @@
 
 #include <ext/spl/spl_exceptions.h>
 
+#include "arrays.h"
 #include "compat_string.h"
 #include "ddtrace.h"
 #include "dispatch.h"
@@ -68,10 +69,10 @@ zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, u
         // downcase the class name before lookup as class names are case insensitive.
         zval *class_name_prev = class_name;
         MAKE_STD_ZVAL(class_name);
-        ZVAL_STRING(class_name, Z_STRVAL_P(class_name_prev), 1);
+        ZVAL_STRINGL(class_name, Z_STRVAL_P(class_name_prev), Z_STRLEN_P(class_name_prev), 1);
         ddtrace_downcase_zval(class_name);
         overridable_lookup =
-            zend_hash_str_find_ptr(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name));
+            ddtrace_hash_find_ptr(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name));
         if (!overridable_lookup) {
             overridable_lookup = ddtrace_new_class_lookup(class_name TSRMLS_CC);
         }

--- a/src/ext/php5/dispatch.c
+++ b/src/ext/php5/dispatch.c
@@ -19,8 +19,6 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
     } while (0)
 #endif
 
-extern inline void *zend_hash_str_find_ptr(const HashTable *ht, const char *key, size_t length);
-
 zend_function *ddtrace_function_get(const HashTable *table, zval *name) {
     char *key = zend_str_tolower_dup(Z_STRVAL_P(name), Z_STRLEN_P(name));
 

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -63,6 +63,19 @@ static bool _dd_should_trace_call(zend_execute_data *call, zend_function *fbc, d
     ZVAL_STR(&fname, fbc->common.function_name);
 
     zval *this = _dd_this(call);
+
+    /* TODO: we can possibly grab the lowercased variants off the opline.
+     * Levi: Do we store the function and method names lowered in the oplines
+     *       anywhere?
+     * Nikita: yes
+     * Nikita: Function call opcodes and similar usually have multiple
+     *         literals in a row
+     * Nikita: So the CONST operand points to the first literal, and then
+     *         there's a few more after it, with lowercased variants, or
+     *         variants without namespace etc
+     *
+     * It would avoid lowering the string and reduce memory churn; win-win.
+     */
     *dispatch = ddtrace_find_dispatch(this ? Z_OBJCE_P(this) : fbc->common.scope, &fname);
 
     if (!*dispatch || (*dispatch)->busy) {


### PR DESCRIPTION
### Description

`ddtrace_hash_find_ptr` is `zend_hash_str_find_ptr` for both PHP 5 and 7.

`ddtrace_hash_find_ptr_lc` lowercases its string parameter, using the stack if the string is small enough (probably is), and then calls ddtrace_hash_find_ptr. This improved performance in a local
test using dtrace by about 4% (will be less pronounced in real apps).

Also adds some ZEND_STRL's in serializer. I thought I found a bug due to being off by one, but turned out to not be a bug; left a comment to save someone some time in the future.

### Readiness checklist
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
