### PR TITLE
Enable OpenTracing test suite in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -406,9 +406,8 @@
         "memory_test": "echo $COMPOSER_MEMORY_LIMIT",
 
         "opentracing-10-test": [
-            "@composer scenario:update",
             "@composer scenario opentracing1",
-            "@composer test -- tests/OpenTracerUnit/TracerTest.php"
+            "@composer test -- tests/OpenTracerUnit"
         ],
 
         "test-unit": "phpunit --colors=always --configuration=phpunit.xml --testsuite=unit",

--- a/tests/OpenTracerUnit/GlobalTracerTest.php
+++ b/tests/OpenTracerUnit/GlobalTracerTest.php
@@ -9,10 +9,17 @@ use PHPUnit\Framework;
 
 final class GlobalTracerTest extends Framework\TestCase
 {
-    public function testOpenTracingTracerIsSetWithWrapper()
+    public function testOpenTracingTracerCanBeSetUsingDDWrapper()
     {
+        // Simulating DD tracer has already been set
         $tracer = new Tracer(new Noop());
         GlobalTracer::set($tracer);
+
+        // As suggested in our docs: https://docs.datadoghq.com/tracing/opentracing/php/
+        $otTracer = new \DDTrace\OpenTracer\Tracer(\DDTrace\GlobalTracer::get());
+        \OpenTracing\GlobalTracer::set($otTracer);
+
+        // Now accessing the OT tracer should return our wrapper
         $this->assertInstanceOf(
             '\DDTrace\OpenTracer\Tracer',
             \OpenTracing\GlobalTracer::get()


### PR DESCRIPTION
### Description

Due to the fact that we have to whitelist tests, we were running in CI only `tests/OpenTracer/Unit/TracerTest.php` instead of the entire suite `tests/OpenTracer/Unit/`.

Moreover, as a consequence of this, we had not realized that the tests the verifies automatic registration in OT was failing, as we no longer automatically register the OT tracer as of #899.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
