### PR TITLE
Enable sandboxed integration for Symfony on PHP 5

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -120,10 +120,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Predis\PredisSandboxedIntegration';
             $this->integrations[SlimSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Slim\SlimSandboxedIntegration';
-            if (\PHP_MAJOR_VERSION > 5) {
-                $this->integrations[SymfonySandboxedIntegration::NAME] =
-                    '\DDTrace\Integrations\Symfony\SymfonySandboxedIntegration';
-            }
+            $this->integrations[SymfonySandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\Symfony\SymfonySandboxedIntegration';
             $this->integrations[WordPressSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\WordPress\WordPressSandboxedIntegration';
             $this->integrations[YiiSandboxedIntegration::NAME] =


### PR DESCRIPTION
### Description

This integration was already written; it just wasn't enabled. Sammy guesses that it's because we didn't support close-on-exit on PHP 5 at the time. We support it on PHP 5.6 now, so this should be good to go as long as the tests pass in CI.

### Readiness checklist
- [ ] Changelog has been added to the appropriate release draft.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
