### PR TITLE
Add ddtrace_config_distributed_tracing_enabled

### DIFF
--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -46,7 +46,7 @@ class Configuration extends AbstractConfiguration
      */
     public function isDistributedTracingEnabled()
     {
-        return $this->boolValue('distributed.tracing', true);
+        return \ddtrace_config_distributed_tracing_enabled();
     }
 
     /**

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -131,9 +131,9 @@ class CurlIntegration extends Integration
                 // Note that curl_setopt with option CURLOPT_HTTPHEADER overwrite data instead of appending it if called
                 // multiple times on the same resource.
                 if (
-                    $option === CURLOPT_HTTPHEADER
-                    && Configuration::get()->isDistributedTracingEnabled()
-                    && is_array($value)
+                    $option === \CURLOPT_HTTPHEADER
+                    && \is_array($value)
+                    && \ddtrace_config_distributed_tracing_enabled()
                 ) {
                     // Storing data to be used during exec as it cannot be retrieved at then.
                     ArrayKVStore::putForResource($ch, Format::CURL_HTTP_HEADERS, $value);
@@ -148,10 +148,7 @@ class CurlIntegration extends Integration
             'innerhook' => function ($ch, $options) {
                 // Note that curl_setopt with option CURLOPT_HTTPHEADER overwrite data instead of appending it if called
                 // multiple times on the same resource.
-                if (
-                    Configuration::get()->isDistributedTracingEnabled()
-                    && array_key_exists(CURLOPT_HTTPHEADER, $options)
-                ) {
+                if (\ddtrace_config_distributed_tracing_enabled() && isset($options[\CURLOPT_HTTPHEADER])) {
                     // Storing data to be used during exec as it cannot be retrieved at then.
                     ArrayKVStore::putForResource($ch, Format::CURL_HTTP_HEADERS, $options[CURLOPT_HTTPHEADER]);
                 }
@@ -166,7 +163,7 @@ class CurlIntegration extends Integration
                 $ch2 = dd_trace_forward_call();
                 /* The store needs to copy the CURLOPT_HTTPHEADER value to the new handle;
                  * see https://github.com/DataDog/dd-trace-php/issues/502 */
-                if (\is_resource($ch2) && Configuration::get()->isDistributedTracingEnabled()) {
+                if (\is_resource($ch2) && \ddtrace_config_distributed_tracing_enabled()) {
                     $httpHeaders = ArrayKVStore::getForResource($ch1, Format::CURL_HTTP_HEADERS, []);
                     if (\is_array($httpHeaders)) {
                         ArrayKVStore::putForResource($ch2, Format::CURL_HTTP_HEADERS, $httpHeaders);
@@ -192,7 +189,7 @@ class CurlIntegration extends Integration
      */
     public static function injectDistributedTracingHeaders($ch)
     {
-        if (!Configuration::get()->isDistributedTracingEnabled()) {
+        if (!\ddtrace_config_distributed_tracing_enabled()) {
             return;
         }
 

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -126,7 +126,7 @@ final class GuzzleIntegration extends Integration
     {
         $self = $this;
         return function (array $args) use ($self) {
-            if (!Configuration::get()->isDistributedTracingEnabled()) {
+            if (!\ddtrace_config_distributed_tracing_enabled()) {
                 return null;
             }
 
@@ -177,7 +177,7 @@ final class GuzzleIntegration extends Integration
      */
     public function applyDistributedTracingHeaders(Span $span, $request)
     {
-        if (!Configuration::get()->isDistributedTracingEnabled()) {
+        if (!\ddtrace_config_distributed_tracing_enabled()) {
             return;
         }
 

--- a/src/DDTrace/StartSpanOptionsFactory.php
+++ b/src/DDTrace/StartSpanOptionsFactory.php
@@ -20,10 +20,8 @@ class StartSpanOptionsFactory
      */
     public static function createForWebRequest(TracerInterface $tracer, array $options = [], array $headers = [])
     {
-        $globalConfiguration = Configuration::get();
-
         if (
-            $globalConfiguration->isDistributedTracingEnabled()
+            \ddtrace_config_distributed_tracing_enabled()
             && $spanContext = $tracer->extract(Format::HTTP_HEADERS, $headers)
         ) {
             $options[Reference::CHILD_OF] = $spanContext;

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -4,6 +4,38 @@
 #include <stdbool.h>
 
 #include "compatibility.h"
+#include "ddtrace_string.h"
+#include "env_config.h"
+
+/**
+ * Returns true if `subject` matches "true" or "1".
+ * Returns false if `subject` matches "false" or "0".
+ * Returns `default_value` otherwise.
+ * @param subject An already lowercased string
+ * @param default_value
+ * @return
+ */
+bool ddtrace_config_bool(ddtrace_string subject, bool default_value);
+
+/**
+ * Fetch the environment variable represented by `env_name` from the SAPI env
+ * or regular environment and test if it is a boolean config value.
+ * @see ddtrace_config_bool
+ * @param env_name Name of the environment variable to fetch.
+ * @param default_value
+ * @return If the environment variable does not exist or is not bool-ish, return `default_value` instead.
+ */
+bool ddtrace_config_env_bool(ddtrace_string env_name, bool default_value TSRMLS_DC);
+
+bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D);
+bool ddtrace_config_trace_enabled(TSRMLS_D);
+
+// note: only call this if ddtrace_config_trace_enabled() returns true
+bool ddtrace_config_integration_enabled(ddtrace_string integration TSRMLS_DC);
+
+inline ddtrace_string ddtrace_string_getenv(char *str, size_t len TSRMLS_DC) {
+    return ddtrace_string_cstring_ctor(ddtrace_getenv(str, len TSRMLS_CC));
+}
 
 struct ddtrace_memoized_configuration_t;
 extern struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration;

--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -18,6 +18,9 @@ struct ddtrace_string {
 };
 typedef struct ddtrace_string ddtrace_string;
 
+#define DDTRACE_STRING_LITERAL(str) \
+    { .ptr = str, .len = sizeof(str) - 1 }
+
 inline ddtrace_string ddtrace_string_cstring_ctor(char *ptr) {
     ddtrace_string string = {
         .ptr = ptr,

--- a/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -667,9 +667,10 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
     /**
      * @param $fn
      * @param null $tracer
+     * @param array $config
      * @return array[]
      */
-    public function isolateTracer($fn, $tracer = null)
+    public function isolateTracer($fn, $tracer = null, $config = [])
     {
         $traces = parent::isolateTracer($fn, $tracer);
         return array_filter_recursive(__NAMESPACE__ . '\\keep_non_symfony_spans', $traces);

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -50,6 +50,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
     protected function tearDown()
     {
         parent::tearDown();
+        putenv('DD_DISTRIBUTED_TRACING');
         putenv('DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN');
     }
 
@@ -165,11 +166,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
 
     public function testDistributedTracingIsNotPropagatedIfDisabled()
     {
+        putenv('DD_DISTRIBUTED_TRACING=false');
         $client = new Client();
         $found = [];
-        Configuration::replace(\Mockery::mock(Configuration::get(), [
-            'isDistributedTracingEnabled' => false,
-        ]));
 
         $this->isolateTracer(function () use (&$found, $client) {
             /** @var Tracer $tracer */

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -42,6 +42,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
     protected function tearDown()
     {
         parent::tearDown();
+        putenv('DD_DISTRIBUTED_TRACING');
         putenv('DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN');
     }
 
@@ -160,11 +161,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
 
     public function testDistributedTracingIsNotPropagatedIfDisabled()
     {
+        putenv('DD_DISTRIBUTED_TRACING=false');
         $client = $this->getRealClient();
         $found = [];
-        Configuration::replace(\Mockery::mock(Configuration::get(), [
-            'isDistributedTracingEnabled' => false,
-        ]));
 
         $this->isolateTracer(function () use (&$found, $client) {
             /** @var Tracer $tracer */

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -24,12 +24,12 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_INTEGRATIONS_DISABLED');
         putenv('DD_PRIORITY_SAMPLING');
         putenv('DD_SAMPLING_RATE');
+        putenv('DD_SERVICE_MAPPING');
         putenv('DD_TRACE_ANALYTICS_ENABLED');
         putenv('DD_TRACE_DEBUG');
         putenv('DD_TRACE_ENABLED');
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
-        putenv('DD_SERVICE_MAPPING');
     }
 
     public function testTracerEnabledByDefault()
@@ -57,12 +57,14 @@ final class ConfigurationTest extends BaseTestCase
     public function testDistributedTracingEnabledByDefault()
     {
         $this->assertTrue(Configuration::get()->isDistributedTracingEnabled());
+        $this->assertTrue(\ddtrace_config_distributed_tracing_enabled());
     }
 
     public function testDistributedTracingDisabled()
     {
         putenv('DD_DISTRIBUTED_TRACING=false');
         $this->assertFalse(Configuration::get()->isDistributedTracingEnabled());
+        $this->assertFalse(\ddtrace_config_distributed_tracing_enabled());
     }
 
     public function testPrioritySamplingEnabledByDefault()

--- a/tests/Unit/StartSpanOptionsFactoryTest.php
+++ b/tests/Unit/StartSpanOptionsFactoryTest.php
@@ -18,6 +18,7 @@ final class StartSpanOptionsFactoryTest extends BaseTestCase
 
     protected function setUp()
     {
+        putenv('DD_DISTRIBUTED_TRACING');
         parent::setUp();
         $this->tracer = \Mockery::mock('DDTrace\Contracts\Tracer');
     }
@@ -44,10 +45,7 @@ final class StartSpanOptionsFactoryTest extends BaseTestCase
 
     public function testCreateForWebRequestNotExtractedContextIfDisabled()
     {
-        Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
-            'isDistributedTracingEnabled' => false,
-            'isDebugModeEnabled' => false,
-        ]));
+        putenv('DD_DISTRIBUTED_TRACING=false');
         $this->tracer->shouldReceive('extract')->never();
 
         $startSpanOptions = StartSpanOptionsFactory::createForWebRequest($this->tracer);


### PR DESCRIPTION
### Description

Create `ddtrace_config_distributed_tracing_enabled()` for both PHP and the C extension.
- Migrate uses of `DDTrace\Configuration->isDistributedTracingEnabled()` to `ddtrace_config_distributed_tracing_enabled()` for both PHP and C extension.
- Migrate `DDTrace\Configuration->isDistributedTracingEnabled()` itself to use `ddtrace_config_distributed_tracing_enabled()` for backwards compatibility.

Also cleanup some recently added configuration related code in ddtrace.c by moving it into configuration.{c,h}.

This work has been split off from #833 and improved.

### Readiness checklist
- [x] ~Tests added for this feature/bug.~ I judged existing tests to be adequate.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.