### PR TITLE
Consistent env vars: DD_TRACE_AGENT_URL

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -43,11 +43,7 @@
             <directory>tests/Integrations/Slim/V3_12</directory>
         </testsuite>
         <testsuite name="custom-framework-autoloaded-test">
-            <file>tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php</file>
-            <file>tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php</file>
-            <file>tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php</file>
-            <file>tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php</file>
-            <file>tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php</file>
+            <directory>tests/Integrations/Custom/Autoloaded</directory>
             <directory>tests/Integrations/CLI/Custom/Autoloaded</directory>
         </testsuite>
         <testsuite name="unit">

--- a/src/ext/coms.h
+++ b/src/ext/coms.h
@@ -58,6 +58,7 @@ uint32_t ddtrace_coms_test_msgpack_consumer(void);
 /* }}} */
 
 /* exposed for diagnostics {{{ */
+char *ddtrace_agent_url(void);
 void ddtrace_curl_set_hostname(CURL *curl);
 void ddtrace_curl_set_timeout(CURL *curl);
 void ddtrace_curl_set_connect_timeout(CURL *curl);

--- a/src/ext/php5/startup_logging.c
+++ b/src/ext/php5/startup_logging.c
@@ -81,12 +81,6 @@ static bool _dd_parse_bool(const char *name, size_t name_len) {
     }
 }
 
-static void _dd_get_agent_url(char *buf) {
-    char *host = get_dd_agent_host();
-    sprintf(buf, "http://%s:%d", host, (int)get_dd_trace_agent_port());
-    free(host);
-}
-
 static void _dd_get_startup_config(HashTable *ht) {
     // Cross-language tracer values
     char time[ISO_8601_LEN];
@@ -109,9 +103,7 @@ static void _dd_get_startup_config(HashTable *ht) {
     _dd_add_assoc_string_free(ht, ZEND_STRL("service"), get_dd_service());
     _dd_add_assoc_bool(ht, ZEND_STRL("enabled_cli"), get_dd_trace_cli_enabled());
 
-    char agent_url[64];
-    _dd_get_agent_url(agent_url);
-    _dd_add_assoc_string(ht, ZEND_STRL("agent_url"), agent_url);
+    _dd_add_assoc_string_free(ht, ZEND_STRL("agent_url"), ddtrace_agent_url());
 
     _dd_add_assoc_bool(ht, ZEND_STRL("debug"), get_dd_trace_debug());
     _dd_add_assoc_bool(ht, ZEND_STRL("analytics_enabled"), get_dd_trace_analytics_enabled());

--- a/src/ext/php7/startup_logging.c
+++ b/src/ext/php7/startup_logging.c
@@ -84,12 +84,6 @@ static bool _dd_parse_bool(const char *name, size_t name_len) {
     }
 }
 
-static void _dd_get_agent_url(char *buf) {
-    char *host = get_dd_agent_host();
-    sprintf(buf, "http://%s:%d", host, (int)get_dd_trace_agent_port());
-    free(host);
-}
-
 static void _dd_get_startup_config(HashTable *ht) {
     // Cross-language tracer values
     char time[ISO_8601_LEN];
@@ -106,9 +100,7 @@ static void _dd_get_startup_config(HashTable *ht) {
     _dd_add_assoc_string_free(ht, ZEND_STRL("service"), get_dd_service());
     _dd_add_assoc_bool(ht, ZEND_STRL("enabled_cli"), get_dd_trace_cli_enabled());
 
-    char agent_url[64];
-    _dd_get_agent_url(agent_url);
-    _dd_add_assoc_string(ht, ZEND_STRL("agent_url"), agent_url);
+    _dd_add_assoc_string_free(ht, ZEND_STRL("agent_url"), ddtrace_agent_url());
 
     _dd_add_assoc_bool(ht, ZEND_STRL("debug"), get_dd_trace_debug());
     _dd_add_assoc_bool(ht, ZEND_STRL("analytics_enabled"), get_dd_trace_analytics_enabled());

--- a/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarInvalidTest.php
+++ b/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarInvalidTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class AgentUrlEnvVarInvalidTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_AGENT_URL' => 'http://invalid_hostname:1337',
+        ]);
+    }
+
+    public function testInvalidAgentUrlEnvVarTakesPrecedence()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('Invalid DD_TRACE_AGENT_URL takes precedence', '/simple');
+            $this->call($spec);
+        });
+
+        self::assertEmpty($traces);
+    }
+}

--- a/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarTest.php
+++ b/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class AgentUrlEnvVarTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_AGENT_URL' => 'http://request-replayer:80',
+            'DD_AGENT_HOST' => 'invalid_hostname',
+            'DD_TRACE_AGENT_PORT' => 1337,
+        ]);
+    }
+
+    public function testAgentUrlEnvVarTakesPrecedence()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create('DD_TRACE_AGENT_URL takes precedence', '/simple');
+            $this->call($spec);
+        });
+
+        self::assertSame('GET /simple', $traces[0][0]['resource']);
+    }
+}


### PR DESCRIPTION
### Description

This is a followup PR to the awesome work @nurcahyo did in #926. This PR adds tests for `DD_TRACE_AGENT_URL` and also consolidates the Agent URL generation logic to be shared with the startup logging diagnostic checks.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
