### PR TITLE
Do our own clock_gettime checks

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -7,6 +7,7 @@ PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
 if test "$PHP_DDTRACE" != "no"; then
   m4_include([m4/polyfill.m4])
   m4_include([m4/ax_execinfo.m4])
+  m4_include([m4/ddtrace_clock_gettime.m4])
 
   AX_EXECINFO
 
@@ -17,6 +18,13 @@ if test "$PHP_DDTRACE" != "no"; then
     PHP_CHECK_LIBRARY(execinfo, backtrace,
       [PHP_ADD_LIBRARY(execinfo, , EXTRA_LDFLAGS)])
   )
+
+  DDTRACE_CLOCK_GETTIME
+
+  if test "$DDTRACE_HAVE_CLOCK_GETTIME" != "no"; then
+    PHP_CHECK_LIBRARY(rt, clock_gettime,
+      [PHP_ADD_LIBRARY(rt, , EXTRA_LDFLAGS)])
+  fi
 
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     PHP_ADD_LIBRARY(asan, , EXTRA_LDFLAGS)

--- a/m4/ddtrace_clock_gettime.m4
+++ b/m4/ddtrace_clock_gettime.m4
@@ -1,0 +1,29 @@
+dnl This is copied and modified from PHP's own source code for HAVE_CLOCK_GETTIME
+dnl We cannot use PHP's HAVE_CLOCK_GETTIME as it may not get run depending on
+dnl what configure flags were passed
+AC_DEFUN([DDTRACE_CLOCK_GETTIME],
+[
+  have_clock_gettime=no
+  AC_MSG_CHECKING([for clock_gettime])
+  AC_TRY_LINK([ #include <time.h> ], [struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);], [
+    have_clock_gettime=yes
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_MSG_RESULT([no])
+  ])
+  if test "$have_clock_gettime" = "no"; then
+    AC_MSG_CHECKING([for clock_gettime in -lrt])
+    SAVED_LIBS="$LIBS"
+    LIBS="$LIBS -lrt"
+    AC_TRY_LINK([ #include <time.h> ], [struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);], [
+      have_clock_gettime=yes
+      AC_MSG_RESULT([yes])
+    ], [
+      LIBS="$SAVED_LIBS"
+      AC_MSG_RESULT([no])
+    ])
+  fi
+  if test "$have_clock_gettime" = "yes"; then
+    AC_DEFINE([DDTRACE_HAVE_CLOCK_GETTIME], 1, [do we have clock_gettime?])
+  fi
+])

--- a/package.xml
+++ b/package.xml
@@ -331,6 +331,7 @@
             <file name="config.m4" role="src" />
             <dir name="m4">
                 <file name="ax_execinfo.m4" role="src" />
+                <file name="ddtrace_clock_gettime.m4" role="src" />
                 <file name="polyfill.m4" role="src" />
             </dir>
             <file name="LICENSE" role="doc" />

--- a/src/ext/clocks.c
+++ b/src/ext/clocks.c
@@ -1,7 +1,8 @@
 #include "clocks.h"
 
-#include <php_config.h>   // for HAVE_CLOCK_GETTIME
 #include <php_version.h>  // for PHP_VERSION_ID
+
+#include "config.h"  // for DDTRACE_HAVE_CLOCK_GETTIME
 
 // UNEXPECTED is in different places in PHP 5 and 7
 #if PHP_VERSION_ID < 70000
@@ -10,7 +11,9 @@
 #include <Zend/zend_portability.h>
 #endif
 
-#if HAVE_CLOCK_GETTIME
+#if !defined(DDTRACE_HAVE_CLOCK_GETTIME)
+#error Unabled to find clock_gettime. Please open a bug report with the operating system information.
+#endif
 
 #include <time.h>  // for clock_gettime, CLOCK_MONOTONIC
 
@@ -37,8 +40,3 @@ ddtrace_realtime_nsec_t ddtrace_realtime_nsec(void) {
     }
     return ((uint64_t)timespec.tv_sec) * UINT64_C(1000000000) + ((uint64_t)timespec.tv_nsec);
 }
-#else
-ddtrace_monotonic_nsec_t ddtrace_monotonic_nsec(void) { return 0; }
-ddtrace_monotonic_usec_t ddtrace_monotonic_usec(void) { return 0; }
-ddtrace_realtime_nsec_t ddtrace_realtime_nsec(void) { return 0; }
-#endif


### PR DESCRIPTION
### Description

Starting from ddtrace 0.43.0 we used PHP's HAVE_CLOCK_GETTIME configuration check to make sure we had a clock available. However, this config check is sensitive to how PHP was built. This PR does our own check.

### Readiness checklist
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
