### PR TITLE
Fix curl integrations

### DIFF
--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -32,6 +32,7 @@ abstract class IntegrationTestCase extends TestCase
     {
         parent::tearDownAfterClass();
         putenv('DD_TRACE_SANDBOX_ENABLED');
+        \dd_trace_internal_fn('ddtrace_reload_config');
     }
 
     protected static function isSandboxed()
@@ -53,6 +54,7 @@ abstract class IntegrationTestCase extends TestCase
         parent::tearDown();
         error_reporting($this->errorReportingBefore);
         \PHPUnit_Framework_Error_Warning::$enabled = true;
+        \dd_trace_internal_fn('ddtrace_reload_config');
     }
 
     protected function disableTranslateWarningsIntoErrors()


### PR DESCRIPTION
### Description

Both legacy and sandboxed integrations were caching the result of
Configuration::get() -- I'm not sure which recent change makes this
impossible, but nonetheless that's how it currently is.

Also fix sandboxed curl integration's `copy_curl_handle` and distributed
tracing checks.

This PR is unnecessary if we merge in #833 soon, as the configuration
and curl fixes are also contained in that branch.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
