### PR TITLE
Use normalized URL as the resource name for curl

### DIFF
--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -77,6 +77,8 @@ class CurlIntegration extends Integration
 
                 $info = curl_getinfo($ch);
                 $sanitizedUrl = Urls::sanitize($info['url']);
+                $normalizer = new Urls(explode(',', getenv('DD_TRACE_RESOURCE_URI_MAPPING')));
+                $normalizedUrl = $normalizer->normalize($info['url']);
                 unset($info['url']);
 
                 if (Configuration::get()->isHttpClientSplitByDomain()) {
@@ -84,7 +86,7 @@ class CurlIntegration extends Integration
                 } else {
                     $span->setTag(Tag::SERVICE_NAME, 'curl');
                 }
-                $span->setTag(Tag::RESOURCE_NAME, $sanitizedUrl);
+                $span->setTag(Tag::RESOURCE_NAME, $normalizedUrl);
 
 
                 // Special case the Datadog Standard Attributes

--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -68,13 +68,15 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
 
                 $info = \curl_getinfo($ch);
                 $sanitizedUrl = Urls::sanitize($info['url']);
+                $normalizer = new Urls(explode(',', getenv('DD_TRACE_RESOURCE_URI_MAPPING')));
+                $normalizedUrl = $normalizer->normalize($info['url']);
                 unset($info['url']);
 
                 if ($globalConfig->isHttpClientSplitByDomain()) {
                     $span->service = Urls::hostnameForTag($sanitizedUrl);
                 }
 
-                $span->resource = $sanitizedUrl;
+                $span->resource = $normalizedUrl;
 
                 /* Special case the Datadog Standard Attributes
                  * See https://docs.datadoghq.com/logs/processing/attributes_naming_convention/

--- a/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
@@ -48,7 +48,7 @@ final class NoRootSpanTest extends CLITestCase
                 ),
                 SpanAssertion::exists(
                     'curl_exec',
-                    'http://httpbin_integration/status/200'
+                    'http://httpbin_integration/status/?'
                 ),
             ])
         ]);

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -76,7 +76,7 @@ class CurlIntegrationTest extends IntegrationTestCase
         });
 
         $this->assertSpans($traces, [
-            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/200')
+            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
@@ -100,7 +100,7 @@ class CurlIntegrationTest extends IntegrationTestCase
         });
 
         $this->assertSpans($traces, [
-            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/200')
+            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
@@ -122,7 +122,7 @@ class CurlIntegrationTest extends IntegrationTestCase
         });
 
         $this->assertSpans($traces, [
-            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/200')
+            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
@@ -142,7 +142,7 @@ class CurlIntegrationTest extends IntegrationTestCase
         });
 
         $this->assertSpans($traces, [
-            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/200')
+            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
@@ -164,7 +164,7 @@ class CurlIntegrationTest extends IntegrationTestCase
         });
 
         $this->assertSpans($traces, [
-            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/404')
+            SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([
                     'http.url' => self::URL . '/status/404',
@@ -439,7 +439,7 @@ class CurlIntegrationTest extends IntegrationTestCase
                 'curl_exec',
                 'host-httpbin_integration',
                 'http',
-                'http://httpbin_integration/status/200'
+                'http://httpbin_integration/status/?'
             )
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags([


### PR DESCRIPTION
### Description

Use the normalized URL rather than the sanitized URL as the resource name for curl requests. This allows for URLs like users/123 and users/456 to be grouped togerher providing more useful summary statistics in datadog.

See: https://github.com/DataDog/dd-trace-php/issues/864

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
