### PR TITLE
Bump phpstan to 0.12 and fix issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,10 @@ jobs:
       - prepare_extension_and_composer_with_cache
       - run:
           name: Install phpstan
-          command: composer global require phpstan/phpstan:0.11.* ; composer scenario:update
+          command: |
+            composer global require phpstan/phpstan:0.12.*
+            composer global require psr/log
+            composer scenario:update
       - run:
           name: Running phpstan
           command: composer scenario opentracing1 ; PATH=$PATH:~/.composer/vendor/bin composer static-analyze

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,8 @@
 parameters:
+	ignoreErrors:
+		-
+			message: '#Method DDTrace\\Propagators\\CurlHeadersMap::extract\(\) should return DDTrace\\Contracts\\SpanContext but return statement is missing\.#'
+			path: src/DDTrace/Propagators/CurlHeadersMap.php
 	autoload_files:
 		- bridge/configuration.php
 	excludes_analyse:

--- a/src/DDTrace/Configuration/AbstractConfiguration.php
+++ b/src/DDTrace/Configuration/AbstractConfiguration.php
@@ -17,7 +17,7 @@ abstract class AbstractConfiguration implements Registry
      */
     protected $registry;
 
-    protected function __construct()
+    final protected function __construct()
     {
         $this->registry = new EnvVariableRegistry();
     }

--- a/src/DDTrace/NoopScopeManager.php
+++ b/src/DDTrace/NoopScopeManager.php
@@ -24,6 +24,7 @@ final class NoopScopeManager implements ScopeManagerInterface
         SpanInterface $span,
         $finishSpanOnClose = ScopeManagerInterface::DEFAULT_FINISH_SPAN_ON_CLOSE
     ) {
+        return NoopScope::create();
     }
 
     /**

--- a/src/DDTrace/NoopTracer.php
+++ b/src/DDTrace/NoopTracer.php
@@ -55,7 +55,7 @@ final class NoopTracer implements TracerInterface
     /**
      * {@inheritdoc}
      */
-    public function startActiveSpan($operationName, $finishSpanOnClose = true, $options = [])
+    public function startActiveSpan($operationName, $options = [])
     {
         return NoopScope::create();
     }


### PR DESCRIPTION
### Description

While fixing phpstan errors for another branch I remembered we don't use the latest phpstan version because there were issues with the new version. It's stable now and there are only a handful of failures, which are genuine.

Note that I ignore one issue. Throwing an exception would make the issue go away and is arguably what should have been done when it was stubbed, but that could cause issues for clients. So we'll just ignore it.

### Readiness checklist
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
