### PR TITLE
Removed obsolete pre-integrations loading check from dd-doctor.php

### DIFF
--- a/examples/apache-mod_php/docker-compose.yml
+++ b/examples/apache-mod_php/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       DD_AGENT_HOST: agent
     ports:
       - 8889:80
+    depends_on:
+      - agent
 
   agent:
     image: datadog/agent:latest

--- a/examples/apache-mod_php/public/index.php
+++ b/examples/apache-mod_php/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+header('Content-Type: text/plain');
+
 echo 'Agent configured as HOST environment variable: ' . getenv('DD_AGENT_HOST') . "\n";
 echo 'Port configured in Virtual-Host via SetEnv: ' . getenv('DD_TRACE_AGENT_PORT') . "\n";
 

--- a/examples/nginx-php-fpm/docker-compose.yml
+++ b/examples/nginx-php-fpm/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile_php_fpm
       args:
         DD_TRACER_VERSION: ${DD_TRACER_VERSION}
+    depends_on:
+      - agent
 
   nginx:
     image: nginx
@@ -16,6 +18,8 @@ services:
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf
       - ./public:/var/www/public
+    depends_on:
+      - php-fpm
 
   agent:
     image: datadog/agent:latest

--- a/examples/nginx-php-fpm/public/index.php
+++ b/examples/nginx-php-fpm/public/index.php
@@ -1,3 +1,5 @@
 <?php
 
+header('Content-Type: text/plain');
+
 echo "Hi!\n";

--- a/src/dd-doctor.php
+++ b/src/dd-doctor.php
@@ -242,12 +242,6 @@ class AutoloadTest
 $integrationsLoaderExists = class_exists('\\DDTrace\\Integrations\\IntegrationsLoader');
 renderSuccessOrFailure('IntegrationsLoader exists', $integrationsLoaderExists);
 if ($integrationsLoaderExists) {
-    $notLoaded = \DDTrace\Integrations\IntegrationsLoader::get()->getLoadingStatus('web');
-    renderSuccessOrFailure('Integrations not loaded yet', 0 === $notLoaded);
-
-    echo '- Registering an autoloader...' . PHP_EOL;
-    spl_autoload_register('AutoloadTest::load');
-
     $loaded = \DDTrace\Integrations\IntegrationsLoader::get()->getLoadingStatus('web');
     renderSuccessOrFailure('Integrations loaded', 0 !== $loaded);
 }


### PR DESCRIPTION
### Description

Before in `dd-doctor.php` we used to:
- check that initially integration `web` was not loaded
- trigger the `spl_autoload_register` mechanism
- check that integration `web` is now loaded

Because we are not using the `spl_autoload_register` mechanism and we load, instead, a separate noop public api and a separate internal api, this check no longer applies and it would always fail.

This PR remove the pre-check and only verify integrations are actually (always) loaded.

Along the way, I fixed `Content-Type: text/plain` in example applications (used to manually check this change) that weren't properly rendered text messages.

### Readiness checklist
- [*] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
~- [ ] Tests added for this feature/bug.~ Manually tested

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
