### PR TITLE
Defaults for name and resource on SpanData

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -259,3 +259,4 @@ ext/pdo/tests/pdo_023.phpt
 ext/pdo_sqlite/tests/pdo_013.phpt
 tests/lang/bug23584.phpt
 Zend/tests/bug48930.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/5.6.list
+++ b/dockerfiles/ci/xfail_tests/5.6.list
@@ -290,3 +290,4 @@ ext/phar/tests/phar_buildfromiterator8.phpt
 ext/pdo_sqlite/tests/bug_52098.phpt
 ext/pdo_sqlite/tests/pdo_013.phpt
 ext/pdo_sqlite/tests/pdo_023.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -332,3 +332,4 @@ Zend/tests/bug70253.phpt
 Zend/tests/bug70258.phpt
 ext/phar/tests/phar_buildfromiterator10.phpt
 ext/phar/tests/phar_buildfromiterator8.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -345,3 +345,4 @@ Zend/tests/bug70253.phpt
 Zend/tests/bug70258.phpt
 ext/phar/tests/phar_buildfromiterator10.phpt
 ext/phar/tests/phar_buildfromiterator8.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -295,3 +295,4 @@ Zend/tests/bug70253.phpt
 Zend/tests/bug70258.phpt
 ext/phar/tests/phar_buildfromiterator10.phpt
 ext/phar/tests/phar_buildfromiterator8.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -314,3 +314,4 @@ Zend/tests/bug70253.phpt
 Zend/tests/bug70258.phpt
 ext/phar/tests/phar_buildfromiterator10.phpt
 ext/phar/tests/phar_buildfromiterator8.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -391,3 +391,4 @@ ext/curl/tests/bug79033.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/phar/tests/phar_buildfromiterator10.phpt
 ext/phar/tests/phar_buildfromiterator8.phpt
+ext/standard/tests/file/lstat_stat_variation10.phpt

--- a/package.xml
+++ b/package.xml
@@ -205,6 +205,7 @@
                         <file name="auto_flush_userland_root_span.phpt" role="test" />
                         <file name="close-on-exit.phpt" role="test" />
                         <file name="close-on-exit-retval.phpt" role="test" />
+                        <file name="dd_dumper.inc" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />
                         <file name="dd_trace_api_error.phpt" role="test" />
                         <file name="dd_trace_function_complex.phpt" role="test" />
@@ -215,6 +216,8 @@
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />
                         <file name="dd_trace_set_trace_id.phpt" role="test" />
+                        <file name="default_span_properties.phpt" role="test" />
+                        <file name="default_span_properties_method.phpt" role="test" />
                         <file name="distributed_tracing.inc" role="test" />
                         <file name="distributed_tracing_curl.phpt" role="test" />
                         <file name="distributed_tracing_curl_copy_handle.phpt" role="test" />

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -181,6 +181,10 @@ static void register_span_data_ce(TSRMLS_D) {
 
     // trace_id, span_id, parent_id, start & duration are stored directly on
     // ddtrace_span_t so we don't need to make them properties on DDTrace\SpanData
+    /*
+     * ORDER MATTERS: If you make any changes to the properties below, update the
+     * corresponding ddtrace_spandata_property_*() function with the proper offset.
+     */
     zend_declare_property_null(ddtrace_ce_span_data, "name", sizeof("name") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ddtrace_ce_span_data, "resource", sizeof("resource") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ddtrace_ce_span_data, "service", sizeof("service") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
@@ -188,6 +192,21 @@ static void register_span_data_ce(TSRMLS_D) {
     zend_declare_property_null(ddtrace_ce_span_data, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
 }
+
+#if PHP_VERSION_ID >= 70000
+// SpanData::$name
+zval *ddtrace_spandata_property_name(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 0); }
+// SpanData::$resource
+zval *ddtrace_spandata_property_resource(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 1); }
+// SpanData::$service
+zval *ddtrace_spandata_property_service(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 2); }
+// SpanData::$type
+zval *ddtrace_spandata_property_type(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 3); }
+// SpanData::$meta
+zval *ddtrace_spandata_property_meta(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 4); }
+// SpanData::$metrics
+zval *ddtrace_spandata_property_metrics(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 5); }
+#endif
 
 static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
     if (strcmp("fpm-fcgi", sapi_module.name) == 0 || strcmp("apache2handler", sapi_module.name) == 0 ||

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -11,6 +11,15 @@
 extern zend_module_entry ddtrace_module_entry;
 extern zend_class_entry *ddtrace_ce_span_data;
 
+#if PHP_VERSION_ID >= 70000
+zval *ddtrace_spandata_property_name(zval *spandata);
+zval *ddtrace_spandata_property_resource(zval *spandata);
+zval *ddtrace_spandata_property_service(zval *spandata);
+zval *ddtrace_spandata_property_type(zval *spandata);
+zval *ddtrace_spandata_property_meta(zval *spandata);
+zval *ddtrace_spandata_property_metrics(zval *spandata);
+#endif
+
 BOOL_T ddtrace_tracer_is_limited(TSRMLS_D);
 
 typedef struct _ddtrace_original_context {

--- a/src/ext/php7/serializer.c
+++ b/src/ext/php7/serializer.c
@@ -283,6 +283,13 @@ static void _serialize_meta(zval *el, ddtrace_span_t *span) {
     }
 }
 
+static void _dd_add_assoc_zval_as_string(zval *el, const char *name, zval *value) {
+    zval value_as_string;
+    ddtrace_convert_to_string(&value_as_string, value);
+    _add_assoc_zval_copy(el, name, &value_as_string);
+    zval_dtor(&value_as_string);
+}
+
 void ddtrace_serialize_span_to_array(ddtrace_span_t *span, zval *array TSRMLS_DC) {
     zval *el;
     zval zv;
@@ -307,11 +314,8 @@ void ddtrace_serialize_span_to_array(ddtrace_span_t *span, zval *array TSRMLS_DC
 
     // SpanData::$resource defaults to SpanData::$name
     zval *prop_resource = ddtrace_spandata_property_resource(span->span_data);
-    zval prop_resource_as_string;
     if (Z_TYPE_P(prop_resource) != IS_NULL) {
-        ddtrace_convert_to_string(&prop_resource_as_string, prop_resource);
-        _add_assoc_zval_copy(el, "resource", &prop_resource_as_string);
-        zval_dtor(&prop_resource_as_string);
+        _dd_add_assoc_zval_as_string(el, "resource", prop_resource);
     } else {
         _add_assoc_zval_copy(el, "resource", &prop_name_as_string);
     }
@@ -322,20 +326,14 @@ void ddtrace_serialize_span_to_array(ddtrace_span_t *span, zval *array TSRMLS_DC
 
     // TODO: SpanData::$service defaults to parent SpanData::$service or DD_SERVICE if root span
     zval *prop_service = ddtrace_spandata_property_service(span->span_data);
-    zval prop_service_as_string;
     if (Z_TYPE_P(prop_service) != IS_NULL) {
-        ddtrace_convert_to_string(&prop_service_as_string, prop_service);
-        _add_assoc_zval_copy(el, "service", &prop_service_as_string);
-        zval_dtor(&prop_service_as_string);
+        _dd_add_assoc_zval_as_string(el, "service", prop_service);
     }
 
     // SpanData::$type is optional and defaults to 'custom' at the Agent level
     zval *prop_type = ddtrace_spandata_property_type(span->span_data);
-    zval prop_type_as_string;
     if (Z_TYPE_P(prop_type) != IS_NULL) {
-        ddtrace_convert_to_string(&prop_type_as_string, prop_type);
-        _add_assoc_zval_copy(el, "type", &prop_type_as_string);
-        zval_dtor(&prop_type_as_string);
+        _dd_add_assoc_zval_as_string(el, "type", prop_type);
     }
 
     _serialize_meta(el, span TSRMLS_CC);

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -126,7 +126,7 @@ array(3) {
     }
   }
   [1]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -139,6 +139,8 @@ array(3) {
     int(%d)
     ["name"]=>
     string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
     ["meta"]=>
     array(1) {
       ["rand.range"]=>
@@ -146,7 +148,7 @@ array(3) {
     }
   }
   [2]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -156,6 +158,8 @@ array(3) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
     string(7) "TestFoo"
     ["meta"]=>
     array(1) {

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -38,7 +38,7 @@ echo PHP_EOL;
 3
 6
 Flushing tracer...
-main
+main (main)
 array_sum (6)
 array_sum (3)
 Tracer reset
@@ -46,7 +46,7 @@ Tracer reset
 10
 15
 Flushing tracer...
-main
+main (main)
 array_sum (15)
 array_sum (10)
 Tracer reset
@@ -54,7 +54,7 @@ Tracer reset
 21
 28
 Flushing tracer...
-main
+main (main)
 array_sum (28)
 array_sum (21)
 Tracer reset

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -40,6 +40,6 @@ try {
 ?>
 --EXPECT--
 Flushing tracer...
-Foo.bar (error: Oops!)
+Foo.bar (Foo.bar) (error: Oops!)
 Tracer reset
 Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -43,7 +43,7 @@ echo PHP_EOL;
 3
 6
 Flushing tracer...
-main
+main (main)
 array_sum (6)
 array_sum (3)
 Tracer reset
@@ -51,7 +51,7 @@ Tracer reset
 10
 15
 Flushing tracer...
-main
+main (main)
 array_sum (15)
 array_sum (10)
 Tracer reset
@@ -59,7 +59,7 @@ Tracer reset
 21
 28
 Flushing tracer...
-main
+main (main)
 array_sum (28)
 array_sum (21)
 Tracer reset

--- a/tests/ext/sandbox/dd_dumper.inc
+++ b/tests/ext/sandbox/dd_dumper.inc
@@ -1,0 +1,38 @@
+<?php
+
+function dd_dump_spans()
+{
+    $spans = dd_trace_serialize_closed_spans();
+    echo 'spans(\\DDTrace\\SpanData) (' . count($spans) . ') {' . PHP_EOL;
+    array_map(function($span) {
+        $values = [];
+        if (isset($span['service'])) {
+            $values[] = $span['service'];
+        }
+        if (isset($span['resource'])) {
+            $values[] = $span['resource'];
+        }
+        if (isset($span['type'])) {
+            $values[] = $span['type'];
+        }
+
+        if (isset($span['name'])) {
+            echo '  ' . $span['name'];
+        }
+        if (!empty($values)) {
+            echo ' (' . implode(', ', $values) . ')';
+        }
+        if (isset($span['meta']['error.msg'])) {
+            echo ' (error: ' . $span['meta']['error.msg'] . ')';
+        }
+        if (isset($span['meta'])) {
+            echo PHP_EOL;
+            foreach ($span['meta'] as $k => $v) {
+                echo '    ' . $k . ' => ' . $v . PHP_EOL;
+            }
+        } else {
+            echo PHP_EOL;
+        }
+    }, $spans);
+    echo '}' . PHP_EOL;
+}

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -133,7 +133,7 @@ array(5) {
     }
   }
   [1]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -146,9 +146,11 @@ array(5) {
     int(%d)
     ["name"]=>
     string(8) "ArraySum"
+    ["resource"]=>
+    string(8) "ArraySum"
   }
   [2]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -161,9 +163,11 @@ array(5) {
     int(%d)
     ["name"]=>
     string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
   }
   [3]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -174,6 +178,8 @@ array(5) {
     int(%d)
     ["name"]=>
     string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
     ["meta"]=>
     array(1) {
       ["system.pid"]=>
@@ -181,7 +187,7 @@ array(5) {
     }
   }
   [4]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -191,6 +197,8 @@ array(5) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
     string(7) "TestFoo"
     ["meta"]=>
     array(1) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -25,7 +25,7 @@ int(9)
 ---
 array(1) {
   [0]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -35,6 +35,8 @@ array(1) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(8) "ArraySum"
+    ["resource"]=>
     string(8) "ArraySum"
     ["meta"]=>
     array(1) {

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -40,7 +40,7 @@ array (
 ---
 array(1) {
   [0]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -50,6 +50,8 @@ array(1) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(15) "filter_to_array"
+    ["resource"]=>
     string(15) "filter_to_array"
     ["meta"]=>
     array(1) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -141,7 +141,7 @@ array(3) {
     }
   }
   [1]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -154,6 +154,8 @@ array(3) {
     int(%d)
     ["name"]=>
     string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
     ["meta"]=>
     array(2) {
       ["rand.range"]=>
@@ -163,7 +165,7 @@ array(3) {
     }
   }
   [2]=>
-  array(6) {
+  array(7) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -173,6 +175,8 @@ array(3) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
     string(7) "TestFoo"
     ["meta"]=>
     array(1) {

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Span properties defaults to values if not explicitly set (functions)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,range
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+dd_trace_function('array_sum', function (SpanData $span, array $args, $retval) {
+    $span->meta = ['retval' => $retval];
+});
+
+dd_trace_function('range', function (SpanData $span) {
+    $span->name = 'MyRange';
+});
+
+dd_trace_function('main', function (SpanData $span, array $args) {
+    $span->meta = ['max' => $args[0]];
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(6);
+
+include 'dd_dumper.inc';
+dd_dump_spans();
+?>
+--EXPECTF--
+21
+28
+spans(\DDTrace\SpanData) (5) {
+  main (main)
+    max => 6
+    system.pid => %d
+  array_sum (array_sum)
+    retval => 28
+  MyRange (MyRange)
+  array_sum (array_sum)
+    retval => 21
+  MyRange (MyRange)
+}

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Span properties defaults to values if not explicitly set (methods)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::__construct,DateTime::format
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+date_default_timezone_set('UTC');
+
+dd_trace_method('DateTime', '__construct', function (SpanData $span, array $args) {
+    $span->meta = ['date' => $args[0]];
+});
+
+dd_trace_method('DateTime', 'format', function (SpanData $span, array $args) {
+    $span->name = 'MyDateTimeFormat';
+    $span->meta = ['format' => $args[0]];
+});
+
+dd_trace_method('Foo', 'main', function (SpanData $span, array $args) {
+    $span->meta = ['year' => $args[0]];
+});
+
+class Foo
+{
+    public function main($year)
+    {
+        $dt = new DateTime($year . '-06-15');
+        echo $dt->format('m') . PHP_EOL;
+    }
+}
+
+$foo = new Foo();
+$foo->main(2020);
+
+include 'dd_dumper.inc';
+dd_dump_spans();
+?>
+--EXPECTF--
+06
+spans(\DDTrace\SpanData) (3) {
+  Foo.main (Foo.main)
+    year => 2020
+    system.pid => %d
+  MyDateTimeFormat (MyDateTimeFormat)
+    format => m
+  DateTime.__construct (DateTime.__construct)
+    date => 2020-06-15
+}

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -24,7 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 testErrorFromUserland()
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     int(%d)
     ["span_id"]=>
@@ -34,6 +34,8 @@ array(1) {
     ["duration"]=>
     int(%d)
     ["name"]=>
+    string(21) "testErrorFromUserland"
+    ["resource"]=>
     string(21) "testErrorFromUserland"
     ["error"]=>
     int(1)

--- a/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
+++ b/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
@@ -73,6 +73,6 @@ array_map(function($span) {
 BarException caught
 BarException caught
 embeddedCatch, BarException caught
-throwException, Oops!
+throwException, throwException, Oops!
 multiCatch, BarException caught
-throwException, Oops!
+throwException, throwException, Oops!

--- a/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
+++ b/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
@@ -81,5 +81,5 @@ Exception was handled by level1(): Oops!
 HANDLED
 Span: level0-HANDLED
 Span: level1-HANDLED
-Span: level2 (Oops!)
-Span: level3 (Oops!)
+Span: level2-level2 (Oops!)
+Span: level3-level3 (Oops!)

--- a/tests/ext/sandbox/exception_handled_in_multicatch.phpt
+++ b/tests/ext/sandbox/exception_handled_in_multicatch.phpt
@@ -45,4 +45,4 @@ array_map(function($span) {
 --EXPECT--
 FooException caught
 multiCatch, FooException caught
-throwException, Oops!
+throwException, throwException, Oops!

--- a/tests/ext/sandbox/exception_handled_with_finally.phpt
+++ b/tests/ext/sandbox/exception_handled_with_finally.phpt
@@ -44,4 +44,4 @@ array_map(function($span) {
 --EXPECT--
 Finally retval
 doCatchWithFinally, Finally retval
-throwException, Oops!
+throwException, throwException, Oops!

--- a/tests/ext/sandbox/safe_to_string_properties.phpt
+++ b/tests/ext/sandbox/safe_to_string_properties.phpt
@@ -107,8 +107,8 @@ string(%d) "object(Closure)#%d"
 string(%d) "object(Closure)#%d"
 
 NULL
-'name' dropped
-'resource' dropped
+string(14) "prop_to_string"
+string(14) "prop_to_string"
 'service' dropped
 'type' dropped
 


### PR DESCRIPTION
### Description

This PR adds default values to `DDTrace\SpanData::$name` and `DDTrace\SpanData::$resource` when they are not explicitly set from a tracing closure.

* `SpanData::$name` defaults to the fully qualified name of the instrumented call in the form of `ClassName.methodName` or `functionName`
* `SpanData::$resource` defaults to the value of `SpanData::$name`

In a future PR `SpanData::$service` will default to the value of the parent span's `SpanData::$service`, or `DD_SERVICE` for top-level spans.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
