### PR TITLE
Add support for service name configuration via DD_SERVICE

### DIFF
--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -6,7 +6,8 @@
 #include "env_config.h"
 
 extern inline ddtrace_string ddtrace_string_getenv(char* str, size_t len TSRMLS_DC);
-extern inline ddtrace_string ddtrace_string_getenv_multi(char* primary, size_t primary_len, char* secondary, size_t secondary_len TSRMLS_DC);
+extern inline ddtrace_string ddtrace_string_getenv_multi(char* primary, size_t primary_len, char* secondary,
+                                                         size_t secondary_len TSRMLS_DC);
 
 struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {
 #define CHAR(...) NULL, FALSE,

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -6,7 +6,7 @@
 #include "env_config.h"
 
 extern inline ddtrace_string ddtrace_string_getenv(char* str, size_t len TSRMLS_DC);
-extern inline ddtrace_string ddtrace_string_getenv_multi(char* main, size_t main_len, char* fallback, size_t fallback_len TSRMLS_DC);
+extern inline ddtrace_string ddtrace_string_getenv_multi(char* primary, size_t primary_len, char* secondary, size_t secondary_len TSRMLS_DC);
 
 struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {
 #define CHAR(...) NULL, FALSE,

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -6,6 +6,7 @@
 #include "env_config.h"
 
 extern inline ddtrace_string ddtrace_string_getenv(char* str, size_t len TSRMLS_DC);
+extern inline ddtrace_string ddtrace_string_getenv_multi(char* main, size_t main_len, char* fallback, size_t fallback_len TSRMLS_DC);
 
 struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration = {
 #define CHAR(...) NULL, FALSE,

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -38,14 +38,14 @@ inline ddtrace_string ddtrace_string_getenv(char *str, size_t len TSRMLS_DC) {
 }
 
 // Returns an env var value as string. If the env is not defined it uses a fallback env variable name.
-// Used when for backward compatibility we need to support a main and fallback env variable name.
+// Used when for backward compatibility we need to support a primary and secondary env variable name.
 inline ddtrace_string ddtrace_string_getenv_multi(
-    char *main,
-    size_t main_len,
-    char *fallback,
-    size_t fallback_len TSRMLS_DC
+    char *primary,
+    size_t primary_len,
+    char *secondary,
+    size_t secondary_len TSRMLS_DC
 ) {
-    return ddtrace_string_cstring_ctor(ddtrace_getenv_multi(main, main_len, fallback, fallback_len TSRMLS_CC));
+    return ddtrace_string_cstring_ctor(ddtrace_getenv_multi(primary, primary_len, secondary, secondary_len TSRMLS_CC));
 }
 
 struct ddtrace_memoized_configuration_t;

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -39,12 +39,8 @@ inline ddtrace_string ddtrace_string_getenv(char *str, size_t len TSRMLS_DC) {
 
 // Returns an env var value as string. If the env is not defined it uses a fallback env variable name.
 // Used when for backward compatibility we need to support a primary and secondary env variable name.
-inline ddtrace_string ddtrace_string_getenv_multi(
-    char *primary,
-    size_t primary_len,
-    char *secondary,
-    size_t secondary_len TSRMLS_DC
-) {
+inline ddtrace_string ddtrace_string_getenv_multi(char *primary, size_t primary_len, char *secondary,
+                                                  size_t secondary_len TSRMLS_DC) {
     return ddtrace_string_cstring_ctor(ddtrace_getenv_multi(primary, primary_len, secondary, secondary_len TSRMLS_CC));
 }
 

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -37,6 +37,17 @@ inline ddtrace_string ddtrace_string_getenv(char *str, size_t len TSRMLS_DC) {
     return ddtrace_string_cstring_ctor(ddtrace_getenv(str, len TSRMLS_CC));
 }
 
+// Returns an env var value as string. If the env is not defined it uses a fallback env variable name.
+// Used when for backward compatibility we need to support a main and fallback env variable name.
+inline ddtrace_string ddtrace_string_getenv_multi(
+    char *main,
+    size_t main_len,
+    char *fallback,
+    size_t fallback_len TSRMLS_DC
+) {
+    return ddtrace_string_cstring_ctor(ddtrace_getenv_multi(main, main_len, fallback, fallback_len TSRMLS_CC));
+}
+
 struct ddtrace_memoized_configuration_t;
 extern struct ddtrace_memoized_configuration_t ddtrace_memoized_configuration;
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -923,7 +923,7 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
     }
 #endif
 
-    ddtrace_string app_name = ddtrace_string_getenv(ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
+    ddtrace_string app_name = ddtrace_string_getenv_multi(ZEND_STRL("DD_SERVICE"), ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
     bool should_free_app_name = app_name.ptr;
     if (!app_name.len) {
         if (should_free_app_name) {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -923,7 +923,8 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
     }
 #endif
 
-    ddtrace_string app_name = ddtrace_string_getenv_multi(ZEND_STRL("DD_SERVICE"), ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
+    ddtrace_string app_name =
+        ddtrace_string_getenv_multi(ZEND_STRL("DD_SERVICE"), ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
     bool should_free_app_name = app_name.ptr;
     if (!app_name.len) {
         if (should_free_app_name) {

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -24,6 +24,16 @@ char *ddtrace_getenv(char *name, size_t name_len TSRMLS_DC) {
     return env ? estrdup(env) : NULL;
 }
 
+char *ddtrace_getenv_multi(char *str1, size_t str1_len, char *str2, size_t str2_len TSRMLS_DC) {
+    // Primary env name, if exists
+    char *env = ddtrace_getenv(str1, str1_len TSRMLS_CC);
+    if (env) {
+        return env;
+    }
+    // Otherwise we use the fallback env  name
+    return ddtrace_getenv(str2, str2_len TSRMLS_CC);
+}
+
 char *get_local_env_or_sapi_env(char *name TSRMLS_DC) {
     char *env = NULL, *tmp = getenv(name);
     if (tmp) {

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -24,14 +24,14 @@ char *ddtrace_getenv(char *name, size_t name_len TSRMLS_DC) {
     return env ? estrdup(env) : NULL;
 }
 
-char *ddtrace_getenv_multi(char *str1, size_t str1_len, char *str2, size_t str2_len TSRMLS_DC) {
+char *ddtrace_getenv_multi(char *primary, size_t primary_len, char *secondary, size_t secondary_len TSRMLS_DC) {
     // Primary env name, if exists
-    char *env = ddtrace_getenv(str1, str1_len TSRMLS_CC);
+    char *env = ddtrace_getenv(primary, primary_len TSRMLS_CC);
     if (env) {
         return env;
     }
-    // Otherwise we use the fallback env  name
-    return ddtrace_getenv(str2, str2_len TSRMLS_CC);
+    // Otherwise we use the secondary env name
+    return ddtrace_getenv(secondary, secondary_len TSRMLS_CC);
 }
 
 char *get_local_env_or_sapi_env(char *name TSRMLS_DC) {

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -14,6 +14,15 @@
  */
 char *ddtrace_getenv(char *name, size_t name_len TSRMLS_DC);
 
+/* ddtrace_getenv_multi duplicates; efree it when done.
+ * Do not call ddtrace_getenv_multi from the background thread.
+ * Returns the sapi_getenv or getenv.
+ * If a value for name1 exists then it uses it, otherwise the fallback name name2 is used.
+ * This can be used in the common case when for BC compatibility we need to support multiple names for the same
+ * environment variable.
+ */
+char *ddtrace_getenv_multi(char *name1, size_t name1_len, char *name2, size_t name2_len TSRMLS_DC);
+
 BOOL_T ddtrace_get_bool_config(char *name, BOOL_T def TSRMLS_DC);
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC);
 int64_t ddtrace_get_int_config(char *name, int64_t def TSRMLS_DC);

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -17,11 +17,11 @@ char *ddtrace_getenv(char *name, size_t name_len TSRMLS_DC);
 /* ddtrace_getenv_multi duplicates; efree it when done.
  * Do not call ddtrace_getenv_multi from the background thread.
  * Returns the sapi_getenv or getenv.
- * If a value for name1 exists then it uses it, otherwise the fallback name name2 is used.
+ * If a value for primary exists then it uses it, otherwise the fallback name secondary is used.
  * This can be used in the common case when for BC compatibility we need to support multiple names for the same
  * environment variable.
  */
-char *ddtrace_getenv_multi(char *name1, size_t name1_len, char *name2, size_t name2_len TSRMLS_DC);
+char *ddtrace_getenv_multi(char *primary, size_t primary_len, char *secondary, size_t secondary_len TSRMLS_DC);
 
 BOOL_T ddtrace_get_bool_config(char *name, BOOL_T def TSRMLS_DC);
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC);

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -15,7 +15,7 @@ class CommonScenariosTest extends CLITestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'cake_console_test_app',
+            'DD_SERVICE' => 'cake_console_test_app',
         ]);
     }
 

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -15,7 +15,7 @@ final class CommonScenariosTest extends CLITestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'console_test_app',
+            'DD_SERVICE' => 'console_test_app',
         ]);
     }
 

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -16,7 +16,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'cakephp_test_app',
+            'DD_SERVICE' => 'cakephp_test_app',
         ]);
     }
 

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -20,7 +20,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'codeigniter_test_app',
+            'DD_SERVICE' => 'codeigniter_test_app',
         ]);
     }
 

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -148,7 +148,7 @@ class CurlIntegrationTest extends IntegrationTestCase
             },
             __DIR__ . '/curl_in_web_request.php',
             [
-                'DD_SERVICE_NAME' => 'top_level_app',
+                'DD_SERVICE' => 'top_level_app',
                 'DD_TRACE_SANDBOX_ENABLED' => static::IS_SANDBOX,
                 'DD_TRACE_NO_AUTOLOADER' => true,
             ]

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -259,7 +259,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             },
             __DIR__ . '/guzzle_in_web_request.php',
             [
-                'DD_SERVICE_NAME' => 'top_level_app',
+                'DD_SERVICE' => 'top_level_app',
                 'DD_TRACE_SANDBOX_ENABLED' => static::IS_SANDBOX,
                 'DD_TRACE_NO_AUTOLOADER' => true,
             ]

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -253,7 +253,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             },
             __DIR__ . '/guzzle_in_web_request.php',
             [
-                'DD_SERVICE_NAME' => 'top_level_app',
+                'DD_SERVICE' => 'top_level_app',
                 'DD_TRACE_SANDBOX_ENABLED' => static::IS_SANDBOX,
                 'DD_TRACE_NO_AUTOLOADER' => true,
             ]

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -18,7 +18,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'lumen_test_app',
+            'DD_SERVICE' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosSandboxedTest.php
@@ -16,7 +16,7 @@ class CommonScenariosSandboxedTest extends V5_2_CommonScenariosSandboxedTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'lumen_test_app',
+            'DD_SERVICE' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -18,7 +18,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'lumen_test_app',
+            'DD_SERVICE' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_8/CommonScenariosTest.php
@@ -18,7 +18,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'lumen_test_app',
+            'DD_SERVICE' => 'lumen_test_app',
         ]);
     }
 

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -18,7 +18,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'slim_test_app',
+            'DD_SERVICE' => 'slim_test_app',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -18,7 +18,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'test_symfony_34',
+            'DD_SERVICE' => 'test_symfony_34',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -19,7 +19,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
-            'DD_SERVICE_NAME' => 'test_symfony_40',
+            'DD_SERVICE' => 'test_symfony_40',
         ]);
     }
 

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -19,7 +19,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
-            'DD_SERVICE_NAME' => 'test_symfony_42',
+            'DD_SERVICE' => 'test_symfony_42',
         ]);
     }
 

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -25,7 +25,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'wordpress_test_app',
+            'DD_SERVICE' => 'wordpress_test_app',
         ]);
     }
 

--- a/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
+++ b/tests/Integrations/Yii/V2_0_26/CommonScenariosTest.php
@@ -20,7 +20,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'yii2_test_app',
+            'DD_SERVICE' => 'yii2_test_app',
         ]);
     }
 

--- a/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0_26/ParameterizedRouteTest.php
@@ -23,7 +23,7 @@ class ParameterizedRouteTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_SERVICE_NAME' => 'yii2_test_app',
+            'DD_SERVICE' => 'yii2_test_app',
         ]);
     }
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -160,6 +160,13 @@ final class ConfigurationTest extends BaseTestCase
         $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
     }
 
+    public function testServiceNameViaDDServiceNameForBackwardCompatibility()
+    {
+        $this->putEnvAndReloadConfig(['DD_SERVICE_NAME=my_app']);
+        $this->assertSame('my_app', Configuration::get()->appName('__default__'));
+        $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
+    }
+
     public function testServiceNameHasPrecedenceOverDeprecatedMethods()
     {
         $this->putEnvAndReloadConfig([

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -146,13 +146,6 @@ final class ConfigurationTest extends BaseTestCase
         $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
     }
 
-    public function testServiceNameViaDDService()
-    {
-        $this->putEnvAndReloadConfig(['DD_SERVICE=my_app']);
-        $this->assertSame('my_app', Configuration::get()->appName('__default__'));
-        $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
-    }
-
     public function testServiceNameViaDDServiceWinsOverDDServiceName()
     {
         $this->putEnvAndReloadConfig(['DD_SERVICE=my_app', 'DD_SERVICE_NAME=legacy']);

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -25,6 +25,8 @@ final class ConfigurationTest extends BaseTestCase
         putenv('DD_PRIORITY_SAMPLING');
         putenv('DD_SAMPLING_RATE');
         putenv('DD_SERVICE_MAPPING');
+        putenv('DD_SERVICE_NAME');
+        putenv('DD_SERVICE');
         putenv('DD_TRACE_ANALYTICS_ENABLED');
         putenv('DD_TRACE_DEBUG');
         putenv('DD_TRACE_ENABLED');
@@ -134,20 +136,34 @@ final class ConfigurationTest extends BaseTestCase
 
     public function testServiceName()
     {
-        $this->putEnvAndReloadConfig(['DD_SERVICE_NAME', 'DD_TRACE_APP_NAME', 'ddtrace_app_name']);
+        $this->putEnvAndReloadConfig(['DD_SERVICE', 'DD_TRACE_APP_NAME', 'ddtrace_app_name']);
 
         $this->assertSame('__default__', Configuration::get()->appName('__default__'));
         $this->assertSame('__default__', \ddtrace_config_app_name('__default__'));
 
-        $this->putEnvAndReloadConfig(['DD_SERVICE_NAME=my_app']);
+        $this->putEnvAndReloadConfig(['DD_SERVICE=my_app']);
         $this->assertSame('my_app', Configuration::get()->appName('my_app'));
         $this->assertSame('my_app', \ddtrace_config_app_name('my_app'));
+    }
+
+    public function testServiceNameViaDDService()
+    {
+        $this->putEnvAndReloadConfig(['DD_SERVICE=my_app']);
+        $this->assertSame('my_app', Configuration::get()->appName('__default__'));
+        $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
+    }
+
+    public function testServiceNameViaDDServiceWinsOverDDServiceName()
+    {
+        $this->putEnvAndReloadConfig(['DD_SERVICE=my_app', 'DD_SERVICE_NAME=legacy']);
+        $this->assertSame('my_app', Configuration::get()->appName('__default__'));
+        $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
     }
 
     public function testServiceNameHasPrecedenceOverDeprecatedMethods()
     {
         $this->putEnvAndReloadConfig([
-            'DD_SERVICE_NAME=my_app',
+            'DD_SERVICE=my_app',
             'DD_TRACE_APP_NAME=wrong_app',
             'ddtrace_app_name=wrong_app',
         ]);

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -142,8 +142,8 @@ final class ConfigurationTest extends BaseTestCase
         $this->assertSame('__default__', \ddtrace_config_app_name('__default__'));
 
         $this->putEnvAndReloadConfig(['DD_SERVICE=my_app']);
-        $this->assertSame('my_app', Configuration::get()->appName('my_app'));
-        $this->assertSame('my_app', \ddtrace_config_app_name('my_app'));
+        $this->assertSame('my_app', Configuration::get()->appName('__default__'));
+        $this->assertSame('my_app', \ddtrace_config_app_name('__default__'));
     }
 
     public function testServiceNameViaDDService()


### PR DESCRIPTION
### Description

**Deprecation notice**"  Setting service name via `DD_SERVICE_NAME` is now deprecated and will be removed in a future release. Use `DD_SERVICE` instead for consistency with other Datadog tracers and services.

This PR adds support for both `DD_SERVICE` (primary) and `DD_SERVICE_NAME` (secondary) as env variable names to configure the service name.

This was done as part of an effort to increase consistency among different tracers and Datadog products.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
