### PR TITLE
Add a test for non-zero durations

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -266,6 +266,7 @@
                         <file name="keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
                         <file name="memory_limit_graceful_bailout.phpt" role="test" />
                         <file name="new_static.phpt" role="test" />
+                        <file name="non-zero_duration.phpt" role="test" />
                         <file name="return_by_ref.phpt" role="test" />
                         <file name="retval_is_null_with_exception.phpt" role="test" />
                         <file name="safe_to_string_metadata.phpt" role="test" />

--- a/tests/ext/sandbox/non-zero_duration.phpt
+++ b/tests/ext/sandbox/non-zero_duration.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Test that the sandbox API has non-zero durations
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
+--FILE--
+<?php
+
+DDTrace\trace_function(
+    'function1',
+    function (DDTrace\SpanData $span) {
+        echo "function1 traced.\n";
+        $span->service = 'phpt';
+    }
+);
+
+function function1() {
+    echo __FUNCTION__, " called.\n";
+}
+
+function1();
+
+$closedSpans = dd_trace_serialize_closed_spans();
+if (empty($closedSpans)) {
+    die("No spans found; test is not set up as expected.\n");
+}
+if (count($closedSpans) !== 1) {
+    die("More than one span found; test is not set up as expected\n.");
+}
+
+if (!isset($closedSpans[0]['service'])) {
+    die("Service not found!\n");
+}
+if ($closedSpans[0]['service'] !== 'phpt') {
+   die("Unexpected service '{$closedSpans[0]['service']}'; expected 'phpt'.\n");
+}
+
+function duration_missing_or_zero(array $span) {
+    return !isset($span['duration']) || $span['duration'] == 0;
+}
+
+$result = array_filter($closedSpans, 'duration_missing_or_zero');
+
+if (empty($result)) {
+    echo "All spans had durations.\n";
+} else {
+    echo "Spans were missing durations!\n";
+    var_dump($result);
+}
+
+// let's make sure our filter function is working as expected
+$closedSpans[0]['duration'] = 0;
+$result = array_filter($closedSpans, 'duration_missing_or_zero');
+$errors = count($result) == 1 ? 0 : 1;
+
+unset($closedSpans[0]['duration']);
+$result = array_filter($closedSpans, 'duration_missing_or_zero');
+$errors += count($result) == 1 ? 0 : 1;
+
+if ($errors) {
+    die("The test itself seems to have a problem!\n");
+}
+
+?>
+--EXPECT--
+function1 called.
+function1 traced.
+All spans had durations.
+


### PR DESCRIPTION
### Description

A while back we had a clock issue where spans generated by `dd_trace_function`/`dd_trace_method` would have durations of 0. This adds a test so that if a similar issue happens again we might notice it.

### Readiness checklist
- [x] Changelog has been added to the appropriate release draft.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft.
