### PR TITLE
Add support for DD_TAGS, fallback to DD_TRACE_GLOBAL_TAGS

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -306,7 +306,12 @@ function ddtrace_config_integration_analytics_sample_rate($name)
  */
 function ddtrace_config_global_tags()
 {
-    return \_ddtrace_config_associative_array(\getenv('DD_TRACE_GLOBAL_TAGS'), []);
+    $rawValue = \getenv('DD_TAGS');
+    if (false === $rawValue) {
+        // Fallback to legacy env variable name
+        $rawValue = \getenv('DD_TRACE_GLOBAL_TAGS');
+    }
+    return \_ddtrace_config_associative_array($rawValue, []);
 }
 
 /**

--- a/src/api/Configuration.php
+++ b/src/api/Configuration.php
@@ -161,7 +161,7 @@ class Configuration extends AbstractConfiguration
      */
     public function getGlobalTags()
     {
-        return $this->associativeStringArrayValue('trace.global.tags');
+        return $this->associativeStringArrayValue('tags') ?: $this->associativeStringArrayValue('trace.global.tags');
     }
 
     /**

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -17,12 +17,12 @@ final class TracerTest extends BaseTestCase
     protected function setUp()
     {
         parent::setUp();
-        \putenv('DD_TRACE_GLOBAL_TAGS=global_tag:global,also_in_span:should_not_ovverride');
+        \putenv('DD_TAGS=global_tag:global,also_in_span:should_not_ovverride');
     }
 
     protected function tearDown()
     {
-        \putenv('DD_TRACE_GLOBAL_TAGS');
+        \putenv('DD_TAGS');
         \putenv('DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED');
         \putenv('DD_SERVICE_MAPPING');
         parent::tearDown();

--- a/tests/Integrations/Laravel/V4/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosSandboxedTest.php
@@ -19,7 +19,7 @@ class CommonScenariosSandboxedTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
-            'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
+            'DD_TAGS' => 'some.key1:value,some.key2:value2',
         ]);
     }
 

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -19,7 +19,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_DEBUG' => 'true',
-            'DD_TRACE_GLOBAL_TAGS' => 'some.key1:value,some.key2:value2',
+            'DD_TAGS' => 'some.key1:value,some.key2:value2',
         ]);
     }
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -388,16 +388,16 @@ final class ConfigurationTest extends BaseTestCase
 
     public function testGlobalTags()
     {
-        $this->putEnvAndReloadConfig(['DD_TAGS=k1:v1,k2:v2']);
-        $this->assertEquals(['k1' => 'v1', 'k2' => 'v2'], Configuration::get()->getGlobalTags());
-        $this->assertEquals(['k1' => 'v1', 'k2' => 'v2'], \ddtrace_config_global_tags());
+        $this->putEnvAndReloadConfig(['DD_TAGS=key1:value1,key2:value2']);
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], Configuration::get()->getGlobalTags());
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \ddtrace_config_global_tags());
     }
 
     public function testGlobalTagsLegacyEnv()
     {
-        $this->putEnvAndReloadConfig(['DD_TRACE_GLOBAL_TAGS=k1:v1,k2:v2']);
-        $this->assertEquals(['k1' => 'v1', 'k2' => 'v2'], Configuration::get()->getGlobalTags());
-        $this->assertEquals(['k1' => 'v1', 'k2' => 'v2'], \ddtrace_config_global_tags());
+        $this->putEnvAndReloadConfig(['DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2']);
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], Configuration::get()->getGlobalTags());
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \ddtrace_config_global_tags());
     }
 
     public function testGlobalTagsNewEnvWinsOverLegacyEnv()

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -28,7 +28,7 @@ final class TracerTest extends BaseTestCase
     {
         \putenv('DD_AUTOFINISH_SPANS');
         \putenv('DD_TRACE_REPORT_HOSTNAME');
-        \putenv('DD_TRACE_GLOBAL_TAGS');
+        \putenv('DD_TAGS');
         parent::setUp();
     }
 
@@ -37,7 +37,7 @@ final class TracerTest extends BaseTestCase
         parent::tearDown();
         \putenv('DD_TRACE_REPORT_HOSTNAME');
         \putenv('DD_AUTOFINISH_SPANS');
-        \putenv('DD_TRACE_GLOBAL_TAGS');
+        \putenv('DD_TAGS');
     }
 
     public function testStartSpanAsNoop()
@@ -265,7 +265,7 @@ final class TracerTest extends BaseTestCase
 
     public function testHonorGlobalTags()
     {
-        \putenv('DD_TRACE_GLOBAL_TAGS=key1:value1,key2:value2');
+        \putenv('DD_TAGS=key1:value1,key2:value2');
 
         $transport = new DebugTransport();
         $tracer = new Tracer($transport);


### PR DESCRIPTION
### Description

This PR adds support for `DD_TAGS` to configure global tags to be set on every span. This new environment variable replaces `DD_TRACE_GLOBAL_TAGS` for consistency with other tracers and Datadog products. **NOTE**: the legacy `DD_TRACE_GLOBAL_TAGS` is still supported as a fallback mechanism for backward compatibility but it will removed in a future version.

`DD_TAGS` preserves the same associative array format, e.g. `DD_TAGS=key1:value1,key2:value2` 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
