### PR TITLE
Add a separate PHP 5 only file

### DIFF
--- a/bridge/dd_init.php
+++ b/bridge/dd_init.php
@@ -3,10 +3,7 @@
 namespace DDTrace\Bridge;
 
 use DDTrace\Bootstrap;
-use DDTrace\Format;
-use DDTrace\GlobalTracer;
 use DDTrace\Integrations\IntegrationsLoader;
-use DDTrace\SpanContext;
 
 if (\PHP_VERSION_ID < 70000) {
     \date_default_timezone_set(@\date_default_timezone_get());
@@ -54,38 +51,6 @@ function dd_env_as_boolean($name, $default)
     }
 }
 
-// This gets called before curl_exec() calls from the C extension on PHP 5
-function curl_inject_distributed_headers($ch, array $headers)
-{
-    if (
-        !\class_exists('DDTrace\\SpanContext', false)
-        || !\class_exists('DDTrace\\GlobalTracer', false)
-        || !\class_exists('DDTrace\\Format', false)
-    ) {
-        return;
-    }
-    $span = GlobalTracer::get()->getActiveSpan();
-    if (null === $span) {
-        return;
-    }
-    $context = $span->getContext();
-    if (!\property_exists($context, 'origin')) {
-        return;
-    }
-
-    /*
-     * We can't use the existing context because only userland spans are represented.
-     * As a result, we create a new context with dd_trace_peek_span_id() to get the
-     * active span ID.
-     */
-    $newContext = new SpanContext($context->getTraceId(), \dd_trace_peek_span_id());
-    $newContext->origin = $context->origin;
-
-    GlobalTracer::get()->inject($newContext, Format::CURL_HTTP_HEADERS, $headers);
-
-    \curl_setopt($ch, \CURLOPT_HTTPHEADER, $headers);
-}
-
 // trigger configuration reload to memoize values of all configuration options as set by environment variables
 function_exists('dd_trace_internal_fn') && \dd_trace_internal_fn('ddtrace_reload_config');
 if (!dd_tracing_enabled()) {
@@ -95,6 +60,10 @@ if (!dd_tracing_enabled()) {
 
 // Required classes and functions
 require __DIR__ . '/autoload.php';
+if (\PHP_MAJOR_VERSION === 5) {
+    require __DIR__ . '/php5.php';
+}
+
 // Optional classes and functions
 require __DIR__ . '/dd_register_optional_deps_autoloader.php';
 

--- a/bridge/php5.php
+++ b/bridge/php5.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DDTrace\Bridge {
+
+    use DDTrace\Format;
+    use DDTrace\GlobalTracer;
+    use DDTrace\SpanContext;
+
+    // This gets called before curl_exec() calls from the C extension on PHP 5
+    function curl_inject_distributed_headers($ch, array $headers)
+    {
+        if (
+            !\class_exists('DDTrace\\SpanContext', false)
+            || !\class_exists('DDTrace\\GlobalTracer', false)
+            || !\class_exists('DDTrace\\Format', false)
+        ) {
+            return;
+        }
+        $span = GlobalTracer::get()->getActiveSpan();
+        if (null === $span) {
+            return;
+        }
+        $context = $span->getContext();
+        if (!\property_exists($context, 'origin')) {
+            return;
+        }
+
+        /* We can't use the existing context because only userland spans are
+         * represented. As a result, we create a new context with
+         * dd_trace_peek_span_id() to get the active span ID.
+         */
+        $activeSpanId = \dd_trace_peek_span_id();
+        $newContext = new SpanContext($context->getTraceId(), $activeSpanId);
+        $newContext->origin = $context->origin;
+
+        $format = Format::CURL_HTTP_HEADERS;
+        GlobalTracer::get()->inject($newContext, $format, $headers);
+
+        \curl_setopt($ch, \CURLOPT_HTTPHEADER, $headers);
+    }
+
+}

--- a/tests/Integration/ResponseStatusCodeTest_files/index.php
+++ b/tests/Integration/ResponseStatusCodeTest_files/index.php
@@ -7,3 +7,5 @@ switch ($_SERVER['REQUEST_URI']) {
     case "/error":
         http_response_code(500);
 }
+
+echo "Done.\n";

--- a/tests/Integration/TracerTest_files/index.php
+++ b/tests/Integration/TracerTest_files/index.php
@@ -23,4 +23,4 @@ if ('/curl-ip' === $uriPath) {
     error_log('/curl-ip completed');
 }
 
-return "OK\n";
+echo "OK\n";

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -321,7 +321,11 @@ class CurlIntegrationTest extends IntegrationTestCase
             $span->finish();
         });
 
-        $this->assertTrue(function_exists('DDTrace\\Bridge\\curl_inject_distributed_headers'));
+        $this->assertEquals(
+            PHP_MAJOR_VERSION === 5,
+            function_exists('DDTrace\\Bridge\\curl_inject_distributed_headers')
+        );
+
         // trace is: custom
         $this->assertSame($traces[0][0]['trace_id'], (int) $found['headers']['X-Datadog-Trace-Id']);
         // parent is: curl_exec


### PR DESCRIPTION
### Description

In Sandbox cURL (PHP 5) #911 we added another function to `dd_init.php` and even though this function is needed only on PHP 5 it still increased memory usage on PHP 7. This PR adds a `php5.php` file that PHP 5 specific functions can go into without affecting PHP 7 much.

This PR also adds output to 2 more of our tests which were segfaulting because there wasn't any output. This is a known issue with the PHP CLI web server that isn't fixable; we have to keep mitigating it until we move off of this SAPI entirely.

### Readiness checklist
- [x] Changelog has been added to the appropriate release draft.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft.