### PR TITLE
improve CGI usage in test suite

### DIFF
--- a/tests/ext/startup_logging.inc
+++ b/tests/ext/startup_logging.inc
@@ -2,8 +2,12 @@
 
 function dd_get_php_cgi()
 {
-    $executable = dirname(getenv('TEST_PHP_EXECUTABLE')) . '/php-cgi';
-    return file_exists($executable) && is_executable($executable) ? $executable : '';
+    $executable = getenv('TEST_PHP_CGI_EXECUTABLE') ?: getenv('TEST_PHP_EXECUTABLE') . '-cgi';
+    if (file_exists($executable) && is_executable($executable)) {
+		$args = getenv('TEST_PHP_ARGS');
+		return $args ? "$executable $args" : "$executable";
+	}
+	return '';
 }
 
 function dd_get_startup_logs(array $args = [], array $env = [])

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -31,7 +31,7 @@ dd_dump_startup_logs($logs, [
 ]);
 ?>
 --EXPECTF--
-agent_error: "Could not resolve host: invalid_host"
+agent_error: %sinvalid_host%s
 open_basedir_init_hook_allowed: false
 open_basedir_container_tagging_allowed: false
 service_name: "foo_service"


### PR DESCRIPTION
honors standard env. variable.

especially TEST_PHP_ARGS which may provides directive to load needed extension (json)

For ex, for RPM, we use `TEST_PHP_ARGS="-n -d extension=curl.so -d extension=json.so -d extension=posix.so -d extension=$PWD/modules/ddtrace.so"

And TEST_PHP_EXECUTABLE can be /usr/bin/zts-php (if this case, as /usr/bin/zts-php-cgi doesn't exists, tests are skipped).