### PR TITLE
Bump version to 0.45.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,7 @@
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
 ## Important behavior changes in this release
-As of this release you can no longer trace a function or method if it has already been called. All instrumentation should happen before the target calls are run (and ideally before it is even defined, which can enable more aggressive optimizations in the future).
+If you are using `dd_trace`, `dd_trace_function`, or `dd_trace_method` then you need to call these functions before the first invocation of the target e.g. `dd_trace('foo', ...)` should be done before `foo` is called for the first time.
 
 ### Changed
 

--- a/package.xml
+++ b/package.xml
@@ -10,17 +10,35 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
-    <date>${date}</date>
+    <date>2020-05-12</date>
     <version>
-        <release>${version}</release>
-        <api>${version}</api>
+        <release>0.45.0</release>
+        <api>0.45.0</api>
     </version>
     <stability>
         <release>stable</release>
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+## Important behavior changes in this release
+As of this release you can no longer trace a function or method if it has already been called. All instrumentation should happen before the target calls are run (and ideally before it is even defined, which can enable more aggressive optimizations in the future).
+
+### Changed
+
+- Compile to one single file #840, #874
+- Simplify configuration #833, #870
+- Refactor module blacklist #852
+- Cache that a function is not traced #854, #863
+- Simplify spl_autoload_register instrumentation #867
+- Use normalized URL as the resource name for curl #869 (thanks, @akdh!)
+- Sandbox header and http_response_code #875
+
+### Fixed
+
+- Fix variadic args with empty function signature #872
+- Bump phpstan to 0.12 and fix issues #841
+    </notes>
     <contents>
         <dir name="/">
             <dir name="src">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '1.0.0-nightly'; // Update ./version.php too
+    const VERSION = '0.45.0'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '1.0.0-nightly'; // Update Tracer::VERSION too
+return '0.45.0'; // Update Tracer::VERSION too

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.45.0"
 #endif


### PR DESCRIPTION
### Description

If you are using dd_trace, dd_trace_function, or dd_trace_method then you need to call these functions before the first invocation of the target e.g. dd_trace('foo', ...) should be done before foo is called for the first time.

### Changed

- Compile to one single file #840, #874
- Simplify configuration #833, #870
- Refactor module blacklist #852
- Cache that a function is not traced #854, #863
- Simplify spl_autoload_register instrumentation #867
- Use normalized URL as the resource name for curl #869 (thanks, @akdh!)
- Sandbox header and http_response_code #875

### Fixed

- Fix variadic args with empty function signature #872
- Bump phpstan to 0.12 and fix issues #841

