### PR TITLE
Make compilation to single file compatible with `include __DIR__ . '...'` in files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,10 @@
     },
     "prefer-stable": true,
     "scripts": {
-        "compile": "classpreloader.php compile --config=./bridge/_files.php --output=./bridge/_generated.php --strip_comments=1",
+        "compile": [
+            "classpreloader.php compile --config=./bridge/_files.php --output=./bridge/_generated.php --strip_comments=1",
+            "sed -i \"s/'[^']\\+bridge\\/\\.\\./__DIR__ . '\\/../g\" ./bridge/_generated.php"
+        ],
         "compile-verify": "php ./bridge/autoload.php",
         "fix-lint": "phpcbf",
         "lint": "phpcs -s --ignore=src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php,dockerfiles/,tests/xdebug/",


### PR DESCRIPTION
### Description

#### Problem

For performance reasons, we compile all our files into a single file that is then served from the `bridge` folder. The problem with this is that in 3 classes of files in our code base relies on `include __DIR__ . '...';`. During compilation `__DIR__` is replaced with the actual absolute path of the machine when compilation happens, e.g. `/home/circleci/datadog/...`. This is clearly not compatible with our deployments that are installed in either `/opt/...` or any custom folder the user likes.

#### Which types of files and who is impacted?

Only users on PHP 5.4, because

1. Legacy integrations because of the include of `try_catch_finally.php` include. Hence only users on PHP 5.4 are impacted as the new sandboxed integrations are not using this mechanism.
2. `Tracer::version()` method: this impact no one in production, it only breaks one line in `dd-doctor.php`.

#### What is the short term proposal?

After we generate the dingle file, we change all absolute import from bridge to the bridge dir itself.

#### What is the long term proposal?

1. Legacy integrations are disappearing as 5.4 will be soon migrated into the sandboxed api.
2. Remove the `Tracer::version()` check which was only used to compare composer vs ext versions. This is now no longer requested after we are providing the noop classes in `src/api`.

#### What other options where tried

`--skip_dir_file`, `--fix_dir` and `--fix_files` from https://github.com/ClassPreloader/ClassPreloader but the problem is that even relative paths from bridge would be different in dev and in production.

#### Why we did not catch in tests and what we will do?

When executing tests locally and in CI, we build in the same machine where we execute tests, so files happen to be there accidentally. We were using those files without even realizing.

- short term: the release will be tested manually on PHP 5.4 and released.
- mid term: we will be testing the installed version in CI.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
