### PR TITLE
Fix CI build after latest Buster container updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts
+
   php_language_tests:
     parameters:
       docker_image:
@@ -358,14 +359,14 @@ jobs:
           command: |
             sudo rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
             if [[ ! "<<parameters.xfail_list>>" == "none" ]]; then
-              cp "<<parameters.xfail_list>>" /usr/src/php/xfail_tests.list
+              cp "<<parameters.xfail_list>>" /usr/local/src/php/xfail_tests.list
               (
-                cd /usr/src/php
+                cd /usr/local/src/php
                 cat xfail_tests.list | xargs -n 1 grep -L '\-\-SKIPIF\-\-' | xargs -n 1 -r sed -i -e $'s/\(--FILE.*--\)/--SKIPIF--\\\n\\1/g' || true
                 cat xfail_tests.list | xargs -n 1 sed -i -e $'s/\(--SKIPIF--\)/\\1\\\nskip Unreliable output or flaky test/g'
               )
             fi
-            cd /usr/src/php
+            cd /usr/local/src/php
             export DD_TRACE_CLI_ENABLED=true
             export REPORT_EXIT_STATUS=1
             export TEST_PHP_JUNIT=/tmp/artifacts/tests/php-tests.xml
@@ -376,7 +377,7 @@ jobs:
               -d ddtrace.request_init_hook=/home/circleci/datadog/bridge/dd_wrap_autoloader.php
       - run:
           command: |
-            cd /usr/src/php
+            cd /usr/local/src/php
             mkdir -p /tmp/artifacts/core_dumps
             find ./ -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
             mkdir -p /tmp/artifacts/diffs

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -301,3 +301,4 @@ Zend/tests/gc_041.phpt
 Zend/tests/gc_042.phpt
 ext/readline/tests/libedit_callback_handler_install_001.phpt
 ext/readline/tests/libedit_callback_handler_remove_001.phpt
+ext/simplexml/tests/bug51615.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -374,3 +374,7 @@ Zend/tests/bug78999.phpt
 Zend/tests/overloaded_assign_prop_return_value.phpt
 ext/session/tests/bug79031.phpt
 ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
+Zend/tests/bug79155.phpt
+ext/simplexml/tests/bug51615.phpt
+ext/standard/tests/array/arsort_object1.phpt
+ext/standard/tests/array/arsort_object2.phpt


### PR DESCRIPTION
### Description

The Buster containers were updated to the latest patch versions of PHP. There were a few new tests that have object ID's in the output that were added to the xfail list.

The PHP source directory also moved from `/usr/src/php` to `/usr/local/src/php`.
