### PR TITLE
Only build on 64-bit platforms

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,6 +5,15 @@ PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
   [  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
 if test "$PHP_DDTRACE" != "no"; then
+  AC_CHECK_SIZEOF([long])
+  AC_MSG_CHECKING([for 64-bit platform])
+  AS_IF([test "$ac_cv_sizeof_long" -eq 4],[
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([ddtrace only supports 64-bit platforms])
+  ],[
+    AC_MSG_RESULT([yes])
+  ])
+
   m4_include([m4/polyfill.m4])
   m4_include([m4/ax_execinfo.m4])
 


### PR DESCRIPTION
### Description

This PR addresses the issue raised in #912 where ddtrace builds on 32-bit platforms when only 64-bit is supported. This adds a check to the config.m4 to fail on 32-bit platforms.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- ~~[ ] Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
