### PR TITLE
Be compatible with psr4 composer autoloading now that we have non-psr4 config functions

### DIFF
--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -115,13 +115,14 @@ function dd_wrap_autoloader()
             return $originalAutoloaderRegistered;
         }
 
+        dd_untrace('spl_autoload_register');
+
         // In case of composer, we need to be in front of it so our generated classes are loaded,
         // including non-psr4 classes and files.
         // This will not be required anymore once we move in the next release to a non wrapped autoloader.
         dd_unregister_autoloader();
         dd_register_autoloader();
 
-        dd_untrace('spl_autoload_register');
         require __DIR__ . '/dd_init.php';
     });
 }

--- a/bridge/functions.php
+++ b/bridge/functions.php
@@ -115,6 +115,12 @@ function dd_wrap_autoloader()
             return $originalAutoloaderRegistered;
         }
 
+        // In case of composer, we need to be in front of it so our generated classes are loaded,
+        // including non-psr4 classes and files.
+        // This will not be required anymore once we move in the next release to a non wrapped autoloader.
+        dd_unregister_autoloader();
+        dd_register_autoloader();
+
         dd_untrace('spl_autoload_register');
         require __DIR__ . '/dd_init.php';
     });

--- a/tests/AutoInstrumentation/AutoInstrumentationTest.php
+++ b/tests/AutoInstrumentation/AutoInstrumentationTest.php
@@ -33,7 +33,9 @@ class AutoInstrumentationTest extends BaseTestCase
 
             // We want to make sure that the version declared in composer.json is picked up instead of the installed
             // version.
-            ['composer_with_ddtrace_dependency', '0.31.0', true],
+            // NOTE: starting from 0.45.2 our autoloader is placed BEFORE composer. This means that classes from
+            // the extension win over classes from composer. An anticipation of what will happen on 0.46+.
+            ['composer_with_ddtrace_dependency', $currentTracerVersion, true],
 
             // We want to make sure that users can safely declare a dependency in the latest version of our
             // tracer in composer even if not required.

--- a/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_with_local_code_dependency/composer.json
@@ -1,5 +1,7 @@
 {
     "autoload": {
-        "files": ["../../../../bridge/autoload.php"]
+        "psr-4": {
+            "DDTrace\\": "../../../../src/DDTrace"
+        }
     }
 }


### PR DESCRIPTION
### Description

**What happened**
We recently moved from a psr4 compliant class map for our tracer to a hybrid psr4/files approach to
boost performance.
One of the changes involved was to move from psr4 `DDTrace\Configuration` class to a number of functions
in `bridge/configuration.php` hard-loaded during the required dependencies.
When a user depends in composer on datadog/dd-trace the following chain of classloaders is executed:

```
1. Composer
2. DDTrace Required
3. DDTrace Optional
```

Before configuration was accessed through `Configuration::*`. When we instantiated the `Tracer` the config class was loaded
by composer and the worst thing that could happene was a non updated version.
Now configuration is loaded from `\dd_config_*` (non-psr4) in the Tracer (Tracer is loaded from composer) but no-one, this far
required any required deps, which would bring the configuration functions.

**What this PR do**
We put our autoloader in front of composer.

```
1. DDTrace Required
2. DDTrace Optional
3. Composer
```

So now we are in charge of loading our classes.

**Why we did not detect this**

We have recently [changed](https://github.com/DataDog/dd-trace-php/commit/767170bd61dfb878729511a6d634e8e31b19f8ec) our tests that had to detect such scenarios from a psr4 dependency on our local code to a hard-coded `files` approach. This has the consequence that were not testing anymore our co-existence with psr4 envs using manual instrumentation (AKA the standard case of composer).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
