### PR TITLE
Fix doctrine/migrations dependency in Symfony 4.2 and 4.4 test

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_0/composer.json
@@ -26,6 +26,7 @@
         "symfony/yaml": "4.0.*"
     },
     "require-dev": {
+        "doctrine/migrations": "^2.0",
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "^1.0",
         "symfony/profiler-pack": "*",

--- a/tests/Frameworks/Symfony/Version_4_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_2/composer.json
@@ -26,6 +26,7 @@
         "symfony/yaml": "4.2.*"
     },
     "require-dev": {
+        "doctrine/migrations": "^2.0",
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "^1.0",
         "symfony/profiler-pack": "*",


### PR DESCRIPTION
### Description

`doctrine/migrations 3.0.0` was [released yesterday](https://github.com/doctrine/migrations/releases/tag/3.0.0) which is not compatible with migrations command in Symfony 4.2 and 4.4.

This PR pin `doctrine/migrations` to 2.* for those test suite.

### Readiness checklist
~- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~
~- [ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
