### PR TITLE
Prevent curl and guzzle from inheriting top level app name

### DIFF
--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -43,12 +43,10 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
             return SandboxedIntegration::NOT_LOADED;
         }
 
-        $service = \ddtrace_config_app_name(self::NAME);
-
         \dd_trace_function('curl_exec', [
             // the ddtrace extension will handle distributed headers
             'instrument_when_limited' => 0,
-            'posthook' => function (SpanData $span, $args, $retval) use ($service) {
+            'posthook' => function (SpanData $span, $args, $retval) {
                 $span->name = $span->resource = 'curl_exec';
                 $span->type = Type::HTTP_CLIENT;
                 $span->service = $service;
@@ -71,6 +69,8 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
 
                 if (\ddtrace_config_http_client_split_by_domain_enabled()) {
                     $span->service = Urls::hostnameForTag($sanitizedUrl);
+                } else {
+                    $span->service = 'curl';
                 }
 
                 $span->resource = $normalizedUrl;

--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -49,7 +49,7 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
             'posthook' => function (SpanData $span, $args, $retval) {
                 $span->name = $span->resource = 'curl_exec';
                 $span->type = Type::HTTP_CLIENT;
-                $span->service = $service;
+                $span->service = 'curl';
 
                 if (!isset($args[0])) {
                     return;
@@ -69,8 +69,6 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
 
                 if (\ddtrace_config_http_client_split_by_domain_enabled()) {
                     $span->service = Urls::hostnameForTag($sanitizedUrl);
-                } else {
-                    $span->service = 'curl';
                 }
 
                 $span->resource = $normalizedUrl;

--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -32,7 +32,6 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
         }
 
         $integration = $this;
-        $service = \ddtrace_config_app_name(self::NAME);
 
         /* Until we support both pre- and post- hooks on the same function, do
          * not send distributed tracing headers; curl will almost guaranteed do
@@ -41,10 +40,10 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
         \dd_trace_method(
             'GuzzleHttp\Client',
             'send',
-            function (SpanData $span, $args, $retval) use ($integration, $service) {
+            function (SpanData $span, $args, $retval) use ($integration) {
                 $span->resource = 'send';
                 $span->name = 'GuzzleHttp\Client.send';
-                $span->service = $service;
+                $span->service = 'guzzle';
                 $span->type = Type::HTTP_CLIENT;
 
                 if (isset($args[0])) {
@@ -72,10 +71,10 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
         \dd_trace_method(
             'GuzzleHttp\Client',
             'transfer',
-            function (SpanData $span, $args, $retval) use ($integration, $service) {
+            function (SpanData $span, $args, $retval) use ($integration) {
                 $span->resource = 'transfer';
                 $span->name = 'GuzzleHttp\Client.transfer';
-                $span->service = $service;
+                $span->service = 'guzzle';
                 $span->type = Type::HTTP_CLIENT;
 
                 if (isset($args[0])) {

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -195,10 +195,17 @@ final class SpanChecker
         foreach ($flatSpans as $span) {
             $byId[$span['span_id']] = ['span' => $span, 'children' => []];
         }
+        // PHP 5.6 and 7.* handle differently the way a foreach is done while removing in the loop items
+        // from the array itself. As a quick fix, we iterate over keys instead of elements themselves.
+        $spanIds = \array_keys($byId);
 
         do {
             $lastCount = count($byId);
-            foreach ($byId as $id => $data) {
+            foreach ($spanIds as $id) {
+                if (!\array_key_exists($id, $byId)) {
+                    continue;
+                }
+                $data = $byId[$id];
                 $span = $data['span'];
                 $hasPendingChildren = false;
                 foreach ($byId as $candidateId => $candidateData) {

--- a/tests/Integrations/Curl/curl_in_web_request.php
+++ b/tests/Integrations/Curl/curl_in_web_request.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, 'http://httpbin_integration/status/200');

--- a/tests/Integrations/Curl/curl_in_web_request.php
+++ b/tests/Integrations/Curl/curl_in_web_request.php
@@ -1,0 +1,6 @@
+<?
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'http://httpbin_integration/status/200');
+curl_exec($ch);
+curl_close($ch);

--- a/tests/Integrations/Guzzle/V5/guzzle_in_web_request.php
+++ b/tests/Integrations/Guzzle/V5/guzzle_in_web_request.php
@@ -1,0 +1,10 @@
+<?
+
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\Request;
+
+$client = new Client();
+$request = new Request('get', 'http://httpbin_integration/status/200');
+$client->send($request);

--- a/tests/Integrations/Guzzle/V5/guzzle_in_web_request.php
+++ b/tests/Integrations/Guzzle/V5/guzzle_in_web_request.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 require __DIR__ . '/../../../../vendor/autoload.php';
 

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Psr7\Response;
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\GlobalTracer;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 class GuzzleIntegrationTest extends IntegrationTestCase
 {
@@ -240,6 +241,41 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://example.com',
                     'http.status_code' => '200',
+                ]),
+        ]);
+    }
+
+    public function testDoesNotInheritTopLevelAppName()
+    {
+        $traces = $this->inWebServer(
+            function ($execute) {
+                $execute(GetSpec::create('GET', '/'));
+            },
+            __DIR__ . '/guzzle_in_web_request.php',
+            [
+                'DD_SERVICE_NAME' => 'top_level_app',
+                'DD_TRACE_SANDBOX_ENABLED' => static::IS_SANDBOX,
+                'DD_TRACE_NO_AUTOLOADER' => true,
+            ]
+        );
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build('web.request', 'top_level_app', 'web', 'GET /')
+                ->withExistingTagsNames(['http.method', 'http.url', 'http.status_code'])
+                ->withChildren([
+                    SpanAssertion::build('GuzzleHttp\Client.send', 'guzzle', 'http', 'send')
+                        ->setTraceAnalyticsCandidate()
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => self::URL . '/status/200',
+                            'http.status_code' => '200',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('GuzzleHttp\Client.transfer')
+                                ->withChildren([
+                                    SpanAssertion::exists('curl_exec'),
+                                ]),
+                        ]),
                 ]),
         ]);
     }

--- a/tests/Integrations/Guzzle/V6/guzzle_in_web_request.php
+++ b/tests/Integrations/Guzzle/V6/guzzle_in_web_request.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 require __DIR__ . '/../../../../vendor/autoload.php';
 

--- a/tests/Integrations/Guzzle/V6/guzzle_in_web_request.php
+++ b/tests/Integrations/Guzzle/V6/guzzle_in_web_request.php
@@ -1,0 +1,10 @@
+<?
+
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+
+$client = new Client();
+$request = new Request('get', 'http://httpbin_integration/status/200');
+$client->send($request);


### PR DESCRIPTION
### Description

Problem:
 - `curl` and `guzzle` should not inherit the top level service name. Their service name should instead always be `curl` and `guzzle` respectively.
- If they inherit top level app name as a service, then service mapping is impossible.

What was happening:
- For `curl` and `guzzle` we were computing the service name as `$service = \ddtrace_config_app_name(self::NAME);` when we were 'loading' the integration.
- If a user DID NOT set `DD_SERVICE_NAME` then what we would end up with was `curl'/'guzzle`.
- If a user DID set `DD_SERVICE_NAME` then the default `self::NAME` was not used and the service name was set to the top level service name, making service mapping impossible.

Why we did not detect it in tests?
- We only tested `curl` and `guzzle` in integration (not in a web request with `DD_SERVICE_NAME` set.
- In all our tests we actually could test `curl`/`guzzle` then.

What this PR does?
- We fix the behavior so now service mapping can work.
- We added tests for `curl`, `guzzle5` and `guzzle6` in real web requests with altered `DD_SERVICE_NAME`.
- All other libraries were manually checked and do not present this issue, but a Jira was created to make sure we assert this kind of behavior (in a separate PR with lower priority) for all our remaining library integrations.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
