### PR TITLE
Update version to 0.43.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts
+
   php_language_tests:
     parameters:
       docker_image:
@@ -358,14 +359,14 @@ jobs:
           command: |
             sudo rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
             if [[ ! "<<parameters.xfail_list>>" == "none" ]]; then
-              cp "<<parameters.xfail_list>>" /usr/src/php/xfail_tests.list
+              cp "<<parameters.xfail_list>>" /usr/local/src/php/xfail_tests.list
               (
-                cd /usr/src/php
+                cd /usr/local/src/php
                 cat xfail_tests.list | xargs -n 1 grep -L '\-\-SKIPIF\-\-' | xargs -n 1 -r sed -i -e $'s/\(--FILE.*--\)/--SKIPIF--\\\n\\1/g' || true
                 cat xfail_tests.list | xargs -n 1 sed -i -e $'s/\(--SKIPIF--\)/\\1\\\nskip Unreliable output or flaky test/g'
               )
             fi
-            cd /usr/src/php
+            cd /usr/local/src/php
             export DD_TRACE_CLI_ENABLED=true
             export REPORT_EXIT_STATUS=1
             export TEST_PHP_JUNIT=/tmp/artifacts/tests/php-tests.xml
@@ -376,7 +377,7 @@ jobs:
               -d ddtrace.request_init_hook=/home/circleci/datadog/bridge/dd_wrap_autoloader.php
       - run:
           command: |
-            cd /usr/src/php
+            cd /usr/local/src/php
             mkdir -p /tmp/artifacts/core_dumps
             find ./ -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
             mkdir -p /tmp/artifacts/diffs

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -301,3 +301,4 @@ Zend/tests/gc_041.phpt
 Zend/tests/gc_042.phpt
 ext/readline/tests/libedit_callback_handler_install_001.phpt
 ext/readline/tests/libedit_callback_handler_remove_001.phpt
+ext/simplexml/tests/bug51615.phpt

--- a/package.xml
+++ b/package.xml
@@ -10,10 +10,10 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>2020-04-22</date>
+    <date>2020-04-27</date>
     <version>
-        <release>0.43.0</release>
-        <api>0.43.0</api>
+        <release>0.43.1</release>
+        <api>0.43.1</api>
     </version>
     <stability>
         <release>stable</release>
@@ -21,23 +21,8 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-        **Note: This release comes with minor behavior changes for tracing closures on PHP 7. Please see [the PR for details](https://github.com/DataDog/dd-trace-php/pull/762).**
-
-        ### Added
-
-        - Service mapping with `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db` #801, #817
-        - Auto flushing with `DD_TRACE_AUTO_FLUSH_ENABLED=1` (PHP 7) #819, #826
-        - Disable automatic root-span creation with `DD_TRACE_GENERATE_ROOT_SPAN=0` #834
-
-        ### Changed
-
-        - Always return unaltered VM dispatch (PHP 7) #762
-        - Uri to resource name ON by default #798
-        - Sandbox Guzzle #809, #816
-        - Sandbox predis integration #813
-        - Sandbox curl (PHP 7) #814, #817, #831
-        - Convert pid from long to string for internal spans #825
-        - Move some Configuration methods to functions written at the C level #829
+        ### Fixed
+          - Fix ddtrace_config_* functions to use sapi_getenv #848
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '0.43.0'; // Update ./version.php too
+    const VERSION = '0.43.1'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '0.43.0'; // Update Tracer::VERSION too
+return '0.43.1'; // Update Tracer::VERSION too


### PR DESCRIPTION
### Description

Update version to 0.43.1 which includes a fix for issue 846.

To see the full diff between 0.43.0 and this PR, see [here](https://github.com/DataDog/dd-trace-php/compare/ddtrace-0.43.0...release-0.43.1).