### PR TITLE
Noop the legacy API when a potentially conflicting module detected

### DIFF
--- a/src/ext/blacklist.h
+++ b/src/ext/blacklist.h
@@ -4,6 +4,7 @@
 #include <php.h>
 #include <stdbool.h>
 
+extern bool ddtrace_blacklisted_disable_legacy;
 extern bool ddtrace_has_blacklisted_module;
 
 void ddtrace_blacklist_startup();

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -29,6 +29,7 @@ typedef struct _ddtrace_original_context {
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
 zend_bool disable_in_current_request;
+zend_bool ignore_legacy_blacklist;
 char *request_init_hook;
 zend_bool strict_mode;
 

--- a/src/ext/php5/blacklist.c
+++ b/src/ext/php5/blacklist.c
@@ -17,6 +17,7 @@ void ddtrace_blacklist_startup() {
     zend_module_entry *module;
     HashPosition pos;
 
+    ddtrace_blacklisted_disable_legacy = false;
     ddtrace_has_blacklisted_module = false;
 
     zend_hash_internal_pointer_reset_ex(&module_registry, &pos);

--- a/src/ext/php7/blacklist.c
+++ b/src/ext/php7/blacklist.c
@@ -8,7 +8,7 @@
 #include "logging.h"
 
 static bool _dd_is_blacklisted_module(zend_module_entry *module) {
-    if (strcmp("ionCube Loader", module->name) == 0 || strcmp("newrelic", module->name) == 0) {
+    if (strcmp("ionCube Loader", module->name) == 0) {
         ddtrace_log_debugf("Found blacklisted module: %s, disabling conflicting functionality", module->name);
         return true;
     }
@@ -46,12 +46,16 @@ static bool _dd_is_blacklisted_module(zend_module_entry *module) {
             return true;
         }
     }
+    if (strcmp("newrelic", module->name) == 0) {
+        ddtrace_blacklisted_disable_legacy = true;
+    }
     return false;
 }
 
 void ddtrace_blacklist_startup() {
     zend_module_entry *module;
 
+    ddtrace_blacklisted_disable_legacy = false;
     ddtrace_has_blacklisted_module = false;
 
     ZEND_HASH_FOREACH_PTR(&module_registry, module) {


### PR DESCRIPTION
### Description

This upgrades the module blacklist functionality to noop the legacy API when a potentially conflicting module is detected. The `dd_trace()` function can be re-enabled by setting the INI setting `ddtrace.ignore_legacy_blacklist=1`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug (separately).

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
