### PR TITLE
Sandbox Lumen on PHP 5

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -104,10 +104,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Guzzle\GuzzleSandboxedIntegration';
             $this->integrations[LaravelSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Laravel\LaravelSandboxedIntegration';
-            if (\PHP_MAJOR_VERSION > 5) {
-                $this->integrations[LumenSandboxedIntegration::NAME] =
-                    '\DDTrace\Integrations\Lumen\LumenSandboxedIntegration';
-            }
+            $this->integrations[LumenSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Lumen\LumenSandboxedIntegration';
             $this->integrations[MemcachedSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Memcached\MemcachedSandboxedIntegration';
             $this->integrations[MongoSandboxedIntegration::NAME] =

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -81,6 +81,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/simple',
                 'http.status_code' => '200',
+            ])->withChildren([
+                SpanAssertion::build(
+                    'Laravel\Lumen\Application.handleFoundRoute',
+                    'lumen_test_app',
+                    'web',
+                    'Laravel\Lumen\Application.handleFoundRoute'
+                )->withExactTags([])
+                ->skipIf(!static::IS_SANDBOX),
             ]),
         ];
     }
@@ -98,7 +106,18 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/error',
                 'http.status_code' => '500',
-            ])->setError(),
+            ])->setError()
+            ->withChildren([
+                SpanAssertion::build(
+                    'Laravel\Lumen\Application.handleFoundRoute',
+                    'lumen_test_app',
+                    '',
+                    'Laravel\Lumen\Application.handleFoundRoute'
+                )->withExistingTagsNames([
+                    'error.stack'
+                ])->setError('Exception', 'Controller error')
+                ->skipIf(!static::IS_SANDBOX),
+            ]),
         ];
     }
 }

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -51,7 +51,15 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
-                    ]),
+                    ])
+                    ->withChildren([
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.handleFoundRoute',
+                            'lumen',
+                            'web',
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )->skipIf(!static::IS_SANDBOX),
+                    ])
             ]
         );
     }

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosSandboxedTest.php
@@ -51,6 +51,13 @@ class CommonScenariosSandboxedTest extends V5_2_CommonScenariosSandboxedTest
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.handleFoundRoute',
+                            'lumen_test_app',
+                            'web',
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -66,17 +73,24 @@ class CommonScenariosSandboxedTest extends V5_2_CommonScenariosSandboxedTest
                         'http.status_code' => '200',
                     ])->withChildren([
                         SpanAssertion::build(
-                            'laravel.view.render',
+                            'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen_test_app',
                             'web',
-                            'simple_view'
-                        )->withExactTags([])->withChildren([
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )->withChildren([
                             SpanAssertion::build(
-                                'lumen.view',
+                                'laravel.view.render',
                                 'lumen_test_app',
                                 'web',
-                                '*/resources/views/simple_view.blade.php'
-                            )->withExactTags([]),
+                                'simple_view'
+                            )->withExactTags([])->withChildren([
+                                SpanAssertion::build(
+                                    'lumen.view',
+                                    'lumen_test_app',
+                                    'web',
+                                    '*/resources/views/simple_view.blade.php'
+                                )->withExactTags([]),
+                            ]),
                         ]),
                     ]),
                 ],
@@ -93,7 +107,23 @@ class CommonScenariosSandboxedTest extends V5_2_CommonScenariosSandboxedTest
                         'http.status_code' => '500',
                     ])->withExistingTagsNames([
                         'error.stack',
-                    ])->setError('Exception', 'Controller error'),
+                    ])->setError('Exception', 'Controller error')
+                    ->withChildren([
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.handleFoundRoute',
+                            'lumen_test_app',
+                            'web',
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )->withExistingTagsNames([
+                            'error.stack',
+                        ])->setError('Exception', 'Controller error'),
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.sendExceptionToHandler',
+                            'lumen_test_app',
+                            'web',
+                            'Laravel\Lumen\Application.sendExceptionToHandler'
+                        ),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -51,6 +51,14 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.handleFoundRoute',
+                            'lumen',
+                            'web',
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )->skipIf(!static::IS_SANDBOX),
                     ]),
             ]
         );

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -51,6 +51,14 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                    ])
+                    ->withChildren([
+                        SpanAssertion::build(
+                            'Laravel\Lumen\Application.handleFoundRoute',
+                            'lumen',
+                            'web',
+                            'Laravel\Lumen\Application.handleFoundRoute'
+                        )->skipIf(!static::IS_SANDBOX),
                     ]),
             ]
         );


### PR DESCRIPTION
### Description

This adds some un-necessary spans that can be removed once the non-tracing API is completed, but it is worth it to get off of `dd_trace`.

### Readiness checklist
- [x] Changelog has been added to the appropriate release draft.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
