### PR TITLE
Move setting that ignores legacy blacklist to env var

### DIFF
--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -89,6 +89,7 @@ void ddtrace_config_shutdown(void);
     INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", DD_TRACE_AGENT_TIMEOUT)                                \
     INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", DD_TRACE_AGENT_CONNECT_TIMEOUT)        \
     INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
+    BOOL(get_dd_trace_ignore_legacy_blacklist, "DD_TRACE_IGNORE_LEGACY_BLACKLIST", false)                            \
     BOOL(get_dd_log_backtrace, "DD_LOG_BACKTRACE", false)                                                            \
     BOOL(get_dd_trace_generate_root_span, "DD_TRACE_GENERATE_ROOT_SPAN", true)                                       \
     BOOL(get_dd_trace_sandbox_enabled, "DD_TRACE_SANDBOX_ENABLED", DD_TRACE_SANDBOX_ENABLED)                         \

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -48,8 +48,6 @@ ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 PHP_INI_BEGIN()
 STD_PHP_INI_BOOLEAN("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals,
                     ddtrace_globals)
-STD_PHP_INI_BOOLEAN("ddtrace.ignore_legacy_blacklist", "0", PHP_INI_SYSTEM, OnUpdateBool, ignore_legacy_blacklist,
-                    zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateString, request_init_hook,
                   zend_ddtrace_globals, ddtrace_globals)
 STD_PHP_INI_BOOLEAN("ddtrace.strict_mode", "0", PHP_INI_SYSTEM, OnUpdateBool, strict_mode, zend_ddtrace_globals,
@@ -548,10 +546,10 @@ static PHP_FUNCTION(dd_trace) {
         DD_PRINTF("Class name: %s", Z_STRVAL_P(class_name));
     }
     DD_PRINTF("Function name: %s", Z_STRVAL_P(function));
-    if (ddtrace_blacklisted_disable_legacy && !DDTRACE_G(ignore_legacy_blacklist)) {
+    if (ddtrace_blacklisted_disable_legacy && !get_dd_trace_ignore_legacy_blacklist()) {
         ddtrace_log_debugf(
             "Cannot instrument '%s()' with dd_trace(). This functionality is disabled due to a potentially conflicting "
-            "module. To re-enable dd_trace(), please set the INI setting: ddtrace.ignore_legacy_blacklist=1",
+            "module. To re-enable dd_trace(), please set the environment variable: DD_TRACE_IGNORE_LEGACY_BLACKLIST=1",
             Z_STRVAL_P(function));
         RETURN_BOOL(0);
     }

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -29,7 +29,6 @@ typedef struct _ddtrace_original_context {
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 zend_bool disable;
 zend_bool disable_in_current_request;
-zend_bool ignore_legacy_blacklist;
 char *request_init_hook;
 zend_bool strict_mode;
 

--- a/src/ext/php5_4/blacklist.c
+++ b/src/ext/php5_4/blacklist.c
@@ -14,6 +14,7 @@ void ddtrace_blacklist_startup() {
     zend_module_entry *module;
     HashPosition pos;
 
+    ddtrace_blacklisted_disable_legacy = false;
     ddtrace_has_blacklisted_module = false;
 
     zend_hash_internal_pointer_reset_ex(&module_registry, &pos);


### PR DESCRIPTION
### Description

This is a follow up PR to #900.

Since there are a number of changes that need to be done before we move to INI settings, this PR moves the `ddtrace.ignore_legacy_blacklist` INI setting (not released yet) to the `DD_TRACE_IGNORE_LEGACY_BLACKLIST` environment variable.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug. (Tested separately)

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
