### PR TITLE
Move Slim to Sandboxed API

### DIFF
--- a/bridge/_files.php
+++ b/bridge/_files.php
@@ -84,6 +84,7 @@ return [
     __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/Slim/SlimIntegration.php',
+    __DIR__ . '/../src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/Symfony/SymfonyIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchCommon.php',

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -26,6 +26,7 @@ use DDTrace\Integrations\PDO\PDOSandboxedIntegration;
 use DDTrace\Integrations\Predis\PredisIntegration;
 use DDTrace\Integrations\Predis\PredisSandboxedIntegration;
 use DDTrace\Integrations\Slim\SlimIntegration;
+use DDTrace\Integrations\Slim\SlimSandboxedIntegration;
 use DDTrace\Integrations\Symfony\SymfonyIntegration;
 use DDTrace\Integrations\Symfony\SymfonySandboxedIntegration;
 use DDTrace\Integrations\Web\WebIntegration;
@@ -111,6 +112,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\PDO\PDOSandboxedIntegration';
             $this->integrations[PredisSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Predis\PredisSandboxedIntegration';
+            $this->integrations[SlimSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Slim\SlimSandboxedIntegration';
             if (\PHP_MAJOR_VERSION > 5) {
                 $this->integrations[SymfonySandboxedIntegration::NAME] =
                     '\DDTrace\Integrations\Symfony\SymfonySandboxedIntegration';

--- a/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace DDTrace\Integrations\Slim;
+
+use DDTrace\GlobalTracer;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+use Psr\Http\Message\ServerRequestInterface;
+
+class SlimSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'slim';
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Add instrumentation to PDO requests
+     */
+    public function init()
+    {
+        $integration = $this;
+        $appName = \ddtrace_config_app_name(self::NAME);
+
+        \dd_trace_method('Slim\App', '__construct', function () use ($integration, $appName) {
+            // At the moment we only report internals of Slim 3.*
+            $majorVersion = substr(self::VERSION, 0, 1);
+            if ('3' !== $majorVersion) {
+                return false;
+            }
+
+             // Overwrite root span info
+             $rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
+             $rootSpan->setIntegration($integration);
+             $rootSpan->setTraceAnalyticsCandidate();
+             $rootSpan->overwriteOperationName('slim.request');
+             $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
+
+             // Hook into the router to extract the proper route name
+            \dd_trace_method('Slim\Router', 'lookupRoute', function (SpanData $span, $args, $return) use ($rootSpan) {
+                /** @var \Slim\Interfaces\RouteInterface $route */
+                $route = $return;
+                $rootSpan->setTag(
+                    Tag::RESOURCE_NAME,
+                    $_SERVER['REQUEST_METHOD'] . ' ' . ($route->getName() ?: $route->getPattern())
+                );
+                return false;
+            });
+
+            // Providing info about the controller
+            $traceControllers = function (SpanData $span, $args) use ($rootSpan, $appName) {
+                $callable = $args[0];
+                $callableName = '{unknown callable}';
+                \is_callable($callable, false, $callableName);
+                $rootSpan->setTag('slim.route.controller', $callableName);
+
+                $span->name = 'slim.route.controller';
+                $span->resource = $callableName ?: 'controller';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $appName;
+
+                /** @var ServerRequestInterface $request */
+                $request = $args[1];
+                $rootSpan->setTag(Tag::HTTP_URL, (string) $request->getUri());
+            };
+            // If the tracer ever supports tracing an interface, we should trace the following:
+            // Slim\Interfaces\InvocationStrategyInterface::__invoke
+            \dd_trace_method('Slim\Handlers\Strategies\RequestResponse', '__invoke', [
+                'prehook' => $traceControllers,
+            ]);
+            \dd_trace_method('Slim\Handlers\Strategies\RequestResponseArgs', '__invoke', [
+                'prehook' => $traceControllers,
+            ]);
+
+            // Handling Twig views
+            \dd_trace_method('Slim\Views\Twig', 'render', function (SpanData $span, $args) use ($appName) {
+                $span->name = 'slim.view';
+                $span->service = $appName;
+                $span->type = Type::WEB_SERVLET;
+                $template = $args[1];
+                $span->resource = $template;
+                $span->meta['slim.view'] = $template;
+                $span->meta['integration.name'] = SlimSandboxedIntegration::NAME;
+            });
+
+            return false;
+        });
+
+        return SandboxedIntegration::LOADED;
+    }
+}

--- a/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
@@ -36,14 +36,14 @@ class SlimSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
 
-             // Overwrite root span info
-             $rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
-             $rootSpan->setIntegration($integration);
-             $rootSpan->setTraceAnalyticsCandidate();
-             $rootSpan->overwriteOperationName('slim.request');
-             $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
+            // Overwrite root span info
+            $rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
+            $rootSpan->setIntegration($integration);
+            $rootSpan->setTraceAnalyticsCandidate();
+            $rootSpan->overwriteOperationName('slim.request');
+            $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
 
-             // Hook into the router to extract the proper route name
+            // Hook into the router to extract the proper route name
             \dd_trace_method('Slim\Router', 'lookupRoute', function (SpanData $span, $args, $return) use ($rootSpan) {
                 /** @var \Slim\Interfaces\RouteInterface $route */
                 $route = $return;

--- a/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
@@ -22,7 +22,7 @@ class SlimSandboxedIntegration extends SandboxedIntegration
     }
 
     /**
-     * Add instrumentation to PDO requests
+     * Add instrumentation to Slim requests
      */
     public function init()
     {

--- a/tests/Integrations/Slim/V3_12/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosSandboxedTest.php
@@ -4,6 +4,7 @@ namespace DDTrace\Tests\Integrations\Slim\V3_12;
 
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+use DDTrace\Util\Versions;
 
 final class CommonScenariosSandboxedTest extends CommonScenariosTest
 {
@@ -26,48 +27,36 @@ final class CommonScenariosSandboxedTest extends CommonScenariosTest
 
     public function provideSpecs()
     {
-        return $this->buildDataProvider(
-            [
-                'A simple GET request returning a string' => [
-                    SpanAssertion::build(
-                        'slim.request',
-                        'slim_test_app',
-                        'web',
-                        'GET simple-route'
-                    )->withExactTags([
-                        'slim.route.controller' => 'Closure::__invoke',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                        'integration.name' => 'slim',
-                    ])->withChildren([
+        if (Versions::phpVersionMatches('5.6')) {
+            // Controller's __invoke method is not traced until we move the Sandboxed API to zend_execute_ex and
+            // zend_execute_internals so some metadata is missing in 5.6, e.g. controller name.
+            return $this->buildDataProvider(
+                [
+                    'A simple GET request returning a string' => [
                         SpanAssertion::build(
-                            'slim.route.controller',
+                            'slim.request',
                             'slim_test_app',
                             'web',
-                            'Closure::__invoke'
-                        )
-                    ]),
-                ],
-                'A simple GET request with a view' => [
-                    SpanAssertion::build(
-                        'slim.request',
-                        'slim_test_app',
-                        'web',
-                        'GET /simple_view'
-                    )->withExactTags([
-                        'slim.route.controller' => 'App\SimpleViewController::index',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple_view',
-                        'http.status_code' => '200',
-                        'integration.name' => 'slim',
-                    ])->withChildren([
+                            'GET simple-route'
+                        )->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => '/simple',
+                            'http.status_code' => '200',
+                            'integration.name' => 'slim',
+                        ]),
+                    ],
+                    'A simple GET request with a view' => [
                         SpanAssertion::build(
-                            'slim.route.controller',
+                            'slim.request',
                             'slim_test_app',
                             'web',
-                            'App\SimpleViewController::index'
-                        )->withChildren([
+                            'GET /simple_view'
+                        )->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => '/simple_view',
+                            'http.status_code' => '200',
+                            'integration.name' => 'slim',
+                        ])->withChildren([
                             SpanAssertion::build(
                                 'slim.view',
                                 'slim_test_app',
@@ -77,34 +66,104 @@ final class CommonScenariosSandboxedTest extends CommonScenariosTest
                                 'slim.view' => 'simple_view.phtml',
                                 'integration.name' => 'slim',
                             ])
-                        ])
-                    ]),
-                ],
-                'A GET request with an exception' => [
-                    SpanAssertion::build(
-                        'slim.request',
-                        'slim_test_app',
-                        'web',
-                        'GET /error'
-                    )->withExactTags([
-                        'slim.route.controller' => 'Closure::__invoke',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/error',
-                        'http.status_code' => '500',
-                        'integration.name' => 'slim',
-                    ])->setError(null, null)
-                        ->withChildren([
+                        ]),
+                    ],
+                    'A GET request with an exception' => [
+                        SpanAssertion::build(
+                            'slim.request',
+                            'slim_test_app',
+                            'web',
+                            'GET /error'
+                        )->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => '/error',
+                            'http.status_code' => '500',
+                            'integration.name' => 'slim',
+                        ])->setError(null, null /* On PHP 5.6 slim error messages are not traced on sandboxed */),
+                    ],
+                ]
+            );
+        } else {
+            return $this->buildDataProvider(
+                [
+                    'A simple GET request returning a string' => [
+                        SpanAssertion::build(
+                            'slim.request',
+                            'slim_test_app',
+                            'web',
+                            'GET simple-route'
+                        )->withExactTags([
+                            'slim.route.controller' => 'Closure::__invoke',
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/simple',
+                            'http.status_code' => '200',
+                            'integration.name' => 'slim',
+                        ])->withChildren([
                             SpanAssertion::build(
                                 'slim.route.controller',
                                 'slim_test_app',
                                 'web',
                                 'Closure::__invoke'
-                            )->withExistingTagsNames([
-                                'error.stack'
-                            ])->setError(null, 'Foo error')
+                            )
                         ]),
-                ],
-            ]
-        );
+                    ],
+                    'A simple GET request with a view' => [
+                        SpanAssertion::build(
+                            'slim.request',
+                            'slim_test_app',
+                            'web',
+                            'GET /simple_view'
+                        )->withExactTags([
+                            'slim.route.controller' => 'App\SimpleViewController::index',
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/simple_view',
+                            'http.status_code' => '200',
+                            'integration.name' => 'slim',
+                        ])->withChildren([
+                            SpanAssertion::build(
+                                'slim.route.controller',
+                                'slim_test_app',
+                                'web',
+                                'App\SimpleViewController::index'
+                            )->withChildren([
+                                SpanAssertion::build(
+                                    'slim.view',
+                                    'slim_test_app',
+                                    'web',
+                                    'simple_view.phtml'
+                                )->withExactTags([
+                                    'slim.view' => 'simple_view.phtml',
+                                    'integration.name' => 'slim',
+                                ])
+                            ])
+                        ]),
+                    ],
+                    'A GET request with an exception' => [
+                        SpanAssertion::build(
+                            'slim.request',
+                            'slim_test_app',
+                            'web',
+                            'GET /error'
+                        )->withExactTags([
+                            'slim.route.controller' => 'Closure::__invoke',
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/error',
+                            'http.status_code' => '500',
+                            'integration.name' => 'slim',
+                        ])->setError(null, null)
+                            ->withChildren([
+                                SpanAssertion::build(
+                                    'slim.route.controller',
+                                    'slim_test_app',
+                                    'web',
+                                    'Closure::__invoke'
+                                )->withExistingTagsNames([
+                                    'error.stack'
+                                ])->setError(null, 'Foo error')
+                            ]),
+                    ],
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR moves the Slim integration to the sandbox api. One span (the one for controller) added to the stack as we need to instrument the controller in order to extract relevant metadata and non-instrumentation api is not implemented yet, so as a consequence we would see orphaned spans.

Cavits: `error.msg` is missing in php 5.6 as we are not able to trace `*->__invoke`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
