### PR TITLE
Fix uncaught exceptions with auto flushing enabled

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -158,7 +158,9 @@
                     <file name="dd_trace_tracer_is_limited_memory.phpt" role="test" />
                     <dir name="sandbox">
                         <file name="auto_flush.phpt" role="test" />
+                        <file name="auto_flush_attach_exception.phpt" role="test" />
                         <file name="auto_flush_disables_tracing.phpt" role="test" />
+                        <file name="auto_flush_sandbox_exception.phpt" role="test" />
                         <file name="auto_flush_userland_root_span.phpt" role="test" />
                         <file name="close-on-exit.phpt" role="test" />
                         <file name="close-on-exit-retval.phpt" role="test" />
@@ -191,7 +193,9 @@
                         <file name="exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt" role="test" />
                         <file name="exceptions_in_tracing_closure_and_original_call.phpt" role="test" />
                         <file name="exit_and_drop_span.phpt" role="test" />
+                        <file name="fake_global_tracer.inc" role="test" />
                         <file name="fake_tracer.inc" role="test" />
+                        <file name="fake_tracer_exception.inc" role="test" />
                         <file name="fatal_errors_ignored_in_shutdown.phpt" role="test" />
                         <file name="fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
                         <file name="generator.phpt" role="test" />

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -10,6 +10,7 @@ DD_TRACE_AUTO_FLUSH_ENABLED=1
 use DDTrace\SpanData;
 
 require 'fake_tracer.inc';
+require 'fake_global_tracer.inc';
 
 dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Auto-flushing will attach an exception during exception cleanup
+--DESCRIPTION--
+@see https://github.com/DataDog/dd-trace-php/issues/879
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require 'fake_tracer.inc';
+require 'fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+dd_trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer...
+Foo.bar (error: Oops!)
+Tracer reset
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -10,6 +10,7 @@ DD_TRACE_AUTO_FLUSH_ENABLED=1
 use DDTrace\SpanData;
 
 require 'fake_tracer.inc';
+require 'fake_global_tracer.inc';
 
 // This is called from the flush() method of the fake tracer
 dd_trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Auto-flushing will sandbox an exception thrown from the tracer flush
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require 'fake_tracer_exception.inc';
+require 'fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+dd_trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer with exception...
+Unable to auto flush the tracer
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -10,6 +10,7 @@ DD_TRACE_AUTO_FLUSH_ENABLED=1
 use DDTrace\SpanData;
 
 require 'fake_tracer.inc';
+require 'fake_global_tracer.inc';
 
 dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';

--- a/tests/ext/sandbox/fake_global_tracer.inc
+++ b/tests/ext/sandbox/fake_global_tracer.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace DDTrace;
+
+class GlobalTracer
+{
+    private static $instance;
+
+    public static function set(Tracer $tracer)
+    {
+        self::$instance = $tracer;
+    }
+
+    public static function get()
+    {
+        if (null !== self::$instance) {
+            return self::$instance;
+        }
+        return self::$instance = new Tracer();
+    }
+}

--- a/tests/ext/sandbox/fake_tracer.inc
+++ b/tests/ext/sandbox/fake_tracer.inc
@@ -25,6 +25,9 @@ class Tracer
             if (!empty($values)) {
                 echo ' (' . implode(', ', $values) . ')';
             }
+            if (isset($span['meta']['error.msg'])) {
+                echo ' (error: ' . $span['meta']['error.msg'] . ')';
+            }
             echo PHP_EOL;
         }, dd_trace_serialize_closed_spans());
 
@@ -35,24 +38,6 @@ class Tracer
     public function reset()
     {
         echo 'Tracer reset' . PHP_EOL;
-    }
-}
-
-class GlobalTracer
-{
-    private static $instance;
-
-    public static function set(Tracer $tracer)
-    {
-        self::$instance = $tracer;
-    }
-
-    public static function get()
-    {
-        if (null !== self::$instance) {
-            return self::$instance;
-        }
-        return self::$instance = new Tracer();
     }
 }
 

--- a/tests/ext/sandbox/fake_tracer_exception.inc
+++ b/tests/ext/sandbox/fake_tracer_exception.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace DDTrace;
+
+class Tracer
+{
+    public function flush()
+    {
+        echo 'Flushing tracer with exception...' . PHP_EOL;
+        throw new \Exception('You should not see this');
+    }
+
+    public function reset()
+    {
+        echo 'Tracer reset' . PHP_EOL;
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes #879. When `DD_TRACE_AUTO_FLUSH_ENABLED=1`, the tracer will flush automatically when the open span stack reaches `0`. If there is an exception that has not been caught by the time it bubbles past the root span, the exception will get cleared when the tracer auto flushes. This occurs before PHP has finished handling the exception and causes a crash.

This PR prevents the original exception from being cleared during auto flushing. And although the auto flushing was sandboxed for PHP errors, it was not sandboxed for exceptions. This PR ensures that if an exception is thrown from the userland tracer during an auto flush, it will also be sandboxed.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
