### PR TITLE
Extract ddtrace_sandbox_begin/ddtrace_sandbox_end helpers

### DIFF
--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -66,8 +66,11 @@ int64_t ddtrace_compile_time_get(TSRMLS_D) { return DDTRACE_G(compile_time_micro
 
 extern inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC);
 extern inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC);
+extern inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC);
 #if PHP_VERSION_ID < 70000
+extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC);
 extern inline void ddtrace_maybe_clear_exception(TSRMLS_D);
 #else
+extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void);
 extern inline void ddtrace_maybe_clear_exception(void);
 #endif

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -6,6 +6,7 @@
 #include <php.h>
 #include <stdint.h>
 
+#include "compatibility.h"
 #include "ddtrace.h"
 #include "ddtrace_string.h"
 
@@ -33,6 +34,15 @@ struct ddtrace_error_handling {
     zend_error_handling error_handling;
 };
 typedef struct ddtrace_error_handling ddtrace_error_handling;
+
+struct ddtrace_sandbox_backup {
+    ddtrace_error_handling eh;
+    ddtrace_exception_t *exception, *prev_exception;
+#if PHP_VERSION_ID < 70000
+    zend_op *opline_before_exception;
+#endif
+};
+typedef struct ddtrace_sandbox_backup ddtrace_sandbox_backup;
 
 inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC) {
     eh->type = PG(last_error_type);
@@ -88,6 +98,50 @@ inline void ddtrace_maybe_clear_exception(void) {
     }
 }
 #endif
+
+#if PHP_VERSION_ID < 70000
+inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC) {
+#else
+inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void) {
+#endif
+    ddtrace_sandbox_backup backup = {.exception = NULL, .prev_exception = NULL};
+    if (EG(exception)) {
+        backup.exception = EG(exception);
+        backup.prev_exception = EG(prev_exception);
+        EG(exception) = NULL;
+        EG(prev_exception) = NULL;
+
+#if PHP_VERSION_ID < 70000
+        backup.opline_before_exception = opline_before_exception;
+#endif
+    }
+
+#if PHP_VERSION_ID < 70000
+    zend_error_handling_t mode = EH_SUPPRESS;
+#else
+    zend_error_handling_t mode = EH_THROW;
+#endif
+
+    ddtrace_backup_error_handling(&backup.eh, mode TSRMLS_CC);
+    return backup;
+}
+
+inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC) {
+    ddtrace_restore_error_handling(&backup->eh TSRMLS_CC);
+    ddtrace_maybe_clear_exception(TSRMLS_C);
+
+    if (backup->exception) {
+        EG(exception) = backup->exception;
+        EG(prev_exception) = backup->prev_exception;
+
+#if PHP_VERSION_ID < 70000
+        EG(opline_before_exception) = backup->opline_before_exception;
+        EG(current_execute_data)->opline = EG(exception_op);
+#else
+        zend_throw_exception_internal(NULL);
+#endif
+    }
+}
 
 #if PHP_VERSION_ID >= 70000
 PHP_FUNCTION(ddtrace_internal_function_handler);

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -578,40 +578,30 @@ void _dd_set_default_properties(TSRMLS_D) {
     }
 }
 
-static void _dd_end_span(ddtrace_span_t *span, zval *user_retval, const zend_op *opline_before_exception TSRMLS_DC) {
+static void _dd_end_span(ddtrace_span_t *span, zval *user_retval, zend_op *opline_before_exception TSRMLS_DC) {
     zend_execute_data *call = span->call;
     ddtrace_dispatch_t *dispatch = span->dispatch;
     zval *user_args;
     ALLOC_INIT_ZVAL(user_args);
-    zval *exception = NULL, *prev_exception = NULL;
 
     dd_trace_stop_span_time(span);
 
     ddtrace_copy_function_args(call, user_args);
-    if (EG(exception)) {
-        exception = EG(exception);
-        EG(exception) = NULL;
-        prev_exception = EG(prev_exception);
-        EG(prev_exception) = NULL;
-        ddtrace_span_attach_exception(span, exception);
-        zend_clear_exception(TSRMLS_C);
-    }
+    ddtrace_span_attach_exception(span, EG(exception));
+
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin(opline_before_exception TSRMLS_CC);
 
     BOOL_T keep_span = TRUE;
     if (Z_TYPE(dispatch->callable) == IS_OBJECT) {
-        ddtrace_error_handling eh;
-        ddtrace_backup_error_handling(&eh, EH_SUPPRESS TSRMLS_CC);
-
         keep_span = ddtrace_execute_tracing_closure(dispatch, span->span_data, call, user_args, user_retval,
-                                                    exception TSRMLS_CC);
+                                                    backup.exception TSRMLS_CC);
 
-        if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+        if (get_dd_trace_debug() && PG(last_error_message) && backup.eh.message != PG(last_error_message)) {
             const char *fname = Z_STRVAL(dispatch->function_name);
             ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname,
                              PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
         }
 
-        ddtrace_restore_error_handling(&eh TSRMLS_CC);
         // If the tracing closure threw an exception, ignore it to not impact the original call
         if (get_dd_trace_debug() && EG(exception)) {
             zval *ex = EG(exception), *message = NULL;
@@ -622,7 +612,6 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval, const zend_op 
                                                                         : "(internal error reading exception message)";
             ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
         }
-        ddtrace_maybe_clear_exception(TSRMLS_C);
     }
 
     if (keep_span == TRUE) {
@@ -632,19 +621,14 @@ static void _dd_end_span(ddtrace_span_t *span, zval *user_retval, const zend_op 
         ddtrace_drop_top_open_span(TSRMLS_C);
     }
 
-    if (exception) {
-        EG(exception) = exception;
-        EG(prev_exception) = prev_exception;
-        EG(opline_before_exception) = (zend_op *)opline_before_exception;
-        EG(current_execute_data)->opline = EG(exception_op);
-    }
+    ddtrace_sandbox_end(&backup TSRMLS_CC);
 
     zval_ptr_dtor(&user_args);
 }
 
 static void ddtrace_trace_dispatch(ddtrace_dispatch_t *dispatch, zend_function *fbc,
                                    zend_execute_data *execute_data TSRMLS_DC) {
-    const zend_op *opline = EX(opline);
+    zend_op *opline = EX(opline);
 
     zval *user_retval = NULL;
     ALLOC_INIT_ZVAL(user_retval);
@@ -827,39 +811,29 @@ static bool _dd_should_trace_dispatch(ddtrace_dispatch_t *dispatch TSRMLS_DC) {
 }
 
 static void _dd_execute_end_span(zend_execute_data *call, ddtrace_span_t *span, zval *user_retval,
-                                 const zend_op *opline_before_exception TSRMLS_DC) {
+                                 zend_op *opline_before_exception TSRMLS_DC) {
     ddtrace_dispatch_t *dispatch = span->dispatch;
     zval *user_args;
     ALLOC_INIT_ZVAL(user_args);
-    zval *exception = NULL, *prev_exception = NULL;
 
     dd_trace_stop_span_time(span);
 
     ddtrace_copy_function_args(call, user_args);
-    if (EG(exception)) {
-        exception = EG(exception);
-        EG(exception) = NULL;
-        prev_exception = EG(prev_exception);
-        EG(prev_exception) = NULL;
-        ddtrace_span_attach_exception(span, exception);
-        zend_clear_exception(TSRMLS_C);
-    }
+    ddtrace_span_attach_exception(span, EG(exception));
+
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin(opline_before_exception TSRMLS_CC);
 
     BOOL_T keep_span = TRUE;
     if (Z_TYPE(dispatch->callable) == IS_OBJECT) {
-        ddtrace_error_handling eh;
-        ddtrace_backup_error_handling(&eh, EH_SUPPRESS TSRMLS_CC);
-
         keep_span = ddtrace_execute_tracing_closure(dispatch, span->span_data, call, user_args, user_retval,
-                                                    exception TSRMLS_CC);
+                                                    backup.exception TSRMLS_CC);
 
-        if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+        if (get_dd_trace_debug() && PG(last_error_message) && backup.eh.message != PG(last_error_message)) {
             const char *fname = Z_STRVAL(dispatch->function_name);
             ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname,
                              PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
         }
 
-        ddtrace_restore_error_handling(&eh TSRMLS_CC);
         // If the tracing closure threw an exception, ignore it to not impact the original call
         if (get_dd_trace_debug() && EG(exception)) {
             zval *ex = EG(exception), *message = NULL;
@@ -870,7 +844,6 @@ static void _dd_execute_end_span(zend_execute_data *call, ddtrace_span_t *span, 
                                                                         : "(internal error reading exception message)";
             ddtrace_log_errf("%s thrown in tracing closure for %s: %s", type, name, msg);
         }
-        ddtrace_maybe_clear_exception(TSRMLS_C);
     }
 
     if (keep_span == TRUE) {
@@ -880,12 +853,7 @@ static void _dd_execute_end_span(zend_execute_data *call, ddtrace_span_t *span, 
         ddtrace_drop_top_open_span(TSRMLS_C);
     }
 
-    if (exception) {
-        EG(exception) = exception;
-        EG(prev_exception) = prev_exception;
-        EG(opline_before_exception) = (zend_op *)opline_before_exception;
-        EG(current_execute_data)->opline = EG(exception_op);
-    }
+    ddtrace_sandbox_end(&backup TSRMLS_CC);
 
     zval_ptr_dtor(&user_args);
 }

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -330,7 +330,6 @@ static zend_class_entry *_dd_get_exception_base(zval *object) {
 static bool _dd_call_sandboxed_tracing_closure(ddtrace_span_t *span, zval *callable, zval *user_retval) {
     zend_execute_data *call = span->call;
     ddtrace_dispatch_t *dispatch = span->dispatch;
-    zend_object *exception = NULL, *prev_exception = NULL;
     zval user_args;
 
     if (Z_TYPE_P(callable) != IS_OBJECT) {
@@ -338,27 +337,18 @@ static bool _dd_call_sandboxed_tracing_closure(ddtrace_span_t *span, zval *calla
     }
 
     _dd_copy_function_args(call, &user_args, dispatch->options & DDTRACE_DISPATCH_POSTHOOK);
-    if (EG(exception)) {
-        exception = EG(exception);
-        EG(exception) = NULL;
-        prev_exception = EG(prev_exception);
-        EG(prev_exception) = NULL;
-        zend_clear_exception();
-    }
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
 
     bool keep_span = true;
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
 
-    keep_span = _dd_execute_tracing_closure(callable, span->span_data, call, &user_args, user_retval, exception);
+    keep_span = _dd_execute_tracing_closure(callable, span->span_data, call, &user_args, user_retval, backup.exception);
 
-    if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
+    if (get_dd_trace_debug() && PG(last_error_message) && backup.eh.message != PG(last_error_message)) {
         const char *fname = Z_STRVAL(dispatch->function_name);
         ddtrace_log_errf("Error raised in tracing closure for %s(): %s in %s on line %d", fname, PG(last_error_message),
                          PG(last_error_file), PG(last_error_lineno));
     }
 
-    ddtrace_restore_error_handling(&eh);
     // If the tracing closure threw an exception, ignore it to not impact the original call
     if (get_dd_trace_debug() && EG(exception)) {
         zend_object *ex = EG(exception);
@@ -374,16 +364,10 @@ static bool _dd_call_sandboxed_tracing_closure(ddtrace_span_t *span, zval *calla
             zval_dtor(message);
         }
     }
-    ddtrace_maybe_clear_exception();
+
+    ddtrace_sandbox_end(&backup);
 
     zval_dtor(&user_args);
-
-    if (exception) {
-        EG(exception) = exception;
-        EG(prev_exception) = prev_exception;
-
-        zend_throw_exception_internal(NULL);
-    }
 
     return keep_span;
 }

--- a/src/ext/php7/handlers_curl.c
+++ b/src/ext/php7/handlers_curl.c
@@ -121,16 +121,14 @@ static void _dd_ArrayKVStore_putForResource(zval *ch, zval *format, zval *value)
 ZEND_FUNCTION(ddtrace_curl_close) {
     zval *ch;
 
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
 
     if (_dd_load_curl_integration() &&
         zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "r", &ch) == SUCCESS) {
         _dd_ArrayKVStore_deleteResource(ch);
     }
 
-    ddtrace_restore_error_handling(&eh);
-    ddtrace_maybe_clear_exception();
+    ddtrace_sandbox_end(&backup);
 
     _dd_curl_close_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -146,8 +144,7 @@ ZEND_FUNCTION(ddtrace_curl_copy_handle) {
 
     _dd_curl_copy_handle_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
 
     if (Z_TYPE_P(return_value) == IS_RESOURCE && ddtrace_config_distributed_tracing_enabled()) {
         zval *ch2 = return_value;
@@ -166,8 +163,7 @@ ZEND_FUNCTION(ddtrace_curl_copy_handle) {
         zval_dtor(&default_headers);
     }
 
-    ddtrace_restore_error_handling(&eh);
-    ddtrace_maybe_clear_exception();
+    ddtrace_sandbox_end(&backup);
 }
 
 /* curl_exec {{{ */
@@ -291,8 +287,7 @@ ZEND_FUNCTION(ddtrace_curl_exec) {
 
     if (le_curl && _dd_load_curl_integration() && Z_TYPE(_dd_curl_httpheaders) == IS_LONG &&
         zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "r", &ch) == SUCCESS) {
-        ddtrace_error_handling eh;
-        ddtrace_backup_error_handling(&eh, EH_THROW);
+        ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
         void *resource = zend_fetch_resource(Z_RES_P(ch), NULL, le_curl);
         if (resource && ddtrace_config_distributed_tracing_enabled()) {
             zval default_headers;
@@ -315,8 +310,7 @@ ZEND_FUNCTION(ddtrace_curl_exec) {
             }
             zval_dtor(&default_headers);
         }
-        ddtrace_restore_error_handling(&eh);
-        ddtrace_maybe_clear_exception();
+        ddtrace_sandbox_end(&backup);
     }
 
     _dd_curl_exec_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -348,8 +342,7 @@ ZEND_FUNCTION(ddtrace_curl_setopt) {
 
     _dd_curl_setopt_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
+    ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
 
     bool call_succeeded = Z_TYPE_P(return_value) == IS_TRUE;
     bool option_matches = Z_TYPE(_dd_curl_httpheaders) == IS_LONG && Z_LVAL(_dd_curl_httpheaders) == option;
@@ -357,8 +350,7 @@ ZEND_FUNCTION(ddtrace_curl_setopt) {
         _dd_ArrayKVStore_putForResource(zid, &_dd_format_curl_http_headers, zvalue);
     }
 
-    ddtrace_restore_error_handling(&eh);
-    ddtrace_maybe_clear_exception();
+    ddtrace_sandbox_end(&backup);
 }
 
 ZEND_FUNCTION(ddtrace_curl_setopt_array) {
@@ -366,8 +358,7 @@ ZEND_FUNCTION(ddtrace_curl_setopt_array) {
 
     if (le_curl && _dd_load_curl_integration() &&
         zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "ra", &zid, &arr) == SUCCESS) {
-        ddtrace_error_handling eh;
-        ddtrace_backup_error_handling(&eh, EH_THROW);
+        ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
 
         void *resource = zend_fetch_resource(Z_RES_P(zid), NULL, le_curl);
         if (resource && ddtrace_config_distributed_tracing_enabled()) {
@@ -379,8 +370,7 @@ ZEND_FUNCTION(ddtrace_curl_setopt_array) {
             }
         }
 
-        ddtrace_restore_error_handling(&eh);
-        ddtrace_maybe_clear_exception();
+        ddtrace_sandbox_end(&backup);
     }
 
     _dd_curl_setopt_array_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);


### PR DESCRIPTION
### Description

Most of the time the sandboxing code is the same, so let's de-duplicate it. We're going to start using it more too, for example:

- Non-instrumentation API
- Loading integrations on-demand

Note that the PHP 7 curl handlers were only partly sandboxed as they don't expect exceptions from curl calls; they now backup the exception info anyway.

### Readiness checklist
- [ ] Changelog has been added to the appropriate release draft.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
