### PR TITLE
Fix post-install on debug build of PHP

### DIFF
--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -159,6 +159,10 @@ if [[ -n $PHP_THREAD_SAFETY ]]; then
     VERSION_SUFFIX="-zts"
 fi
 
+if [ "$(invoke_php -i | awk '/^Debug Build/ { print $4 }')" = "yes" ] ; then
+    VERSION_SUFFIX="${VERSION_SUFFIX?}-debug"
+fi
+
 EXTENSION_NAME="ddtrace-${PHP_VERSION}${VERSION_SUFFIX}.so"
 EXTENSION_FILE_PATH="${EXTENSION_DIR}/${EXTENSION_NAME}"
 INI_FILE_CONTENTS=$(cat <<EOF


### PR DESCRIPTION
### Description

The post-install script currently isn't checking for debug builds, so installing a packaged extension doesn't work if the system's PHP is a debug build. You get an error like:

```
PHP Warning:  PHP Startup: ddtrace: Unable to initialize module
Module compiled with build ID=API20131226,NTS
PHP    compiled with build ID=API20131226,NTS,debug
These options need to match
 in Unknown on line 0
```

Unfortunately, this PR is incomplete because the `-debug.so` file that is shipped is not built with a debug version of PHP.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
