### PR TITLE
Remove legacy hook for OpenTracing

### DIFF
--- a/docs/open_tracing.md
+++ b/docs/open_tracing.md
@@ -1,3 +1,3 @@
 # Datadog PHP OpenTracing Support
 
-This page has been moved to the [advanced-instrumentation documentation](https://docs.datadoghq.com/tracing/advanced_usage/?tab=php#opentracing).
+This page has been moved to the [OpenTracing documentation](https://docs.datadoghq.com/tracing/opentracing/php/).

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -28,7 +28,6 @@ final class Bootstrap
         self::$bootstrapped = true;
 
         $tracer = self::resetTracer();
-        self::registerOpenTracing();
 
         $flushTracer = function () {
             dd_trace_disable_in_request(); //disable function tracing to speedup shutdown
@@ -98,25 +97,6 @@ final class Bootstrap
         $tracer = new Tracer();
         GlobalTracer::set($tracer);
         return $tracer;
-    }
-
-    /**
-     * Replace the OT tracer with a wrapper containing the datadog tracer.
-     */
-    private static function registerOpenTracing()
-    {
-        dd_trace('OpenTracing\GlobalTracer', 'get', function () {
-            $original = \OpenTracing\GlobalTracer::get();
-
-            if (is_a($original, 'DDTrace\OpenTracer')) {
-                return $original;
-            }
-
-            $otWrapper = new \DDTrace\OpenTracer\Tracer(GlobalTracer::get());
-            \OpenTracing\GlobalTracer::set($otWrapper);
-
-            return $otWrapper;
-        });
     }
 
     /**


### PR DESCRIPTION
### Description

This PR removes the legacy API from the OpenTracing implementation. This introduces a breaking change in the way OpenTracing is initialized with ddtrace. Before this change, an OpenTracing-compatible tracer (`\DDTrace\OpenTracer\Tracer`) would be automatically returned from `\OpenTracing\GlobalTracer::get()`. After this change, the OpenTracing-compatible tracer must be set manually.

```php
# Before
$otTracer = \OpenTracing\GlobalTracer::get();

# After
$otTracer = new \DDTrace\OpenTracer\Tracer(\DDTrace\GlobalTracer::get());
\OpenTracing\GlobalTracer::set($otTracer);
```

The [OpenTracing documentation](https://docs.datadoghq.com/tracing/opentracing/php/) will be updated as part of this PR.

**Edit:** [Preview link](https://docs-staging.datadoghq.com/sammyk/php/open-tracing/tracing/opentracing/php/) of the documentation changes from DataDog/documentation#7528.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
