### PR TITLE
Sandbox the CakePHP integration

### DIFF
--- a/bridge/_files.php
+++ b/bridge/_files.php
@@ -62,6 +62,7 @@ return [
     __DIR__ . '/../src/DDTrace/Integrations/Integration.php',
     __DIR__ . '/../src/DDTrace/Integrations/SandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php',
+    __DIR__ . '/../src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/Web/WebIntegration.php',
     __DIR__ . '/../src/DDTrace/Integrations/IntegrationsLoader.php',

--- a/composer.json
+++ b/composer.json
@@ -249,6 +249,8 @@
         "test-web-70": [
             "@test-cache-link",
             "@test-metrics",
+            "@cakephp-28-update",
+            "@cakephp-28-test",
             "@codeigniter-22-test",
             "@laravel-42-update",
             "@laravel-42-test",
@@ -267,6 +269,8 @@
         "test-web-71": [
             "@test-cache-link",
             "@test-metrics",
+            "@cakephp-28-update",
+            "@cakephp-28-test",
             "@codeigniter-22-test",
             "@laravel-42-update",
             "@laravel-42-test",

--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -5,9 +5,6 @@ namespace DDTrace\Integrations\CakePHP;
 use DDTrace\Integrations\CakePHP\V2\CakePHPIntegrationLoader;
 use DDTrace\Integrations\Integration;
 
-/**
- * The base Laravel integration which delegates loading to the appropriate integration version.
- */
 class CakePHPIntegration extends Integration
 {
     const NAME = 'cakephp';

--- a/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace DDTrace\Integrations\CakePHP;
+
+use CakeRequest;
+use DDTrace\GlobalTracer;
+use DDTrace\Integrations\SandboxedIntegration;
+use DDTrace\SpanData;
+use DDTrace\Tag;
+use DDTrace\Type;
+use Router;
+
+class CakePHPSandboxedIntegration extends SandboxedIntegration
+{
+    const NAME = 'cakephp';
+
+    public $appName;
+    public $rootSpan;
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function init()
+    {
+        if (!self::shouldLoad(self::NAME)) {
+            return self::NOT_AVAILABLE;
+        }
+
+        $integration = $this;
+
+        // CakePHP v2.x - we don't need to check for v3 since it does not have \Dispatcher or \ShellDispatcher
+        $initCakeV2 = function () use ($integration) {
+            // Since "Dispatcher" and "App" are common names, check for a CakePHP signature before loading
+            if (!defined('CAKE_CORE_INCLUDE_PATH')) {
+                return false;
+            }
+
+            $scope = GlobalTracer::get()->getRootScope();
+            if (!$scope) {
+                return false;
+            }
+            $integration->appName = \ddtrace_config_app_name(CakePHPSandboxedIntegration::NAME);
+            $integration->rootSpan = $scope->getSpan();
+            $integration->rootSpan->setIntegration($integration);
+            $integration->rootSpan->setTraceAnalyticsCandidate();
+            $integration->rootSpan->setTag(Tag::SERVICE_NAME, $integration->appName);
+            if ('cli' === PHP_SAPI) {
+                $integration->rootSpan->overwriteOperationName('cakephp.console');
+                $integration->rootSpan->setTag(
+                    Tag::RESOURCE_NAME,
+                    !empty($_SERVER['argv'][1]) ? 'cake_console ' . $_SERVER['argv'][1] : 'cake_console'
+                );
+            } else {
+                $integration->rootSpan->overwriteOperationName('cakephp.request');
+            }
+
+            \dd_trace_method('Controller', 'invokeAction', function (SpanData $span, array $args) use ($integration) {
+                $span->name = $span->resource = 'Controller.invokeAction';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $integration->appName;
+
+                $request = $args[0];
+                if (!$request instanceof CakeRequest) {
+                    return;
+                }
+
+                $integration->rootSpan->setTag(
+                    Tag::RESOURCE_NAME,
+                    $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action']
+                );
+                $integration->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
+                $integration->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
+                $integration->rootSpan->setTag('cakephp.route.action', $request->params['action']);
+                if (isset($request->params['plugin'])) {
+                    $integration->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
+                }
+            });
+
+            // This only traces the default exception renderer
+            // Remove this when error tracking is added
+            // Other possible places to trace
+            // - ErrorHandler::handleException()
+            // - Controller::appError()
+            // - Exception.handler
+            // - Exception.renderer
+            \dd_trace_method('ExceptionRenderer', '__construct', [
+                'instrument_when_limited' => 1,
+                'posthook' => function (SpanData $span, array $args) use ($integration) {
+                    $integration->rootSpan->setError($args[0]);
+                    return false;
+                },
+            ]);
+
+            // Create a trace span for every template rendered
+            \dd_trace_method('View', 'render', function (SpanData $span) use ($integration) {
+                $span->name = 'cakephp.view';
+                $span->type = Type::WEB_SERVLET;
+                $file = $this->viewPath . '/' . $this->view . $this->ext;
+                $span->resource = $file;
+                $span->meta = ['cakephp.view' => $file];
+                $span->service = $integration->appName;
+                $integration->addIntegrationInfo($span);
+            });
+
+            return false;
+        };
+
+        if ('cli' === PHP_SAPI) {
+            // CLI bootstrap
+            //\dd_trace_method('ShellDispatcher', '__construct', $initCakeV2);
+            // Workaround until we fix request_init_hook for non-autoloaded projects
+            \dd_trace_method('App', 'init', $initCakeV2);
+        } else {
+            // Web bootstrap
+            \dd_trace_method('Dispatcher', '__construct', $initCakeV2);
+        }
+
+        return SandboxedIntegration::LOADED;
+    }
+}

--- a/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
+++ b/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\CakePHP\V2;
 
-use CakeEvent;
 use CakeRequest;
 use DDTrace\GlobalTracer;
 use DDTrace\Integrations\CakePHP\CakePHPIntegration;
@@ -60,6 +59,13 @@ class CakePHPIntegrationLoader
         dd_trace('ExceptionRenderer', '__construct', function ($exception) use ($loader) {
             $loader->rootSpan->setError($exception);
             return dd_trace_forward_call();
+        });
+
+        // Set the HTTP status code
+        dd_trace('CakeResponse', 'statusCode', function () use ($loader) {
+            $code = dd_trace_forward_call();
+            $loader->rootSpan->setTag(Tag::HTTP_STATUS_CODE, $code);
+            return $code;
         });
 
         // Create a trace span for every template rendered

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Integrations;
 
 use DDTrace\Integrations\CakePHP\CakePHPIntegration;
+use DDTrace\Integrations\CakePHP\CakePHPSandboxedIntegration;
 use DDTrace\Integrations\CodeIgniter\V2\CodeIgniterSandboxedIntegration;
 use DDTrace\Integrations\Curl\CurlIntegration;
 use DDTrace\Integrations\Curl\CurlSandboxedIntegration;
@@ -88,6 +89,8 @@ class IntegrationsLoader
         $this->integrations = $integrations;
         // Sandboxed integrations get loaded with a feature flag
         if (\ddtrace_config_sandbox_enabled()) {
+            $this->integrations[CakePHPSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\CakePHP\CakePHPSandboxedIntegration';
             $this->integrations[CodeIgniterSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\CodeIgniter\V2\CodeIgniterSandboxedIntegration';
             if (\PHP_MAJOR_VERSION > 5) {

--- a/tests/Integrations/CLI/CLITestCase.php
+++ b/tests/Integrations/CLI/CLITestCase.php
@@ -26,7 +26,7 @@ abstract class CLITestCase extends IntegrationTestCase
      */
     protected static function getEnvs()
     {
-        return [
+        $envs = [
             'DD_TRACE_CLI_ENABLED' => 'true',
             'DD_AGENT_HOST' => 'request-replayer',
             'DD_TRACE_AGENT_PORT' => '80',
@@ -35,6 +35,10 @@ abstract class CLITestCase extends IntegrationTestCase
             'DD_TEST_INTEGRATION' => 'true',
             'DD_TRACE_ENCODER' => 'json',
         ];
+        if (!self::isSandboxed()) {
+            $envs['DD_TRACE_SANDBOX_ENABLED'] = 'false';
+        }
+        return $envs;
     }
 
     /**

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosSandboxedTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CLI\CakePHP\V2_8;
+
+class CommonScenariosSandboxedTest extends CommonScenariosTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -5,7 +5,7 @@ namespace DDTrace\Tests\Integrations\CLI\CakePHP\V2_8;
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Integrations\CLI\CLITestCase;
 
-final class CommonScenariosTest extends CLITestCase
+class CommonScenariosTest extends CLITestCase
 {
     protected function getScriptLocation()
     {

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosSandboxedTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\CakePHP\V2_8;
+
+class CommonScenariosSandboxedTest extends CommonScenariosTest
+{
+    const IS_SANDBOX = true;
+}

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -6,7 +6,7 @@ use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
-final class CommonScenariosTest extends WebFrameworkTestCase
+class CommonScenariosTest extends WebFrameworkTestCase
 {
     protected static function getAppIndexScript()
     {
@@ -32,7 +32,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
-        $this->assertExpectedSpans($traces, $spanExpectations);
+        $this->assertFlameGraph($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -52,6 +52,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
                         'integration.name' => 'cakephp',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'Controller.invokeAction',
+                            'cakephp_test_app',
+                            'web',
+                            'Controller.invokeAction'
+                        )->onlyIf(static::IS_SANDBOX),
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -67,15 +74,22 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
                         'integration.name' => 'cakephp',
-                    ]),
-                    SpanAssertion::build(
-                        'cakephp.view',
-                        'cakephp_test_app',
-                        'web',
-                        'SimpleView/index.ctp'
-                    )->withExactTags([
-                        'cakephp.view' => 'SimpleView/index.ctp',
-                        'integration.name' => 'cakephp',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'Controller.invokeAction',
+                            'cakephp_test_app',
+                            'web',
+                            'Controller.invokeAction'
+                        )->onlyIf(static::IS_SANDBOX),
+                        SpanAssertion::build(
+                            'cakephp.view',
+                            'cakephp_test_app',
+                            'web',
+                            'SimpleView/index.ctp'
+                        )->withExactTags([
+                            'cakephp.view' => 'SimpleView/index.ctp',
+                            'integration.name' => 'cakephp',
+                        ]),
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -89,20 +103,31 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'cakephp.route.action' => 'index',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
-                        // CakePHP doesn't appear to set the proper error code
-                        'http.status_code' => '200',
+                        'http.status_code' => '500',
                         'integration.name' => 'cakephp',
                     ])->withExistingTagsNames([
                         'error.stack'
-                    ])->setError(null, 'Foo error'),
-                    SpanAssertion::build(
-                        'cakephp.view',
-                        'cakephp_test_app',
-                        'web',
-                        'Errors/index.ctp'
-                    )->withExactTags([
-                        'cakephp.view' => 'Errors/index.ctp',
-                        'integration.name' => 'cakephp',
+                    ])->setError(
+                        null,
+                        'Foo error'
+                    )->withChildren([
+                        SpanAssertion::build(
+                            'Controller.invokeAction',
+                            'cakephp_test_app',
+                            'web',
+                            'Controller.invokeAction'
+                        )->withExistingTagsNames([
+                            'error.stack'
+                        ])->setError(null, 'Foo error')->onlyIf(static::IS_SANDBOX),
+                        SpanAssertion::build(
+                            'cakephp.view',
+                            'cakephp_test_app',
+                            'web',
+                            'Errors/index.ctp'
+                        )->withExactTags([
+                            'cakephp.view' => 'Errors/index.ctp',
+                            'integration.name' => 'cakephp',
+                        ]),
                     ]),
                 ],
             ]


### PR DESCRIPTION
### Description

This PR sandboxes the CakePHP integration. It also fixes an issue in the legacy integration that did not set the proper HTTP response code on the root span.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
