### PR TITLE
fix opcache check in dd-doctor

### DIFF
--- a/src/dd-doctor.php
+++ b/src/dd-doctor.php
@@ -120,9 +120,10 @@ function env($key)
 function check_opcache()
 {
     if (!function_exists('opcache_get_configuration')) {
-        render('Opcache enabled:', 'NO');
+        render('Opcache installed:', 'NO');
+        return;
     }
-    render('Opcache enabled:', 'YES');
+    render('Opcache installed:', 'YES');
     $configs = opcache_get_configuration();
     foreach ($configs['directives'] as $name => $value) {
         sub_paragraph("$name = $value");


### PR DESCRIPTION
### Description

*Problems this PR fix*
- We said `Opcache enabled` while the fact that the function exists only tells if opcache is installed, while the following props will tell if opcache is enabled.
- We did not `return;` if the function did not exist, causing an error
- If opcache was enabled, we did say `Opcache enabled [NO]` + `Opcache enabled [YES]`

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
~- [ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
