### PR TITLE
Add startup logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,6 +439,7 @@ jobs:
             fi
             cd /usr/local/src/php
             export DD_TRACE_CLI_ENABLED=true
+            export DD_TRACE_STARTUP_LOGS=0
             export REPORT_EXIT_STATUS=1
             export TEST_PHP_JUNIT=/tmp/artifacts/tests/php-tests.xml
             mkdir -p /tmp/artifacts/tests

--- a/config.m4
+++ b/config.m4
@@ -69,6 +69,7 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php5_4/engine_hooks.c \
       src/ext/php5_4/handlers_internal.c \
       src/ext/php5_4/serializer.c \
+      src/ext/php5/startup_logging.c \
     "
   elif test $PHP_VERSION -lt 70000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
@@ -81,6 +82,7 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php5/handlers_curl.c \
       src/ext/php5/handlers_internal.c \
       src/ext/php5/serializer.c \
+      src/ext/php5/startup_logging.c \
     "
   elif test $PHP_VERSION -lt 80000; then
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES="\
@@ -96,6 +98,7 @@ if test "$PHP_DDTRACE" != "no"; then
       src/ext/php7/handlers_mysqli.c \
       src/ext/php7/handlers_pdo.c \
       src/ext/php7/serializer.c \
+      src/ext/php7/startup_logging.c \
     "
   else
     DD_TRACE_PHP_VERSION_SPECIFIC_SOURCES=""

--- a/package.xml
+++ b/package.xml
@@ -76,6 +76,7 @@
                     <file name="signals.h" role="src" />
                     <file name="span.c" role="src" />
                     <file name="span.h" role="src" />
+                    <file name="startup_logging.h" role="src" />
                     <file name="version.h" role="src" />
                     <file name="compatibility.h" role="src" />
                     <dir name="mpack">
@@ -103,6 +104,7 @@
                         <file name="engine_hooks.c" role="src" />
                         <file name="handlers_internal.c" role="src" />
                         <file name="serializer.c" role="src" />
+                        <file name="startup_logging.c" role="src" />
                     </dir>
                     <dir name="php7">
                         <file name="auto_flush.c" role="src" />
@@ -118,6 +120,7 @@
                         <file name="handlers_mysqli.c" role="src" />
                         <file name="handlers_pdo.c" role="src" />
                         <file name="serializer.c" role="src" />
+                        <file name="startup_logging.c" role="src" />
                     </dir>
                     <dir name="third-party">
                         <file name="mt19937-64.c" role="src" />
@@ -378,6 +381,14 @@
                     <file name="keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
                     <file name="simple_function_hook.phpt" role="test" />
                     <file name="simple_method_hook.phpt" role="test" />
+                    <file name="startup_logging.inc" role="test" />
+                    <file name="startup_logging.phpt" role="test" />
+                    <file name="startup_logging_config.phpt" role="test" />
+                    <file name="startup_logging_diagnostics.phpt" role="test" />
+                    <file name="startup_logging_disabled.phpt" role="test" />
+                    <file name="startup_logging_json.phpt" role="test" />
+                    <file name="startup_logging_json_config.phpt" role="test" />
+                    <file name="startup_logging_skipif.inc" role="test" />
                     <file name="throw_exception.phpt" role="test" />
                     <file name="trace_method_or_function_that_will_exist_later.phpt" role="test" />
                     <file name="trace_static_method.phpt" role="test" />

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -622,17 +622,17 @@ void ddtrace_coms_curl_shutdown(void) {
 
 static long _dd_max_long(long a, long b) { return a >= b ? a : b; }
 
-static void _dd_curl_set_timeout(CURL *curl) {
+void ddtrace_curl_set_timeout(CURL *curl) {
     long timeout = _dd_max_long(get_dd_trace_bgs_timeout(), get_dd_trace_agent_timeout());
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout);
 }
 
-static void _dd_curl_set_connect_timeout(CURL *curl) {
+void ddtrace_curl_set_connect_timeout(CURL *curl) {
     long timeout = _dd_max_long(get_dd_trace_bgs_connect_timeout(), get_dd_trace_agent_connect_timeout());
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout);
 }
 
-static void _dd_curl_set_hostname(CURL *curl) {
+void ddtrace_curl_set_hostname(CURL *curl) {
     char *hostname = get_dd_agent_host();
     int64_t port = get_dd_trace_agent_port();
     if (port <= 0 || port > 65535) {
@@ -716,9 +716,9 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         struct _grouped_stack_t *kData = read_data;
         _dd_curl_set_headers(writer, kData->total_groups);
         curl_easy_setopt(writer->curl, CURLOPT_READDATA, read_data);
-        _dd_curl_set_hostname(writer->curl);
-        _dd_curl_set_timeout(writer->curl);
-        _dd_curl_set_connect_timeout(writer->curl);
+        ddtrace_curl_set_hostname(writer->curl);
+        ddtrace_curl_set_timeout(writer->curl);
+        ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
         curl_easy_setopt(writer->curl, CURLOPT_INFILESIZE, 10);

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -1,6 +1,7 @@
 #ifndef DD_COMS_H
 #define DD_COMS_H
 
+#include <curl/curl.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -54,6 +55,12 @@ bool ddtrace_coms_on_pid_change(void);
 uint32_t ddtrace_coms_test_writers(void);
 uint32_t ddtrace_coms_test_consumer(void);
 uint32_t ddtrace_coms_test_msgpack_consumer(void);
+/* }}} */
+
+/* exposed for diagnostics {{{ */
+void ddtrace_curl_set_hostname(CURL *curl);
+void ddtrace_curl_set_timeout(CURL *curl);
+void ddtrace_curl_set_connect_timeout(CURL *curl);
 /* }}} */
 
 #endif  // DD_COMS_H

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -85,14 +85,34 @@ void ddtrace_config_shutdown(void);
 
 #define DD_CONFIGURATION                                                                                             \
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
+    BOOL(get_dd_distributed_tracing, "DD_DISTRIBUTED_TRACING", true)                                                 \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
+    CHAR(get_dd_env, "DD_ENV", "")                                                                                   \
+    CHAR(get_dd_integrations_disabled, "DD_INTEGRATIONS_DISABLED", "")                                               \
+    BOOL(get_dd_priority_sampling, "DD_PRIORITY_SAMPLING", true)                                                     \
+    CHAR(get_dd_service, "DD_SERVICE", "")                                                                           \
+    CHAR(get_dd_service_mapping, "DD_SERVICE_MAPPING", "")                                                           \
+    CHAR(get_dd_service_name, "DD_SERVICE_NAME", "")                                                                 \
+    CHAR(get_dd_tags, "DD_TAGS", "")                                                                                 \
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
+    BOOL(get_dd_trace_analytics_enabled, "DD_TRACE_ANALYTICS_ENABLED", false)                                        \
     BOOL(get_dd_trace_auto_flush_enabled, "DD_TRACE_AUTO_FLUSH_ENABLED", false)                                      \
+    BOOL(get_dd_trace_cli_enabled, "DD_TRACE_CLI_ENABLED", false)                                                    \
     BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", true)                                   \
     BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", false)                                                                \
+    BOOL(get_dd_trace_enabled, "DD_TRACE_ENABLED", true)                                                             \
+    CHAR(get_dd_trace_global_tags, "DD_TRACE_GLOBAL_TAGS", "")                                                       \
     BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", false)                               \
     DOUBLE(get_dd_trace_heath_metrics_heartbeat_sample_rate, "DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE", 0.001) \
+    BOOL(get_dd_trace_http_client_split_by_domain, "DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN", false)                    \
     CHAR(get_dd_trace_memory_limit, "DD_TRACE_MEMORY_LIMIT", NULL)                                                   \
+    BOOL(get_dd_trace_report_hostname, "DD_TRACE_REPORT_HOSTNAME", false)                                            \
+    CHAR(get_dd_trace_resource_uri_fragment_regex, "DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX", "")                       \
+    CHAR(get_dd_trace_resource_uri_mapping_incoming, "DD_TRACE_RESOURCE_URI_MAPPING_INCOMING", "")                   \
+    CHAR(get_dd_trace_resource_uri_mapping_outgoing, "DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING", "")                   \
+    DOUBLE(get_dd_trace_sample_rate, "DD_TRACE_SAMPLE_RATE", 1.0)                                                    \
+    CHAR(get_dd_trace_sampling_rules, "DD_TRACE_SAMPLING_RULES", "")                                                 \
+    CHAR(get_dd_trace_traced_internal_functions, "DD_TRACE_TRACED_INTERNAL_FUNCTIONS", "")                           \
     INT(get_dd_trace_agent_timeout, "DD_TRACE_AGENT_TIMEOUT", DD_TRACE_AGENT_TIMEOUT)                                \
     INT(get_dd_trace_agent_connect_timeout, "DD_TRACE_AGENT_CONNECT_TIMEOUT", DD_TRACE_AGENT_CONNECT_TIMEOUT)        \
     INT(get_dd_trace_debug_prng_seed, "DD_TRACE_DEBUG_PRNG_SEED", -1)                                                \
@@ -110,11 +130,13 @@ void ddtrace_config_shutdown(void);
     INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \
     INT(get_dd_trace_agent_flush_after_n_requests, "DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS", 10)                      \
     INT(get_dd_trace_shutdown_timeout, "DD_TRACE_SHUTDOWN_TIMEOUT", 5000)                                            \
+    BOOL(get_dd_trace_startup_logs, "DD_TRACE_STARTUP_LOGS", true)                                                   \
     BOOL(get_dd_trace_agent_debug_verbose_curl, "DD_TRACE_AGENT_DEBUG_VERBOSE_CURL", false)                          \
     BOOL(get_dd_trace_debug_curl_output, "DD_TRACE_DEBUG_CURL_OUTPUT", false)                                        \
     INT(get_dd_trace_beta_high_memory_pressure_percent, "DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT", 80,            \
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
-        "to attempt to flush existing data to trace agent")
+        "to attempt to flush existing data to trace agent")                                                          \
+    CHAR(get_dd_version, "DD_VERSION", "")
 
 // render all configuration getters and define memoization struct
 #include "configuration_render.h"

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -6,6 +6,9 @@
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
+#if PHP_VERSION_ID >= 70000
+#include <Zend/zend_smart_str.h>
+#endif
 #include <Zend/zend_vm.h>
 #include <inttypes.h>
 #include <php.h>
@@ -14,6 +17,9 @@
 
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
+#if PHP_VERSION_ID < 70000
+#include <ext/standard/php_smart_str.h>
+#endif
 
 #include "arrays.h"
 #include "auto_flush.h"
@@ -40,6 +46,7 @@
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"
+#include "startup_logging.h"
 
 bool ddtrace_blacklisted_disable_legacy;
 bool ddtrace_has_blacklisted_module;
@@ -64,6 +71,7 @@ static int ddtrace_startup(struct _zend_extension *extension) {
 
     ddtrace_blacklist_startup();
     ddtrace_internal_handlers_startup();
+    ddtrace_startup_logging_startup();
     return SUCCESS;
 }
 
@@ -157,6 +165,9 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_init, 0, 0, 1)
 ZEND_ARG_INFO(0, dir)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, sizeof(zend_ddtrace_globals)); }
@@ -405,6 +416,100 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
 
 static int datadog_info_print(const char *str TSRMLS_DC) { return php_output_write(str, strlen(str) TSRMLS_CC); }
 
+static void _dd_info_tracer_config(void) {
+    smart_str buf = {0};
+    ddtrace_startup_logging_json(&buf);
+#if PHP_VERSION_ID >= 70000
+    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", ZSTR_VAL(buf.s));
+#else
+    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", buf.c);
+#endif
+    smart_str_free(&buf);
+}
+
+static void _dd_info_diagnostics_row(const char *key, const char *value TSRMLS_DC) {
+    if (sapi_module.phpinfo_as_text) {
+        php_info_print_table_row(2, key, value);
+        return;
+    }
+    datadog_info_print("<tr><td class='e'>" TSRMLS_CC);
+    datadog_info_print(key TSRMLS_CC);
+    datadog_info_print("</td><td class='v' style='background-color:#f0e881;'>" TSRMLS_CC);
+    datadog_info_print(value TSRMLS_CC);
+    datadog_info_print("</td></tr>" TSRMLS_CC);
+}
+
+static void _dd_info_diagnostics_table(TSRMLS_D) {
+    php_info_print_table_start();
+    php_info_print_table_colspan_header(2, "Diagnostics");
+
+    HashTable *ht;
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, 8, NULL, ZVAL_PTR_DTOR, 0);
+
+    ddtrace_startup_diagnostics(ht);
+
+#if PHP_VERSION_ID >= 70000
+    zend_string *key;
+    zval *val;
+    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
+        switch (Z_TYPE_P(val)) {
+            case IS_STRING:
+                _dd_info_diagnostics_row(ZSTR_VAL(key), Z_STRVAL_P(val) TSRMLS_CC);
+                break;
+            case IS_NULL:
+                _dd_info_diagnostics_row(ZSTR_VAL(key), "NULL" TSRMLS_CC);
+                break;
+            case IS_TRUE:
+            case IS_FALSE:
+                _dd_info_diagnostics_row(ZSTR_VAL(key), Z_TYPE_P(val) == IS_TRUE ? "true" : "false" TSRMLS_CC);
+                break;
+            default:
+                _dd_info_diagnostics_row(ZSTR_VAL(key), "{unknown type}" TSRMLS_CC);
+                break;
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+#else
+    int key_type;
+    zval **val;
+    HashPosition pos;
+    char *key;
+    uint key_len;
+    ulong num_key;
+    zend_hash_internal_pointer_reset_ex(ht, &pos);
+    while (zend_hash_get_current_data_ex(ht, (void **)&val, &pos) == SUCCESS) {
+        key_type = zend_hash_get_current_key_ex(ht, &key, &key_len, &num_key, 0, &pos);
+        if (key_type == HASH_KEY_IS_STRING) {
+            switch (Z_TYPE_PP(val)) {
+                case IS_STRING:
+                    _dd_info_diagnostics_row(key, Z_STRVAL_PP(val) TSRMLS_CC);
+                    break;
+                case IS_NULL:
+                    _dd_info_diagnostics_row(key, "NULL" TSRMLS_CC);
+                    break;
+                case IS_BOOL:
+                    _dd_info_diagnostics_row(key, Z_BVAL_PP(val) ? "true" : "false" TSRMLS_CC);
+                    break;
+                default:
+                    _dd_info_diagnostics_row(key, "{unknown type}" TSRMLS_CC);
+                    break;
+            }
+        }
+        zend_hash_move_forward_ex(ht, &pos);
+    }
+#endif
+
+    if (zend_hash_num_elements(ht) == 0) {
+        php_info_print_table_row(2, "All diagnostic checks", "passed");
+    }
+
+    zend_hash_destroy(ht);
+    FREE_HASHTABLE(ht);
+
+    php_info_print_table_end();
+}
+
 static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
@@ -421,13 +526,16 @@ static PHP_MINFO_FUNCTION(ddtrace) {
             "https://docs.datadoghq.com/tracing/languages/php/" TSRMLS_CC);
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n" TSRMLS_CC);
-    datadog_info_print("(c) Datadog 2019\n" TSRMLS_CC);
+    datadog_info_print("(c) Datadog 2020\n" TSRMLS_CC);
     php_info_print_box_end();
 
     php_info_print_table_start();
     php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
+    _dd_info_tracer_config();
     php_info_print_table_end();
+
+    _dd_info_diagnostics_table(TSRMLS_C);
 
     DISPLAY_INI_ENTRIES();
 }
@@ -1248,6 +1356,20 @@ static PHP_FUNCTION(dd_trace_compile_time_microseconds) {
     RETURN_LONG(ddtrace_compile_time_get(TSRMLS_C));
 }
 
+static PHP_FUNCTION(startup_logs) {
+    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
+    PHP7_UNUSED(execute_data);
+
+    smart_str buf = {0};
+    ddtrace_startup_logging_json(&buf);
+#if PHP_VERSION_ID >= 70000
+    ZVAL_NEW_STR(return_value, buf.s);
+#else
+    ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
+    smart_str_free(&buf);
+#endif
+}
+
 static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace, NULL),
     DDTRACE_FE(dd_trace_buffer_span, arginfo_dd_trace_buffer_span),
@@ -1287,6 +1409,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_NS_FE(trace_method, arginfo_ddtrace_trace_method),
     DDTRACE_FALIAS(dd_trace_method, trace_method, arginfo_ddtrace_trace_method),
 #endif
+    DDTRACE_NS_FE(startup_logs, arginfo_ddtrace_void),
     DDTRACE_FE_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -500,9 +500,7 @@ static void _dd_info_diagnostics_table(TSRMLS_D) {
     }
 #endif
 
-    if (zend_hash_num_elements(ht) == 0) {
-        php_info_print_table_row(2, "All diagnostic checks", "passed");
-    }
+    php_info_print_table_row(2, "Diagnostic checks", zend_hash_num_elements(ht) == 0 ? "passed" : "failed");
 
     zend_hash_destroy(ht);
     FREE_HASHTABLE(ht);

--- a/src/ext/php5/startup_logging.c
+++ b/src/ext/php5/startup_logging.c
@@ -1,0 +1,435 @@
+#include "startup_logging.h"
+
+#include <SAPI.h>
+#include <Zend/zend_API.h>
+#include <curl/curl.h>
+#include <php.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include <ext/standard/info.h>
+#include <ext/standard/php_smart_str.h>
+
+#include "coms.h"
+#include "configuration.h"
+#include "logging.h"
+#include "version.h"
+
+#define ISO_8601_LEN (20 + 1)  // +1 for terminating null-character
+
+// True global; only modify on MINIT/STARTUP
+static time_t startup_time = -1;
+
+static void _dd_get_startup_time(char *buf) {
+    time_t now = (startup_time == -1) ? time(NULL) : startup_time;
+    struct tm *tm = gmtime(&now);
+    if (tm) {
+        strftime(buf, ISO_8601_LEN, "%Y-%m-%dT%TZ", tm);
+    } else {
+        ddtrace_log_debug("Error getting startup time");
+    }
+}
+
+static void _dd_add_assoc_string(HashTable *ht, const char *name, size_t name_len, const char *str) {
+    zval *value;
+    MAKE_STD_ZVAL(value);
+    size_t str_len = str ? strlen(str) : 0;
+    if (str_len > 0) {
+        ZVAL_STRINGL(value, str, str_len, 1);
+    } else {
+        ZVAL_NULL(value);
+    }
+    zend_symtable_update(ht, name, (name_len + 1), (void **)&value, sizeof(zval *), NULL);
+}
+
+static void _dd_add_assoc_string_free(HashTable *ht, const char *name, size_t name_len, char *str) {
+    _dd_add_assoc_string(ht, name, name_len, (const char *)str);
+    free(str);
+}
+
+static void _dd_add_assoc_bool(HashTable *ht, const char *name, size_t name_len, bool v) {
+    zval *value;
+    MAKE_STD_ZVAL(value);
+    ZVAL_BOOL(value, v);
+    zend_symtable_update(ht, name, (name_len + 1), (void **)&value, sizeof(zval *), NULL);
+}
+
+static void _dd_add_assoc_double(HashTable *ht, const char *name, size_t name_len, double num) {
+    zval *value;
+    MAKE_STD_ZVAL(value);
+    ZVAL_DOUBLE(value, num);
+    zend_symtable_update(ht, name, (name_len + 1), (void **)&value, sizeof(zval *), NULL);
+}
+
+static char *_dd_get_ini(const char *name, size_t name_len) { return zend_ini_string((char *)name, (name_len + 1), 0); }
+
+static bool _dd_ini_is_set(const char *name, size_t name_len) {
+    const char *ini = _dd_get_ini(name, name_len);
+    return ini && (strcmp(ini, "") != 0);
+}
+
+// Modified version of zend_ini_parse_bool()
+// @see https://github.com/php/php-src/blob/28b4761/Zend/zend_ini.c#L493-L502
+static bool _dd_parse_bool(const char *name, size_t name_len) {
+    const char *ini = _dd_get_ini(name, name_len);
+    size_t ini_len = strlen(ini);
+    if ((ini_len == 4 && strcasecmp(ini, "true") == 0) || (ini_len == 3 && strcasecmp(ini, "yes") == 0) ||
+        (ini_len == 2 && strcasecmp(ini, "on") == 0)) {
+        return 1;
+    } else {
+        return atoi(ini) != 0;
+    }
+}
+
+static void _dd_get_agent_url(char *buf) {
+    char *host = get_dd_agent_host();
+    sprintf(buf, "https://%s:%d", host, (int)get_dd_trace_agent_port());
+    free(host);
+}
+
+static void _dd_get_startup_config(HashTable *ht) {
+    // Cross-language tracer values
+    char time[ISO_8601_LEN];
+    _dd_get_startup_time(time);
+    _dd_add_assoc_string(ht, ZEND_STRL("date"), time);
+
+    char *os_name = php_get_uname('a');
+    _dd_add_assoc_string(ht, ZEND_STRL("os_name"), os_name);
+    efree(os_name);
+
+    char *os_version = php_get_uname('r');
+    _dd_add_assoc_string(ht, ZEND_STRL("os_version"), os_version);
+    efree(os_version);
+
+    _dd_add_assoc_string(ht, ZEND_STRL("version"), PHP_DDTRACE_VERSION);
+    _dd_add_assoc_string(ht, ZEND_STRL("lang"), "php");
+    _dd_add_assoc_string(ht, ZEND_STRL("lang_version"), PHP_VERSION);
+    _dd_add_assoc_string_free(ht, ZEND_STRL("env"), get_dd_env());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled"), !_dd_parse_bool(ZEND_STRL("ddtrace.disable")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("service"), get_dd_service());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled_cli"), get_dd_trace_cli_enabled());
+
+    char agent_url[64];
+    _dd_get_agent_url(agent_url);
+    _dd_add_assoc_string(ht, ZEND_STRL("agent_url"), agent_url);
+
+    _dd_add_assoc_bool(ht, ZEND_STRL("debug"), get_dd_trace_debug());
+    _dd_add_assoc_bool(ht, ZEND_STRL("analytics_enabled"), get_dd_trace_analytics_enabled());
+    _dd_add_assoc_double(ht, ZEND_STRL("sample_rate"), get_dd_trace_sample_rate());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("sampling_rules"), get_dd_trace_sampling_rules());
+    // TODO Add integration-specific config: integration_<integration>_analytics_enabled,
+    // integration_<integration>_sample_rate, integrations_loaded
+    _dd_add_assoc_string_free(ht, ZEND_STRL("tags"), get_dd_tags());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("service_mapping"), get_dd_service_mapping());
+    // "log_injection_enabled" N/A for PHP
+    // "runtime_metrics_enabled" N/A for PHP
+    // "configuration_file" N/A for PHP
+    // "vm" N/A for PHP
+    // "partial_flushing_enabled" N/A for PHP
+    _dd_add_assoc_bool(ht, ZEND_STRL("distributed_tracing_enabled"), get_dd_distributed_tracing());
+    _dd_add_assoc_bool(ht, ZEND_STRL("priority_sampling_enabled"), get_dd_priority_sampling());
+    // "logs_correlation_enabled" N/A for PHP
+    // "profiling_enabled" N/A for PHP
+    _dd_add_assoc_string_free(ht, ZEND_STRL("dd_version"), get_dd_version());
+    // "health_metrics_enabled" N/A for PHP
+
+    char *architecture = php_get_uname('m');
+    _dd_add_assoc_string(ht, ZEND_STRL("architecture"), architecture);
+    efree(architecture);
+
+    // PHP-specific values
+    _dd_add_assoc_string(ht, ZEND_STRL("sapi"), sapi_module.name);
+    _dd_add_assoc_string(ht, ZEND_STRL("ddtrace.request_init_hook"),
+                         _dd_get_ini(ZEND_STRL("ddtrace.request_init_hook")));
+    _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_configured"), _dd_ini_is_set(ZEND_STRL("open_basedir")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_fragment_regex"), get_dd_trace_resource_uri_fragment_regex());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_mapping_incoming"), get_dd_trace_resource_uri_mapping_incoming());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_mapping_outgoing"), get_dd_trace_resource_uri_mapping_outgoing());
+    _dd_add_assoc_bool(ht, ZEND_STRL("auto_flush_enabled"), get_dd_trace_auto_flush_enabled());
+    _dd_add_assoc_bool(ht, ZEND_STRL("generate_root_span"), get_dd_trace_generate_root_span());
+    _dd_add_assoc_bool(ht, ZEND_STRL("http_client_split_by_domain"), get_dd_trace_http_client_split_by_domain());
+    _dd_add_assoc_bool(ht, ZEND_STRL("measure_compile_time"), get_dd_trace_measure_compile_time());
+    _dd_add_assoc_bool(ht, ZEND_STRL("report_hostname_on_root_span"), get_dd_trace_report_hostname());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("traced_internal_functions"), get_dd_trace_traced_internal_functions());
+    _dd_add_assoc_bool(ht, ZEND_STRL("auto_prepend_file_configured"), _dd_ini_is_set(ZEND_STRL("auto_prepend_file")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("integrations_disabled"), get_dd_integrations_disabled());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled_from_env"), get_dd_trace_enabled());
+    _dd_add_assoc_string(ht, ZEND_STRL("opcache.file_cache"), _dd_get_ini(ZEND_STRL("opcache.file_cache")));
+}
+
+static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    UNUSED(ptr, userdata);
+    return size * nmemb;
+}
+
+static size_t _dd_check_for_agent_error(char *error) {
+    CURL *curl = curl_easy_init();
+    ddtrace_curl_set_hostname(curl);
+    ddtrace_curl_set_timeout(curl);
+    ddtrace_curl_set_connect_timeout(curl);
+
+    const char *body = "[]";
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(body));
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _dd_curl_write_noop);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error);
+    error[0] = 0;
+
+    CURLcode res = curl_easy_perform(curl);
+
+    size_t error_len = strlen(error);
+    if (res != CURLE_OK && !error_len) {
+        strcpy(error, curl_easy_strerror(res));
+        error_len = strlen(error);
+    }
+    curl_easy_cleanup(curl);
+    return error_len;
+}
+
+static bool _dd_file_exists(const char *file TSRMLS_DC) {
+    if (!strlen(file)) {
+        return false;
+    }
+    // TSRMLS_CC is embedded in the VCWD_ACCESS macro
+    return (VCWD_ACCESS(file, R_OK) == 0);
+}
+
+static bool _dd_open_basedir_allowed(const char *file TSRMLS_DC) {
+    return (php_check_open_basedir_ex(file, 0 TSRMLS_CC) != -1);
+}
+
+/* Supported zval types for diagnostics: string, bool, null
+ * To support other types, update:
+ *     - ddtrace.c:_dd_info_diagnostics_table(); PHP info output
+ *     - _dd_print_values_to_log(); Debug log output
+ */
+void ddtrace_startup_diagnostics(HashTable *ht) {
+    TSRMLS_FETCH();
+    // Cross-language tracer values
+    char agent_error[CURL_ERROR_SIZE];
+    if (_dd_check_for_agent_error(agent_error)) {
+        _dd_add_assoc_string(ht, ZEND_STRL("agent_error"), agent_error);
+    }
+    //_dd_add_assoc_string(ht, ZEND_STRL("sampling_rules_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("service_mapping_error"), ""); // TODO Parse at C level
+
+    // PHP-specific values
+    const char *rih = _dd_get_ini(ZEND_STRL("ddtrace.request_init_hook"));
+    bool rih_exists = _dd_file_exists(rih TSRMLS_CC);
+    if (!rih_exists) {
+        _dd_add_assoc_bool(ht, ZEND_STRL("ddtrace.request_init_hook_reachable"), rih_exists);
+    } else {
+        bool rih_allowed = _dd_open_basedir_allowed(rih TSRMLS_CC);
+        if (!rih_allowed) {
+            _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_init_hook_allowed"), rih_allowed);
+        }
+    }
+
+    bool container_allowed = _dd_open_basedir_allowed("/proc/self/cgroup" TSRMLS_CC);
+    if (!container_allowed) {
+        _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_container_tagging_allowed"), container_allowed);
+    }
+
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_fragment_regex_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_incoming_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_outgoing_error"), ""); // TODO Parse at C level
+
+    char *old_service = get_dd_service_name();
+    if (strcmp(old_service, "") != 0) {
+        _dd_add_assoc_string(ht, ZEND_STRL("service_name"), old_service);
+        _dd_add_assoc_string(ht, ZEND_STRL("service_name_error"),
+                             "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead.");
+    }
+    free(old_service);
+
+    char *old_tags = get_dd_trace_global_tags();
+    if (strcmp(old_tags, "") != 0) {
+        _dd_add_assoc_string(ht, ZEND_STRL("global_tags"), old_tags);
+        _dd_add_assoc_string(ht, ZEND_STRL("global_tags_error"),
+                             "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead.");
+    }
+    free(old_tags);
+}
+
+static void _dd_json_escape_string(smart_str *buf, const char *val, size_t len) {
+    // Empty strings are treated as null
+    if (len == 0) {
+        smart_str_appendl(buf, "null", 4);
+        return;
+    }
+
+    size_t newlen;                     // Used by smart_str_alloc macro
+    smart_str_alloc(buf, len + 2, 0);  // +2 for quotes
+    smart_str_appendc(buf, '"');
+
+    unsigned long pos = 0;
+    unsigned char c;
+    while (pos < len) {
+        c = val[pos++];
+        // @see http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+        switch (c) {
+            case '"':
+                smart_str_appendl(buf, "\\\"", 2);
+                break;
+            case '\\':
+                smart_str_appendl(buf, "\\\\", 2);
+                break;
+            // Ignoring case '/' as JSON will not be used in scripting contexts
+            case '\b':
+                smart_str_appendl(buf, "\\b", 2);
+                break;
+            case '\f':
+                smart_str_appendl(buf, "\\f", 2);
+                break;
+            case '\n':
+                smart_str_appendl(buf, "\\n", 2);
+                break;
+            case '\r':
+                smart_str_appendl(buf, "\\r", 2);
+                break;
+            case '\t':
+                smart_str_appendl(buf, "\\t", 2);
+                break;
+            default:
+                smart_str_appendc(buf, c);
+                break;
+        }
+    }
+
+    smart_str_appendc(buf, '"');
+}
+
+static void _dd_serialize_json(HashTable *ht, smart_str *buf) {
+    int key_type;
+    zval **val;
+    HashPosition pos;
+    char *key;
+    uint key_len;
+    ulong num_key;
+
+    bool first_elem = true;
+    smart_str_appendc(buf, '{');
+
+    zend_hash_internal_pointer_reset_ex(ht, &pos);
+    while (zend_hash_get_current_data_ex(ht, (void **)&val, &pos) == SUCCESS) {
+        key_type = zend_hash_get_current_key_ex(ht, &key, &key_len, &num_key, 0, &pos);
+        if (key_type == HASH_KEY_IS_STRING) {
+            if (first_elem) {
+                first_elem = false;
+                smart_str_appendc(buf, '"');
+            } else {
+                smart_str_appendl(buf, ",\"", 2);
+            }
+            smart_str_appendl(buf, key, (key_len - 1));
+            smart_str_appendl(buf, "\":", 2);
+            switch (Z_TYPE_PP(val)) {
+                case IS_STRING:
+                    _dd_json_escape_string(buf, Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+                    break;
+                case IS_NULL:
+                    smart_str_appendl(buf, "null", 4);
+                    break;
+                case IS_DOUBLE: {
+                    char *tmp;
+                    int l = spprintf(&tmp, 0, "%f", Z_DVAL_PP(val));
+                    smart_str_appendl(buf, tmp, l);
+                    efree(tmp);
+                } break;
+                case IS_LONG:
+                    smart_str_append_long(buf, Z_LVAL_PP(val));
+                    break;
+                case IS_BOOL:
+                    if (Z_BVAL_PP(val)) {
+                        smart_str_appendl(buf, "true", 4);
+                    } else {
+                        smart_str_appendl(buf, "false", 5);
+                    }
+                    break;
+                default:
+                    smart_str_appendl(buf, "\"{unknown type}\"", 16);
+                    break;
+            }
+        }
+        zend_hash_move_forward_ex(ht, &pos);
+    }
+
+    smart_str_appendc(buf, '}');
+    smart_str_0(buf);
+}
+
+void ddtrace_startup_logging_json(smart_str *buf) {
+    HashTable *ht;
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, DDTRACE_STARTUP_STAT_COUNT, NULL, ZVAL_PTR_DTOR, 0);
+
+    _dd_get_startup_config(ht);
+    ddtrace_startup_diagnostics(ht);
+
+    _dd_serialize_json(ht, buf);
+
+    zend_hash_destroy(ht);
+    FREE_HASHTABLE(ht);
+}
+
+static void _dd_print_values_to_log(HashTable *ht, char *time) {
+    int key_type;
+    zval **val;
+    HashPosition pos;
+    char *key;
+    uint key_len;
+    ulong num_key;
+
+    zend_hash_internal_pointer_reset_ex(ht, &pos);
+    while (zend_hash_get_current_data_ex(ht, (void **)&val, &pos) == SUCCESS) {
+        key_type = zend_hash_get_current_key_ex(ht, &key, &key_len, &num_key, 0, &pos);
+        if (key_type == HASH_KEY_IS_STRING) {
+            switch (Z_TYPE_PP(val)) {
+                case IS_STRING:
+                    ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: %s", time, key, Z_STRVAL_PP(val));
+                    break;
+                case IS_NULL:
+                    ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: NULL", time, key);
+                    break;
+                case IS_BOOL:
+                    if (Z_BVAL_PP(val)) {
+                        ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: true", time, key);
+                    } else {
+                        ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: false", time, key);
+                    }
+                    break;
+                default:
+                    ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: {unknown type}", time, key);
+                    break;
+            }
+        }
+        zend_hash_move_forward_ex(ht, &pos);
+    }
+}
+
+void ddtrace_startup_logging_startup(void) {
+    startup_time = time(NULL);
+    if (!get_dd_trace_startup_logs() || strcmp("cli", sapi_module.name) == 0) {
+        return;
+    }
+
+    char time[ISO_8601_LEN];
+    _dd_get_startup_time(time);
+
+    HashTable *ht;
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, DDTRACE_STARTUP_STAT_COUNT, NULL, ZVAL_PTR_DTOR, 0);
+
+    ddtrace_startup_diagnostics(ht);
+    if (get_dd_trace_debug()) {
+        _dd_print_values_to_log(ht, time);
+    }
+    _dd_get_startup_config(ht);
+
+    smart_str buf = {0};
+    _dd_serialize_json(ht, &buf);
+    ddtrace_log_errf("[%s] DATADOG TRACER CONFIGURATION - %s", time, buf.c);
+    smart_str_free(&buf);
+
+    zend_hash_destroy(ht);
+    FREE_HASHTABLE(ht);
+}

--- a/src/ext/php5/startup_logging.c
+++ b/src/ext/php5/startup_logging.c
@@ -83,7 +83,7 @@ static bool _dd_parse_bool(const char *name, size_t name_len) {
 
 static void _dd_get_agent_url(char *buf) {
     char *host = get_dd_agent_host();
-    sprintf(buf, "https://%s:%d", host, (int)get_dd_trace_agent_port());
+    sprintf(buf, "http://%s:%d", host, (int)get_dd_trace_agent_port());
     free(host);
 }
 

--- a/src/ext/php7/startup_logging.c
+++ b/src/ext/php7/startup_logging.c
@@ -86,7 +86,7 @@ static bool _dd_parse_bool(const char *name, size_t name_len) {
 
 static void _dd_get_agent_url(char *buf) {
     char *host = get_dd_agent_host();
-    sprintf(buf, "https://%s:%d", host, (int)get_dd_trace_agent_port());
+    sprintf(buf, "http://%s:%d", host, (int)get_dd_trace_agent_port());
     free(host);
 }
 

--- a/src/ext/php7/startup_logging.c
+++ b/src/ext/php7/startup_logging.c
@@ -1,0 +1,402 @@
+#include "startup_logging.h"
+
+#include <SAPI.h>
+#include <Zend/zend_API.h>
+#include <Zend/zend_smart_str.h>
+#include <curl/curl.h>
+#include <php.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include <ext/standard/info.h>
+
+#include "coms.h"
+#include "configuration.h"
+#include "logging.h"
+#include "version.h"
+
+#define ISO_8601_LEN (20 + 1)  // +1 for terminating null-character
+
+// True global; only modify on MINIT/STARTUP
+static time_t startup_time = -1;
+
+static void _dd_get_startup_time(char *buf) {
+    time_t now = (startup_time == -1) ? time(NULL) : startup_time;
+    struct tm *tm = gmtime(&now);
+    if (tm) {
+        strftime(buf, ISO_8601_LEN, "%Y-%m-%dT%TZ", tm);
+    } else {
+        ddtrace_log_debug("Error getting startup time");
+    }
+}
+
+static void _dd_add_assoc_string(HashTable *ht, const char *name, size_t name_len, const char *str) {
+    zval value;
+    size_t str_len = str ? strlen(str) : 0;
+    if (str_len > 0) {
+        ZVAL_STRINGL(&value, str, str_len);
+    } else {
+        ZVAL_NULL(&value);
+    }
+    zend_hash_str_update(ht, name, name_len, &value);
+}
+
+static void _dd_add_assoc_string_free(HashTable *ht, const char *name, size_t name_len, char *str) {
+    _dd_add_assoc_string(ht, name, name_len, (const char *)str);
+    free(str);
+}
+
+static void _dd_add_assoc_zstring(HashTable *ht, const char *name, size_t name_len, zend_string *str) {
+    zval value;
+    ZVAL_STR(&value, str);
+    zend_hash_str_update(ht, name, name_len, &value);
+}
+
+static void _dd_add_assoc_bool(HashTable *ht, const char *name, size_t name_len, bool v) {
+    zval value;
+    ZVAL_BOOL(&value, v);
+    zend_hash_str_update(ht, name, name_len, &value);
+}
+
+static void _dd_add_assoc_double(HashTable *ht, const char *name, size_t name_len, double num) {
+    zval value;
+    ZVAL_DOUBLE(&value, num);
+    zend_hash_str_update(ht, name, name_len, &value);
+}
+
+static char *_dd_get_ini(const char *name, size_t name_len) { return zend_ini_string((char *)name, name_len, 0); }
+
+static bool _dd_ini_is_set(const char *name, size_t name_len) {
+    const char *ini = _dd_get_ini(name, name_len);
+    return ini && (strcmp(ini, "") != 0);
+}
+
+// Modified version of zend_ini_parse_bool()
+// @see https://github.com/php/php-src/blob/28b4761/Zend/zend_ini.c#L493-L502
+static bool _dd_parse_bool(const char *name, size_t name_len) {
+    const char *ini = _dd_get_ini(name, name_len);
+    size_t ini_len = strlen(ini);
+    if ((ini_len == 4 && strcasecmp(ini, "true") == 0) || (ini_len == 3 && strcasecmp(ini, "yes") == 0) ||
+        (ini_len == 2 && strcasecmp(ini, "on") == 0)) {
+        return 1;
+    } else {
+        return atoi(ini) != 0;
+    }
+}
+
+static void _dd_get_agent_url(char *buf) {
+    char *host = get_dd_agent_host();
+    sprintf(buf, "https://%s:%d", host, (int)get_dd_trace_agent_port());
+    free(host);
+}
+
+static void _dd_get_startup_config(HashTable *ht) {
+    // Cross-language tracer values
+    char time[ISO_8601_LEN];
+    _dd_get_startup_time(time);
+    _dd_add_assoc_string(ht, ZEND_STRL("date"), time);
+
+    _dd_add_assoc_zstring(ht, ZEND_STRL("os_name"), php_get_uname('a'));
+    _dd_add_assoc_zstring(ht, ZEND_STRL("os_version"), php_get_uname('r'));
+    _dd_add_assoc_string(ht, ZEND_STRL("version"), PHP_DDTRACE_VERSION);
+    _dd_add_assoc_string(ht, ZEND_STRL("lang"), "php");
+    _dd_add_assoc_string(ht, ZEND_STRL("lang_version"), PHP_VERSION);
+    _dd_add_assoc_string_free(ht, ZEND_STRL("env"), get_dd_env());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled"), !_dd_parse_bool(ZEND_STRL("ddtrace.disable")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("service"), get_dd_service());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled_cli"), get_dd_trace_cli_enabled());
+
+    char agent_url[64];
+    _dd_get_agent_url(agent_url);
+    _dd_add_assoc_string(ht, ZEND_STRL("agent_url"), agent_url);
+
+    _dd_add_assoc_bool(ht, ZEND_STRL("debug"), get_dd_trace_debug());
+    _dd_add_assoc_bool(ht, ZEND_STRL("analytics_enabled"), get_dd_trace_analytics_enabled());
+    _dd_add_assoc_double(ht, ZEND_STRL("sample_rate"), get_dd_trace_sample_rate());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("sampling_rules"), get_dd_trace_sampling_rules());
+    // TODO Add integration-specific config: integration_<integration>_analytics_enabled,
+    // integration_<integration>_sample_rate, integrations_loaded
+    _dd_add_assoc_string_free(ht, ZEND_STRL("tags"), get_dd_tags());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("service_mapping"), get_dd_service_mapping());
+    // "log_injection_enabled" N/A for PHP
+    // "runtime_metrics_enabled" N/A for PHP
+    // "configuration_file" N/A for PHP
+    // "vm" N/A for PHP
+    // "partial_flushing_enabled" N/A for PHP
+    _dd_add_assoc_bool(ht, ZEND_STRL("distributed_tracing_enabled"), get_dd_distributed_tracing());
+    _dd_add_assoc_bool(ht, ZEND_STRL("priority_sampling_enabled"), get_dd_priority_sampling());
+    // "logs_correlation_enabled" N/A for PHP
+    // "profiling_enabled" N/A for PHP
+    _dd_add_assoc_string_free(ht, ZEND_STRL("dd_version"), get_dd_version());
+    // "health_metrics_enabled" N/A for PHP
+    _dd_add_assoc_zstring(ht, ZEND_STRL("architecture"), php_get_uname('m'));
+
+    // PHP-specific values
+    _dd_add_assoc_string(ht, ZEND_STRL("sapi"), sapi_module.name);
+    _dd_add_assoc_string(ht, ZEND_STRL("ddtrace.request_init_hook"),
+                         _dd_get_ini(ZEND_STRL("ddtrace.request_init_hook")));
+    _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_configured"), _dd_ini_is_set(ZEND_STRL("open_basedir")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_fragment_regex"), get_dd_trace_resource_uri_fragment_regex());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_mapping_incoming"), get_dd_trace_resource_uri_mapping_incoming());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("uri_mapping_outgoing"), get_dd_trace_resource_uri_mapping_outgoing());
+    _dd_add_assoc_bool(ht, ZEND_STRL("auto_flush_enabled"), get_dd_trace_auto_flush_enabled());
+    _dd_add_assoc_bool(ht, ZEND_STRL("generate_root_span"), get_dd_trace_generate_root_span());
+    _dd_add_assoc_bool(ht, ZEND_STRL("http_client_split_by_domain"), get_dd_trace_http_client_split_by_domain());
+    _dd_add_assoc_bool(ht, ZEND_STRL("measure_compile_time"), get_dd_trace_measure_compile_time());
+    _dd_add_assoc_bool(ht, ZEND_STRL("report_hostname_on_root_span"), get_dd_trace_report_hostname());
+    _dd_add_assoc_string_free(ht, ZEND_STRL("traced_internal_functions"), get_dd_trace_traced_internal_functions());
+    _dd_add_assoc_bool(ht, ZEND_STRL("auto_prepend_file_configured"), _dd_ini_is_set(ZEND_STRL("auto_prepend_file")));
+    _dd_add_assoc_string_free(ht, ZEND_STRL("integrations_disabled"), get_dd_integrations_disabled());
+    _dd_add_assoc_bool(ht, ZEND_STRL("enabled_from_env"), get_dd_trace_enabled());
+    _dd_add_assoc_string(ht, ZEND_STRL("opcache.file_cache"), _dd_get_ini(ZEND_STRL("opcache.file_cache")));
+}
+
+static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    UNUSED(ptr, userdata);
+    return size * nmemb;
+}
+
+static size_t _dd_check_for_agent_error(char *error) {
+    CURL *curl = curl_easy_init();
+    ddtrace_curl_set_hostname(curl);
+    ddtrace_curl_set_timeout(curl);
+    ddtrace_curl_set_connect_timeout(curl);
+
+    const char *body = "[]";
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(body));
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _dd_curl_write_noop);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error);
+    error[0] = 0;
+
+    CURLcode res = curl_easy_perform(curl);
+
+    size_t error_len = strlen(error);
+    if (res != CURLE_OK && !error_len) {
+        strcpy(error, curl_easy_strerror(res));
+        error_len = strlen(error);
+    }
+    curl_easy_cleanup(curl);
+    return error_len;
+}
+
+static bool _dd_file_exists(const char *file) {
+    if (!strlen(file)) {
+        return false;
+    }
+    return (VCWD_ACCESS(file, R_OK) == 0);
+}
+
+static bool _dd_open_basedir_allowed(const char *file) { return (php_check_open_basedir_ex(file, 0) != -1); }
+
+/* Supported zval types for diagnostics: string, bool, null
+ * To support other types, update:
+ *     - ddtrace.c:_dd_info_diagnostics_table(); PHP info output
+ *     - _dd_print_values_to_log(); Debug log output
+ */
+void ddtrace_startup_diagnostics(HashTable *ht) {
+    // Cross-language tracer values
+    char agent_error[CURL_ERROR_SIZE];
+    if (_dd_check_for_agent_error(agent_error)) {
+        _dd_add_assoc_string(ht, ZEND_STRL("agent_error"), agent_error);
+    }
+    //_dd_add_assoc_string(ht, ZEND_STRL("sampling_rules_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("service_mapping_error"), ""); // TODO Parse at C level
+
+    // PHP-specific values
+    const char *rih = _dd_get_ini(ZEND_STRL("ddtrace.request_init_hook"));
+    bool rih_exists = _dd_file_exists(rih);
+    if (!rih_exists) {
+        _dd_add_assoc_bool(ht, ZEND_STRL("ddtrace.request_init_hook_reachable"), rih_exists);
+    } else {
+        bool rih_allowed = _dd_open_basedir_allowed(rih);
+        if (!rih_allowed) {
+            _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_init_hook_allowed"), rih_allowed);
+        }
+    }
+
+    bool container_allowed = _dd_open_basedir_allowed("/proc/self/cgroup");
+    if (!container_allowed) {
+        _dd_add_assoc_bool(ht, ZEND_STRL("open_basedir_container_tagging_allowed"), container_allowed);
+    }
+
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_fragment_regex_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_incoming_error"), ""); // TODO Parse at C level
+    //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_outgoing_error"), ""); // TODO Parse at C level
+
+    char *old_service = get_dd_service_name();
+    if (strcmp(old_service, "") != 0) {
+        _dd_add_assoc_string(ht, ZEND_STRL("service_name"), old_service);
+        _dd_add_assoc_string(ht, ZEND_STRL("service_name_error"),
+                             "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead.");
+    }
+    free(old_service);
+
+    char *old_tags = get_dd_trace_global_tags();
+    if (strcmp(old_tags, "") != 0) {
+        _dd_add_assoc_string(ht, ZEND_STRL("global_tags"), old_tags);
+        _dd_add_assoc_string(ht, ZEND_STRL("global_tags_error"),
+                             "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead.");
+    }
+    free(old_tags);
+}
+
+static void _dd_json_escape_string(smart_str *buf, const char *val, size_t len) {
+    // Empty strings are treated as null
+    if (len == 0) {
+        smart_str_appendl(buf, "null", 4);
+        return;
+    }
+
+    smart_str_alloc(buf, len + 2, 0);  // +2 for quotes
+    smart_str_appendc(buf, '"');
+
+    unsigned long pos = 0;
+    unsigned char c;
+    while (pos < len) {
+        c = val[pos++];
+        // @see http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+        switch (c) {
+            case '"':
+                smart_str_appendl(buf, "\\\"", 2);
+                break;
+            case '\\':
+                smart_str_appendl(buf, "\\\\", 2);
+                break;
+            // Ignoring case '/' as JSON will not be used in scripting contexts
+            case '\b':
+                smart_str_appendl(buf, "\\b", 2);
+                break;
+            case '\f':
+                smart_str_appendl(buf, "\\f", 2);
+                break;
+            case '\n':
+                smart_str_appendl(buf, "\\n", 2);
+                break;
+            case '\r':
+                smart_str_appendl(buf, "\\r", 2);
+                break;
+            case '\t':
+                smart_str_appendl(buf, "\\t", 2);
+                break;
+            default:
+                smart_str_appendc(buf, c);
+                break;
+        }
+    }
+
+    smart_str_appendc(buf, '"');
+}
+
+static void _dd_serialize_json(HashTable *ht, smart_str *buf) {
+    zend_string *key;
+    zval *val;
+    bool first_elem = true;
+    smart_str_appendc(buf, '{');
+    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
+        if (first_elem) {
+            first_elem = false;
+            smart_str_appendc(buf, '"');
+        } else {
+            smart_str_appendl(buf, ",\"", 2);
+        }
+        smart_str_appendl(buf, ZSTR_VAL(key), ZSTR_LEN(key));
+        smart_str_appendl(buf, "\":", 2);
+        switch (Z_TYPE_P(val)) {
+            case IS_STRING:
+                _dd_json_escape_string(buf, Z_STRVAL_P(val), Z_STRLEN_P(val));
+                break;
+            case IS_NULL:
+                smart_str_appendl(buf, "null", 4);
+                break;
+            case IS_DOUBLE: {
+                char *tmp;
+                int l = spprintf(&tmp, 0, "%f", Z_DVAL_P(val));
+                smart_str_appendl(buf, tmp, l);
+                efree(tmp);
+            } break;
+            case IS_LONG:
+                smart_str_append_long(buf, Z_LVAL_P(val));
+                break;
+            case IS_TRUE:
+                smart_str_appendl(buf, "true", 4);
+                break;
+            case IS_FALSE:
+                smart_str_appendl(buf, "false", 5);
+                break;
+            default:
+                smart_str_appendl(buf, "\"{unknown type}\"", 16);
+                break;
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+    smart_str_appendc(buf, '}');
+    smart_str_0(buf);
+}
+
+void ddtrace_startup_logging_json(smart_str *buf) {
+    HashTable *ht;
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, DDTRACE_STARTUP_STAT_COUNT, NULL, ZVAL_PTR_DTOR, 0);
+
+    _dd_get_startup_config(ht);
+    ddtrace_startup_diagnostics(ht);
+
+    _dd_serialize_json(ht, buf);
+
+    zend_hash_destroy(ht);
+    FREE_HASHTABLE(ht);
+}
+
+static void _dd_print_values_to_log(HashTable *ht, char *time) {
+    zend_string *key;
+    zval *val;
+    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
+        switch (Z_TYPE_P(val)) {
+            case IS_STRING:
+                ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: %s", time, ZSTR_VAL(key), Z_STRVAL_P(val));
+                break;
+            case IS_NULL:
+                ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: NULL", time, ZSTR_VAL(key));
+                break;
+            case IS_TRUE:
+                ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: true", time, ZSTR_VAL(key));
+                break;
+            case IS_FALSE:
+                ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: false", time, ZSTR_VAL(key));
+                break;
+            default:
+                ddtrace_log_errf("[%s] DATADOG TRACER DIAGNOSTICS - %s: {unknown type}", time, ZSTR_VAL(key));
+                break;
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+}
+
+void ddtrace_startup_logging_startup(void) {
+    startup_time = time(NULL);
+    if (!get_dd_trace_startup_logs() || strcmp("cli", sapi_module.name) == 0) {
+        return;
+    }
+
+    char time[ISO_8601_LEN];
+    _dd_get_startup_time(time);
+
+    HashTable *ht;
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, DDTRACE_STARTUP_STAT_COUNT, NULL, ZVAL_PTR_DTOR, 0);
+
+    ddtrace_startup_diagnostics(ht);
+    if (get_dd_trace_debug()) {
+        _dd_print_values_to_log(ht, time);
+    }
+    _dd_get_startup_config(ht);
+
+    smart_str buf = {0};
+    _dd_serialize_json(ht, &buf);
+    ddtrace_log_errf("[%s] DATADOG TRACER CONFIGURATION - %s", time, ZSTR_VAL(buf.s));
+    smart_str_free(&buf);
+
+    zend_hash_destroy(ht);
+    FREE_HASHTABLE(ht);
+}

--- a/src/ext/startup_logging.h
+++ b/src/ext/startup_logging.h
@@ -1,0 +1,25 @@
+#ifndef DD_TRACE_STARTUP_LOGGING_H
+#define DD_TRACE_STARTUP_LOGGING_H
+
+#include <php.h>
+
+#if PHP_VERSION_ID >= 70000
+#include <Zend/zend_smart_str.h>
+#else
+#include <ext/standard/php_smart_str.h>
+#endif
+
+#define DDTRACE_STARTUP_STAT_COUNT 43  // Number of config & diagnostic values
+
+void ddtrace_startup_logging_startup(void);
+void ddtrace_startup_diagnostics(HashTable *ht);
+
+/* Returns a json-encoded string of config/diagnostic info; caller must free.
+ *     smart_str buf = {0};
+ *     ddtrace_startup_logging_json(&buf);
+ *     // don't forget!
+ *     smart_str_free(&buf);
+ */
+void ddtrace_startup_logging_json(smart_str *buf);
+
+#endif  // DD_TRACE_STARTUP_LOGGING_H

--- a/tests/ext/startup_logging.inc
+++ b/tests/ext/startup_logging.inc
@@ -1,0 +1,72 @@
+<?php
+
+function dd_get_php_cgi()
+{
+    $executable = dirname(getenv('TEST_PHP_EXECUTABLE')) . '/php-cgi';
+    return file_exists($executable) && is_executable($executable) ? $executable : '';
+}
+
+function dd_get_startup_logs(array $args = [], array $env = [])
+{
+    // If we don't reset these before executing php-cgi, the test will hang
+    // @see https://github.com/php/php-src/blob/16f194c75e/sapi/cgi/tests/include.inc#L53-L63
+    putenv("REDIRECT_STATUS");
+    putenv("QUERY_STRING");
+    putenv("PATH_TRANSLATED");
+    putenv("SCRIPT_FILENAME");
+    putenv("SERVER_SOFTWARE");
+    putenv("SERVER_NAME");
+    putenv("GATEWAY_INTERFACE");
+    putenv("REQUEST_METHOD");
+
+    $argList = implode(' ', $args);
+    $envVars = implode(' ', $env);
+    $cgi = dd_get_php_cgi();
+    $cmd = $envVars . ' ' . $cgi . ' ' . $argList . ' -v 2>&1';
+    exec($cmd, $o);
+
+    $target = 'DATADOG TRACER CONFIGURATION - ';
+    $json = '';
+    foreach ($o as $line) {
+        $pos = strpos($line, $target);
+        if ($pos !== false) {
+            $json = substr($line, $pos + strlen($target));
+            break;
+        }
+    }
+
+    if (!$json) {
+        echo $cmd . PHP_EOL;
+        echo 'No JSON found: (' . implode('; ', $o) . ')' . PHP_EOL;
+        return [];
+    }
+    $logs = json_decode($json, true);
+    if (!$logs) {
+        echo $cmd . PHP_EOL;
+        echo 'Invalid JSON: (' . $json . ')' . PHP_EOL;
+        return [];
+    }
+    return $logs;
+}
+
+function dd_dump_startup_logs($logs, array $only = [])
+{
+    foreach ($logs as $k => $v) {
+        if ($only && !in_array($k, $only, true)) {
+            continue;
+        }
+        echo $k . ': ';
+        if (is_string($v)) {
+            echo '"' . $v . '"';
+        } elseif (is_bool($v)) {
+            echo $v ? 'true' : 'false';
+        } elseif (is_null($v)) {
+            echo 'null';
+        } elseif (is_int($v)) {
+            echo $v;
+        } elseif (is_float($v)) {
+            printf('%.4f', $v);
+        }
+        echo PHP_EOL;
+    }
+}

--- a/tests/ext/startup_logging.phpt
+++ b/tests/ext/startup_logging.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Startup logging is enabled by default
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
+<?php include 'startup_logging_skipif.inc'; ?>
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$logs = dd_get_startup_logs(['-dddtrace.request_init_hook=']);
+
+// Ignore any Agent connection errors for now
+unset($logs['agent_error']);
+
+dd_dump_startup_logs($logs);
+?>
+--EXPECTF--
+ddtrace.request_init_hook_reachable: false
+date: "%s"
+os_name: "%s"
+os_version: "%s"
+version: "%s"
+lang: "php"
+lang_version: "%s"
+env: null
+enabled: true
+service: null
+enabled_cli: %s
+agent_url: "%s"
+debug: false
+analytics_enabled: false
+sample_rate: 1.0000
+sampling_rules: null
+tags: null
+service_mapping: null
+distributed_tracing_enabled: true
+priority_sampling_enabled: true
+dd_version: null
+architecture: "%s"
+sapi: "cgi-fcgi"
+ddtrace.request_init_hook: null
+open_basedir_configured: false
+uri_fragment_regex: null
+uri_mapping_incoming: null
+uri_mapping_outgoing: null
+auto_flush_enabled: false
+generate_root_span: true
+http_client_split_by_domain: false
+measure_compile_time: true
+report_hostname_on_root_span: false
+traced_internal_functions: null
+auto_prepend_file_configured: false
+integrations_disabled: null
+enabled_from_env: true
+opcache.file_cache: null

--- a/tests/ext/startup_logging_config.phpt
+++ b/tests/ext/startup_logging_config.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Startup logging config
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
+<?php include 'startup_logging_skipif.inc'; ?>
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$ini = [
+    '-dauto_prepend_file=/foo/fake.php',
+];
+$env = [
+    'DD_ENV=my-env',
+    'DD_SERVICE=my-service',
+    'DD_TRACE_CLI_ENABLED=1',
+    'DD_TRACE_DEBUG=1',
+    'DD_TRACE_SAMPLE_RATE=0.42',
+    'DD_TRACE_SAMPLING_RULES=\'[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]\'',
+    'DD_TAGS=\'key1:value1,key2:value2\'',
+    'DD_SERVICE_MAPPING=\'pdo:payments-db,mysqli:orders-db\'',
+    'DD_DISTRIBUTED_TRACING=0',
+    'DD_PRIORITY_SAMPLING=0',
+    'DD_VERSION=4.2',
+    'DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX=\'^[a-f0-9]{7}$\'',
+    'DD_TRACE_RESOURCE_URI_MAPPING_INCOMING=\'cities/*,articles/*\'',
+    'DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING=\'foo/*,bar/*\'',
+    'DD_TRACE_AUTO_FLUSH_ENABLED=1',
+    'DD_TRACE_GENERATE_ROOT_SPAN=0',
+    'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=1',
+    'DD_TRACE_MEASURE_COMPILE_TIME=0',
+    'DD_TRACE_REPORT_HOSTNAME=1',
+    'DD_TRACE_TRACED_INTERNAL_FUNCTIONS=\'array_sum,mt_rand,DateTime::add\'',
+    'DD_INTEGRATIONS_DISABLED=\'curl,mysqli\'',
+    'DD_TRACE_ENABLED=0',
+];
+$logs = dd_get_startup_logs($ini, $env);
+
+dd_dump_startup_logs($logs, [
+    'env',
+    'service',
+    'enabled_cli',
+    'debug',
+    'sample_rate',
+    'sampling_rules',
+    // TODO Add integration config
+    'tags',
+    'service_mapping',
+    'distributed_tracing_enabled',
+    'priority_sampling_enabled',
+    'dd_version',
+    'uri_fragment_regex',
+    'uri_mapping_incoming',
+    'uri_mapping_outgoing',
+    'auto_flush_enabled',
+    'generate_root_span',
+    'http_client_split_by_domain',
+    'measure_compile_time',
+    'report_hostname_on_root_span',
+    'traced_internal_functions',
+    'auto_prepend_file_configured',
+    'integrations_disabled',
+    'enabled_from_env',
+]);
+?>
+--EXPECT--
+env: "my-env"
+service: "my-service"
+enabled_cli: true
+debug: true
+sample_rate: 0.4200
+sampling_rules: "[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]"
+tags: "key1:value1,key2:value2"
+service_mapping: "pdo:payments-db,mysqli:orders-db"
+distributed_tracing_enabled: false
+priority_sampling_enabled: false
+dd_version: "4.2"
+uri_fragment_regex: "^[a-f0-9]{7}$"
+uri_mapping_incoming: "cities/*,articles/*"
+uri_mapping_outgoing: "foo/*,bar/*"
+auto_flush_enabled: true
+generate_root_span: false
+http_client_split_by_domain: true
+measure_compile_time: false
+report_hostname_on_root_span: true
+traced_internal_functions: "array_sum,mt_rand,DateTime::add"
+auto_prepend_file_configured: true
+integrations_disabled: "curl,mysqli"
+enabled_from_env: false

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Startup logging diagnostics
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
+<?php include 'startup_logging_skipif.inc'; ?>
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$args = [
+    '-dopen_basedir=' . __DIR__ . '/sandbox',
+    '-dddtrace.request_init_hook=' . __DIR__ . '/includes/request_init_hook.inc',
+];
+$env = [
+    'DD_AGENT_HOST=invalid_host',
+    'DD_SERVICE_NAME=foo_service',
+    'DD_TRACE_GLOBAL_TAGS=foo_tag',
+];
+$logs = dd_get_startup_logs($args, $env);
+
+dd_dump_startup_logs($logs, [
+    'agent_error',
+    'open_basedir_init_hook_allowed',
+    'open_basedir_container_tagging_allowed',
+    'service_name',
+    'service_name_error',
+    'global_tags',
+    'global_tags_error',
+    'agent_url',
+    'ddtrace.request_init_hook',
+    'open_basedir_configured',
+]);
+?>
+--EXPECTF--
+agent_error: "Could not resolve host: invalid_host"
+open_basedir_init_hook_allowed: false
+open_basedir_container_tagging_allowed: false
+service_name: "foo_service"
+service_name_error: "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead."
+global_tags: "foo_tag"
+global_tags_error: "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead."
+agent_url: "https://invalid_host:8126"
+ddtrace.request_init_hook: "%s/includes/request_init_hook.inc"
+open_basedir_configured: true

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -38,6 +38,6 @@ service_name: "foo_service"
 service_name_error: "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead."
 global_tags: "foo_tag"
 global_tags_error: "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead."
-agent_url: "https://invalid_host:8126"
+agent_url: "http://invalid_host:8126"
 ddtrace.request_init_hook: "%s/includes/request_init_hook.inc"
 open_basedir_configured: true

--- a/tests/ext/startup_logging_disabled.phpt
+++ b/tests/ext/startup_logging_disabled.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Startup logging is disabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
+<?php include 'startup_logging_skipif.inc'; ?>
+--ENV--
+DD_TRACE_STARTUP_LOGS=0
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$logs = dd_get_startup_logs();
+
+var_dump($logs);
+?>
+--EXPECTF--
+%s/php-cgi %s
+No JSON found: (%s)
+array(0) {
+}

--- a/tests/ext/startup_logging_json.phpt
+++ b/tests/ext/startup_logging_json.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Startup logging from JSON fetched at runtime
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$logs = json_decode(\DDTrace\startup_logs(), true);
+
+// Ignore any Agent connection errors for now
+unset($logs['agent_error']);
+
+dd_dump_startup_logs($logs);
+?>
+--EXPECTF--
+date: "%s"
+os_name: "%s"
+os_version: "%s"
+version: "%s"
+lang: "php"
+lang_version: "%s"
+env: null
+enabled: true
+service: null
+enabled_cli: %s
+agent_url: "%s"
+debug: false
+analytics_enabled: false
+sample_rate: 1.0000
+sampling_rules: null
+tags: null
+service_mapping: null
+distributed_tracing_enabled: true
+priority_sampling_enabled: true
+dd_version: null
+architecture: "%s"
+sapi: "cli"
+ddtrace.request_init_hook: null
+open_basedir_configured: false
+uri_fragment_regex: null
+uri_mapping_incoming: null
+uri_mapping_outgoing: null
+auto_flush_enabled: false
+generate_root_span: true
+http_client_split_by_domain: false
+measure_compile_time: true
+report_hostname_on_root_span: false
+traced_internal_functions: null
+auto_prepend_file_configured: false
+integrations_disabled: null
+enabled_from_env: true
+opcache.file_cache: null
+ddtrace.request_init_hook_reachable: false

--- a/tests/ext/startup_logging_json_config.phpt
+++ b/tests/ext/startup_logging_json_config.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Startup logging config from JSON fetched at runtime
+--ENV--
+DD_ENV=my-env
+DD_SERVICE=my-service
+DD_TRACE_CLI_ENABLED=1
+DD_TRACE_DEBUG=1
+DD_TRACE_SAMPLE_RATE=0.42
+DD_TRACE_SAMPLING_RULES=[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]
+DD_TAGS=key1:value1,key2:value2
+DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db
+DD_DISTRIBUTED_TRACING=0
+DD_PRIORITY_SAMPLING=0
+DD_VERSION=4.2
+DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX=^[a-f0-9]{7}$
+DD_TRACE_RESOURCE_URI_MAPPING_INCOMING=cities/*,articles/*
+DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING=foo/*,bar/*
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN=1
+DD_TRACE_MEASURE_COMPILE_TIME=0
+DD_TRACE_REPORT_HOSTNAME=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand,DateTime::add
+DD_INTEGRATIONS_DISABLED=curl,mysqli
+DD_TRACE_ENABLED=0
+--INI--
+auto_prepend_file={PWD}/includes/sanity_check.php
+--FILE--
+<?php
+include_once 'startup_logging.inc';
+$logs = json_decode(\DDTrace\startup_logs(), true);
+
+dd_dump_startup_logs($logs, [
+    'env',
+    'service',
+    'enabled_cli',
+    'debug',
+    'sample_rate',
+    'sampling_rules',
+    // TODO Add integration config
+    'tags',
+    'service_mapping',
+    'distributed_tracing_enabled',
+    'priority_sampling_enabled',
+    'dd_version',
+    'uri_fragment_regex',
+    'uri_mapping_incoming',
+    'uri_mapping_outgoing',
+    'auto_flush_enabled',
+    'generate_root_span',
+    'http_client_split_by_domain',
+    'measure_compile_time',
+    'report_hostname_on_root_span',
+    'traced_internal_functions',
+    'auto_prepend_file_configured',
+    'integrations_disabled',
+    'enabled_from_env',
+]);
+?>
+--EXPECT--
+Sanity check
+env: "my-env"
+service: "my-service"
+enabled_cli: true
+debug: true
+sample_rate: 0.4200
+sampling_rules: "[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]"
+tags: "key1:value1,key2:value2"
+service_mapping: "pdo:payments-db,mysqli:orders-db"
+distributed_tracing_enabled: false
+priority_sampling_enabled: false
+dd_version: "4.2"
+uri_fragment_regex: "^[a-f0-9]{7}$"
+uri_mapping_incoming: "cities/*,articles/*"
+uri_mapping_outgoing: "foo/*,bar/*"
+auto_flush_enabled: true
+generate_root_span: false
+http_client_split_by_domain: true
+measure_compile_time: false
+report_hostname_on_root_span: true
+traced_internal_functions: "array_sum,mt_rand,DateTime::add"
+auto_prepend_file_configured: true
+integrations_disabled: "curl,mysqli"
+enabled_from_env: false

--- a/tests/ext/startup_logging_skipif.inc
+++ b/tests/ext/startup_logging_skipif.inc
@@ -1,0 +1,4 @@
+<?php
+
+include_once 'startup_logging.inc';
+if (!dd_get_php_cgi()) die('skip: php-cgi SAPI required');


### PR DESCRIPTION
### Description

This PR adds startup logs that contain a JSON-encoded string of configuration and diagnostic information. The JSON can be provided to the support team to help identify configuration issues. The log message is only generated on process startup and can be disabled by setting `DD_TRACE_STARTUP_LOGS=0`.

#### Example startup message

```
[2020-07-01T17:42:50Z] DATADOG TRACER CONFIGURATION - {"agent_error":"Couldn't connect to server","ddtrace.request_init_hook_reachable":false,"date":"2020-07-01T17:42:50Z","os_name":"Linux 49b1cb4bdd12 4.19.76-linuxkit #1 SMP Tue May 26 11:42:35 UTC 2020 x86_64","os_version":"4.19.76-linuxkit","version":"1.0.0-nightly","lang":"php","lang_version":"7.4.5","env":null,"enabled":true,"service":null,"enabled_cli":false,"agent_url":"https://localhost:8126","debug":false,"analytics_enabled":false,"sample_rate":1.000000,"sampling_rules":null,"tags":null,"service_mapping":null,"distributed_tracing_enabled":true,"priority_sampling_enabled":true,"dd_version":null,"architecture":"x86_64","sapi":"cgi-fcgi","ddtrace.request_init_hook":null,"open_basedir_configured":false,"uri_fragment_regex":null,"uri_mapping_incoming":null,"uri_mapping_outgoing":null,"auto_flush_enabled":false,"generate_root_span":true,"http_client_split_by_domain":false,"measure_compile_time":true,"report_hostname_on_root_span":false,"traced_internal_functions":null,"auto_prepend_file_configured":false,"integrations_disabled":null,"enabled_from_env":true,"opcache.file_cache":null}
```

When debug mode is enabled (`DD_TRACE_DEBUG=1`), failed diagnostic tests will also generate log messages:

```
[2020-07-01T17:35:25Z] DATADOG TRACER DIAGNOSTICS - agent_error: Couldn't connect to server
[2020-07-01T17:35:25Z] DATADOG TRACER DIAGNOSTICS - ddtrace.request_init_hook_reachable: false
```

#### PHP Info

The JSON string can also be obtained from the PHP info page and the diagnostic information will be displayed in a separate table to help diagnose common issues.

<img width="948" alt="ddtrace PHP info page" src="https://user-images.githubusercontent.com/578780/86279758-62c4bf00-bb8f-11ea-9677-fa3c4a1f0692.png">

From the CLI SAPI, the info can be obtained from `php --ri=ddtrace`.

```
ddtrace


Datadog PHP tracer extension
For help, check out the documentation at https://docs.datadoghq.com/tracing/languages/php/
(c) Datadog 2020

Datadog tracing support => enabled
Version => 1.0.0-nightly
DATADOG TRACER CONFIGURATION => {"date":"2020-07-01T17:43:54Z","os_name":"Linux 49b1cb4bdd12 4.19.76-linuxkit #1 SMP Tue May 26 11:42:35 UTC 2020 x86_64","os_version":"4.19.76-linuxkit","version":"1.0.0-nightly","lang":"php","lang_version":"7.4.5","env":null,"enabled":true,"service":null,"enabled_cli":false,"agent_url":"https://localhost:8126","debug":false,"analytics_enabled":false,"sample_rate":1.000000,"sampling_rules":null,"tags":null,"service_mapping":null,"distributed_tracing_enabled":true,"priority_sampling_enabled":true,"dd_version":null,"architecture":"x86_64","sapi":"cli","ddtrace.request_init_hook":null,"open_basedir_configured":false,"uri_fragment_regex":null,"uri_mapping_incoming":null,"uri_mapping_outgoing":null,"auto_flush_enabled":false,"generate_root_span":true,"http_client_split_by_domain":false,"measure_compile_time":true,"report_hostname_on_root_span":false,"traced_internal_functions":null,"auto_prepend_file_configured":false,"integrations_disabled":null,"enabled_from_env":true,"opcache.file_cache":null,"agent_error":"Couldn't connect to server","ddtrace.request_init_hook_reachable":false}

                               Diagnostics
agent_error => Couldn't connect to server
ddtrace.request_init_hook_reachable => false

Directive => Local Value => Master Value
ddtrace.disable => Off => Off
...
```

The JSON string can also be accessed at runtime from `\DDTrace\startup_logs()`.

```php
echo \DDTrace\startup_logs() . PHP_EOL;
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
