### PR TITLE
Change PDO service name to lowercase

### DIFF
--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -77,7 +77,7 @@ class PDOIntegration extends Integration
             );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             $span->setTag(Tag::RESOURCE_NAME, 'PDO.__construct');
 
             // PHP 5.4 compatible try-catch-finally
@@ -113,7 +113,7 @@ class PDOIntegration extends Integration
             $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.exec');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             $span->setTag(Tag::RESOURCE_NAME, $statement);
             $span->setTraceAnalyticsCandidate();
             PDOIntegration::setConnectionTags($this, $span);
@@ -155,7 +155,7 @@ class PDOIntegration extends Integration
             $args = func_get_args();
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             $span->setTag(Tag::RESOURCE_NAME, $args[0]);
             $span->setTraceAnalyticsCandidate();
             PDOIntegration::setConnectionTags($this, $span);
@@ -196,7 +196,7 @@ class PDOIntegration extends Integration
             $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.commit');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             PDOIntegration::setConnectionTags($this, $span);
 
             // PHP 5.4 compatible try-catch-finally
@@ -229,7 +229,7 @@ class PDOIntegration extends Integration
             $scope = $tracer->startIntegrationScopeAndSpan(PDOIntegration::getInstance(), 'PDO.prepare');
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             $span->setTag(Tag::RESOURCE_NAME, $args[0]);
             PDOIntegration::setConnectionTags($this, $span);
 
@@ -265,7 +265,7 @@ class PDOIntegration extends Integration
             );
             $span = $scope->getSpan();
             $span->setTag(Tag::SPAN_TYPE, Type::SQL);
-            $span->setTag(Tag::SERVICE_NAME, 'PDO');
+            $span->setTag(Tag::SERVICE_NAME, 'pdo');
             $span->setTag(Tag::RESOURCE_NAME, $this->queryString);
             $span->setTraceAnalyticsCandidate();
             PDOIntegration::setStatementTags($this, $span);

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -47,7 +47,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = $span->resource = 'PDO.__construct';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             $span->meta = PDOSandboxedIntegration::storeConnectionParams($this, $args);
         });
@@ -58,7 +58,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.exec';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             $span->resource = $args[0];
             if (is_numeric($retval)) {
@@ -81,7 +81,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.query';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             $span->resource = $args[0];
             if ($retval instanceof \PDOStatement) {
@@ -101,7 +101,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = $span->resource = 'PDO.commit';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             PDOSandboxedIntegration::setConnectionTags($this, $span);
         });
@@ -112,7 +112,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDO.prepare';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             $span->resource = $args[0];
             PDOSandboxedIntegration::setConnectionTags($this, $span);
@@ -125,7 +125,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
                 return false;
             }
             $span->name = 'PDOStatement.execute';
-            $span->service = 'PDO';
+            $span->service = 'pdo';
             $span->type = Type::SQL;
             $span->resource = $this->queryString;
             if ($retval === true) {

--- a/tests/Integrations/PDO/PDOSandboxedTest.php
+++ b/tests/Integrations/PDO/PDOSandboxedTest.php
@@ -51,13 +51,13 @@ final class PDOSandboxedTest extends PDOTest
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build(
                 'PDO.prepare',
-                'PDO',
+                'pdo',
                 'sql',
                 $query
             )->withExactTags($this->baseTags()),
             SpanAssertion::build(
                 'PDOStatement.execute',
-                'PDO',
+                'pdo',
                 'sql',
                 $query
             )
@@ -90,13 +90,13 @@ final class PDOSandboxedTest extends PDOTest
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build(
                 'PDO.prepare',
-                'PDO',
+                'pdo',
                 'sql',
                 'object(DDTrace\Tests\Integrations\PDO\BrokenPDOStatement)#' . $objId
             )->withExactTags(SpanAssertion::NOT_TESTED),
             SpanAssertion::build(
                 'PDOStatement.execute',
-                'PDO',
+                'pdo',
                 'sql',
                 $query
             )

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -39,7 +39,7 @@ class PDOTest extends IntegrationTestCase
                 $this->pdoInstance();
         });
         $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
+            SpanAssertion::build('PDO.__construct', 'pdo', 'sql', 'PDO.__construct')
                 ->withExactTags($this->baseTags()),
         ], static::IS_SANDBOX);
     }
@@ -53,7 +53,7 @@ class PDOTest extends IntegrationTestCase
             }
         });
         $this->assertSpans($traces, [
-            SpanAssertion::build('PDO.__construct', 'PDO', 'sql', 'PDO.__construct')
+            SpanAssertion::build('PDO.__construct', 'pdo', 'sql', 'PDO.__construct')
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.user' => 'wrong_user',
                 ]))
@@ -73,7 +73,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.rowcount' => '1',
@@ -97,7 +97,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
                 ->withExactTags($this->baseTags()),
@@ -122,7 +122,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.exec', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_EXEC, true)
                 ->withExactTags($this->baseTags()),
@@ -139,7 +139,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.rowcount' => '1',
@@ -160,7 +160,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
                 ->withExactTags($this->baseTags()),
@@ -181,7 +181,7 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.query', 'PDO', 'sql', $query)
+            SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_QUERY, true)
                 ->withExactTags($this->baseTags()),
@@ -201,7 +201,7 @@ class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::exists('PDO.exec'),
-            SpanAssertion::build('PDO.commit', 'PDO', 'sql', 'PDO.commit')
+            SpanAssertion::build('PDO.commit', 'pdo', 'sql', 'PDO.commit')
                 ->withExactTags($this->baseTags()),
         ]);
     }
@@ -223,13 +223,13 @@ class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build(
                 'PDO.prepare',
-                'PDO',
+                'pdo',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
             )->withExactTags($this->baseTags()),
             SpanAssertion::build(
                 'PDOStatement.execute',
-                'PDO',
+                'pdo',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
             )
@@ -295,9 +295,9 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
+            SpanAssertion::build('PDO.prepare', 'pdo', 'sql', "WRONG QUERY")
                 ->withExactTags($this->baseTags()),
-            SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
+            SpanAssertion::build('PDOStatement.execute', 'pdo', 'sql', "WRONG QUERY")
                 ->settraceanalyticscandidate()
                 ->seterror('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
                     ->withExactTags($this->baseTags()),
@@ -322,9 +322,9 @@ class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
-            SpanAssertion::build('PDO.prepare', 'PDO', 'sql', "WRONG QUERY")
+            SpanAssertion::build('PDO.prepare', 'pdo', 'sql', "WRONG QUERY")
                 ->withExactTags($this->baseTags()),
-            SpanAssertion::build('PDOStatement.execute', 'PDO', 'sql', "WRONG QUERY")
+            SpanAssertion::build('PDOStatement.execute', 'pdo', 'sql', "WRONG QUERY")
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_STATEMENT, true)
                 ->withExactTags($this->baseTags()),


### PR DESCRIPTION
### Description

Problem: we found out the having UC PDO name as sa service generates confusion with service mapping
as users were trying to do pdo:something. The reason is that service name appears as 'pdo' LC
in UI

Possible issues: manually testing this showed no drawbacks can be thought of:
  - traces already appear as 'pdo' in UI
  - the LC version is used in service map
  - search and monitors work with LC

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
