### PR TITLE
Fix compilation on older GCC compilers

### DIFF
--- a/src/ext/ddtrace_string.h
+++ b/src/ext/ddtrace_string.h
@@ -19,7 +19,7 @@ struct ddtrace_string {
 typedef struct ddtrace_string ddtrace_string;
 
 #define DDTRACE_STRING_LITERAL(str) \
-    (ddtrace_string) { .ptr = str, .len = sizeof(str) - 1 }
+    { .ptr = str, .len = sizeof(str) - 1 }
 
 #if PHP_VERSION_ID < 70000
 #define DDTRACE_STRING_ZVAL_L(zval_ptr, str) ZVAL_STRINGL(zval_ptr, str.ptr, str.len, 1)

--- a/src/ext/integrations/elasticsearch.h
+++ b/src/ext/integrations/elasticsearch.h
@@ -7,7 +7,8 @@
     DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load")
 
 static inline void _dd_es_initialize_deferred_integration(TSRMLS_D) {
-    if (!ddtrace_config_integration_enabled(DDTRACE_STRING_LITERAL("elasticsearch") TSRMLS_CC)) {
+    ddtrace_string elasticsearch = DDTRACE_STRING_LITERAL("elasticsearch");
+    if (!ddtrace_config_integration_enabled(elasticsearch TSRMLS_CC)) {
         return;
     }
 

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -4,9 +4,13 @@
 #include "test_integration.h"
 
 #if PHP_VERSION_ID >= 70000
-#define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                         \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class_str), DDTRACE_STRING_LITERAL(fname_str), \
-                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK)
+#define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                                    \
+    do {                                                                                                   \
+        ddtrace_string dd_tmp_class_str = DDTRACE_STRING_LITERAL(class_str);                               \
+        ddtrace_string dd_tmp_fname_str = DDTRACE_STRING_LITERAL(fname_str);                               \
+        ddtrace_string dd_tmp_null = DDTRACE_STRING_LITERAL(NULL);                                         \
+        ddtrace_hook_callable(dd_tmp_class_str, dd_tmp_fname_str, dd_tmp_null, DDTRACE_DISPATCH_POSTHOOK); \
+    } while (0)
 
 static void _dd_register_known_calls(void) {
     DDTRACE_KNOWN_INTEGRATION("wpdb", "query");

--- a/src/ext/integrations/integrations.h
+++ b/src/ext/integrations/integrations.h
@@ -23,9 +23,14 @@
  * It will be executed the first time someMethod is called, then an internal lookup will be repeated
  * for the someMethod to get the actual implementation of tracing function
  **/
-#define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function)              \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
-                          DDTRACE_STRING_LITERAL(loader_function), DDTRACE_DISPATCH_DEFERRED_LOADER TSRMLS_CC)
+#define DDTRACE_DEFERRED_INTEGRATION_LOADER(Class, fname, loader_function)               \
+    do {                                                                                 \
+        ddtrace_string dd_tmp_class = DDTRACE_STRING_LITERAL(Class);                     \
+        ddtrace_string dd_tmp_fname = DDTRACE_STRING_LITERAL(fname);                     \
+        ddtrace_string dd_tmp_loader_function = DDTRACE_STRING_LITERAL(loader_function); \
+        ddtrace_hook_callable(dd_tmp_class, dd_tmp_fname, dd_tmp_loader_function,        \
+                              DDTRACE_DISPATCH_DEFERRED_LOADER TSRMLS_CC);               \
+    } while (0)
 
 /**
  * DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)
@@ -39,9 +44,13 @@
  * options need to specify either DDTRACE_DISPATCH_POSTHOOK or DDTRACE_DISPATCH_PREHOOK
  * in order for the callable to be called by the hooks
  **/
-#define DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)                      \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
-                          DDTRACE_STRING_LITERAL(callable), options TSRMLS_CC)
+#define DDTRACE_INTEGRATION_TRACE(Class, fname, callable, options)                             \
+    do {                                                                                       \
+        ddtrace_string dd_tmp_class = DDTRACE_STRING_LITERAL(Class);                           \
+        ddtrace_string dd_tmp_fname = DDTRACE_STRING_LITERAL(fname);                           \
+        ddtrace_string dd_tmp_callable = DDTRACE_STRING_LITERAL(callable);                     \
+        ddtrace_hook_callable(dd_tmp_class, dd_tmp_fname, dd_tmp_callable, options TSRMLS_CC); \
+    } while (0)
 
 void dd_integrations_initialize(TSRMLS_D);
 #endif


### PR DESCRIPTION
### Description

GCC on CentOS 7 thinks (ddtrace_string) { ... } is not constant, so
we work around this by using local variables. We should start using
the newer developer toolset on CentOS so hacks like this are not
necessary.


### Readiness checklist
- [ ] Changelog has been added to the appropriate release draft.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft.
