### PR TITLE
Fix variadic args with empty function signature

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -213,6 +213,7 @@
                         <file name="spans_out_of_sync.phpt" role="test" />
                         <file name="static_tracing_closures_will_not_bind_this.phpt" role="test" />
                         <file name="variadic_args_internal.phpt" role="test" />
+                        <file name="variadic_no_args.phpt" role="test" />
                         <file name="vm_var_types_return.phpt" role="test" />
                     </dir>
                     <dir name="sandbox-prehook">

--- a/src/ext/php5/handlers_curl.c
+++ b/src/ext/php5/handlers_curl.c
@@ -1,6 +1,4 @@
 #include "handlers_curl.h"
 
-int ddtrace_resource;
-
 void ddtrace_curl_handlers_startup(void) {}
 void ddtrace_curl_handlers_rshutdown(void) {}

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -180,7 +180,7 @@ static void _dd_copy_function_args(zend_execute_data *call, zval *user_args, boo
     array_init_size(user_args, arg_count);
     if (arg_count && call->func) {
         first_extra_arg = call->func->op_array.num_args;
-        bool has_extra_args = first_extra_arg > 0 && arg_count > first_extra_arg;
+        bool has_extra_args = arg_count > first_extra_arg;
 
         zend_hash_real_init(Z_ARRVAL_P(user_args), 1);
         ZEND_HASH_FILL_PACKED(Z_ARRVAL_P(user_args)) {

--- a/tests/ext/sandbox/variadic_no_args.phpt
+++ b/tests/ext/sandbox/variadic_no_args.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Variadic arguments are passed to tracing closure when no arguments exist in function signature
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+function bar($a, $b, $c) {
+    return $a . ', ' . $b . ', ' . $c;
+}
+
+function foo() {
+    $args = func_get_args();
+    $retval = bar($args[0], $args[1], $args[2]);
+    return $retval;
+}
+
+dd_trace_function('foo', function ($span, array $args) {
+    var_dump($args);
+});
+
+echo foo('Cats', 'Dogs', 'Birds') . PHP_EOL;
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(4) "Cats"
+  [1]=>
+  string(4) "Dogs"
+  [2]=>
+  string(5) "Birds"
+}
+Cats, Dogs, Birds


### PR DESCRIPTION
### Description

Variadic arguments were being passed to a tracing closure incorrectly when the function signature was empty. This fixes issue #857. 

This also includes a tiny build fix for PHP 5 on Mac.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
