### PR TITLE
Add DDTrace namespace for internal functions

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -208,10 +208,12 @@
                         <file name="dd_dumper.inc" role="test" />
                         <file name="dd_trace_closed_spans_count.phpt" role="test" />
                         <file name="dd_trace_api_error.phpt" role="test" />
+                        <file name="dd_trace_function_alias.phpt" role="test" />
                         <file name="dd_trace_function_complex.phpt" role="test" />
                         <file name="dd_trace_function_internal.phpt" role="test" />
                         <file name="dd_trace_function_userland.phpt" role="test" />
                         <file name="dd_trace_method.phpt" role="test" />
+                        <file name="dd_trace_method_alias.phpt" role="test" />
                         <file name="dd_trace_method_binds_called_object.phpt" role="test" />
                         <file name="dd_trace_method_works_with_dd_trace.phpt" role="test" />
                         <file name="dd_trace_push_span_id.phpt" role="test" />

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -48,7 +48,7 @@ final class Bootstrap
             }
             return;
         }
-        dd_trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', [
+        \DDTrace\trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', [
             'instrument_when_limited' => 1,
             'posthook' => $flushTracer,
         ]);
@@ -141,7 +141,7 @@ final class Bootstrap
 
         if (\dd_trace_env_config("DD_TRACE_SANDBOX_ENABLED")) {
             $rootSpan = $span;
-            \dd_trace_function('header', function (SpanData $span, $args) use ($rootSpan) {
+            \DDTrace\trace_function('header', function (SpanData $span, $args) use ($rootSpan) {
                 if (isset($args[2])) {
                     $parsedHttpStatusCode = $args[2];
                 } elseif (isset($args[0])) {
@@ -154,7 +154,7 @@ final class Bootstrap
                 return false;
             });
 
-            \dd_trace_function('http_response_code', function (SpanData $span, $args) use ($rootSpan) {
+            \DDTrace\trace_function('http_response_code', function (SpanData $span, $args) use ($rootSpan) {
                 if (isset($args[0]) && \is_numeric($args[0])) {
                     $rootSpan->setTag(Tag::HTTP_STATUS_CODE, $args[0]);
                 }

--- a/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
@@ -58,27 +58,31 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
                 $integration->rootSpan->overwriteOperationName('cakephp.request');
             }
 
-            \DDTrace\trace_method('Controller', 'invokeAction', function (SpanData $span, array $args) use ($integration) {
-                $span->name = $span->resource = 'Controller.invokeAction';
-                $span->type = Type::WEB_SERVLET;
-                $span->service = $integration->appName;
+            \DDTrace\trace_method(
+                'Controller',
+                'invokeAction',
+                function (SpanData $span, array $args) use ($integration) {
+                    $span->name = $span->resource = 'Controller.invokeAction';
+                    $span->type = Type::WEB_SERVLET;
+                    $span->service = $integration->appName;
 
-                $request = $args[0];
-                if (!$request instanceof CakeRequest) {
-                    return;
-                }
+                    $request = $args[0];
+                    if (!$request instanceof CakeRequest) {
+                        return;
+                    }
 
-                $integration->rootSpan->setTag(
-                    Tag::RESOURCE_NAME,
-                    $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action']
-                );
-                $integration->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
-                $integration->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
-                $integration->rootSpan->setTag('cakephp.route.action', $request->params['action']);
-                if (isset($request->params['plugin'])) {
-                    $integration->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
+                    $integration->rootSpan->setTag(
+                        Tag::RESOURCE_NAME,
+                        $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action']
+                    );
+                    $integration->rootSpan->setTag(Tag::HTTP_URL, Router::url($request->here, true));
+                    $integration->rootSpan->setTag('cakephp.route.controller', $request->params['controller']);
+                    $integration->rootSpan->setTag('cakephp.route.action', $request->params['action']);
+                    if (isset($request->params['plugin'])) {
+                        $integration->rootSpan->setTag('cakephp.plugin', $request->params['plugin']);
+                    }
                 }
-            });
+            );
 
             // This only traces the default exception renderer
             // Remove this when error tracking is added

--- a/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPSandboxedIntegration.php
@@ -58,7 +58,7 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
                 $integration->rootSpan->overwriteOperationName('cakephp.request');
             }
 
-            \dd_trace_method('Controller', 'invokeAction', function (SpanData $span, array $args) use ($integration) {
+            \DDTrace\trace_method('Controller', 'invokeAction', function (SpanData $span, array $args) use ($integration) {
                 $span->name = $span->resource = 'Controller.invokeAction';
                 $span->type = Type::WEB_SERVLET;
                 $span->service = $integration->appName;
@@ -87,7 +87,7 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
             // - Controller::appError()
             // - Exception.handler
             // - Exception.renderer
-            \dd_trace_method('ExceptionRenderer', '__construct', [
+            \DDTrace\trace_method('ExceptionRenderer', '__construct', [
                 'instrument_when_limited' => 1,
                 'posthook' => function (SpanData $span, array $args) use ($integration) {
                     $integration->rootSpan->setError($args[0]);
@@ -95,7 +95,7 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
                 },
             ]);
 
-            \dd_trace_method('CakeResponse', 'statusCode', [
+            \DDTrace\trace_method('CakeResponse', 'statusCode', [
                 'instrument_when_limited' => 1,
                 'posthook' => function (SpanData $span, $args, $return) use ($integration) {
                     $integration->rootSpan->setTag(Tag::HTTP_STATUS_CODE, $return);
@@ -104,7 +104,7 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
             ]);
 
             // Create a trace span for every template rendered
-            \dd_trace_method('View', 'render', function (SpanData $span) use ($integration) {
+            \DDTrace\trace_method('View', 'render', function (SpanData $span) use ($integration) {
                 $span->name = 'cakephp.view';
                 $span->type = Type::WEB_SERVLET;
                 $file = $this->viewPath . '/' . $this->view . $this->ext;
@@ -118,12 +118,12 @@ class CakePHPSandboxedIntegration extends SandboxedIntegration
 
         if ('cli' === PHP_SAPI) {
             // CLI bootstrap
-            //\dd_trace_method('ShellDispatcher', '__construct', $initCakeV2);
+            //\DDTrace\trace_method('ShellDispatcher', '__construct', $initCakeV2);
             // Workaround until we fix request_init_hook for non-autoloaded projects
-            \dd_trace_method('App', 'init', $initCakeV2);
+            \DDTrace\trace_method('App', 'init', $initCakeV2);
         } else {
             // Web bootstrap
-            \dd_trace_method('Dispatcher', '__construct', $initCakeV2);
+            \DDTrace\trace_method('Dispatcher', '__construct', $initCakeV2);
         }
 
         return SandboxedIntegration::LOADED;

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php
@@ -37,7 +37,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
         }
         $service = \ddtrace_config_app_name(self::NAME);
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'CI_Router',
             '_set_routing',
             function () use ($integration, $rootScope, $service) {
@@ -79,7 +79,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
         $controller = $router->fetch_class();
         $method = $router->fetch_method();
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $controller,
             $method,
             function (SpanData $span) use ($root, $method, $service) {
@@ -101,7 +101,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
          * function is called, allowing you to define your own function
          * routing rules.
          */
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $controller,
             '_remap',
             function (SpanData $span, $args, $retval, $ex) use ($root, $service) {
@@ -118,7 +118,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'CI_Loader',
             'view',
             function (SpanData $span, $args, $retval, $ex) use ($service) {
@@ -133,7 +133,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
          * from all drivers. All drivers extend CI_DB and I *think* that CI_DB
          * extends either CI_DB_driver or CI_DB_active_rec which in turn
          * extends CI_DB_driver. */
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'CI_DB_driver',
             'query',
             function (SpanData $span, $args, $retval, $ex) use ($service) {
@@ -156,7 +156,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
          * requires a driver, so we can intercept the driver at __get.
          */
         $registered_cache_adapters = array();
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'CI_Cache',
             '__get',
             function (SpanData $span, $args, $retval, $ex) use ($service, &$registered_cache_adapters) {
@@ -178,7 +178,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
      */
     public static function registerCacheAdapter($adapter, $service)
     {
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $adapter,
             'get',
             function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
@@ -190,7 +190,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $adapter,
             'save',
             function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
@@ -202,7 +202,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $adapter,
             'delete',
             function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {
@@ -214,7 +214,7 @@ class CodeIgniterSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             $adapter,
             'clean',
             function (SpanData $span, $args, $retval, $ex) use ($adapter, $service) {

--- a/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php
@@ -43,7 +43,7 @@ final class CurlSandboxedIntegration extends SandboxedIntegration
             return SandboxedIntegration::NOT_LOADED;
         }
 
-        \dd_trace_function('curl_exec', [
+        \DDTrace\trace_function('curl_exec', [
             // the ddtrace extension will handle distributed headers
             'instrument_when_limited' => 0,
             'posthook' => function (SpanData $span, $args, $retval) {

--- a/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchSandboxedIntegration.php
@@ -124,7 +124,7 @@ class ElasticSearchSandboxedIntegration extends SandboxedIntegration
         $this->traceNamespaceMethod('NodesNamespace', 'stats');
 
         // Endpoints
-        dd_trace_method('Elasticsearch\Endpoints\AbstractEndpoint', 'performRequest', function (SpanData $span) {
+        \DDTrace\trace_method('Elasticsearch\Endpoints\AbstractEndpoint', 'performRequest', function (SpanData $span) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -165,7 +165,7 @@ class ElasticSearchSandboxedIntegration extends SandboxedIntegration
         */
         $hookType = (PHP_MAJOR_VERSION >= 7) ? 'prehook' : 'posthook';
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             $class,
             $name,
             [
@@ -194,7 +194,7 @@ class ElasticSearchSandboxedIntegration extends SandboxedIntegration
      */
     public function traceSimpleMethod($class, $name)
     {
-        dd_trace_method($class, $name, function (SpanData $span) use ($class, $name) {
+        \DDTrace\trace_method($class, $name, function (SpanData $span) use ($class, $name) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -214,7 +214,7 @@ class ElasticSearchSandboxedIntegration extends SandboxedIntegration
     {
         $class = 'Elasticsearch\Namespaces\\' . $namespace;
 
-        dd_trace_method($class, $name, function (SpanData $span, $args) use ($namespace, $name) {
+        \DDTrace\trace_method($class, $name, function (SpanData $span, $args) use ($namespace, $name) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }

--- a/src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php
@@ -32,7 +32,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
     {
         $integration = $this;
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Builder',
             'getModels',
             function (SpanData $span) use ($integration) {
@@ -44,7 +44,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Model',
             'performInsert',
             function (SpanData $span) use ($integration) {
@@ -54,7 +54,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Model',
             'performUpdate',
             function (SpanData $span) use ($integration) {
@@ -64,7 +64,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Model',
             'delete',
             function (SpanData $span) use ($integration) {
@@ -74,7 +74,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Model',
             'destroy',
             function (SpanData $span) use ($integration) {
@@ -84,7 +84,7 @@ class EloquentSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Database\Eloquent\Model',
             'refresh',
             function (SpanData $span) use ($integration) {

--- a/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php
@@ -37,7 +37,7 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
          * not send distributed tracing headers; curl will almost guaranteed do
          * it for us anyway. Just do a post-hook to get the response.
          */
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'GuzzleHttp\Client',
             'send',
             function (SpanData $span, $args, $retval) use ($integration) {
@@ -68,7 +68,7 @@ class GuzzleSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'GuzzleHttp\Client',
             'transfer',
             function (SpanData $span, $args, $retval) use ($integration) {

--- a/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
@@ -119,12 +119,16 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \DDTrace\trace_method('Illuminate\Events\Dispatcher', 'fire', function (SpanData $span, $args) use ($integration) {
-            $span->name = 'laravel.event.handle';
-            $span->type = Type::WEB_SERVLET;
-            $span->service = $integration->getServiceName();
-            $span->resource = $args[0];
-        });
+        \DDTrace\trace_method(
+            'Illuminate\Events\Dispatcher',
+            'fire',
+            function (SpanData $span, $args) use ($integration) {
+                $span->name = 'laravel.event.handle';
+                $span->type = Type::WEB_SERVLET;
+                $span->service = $integration->getServiceName();
+                $span->resource = $args[0];
+            }
+        );
 
         \DDTrace\trace_method('Illuminate\View\View', 'render', function (SpanData $span) use ($integration) {
             $span->name = 'laravel.view.render';

--- a/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php
@@ -55,7 +55,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
 
         $integration = $this;
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Foundation\Application',
             'handle',
             function (SpanData $span, $args, $response) use ($rootSpan, $integration) {
@@ -74,7 +74,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Routing\Router',
             'findRoute',
             function (SpanData $span, $args, $route) use ($rootSpan, $integration) {
@@ -99,7 +99,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Routing\Route',
             'run',
             function (SpanData $span) use ($integration) {
@@ -110,7 +110,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\HttpFoundation\Response',
             'setStatusCode',
             function (SpanData $span, $args) use ($rootSpan) {
@@ -119,21 +119,21 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method('Illuminate\Events\Dispatcher', 'fire', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('Illuminate\Events\Dispatcher', 'fire', function (SpanData $span, $args) use ($integration) {
             $span->name = 'laravel.event.handle';
             $span->type = Type::WEB_SERVLET;
             $span->service = $integration->getServiceName();
             $span->resource = $args[0];
         });
 
-        \dd_trace_method('Illuminate\View\View', 'render', function (SpanData $span) use ($integration) {
+        \DDTrace\trace_method('Illuminate\View\View', 'render', function (SpanData $span) use ($integration) {
             $span->name = 'laravel.view.render';
             $span->type = Type::WEB_SERVLET;
             $span->service = $integration->getServiceName();
             $span->resource = $this->view;
         });
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\View\Engines\CompilerEngine',
             'get',
             function (SpanData $span, $args) use ($integration, $rootSpan) {
@@ -148,7 +148,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Foundation\ProviderRepository',
             'load',
             function (SpanData $span) use ($rootSpan, $integration) {
@@ -162,7 +162,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Illuminate\Console\Application',
             '__construct',
             function () use ($rootSpan, $integration) {
@@ -175,7 +175,7 @@ class LaravelSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\Console\Application',
             'renderException',
             function (SpanData $span, $args) use ($rootSpan) {

--- a/src/DDTrace/Integrations/Lumen/LumenSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenSandboxedIntegration.php
@@ -49,7 +49,7 @@ class LumenSandboxedIntegration extends SandboxedIntegration
         $integration = $this;
         $appName = \ddtrace_config_app_name(self::NAME);
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Laravel\Lumen\Application',
             'prepareRequest',
             function (SpanData $span, $args) use ($rootSpan, $integration, $appName) {
@@ -64,7 +64,7 @@ class LumenSandboxedIntegration extends SandboxedIntegration
         );
 
         // Extracting resource name as in legacy integration
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'Laravel\Lumen\Application',
             'handleFoundRoute',
             [
@@ -104,8 +104,8 @@ class LumenSandboxedIntegration extends SandboxedIntegration
             return false;
         };
 
-        \dd_trace_method('Laravel\Lumen\Application', 'handleUncaughtException', [ 'prehook' => $exceptionRenderer]);
-        \dd_trace_method('Laravel\Lumen\Application', 'sendExceptionToHandler', [ 'prehook' => $exceptionRenderer]);
+        \DDTrace\trace_method('Laravel\Lumen\Application', 'handleUncaughtException', [ 'prehook' => $exceptionRenderer]);
+        \DDTrace\trace_method('Laravel\Lumen\Application', 'sendExceptionToHandler', [ 'prehook' => $exceptionRenderer]);
 
         // View is rendered in laravel as the method name overlaps
 

--- a/src/DDTrace/Integrations/Lumen/LumenSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenSandboxedIntegration.php
@@ -95,7 +95,7 @@ class LumenSandboxedIntegration extends SandboxedIntegration
             ]
         );
 
-        $exceptionRenderer = function (SpanData $span, $args) use ($rootSpan) {
+        $exceptionRender = function (SpanData $span, $args) use ($rootSpan) {
             if (count($args) < 1 || !\is_a($args[0], 'Throwable')) {
                 return false;
             }
@@ -104,8 +104,8 @@ class LumenSandboxedIntegration extends SandboxedIntegration
             return false;
         };
 
-        \DDTrace\trace_method('Laravel\Lumen\Application', 'handleUncaughtException', [ 'prehook' => $exceptionRenderer]);
-        \DDTrace\trace_method('Laravel\Lumen\Application', 'sendExceptionToHandler', [ 'prehook' => $exceptionRenderer]);
+        \DDTrace\trace_method('Laravel\Lumen\Application', 'handleUncaughtException', ['prehook' => $exceptionRender]);
+        \DDTrace\trace_method('Laravel\Lumen\Application', 'sendExceptionToHandler', ['prehook' => $exceptionRender]);
 
         // View is rendered in laravel as the method name overlaps
 

--- a/src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php
@@ -93,14 +93,14 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
         $this->traceCommand('touch');
         $this->traceCommandByKey('touchByKey');
 
-        dd_trace_method('Memcached', 'flush', function (SpanData $span) use ($integration) {
+        \DDTrace\trace_method('Memcached', 'flush', function (SpanData $span) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
             $integration->setCommonData($span, 'flush');
         });
 
-        dd_trace_method('Memcached', 'cas', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('Memcached', 'cas', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -110,7 +110,7 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
             $integration->setServerTags($span, $this);
         });
 
-        dd_trace_method('Memcached', 'casByKey', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('Memcached', 'casByKey', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -128,7 +128,7 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
     public function traceCommand($command)
     {
         $integration = $this;
-        dd_trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
+        \DDTrace\trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -145,7 +145,7 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
     public function traceCommandByKey($command)
     {
         $integration = $this;
-        dd_trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
+        \DDTrace\trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -163,7 +163,7 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
     public function traceMulti($command)
     {
         $integration = $this;
-        dd_trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
+        \DDTrace\trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -179,7 +179,7 @@ class MemcachedSandboxedIntegration extends SandboxedIntegration
     public function traceMultiByKey($command)
     {
         $integration = $this;
-        dd_trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
+        \DDTrace\trace_method('Memcached', $command, function (SpanData $span, $args) use ($integration, $command) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }

--- a/src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php
@@ -33,7 +33,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
          * MongoClient
          */
 
-        dd_trace_method('MongoClient', '__construct', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoClient', '__construct', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -50,7 +50,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoClient', 'selectCollection', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoClient', 'selectCollection', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -63,7 +63,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoClient', 'selectDB', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoClient', 'selectDB', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -73,7 +73,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoClient', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoClient', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -93,7 +93,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
          * MongoCollection
          */
 
-        dd_trace_method('MongoCollection', '__construct', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoCollection', '__construct', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -106,7 +106,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoCollection', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
+        \DDTrace\trace_method('MongoCollection', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -122,7 +122,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoCollection', 'getDBRef', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoCollection', 'getDBRef', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -136,7 +136,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoCollection', 'distinct', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoCollection', 'distinct', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -147,7 +147,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoCollection', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoCollection', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -186,7 +186,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
          * MongoDB
          */
 
-        dd_trace_method('MongoDB', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -196,7 +196,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'setProfilingLevel', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'setProfilingLevel', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -206,7 +206,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'command', function (SpanData $span, $args, $return) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'command', function (SpanData $span, $args, $return) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -221,7 +221,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -234,7 +234,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'getDBRef', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'getDBRef', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -244,7 +244,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'createCollection', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'createCollection', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -257,7 +257,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('MongoDB', 'selectCollection', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('MongoDB', 'selectCollection', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -295,7 +295,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
     public function traceMongoMethod($class, $method)
     {
         $integration = $this;
-        dd_trace_method($class, $method, function (SpanData $span) use ($class, $method, $integration) {
+        \DDTrace\trace_method($class, $method, function (SpanData $span) use ($class, $method, $integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -315,7 +315,7 @@ class MongoSandboxedIntegration extends SandboxedIntegration
     public function traceMongoQuery($class, $method, $isTraceAnalithicsCandidate = true)
     {
         $integration = $this;
-        dd_trace_method(
+        \DDTrace\trace_method(
             $class,
             $method,
             function (SpanData $span, $args) use ($class, $method, $isTraceAnalithicsCandidate, $integration) {

--- a/src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php
@@ -106,21 +106,25 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        \DDTrace\trace_method('MongoCollection', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
-            if (dd_trace_tracer_is_limited()) {
-                return false;
+        \DDTrace\trace_method(
+            'MongoCollection',
+            'createDBRef',
+            function (SpanData $span, $args, $return) use ($integration) {
+                if (dd_trace_tracer_is_limited()) {
+                    return false;
+                }
+                $integration->addSpanDefaultMetadata($span, 'MongoCollection', 'createDBRef');
+                if (!is_array($return)) {
+                    return;
+                }
+                if (isset($return['$id'])) {
+                    $span->meta[Tag::MONGODB_BSON_ID] = $return['$id'];
+                }
+                if (isset($return['$ref'])) {
+                    $span->meta[Tag::MONGODB_COLLECTION] = $return['$ref'];
+                }
             }
-            $integration->addSpanDefaultMetadata($span, 'MongoCollection', 'createDBRef');
-            if (!is_array($return)) {
-                return;
-            }
-            if (isset($return['$id'])) {
-                $span->meta[Tag::MONGODB_BSON_ID] = $return['$id'];
-            }
-            if (isset($return['$ref'])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $return['$ref'];
-            }
-        });
+        );
 
         \DDTrace\trace_method('MongoCollection', 'getDBRef', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
@@ -147,15 +151,19 @@ class MongoSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        \DDTrace\trace_method('MongoCollection', 'setReadPreference', function (SpanData $span, $args) use ($integration) {
-            if (dd_trace_tracer_is_limited()) {
-                return false;
+        \DDTrace\trace_method(
+            'MongoCollection',
+            'setReadPreference',
+            function (SpanData $span, $args) use ($integration) {
+                if (dd_trace_tracer_is_limited()) {
+                    return false;
+                }
+                $integration->addSpanDefaultMetadata($span, 'MongoCollection', 'setReadPreference');
+                if (isset($args[0])) {
+                    $span->meta[Tag::MONGODB_READ_PREFERENCE] = $args[0];
+                }
             }
-            $integration->addSpanDefaultMetadata($span, 'MongoCollection', 'setReadPreference');
-            if (isset($args[0])) {
-                $span->meta[Tag::MONGODB_READ_PREFERENCE] = $args[0];
-            }
-        });
+        );
 
         $this->traceMongoQuery('MongoCollection', 'count', false);
         $this->traceMongoQuery('MongoCollection', 'find');

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -112,7 +112,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($result, 'host_info', MysqliCommon::extractHostInfo($mysqli));
         });
 
-        \DDTrace\trace_function('mysqli_prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+        \DDTrace\trace_function('mysqli_prepare', function (SpanData $span, $args, $retval) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -122,8 +122,8 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setConnectionInfo($span, $mysqli);
 
             $host_info = MysqliCommon::extractHostInfo($mysqli);
-            MysqliCommon::storeQuery($returnedStatement, $query);
-            ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
+            MysqliCommon::storeQuery($retval, $query);
+            ObjectKVStore::put($retval, 'host_info', $host_info);
         });
 
         \DDTrace\trace_function('mysqli_commit', function (SpanData $span, $args) use ($integration) {
@@ -176,7 +176,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($result, 'query', $query);
         });
 
-        \DDTrace\trace_method('mysqli', 'prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+        \DDTrace\trace_method('mysqli', 'prepare', function (SpanData $span, $args, $retval) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -185,8 +185,8 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setDefaultAttributes($span, 'mysqli.prepare', $query);
             $integration->setConnectionInfo($span, $this);
             $host_info = MysqliCommon::extractHostInfo($this);
-            ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
-            MysqliCommon::storeQuery($returnedStatement, $query);
+            ObjectKVStore::put($retval, 'host_info', $host_info);
+            MysqliCommon::storeQuery($retval, $query);
         });
 
         \DDTrace\trace_method('mysqli', 'commit', function (SpanData $span, $args) use ($integration) {
@@ -213,7 +213,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->addTraceAnalyticsIfEnabled($span);
         });
 
-        \DDTrace\trace_method('mysqli_stmt', 'get_result', function (SpanData $span, $args, $result) use ($integration) {
+        \DDTrace\trace_method('mysqli_stmt', 'get_result', function (SpanData $span, $a, $result) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }

--- a/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php
@@ -36,7 +36,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
 
         $integration = $this;
 
-        dd_trace_function('mysqli_connect', function (SpanData $span, $args, $result) use ($integration) {
+        \DDTrace\trace_function('mysqli_connect', function (SpanData $span, $args, $result) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -51,7 +51,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
         });
 
         $mysqli_constructor = PHP_MAJOR_VERSION > 5 ? '__construct' : 'mysqli';
-        dd_trace_method(
+        \DDTrace\trace_method(
             'mysqli',
             $mysqli_constructor,
             function (SpanData $span) use ($integration) {
@@ -73,7 +73,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_function('mysqli_real_connect', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_function('mysqli_real_connect', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -86,7 +86,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('mysqli', 'real_connect', function (SpanData $span) use ($integration) {
+        \DDTrace\trace_method('mysqli', 'real_connect', function (SpanData $span) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -97,7 +97,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
         });
 
 
-        dd_trace_function('mysqli_query', function (SpanData $span, $args, $result) use ($integration) {
+        \DDTrace\trace_function('mysqli_query', function (SpanData $span, $args, $result) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -112,7 +112,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($result, 'host_info', MysqliCommon::extractHostInfo($mysqli));
         });
 
-        dd_trace_function('mysqli_prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+        \DDTrace\trace_function('mysqli_prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -126,7 +126,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($returnedStatement, 'host_info', $host_info);
         });
 
-        dd_trace_function('mysqli_commit', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_function('mysqli_commit', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -141,7 +141,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_function('mysqli_stmt_execute', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_function('mysqli_stmt_execute', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -151,7 +151,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->setDefaultAttributes($span, 'mysqli_stmt_execute', $resource);
         });
 
-        dd_trace_function('mysqli_stmt_get_result', function (SpanData $span, $args, $result) {
+        \DDTrace\trace_function('mysqli_stmt_get_result', function (SpanData $span, $args, $result) {
             list($statement) = $args;
             $resource = MysqliCommon::retrieveQuery($statement, 'mysqli_stmt_get_result');
             MysqliCommon::storeQuery($result, $resource);
@@ -160,7 +160,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             return false;
         });
 
-        dd_trace_method('mysqli', 'query', function (SpanData $span, $args, $result) use ($integration) {
+        \DDTrace\trace_method('mysqli', 'query', function (SpanData $span, $args, $result) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -176,7 +176,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             ObjectKVStore::put($result, 'query', $query);
         });
 
-        dd_trace_method('mysqli', 'prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
+        \DDTrace\trace_method('mysqli', 'prepare', function (SpanData $span, $args, $returnedStatement) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -189,7 +189,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             MysqliCommon::storeQuery($returnedStatement, $query);
         });
 
-        dd_trace_method('mysqli', 'commit', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('mysqli', 'commit', function (SpanData $span, $args) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -203,7 +203,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             }
         });
 
-        dd_trace_method('mysqli_stmt', 'execute', function (SpanData $span) use ($integration) {
+        \DDTrace\trace_method('mysqli_stmt', 'execute', function (SpanData $span) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -213,7 +213,7 @@ class MysqliSandboxedIntegration extends SandboxedIntegration
             $integration->addTraceAnalyticsIfEnabled($span);
         });
 
-        dd_trace_method('mysqli_stmt', 'get_result', function (SpanData $span, $args, $result) use ($integration) {
+        \DDTrace\trace_method('mysqli_stmt', 'get_result', function (SpanData $span, $args, $result) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }

--- a/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php
@@ -42,7 +42,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         $integration = $this;
 
         // public PDO::__construct ( string $dsn [, string $username [, string $passwd [, array $options ]]] )
-        dd_trace_method('PDO', '__construct', function (SpanData $span, array $args) {
+        \DDTrace\trace_method('PDO', '__construct', function (SpanData $span, array $args) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -53,7 +53,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public int PDO::exec(string $query)
-        dd_trace_method('PDO', 'exec', function (SpanData $span, array $args, $retval) use ($integration) {
+        \DDTrace\trace_method('PDO', 'exec', function (SpanData $span, array $args, $retval) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -76,7 +76,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
         // public int PDO::exec(string $query)
-        dd_trace_method('PDO', 'query', function (SpanData $span, array $args, $retval) use ($integration) {
+        \DDTrace\trace_method('PDO', 'query', function (SpanData $span, array $args, $retval) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -96,7 +96,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public bool PDO::commit ( void )
-        dd_trace_method('PDO', 'commit', function (SpanData $span) {
+        \DDTrace\trace_method('PDO', 'commit', function (SpanData $span) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -107,7 +107,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public PDOStatement PDO::prepare ( string $statement [, array $driver_options = array() ] )
-        dd_trace_method('PDO', 'prepare', function (SpanData $span, array $args, $retval) {
+        \DDTrace\trace_method('PDO', 'prepare', function (SpanData $span, array $args, $retval) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }
@@ -120,7 +120,7 @@ class PDOSandboxedIntegration extends SandboxedIntegration
         });
 
         // public bool PDOStatement::execute ([ array $input_parameters ] )
-        dd_trace_method('PDOStatement', 'execute', function (SpanData $span, array $args, $retval) use ($integration) {
+        \DDTrace\trace_method('PDOStatement', 'execute', function (SpanData $span, array $args, $retval) use ($integration) {
             if (dd_trace_tracer_is_limited()) {
                 return false;
             }

--- a/src/DDTrace/Integrations/Predis/PredisSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisSandboxedIntegration.php
@@ -34,7 +34,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
     {
         $integration = $this;
 
-        \dd_trace_method('Predis\Client', '__construct', function (SpanData $span, $args) {
+        \DDTrace\trace_method('Predis\Client', '__construct', function (SpanData $span, $args) {
             $span->name = 'Predis.Client.__construct';
             $span->type = Type::CACHE;
             $span->service = 'redis';
@@ -43,7 +43,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
             PredisSandboxedIntegration::setConnectionTags($this, $span);
         });
 
-        \dd_trace_method('Predis\Client', 'connect', function (SpanData $span, $args) {
+        \DDTrace\trace_method('Predis\Client', 'connect', function (SpanData $span, $args) {
             $span->name = 'Predis.Client.connect';
             $span->type = Type::CACHE;
             $span->service = 'redis';
@@ -51,7 +51,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
             PredisSandboxedIntegration::setConnectionTags($this, $span);
         });
 
-        \dd_trace_method('Predis\Client', 'executeCommand', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('Predis\Client', 'executeCommand', function (SpanData $span, $args) use ($integration) {
             $span->name = 'Predis.Client.executeCommand';
             $span->type = Type::CACHE;
             $span->service = 'redis';
@@ -75,7 +75,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
             $span->meta['redis.raw_command'] = $query;
         });
 
-        \dd_trace_method('Predis\Client', 'executeRaw', function (SpanData $span, $args) use ($integration) {
+        \DDTrace\trace_method('Predis\Client', 'executeRaw', function (SpanData $span, $args) use ($integration) {
             $span->name = 'Predis.Client.executeRaw';
             $span->type = Type::CACHE;
             $span->service = 'redis';
@@ -99,7 +99,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
         // PHP 5 does not support prehook, which is required to get the pipeline count before
         // tasks are dequeued.
         if (Versions::phpVersionMatches('5')) {
-            \dd_trace_method('Predis\Pipeline\Pipeline', 'executePipeline', function (SpanData $span, $args) {
+            \DDTrace\trace_method('Predis\Pipeline\Pipeline', 'executePipeline', function (SpanData $span, $args) {
                 $span->name = 'Predis.Pipeline.executePipeline';
                 $span->resource = $span->name;
                 $span->type = Type::CACHE;
@@ -107,7 +107,7 @@ class PredisSandboxedIntegration extends SandboxedIntegration
                 PredisSandboxedIntegration::setConnectionTags($this, $span);
             });
         } else {
-            \dd_trace_method(
+            \DDTrace\trace_method(
                 'Predis\Pipeline\Pipeline',
                 'executePipeline',
                 [

--- a/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
@@ -43,7 +43,7 @@ class SlimSandboxedIntegration extends SandboxedIntegration
             $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
 
             // Hook into the router to extract the proper route name
-            \DDTrace\trace_method('Slim\Router', 'lookupRoute', function (SpanData $span, $args, $return) use ($rootSpan) {
+            \DDTrace\trace_method('Slim\Router', 'lookupRoute', function (SpanData $s, $a, $return) use ($rootSpan) {
                 /** @var \Slim\Interfaces\RouteInterface $route */
                 $route = $return;
                 $rootSpan->setTag(

--- a/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimSandboxedIntegration.php
@@ -29,7 +29,7 @@ class SlimSandboxedIntegration extends SandboxedIntegration
         $integration = $this;
         $appName = \ddtrace_config_app_name(self::NAME);
 
-        \dd_trace_method('Slim\App', '__construct', function () use ($integration, $appName) {
+        \DDTrace\trace_method('Slim\App', '__construct', function () use ($integration, $appName) {
             // At the moment we only report internals of Slim 3.*
             $majorVersion = substr(self::VERSION, 0, 1);
             if ('3' !== $majorVersion) {
@@ -43,7 +43,7 @@ class SlimSandboxedIntegration extends SandboxedIntegration
             $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
 
             // Hook into the router to extract the proper route name
-            \dd_trace_method('Slim\Router', 'lookupRoute', function (SpanData $span, $args, $return) use ($rootSpan) {
+            \DDTrace\trace_method('Slim\Router', 'lookupRoute', function (SpanData $span, $args, $return) use ($rootSpan) {
                 /** @var \Slim\Interfaces\RouteInterface $route */
                 $route = $return;
                 $rootSpan->setTag(
@@ -71,15 +71,15 @@ class SlimSandboxedIntegration extends SandboxedIntegration
             };
             // If the tracer ever supports tracing an interface, we should trace the following:
             // Slim\Interfaces\InvocationStrategyInterface::__invoke
-            \dd_trace_method('Slim\Handlers\Strategies\RequestResponse', '__invoke', [
+            \DDTrace\trace_method('Slim\Handlers\Strategies\RequestResponse', '__invoke', [
                 'prehook' => $traceControllers,
             ]);
-            \dd_trace_method('Slim\Handlers\Strategies\RequestResponseArgs', '__invoke', [
+            \DDTrace\trace_method('Slim\Handlers\Strategies\RequestResponseArgs', '__invoke', [
                 'prehook' => $traceControllers,
             ]);
 
             // Handling Twig views
-            \dd_trace_method('Slim\Views\Twig', 'render', function (SpanData $span, $args) use ($appName) {
+            \DDTrace\trace_method('Slim\Views\Twig', 'render', function (SpanData $span, $args) use ($appName) {
                 $span->name = 'slim.view';
                 $span->service = $appName;
                 $span->type = Type::WEB_SERVLET;

--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -42,7 +42,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
     {
         $integration = $this;
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\HttpKernel',
             '__construct',
             function () use ($integration) {
@@ -77,7 +77,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         $integration->symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $integration->appName);
         $integration->addTraceAnalyticsIfEnabledLegacy($integration->symfonyRequestSpan);
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\HttpKernel',
             'handle',
             function (SpanData $span, $args, $response) use ($integration) {
@@ -113,7 +113,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         */
         $hookType = (PHP_MAJOR_VERSION >= 7) ? 'prehook' : 'posthook';
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\EventDispatcher\EventDispatcher',
             'dispatch',
             [
@@ -143,7 +143,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
             ]
         );
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\HttpKernel',
             'handleException',
             function (SpanData $span, $args) use ($integration) {
@@ -162,19 +162,19 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
             $resourceName = count($args) > 0 ? get_class($this) . ' ' . $args[0] : get_class($this);
             $span->resource = $resourceName;
         };
-        dd_trace_method('Symfony\Bridge\Twig\TwigEngine', 'render', $renderTraceCallback);
-        dd_trace_method('Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine', 'render', $renderTraceCallback);
-        dd_trace_method('Symfony\Bundle\TwigBundle\TwigEngine', 'render', $renderTraceCallback);
-        dd_trace_method('Symfony\Component\Templating\DelegatingEngine', 'render', $renderTraceCallback);
-        dd_trace_method('Symfony\Component\Templating\PhpEngine', 'render', $renderTraceCallback);
-        dd_trace_method('Twig\Environment', 'render', $renderTraceCallback);
-        dd_trace_method('Twig_Environment', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Bridge\Twig\TwigEngine', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Bundle\TwigBundle\TwigEngine', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Component\Templating\DelegatingEngine', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Component\Templating\PhpEngine', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Twig\Environment', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Twig_Environment', 'render', $renderTraceCallback);
     }
 
     public function loadSymfony2($integration)
     {
         // Symfony 2.x specific resource name assignment
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\Event\FilterControllerEvent',
             'setController',
             function (SpanData $span, $args) use ($integration) {

--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -154,7 +154,7 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         );
 
         // Tracing templating engines
-        $renderTraceCallback = function (SpanData $span, $args) use ($integration) {
+        $traceRender = function (SpanData $span, $args) use ($integration) {
             $span->name = 'symfony.templating.render';
             $span->service = $integration->appName;
             $span->type = Type::WEB_SERVLET;
@@ -162,13 +162,13 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
             $resourceName = count($args) > 0 ? get_class($this) . ' ' . $args[0] : get_class($this);
             $span->resource = $resourceName;
         };
-        \DDTrace\trace_method('Symfony\Bridge\Twig\TwigEngine', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Symfony\Bundle\TwigBundle\TwigEngine', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Symfony\Component\Templating\DelegatingEngine', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Symfony\Component\Templating\PhpEngine', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Twig\Environment', 'render', $renderTraceCallback);
-        \DDTrace\trace_method('Twig_Environment', 'render', $renderTraceCallback);
+        \DDTrace\trace_method('Symfony\Bridge\Twig\TwigEngine', 'render', $traceRender);
+        \DDTrace\trace_method('Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine', 'render', $traceRender);
+        \DDTrace\trace_method('Symfony\Bundle\TwigBundle\TwigEngine', 'render', $traceRender);
+        \DDTrace\trace_method('Symfony\Component\Templating\DelegatingEngine', 'render', $traceRender);
+        \DDTrace\trace_method('Symfony\Component\Templating\PhpEngine', 'render', $traceRender);
+        \DDTrace\trace_method('Twig\Environment', 'render', $traceRender);
+        \DDTrace\trace_method('Twig_Environment', 'render', $traceRender);
     }
 
     public function loadSymfony2($integration)

--- a/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
@@ -42,105 +42,105 @@ class WordPressIntegrationLoader
         }
 
         // Core
-        dd_trace_method('WP', 'main', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'main', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.main';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'init', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'init', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.init';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'parse_request', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'parse_request', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.parse_request';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'send_headers', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'send_headers', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.send_headers';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'query_posts', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'query_posts', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.query_posts';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'handle_404', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'handle_404', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.handle_404';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP', 'register_globals', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP', 'register_globals', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP.register_globals';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('create_initial_post_types', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('create_initial_post_types', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'create_initial_post_types';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('create_initial_taxonomies', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('create_initial_taxonomies', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'create_initial_taxonomies';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('wp_print_head_scripts', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('wp_print_head_scripts', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'wp_print_head_scripts';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
-        dd_trace_function('wp_print_footer_scripts', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('wp_print_footer_scripts', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'wp_print_footer_scripts';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
         // These not called in PHP 5 due to call_user_func_array() bug
-        dd_trace_function('wp_maybe_load_widgets', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('wp_maybe_load_widgets', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'wp_maybe_load_widgets';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('wp_maybe_load_embeds', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('wp_maybe_load_embeds', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'wp_maybe_load_embeds';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('_wp_customize_include', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('_wp_customize_include', function (SpanData $span) use ($service) {
             $span->name = $span->resource = '_wp_customize_include';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
         // Widgets
-        dd_trace_method('WP_Widget_Factory', '_register_widgets', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP_Widget_Factory', '_register_widgets', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP_Widget_Factory._register_widgets';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_method('WP_Widget', 'display_callback', function (SpanData $span) use ($service) {
+        \DDTrace\trace_method('WP_Widget', 'display_callback', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'WP_Widget.display_callback';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
         // Database
-        dd_trace_method('wpdb', '__construct', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_method('wpdb', '__construct', function (SpanData $span, array $args) use ($service) {
             $span->name = $span->resource = 'wpdb.__construct';
             $span->type = Type::SQL;
             $span->service = $service;
@@ -151,7 +151,7 @@ class WordPressIntegrationLoader
             ];
         });
 
-        dd_trace_method('wpdb', 'query', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_method('wpdb', 'query', function (SpanData $span, array $args) use ($service) {
             $span->name = 'wpdb.query';
             $span->resource = $args[0];
             $span->type = Type::SQL;
@@ -159,60 +159,60 @@ class WordPressIntegrationLoader
         });
 
         // Views
-        dd_trace_function('get_header', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('get_header', function (SpanData $span, array $args) use ($service) {
             $span->name = 'get_header';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('wp_head', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('wp_head', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'wp_head';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('the_custom_header_markup', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('the_custom_header_markup', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'the_custom_header_markup';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('body_class', function (SpanData $span) use ($service) {
+        \DDTrace\trace_function('body_class', function (SpanData $span) use ($service) {
             $span->name = $span->resource = 'body_class';
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('load_template', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('load_template', function (SpanData $span, array $args) use ($service) {
             $span->name = 'load_template';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('comments_template', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('comments_template', function (SpanData $span, array $args) use ($service) {
             $span->name = 'comments_template';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('get_sidebar', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('get_sidebar', function (SpanData $span, array $args) use ($service) {
             $span->name = 'get_sidebar';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('dynamic_sidebar', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('dynamic_sidebar', function (SpanData $span, array $args) use ($service) {
             $span->name = 'dynamic_sidebar';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;
             $span->service = $service;
         });
 
-        dd_trace_function('get_footer', function (SpanData $span, array $args) use ($service) {
+        \DDTrace\trace_function('get_footer', function (SpanData $span, array $args) use ($service) {
             $span->name = 'get_footer';
             $span->resource = !empty($args[0]) ? $args[0] : $span->name;
             $span->type = Type::WEB_SERVLET;

--- a/src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php
@@ -53,7 +53,7 @@ class WordPressSandboxedIntegration extends SandboxedIntegration
         $integration = self::getInstance();
 
         // This call happens right after WP registers an autoloader for the first time
-        dd_trace_method('Requests', 'set_certificate_path', function () use ($integration) {
+        \DDTrace\trace_method('Requests', 'set_certificate_path', function () use ($integration) {
             if (!isset($GLOBALS['wp_version']) || !is_string($GLOBALS['wp_version'])) {
                 return false;
             }

--- a/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php
@@ -24,7 +24,7 @@ class YiiIntegrationLoader
         $integration->addTraceAnalyticsIfEnabledLegacy($root);
         $service = \ddtrace_config_app_name(YiiSandboxedIntegration::NAME);
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'yii\web\Application',
             'run',
             function (SpanData $span) use ($service) {
@@ -36,7 +36,7 @@ class YiiIntegrationLoader
 
         // We assume the first controller is the one to assign to app.endpoint
         $firstController = null;
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'yii\web\Application',
             'createController',
             function (SpanData $span, $args, $retval, $ex) use (&$firstController) {
@@ -53,7 +53,7 @@ class YiiIntegrationLoader
          * modules are worth tracing independently, as multiple modules can trigger per
          * application, such as in the event of an unhandled exception.
          */
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'yii\base\Module',
             'runAction',
             function (SpanData $span, $args) use ($service) {
@@ -64,7 +64,7 @@ class YiiIntegrationLoader
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'yii\base\Controller',
             'runAction',
             function (SpanData $span, $args) use (&$firstController, $service, $root) {
@@ -104,7 +104,7 @@ class YiiIntegrationLoader
             }
         );
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'yii\base\View',
             'renderFile',
             function (SpanData $span, $args) use ($service) {

--- a/src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php
@@ -53,7 +53,7 @@ class YiiSandboxedIntegration extends SandboxedIntegration
         $integration = self::getInstance();
 
         // This happens somewhat early in the setup, though there may be a better candidate
-        \dd_trace_method('yii\di\Container', '__construct', function () use ($integration) {
+        \DDTrace\trace_method('yii\di\Container', '__construct', function () use ($integration) {
             if (Versions::versionMatches('2.0', \Yii::getVersion())) {
                 $loader = new V2\YiiIntegrationLoader();
                 $loader->load($integration);

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php
@@ -55,7 +55,7 @@ class ZendFrameworkSandboxedIntegration extends SandboxedIntegration
         // name 'zendframework', we are instead using the 'zf1' prefix.
         $appName = \ddtrace_config_app_name('zf1');
 
-        dd_trace_method(
+        \DDTrace\trace_method(
             'Zend_Controller_Plugin_Broker',
             'preDispatch',
             function (SpanData $spanData, $args) use ($integration, $appName) {
@@ -98,7 +98,7 @@ class ZendFrameworkSandboxedIntegration extends SandboxedIntegration
             }
         );
 
-        dd_trace_method('Zend_Controller_Plugin_Broker', 'postDispatch', function () {
+        \DDTrace\trace_method('Zend_Controller_Plugin_Broker', 'postDispatch', function () {
             $rootScope = GlobalTracer::get()->getRootScope();
             if (null === $rootScope || null === ($rootSpan = $rootScope->getSpan())) {
                 return false;

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -97,13 +97,13 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   STANDARD_ZEND_EXTENSION_PROPERTIES};
 
 #if PHP_VERSION_ID >= 50600
-ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_method, 0, 0, 3)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_trace_method, 0, 0, 3)
 ZEND_ARG_INFO(0, class_name)
 ZEND_ARG_INFO(0, method_name)
 ZEND_ARG_INFO(0, tracing_closure)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_function, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_trace_function, 0, 0, 2)
 ZEND_ARG_INFO(0, function_name)
 ZEND_ARG_INFO(0, tracing_closure)
 ZEND_END_ARG_INFO()
@@ -635,7 +635,7 @@ static PHP_FUNCTION(dd_trace) {
 }
 
 #if PHP_VERSION_ID >= 50600
-static PHP_FUNCTION(dd_trace_method) {
+static PHP_FUNCTION(trace_method) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *class_name = NULL;
     zval *function = NULL;
@@ -683,7 +683,7 @@ static PHP_FUNCTION(dd_trace_method) {
     RETURN_BOOL(rv);
 }
 
-static PHP_FUNCTION(dd_trace_function) {
+static PHP_FUNCTION(trace_function) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *function = NULL;
     zval *tracing_closure = NULL;
@@ -1258,14 +1258,8 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_disable_in_request, NULL),
     DDTRACE_FE(dd_trace_env_config, arginfo_dd_trace_env_config),
     DDTRACE_FE(dd_trace_forward_call, NULL),
-#if PHP_VERSION_ID >= 50600
-    DDTRACE_FE(dd_trace_function, arginfo_dd_trace_function),
-#endif
     DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, NULL),
     DDTRACE_FE(dd_trace_internal_fn, NULL),
-#if PHP_VERSION_ID >= 50600
-    DDTRACE_FE(dd_trace_method, arginfo_dd_trace_method),
-#endif
     DDTRACE_FE(dd_trace_noop, NULL),
     DDTRACE_FE(dd_trace_peek_span_id, NULL),
     DDTRACE_FE(dd_trace_pop_span_id, NULL),
@@ -1287,6 +1281,12 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(ddtrace_config_integration_enabled, arginfo_ddtrace_config_integration_enabled),
     DDTRACE_FE(ddtrace_config_trace_enabled, arginfo_ddtrace_config_trace_enabled),
     DDTRACE_FE(ddtrace_init, arginfo_ddtrace_init),
+#if PHP_VERSION_ID >= 50600
+    DDTRACE_NS_FE(trace_function, arginfo_ddtrace_trace_function),
+    DDTRACE_FALIAS(dd_trace_function, trace_function, arginfo_ddtrace_trace_function),
+    DDTRACE_NS_FE(trace_method, arginfo_ddtrace_trace_method),
+    DDTRACE_FALIAS(dd_trace_method, trace_method, arginfo_ddtrace_trace_method),
+#endif
     DDTRACE_FE_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -100,8 +100,11 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
 
 #define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
     { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
+#define DDTRACE_RAW_FENTRY(zend_name, name, arg_info, flags) \
+    { zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
 
 #define DDTRACE_FE(name, arg_info) DDTRACE_FENTRY(name, ZEND_FN(name), arg_info, 0)
+#define DDTRACE_NS_FE(name, arg_info) DDTRACE_RAW_FENTRY("DDTrace\\" #name, ZEND_FN(name), arg_info, 0)
 #define DDTRACE_FALIAS(name, alias, arg_info) DDTRACE_FENTRY(name, ZEND_FN(alias), arg_info, 0)
 #define DDTRACE_FE_END ZEND_FE_END
 

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -51,7 +51,7 @@ final class TracerTest extends BaseTestCase
         if (Versions::phpVersionMatches('5.4')) {
             $this->markTestSkipped('Internal spans are not enabled yet on PHP 5.4');
         }
-        \dd_trace_method('DDTrace\Tests\Integration\TracerTest', 'dummyMethodGlobalTags', function (SpanData $span) {
+        \DDTrace\trace_method('DDTrace\Tests\Integration\TracerTest', 'dummyMethodGlobalTags', function (SpanData $span) {
             $span->service = 'custom.service';
             $span->name = 'custom.name';
             $span->resource = 'custom.resource';
@@ -135,7 +135,7 @@ final class TracerTest extends BaseTestCase
             $this->markTestSkipped('Internal spans are not enabled yet on PHP 5.4');
         }
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'DDTrace\Tests\Integration\TracerTest',
             'dummyMethodResourceNormalizationInternalApi',
             function (SpanData $span) {
@@ -281,7 +281,7 @@ final class TracerTest extends BaseTestCase
             $this->markTestSkipped('Internal spans are not enabled yet on PHP 5.4');
         }
 
-        \dd_trace_method(
+        \DDTrace\trace_method(
             'DDTrace\Tests\Integration\TracerTest',
             'dummyMethodServiceMappingInternalApi',
             function (SpanData $span) {

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -51,14 +51,18 @@ final class TracerTest extends BaseTestCase
         if (Versions::phpVersionMatches('5.4')) {
             $this->markTestSkipped('Internal spans are not enabled yet on PHP 5.4');
         }
-        \DDTrace\trace_method('DDTrace\Tests\Integration\TracerTest', 'dummyMethodGlobalTags', function (SpanData $span) {
-            $span->service = 'custom.service';
-            $span->name = 'custom.name';
-            $span->resource = 'custom.resource';
-            $span->type = 'custom';
-            $span->meta['local_tag'] = 'local';
-            $span->meta['also_in_span'] = 'span_wins';
-        });
+        \DDTrace\trace_method(
+            'DDTrace\Tests\Integration\TracerTest',
+            'dummyMethodGlobalTags',
+            function (SpanData $span) {
+                $span->service = 'custom.service';
+                $span->name = 'custom.name';
+                $span->resource = 'custom.resource';
+                $span->type = 'custom';
+                $span->meta['local_tag'] = 'local';
+                $span->meta['also_in_span'] = 'span_wins';
+            }
+        );
 
         $test = $this;
         $traces = $this->isolateTracer(function (Tracer $tracer) use ($test) {

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -284,7 +284,7 @@ final class TracerTest extends BaseTestCase
         // Clear existing internal spans
         dd_trace_serialize_closed_spans();
 
-        \dd_trace_function(__NAMESPACE__ . '\\baz', function () {
+        \DDTrace\trace_function(__NAMESPACE__ . '\\baz', function () {
             // Do nothing
         });
         $tracer = new Tracer(new DebugTransport());

--- a/tests/ext/sandbox-prehook/access_modifier_method_access_hook.phpt
+++ b/tests/ext/sandbox-prehook/access_modifier_method_access_hook.phpt
@@ -45,13 +45,13 @@ class Bar
     }
 }
 
-dd_trace_method('Foo', 'aPublic', ['prehook' => function() {
+DDTrace\trace_method('Foo', 'aPublic', ['prehook' => function() {
     $this->getBar()->dPublic();
     var_dump($this->bProtected());
     var_dump($this->cPrivate());
 }]);
 
-dd_trace_method('Bar', 'dPublic', ['prehook' => function() {
+DDTrace\trace_method('Bar', 'dPublic', ['prehook' => function() {
     var_dump($this->eProtected());
     var_dump($this->fPrivate());
 }]);

--- a/tests/ext/sandbox-prehook/access_modifier_property_access_hook.phpt
+++ b/tests/ext/sandbox-prehook/access_modifier_property_access_hook.phpt
@@ -15,7 +15,7 @@ class Test
     }
 }
 
-dd_trace_method("Test", "m", ['prehook' => function() {
+DDTrace\trace_method("Test", "m", ['prehook' => function() {
     echo "PRIVATE PROPERTY IN HOOK " . $this->value_private . PHP_EOL;
     echo "PROTECTED PROPERTY IN HOOK " . $this->value_protected . PHP_EOL;
 }]);

--- a/tests/ext/sandbox-prehook/args_copy_before_mutation.phpt
+++ b/tests/ext/sandbox-prehook/args_copy_before_mutation.phpt
@@ -6,7 +6,7 @@
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('foo', [
+DDTrace\trace_function('foo', [
     'prehook' => function (SpanData $span, array $args) {
         echo 'foo() prehook' . PHP_EOL;
         var_dump($args);

--- a/tests/ext/sandbox-prehook/close_on_exit.phpt
+++ b/tests/ext/sandbox-prehook/close_on_exit.phpt
@@ -16,14 +16,14 @@ register_shutdown_function(function () {
     );
 });
 
-dd_trace_function('outer', ['prehook' => function (SpanData $span) {
+DDTrace\trace_function('outer', ['prehook' => function (SpanData $span) {
     $span->name = 'outer';
     $span->resource = $span->name;
     $span->service = 'test';
     $span->type = 'custom';
 }]);
 
-dd_trace_function('inner', ['prehook' => function (SpanData $span) {
+DDTrace\trace_function('inner', ['prehook' => function (SpanData $span) {
     $span->name = 'inner';
     $span->resource = $span->name;
     $span->service = 'test';

--- a/tests/ext/sandbox-prehook/closure_arg_exception.phpt
+++ b/tests/ext/sandbox-prehook/closure_arg_exception.phpt
@@ -6,7 +6,7 @@
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('foo', [
+DDTrace\trace_function('foo', [
     'prehook' => function (SpanData $span, array $args, $retval, $ex) {
         var_dump($ex);
     }

--- a/tests/ext/sandbox-prehook/closure_arg_retval.phpt
+++ b/tests/ext/sandbox-prehook/closure_arg_retval.phpt
@@ -6,7 +6,7 @@
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('foo', [
+DDTrace\trace_function('foo', [
     'prehook' => function (SpanData $span, array $args, $retval) {
         var_dump($retval);
     }

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -7,19 +7,19 @@ DD_TRACE_DEBUG=1
 --FILE--
 <?php
 # Functions
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'prehook' => 'foo',
 ]));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'prehook' => new stdClass(),
 ]));
 
 # Methods
 echo PHP_EOL;
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'prehook' => 'foo',
 ]));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'prehook' => new stdClass(),
 ]));
 ?>

--- a/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_internal.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[Prehook Regression] dd_trace_function() can trace internal functions with internal spans
+[Prehook Regression] DDTrace\trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
@@ -8,7 +8,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 <?php
 use DDTrace\SpanData;
 
-var_dump(dd_trace_function('array_sum', ['prehook' => function (SpanData $span) {
+var_dump(DDTrace\trace_function('array_sum', ['prehook' => function (SpanData $span) {
     $span->name = 'ArraySum';
 }]));
 

--- a/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_function_userland.phpt
@@ -1,12 +1,12 @@
 --TEST--
-[Prehook Regression] dd_trace_function() can trace userland functions with internal spans
+[Prehook Regression] DDTrace\trace_function() can trace userland functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;
 
-var_dump(dd_trace_function('filter_to_array', ['prehook' => function (SpanData $span) {
+var_dump(DDTrace\trace_function('filter_to_array', ['prehook' => function (SpanData $span) {
     $span->name = 'filter_to_array';
 }]));
 

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[Prehook Regression] dd_trace_method() can trace with internal spans
+[Prehook Regression] DDTrace\trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
@@ -37,10 +37,10 @@ class Foo
     }
 }
 
-dd_trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
     $span->name = 'TestFoo';
 }]);
-dd_trace_method(
+DDTrace\trace_method(
     'Foo', 'bar',
     ['prehook' => function (SpanData $span, $args) {
         $span->name = 'FooName';
@@ -56,7 +56,7 @@ dd_trace_method(
         ];
     }]
 );
-dd_trace_function('mt_rand', ['prehook' => function (SpanData $span, $args) {
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span, $args) {
     $span->name = 'MT';
     $span->meta = [
         'rand.range' => $args[0] . ' - ' . $args[1],

--- a/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[Prehook Regression] dd_trace_method() binds the called object to the tracing closure
+[Prehook Regression] DDTrace\trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
@@ -16,12 +16,12 @@ class Foo
     }
 }
 
-dd_trace_method('Foo', 'testBinding', ['prehook' => function () {
+DDTrace\trace_method('Foo', 'testBinding', ['prehook' => function () {
     echo "Traced testBinding\n";
     var_dump($this);
 }]);
 
-dd_trace_method('DatePeriod', 'getStartDate', ['prehook' => function () {
+DDTrace\trace_method('DatePeriod', 'getStartDate', ['prehook' => function () {
     echo "Traced getStartDate\n";
     var_dump($this instanceof DatePeriod);
 }]);

--- a/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method_works_with_dd_trace.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[Prehook Regression] dd_trace_method() works alongside dd_trace()
+[Prehook Regression] DDTrace\trace_method() works alongside dd_trace()
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --FILE--
@@ -39,7 +39,7 @@ dd_trace('Foo', 'oldWay', function () {
     return $retval;
 });
 
-dd_trace_method(
+DDTrace\trace_method(
     'Foo', 'newWay',
     ['prehook' => function (SpanData $span, $args) {
         echo "TRACED Test::newWay()\n";

--- a/tests/ext/sandbox-prehook/drop_spans.phpt
+++ b/tests/ext/sandbox-prehook/drop_spans.phpt
@@ -10,7 +10,7 @@ use DDTrace\SpanData;
 
 date_default_timezone_set('UTC');
 
-dd_trace_function('array_sum', ['prehook' => function (SpanData $span, array $args) {
+DDTrace\trace_function('array_sum', ['prehook' => function (SpanData $span, array $args) {
     echo 'Traced array_sum' . PHP_EOL;
     $span->name = 'ArraySum';
     if ($args[0][0] === 42) {
@@ -18,7 +18,7 @@ dd_trace_function('array_sum', ['prehook' => function (SpanData $span, array $ar
     }
 }]);
 
-dd_trace_method('DateTime', '__construct', ['prehook' => function (SpanData $span, array $args) {
+DDTrace\trace_method('DateTime', '__construct', ['prehook' => function (SpanData $span, array $args) {
     echo 'Traced DateTime' . PHP_EOL;
     $span->name = 'DateTime: ' . $args[0];
     if ($args[0] === '2019-09-10') {

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -7,7 +7,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
-dd_trace_function('array_sum', ['prehook' => function () {
+DDTrace\trace_function('array_sum', ['prehook' => function () {
     throw new RuntimeException("This exception is expected");
 }]);
 $sum = array_sum([1, 3, 5]);

--- a/tests/ext/sandbox-prehook/exception_handling.phpt
+++ b/tests/ext/sandbox-prehook/exception_handling.phpt
@@ -12,8 +12,8 @@ function inner($message) {
     throw new Exception($message);
 }
 
-dd_trace_function("outer", ['prehook' => function() {}]);
-dd_trace_function("inner", ['prehook' => function() {}]);
+DDTrace\trace_function("outer", ['prehook' => function() {}]);
+DDTrace\trace_function("inner", ['prehook' => function() {}]);
 
 try {
     outer();

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -23,17 +23,17 @@ class Test
     }
 }
 
-dd_trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
     $span->name = 'TestFoo';
     $span->service = $this_normally_raises_a_notice; // E_NOTICE
 }]);
 
-dd_trace_function('mt_srand', ['prehook' => function (SpanData $span) {
+DDTrace\trace_function('mt_srand', ['prehook' => function (SpanData $span) {
     $span->name = 'MTSeed';
     throw new Exception('This should be ignored');
 }]);
 
-dd_trace_function('mt_rand', ['prehook' => function (SpanData $span) {
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span) {
     $span->name = 'MTRand';
     htmlentities('<b>', 0, 'BIG5'); // E_STRICT
 }]);

--- a/tests/ext/sandbox-prehook/exit_and_drop_span.phpt
+++ b/tests/ext/sandbox-prehook/exit_and_drop_span.phpt
@@ -4,7 +4,7 @@
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --FILE--
 <?php
-dd_trace_function('foo', ['prehook' => function () {
+DDTrace\trace_function('foo', ['prehook' => function () {
     echo 'Dropping span' . PHP_EOL;
     return false;
 }]);

--- a/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -14,11 +14,11 @@ function myFunc2($bar) {
     return $bar;
 }
 
-dd_trace_function('myFunc1', ['prehook' => function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('myFunc1', ['prehook' => function (\DDTrace\SpanData $span) {
     $span->name = 'myFunc1';
 }]);
 
-dd_trace_function('myFunc2', [
+DDTrace\trace_function('myFunc2', [
     'instrument_when_limited' => 1,
     'prehook' => function (\DDTrace\SpanData $span) {
         $span->name = 'myFunc2';

--- a/tests/ext/sandbox-prehook/new_static.phpt
+++ b/tests/ext/sandbox-prehook/new_static.phpt
@@ -16,7 +16,7 @@ class Bar extends Foo {
     // Empty
 }
 
-dd_trace_method('Foo', 'get', ['prehook' => function (SpanData $span) {
+DDTrace\trace_method('Foo', 'get', ['prehook' => function (SpanData $span) {
     $span->name = get_called_class();
 }]);
 

--- a/tests/ext/sandbox-prehook/php5_unsupported.phpt
+++ b/tests/ext/sandbox-prehook/php5_unsupported.phpt
@@ -9,7 +9,7 @@ DD_TRACE_DEBUG=1
 <?php
 use DDTrace\SpanData;
 
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'prehook' => function (SpanData $span, array $args) {
         echo 'foo() prehook' . PHP_EOL;
         var_dump($args);

--- a/tests/ext/sandbox-prehook/trace_static_method.phpt
+++ b/tests/ext/sandbox-prehook/trace_static_method.phpt
@@ -13,7 +13,7 @@ class Test
 
 }
 
-dd_trace_method("Test", "public_static_method", ['prehook' => function(){
+DDTrace\trace_method("Test", "public_static_method", ['prehook' => function(){
     echo "test_access hook" . PHP_EOL;
 }]);
 

--- a/tests/ext/sandbox-prehook/variable_length_parameter_list.phpt
+++ b/tests/ext/sandbox-prehook/variable_length_parameter_list.phpt
@@ -14,11 +14,11 @@ class Test {
     }
 }
 
-dd_trace_function("test", ['prehook' => function($s, array $args){
+DDTrace\trace_function("test", ['prehook' => function($s, array $args){
     echo "HOOK " . implode(" ", $args) . PHP_EOL;
 }]);
 
-dd_trace_method("Test", "m", ['prehook' => function($s, array $args){
+DDTrace\trace_method("Test", "m", ['prehook' => function($s, array $args){
     echo "HOOK " . implode(" ", $args) . PHP_EOL;
 }]);
 

--- a/tests/ext/sandbox-prehook/variadic_args_internal.phpt
+++ b/tests/ext/sandbox-prehook/variadic_args_internal.phpt
@@ -6,7 +6,7 @@
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_unshift
 --FILE--
 <?php
-dd_trace_function('array_unshift', ['prehook' => function (DDTrace\SpanData $s, array $args) {
+DDTrace\trace_function('array_unshift', ['prehook' => function (DDTrace\SpanData $s, array $args) {
     var_dump($args);
 }]);
 

--- a/tests/ext/sandbox-regression/access_modifier_method_access_hook.phpt
+++ b/tests/ext/sandbox-regression/access_modifier_method_access_hook.phpt
@@ -45,14 +45,14 @@ class Bar
     }
 }
 
-dd_trace_method('Foo', 'aPublic', function($span, array $args, $retval) {
+DDTrace\trace_method('Foo', 'aPublic', function($span, array $args, $retval) {
     $this->getBar()->dPublic();
     var_dump($this->bProtected());
     var_dump($this->cPrivate());
     var_dump($retval);
 });
 
-dd_trace_method('Bar', 'dPublic', function($span, array $args, $retval) {
+DDTrace\trace_method('Bar', 'dPublic', function($span, array $args, $retval) {
     var_dump($this->eProtected());
     var_dump($this->fPrivate());
     var_dump($retval);

--- a/tests/ext/sandbox-regression/access_modifier_property_access_hook.phpt
+++ b/tests/ext/sandbox-regression/access_modifier_property_access_hook.phpt
@@ -15,7 +15,7 @@ class Test
     }
 }
 
-dd_trace_method("Test", "m", function() {
+DDTrace\trace_method("Test", "m", function() {
     echo "PRIVATE PROPERTY IN HOOK " . $this->value_private . PHP_EOL;
     echo "PROTECTED PROPERTY IN HOOK " . $this->value_protected . PHP_EOL;
 });

--- a/tests/ext/sandbox-regression/allow_overriding_before_overrided_methods_functions_are_defined.phpt
+++ b/tests/ext/sandbox-regression/allow_overriding_before_overrided_methods_functions_are_defined.phpt
@@ -4,11 +4,11 @@
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
-dd_trace_method("Test", "m", function($span, array $args, $retval) {
+DDTrace\trace_method("Test", "m", function($span, array $args, $retval) {
     echo 'HOOK ' . $retval;
 });
 
-dd_trace_function("fun", function($span, array $args, $retval) {
+DDTrace\trace_function("fun", function($span, array $args, $retval) {
     echo 'HOOK ' . $retval;
 });
 

--- a/tests/ext/sandbox-regression/case_insensitive_method_hook.phpt
+++ b/tests/ext/sandbox-regression/case_insensitive_method_hook.phpt
@@ -15,7 +15,7 @@ class Test extends Ancestor{
 }
 
 $no = 1;
-dd_trace_method("Test", "methoD", function() use ($no){
+DDTrace\trace_method("Test", "methoD", function() use ($no){
     echo "HOOK " . $no . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/closure_accessing_outside_variables.phpt
+++ b/tests/ext/sandbox-regression/closure_accessing_outside_variables.phpt
@@ -14,7 +14,7 @@ class Test {
 }
 
 function setup($variable){
-    dd_trace_method("Test", "m", function() use ($variable){
+    DDTrace\trace_method("Test", "m", function() use ($variable){
         echo "HOOK " . $variable . PHP_EOL;
     });
 }

--- a/tests/ext/sandbox-regression/closure_set_inside_object_methods.phpt
+++ b/tests/ext/sandbox-regression/closure_set_inside_object_methods.phpt
@@ -16,13 +16,13 @@ $variable = 1000;
 
 final class TestSetup {
     public function setup(){
-        dd_trace_method("Test", "m", function($span, array $args) {
+        DDTrace\trace_method("Test", "m", function($span, array $args) {
             $variable = $args[0] + 10;
             echo "HOOK " . $variable . PHP_EOL;
         });
     }
     public function setup_ext($j){
-        dd_trace_method("Test", "m", function($span, array $args) use ($j){
+        DDTrace\trace_method("Test", "m", function($span, array $args) use ($j){
             global $variable;
             $variable += $args[0] + $j;
             echo "HOOK " . $variable . PHP_EOL;

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -7,7 +7,7 @@ DD_TRACE_SPANS_LIMIT=1000
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
-dd_trace_function('array_sum', function () {});
+DDTrace\trace_function('array_sum', function () {});
 
 var_dump(dd_trace_tracer_is_limited());
 for ($i = 0; $i < 999; $i++) {

--- a/tests/ext/sandbox-regression/destructor_called_when_this_gets_out_of_scope.phpt
+++ b/tests/ext/sandbox-regression/destructor_called_when_this_gets_out_of_scope.phpt
@@ -15,7 +15,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function($s, $a, $retval) {
+DDTrace\trace_method("Test", "m", function($s, $a, $retval) {
     echo $retval . " OVERRIDE" . PHP_EOL;
 });
 function func() {

--- a/tests/ext/sandbox-regression/disable_tracing_disables_tracing.phpt
+++ b/tests/ext/sandbox-regression/disable_tracing_disables_tracing.phpt
@@ -10,7 +10,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function() {
+DDTrace\trace_method("Test", "m", function() {
     echo 'HOOK ';
 });
 

--- a/tests/ext/sandbox-regression/do_not_check_if_class_or_function_exists_by_default.phpt
+++ b/tests/ext/sandbox-regression/do_not_check_if_class_or_function_exists_by_default.phpt
@@ -20,12 +20,12 @@ function format_bool($rv) {
     return ($rv ? "TRUE" : "FALSE" ) . PHP_EOL;
 }
 
-echo format_bool(dd_trace_method("ThisClassDoesntExists", "m", function(){}));
-echo format_bool(dd_trace_method("ExampleClass", "this_method_exists", function(){}));
-echo format_bool(dd_trace_method("ExampleClass", "method_doesnt_exist", function(){}));
+echo format_bool(DDTrace\trace_method("ThisClassDoesntExists", "m", function(){}));
+echo format_bool(DDTrace\trace_method("ExampleClass", "this_method_exists", function(){}));
+echo format_bool(DDTrace\trace_method("ExampleClass", "method_doesnt_exist", function(){}));
 
-echo format_bool(dd_trace_function("this_function_doesnt_exist", function(){}));
-echo format_bool(dd_trace_function("this_function_exists", function(){}));
+echo format_bool(DDTrace\trace_function("this_function_doesnt_exist", function(){}));
+echo format_bool(DDTrace\trace_function("this_function_exists", function(){}));
 
 echo  "no exception thrown" . PHP_EOL;
 

--- a/tests/ext/sandbox-regression/enable_throw_exception_if_overridable_doesnt_exist.phpt
+++ b/tests/ext/sandbox-regression/enable_throw_exception_if_overridable_doesnt_exist.phpt
@@ -9,7 +9,7 @@ ddtrace.strict_mode=1
 --FILE--
 <?php
 try {
-    dd_trace_method("ThisClassDoesntExists", "m", function($s, $a, $retval){
+    DDTrace\trace_method("ThisClassDoesntExists", "m", function($s, $a, $retval){
         echo $retval . "METHOD HOOK" . PHP_EOL;
     });
 } catch (InvalidArgumentException $ex) {

--- a/tests/ext/sandbox-regression/extension_disabled.phpt
+++ b/tests/ext/sandbox-regression/extension_disabled.phpt
@@ -10,7 +10,7 @@ function test(){
     return "FUNCTION";
 }
 
-dd_trace_function("test", function($s, $a, $retval){
+DDTrace\trace_function("test", function($s, $a, $retval){
     echo $retval . ' HOOK' . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
+++ b/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
@@ -19,7 +19,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "__construct", function () {
+DDTrace\trace_method("Test", "__construct", function () {
     echo "HOOK CONSTRUCT" . $this->append . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/method_returning_array.phpt
+++ b/tests/ext/sandbox-regression/method_returning_array.phpt
@@ -10,7 +10,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function($s, $args, $retval){
+DDTrace\trace_method("Test", "m", function($s, $args, $retval){
     echo implode(PHP_EOL, array_merge(
         (new Test())->m("METHOD"),
         $retval

--- a/tests/ext/sandbox-regression/multiple_instrumentations.phpt
+++ b/tests/ext/sandbox-regression/multiple_instrumentations.phpt
@@ -40,32 +40,32 @@ class Test {
     }
 }
 
-dd_trace_function("test_a", function(){
+DDTrace\trace_function("test_a", function(){
     echo "HOOK A" . PHP_EOL;
 });
 
-dd_trace_function("test_b", function(){
+DDTrace\trace_function("test_b", function(){
     echo "HOOK B" . PHP_EOL;
 });
 
-dd_trace_function("test_c", function(){
+DDTrace\trace_function("test_c", function(){
     echo "HOOK C" . PHP_EOL;
 });
 
-dd_trace_function("test_d", function(){
+DDTrace\trace_function("test_d", function(){
     echo "HOOK D" . PHP_EOL;
 });
 
-dd_trace_method("Test", "m_a", function(){
+DDTrace\trace_method("Test", "m_a", function(){
     echo "HOOK MA" . PHP_EOL;
 });
-dd_trace_method("Test", "m_b", function(){
+DDTrace\trace_method("Test", "m_b", function(){
     echo "HOOK MB" . PHP_EOL;
 });
-dd_trace_method("Test", "m_c", function(){
+DDTrace\trace_method("Test", "m_c", function(){
     echo "HOOK MC" . PHP_EOL;
 });
-dd_trace_method("Test", "m_d", function(){
+DDTrace\trace_method("Test", "m_d", function(){
     echo "HOOK MD" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/namespaces.phpt
+++ b/tests/ext/sandbox-regression/namespaces.phpt
@@ -38,21 +38,21 @@ namespace Klass {
         }
     }
 
-    dd_trace_method("Klass\\Test", "m", function($s, array $args){
+    \DDTrace\trace_method("Klass\\Test", "m", function($s, array $args){
         echo "M HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
     });
 }
 
 namespace {
-    dd_trace_function("Func\\test", function($s, array $args){
+    \DDTrace\trace_function("Func\\test", function($s, array $args){
         echo "F HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
     });
 
-    dd_trace_function("Func\\test_va", function($s, array $args){
+    \DDTrace\trace_function("Func\\test_va", function($s, array $args){
         echo "FVA HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
     });
 
-    dd_trace_method("Klass\\Test", "m2", function($s, array $args){
+    \DDTrace\trace_method("Klass\\Test", "m2", function($s, array $args){
         echo "M2 HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
     });
 

--- a/tests/ext/sandbox-regression/overriding_construct.phpt
+++ b/tests/ext/sandbox-regression/overriding_construct.phpt
@@ -11,7 +11,7 @@ class Test {
 }
 
 $no = 1;
-dd_trace_method("Test", "__construct", function () use ($no) {
+DDTrace\trace_method("Test", "__construct", function () use ($no) {
     echo "HOOK " . $no . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/overriding_method_defined_in_parent.phpt
+++ b/tests/ext/sandbox-regression/overriding_method_defined_in_parent.phpt
@@ -19,11 +19,11 @@ class Test extends Ancestor{
 }
 
 $no = 1;
-dd_trace_method("Test", "m", function($s, $a, $retval) use ($no){
+DDTrace\trace_method("Test", "m", function($s, $a, $retval) use ($no){
     echo "HOOK " .  $retval . ' ' . $no . PHP_EOL;
 });
 
-dd_trace_method("Ancestor", "m2", function($s, $a, $retval){
+DDTrace\trace_method("Ancestor", "m2", function($s, $a, $retval){
     echo "HOOK " . $retval . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/private_method_hook.phpt
+++ b/tests/ext/sandbox-regression/private_method_hook.phpt
@@ -17,7 +17,7 @@ class Test
     }
 }
 
-dd_trace_method('Test', "private_method", function() {
+DDTrace\trace_method('Test', "private_method", function() {
     echo "PRIVATE HOOK" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/private_self_access.phpt
+++ b/tests/ext/sandbox-regression/private_self_access.phpt
@@ -23,7 +23,7 @@ class Test
 
 }
 
-dd_trace_method("Test", "test_access", function(){
+DDTrace\trace_method("Test", "test_access", function(){
     echo "test_access hook start" . PHP_EOL . self::public_static_method() . self::private_static_method() . "test_access hook end" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/protected_method_hook.phpt
+++ b/tests/ext/sandbox-regression/protected_method_hook.phpt
@@ -19,7 +19,7 @@ class Test
     }
 }
 
-dd_trace_method("Test", "protected_method", function(){
+DDTrace\trace_method("Test", "protected_method", function(){
     echo "PROTECTED HOOK" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/recursion.phpt
+++ b/tests/ext/sandbox-regression/recursion.phpt
@@ -32,15 +32,15 @@ class Test {
     }
 }
 
-dd_trace_function("test", function($s, array $args){
+DDTrace\trace_function("test", function($s, array $args){
     echo "F HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
 });
 
-dd_trace_function("test_va", function($s, array $args){
+DDTrace\trace_function("test_va", function($s, array $args){
     echo "FVA HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
 });
 
-dd_trace_method('Test', "m", function($s, array $args){
+DDTrace\trace_method('Test', "m", function($s, array $args){
     echo "M HOOK START " . $args[0] . " END " . $args[1] . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/reset_configured_overrides.phpt
+++ b/tests/ext/sandbox-regression/reset_configured_overrides.phpt
@@ -10,7 +10,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function(){
+DDTrace\trace_method("Test", "m", function(){
     echo "METHOD HOOK" . PHP_EOL;
 });
 
@@ -18,7 +18,7 @@ function test(){
     echo "FUNCTION" . PHP_EOL;
 }
 
-dd_trace_function("test", function(){
+DDTrace\trace_function("test", function(){
     echo "FUNCTION HOOK" . PHP_EOL;
 });
 
@@ -32,11 +32,11 @@ echo (dd_trace_reset() ? "TRUE": "FALSE") . PHP_EOL;
 //$object->m();
 //test();
 
-dd_trace_method("Test", "m", function(){
+DDTrace\trace_method("Test", "m", function(){
     echo "METHOD HOOK2" . PHP_EOL;
 });
 
-dd_trace_function("test", function(){
+DDTrace\trace_function("test", function(){
     echo "FUNCTION HOOK2" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/reset_function_tracing.phpt
+++ b/tests/ext/sandbox-regression/reset_function_tracing.phpt
@@ -7,7 +7,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=spl_autoload_register
 --FILE--
 <?php
 
-dd_trace_function("spl_autoload_register", function() {
+DDTrace\trace_function("spl_autoload_register", function() {
     echo "HOOK" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/return_value_passed.phpt
+++ b/tests/ext/sandbox-regression/return_value_passed.phpt
@@ -13,7 +13,7 @@ class Test {
 }
 
 $no = 1;
-dd_trace_method("Test", "method", function($span, array $args, $retval) use ($no){
+DDTrace\trace_method("Test", "method", function($span, array $args, $retval) use ($no){
     echo $retval . "-override ". $no . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/simple_function_hook.phpt
+++ b/tests/ext/sandbox-regression/simple_function_hook.phpt
@@ -8,7 +8,7 @@ function test(){
     return "FUNCTION";
 }
 
-dd_trace_function("test", function($s, $a, $retval){
+DDTrace\trace_function("test", function($s, $a, $retval){
     echo $retval . ' HOOK' . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/simple_method_hook.phpt
+++ b/tests/ext/sandbox-regression/simple_method_hook.phpt
@@ -10,7 +10,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function(){
+DDTrace\trace_method("Test", "m", function(){
     echo "HOOK" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/throw_exception.phpt
+++ b/tests/ext/sandbox-regression/throw_exception.phpt
@@ -8,7 +8,7 @@ function test($param = 2){
     throw new RuntimeException("FUNCTION " . $param);
 }
 
-dd_trace_function("test", function($s, $a, $r, $e){
+DDTrace\trace_function("test", function($s, $a, $r, $e){
     echo "EXCEPTION IN HOOK " . $e->getMessage() . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/trace_method_or_function_that_will_exist_later.phpt
+++ b/tests/ext/sandbox-regression/trace_method_or_function_that_will_exist_later.phpt
@@ -5,11 +5,11 @@
 --FILE--
 <?php
 
-dd_trace_method("Test", "some_method", function($s, $a, $retval){
+DDTrace\trace_method("Test", "some_method", function($s, $a, $retval){
     echo "HOOK " . $retval;
 });
 
-dd_trace_function("some_function", function($s, $a, $retval){
+DDTrace\trace_function("some_function", function($s, $a, $retval){
     echo 'HOOK2 ' . $retval;
 });
 

--- a/tests/ext/sandbox-regression/trace_static_method.phpt
+++ b/tests/ext/sandbox-regression/trace_static_method.phpt
@@ -14,7 +14,7 @@ class Test
 
 }
 
-dd_trace_method("Test", "public_static_method", function($s, $a, $retval){
+DDTrace\trace_method("Test", "public_static_method", function($s, $a, $retval){
     echo "test_access hook start" . PHP_EOL . $retval . "test_access hook end" . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
@@ -5,13 +5,13 @@
 --FILE--
 <?php
 function test($a){
-    dd_trace_function("test", function($s, $a, $retval){
+    DDTrace\trace_function("test", function($s, $a, $retval){
         echo 'NEW HOOK ' . $retval . PHP_EOL;
     });
     return 'METHOD ' . $a;
 }
 
-dd_trace_function("test", function($s, $a, $retval){
+DDTrace\trace_function("test", function($s, $a, $retval){
     echo 'OLD HOOK ' . $retval . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/variable_length_parameter_list.phpt
+++ b/tests/ext/sandbox-regression/variable_length_parameter_list.phpt
@@ -16,11 +16,11 @@ class Test {
     }
 }
 
-dd_trace_function("test", function($s, array $args){
+DDTrace\trace_function("test", function($s, array $args){
     echo "HOOK " . implode(" ", $args) . PHP_EOL;
 });
 
-dd_trace_method("Test", "m", function($s, array $args){
+DDTrace\trace_method("Test", "m", function($s, array $args){
     echo "HOOK " . implode(" ", $args) . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/very_nested_functions.phpt
+++ b/tests/ext/sandbox-regression/very_nested_functions.phpt
@@ -10,7 +10,7 @@ function test($a){
     return 'FUNCTION ' . $a;
 }
 
-dd_trace_function("test", function($s, $a, $retval){
+DDTrace\trace_function("test", function($s, $a, $retval){
     echo 'HOOK ' . $retval . PHP_EOL;
 });
 

--- a/tests/ext/sandbox-regression/with_params_function_hook.phpt
+++ b/tests/ext/sandbox-regression/with_params_function_hook.phpt
@@ -10,7 +10,7 @@ function test($a, $b, $c){
     echo "FUNCTION " . $a ." ". $b . " " . $c . PHP_EOL;
 }
 
-dd_trace_function("test", function($s, array $args){
+DDTrace\trace_function("test", function($s, array $args){
     list($a, $b, $c) = $args;
     echo "HOOK " . $a ." ". $b . " " . $c . PHP_EOL;
 });

--- a/tests/ext/sandbox-regression/with_params_method_hook.phpt
+++ b/tests/ext/sandbox-regression/with_params_method_hook.phpt
@@ -12,7 +12,7 @@ class Test {
     }
 }
 
-dd_trace_method("Test", "m", function($s, array $args){
+DDTrace\trace_method("Test", "m", function($s, array $args){
     list($a, $b, $c) = $args;
     echo "HOOK " . $a ." ". $b . " " . $c . PHP_EOL;
 });

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -13,12 +13,12 @@ use DDTrace\SpanData;
 require 'fake_tracer.inc';
 require 'fake_global_tracer.inc';
 
-dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
     $span->resource = $retval;
 });
 
-dd_trace_function('main', function (SpanData $span) {
+DDTrace\trace_function('main', function (SpanData $span) {
     $span->name = 'main';
 });
 

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -27,7 +27,7 @@ class Foo
     }
 }
 
-dd_trace_method('Foo', 'bar', function (SpanData $span) {
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
     $span->name = 'Foo.bar';
 });
 

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -14,16 +14,16 @@ require 'fake_tracer.inc';
 require 'fake_global_tracer.inc';
 
 // This is called from the flush() method of the fake tracer
-dd_trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
+DDTrace\trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
     $span->name = 'fake_curl_exec';
 });
 
-dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
     $span->resource = $retval;
 });
 
-dd_trace_function('main', function (SpanData $span) {
+DDTrace\trace_function('main', function (SpanData $span) {
     $span->name = 'main';
 });
 

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -26,7 +26,7 @@ class Foo
     }
 }
 
-dd_trace_method('Foo', 'bar', function (SpanData $span) {
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
     $span->name = 'Foo.bar';
 });
 

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -13,7 +13,7 @@ use DDTrace\SpanData;
 require 'fake_tracer.inc';
 require 'fake_global_tracer.inc';
 
-dd_trace_function('array_sum', function (SpanData $span, $args, $retval) {
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
     $span->resource = $retval;
 });

--- a/tests/ext/sandbox/close-on-exit-retval.phpt
+++ b/tests/ext/sandbox/close-on-exit-retval.phpt
@@ -16,11 +16,11 @@ register_shutdown_function(function () {
     );
 });
 
-dd_trace_function('outer', function (SpanData $span, $args, $retval) {
+DDTrace\trace_function('outer', function (SpanData $span, $args, $retval) {
     $span->name =  'outer' . (isset($retval) ? ' was not null' : ' was null');
 });
 
-dd_trace_function('inner', function (SpanData $span, $args, $retval) {
+DDTrace\trace_function('inner', function (SpanData $span, $args, $retval) {
     $span->name =  'inner' . (isset($retval) ? ' was not null' : ' was null');
 });
 

--- a/tests/ext/sandbox/close-on-exit.phpt
+++ b/tests/ext/sandbox/close-on-exit.phpt
@@ -16,14 +16,14 @@ register_shutdown_function(function () {
     );
 });
 
-dd_trace_function('outer', function (SpanData $span) {
+DDTrace\trace_function('outer', function (SpanData $span) {
     $span->name = 'outer';
     $span->resource = $span->name;
     $span->service = 'test';
     $span->type = 'custom';
 });
 
-dd_trace_function('inner', function (SpanData $span) {
+DDTrace\trace_function('inner', function (SpanData $span) {
     $span->name = 'inner';
     $span->resource = $span->name;
     $span->service = 'test';

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_function() and dd_trace_method() declarative API error cases
+DDTrace\trace_function() and DDTrace\trace_method() declarative API error cases
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
@@ -7,45 +7,45 @@ DD_TRACE_DEBUG=1
 --FILE--
 <?php
 # Functions
-var_dump(dd_trace_function('foo', 'bar'));
-var_dump(dd_trace_function('foo', ['bar']));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', 'bar'));
+var_dump(DDTrace\trace_function('foo', ['bar']));
+var_dump(DDTrace\trace_function('foo', [
     'bar' => 'baz',
 ]));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'instrument_when_limited' => 'foo',
 ]));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'posthook' => 'foo',
 ]));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'posthook' => new stdClass(),
 ]));
-var_dump(dd_trace_function('foo', [
+var_dump(DDTrace\trace_function('foo', [
     'innerhook' => function () {},
 ]));
-var_dump(dd_trace_function('foo', []));
+var_dump(DDTrace\trace_function('foo', []));
 
 # Methods
 echo PHP_EOL;
-var_dump(dd_trace_method('foo', 'foo', 'bar'));
-var_dump(dd_trace_method('foo', 'foo', ['bar']));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', 'bar'));
+var_dump(DDTrace\trace_method('foo', 'foo', ['bar']));
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'bar' => 'baz',
 ]));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'instrument_when_limited' => 'foo',
 ]));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'posthook' => 'foo',
 ]));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'posthook' => new stdClass(),
 ]));
-var_dump(dd_trace_method('foo', 'foo', [
+var_dump(DDTrace\trace_method('foo', 'foo', [
     'innerhook' => function () {},
 ]));
-var_dump(dd_trace_method('foo', 'foo', []));
+var_dump(DDTrace\trace_method('foo', 'foo', []));
 ?>
 --EXPECT--
 bool(false)

--- a/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
+++ b/tests/ext/sandbox/dd_trace_closed_spans_count.phpt
@@ -8,7 +8,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 <?php
 var_dump(dd_trace_closed_spans_count());
 
-dd_trace_function('array_sum', function () {});
+DDTrace\trace_function('array_sum', function () {});
 array_sum([1, 2, array_sum([2, 3])]);
 var_dump(dd_trace_closed_spans_count());
 
@@ -18,7 +18,7 @@ echo "Simulated open & close of userland span\n";
 var_dump(dd_trace_closed_spans_count());
 
 function foo () {}
-dd_trace_function('foo', function () {
+DDTrace\trace_function('foo', function () {
     echo "Span not closed yet\n";
     var_dump(dd_trace_closed_spans_count());
 });

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -1,0 +1,28 @@
+--TEST--
+dd_trace_function() is aliased to DDTrace\trace_function()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function bar($message)
+{
+    echo "bar($message)\n";
+}
+
+dd_trace_function('bar', function (SpanData $span) {
+    $span->service = 'alias';
+});
+
+bar('hello');
+
+include 'dd_dumper.inc';
+dd_dump_spans();
+?>
+--EXPECTF--
+bar(hello)
+spans(\DDTrace\SpanData) (1) {
+  bar (alias, bar)
+    system.pid => %d
+}

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_function() can trace with internal spans
+DDTrace\trace_function() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
@@ -32,17 +32,17 @@ function bar($thoughts, array $bar = [])
     ];
 }
 
-var_dump(dd_trace_function('array_sum', function (SpanData $span) {
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
     $span->name = 'ArraySum';
 }));
-var_dump(dd_trace_function('mt_rand', null));
-var_dump(dd_trace_function('testFoo', function (SpanData $span) {
+var_dump(DDTrace\trace_function('mt_rand', null));
+var_dump(DDTrace\trace_function('testFoo', function (SpanData $span) {
     $span->name = 'TestFoo';
 }));
-var_dump(dd_trace_function('addOne', function (SpanData $span) {
+var_dump(DDTrace\trace_function('addOne', function (SpanData $span) {
     $span->name = 'AddOne';
 }));
-var_dump(dd_trace_function(
+var_dump(DDTrace\trace_function(
     'bar',
     function (SpanData $span, $args, $retval) {
         $span->name = 'BarName';

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_function() can trace internal functions with internal spans
+DDTrace\trace_function() can trace internal functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
@@ -8,7 +8,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 <?php
 use DDTrace\SpanData;
 
-var_dump(dd_trace_function('array_sum', function (SpanData $span) {
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
     $span->name = 'ArraySum';
 }));
 

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -1,12 +1,12 @@
 --TEST--
-dd_trace_function() can trace userland functions with internal spans
+DDTrace\trace_function() can trace userland functions with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;
 
-var_dump(dd_trace_function('filter_to_array', function (SpanData $span) {
+var_dump(DDTrace\trace_function('filter_to_array', function (SpanData $span) {
     $span->name = 'filter_to_array';
 }));
 

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_method() can trace with internal spans
+DDTrace\trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
@@ -37,11 +37,11 @@ class Foo
     }
 }
 
-var_dump(dd_trace_method('Test', 'testFoo', function (SpanData $span) {
+var_dump(DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
     $span->name = 'TestFoo';
 }));
-var_dump(dd_trace_method('TestService', 'testServiceFoo', null));
-var_dump(dd_trace_method(
+var_dump(DDTrace\trace_method('TestService', 'testServiceFoo', null));
+var_dump(DDTrace\trace_method(
     'Foo', 'bar',
     function (SpanData $span, $args, $retval) {
         $span->name = 'FooName';
@@ -60,7 +60,7 @@ var_dump(dd_trace_method(
         ];
     }
 ));
-var_dump(dd_trace_function('mt_rand', function (SpanData $span, $args, $retval) {
+var_dump(DDTrace\trace_function('mt_rand', function (SpanData $span, $args, $retval) {
     $span->name = 'MT';
     $span->meta = [
         'rand.range' => $args[0] . ' - ' . $args[1],

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -1,0 +1,32 @@
+--TEST--
+dd_trace_method() is aliased to DDTrace\trace_method()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function bar($message)
+    {
+        echo "Foo::bar($message)\n";
+    }
+}
+
+dd_trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->service = 'alias';
+});
+
+$foo = new Foo();
+$foo->bar('hello');
+
+include 'dd_dumper.inc';
+dd_dump_spans();
+?>
+--EXPECTF--
+Foo::bar(hello)
+spans(\DDTrace\SpanData) (1) {
+  Foo.bar (alias, Foo.bar)
+    system.pid => %d
+}

--- a/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
+++ b/tests/ext/sandbox/dd_trace_method_binds_called_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_method() binds the called object to the tracing closure
+DDTrace\trace_method() binds the called object to the tracing closure
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
@@ -16,12 +16,12 @@ class Foo
     }
 }
 
-dd_trace_method('Foo', 'testBinding', function () {
+DDTrace\trace_method('Foo', 'testBinding', function () {
     echo "Traced testBinding\n";
     var_dump($this);
 });
 
-dd_trace_method('DatePeriod', 'getStartDate', function () {
+DDTrace\trace_method('DatePeriod', 'getStartDate', function () {
     echo "Traced getStartDate\n";
     var_dump($this instanceof DatePeriod);
 });

--- a/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
+++ b/tests/ext/sandbox/dd_trace_method_works_with_dd_trace.phpt
@@ -1,5 +1,5 @@
 --TEST--
-dd_trace_method() works alongside dd_trace()
+DDTrace\trace_method() works alongside dd_trace()
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
@@ -38,7 +38,7 @@ var_dump(dd_trace('Foo', 'oldWay', function () {
     var_dump($retval);
     return $retval;
 }));
-var_dump(dd_trace_method(
+var_dump(DDTrace\trace_method(
     'Foo', 'newWay',
     function (SpanData $span, $args, $retval) {
         echo "TRACED Test::newWay()\n";

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -9,7 +9,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('array_sum', function (SpanData $span) {
+DDTrace\trace_function('array_sum', function (SpanData $span) {
     $span->name = 'array_sum';
 });
 

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -8,15 +8,15 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,range
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('array_sum', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('array_sum', function (SpanData $span, array $args, $retval) {
     $span->meta = ['retval' => $retval];
 });
 
-dd_trace_function('range', function (SpanData $span) {
+DDTrace\trace_function('range', function (SpanData $span) {
     $span->name = 'MyRange';
 });
 
-dd_trace_function('main', function (SpanData $span, array $args) {
+DDTrace\trace_function('main', function (SpanData $span, array $args) {
     $span->meta = ['max' => $args[0]];
 });
 

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -10,16 +10,16 @@ use DDTrace\SpanData;
 
 date_default_timezone_set('UTC');
 
-dd_trace_method('DateTime', '__construct', function (SpanData $span, array $args) {
+DDTrace\trace_method('DateTime', '__construct', function (SpanData $span, array $args) {
     $span->meta = ['date' => $args[0]];
 });
 
-dd_trace_method('DateTime', 'format', function (SpanData $span, array $args) {
+DDTrace\trace_method('DateTime', 'format', function (SpanData $span, array $args) {
     $span->name = 'MyDateTimeFormat';
     $span->meta = ['format' => $args[0]];
 });
 
-dd_trace_method('Foo', 'main', function (SpanData $span, array $args) {
+DDTrace\trace_method('Foo', 'main', function (SpanData $span, array $args) {
     $span->meta = ['year' => $args[0]];
 });
 

--- a/tests/ext/sandbox/distributed_tracing_curl.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl.phpt
@@ -12,7 +12,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
-dd_trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
 

--- a/tests/ext/sandbox/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl_copy_handle.phpt
@@ -12,7 +12,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
-dd_trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
 

--- a/tests/ext/sandbox/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl_existing_headers_001.phpt
@@ -12,7 +12,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
-dd_trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
 

--- a/tests/ext/sandbox/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl_existing_headers_002.phpt
@@ -12,7 +12,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
-dd_trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
 

--- a/tests/ext/sandbox/distributed_tracing_curl_sandboxed.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl_sandboxed.phpt
@@ -12,7 +12,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
-dd_trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
 

--- a/tests/ext/sandbox/drop_spans.phpt
+++ b/tests/ext/sandbox/drop_spans.phpt
@@ -10,7 +10,7 @@ use DDTrace\SpanData;
 
 date_default_timezone_set('UTC');
 
-dd_trace_function('array_sum', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('array_sum', function (SpanData $span, array $args, $retval) {
     echo 'Traced array_sum' . PHP_EOL;
     $span->name = 'ArraySum: ' . $retval;
     if ($args[0][0] === 42) {
@@ -18,7 +18,7 @@ dd_trace_function('array_sum', function (SpanData $span, array $args, $retval) {
     }
 });
 
-dd_trace_method('DateTime', '__construct', function (SpanData $span, array $args) {
+DDTrace\trace_method('DateTime', '__construct', function (SpanData $span, array $args) {
     echo 'Traced DateTime' . PHP_EOL;
     $span->name = 'DateTime: ' . $args[0];
     if ($this->format('Y-m-d') === '2019-09-10') {

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -11,7 +11,7 @@ function testErrorFromUserland()
     echo "testErrorFromUserland()\n";
 }
 
-dd_trace_function('testErrorFromUserland', function (SpanData $span) {
+DDTrace\trace_function('testErrorFromUserland', function (SpanData $span) {
     $span->name = 'testErrorFromUserland';
     $span->meta = ['error.msg' => 'Foo error'];
 });

--- a/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
+++ b/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
@@ -32,17 +32,17 @@ function doException() {
     return 'You should not see this either';
 }
 
-dd_trace_function('main', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('main', function(SpanData $s, $a, $retval) {
     $s->name = 'main';
     $s->resource = $retval;
 });
 
-dd_trace_function('handle', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('handle', function(SpanData $s, $a, $retval) {
     $s->name = 'handle';
     $s->resource = $retval;
 });
 
-dd_trace_function('handleException', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('handleException', function(SpanData $s, $a, $retval) {
     $s->name = 'handleException';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -7,7 +7,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
-dd_trace_function('array_sum', function () {
+DDTrace\trace_function('array_sum', function () {
     throw new RuntimeException("This exception is expected");
 });
 $sum = array_sum([1, 3, 5]);

--- a/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
+++ b/tests/ext/sandbox/exception_from_user_error_handler_internal.phpt
@@ -17,7 +17,7 @@ class FooErrorHandler
 
 set_error_handler('FooErrorHandler::handleError');
 
-dd_trace_function('scandir', function() {});
+DDTrace\trace_function('scandir', function() {});
 
 try {
     var_dump(scandir(''));

--- a/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
+++ b/tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt
@@ -45,16 +45,16 @@ function embeddedCatch() {
     }
 }
 
-dd_trace_function('throwException', function(SpanData $s) {
+DDTrace\trace_function('throwException', function(SpanData $s) {
     $s->name = 'throwException';
 });
 
-dd_trace_function('multiCatch', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('multiCatch', function(SpanData $s, $a, $retval) {
     $s->name = 'multiCatch';
     $s->resource = $retval;
 });
 
-dd_trace_function('embeddedCatch', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('embeddedCatch', function(SpanData $s, $a, $retval) {
     $s->name = 'embeddedCatch';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
+++ b/tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt
@@ -43,22 +43,22 @@ function level3() {
     return 'You should not see this ' . __FUNCTION__;
 }
 
-dd_trace_function('level0', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('level0', function(SpanData $s, $a, $retval) {
     $s->name = 'level0';
     $s->resource = $retval;
 });
 
-dd_trace_function('level1', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('level1', function(SpanData $s, $a, $retval) {
     $s->name = 'level1';
     $s->resource = $retval;
 });
 
-dd_trace_function('level2', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('level2', function(SpanData $s, $a, $retval) {
     $s->name = 'level2';
     $s->resource = $retval;
 });
 
-dd_trace_function('level3', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('level3', function(SpanData $s, $a, $retval) {
     $s->name = 'level3';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/exception_handled_in_multicatch.phpt
+++ b/tests/ext/sandbox/exception_handled_in_multicatch.phpt
@@ -24,11 +24,11 @@ function multiCatch() {
     }
 }
 
-dd_trace_function('throwException', function(SpanData $s) {
+DDTrace\trace_function('throwException', function(SpanData $s) {
     $s->name = 'throwException';
 });
 
-dd_trace_function('multiCatch', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('multiCatch', function(SpanData $s, $a, $retval) {
     $s->name = 'multiCatch';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/exception_handled_with_finally.phpt
+++ b/tests/ext/sandbox/exception_handled_with_finally.phpt
@@ -23,11 +23,11 @@ function doCatchWithFinally() {
     }
 }
 
-dd_trace_function('throwException', function(SpanData $s) {
+DDTrace\trace_function('throwException', function(SpanData $s) {
     $s->name = 'throwException';
 });
 
-dd_trace_function('doCatchWithFinally', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doCatchWithFinally', function(SpanData $s, $a, $retval) {
     $s->name = 'doCatchWithFinally';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/exception_handling.phpt
+++ b/tests/ext/sandbox/exception_handling.phpt
@@ -12,8 +12,8 @@ function inner($message) {
     throw new Exception($message);
 }
 
-dd_trace_function("outer", function() {});
-dd_trace_function("inner", function() {});
+DDTrace\trace_function("outer", function() {});
+DDTrace\trace_function("inner", function() {});
 
 try {
     outer();

--- a/tests/ext/sandbox/exception_handling_php5.phpt
+++ b/tests/ext/sandbox/exception_handling_php5.phpt
@@ -13,8 +13,8 @@ function inner($message) {
     throw new Exception($message);
 }
 
-dd_trace_function("outer", function() {});
-dd_trace_function("inner", function() {});
+DDTrace\trace_function("outer", function() {});
+DDTrace\trace_function("inner", function() {});
 
 try {
     outer();

--- a/tests/ext/sandbox/exception_is_defined.phpt
+++ b/tests/ext/sandbox/exception_is_defined.phpt
@@ -8,7 +8,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 <?php
 
 var_dump(error_get_last());
-dd_trace_function('array_sum', function ($span, $args, $retval, $ex) {
+DDTrace\trace_function('array_sum', function ($span, $args, $retval, $ex) {
     var_dump(\is_null($ex));
     var_dump(error_get_last());
 });

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -23,17 +23,17 @@ class Test
     }
 }
 
-dd_trace_method('Test', 'testFoo', function (SpanData $span) {
+DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
     $span->name = 'TestFoo';
     $span->service = $this_normally_raises_a_notice; // E_NOTICE
 });
 
-dd_trace_function('mt_srand', function (SpanData $span) {
+DDTrace\trace_function('mt_srand', function (SpanData $span) {
     $span->name = 'MTSeed';
     throw new Exception('This should be ignored');
 });
 
-dd_trace_function('mt_rand', function (SpanData $span) {
+DDTrace\trace_function('mt_rand', function (SpanData $span) {
     $span->name = 'MTRand';
     htmlentities('<b>', 0, 'BIG5'); // E_STRICT
 });

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt
@@ -17,12 +17,12 @@ function testExceptionIsPassed()
     throw new Exception('Oops!');
 }
 
-dd_trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
+DDTrace\trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
     $span->name = 'TestNull';
     var_dump($ex === null);
 });
 
-dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
+DDTrace\trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
     $span->name = 'TestEx';
     var_dump($ex instanceof Exception);
 });

--- a/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt
@@ -28,12 +28,12 @@ function testExceptionIsPassed()
     throw new Exception('Oops!');
 }
 
-dd_trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
+DDTrace\trace_function('testExceptionIsNull', function (SpanData $span, array $args, $retval, $ex) {
     $span->name = 'TestNull';
     var_dump($ex === null);
 });
 
-dd_trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
+DDTrace\trace_function('testExceptionIsPassed', function (SpanData $span, array $args, $retval, $ex) {
     $span->name = 'TestEx';
     var_dump($ex instanceof Exception);
 });

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt
@@ -11,7 +11,7 @@ function a(){
     throw new Exception('Oops!');
 }
 
-dd_trace_function('a', function($s, $args, $r, $ex) {
+DDTrace\trace_function('a', function($s, $args, $r, $ex) {
     $s->name = 'a';
     throw $ex;
 });

--- a/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
+++ b/tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure_php5.phpt
@@ -20,7 +20,7 @@ function a(){
     throw new Exception('Oops!');
 }
 
-dd_trace_function('a', function($s, $args, $r, $ex) {
+DDTrace\trace_function('a', function($s, $args, $r, $ex) {
     $s->name = 'a';
     throw $ex;
 });

--- a/tests/ext/sandbox/exceptions_in_tracing_closure_and_original_call.phpt
+++ b/tests/ext/sandbox/exceptions_in_tracing_closure_and_original_call.phpt
@@ -11,7 +11,7 @@ function a(){
     throw new SubException('Oops!');
 }
 
-dd_trace_function('a', function($span, $args, $r, $ex) {
+DDTrace\trace_function('a', function($span, $args, $r, $ex) {
     var_dump($ex instanceof SubException);
     throw new Exception('!');
 });

--- a/tests/ext/sandbox/exit_and_drop_span.phpt
+++ b/tests/ext/sandbox/exit_and_drop_span.phpt
@@ -4,7 +4,7 @@ Exit gracefully handles a dropped span
 <?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
-dd_trace_function('foo', function () {
+DDTrace\trace_function('foo', function () {
     echo 'Dropping span' . PHP_EOL;
     return false;
 });

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -38,7 +38,7 @@ register_shutdown_function(function () {
     var_dump(error_get_last());
 });
 
-dd_trace_function('flushTracer', function () {
+DDTrace\trace_function('flushTracer', function () {
     echo 'Flushing...' . PHP_EOL;
     array_map(function($span) {
         echo $span['name'] . PHP_EOL;
@@ -49,7 +49,7 @@ dd_trace_function('flushTracer', function () {
     var_dump(error_get_last());
 });
 
-dd_trace_function('array_sum', function (DDTrace\SpanData $span) {
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
     $span->name = 'array_sum';
 });
 

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
@@ -7,7 +7,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
-dd_trace_function('array_sum', function (DDTrace\SpanData $span) {
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
     $span->name = 'array_sum';
     this_function_does_not_exist();
 });

--- a/tests/ext/sandbox/generator.phpt
+++ b/tests/ext/sandbox/generator.phpt
@@ -21,12 +21,12 @@ function doSomething() {
     return 'Done';
 }
 
-dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('getResults', function(SpanData $s, $a, $retval) {
     $s->name = 'getResults';
     $s->resource = $retval;
 });
 
-dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
     $s->name = 'doSomething';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/generator_not_supported.phpt
+++ b/tests/ext/sandbox/generator_not_supported.phpt
@@ -25,12 +25,12 @@ function doSomething() {
     return 'Done';
 }
 
-dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('getResults', function(SpanData $s, $a, $retval) {
     $s->name = 'getResults';
     $s->resource = $retval;
 });
 
-dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
     $s->name = 'doSomething';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/generator_with_exception.phpt
+++ b/tests/ext/sandbox/generator_with_exception.phpt
@@ -32,12 +32,12 @@ function doSomething() {
     }
 }
 
-dd_trace_function('maybeThrowException', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('maybeThrowException', function(SpanData $s, $a, $retval) {
     $s->name = 'maybeThrowException';
     $s->resource = $retval;
 });
 
-dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
     $s->name = 'doSomething';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/generator_with_return.phpt
+++ b/tests/ext/sandbox/generator_with_return.phpt
@@ -23,12 +23,12 @@ function doSomething() {
     return 'Done';
 }
 
-dd_trace_function('getResultsWithReturn', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('getResultsWithReturn', function(SpanData $s, $a, $retval) {
     $s->name = 'getResultsWithReturn';
     $s->resource = $retval;
 });
 
-dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
     $s->name = 'doSomething';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/generator_yield_from.phpt
+++ b/tests/ext/sandbox/generator_yield_from.phpt
@@ -19,12 +19,12 @@ function doSomething() {
     return 'Done';
 }
 
-dd_trace_function('getResults', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('getResults', function(SpanData $s, $a, $retval) {
     $s->name = 'getResults';
     $s->resource = $retval[0];
 });
 
-dd_trace_function('doSomething', function(SpanData $s, $a, $retval) {
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
     $s->name = 'doSomething';
     $s->resource = $retval;
 });

--- a/tests/ext/sandbox/get_last_error.phpt
+++ b/tests/ext/sandbox/get_last_error.phpt
@@ -14,7 +14,7 @@ if (
     && $last_error['type'] == E_NOTICE
     && strpos($last_error['message'], 'Undefined variable') === 0
 ) {
-    dd_trace_function('array_sum', function () {
+    DDTrace\trace_function('array_sum', function () {
         echo $i_also_do_not_exist;
     });
     array_sum([]);

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -7,10 +7,10 @@ DD_TRACE_SPANS_LIMIT=5
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php
-dd_trace_function('array_sum', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('array_sum', function (\DDTrace\SpanData $span) {
     $span->name = 'array_sum';
 });
-dd_trace_function('mt_rand', [
+DDTrace\trace_function('mt_rand', [
     'instrument_when_limited' => 1,
     'posthook' => function (\DDTrace\SpanData $span) {
         $span->name = 'mt_rand';

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -9,10 +9,10 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::format,DateTime::setTime
 <?php
 date_default_timezone_set('UTC');
 
-dd_trace_method('DateTime', 'format', function (\DDTrace\SpanData $span) {
+DDTrace\trace_method('DateTime', 'format', function (\DDTrace\SpanData $span) {
     $span->name = 'DateTime.format';
 });
-dd_trace_method('DateTime', 'setTime', [
+DDTrace\trace_method('DateTime', 'setTime', [
     'instrument_when_limited' => 1,
     'posthook' => function (\DDTrace\SpanData $span) {
         $span->name = 'DateTime.setTime';

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -14,10 +14,10 @@ function myFunc2($bar) {
     return $bar;
 }
 
-dd_trace_function('myFunc1', function (\DDTrace\SpanData $span) {
+DDTrace\trace_function('myFunc1', function (\DDTrace\SpanData $span) {
     $span->name = 'myFunc1';
 });
-dd_trace_function('myFunc2', [
+DDTrace\trace_function('myFunc2', [
     'instrument_when_limited' => 1,
     'posthook' => function (\DDTrace\SpanData $span) {
         $span->name = 'myFunc2';

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
@@ -17,10 +17,10 @@ class MyClass
     }
 }
 
-dd_trace_method('MyClass', 'myMethod1', function (\DDTrace\SpanData $span) {
+DDTrace\trace_method('MyClass', 'myMethod1', function (\DDTrace\SpanData $span) {
     $span->name = 'MyClass.myMethod1';
 });
-dd_trace_method('MyClass', 'myMethod2', [
+DDTrace\trace_method('MyClass', 'myMethod2', [
     'instrument_when_limited' => 1,
     'posthook' => function (\DDTrace\SpanData $span) {
         $span->name = 'MyClass.myMethod2';

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -21,7 +21,7 @@ register_shutdown_function(function () {
     echo 'You should not see this.' . PHP_EOL;
 });
 
-dd_trace_function('array_sum', function (DDTrace\SpanData $span) {
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
     $span->name = 'array_sum' . str_repeat('.', 500);
     $span->resource = 'array_sum' . str_repeat('-', 500);
     $span->service = 'php';

--- a/tests/ext/sandbox/new_static.phpt
+++ b/tests/ext/sandbox/new_static.phpt
@@ -16,7 +16,7 @@ class Bar extends Foo {
     // Empty
 }
 
-dd_trace_method('Foo', 'get', function (SpanData $span) {
+DDTrace\trace_method('Foo', 'get', function (SpanData $span) {
     $span->name = get_called_class();
 });
 

--- a/tests/ext/sandbox/return_by_ref.phpt
+++ b/tests/ext/sandbox/return_by_ref.phpt
@@ -7,7 +7,7 @@ Functions that return by reference are instrumented
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('foo', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('foo', function (SpanData $span, array $args, $retval) {
     $span->name = 'foo';
     var_dump($retval);
 });

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -17,7 +17,7 @@ function foo()
     return 42;
 }
 
-dd_trace_function('foo', function (SpanData $span, array $args, $retval, $ex) {
+DDTrace\trace_function('foo', function (SpanData $span, array $args, $retval, $ex) {
     var_dump($ex instanceof Exception);
     var_dump($retval);
 });

--- a/tests/ext/sandbox/safe_to_string_metadata.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata.phpt
@@ -21,7 +21,7 @@ class MyDt extends DateTime {
 
 function meta_to_string() {}
 
-dd_trace_function('meta_to_string', function (SpanData $span, array $args) {
+DDTrace\trace_function('meta_to_string', function (SpanData $span, array $args) {
     $span->name = 'MetaToString';
     $span->meta = [];
     foreach ($args as $key => $arg) {

--- a/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
@@ -8,7 +8,7 @@ use DDTrace\SpanData;
 
 function meta_to_string() {}
 
-dd_trace_function('meta_to_string', function (SpanData $span) {
+DDTrace\trace_function('meta_to_string', function (SpanData $span) {
     $span->name = 'MetaToString';
     $span->meta = [
         'answer_to_universe' => 42,

--- a/tests/ext/sandbox/safe_to_string_properties.phpt
+++ b/tests/ext/sandbox/safe_to_string_properties.phpt
@@ -16,7 +16,7 @@ class MyDt extends DateTime {
 
 function prop_to_string($data) {}
 
-dd_trace_function('prop_to_string', function (SpanData $span, array $args) {
+DDTrace\trace_function('prop_to_string', function (SpanData $span, array $args) {
     $span->name = $args[0];
     $span->resource = $args[0];
     $span->service = $args[0];

--- a/tests/ext/sandbox/sandbox_api_not_available_on_unsupported_versions.phpt
+++ b/tests/ext/sandbox/sandbox_api_not_available_on_unsupported_versions.phpt
@@ -4,8 +4,8 @@ Sandbox API is not available on unsupported versions
 <?php if (PHP_VERSION_ID >= 50600) die('skip Test is only for versions that do not support the sandbox API'); ?>
 --FILE--
 <?php
-var_dump(function_exists('dd_trace_function'));
-var_dump(function_exists('dd_trace_method'));
+var_dump(function_exists('DDTrace\trace_function'));
+var_dump(function_exists('DDTrace\trace_method'));
 ?>
 --EXPECT--
 bool(false)

--- a/tests/ext/sandbox/spans_out_of_sync.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync.phpt
@@ -9,7 +9,7 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
 <?php
 // Since dd_trace_serialize_closed_spans() destroys the open span stack,
 // when this closure runs, DDTrace\SpanData will have been freed already.
-dd_trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
     echo 'You should not see this.' . PHP_EOL;
     $span->name = 'dd_trace_serialize_closed_spans';
 });

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -16,7 +16,7 @@ class Foo
     }
 }
 
-dd_trace_method('Foo', 'test', static function () {
+DDTrace\trace_method('Foo', 'test', static function () {
     echo "TRACED Foo::test()\n";
 });
 

--- a/tests/ext/sandbox/variadic_args_internal.phpt
+++ b/tests/ext/sandbox/variadic_args_internal.phpt
@@ -6,7 +6,7 @@ Variadic arguments are passed to tracing closure for internal functions
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=sscanf
 --FILE--
 <?php
-dd_trace_function('sscanf', function (DDTrace\SpanData $s, array $args) {
+DDTrace\trace_function('sscanf', function (DDTrace\SpanData $s, array $args) {
     var_dump($args);
 });
 

--- a/tests/ext/sandbox/variadic_no_args.phpt
+++ b/tests/ext/sandbox/variadic_no_args.phpt
@@ -14,7 +14,7 @@ function foo() {
     return $retval;
 }
 
-dd_trace_function('foo', function ($span, array $args) {
+DDTrace\trace_function('foo', function ($span, array $args) {
     var_dump($args);
 });
 

--- a/tests/ext/sandbox/vm_var_types_return.phpt
+++ b/tests/ext/sandbox/vm_var_types_return.phpt
@@ -6,25 +6,25 @@ VM variable types are handled properly for return
 <?php
 use DDTrace\SpanData;
 
-dd_trace_function('retval_IS_CONST', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('retval_IS_CONST', function (SpanData $span, array $args, $retval) {
     $span->name = 'retval_IS_CONST';
     $span->resource = $retval;
     var_dump($retval);
 });
 
-dd_trace_function('retval_IS_CV', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('retval_IS_CV', function (SpanData $span, array $args, $retval) {
     $span->name = 'retval_IS_CV';
     $span->resource = $retval;
     var_dump($retval);
 });
 
-dd_trace_function('retval_IS_VAR', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('retval_IS_VAR', function (SpanData $span, array $args, $retval) {
     $span->name = 'retval_IS_VAR';
     $span->resource = $retval;
     var_dump($retval);
 });
 
-dd_trace_function('retval_IS_TMP_VAR', function (SpanData $span, array $args, $retval) {
+DDTrace\trace_function('retval_IS_TMP_VAR', function (SpanData $span, array $args, $retval) {
     $span->name = 'retval_IS_TMP_VAR';
     $span->resource = $retval;
     var_dump($retval);

--- a/tests/ext/traced_internal_functions_override_01.phpt
+++ b/tests/ext/traced_internal_functions_override_01.phpt
@@ -3,11 +3,11 @@ Ensure that if a user adds an internal function we already trace to traced inter
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=header
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip: requires dd_trace_function'); ?>
+<?php if (PHP_VERSION_ID < 50500) die('skip: requires DDTrace\\trace_function'); ?>
 --FILE--
 <?php
 
-dd_trace_function('header', function () {
+DDTrace\trace_function('header', function () {
     echo "Traced header.\n";
 });
 

--- a/tests/opcache/basic.phpt
+++ b/tests/opcache/basic.phpt
@@ -16,10 +16,10 @@ Datadog\NegativeClass::negativeMethod();
 Datadog\negative_function();
 
 // Add instrumentation calls (that will not work)
-dd_trace_method('datadog\\negativeclass', 'negativemethod', function () {
+\DDTrace\trace_method('datadog\\negativeclass', 'negativemethod', function () {
     echo "NegativeClass::negative_method\n";
 });
-dd_trace_function('datadog\\negative_function', function () {
+\DDTrace\trace_function('datadog\\negative_function', function () {
     echo "negative_function\n";
 });
 

--- a/tests/opcache/file_cache.phpt
+++ b/tests/opcache/file_cache.phpt
@@ -20,10 +20,10 @@ Datadog\NegativeClass::negativeMethod();
 Datadog\negative_function();
 
 // Add instrumentation calls (that will not work)
-dd_trace_method('datadog\\negativeclass', 'negativemethod', function () {
+\DDTrace\trace_method('datadog\\negativeclass', 'negativemethod', function () {
     echo "NegativeClass::negative_method\n";
 });
-dd_trace_function('datadog\\negative_function', function () {
+\DDTrace\trace_function('datadog\\negative_function', function () {
     echo "negative_function\n";
 });
 

--- a/tests/opcache/preload.phpt
+++ b/tests/opcache/preload.phpt
@@ -17,10 +17,10 @@ Datadog\NegativeClass::negativeMethod();
 Datadog\negative_function();
 
 // Add instrumentation calls (that will not work)
-dd_trace_method('datadog\\negativeclass', 'negativemethod', function () {
+\DDTrace\trace_method('datadog\\negativeclass', 'negativemethod', function () {
     echo "NegativeClass::negative_method\n";
 });
-dd_trace_function('datadog\\negative_function', function () {
+\DDTrace\trace_function('datadog\\negative_function', function () {
     echo "negative_function\n";
 });
 

--- a/tests/opcache/protect_memory.phpt
+++ b/tests/opcache/protect_memory.phpt
@@ -17,10 +17,10 @@ Datadog\NegativeClass::negativeMethod();
 Datadog\negative_function();
 
 // Add instrumentation calls (that will not work)
-dd_trace_method('datadog\\negativeclass', 'negativemethod', function () {
+\DDTrace\trace_method('datadog\\negativeclass', 'negativemethod', function () {
     echo "NegativeClass::negative_method\n";
 });
-dd_trace_function('datadog\\negative_function', function () {
+\DDTrace\trace_function('datadog\\negative_function', function () {
     echo "negative_function\n";
 });
 

--- a/tests/overhead/hyperfine_tests/function_calls.php
+++ b/tests/overhead/hyperfine_tests/function_calls.php
@@ -8,7 +8,7 @@ $val = 0;
 
 
 if ($argc > 1 && $argv[1] == "trace_function") {
-    \dd_trace_function('sample_test', function (SpanData $span, $args, $result) use ($val) {
+    \\DDTrace\trace_function('sample_test', function (SpanData $span, $args, $result) use ($val) {
         $span->name  = "sample_test";
         $span->type = "webb";
         $span->service = "svc";

--- a/tests/overhead/hyperfine_tests/method_calls.php
+++ b/tests/overhead/hyperfine_tests/method_calls.php
@@ -16,7 +16,7 @@ function sample_test($val, $add)
 $val = 0;
 
 if ($argc > 1 && $argv[1] == "trace_method") {
-    \dd_trace_method('Sample', "test", function (SpanData $span, $args, $result) use ($val) {
+    \DDTrace\trace_method('Sample', "test", function (SpanData $span, $args, $result) use ($val) {
         $span->name  = "sample_test";
         $span->type = "webb";
         $span->service = "svc";

--- a/tests/xdebug/fake_request_init_hook.inc
+++ b/tests/xdebug/fake_request_init_hook.inc
@@ -4,7 +4,7 @@ namespace DDTrace;
 
 function init()
 {
-    dd_trace_function('array_sum', function (\DDTrace\SpanData $span) {
+    \DDTrace\trace_function('array_sum', function (\DDTrace\SpanData $span) {
         $span->name = 'array_sum';
     });
     echo 'Request init hook loaded.' . PHP_EOL;


### PR DESCRIPTION
### Description

This PR adds the `DDTrace` namespace to internal functions so that going forward, all new API's can be added under this namespace. This change only applies to two existing functions:

* `dd_trace_function` -> `DDTrace\trace_function`
* `dd_trace_method` -> `DDTrace\trace_method`

The old functions `dd_trace_function` & `dd_trace_method` remain as aliases to their namespaced counterparts.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
