### PR TITLE
Install internal function handlers at startup (PHP 7)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -59,7 +59,7 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php5_4/blacklist.c \
       src/ext/php5_4/dispatch.c \
       src/ext/php5_4/engine_hooks.c \
-      src/ext/php5_4/handlers_curl.c \
+      src/ext/php5_4/handlers_internal.c \
     "
   elif test $PHP_VERSION -lt 70000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
@@ -67,7 +67,7 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php5/blacklist.c \
       src/ext/php5/dispatch.c \
       src/ext/php5/engine_hooks.c \
-      src/ext/php5/handlers_curl.c \
+      src/ext/php5/handlers_internal.c \
     "
   elif test $PHP_VERSION -lt 80000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
@@ -77,6 +77,10 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php7/engine_api.c \
       src/ext/php7/engine_hooks.c \
       src/ext/php7/handlers_curl.c \
+      src/ext/php7/handlers_internal.c \
+      src/ext/php7/handlers_memcached.c \
+      src/ext/php7/handlers_mysqli.c \
+      src/ext/php7/handlers_pdo.c \
     "
   else
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES=""

--- a/package.xml
+++ b/package.xml
@@ -44,7 +44,7 @@
                     <file name="configuration_php_iface.c" role="src" />
                     <file name="coms.c" role="src" />
                     <file name="coms.h" role="src" />
-                    <file name="handlers_curl.h" role="src" />
+                    <file name="handlers_internal.h" role="src" />
                     <file name="macros.h" role="src" />
                     <file name="ddtrace.c" role="src" />
                     <file name="ddtrace.h" role="src" />
@@ -99,7 +99,7 @@
                         <file name="blacklist.c" role="src" />
                         <file name="dispatch.c" role="src" />
                         <file name="engine_hooks.c" role="src" />
-                        <file name="handlers_curl.c" role="src" />
+                        <file name="handlers_internal.c" role="src" />
                     </dir>
                     <dir name="php7">
                         <file name="auto_flush.c" role="src" />
@@ -109,6 +109,10 @@
                         <file name="engine_api.h" role="src" />
                         <file name="engine_hooks.c" role="src" />
                         <file name="handlers_curl.c" role="src" />
+                        <file name="handlers_internal.c" role="src" />
+                        <file name="handlers_memcached.c" role="src" />
+                        <file name="handlers_mysqli.c" role="src" />
+                        <file name="handlers_pdo.c" role="src" />
                     </dir>
                     <dir name="third-party">
                         <file name="mt19937-64.c" role="src" />

--- a/package.xml
+++ b/package.xml
@@ -363,6 +363,8 @@
                     <file name="throw_exception.phpt" role="test" />
                     <file name="trace_method_or_function_that_will_exist_later.phpt" role="test" />
                     <file name="trace_static_method.phpt" role="test" />
+                    <file name="traced_internal_functions_override_01.phpt" role="test" />
+                    <file name="traced_internal_functions_override_02.phpt" role="test" />
                     <file name="used_dispatch_shouldn_t_be_freed.phpt" role="test" />
                     <file name="variable_length_parameter_list.phpt" role="test" />
                     <file name="very_nested_functions.phpt" role="test" />

--- a/src/ext/arrays.c
+++ b/src/ext/arrays.c
@@ -22,7 +22,7 @@ void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *contex
 }
 #endif
 
-void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len) {
+void *ddtrace_hash_find_ptr(const HashTable *ht, const char *str, size_t len) {
     void *result;
 #if PHP_VERSION_ID < 70000
     void **rv = NULL;
@@ -33,7 +33,7 @@ void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len) {
     return result;
 }
 
-void *ddtrace_hash_find_ptr_lc(HashTable *ht, const char *str, size_t len) {
+void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len) {
     void *result;
 #if PHP_VERSION_ID < 70000
     /* The code for the PHP 7 branch will also work on PHP 5, but if we do not

--- a/src/ext/arrays.h
+++ b/src/ext/arrays.h
@@ -12,7 +12,7 @@ void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn, void *context);
  * ht.
  * If you already have a lowered string, use ddtrace_hash_find_ptr.
  */
-void *ddtrace_hash_find_ptr_lc(HashTable *ht, const char *str, size_t len);
-void *ddtrace_hash_find_ptr(HashTable *ht, const char *str, size_t len);
+void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len);
+void *ddtrace_hash_find_ptr(const HashTable *ht, const char *str, size_t len);
 
 #endif  // DDTRACE_ARRAYS_H

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -52,8 +52,6 @@ STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateStrin
                   zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_BOOLEAN("ddtrace.strict_mode", "0", PHP_INI_SYSTEM, OnUpdateBool, strict_mode, zend_ddtrace_globals,
                     ddtrace_globals)
-STD_PHP_INI_ENTRY("ddtrace.traced_internal_functions", "", PHP_INI_SYSTEM, OnUpdateString, traced_internal_functions,
-                  zend_ddtrace_globals, ddtrace_globals)
 PHP_INI_END()
 
 static int ddtrace_startup(struct _zend_extension *extension) {

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -30,6 +30,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 char *auto_prepend_file;
 zend_bool disable;
 zend_bool disable_in_current_request;
+char *traced_internal_functions;
 char *request_init_hook;
 zend_bool request_init_hook_loaded;
 zend_bool strict_mode;

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -30,7 +30,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 char *auto_prepend_file;
 zend_bool disable;
 zend_bool disable_in_current_request;
-char *traced_internal_functions;
 char *request_init_hook;
 zend_bool request_init_hook_loaded;
 zend_bool strict_mode;

--- a/src/ext/ddtrace_string.c
+++ b/src/ext/ddtrace_string.c
@@ -23,6 +23,21 @@ static const char *_dd_memnstr(const char *haystack, const char *needle, int nee
 #endif
 }
 
+/**
+ * @param str The string to search in.
+ * @param c The character to look for.
+ * @return Returns the position of `c` in `str.ptr` if found; `str.len` otherwise.
+ */
+size_t ddtrace_string_find_char(ddtrace_string str, char c) {
+    ddtrace_zppstrlen_t i;
+    for (i = 0; i < str.len; ++i) {
+        if (str.ptr[i] == c) {
+            break;
+        }
+    }
+    return i;
+}
+
 bool ddtrace_string_contains_in_csv(ddtrace_string haystack, ddtrace_string needle) {
     const char *match, *begin, *end;
     begin = haystack.ptr;

--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -65,6 +65,13 @@ inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b) {
     return a.len == b.len && (a.ptr == b.ptr || !memcmp(a.ptr, b.ptr, a.len));
 }
 
+/**
+ * @param str The string to search in.
+ * @param c The character to look for.
+ * @return Returns the position of `c` in `str.ptr` if found; `str.len` otherwise.
+ */
+size_t ddtrace_string_find_char(ddtrace_string str, char c);
+
 /* This function is _case sensitive_.
  * Only call if haystack and needle have len > 0.
  */

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "ddtrace.h"
+#include "ddtrace_string.h"
 
 extern int ddtrace_resource;
 
@@ -86,6 +87,10 @@ inline void ddtrace_maybe_clear_exception(void) {
         zend_clear_exception();
     }
 }
+#endif
+
+#if PHP_VERSION_ID >= 70000
+PHP_FUNCTION(ddtrace_internal_function_handler);
 #endif
 
 #endif  // DD_ENGINE_HOOKS_H

--- a/src/ext/handlers_curl.h
+++ b/src/ext/handlers_curl.h
@@ -1,9 +1,0 @@
-#ifndef DDTRACE_HANDLERS_CURL_H
-#define DDTRACE_HANDLERS_CURL_H
-
-#include "compatibility.h"
-
-void ddtrace_curl_handlers_startup(void);
-void ddtrace_curl_handlers_rshutdown(void);
-
-#endif  // DDTRACE_HANDLERS_CURL_H

--- a/src/ext/handlers_internal.h
+++ b/src/ext/handlers_internal.h
@@ -1,0 +1,16 @@
+#ifndef DDTRACE_HANDLERS_INTERNAL_H
+#define DDTRACE_HANDLERS_INTERNAL_H
+
+#include <php.h>
+
+#include "ddtrace_string.h"
+
+void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname);
+void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]);
+void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, ddtrace_string methods[]);
+
+void ddtrace_internal_handlers_startup(void);
+void ddtrace_internal_handlers_shutdown(void);
+void ddtrace_internal_handlers_rshutdown(void);
+
+#endif  // DDTRACE_HANDLERS_INTERNAL_H

--- a/src/ext/php5/handlers_curl.c
+++ b/src/ext/php5/handlers_curl.c
@@ -1,4 +1,0 @@
-#include "handlers_curl.h"
-
-void ddtrace_curl_handlers_startup(void) {}
-void ddtrace_curl_handlers_rshutdown(void) {}

--- a/src/ext/php5/handlers_internal.c
+++ b/src/ext/php5/handlers_internal.c
@@ -1,0 +1,15 @@
+#include "handlers_internal.h"
+
+#include "compatibility.h"
+
+void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) { PHP5_UNUSED(ht, fname); }
+void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]) {
+    PHP5_UNUSED(ht, functions_len, functions);
+}
+void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, ddtrace_string methods[]) {
+    PHP5_UNUSED(Class, methods_len, methods);
+}
+
+void ddtrace_internal_handlers_startup(void) {}
+void ddtrace_internal_handlers_shutdown(void) {}
+void ddtrace_internal_handlers_rshutdown(void) {}

--- a/src/ext/php5_4/handlers_curl.c
+++ b/src/ext/php5_4/handlers_curl.c
@@ -1,4 +1,0 @@
-#include "handlers_curl.h"
-
-void ddtrace_curl_handlers_startup(void) {}
-void ddtrace_curl_handlers_rshutdown(void) {}

--- a/src/ext/php5_4/handlers_internal.c
+++ b/src/ext/php5_4/handlers_internal.c
@@ -1,0 +1,15 @@
+#include "handlers_internal.h"
+
+#include "compatibility.h"
+
+void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) { PHP5_UNUSED(ht, fname); }
+void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]) {
+    PHP5_UNUSED(ht, functions_len, functions);
+}
+void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, ddtrace_string methods[]) {
+    PHP5_UNUSED(Class, methods_len, methods);
+}
+
+void ddtrace_internal_handlers_startup(void) {}
+void ddtrace_internal_handlers_shutdown(void) {}
+void ddtrace_internal_handlers_rshutdown(void) {}

--- a/src/ext/php7/handlers_curl.c
+++ b/src/ext/php7/handlers_curl.c
@@ -431,8 +431,10 @@ void ddtrace_curl_handlers_startup(void) {
         _dd_install_handler(handlers[i]);
     }
 
-    ddtrace_string curl_exec = DDTRACE_STRING_LITERAL("curl_exec");
-    ddtrace_replace_internal_function(CG(function_table), curl_exec);
+    if (ddtrace_resource != -1) {
+        ddtrace_string curl_exec = DDTRACE_STRING_LITERAL("curl_exec");
+        ddtrace_replace_internal_function(CG(function_table), curl_exec);
+    }
 }
 
 void ddtrace_curl_handlers_rshutdown(void) {

--- a/src/ext/php7/handlers_internal.c
+++ b/src/ext/php7/handlers_internal.c
@@ -1,0 +1,132 @@
+#include "handlers_internal.h"
+
+#include "arrays.h"
+#include "configuration.h"
+#include "ddtrace.h"
+#include "engine_hooks.h"
+
+typedef void (*ddtrace_zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+
+void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) {
+    zend_internal_function *function;
+    function = zend_hash_str_find_ptr(ht, fname.ptr, fname.len);
+    if (function) {
+        ddtrace_zif_handler oldHandler = function->handler;
+        function->handler = PHP_FN(ddtrace_internal_function_handler);
+        function->reserved[ddtrace_resource] = oldHandler;
+    }
+}
+
+void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]) {
+    for (size_t i = 0; i < functions_len; ++i) {
+        ddtrace_string *fname = functions + i;
+        ddtrace_replace_internal_function(ht, *fname);
+    }
+}
+
+void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, ddtrace_string methods[]) {
+    zval *zv = zend_hash_str_find(CG(class_table), Class.ptr, Class.len);
+    if (!zv) {
+        return;
+    }
+
+    zend_class_entry *ce = Z_PTR_P(zv);
+    if (!ce) {
+        return;
+    }
+
+    HashTable *function_table = &ce->function_table;
+    if (!function_table) {
+        return;
+    }
+
+    ddtrace_replace_internal_functions(function_table, methods_len, methods);
+}
+
+void ddtrace_internal_handlers_install(ddtrace_string traced_internal_functions) {
+    while (traced_internal_functions.len) {
+        size_t delimiter = ddtrace_string_find_char(traced_internal_functions, ',');
+        ddtrace_string segment = {
+            .ptr = traced_internal_functions.ptr,
+            .len = delimiter,
+        };
+
+        // let's look for a colon; signifies a method
+        size_t colon = ddtrace_string_find_char(segment, ':');
+        if (colon != delimiter) {
+            // We need at least another colon and one char after the colon for this to be well-formed
+            if (delimiter - colon >= 2 && segment.ptr[colon + 1] == ':') {
+                ddtrace_string Class = {
+                    .ptr = segment.ptr,
+                    .len = colon,
+                };
+                ddtrace_string method = {
+                    .ptr = segment.ptr + colon + 2,
+                    .len = delimiter - colon - 2,
+                };
+                ddtrace_replace_internal_methods(Class, 1, &method);
+            } else {
+                // todo: should we warn?
+            }
+        } else {
+            ddtrace_replace_internal_function(CG(function_table), segment);
+        }
+
+        char *ptr = traced_internal_functions.ptr;
+        // delimiter will either be a position of comma or the end of string; skip the comma
+        delimiter += ((delimiter == traced_internal_functions.len) ? 0 : 1);
+
+        traced_internal_functions.ptr = ptr + delimiter;
+        traced_internal_functions.len -= delimiter;
+    }
+}
+
+void ddtrace_curl_handlers_startup(void);
+void ddtrace_memcached_handlers_startup(void);
+void ddtrace_mysqli_handlers_startup(void);
+void ddtrace_pdo_handlers_startup(void);
+
+void ddtrace_mysqli_handlers_shutdown(void);
+void ddtrace_pdo_handlers_shutdown(void);
+
+void ddtrace_curl_handlers_rshutdown(void);
+
+void ddtrace_internal_handlers_startup(void) {
+    ddtrace_curl_handlers_startup();
+
+    if (!get_dd_trace_sandbox_enabled()) {
+        return;
+    }
+
+    ddtrace_memcached_handlers_startup();
+    ddtrace_mysqli_handlers_startup();
+    ddtrace_pdo_handlers_startup();
+
+    // set up handlers for user-specified internal functions
+    ddtrace_string traced_internal_functions = ddtrace_string_cstring_ctor(DDTRACE_G(traced_internal_functions));
+    if (traced_internal_functions.len) {
+        ALLOCA_FLAG(use_heap)
+        ddtrace_string copy = {
+            .ptr = do_alloca(traced_internal_functions.len + 1, use_heap),
+            .len = traced_internal_functions.len,
+        };
+        zend_str_tolower_copy(copy.ptr, traced_internal_functions.ptr, traced_internal_functions.len);
+        ddtrace_internal_handlers_install(copy);
+        free_alloca(copy.ptr, use_heap);
+    }
+
+    // These don't have a better place to go (yet, anyway)
+    ddtrace_string handlers[] = {
+        DDTRACE_STRING_LITERAL("header"),
+        DDTRACE_STRING_LITERAL("http_response_code"),
+    };
+    size_t handlers_len = sizeof handlers / sizeof handlers[0];
+    ddtrace_replace_internal_functions(CG(function_table), handlers_len, handlers);
+}
+
+void ddtrace_internal_handlers_shutdown(void) {
+    ddtrace_mysqli_handlers_shutdown();
+    ddtrace_pdo_handlers_shutdown();
+}
+
+void ddtrace_internal_handlers_rshutdown(void) { ddtrace_curl_handlers_rshutdown(); }

--- a/src/ext/php7/handlers_internal.c
+++ b/src/ext/php7/handlers_internal.c
@@ -113,16 +113,13 @@ void ddtrace_internal_handlers_startup(void) {
     ddtrace_pdo_handlers_startup();
 
     // set up handlers for user-specified internal functions
-    ddtrace_string traced_internal_functions = ddtrace_string_cstring_ctor(DDTRACE_G(traced_internal_functions));
+    ddtrace_string traced_internal_functions = ddtrace_string_getenv(ZEND_STRL("DD_TRACE_TRACED_INTERNAL_FUNCTIONS"));
     if (traced_internal_functions.len) {
-        ALLOCA_FLAG(use_heap)
-        ddtrace_string copy = {
-            .ptr = do_alloca(traced_internal_functions.len + 1, use_heap),
-            .len = traced_internal_functions.len,
-        };
-        zend_str_tolower_copy(copy.ptr, traced_internal_functions.ptr, traced_internal_functions.len);
-        ddtrace_internal_handlers_install(copy);
-        free_alloca(copy.ptr, use_heap);
+        zend_str_tolower(traced_internal_functions.ptr, traced_internal_functions.len);
+        ddtrace_internal_handlers_install(traced_internal_functions);
+    }
+    if (traced_internal_functions.ptr) {
+        efree(traced_internal_functions.ptr);
     }
 
     // These don't have a better place to go (yet, anyway)

--- a/src/ext/php7/handlers_internal.c
+++ b/src/ext/php7/handlers_internal.c
@@ -11,10 +11,10 @@ typedef void (*ddtrace_zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) {
     zend_internal_function *function;
     function = zend_hash_str_find_ptr(ht, fname.ptr, fname.len);
-    if (function) {
-        ddtrace_zif_handler oldHandler = function->handler;
+    if (function && !function->reserved[ddtrace_resource]) {
+        ddtrace_zif_handler old_handler = function->handler;
         function->handler = PHP_FN(ddtrace_internal_function_handler);
-        function->reserved[ddtrace_resource] = oldHandler;
+        function->reserved[ddtrace_resource] = old_handler;
     }
 }
 

--- a/src/ext/php7/handlers_memcached.c
+++ b/src/ext/php7/handlers_memcached.c
@@ -1,0 +1,41 @@
+#include "handlers_internal.h"
+
+void ddtrace_memcached_handlers_startup(void) {
+    // clang-format off
+    ddtrace_string methods[] = {
+        DDTRACE_STRING_LITERAL("add"),
+        DDTRACE_STRING_LITERAL("addbykey"),
+        DDTRACE_STRING_LITERAL("append"),
+        DDTRACE_STRING_LITERAL("appendbykey"),
+        DDTRACE_STRING_LITERAL("cas"),
+        DDTRACE_STRING_LITERAL("casbykey"),
+        DDTRACE_STRING_LITERAL("decrement"),
+        DDTRACE_STRING_LITERAL("decrementbykey"),
+        DDTRACE_STRING_LITERAL("delete"),
+        DDTRACE_STRING_LITERAL("deletebykey"),
+        DDTRACE_STRING_LITERAL("deletemulti"),
+        DDTRACE_STRING_LITERAL("deletemultibykey"),
+        DDTRACE_STRING_LITERAL("flush"),
+        DDTRACE_STRING_LITERAL("get"),
+        DDTRACE_STRING_LITERAL("getbykey"),
+        DDTRACE_STRING_LITERAL("getmulti"),
+        DDTRACE_STRING_LITERAL("getmultibykey"),
+        DDTRACE_STRING_LITERAL("increment"),
+        DDTRACE_STRING_LITERAL("incrementbykey"),
+        DDTRACE_STRING_LITERAL("prepend"),
+        DDTRACE_STRING_LITERAL("prependbykey"),
+        DDTRACE_STRING_LITERAL("replace"),
+        DDTRACE_STRING_LITERAL("replacebykey"),
+        DDTRACE_STRING_LITERAL("set"),
+        DDTRACE_STRING_LITERAL("setbykey"),
+        DDTRACE_STRING_LITERAL("setmulti"),
+        DDTRACE_STRING_LITERAL("setmultibykey"),
+        DDTRACE_STRING_LITERAL("touch"),
+        DDTRACE_STRING_LITERAL("touchbykey"),
+    };
+    // clang-format on
+
+    ddtrace_string memcached = DDTRACE_STRING_LITERAL("memcached");
+    size_t methods_len = sizeof methods / sizeof methods[0];
+    ddtrace_replace_internal_methods(memcached, methods_len, methods);
+}

--- a/src/ext/php7/handlers_mysqli.c
+++ b/src/ext/php7/handlers_mysqli.c
@@ -1,0 +1,46 @@
+#include "handlers_internal.h"
+
+// clang-format off
+static ddtrace_string ddtrace_mysqli_functions[] = {
+    DDTRACE_STRING_LITERAL("mysqli_commit"),
+    DDTRACE_STRING_LITERAL("mysqli_connect"),
+    DDTRACE_STRING_LITERAL("mysqli_prepare"),
+    DDTRACE_STRING_LITERAL("mysqli_query"),
+    DDTRACE_STRING_LITERAL("mysqli_real_connect"),
+    DDTRACE_STRING_LITERAL("mysqli_stmt_execute"),
+    DDTRACE_STRING_LITERAL("mysqli_stmt_get_result"),
+};
+
+static ddtrace_string ddtrace_mysqli_methods[] = {
+    DDTRACE_STRING_LITERAL("__construct"),
+    DDTRACE_STRING_LITERAL("commit"),
+    DDTRACE_STRING_LITERAL("prepare"),
+    DDTRACE_STRING_LITERAL("query"),
+    DDTRACE_STRING_LITERAL("real_connect"),
+};
+
+static ddtrace_string ddtrace_mysqli_stmt_methods[] = {
+    DDTRACE_STRING_LITERAL("execute"),
+    DDTRACE_STRING_LITERAL("get_result"),
+};
+// clang-format on
+
+void ddtrace_mysqli_handlers_startup(void) {
+    // todo: how to handle ddtrace_resource = -1?
+    ddtrace_string mysqli = DDTRACE_STRING_LITERAL("mysqli");
+    if (!zend_hash_str_exists(&module_registry, mysqli.ptr, mysqli.len)) {
+        return;
+    }
+
+    size_t mysqli_functions_len = sizeof ddtrace_mysqli_functions / sizeof ddtrace_mysqli_functions[0];
+    ddtrace_replace_internal_functions(CG(function_table), mysqli_functions_len, ddtrace_mysqli_functions);
+
+    size_t mysqli_methods_len = sizeof ddtrace_mysqli_methods / sizeof ddtrace_mysqli_methods[0];
+    ddtrace_replace_internal_methods(mysqli, mysqli_methods_len, ddtrace_mysqli_methods);
+
+    ddtrace_string mysqli_stmt = DDTRACE_STRING_LITERAL("mysqli_stmt");
+    size_t mysqli_stmt_methods_len = sizeof ddtrace_mysqli_stmt_methods / sizeof ddtrace_mysqli_stmt_methods[0];
+    ddtrace_replace_internal_methods(mysqli_stmt, mysqli_stmt_methods_len, ddtrace_mysqli_stmt_methods);
+}
+
+void ddtrace_mysqli_handlers_shutdown(void) {}

--- a/src/ext/php7/handlers_mysqli.c
+++ b/src/ext/php7/handlers_mysqli.c
@@ -25,8 +25,8 @@ static ddtrace_string ddtrace_mysqli_stmt_methods[] = {
 };
 // clang-format on
 
+// Do not call this function if ddtrace_resource == -1
 void ddtrace_mysqli_handlers_startup(void) {
-    // todo: how to handle ddtrace_resource = -1?
     ddtrace_string mysqli = DDTRACE_STRING_LITERAL("mysqli");
     if (!zend_hash_str_exists(&module_registry, mysqli.ptr, mysqli.len)) {
         return;

--- a/src/ext/php7/handlers_pdo.c
+++ b/src/ext/php7/handlers_pdo.c
@@ -1,0 +1,31 @@
+#include "handlers_internal.h"
+
+// clang-format off
+static ddtrace_string ddtrace_pdo_methods[] = {
+    DDTRACE_STRING_LITERAL("__construct"),
+    DDTRACE_STRING_LITERAL("commit"),
+    DDTRACE_STRING_LITERAL("exec"),
+    DDTRACE_STRING_LITERAL("prepare"),
+    DDTRACE_STRING_LITERAL("query"),
+};
+
+static ddtrace_string ddtrace_pdostatement_methods[] = {
+    DDTRACE_STRING_LITERAL("execute"),
+};
+// clang-format on
+
+void ddtrace_pdo_handlers_startup(void) {
+    ddtrace_string pdo = DDTRACE_STRING_LITERAL("pdo");
+    if (!zend_hash_str_exists(&module_registry, pdo.ptr, pdo.len)) {
+        return;
+    }
+
+    size_t pdo_methods_len = sizeof ddtrace_pdo_methods / sizeof ddtrace_pdo_methods[0];
+    ddtrace_replace_internal_methods(pdo, pdo_methods_len, ddtrace_pdo_methods);
+
+    ddtrace_string pdostatement = DDTRACE_STRING_LITERAL("pdostatement");
+    size_t pdostatement_methods_len = sizeof ddtrace_pdostatement_methods / sizeof ddtrace_pdostatement_methods[0];
+    ddtrace_replace_internal_methods(pdostatement, pdostatement_methods_len, ddtrace_pdostatement_methods);
+}
+
+void ddtrace_pdo_handlers_shutdown(void) {}

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -12,6 +12,10 @@ use DDTrace\Time;
 use DDTrace\Tracer;
 use DDTrace\Transport\Noop as NoopTransport;
 
+function baz()
+{
+}
+
 final class TracerTest extends BaseTestCase
 {
     const OPERATION_NAME = 'test_span';
@@ -280,12 +284,12 @@ final class TracerTest extends BaseTestCase
         // Clear existing internal spans
         dd_trace_serialize_closed_spans();
 
-        dd_trace_function('array_sum', function () {
+        \dd_trace_function(__NAMESPACE__ . '\\baz', function () {
             // Do nothing
         });
         $tracer = new Tracer(new DebugTransport());
         $span = $tracer->startSpan('foo');
-        array_sum([1, 2]);
+        baz();
         $span->finish();
 
         $this->assertSame(2, dd_trace_closed_spans_count());

--- a/tests/ext/dd_trace_forward_call_for_functions.phpt
+++ b/tests/ext/dd_trace_forward_call_for_functions.phpt
@@ -1,5 +1,7 @@
 --TEST--
 The original function call is invoked from the closure
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --FILE--
 <?php
 function doStuff($foo, array $bar = [])

--- a/tests/ext/dd_trace_forward_call_with_private_callback.phpt
+++ b/tests/ext/dd_trace_forward_call_with_private_callback.phpt
@@ -1,5 +1,7 @@
 --TEST--
 A private method can be used as callback with dd_trace_forward_call()
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/dd_trace_tracer_is_limited_hard.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_tracer_is_limited() limits the tracer with a hard span limit
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
 --FILE--

--- a/tests/ext/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -1,5 +1,7 @@
 --TEST--
 [Legacy] Keep spans in limited mode (internal functions)
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
 --FILE--

--- a/tests/ext/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -1,5 +1,7 @@
 --TEST--
 [Legacy] Keep spans in limited mode (internal methods)
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
 --FILE--

--- a/tests/ext/reset_function_tracing.phpt
+++ b/tests/ext/reset_function_tracing.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Check a function can be untraced.
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION > 5) die('skip: test requires legacy API'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
@@ -2,6 +2,8 @@
 [Prehook Regression] dd_trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
@@ -2,8 +2,8 @@
 [Prehook Regression] dd_trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -2,6 +2,8 @@
 [Prehook Regression] dd_trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -2,8 +2,8 @@
 [Prehook Regression] dd_trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=mt_rand
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
@@ -2,6 +2,8 @@
 [Prehook Regression] dd_trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=DatePeriod::getStartDate
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
@@ -2,8 +2,8 @@
 [Prehook Regression] dd_trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=DatePeriod::getStartDate
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DatePeriod::getStartDate
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox-prehook/drop_spans.phpt
+++ b/tests/ext/sandbox-prehook/drop_spans.phpt
@@ -2,6 +2,8 @@
 [Prehook Regression] Span is dropped when tracing closure returns false
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum,DateTime::__construct
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/drop_spans.phpt
+++ b/tests/ext/sandbox-prehook/drop_spans.phpt
@@ -2,8 +2,8 @@
 [Prehook Regression] Span is dropped when tracing closure returns false
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum,DateTime::__construct
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,DateTime::__construct
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -4,6 +4,8 @@
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', ['prehook' => function () {

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -4,8 +4,7 @@
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', ['prehook' => function () {

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -6,6 +6,7 @@
 DD_TRACE_DEBUG=1
 --INI--
 error_reporting=E_ALL
+ddtrace.traced_internal_functions=mt_rand,mt_srand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -4,9 +4,9 @@
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
 --INI--
 error_reporting=E_ALL
-ddtrace.traced_internal_functions=mt_rand,mt_srand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox-prehook/variadic_args_internal.phpt
+++ b/tests/ext/sandbox-prehook/variadic_args_internal.phpt
@@ -2,6 +2,8 @@
 [Prehook] Variadic arguments are passed to tracing closure for internal functions
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_unshift
 --FILE--
 <?php
 dd_trace_function('array_unshift', ['prehook' => function (DDTrace\SpanData $s, array $args) {

--- a/tests/ext/sandbox-prehook/variadic_args_internal.phpt
+++ b/tests/ext/sandbox-prehook/variadic_args_internal.phpt
@@ -2,8 +2,8 @@
 [Prehook] Variadic arguments are passed to tracing closure for internal functions
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=array_unshift
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_unshift
 --FILE--
 <?php
 dd_trace_function('array_unshift', ['prehook' => function (DDTrace\SpanData $s, array $args) {

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -4,6 +4,8 @@
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function () {});

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -4,8 +4,7 @@
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function () {});

--- a/tests/ext/sandbox-regression/reset_function_tracing.phpt
+++ b/tests/ext/sandbox-regression/reset_function_tracing.phpt
@@ -2,6 +2,8 @@
 [Sandbox regression] Untrace a function
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=spl_autoload_register
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/reset_function_tracing.phpt
+++ b/tests/ext/sandbox-regression/reset_function_tracing.phpt
@@ -2,8 +2,8 @@
 [Sandbox regression] Untrace a function
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=spl_autoload_register
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=spl_autoload_register
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -5,6 +5,8 @@ Spans are automatically flushed when auto-flushing enabled
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -5,8 +5,7 @@ Spans are automatically flushed when auto-flushing enabled
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -5,6 +5,8 @@ Auto-flushing will not instrument while flushing
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -5,8 +5,7 @@ Auto-flushing will not instrument while flushing
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -5,6 +5,8 @@ Userland root spans are automatically flushed when auto-flushing enabled
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -5,8 +5,7 @@ Userland root spans are automatically flushed when auto-flushing enabled
 <?php if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
+++ b/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
@@ -2,6 +2,8 @@
 dd_trace_closed_spans_count() tracks closed spans from userland and C-level
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 var_dump(dd_trace_closed_spans_count());

--- a/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
+++ b/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
@@ -2,8 +2,8 @@
 dd_trace_closed_spans_count() tracks closed spans from userland and C-level
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 var_dump(dd_trace_closed_spans_count());

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -2,6 +2,8 @@
 dd_trace_function() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum,mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -2,8 +2,8 @@
 dd_trace_function() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum,mt_rand
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -2,6 +2,8 @@
 dd_trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -2,8 +2,8 @@
 dd_trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -2,6 +2,8 @@
 dd_trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -2,8 +2,8 @@
 dd_trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=mt_rand
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
@@ -2,6 +2,8 @@
 dd_trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=DatePeriod::getStartDate
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
@@ -2,8 +2,8 @@
 dd_trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=DatePeriod::getStartDate
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DatePeriod::getStartDate
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -4,6 +4,8 @@ Set the trace ID from userland
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -4,8 +4,7 @@ Set the trace ID from userland
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/drop_spans.phpt
+++ b/tests/ext/sandbox/drop_spans.phpt
@@ -2,6 +2,8 @@
 Span is dropped when tracing closure returns false
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum,DateTime::__construct
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/drop_spans.phpt
+++ b/tests/ext/sandbox/drop_spans.phpt
@@ -2,8 +2,8 @@
 Span is dropped when tracing closure returns false
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum,DateTime::__construct
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,DateTime::__construct
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -4,6 +4,8 @@ Exception in tracing closure gets logged
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function () {

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -4,8 +4,7 @@ Exception in tracing closure gets logged
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function () {

--- a/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
+++ b/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
@@ -3,6 +3,8 @@ Exceptions from user error handler are tracked for instrumented internal functio
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
 <?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for handling return value on PHP 5'); ?>
+--INI--
+ddtrace.traced_internal_functions=scandir
 --FILE--
 <?php
 class FooErrorHandler

--- a/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
+++ b/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
@@ -3,8 +3,8 @@ Exceptions from user error handler are tracked for instrumented internal functio
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
 <?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for handling return value on PHP 5'); ?>
---INI--
-ddtrace.traced_internal_functions=scandir
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=scandir
 --FILE--
 <?php
 class FooErrorHandler

--- a/tests/ext/sandbox/exception_is_defined.phpt
+++ b/tests/ext/sandbox/exception_is_defined.phpt
@@ -2,6 +2,8 @@
 Exceptions in the tracing closure callback are always defined
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/exception_is_defined.phpt
+++ b/tests/ext/sandbox/exception_is_defined.phpt
@@ -2,8 +2,8 @@
 Exceptions in the tracing closure callback are always defined
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -6,6 +6,7 @@ Exceptions and errors are ignored when inside a tracing closure
 DD_TRACE_DEBUG=1
 --INI--
 error_reporting=E_ALL
+ddtrace.traced_internal_functions=mt_rand,mt_srand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -4,9 +4,9 @@ Exceptions and errors are ignored when inside a tracing closure
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
 --INI--
 error_reporting=E_ALL
-ddtrace.traced_internal_functions=mt_rand,mt_srand
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -7,6 +7,7 @@ This is how the tracer sandboxes the flushing functionality in userland
 <?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
 --INI--
 memory_limit=2M
+ddtrace.traced_internal_functions=array_sum
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -7,9 +7,9 @@ This is how the tracer sandboxes the flushing functionality in userland
 <?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
 --INI--
 memory_limit=2M
-ddtrace.traced_internal_functions=array_sum
 --ENV--
 DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 function flushTracer() {

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
@@ -4,6 +4,8 @@ Fatal errors are ignored inside a tracing closure (PHP 7)
 <?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function (DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
@@ -4,8 +4,7 @@ Fatal errors are ignored inside a tracing closure (PHP 7)
 <?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
---INI--
-ddtrace.traced_internal_functions=array_sum
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 dd_trace_function('array_sum', function (DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/get_last_error.phpt
+++ b/tests/ext/sandbox/get_last_error.phpt
@@ -2,6 +2,8 @@
 Existing errors are kept
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/get_last_error.phpt
+++ b/tests/ext/sandbox/get_last_error.phpt
@@ -2,8 +2,8 @@
 Existing errors are kept
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=array_sum
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -4,6 +4,8 @@ Keep spans in limited mode (internal functions)
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+--INI--
+ddtrace.traced_internal_functions=array_sum,mt_rand
 --FILE--
 <?php
 dd_trace_function('array_sum', function (\DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -4,8 +4,7 @@ Keep spans in limited mode (internal functions)
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
---INI--
-ddtrace.traced_internal_functions=array_sum,mt_rand
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php
 dd_trace_function('array_sum', function (\DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -4,6 +4,8 @@ Keep spans in limited mode (internal methods)
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+--INI--
+ddtrace.traced_internal_functions=DateTime::format,DateTime::setTime
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -4,8 +4,7 @@ Keep spans in limited mode (internal methods)
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
---INI--
-ddtrace.traced_internal_functions=DateTime::format,DateTime::setTime
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::format,DateTime::setTime
 --FILE--
 <?php
 date_default_timezone_set('UTC');

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -12,6 +12,7 @@ DD_TRACE_MEMORY_LIMIT=0
 memory_limit=2M
 max_execution_time=5
 ddtrace.request_init_hook=
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 register_shutdown_function(function () {

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -8,11 +8,11 @@ This test ensures that when the span stack is left in a "dirty" state from a zen
 --ENV--
 DD_TRACE_SPANS_LIMIT=-1
 DD_TRACE_MEMORY_LIMIT=0
+DD_TRACE_TRACE_INTERNAL_FUNCTIONS=array_sum
 --INI--
 memory_limit=2M
 max_execution_time=5
 ddtrace.request_init_hook=
-ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 register_shutdown_function(function () {

--- a/tests/ext/sandbox/spans_out_of_sync.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync.phpt
@@ -4,6 +4,8 @@ Gracefully handle out-of-sync spans
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
+--INI--
+ddtrace.traced_internal_functions=dd_trace_serialize_closed_spans
 --FILE--
 <?php
 // Since dd_trace_serialize_closed_spans() destroys the open span stack,

--- a/tests/ext/sandbox/spans_out_of_sync.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync.phpt
@@ -4,8 +4,7 @@ Gracefully handle out-of-sync spans
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
---INI--
-ddtrace.traced_internal_functions=dd_trace_serialize_closed_spans
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
 --FILE--
 <?php
 // Since dd_trace_serialize_closed_spans() destroys the open span stack,

--- a/tests/ext/sandbox/variadic_args_internal.phpt
+++ b/tests/ext/sandbox/variadic_args_internal.phpt
@@ -2,6 +2,8 @@
 Variadic arguments are passed to tracing closure for internal functions
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--INI--
+ddtrace.traced_internal_functions=sscanf
 --FILE--
 <?php
 dd_trace_function('sscanf', function (DDTrace\SpanData $s, array $args) {

--- a/tests/ext/sandbox/variadic_args_internal.phpt
+++ b/tests/ext/sandbox/variadic_args_internal.phpt
@@ -2,8 +2,8 @@
 Variadic arguments are passed to tracing closure for internal functions
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
---INI--
-ddtrace.traced_internal_functions=sscanf
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=sscanf
 --FILE--
 <?php
 dd_trace_function('sscanf', function (DDTrace\SpanData $s, array $args) {

--- a/tests/ext/traced_internal_functions_override_01.phpt
+++ b/tests/ext/traced_internal_functions_override_01.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Ensure that if a user adds an internal function we already trace to traced internal functions list that it doesn't misbehave
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=header
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: requires dd_trace_function'); ?>
+--FILE--
+<?php
+
+dd_trace_function('header', function () {
+    echo "Traced header.\n";
+});
+
+header("x-datatdog-test-header: foo");
+
+?>
+--EXPECT--
+Traced header.
+

--- a/tests/ext/traced_internal_functions_override_02.phpt
+++ b/tests/ext/traced_internal_functions_override_02.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Ensure that if a user adds an internal function we already trace to traced internal functions list that it doesn't misbehave
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=header
+--FILE--
+<?php
+
+header("x-datatdog-test-header: foo");
+
+echo "Done.\n";
+
+?>
+--EXPECT--
+Done.
+

--- a/tests/xdebug/2.9.5/request_init_hook.phpt
+++ b/tests/xdebug/2.9.5/request_init_hook.phpt
@@ -5,6 +5,7 @@ The request init hook can run with Xdebug installed and xdebug.remote_enable=1
 --INI--
 xdebug.remote_enable=1
 ddtrace.request_init_hook={PWD}/../fake_request_init_hook.inc
+ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
 if (!extension_loaded('Xdebug') || version_compare(phpversion('Xdebug'), '2.9.5') < 0) die('Xdebug 2.9.5+ required');

--- a/tests/xdebug/2.9.5/request_init_hook.phpt
+++ b/tests/xdebug/2.9.5/request_init_hook.phpt
@@ -2,6 +2,8 @@
 The request init hook can run with Xdebug installed and xdebug.remote_enable=1
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70100) die('skip: PHP 7.1+ required'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --INI--
 xdebug.remote_enable=1
 ddtrace.request_init_hook={PWD}/../fake_request_init_hook.inc


### PR DESCRIPTION
### Description

This moves our internal function checks to startup instead of at runtime on PHP 7. When complete, this will have much less overhead than what we did before. This does mean that we have to know all internal functions that will ever be traced when the process starts up. To allow users (and ourselves in our tests) to instrument internal functions other than the ones in our integrations, there is a new environment variable `DD_TRACE_TRACED_INTERNAL_FUNCTIONS` which takes a csv of functions or methods that will be traced e.g. `DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand,DateTime::add`.

I use the reserved slot of the internal function to store the previous handler so I can use the same PHP_FUNCTION for all of the handlers, and also handle user-supplied functions in `DD_TRACE_TRACED_INTERNAL_FUNCTIONS`.

This PR tries to not install certain handlers when possible; if sandboxing is enabled then it won't install icall and zend_execute_internal hooks. This branch has been reworked a few times before the current state, so need to do a second-pass to make sure my sandboxing_enabled checks make sense.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft.
