### PR TITLE
Dispatch pooling initial implementation - and deduplication of loader

### DIFF
--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -7,6 +7,7 @@
 #include "random.h"
 #include "span.h"
 #include "version.h"
+struct ddtrace_dispatch_pool_t;
 
 extern zend_module_entry ddtrace_module_entry;
 extern zend_class_entry *ddtrace_ce_span_data;
@@ -45,7 +46,7 @@ zend_bool request_init_hook_loaded;
 uint32_t traces_group_id;
 HashTable *class_lookup;
 HashTable *function_lookup;
-ddtrace_dispatch_pool_t *dispatch_pools;
+struct ddtrace_dispatch_pool_t *dispatch_pools;
 uint32_t dispatch_pools_size;
 zend_bool log_backtrace;
 zend_bool backtrace_handler_already_run;

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -45,6 +45,8 @@ zend_bool request_init_hook_loaded;
 uint32_t traces_group_id;
 HashTable *class_lookup;
 HashTable *function_lookup;
+ddtrace_dispatch_pool_t *dispatch_pools;
+uint32_t dispatch_pools_size;
 zend_bool log_backtrace;
 zend_bool backtrace_handler_already_run;
 dogstatsd_client dogstatsd_client;

--- a/src/ext/dispatch.c
+++ b/src/ext/dispatch.c
@@ -20,6 +20,61 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 extern inline void ddtrace_dispatch_copy(ddtrace_dispatch_t *dispatch);
 extern inline void ddtrace_dispatch_release(ddtrace_dispatch_t *dispatch);
 
+
+
+static void _ddtrace_dispatch_pools_rinit() {
+    if (DDTRACE_G(dispatch_pools) == NULL) {
+        DDTRACE_G(dispatch_pools_size) = DDTRACE_DISPATCH_POOLS_COUNT;
+        DDTRACE_G(dispatch_pools) = calloc(DDTRACE_G(dispatch_pools_size), sizeof(ddtrace_dispatch_pool_t));
+    }
+}
+
+// TODO: eventually all dispatch objects should be allocated on a pool
+static ddtrace_dispatch_t *_new_non_pool_dispatch() {
+    ddtrace_dispatch_t *dispatch = calloc(1, sizeof(ddtrace_dispatch_t));
+    dispatch->non_pool = true;
+    ZVAL_NULL(&dispatch->callable);
+    ZVAL_NULL(&dispatch->function_name);
+    return dispatch;
+}
+
+static ddtrace_dispatch_pool_t *_ddtrace_dispatch_get_pool(uint32_t pool_id) {
+    if (DDTRACE_G(dispatch_pools) != NULL && pool_id < DDTRACE_G(dispatch_pools_size)){
+        return &DDTRACE_G(dispatch_pools)[pool_id];
+    }
+    return NULL;
+}
+
+// @Levi example of future use for caching in opcache
+// ddtrace_dispatch_t dispatch_from_id(uint64_t id) {
+//     uint32_t pool_id = (u32)(id & 0xFFFFFFFFLL);
+//     uint32_t dispatch_id = (u32)((id & 0xFFFFFFFF00000000LL) >> 32);
+
+//     _dispatch_from_pool(pool_id, dispatch_id);
+// }
+
+static ddtrace_dispatch_t *_dispatch_from_pool(uint32_t pool_id, uint32_t dispatch_id) {
+    ddtrace_dispatch_pool_t *pool = _ddtrace_dispatch_get_pool(pool_id);
+    return ddtrace_get_from_dispatch_pool(pool, dispatch_id);
+}
+
+ddtrace_dispatch_pool_t *ddtrace_initialize_new_dispatch_pool(uint32_t pool_id, uint32_t number_of_dispatches) {
+    ddtrace_dispatch_pool_t *pool = _ddtrace_dispatch_get_pool(pool_id);
+    if (pool == NULL || pool->dispatches != NULL){ // if pool->dispatches was already allocated - then this pool was used previously
+        return NULL;
+    }
+
+    pool->dispatches = calloc(number_of_dispatches, sizeof(ddtrace_dispatch_t));
+    return pool;
+}
+
+ddtrace_dispatch_t *ddtrace_get_from_dispatch_pool(ddtrace_dispatch_pool_t *pool, uint32_t dispatch_id) {
+    if (pool->dispatches != NULL && dispatch_id < pool->size) {
+        return &pool->dispatches[dispatch_id];
+    }
+    return NULL;
+}
+
 static ddtrace_dispatch_t *_dd_find_function_dispatch(HashTable *ht, zval *fname) {
     return ddtrace_hash_find_ptr_lc(ht, Z_STRVAL_P(fname), Z_STRLEN_P(fname));
 }
@@ -77,6 +132,8 @@ void ddtrace_dispatch_init(TSRMLS_D) {
         ALLOC_HASHTABLE(DDTRACE_G(function_lookup));
         zend_hash_init(DDTRACE_G(function_lookup), 8, NULL, (dtor_func_t)ddtrace_class_lookup_release_compat, 0);
     }
+
+    _ddtrace_dispatch_pools_rinit();
 }
 
 void ddtrace_dispatch_destroy(TSRMLS_D) {
@@ -138,43 +195,53 @@ zend_bool ddtrace_trace(zval *class_name, zval *function_name, zval *callable, u
         return FALSE;
     }
 
-    ddtrace_dispatch_t dispatch;
-    memset(&dispatch, 0, sizeof(ddtrace_dispatch_t));
-    if (callable != NULL) {
-        dispatch.callable = *callable;
-        zval_copy_ctor(&dispatch.callable);
-    } else {
-        ZVAL_NULL(&dispatch.callable);
+    ddtrace_dispatch_t *dispatch = NULL;
+    if (overridable_lookup) {
+        dispatch = _dd_find_function_dispatch(overridable_lookup, function_name);
+    }
+    zend_bool needs_storing = false;
+    if (dispatch == NULL) {
+        dispatch = _new_non_pool_dispatch();
+        needs_storing = true;
     }
 
+    if (Z_TYPE(dispatch->function_name) == IS_NULL || Z_TYPE(dispatch->callable) == IS_UNDEF) {
 #if PHP_VERSION_ID < 70000
-    ZVAL_STRINGL(&dispatch.function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name), 1);
+        ZVAL_STRINGL(&dispatch->function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name), 1);
 #else
-    ZVAL_STRINGL(&dispatch.function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name));
+        ZVAL_STRINGL(&dispatch->function_name, Z_STRVAL_P(function_name), Z_STRLEN_P(function_name));
 #endif
-    ddtrace_downcase_zval(&dispatch.function_name);  // method/function names are case insensitive in PHP
-    dispatch.options = options;
+        ddtrace_downcase_zval(&dispatch->function_name);  // method/function names are case insensitive in PHP
+    }
 
-    if (ddtrace_dispatch_store(overridable_lookup, &dispatch)) {
-        return TRUE;
+    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->callable) != IS_UNDEF) {
+        zval_dtor(&dispatch->callable);
+        ZVAL_NULL(&dispatch->callable);
+    }
+
+    if (callable != NULL) {
+        dispatch->callable = *callable;
+        zval_copy_ctor(&dispatch->callable);
     } else {
-        ddtrace_dispatch_dtor(&dispatch);
-        return FALSE;
+        ZVAL_NULL(&dispatch->callable);
+    }
+
+    dispatch->options = options;
+    if (!needs_storing) {
+        return true;
+    }
+
+    if (ddtrace_dispatch_store(overridable_lookup, dispatch)) {
+        return true;
+    } else {
+        ddtrace_dispatch_dtor(dispatch);
+        return false;
     }
 }
 
 zend_bool ddtrace_hook_callable(ddtrace_string class_name, ddtrace_string function_name, ddtrace_string callable,
-                                uint32_t options TSRMLS_DC) {
+                                uint32_t options, uint32_t pool_id, uint32_t dispatch_id TSRMLS_DC) {
     HashTable *overridable_lookup;
-    ddtrace_dispatch_t dispatch;
-    memset(&dispatch, 0, sizeof(ddtrace_dispatch_t));
-    dispatch.options = options;
-    DDTRACE_STRING_ZVAL_L(&dispatch.function_name, function_name);
-    if (callable.ptr) {
-        DDTRACE_STRING_ZVAL_L(&dispatch.callable, callable);
-    } else {
-        ZVAL_NULL(&dispatch.callable);
-    }
 
     if (class_name.ptr) {
         zval z_class_name;
@@ -186,13 +253,48 @@ zend_bool ddtrace_hook_callable(ddtrace_string class_name, ddtrace_string functi
     } else {
         overridable_lookup = _get_lookup_for_target(NULL TSRMLS_CC);
     }
-    zend_bool dispatch_stored = FALSE;
+
+
+    ddtrace_dispatch_t *dispatch = NULL;
     if (overridable_lookup) {
-        dispatch_stored = ddtrace_dispatch_store(overridable_lookup, &dispatch);
+        zval z_function_name;
+        DDTRACE_STRING_ZVAL_L(&z_function_name, function_name);
+
+        dispatch = _dd_find_function_dispatch(overridable_lookup, &z_function_name);
+        zval_dtor(&z_function_name);
+    }
+
+    zend_bool needs_storing = false;
+    if (dispatch != NULL) {
+        ddtrace_dispatch_dtor(dispatch);
+    } else {
+        dispatch = _dispatch_from_pool(pool_id, dispatch_id);
+        needs_storing = true;
+    }
+
+    if (dispatch == NULL) {
+        return FALSE;
+    }
+
+    dispatch->options = options;
+    DDTRACE_STRING_ZVAL_L(&dispatch->function_name, function_name);
+    if (callable.ptr) {
+        DDTRACE_STRING_ZVAL_L(&dispatch->callable, callable);
+    } else {
+        ZVAL_NULL(&dispatch->callable);
+    }
+
+    if (!needs_storing) {
+        return true;
+    }
+
+    zend_bool dispatch_stored = false;
+    if (overridable_lookup) {
+        dispatch_stored = ddtrace_dispatch_store(overridable_lookup, dispatch);
     }
 
     if (!dispatch_stored) {
-        ddtrace_dispatch_dtor(&dispatch);
+        ddtrace_dispatch_dtor(dispatch);
     }
     return dispatch_stored;
 }

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -36,7 +36,7 @@ typedef struct ddtrace_dispatch_t {
 } ddtrace_dispatch_t;
 
 #define DDTRACE_DISPATCH_POOLS_COUNT 100
-#define DDTRACE_NON_POOLED_DISPATCH 0xFFFFFFFF
+#define DDTRACE_NON_POOLED_DISPATCH 0xFFFFFFFFU
 
 typedef struct ddtrace_dispatch_pool_t {
     ddtrace_dispatch_t *dispatches;
@@ -51,6 +51,7 @@ zend_bool ddtrace_hook_callable(ddtrace_string class_name, ddtrace_string functi
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch);
 
+ddtrace_dispatch_pool_t *ddtrace_dispatch_get_pool(uint32_t pool_id);
 ddtrace_dispatch_pool_t *ddtrace_initialize_new_dispatch_pool(uint32_t pool_id, uint32_t number_of_dispatches);
 ddtrace_dispatch_t *ddtrace_get_from_dispatch_pool(ddtrace_dispatch_pool_t *pool, uint32_t dispatch_id);
 
@@ -59,6 +60,9 @@ inline void ddtrace_dispatch_copy(ddtrace_dispatch_t *dispatch) { dispatch->acqu
 inline void ddtrace_dispatch_release(ddtrace_dispatch_t *dispatch) {
     if (--dispatch->acquired == 0) {
         ddtrace_dispatch_dtor(dispatch);
+        if (dispatch->id == DDTRACE_NON_POOLED_DISPATCH) {
+            free(dispatch);
+        }
     }
 }
 

--- a/src/ext/dispatch.h
+++ b/src/ext/dispatch.h
@@ -15,7 +15,7 @@
 #define DDTRACE_DISPATCH_PREHOOK (1u << 3u)
 #define DDTRACE_DISPATCH_DEFERRED_LOADER (1u << 4u)
 
-typedef struct _ddtrace_dispatch_t {
+typedef struct ddtrace_dispatch_t {
     uint16_t options;
     bool busy;
     uint32_t acquired;
@@ -25,13 +25,20 @@ typedef struct _ddtrace_dispatch_t {
         zval prehook;
         zval posthook;
     };
-    bool non_pool;
+    union {
+        uint32_t id;
+        struct {
+            uint16_t dispatch_id;
+            uint16_t pool_id;
+        };
+    };
     zval function_name;
 } ddtrace_dispatch_t;
 
 #define DDTRACE_DISPATCH_POOLS_COUNT 100
+#define DDTRACE_NON_POOLED_DISPATCH 0xFFFFFFFF
 
-typedef struct _ddtrace_dispatch_pool_t {
+typedef struct ddtrace_dispatch_pool_t {
     ddtrace_dispatch_t *dispatches;
     uint32_t allocated;
     uint32_t size;

--- a/src/ext/integrations/elasticsearch.h
+++ b/src/ext/integrations/elasticsearch.h
@@ -5,103 +5,103 @@
 
 #define ES_INTEGRATION_POOL_ID 2
 
-#define _DD_AL_ES(class, method) \
-    DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load", 2, 0)
+#define _DD_AL_ES(class, method, id)                                                                     \
+    DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load", \
+                                        ES_INTEGRATION_POOL_ID, id)
 
 static inline void _dd_es_initialize_deferred_integration(TSRMLS_D) {
     ddtrace_string elasticsearch = DDTRACE_STRING_LITERAL("elasticsearch");
     if (!ddtrace_config_integration_enabled(elasticsearch TSRMLS_CC)) {
         return;
     }
-    if (!ddtrace_initialize_new_dispatch_pool(ES_INTEGRATION_POOL_ID, 84)) {
+    if (!ddtrace_initialize_new_dispatch_pool(ES_INTEGRATION_POOL_ID, 85)) {
         return;
     }
-
-    _DD_AL_ES("elasticsearch\\client", "__construct");
-    _DD_AL_ES("elasticsearch\\client", "count");
-    _DD_AL_ES("elasticsearch\\client", "delete");
-    _DD_AL_ES("elasticsearch\\client", "exists");
-    _DD_AL_ES("elasticsearch\\client", "explain");
-    _DD_AL_ES("elasticsearch\\client", "get");
-    _DD_AL_ES("elasticsearch\\client", "index");
-    _DD_AL_ES("elasticsearch\\client", "scroll");
-    _DD_AL_ES("elasticsearch\\client", "search");
-    _DD_AL_ES("elasticsearch\\client", "update");
-    _DD_AL_ES("elasticsearch\\serializers\\arraytojsonserializer", "serialize");
-    _DD_AL_ES("elasticsearch\\serializers\\arraytojsonserializer", "deserialize");
-    _DD_AL_ES("elasticsearch\\serializers\\everythingtojsonserializer", "serialize");
-    _DD_AL_ES("elasticsearch\\serializers\\everythingtojsonserializer", "deserialize");
-    _DD_AL_ES("elasticsearch\\serializers\\smartserializer", "serialize");
-    _DD_AL_ES("elasticsearch\\serializers\\smartserializer", "deserialize");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "analyze");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "clearcache");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "close");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "create");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "delete");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletealias");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletemapping");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletetemplate");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletewarmer");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "exists");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existsalias");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existstemplate");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existstype");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "flush");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getalias");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getaliases");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getfieldmapping");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getmapping");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getsettings");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "gettemplate");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getwarmer");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "open");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "optimize");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putalias");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putmapping");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putsettings");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "puttemplate");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putwarmer");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "recovery");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "refresh");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "segments");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "snapshotindex");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "stats");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "status");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "updatealiases");
-    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "validatequery");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "aliases");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "allocation");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "count");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "fielddata");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "health");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "help");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "indices");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "master");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "nodes");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "pendingtasks");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "recovery");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "shards");
-    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "threadpool");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "create");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "createrepository");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "delete");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "deleterepository");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "get");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "getrepository");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "restore");
-    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "status");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "getsettings");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "health");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "pendingtasks");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "putsettings");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "reroute");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "state");
-    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "stats");
-    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "hotthreads");
-    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "info");
-    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "shutdown");
-    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "stats");
-    _DD_AL_ES("elasticsearch\\endpoints\\abstractendpoint", "performrequest");
+    _DD_AL_ES("elasticsearch\\client", "__construct", 0);
+    _DD_AL_ES("elasticsearch\\client", "count", 1);
+    _DD_AL_ES("elasticsearch\\client", "delete", 2);
+    _DD_AL_ES("elasticsearch\\client", "exists", 3);
+    _DD_AL_ES("elasticsearch\\client", "explain", 4);
+    _DD_AL_ES("elasticsearch\\client", "get", 5);
+    _DD_AL_ES("elasticsearch\\client", "index", 6);
+    _DD_AL_ES("elasticsearch\\client", "scroll", 7);
+    _DD_AL_ES("elasticsearch\\client", "search", 8);
+    _DD_AL_ES("elasticsearch\\client", "update", 9);
+    _DD_AL_ES("elasticsearch\\serializers\\arraytojsonserializer", "serialize", 10);
+    _DD_AL_ES("elasticsearch\\serializers\\arraytojsonserializer", "deserialize", 11);
+    _DD_AL_ES("elasticsearch\\serializers\\everythingtojsonserializer", "serialize", 12);
+    _DD_AL_ES("elasticsearch\\serializers\\everythingtojsonserializer", "deserialize", 13);
+    _DD_AL_ES("elasticsearch\\serializers\\smartserializer", "serialize", 14);
+    _DD_AL_ES("elasticsearch\\serializers\\smartserializer", "deserialize", 15);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "analyze", 16);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "clearcache", 17);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "close", 18);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "create", 19);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "delete", 20);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletealias", 21);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletemapping", 22);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletetemplate", 23);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "deletewarmer", 24);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "exists", 25);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existsalias", 26);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existstemplate", 27);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "existstype", 28);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "flush", 29);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getalias", 30);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getaliases", 31);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getfieldmapping", 32);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getmapping", 33);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getsettings", 34);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "gettemplate", 35);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "getwarmer", 36);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "open", 37);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "optimize", 38);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putalias", 39);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putmapping", 40);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putsettings", 41);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "puttemplate", 42);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "putwarmer", 43);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "recovery", 44);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "refresh", 45);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "segments", 46);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "snapshotindex", 47);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "stats", 48);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "status", 49);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "updatealiases", 50);
+    _DD_AL_ES("elasticsearch\\namespaces\\indicesnamespace", "validatequery", 51);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "aliases", 52);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "allocation", 53);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "count", 54);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "fielddata", 55);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "health", 56);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "help", 57);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "indices", 58);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "master", 59);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "nodes", 60);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "pendingtasks", 61);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "recovery", 62);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "shards", 63);
+    _DD_AL_ES("elasticsearch\\namespaces\\catnamespace", "threadpool", 64);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "create", 65);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "createrepository", 66);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "delete", 67);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "deleterepository", 68);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "get", 69);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "getrepository", 70);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "restore", 71);
+    _DD_AL_ES("elasticsearch\\namespaces\\snapshotnamespace", "status", 72);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "getsettings", 73);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "health", 74);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "pendingtasks", 75);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "putsettings", 76);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "reroute", 77);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "state", 78);
+    _DD_AL_ES("elasticsearch\\namespaces\\clusternamespace", "stats", 79);
+    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "hotthreads", 80);
+    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "info", 81);
+    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "shutdown", 82);
+    _DD_AL_ES("elasticsearch\\namespaces\\nodesnamespace", "stats", 83);
+    _DD_AL_ES("elasticsearch\\endpoints\\abstractendpoint", "performrequest", 84);
 }
 
 #endif

--- a/src/ext/integrations/elasticsearch.h
+++ b/src/ext/integrations/elasticsearch.h
@@ -3,14 +3,17 @@
 #include "configuration.h"
 #include "integrations.h"
 
+#define ELASTIC_POOL_ID 2
+
 #define _DD_AL_ES(class, method) \
-    DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load")
+    DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load", 2, 0)
 
 static inline void _dd_es_initialize_deferred_integration(TSRMLS_D) {
     ddtrace_string elasticsearch = DDTRACE_STRING_LITERAL("elasticsearch");
     if (!ddtrace_config_integration_enabled(elasticsearch TSRMLS_CC)) {
         return;
     }
+    ddtrace_initialize_new_dispatch_pool(2, 84);
 
     _DD_AL_ES("elasticsearch\\client", "__construct");
     _DD_AL_ES("elasticsearch\\client", "count");

--- a/src/ext/integrations/elasticsearch.h
+++ b/src/ext/integrations/elasticsearch.h
@@ -3,7 +3,7 @@
 #include "configuration.h"
 #include "integrations.h"
 
-#define ELASTIC_POOL_ID 2
+#define ES_INTEGRATION_POOL_ID 2
 
 #define _DD_AL_ES(class, method) \
     DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load", 2, 0)
@@ -13,7 +13,9 @@ static inline void _dd_es_initialize_deferred_integration(TSRMLS_D) {
     if (!ddtrace_config_integration_enabled(elasticsearch TSRMLS_CC)) {
         return;
     }
-    ddtrace_initialize_new_dispatch_pool(2, 84);
+    if (!ddtrace_initialize_new_dispatch_pool(ES_INTEGRATION_POOL_ID, 84)) {
+        return;
+    }
 
     _DD_AL_ES("elasticsearch\\client", "__construct");
     _DD_AL_ES("elasticsearch\\client", "count");

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -6,7 +6,7 @@
 #if PHP_VERSION_ID >= 70000
 #define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                         \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class_str), DDTRACE_STRING_LITERAL(fname_str), \
-                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK)
+                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK, 0, 0)
 
 static void _dd_register_known_calls(void) {
     DDTRACE_KNOWN_INTEGRATION("wpdb", "query");

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -6,13 +6,14 @@
 #define KNOWN_INTEGRATIONS_POOL 4
 
 #if PHP_VERSION_ID >= 70000
-#define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                         \
+#define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str, id)                                     \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class_str), DDTRACE_STRING_LITERAL(fname_str), \
-                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK, KNOWN_INTEGRATIONS_POOL, 0)
+                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK, KNOWN_INTEGRATIONS_POOL, id)
 
 static void _dd_register_known_calls(void) {
-    DDTRACE_KNOWN_INTEGRATION("wpdb", "query");
-    DDTRACE_KNOWN_INTEGRATION("illuminate\\events\\dispatcher", "fire");
+    ddtrace_initialize_new_dispatch_pool(KNOWN_INTEGRATIONS_POOL, 3);
+    DDTRACE_KNOWN_INTEGRATION("wpdb", "query", 0);
+    DDTRACE_KNOWN_INTEGRATION("illuminate\\events\\dispatcher", "fire", 1);
 }
 #endif
 

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -3,10 +3,12 @@
 #include "elasticsearch.h"
 #include "test_integration.h"
 
+#define KNOWN_INTEGRATIONS_POOL 4
+
 #if PHP_VERSION_ID >= 70000
 #define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                         \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class_str), DDTRACE_STRING_LITERAL(fname_str), \
-                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK, 0, 0)
+                          DDTRACE_STRING_LITERAL(NULL), DDTRACE_DISPATCH_POSTHOOK, KNOWN_INTEGRATIONS_POOL, 0)
 
 static void _dd_register_known_calls(void) {
     DDTRACE_KNOWN_INTEGRATION("wpdb", "query");

--- a/src/ext/integrations/integrations.h
+++ b/src/ext/integrations/integrations.h
@@ -23,9 +23,9 @@
  * It will be executed the first time someMethod is called, then an internal lookup will be repeated
  * for the someMethod to get the actual implementation of tracing function
  **/
-#define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function)              \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
-                          DDTRACE_STRING_LITERAL(loader_function), DDTRACE_DISPATCH_DEFERRED_LOADER TSRMLS_CC)
+#define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function, pool_id, dispatch_id) \
+    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname),       \
+                          DDTRACE_STRING_LITERAL(loader_function), DDTRACE_DISPATCH_DEFERRED_LOADER, pool_id, dispatch_id TSRMLS_CC)
 
 /**
  * DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)
@@ -41,7 +41,8 @@
  **/
 #define DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)                      \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
-                          DDTRACE_STRING_LITERAL(callable), options TSRMLS_CC)
+                          DDTRACE_STRING_LITERAL(callable), options, 0, 0 TSRMLS_CC)
 
 void dd_integrations_initialize(TSRMLS_D);
+
 #endif

--- a/src/ext/integrations/integrations.h
+++ b/src/ext/integrations/integrations.h
@@ -23,9 +23,10 @@
  * It will be executed the first time someMethod is called, then an internal lookup will be repeated
  * for the someMethod to get the actual implementation of tracing function
  **/
-#define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function, pool_id, dispatch_id) \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname),       \
-                          DDTRACE_STRING_LITERAL(loader_function), DDTRACE_DISPATCH_DEFERRED_LOADER, pool_id, dispatch_id TSRMLS_CC)
+#define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function, pool_id, dispatch_id)              \
+    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname),                       \
+                          DDTRACE_STRING_LITERAL(loader_function), DDTRACE_DISPATCH_DEFERRED_LOADER, pool_id, \
+                          dispatch_id TSRMLS_CC)
 
 /**
  * DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)
@@ -39,9 +40,9 @@
  * options need to specify either DDTRACE_DISPATCH_POSTHOOK or DDTRACE_DISPATCH_PREHOOK
  * in order for the callable to be called by the hooks
  **/
-#define DDTRACE_INTEGRATION_TRACE(class, fname, callable, options)                      \
-    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
-                          DDTRACE_STRING_LITERAL(callable), options, 0, 0 TSRMLS_CC)
+#define DDTRACE_INTEGRATION_TRACE(class, fname, callable, options, pool_id, dispatch_id) \
+    ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname),  \
+                          DDTRACE_STRING_LITERAL(callable), options, pool_id, dispatch_id TSRMLS_CC)
 
 void dd_integrations_initialize(TSRMLS_D);
 

--- a/src/ext/integrations/test_integration.h
+++ b/src/ext/integrations/test_integration.h
@@ -10,12 +10,17 @@ static inline void _dd_load_test_integrations(TSRMLS_D) {
     if (!test_deferred) {
         return;
     }
-    if (!ddtrace_initialize_new_dispatch_pool(TEST_INTEGRATION_POOL_ID, 2)) {
+    if (!ddtrace_initialize_new_dispatch_pool(TEST_INTEGRATION_POOL_ID, 3)) {
         return;
     }
 
-    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration", TEST_INTEGRATION_POOL_ID, 0);
-    DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK, TEST_INTEGRATION_POOL_ID, 1);
+    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration",
+                                        TEST_INTEGRATION_POOL_ID, 0);
+    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "second_public_static_method", "load_test_integration",
+                                        TEST_INTEGRATION_POOL_ID, 2);
+
+    DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK,
+                              TEST_INTEGRATION_POOL_ID, 1);
 }
 
 #endif

--- a/src/ext/integrations/test_integration.h
+++ b/src/ext/integrations/test_integration.h
@@ -10,7 +10,7 @@ static inline void _dd_load_test_integrations(TSRMLS_D) {
         return;
     }
 
-    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration");
+    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration", 1, 0);
     DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK);
 }
 

--- a/src/ext/integrations/test_integration.h
+++ b/src/ext/integrations/test_integration.h
@@ -3,15 +3,19 @@
 #include <stdlib.h>
 
 #include "integrations.h"
+#define TEST_INTEGRATION_POOL_ID 3
 
 static inline void _dd_load_test_integrations(TSRMLS_D) {
     char *test_deferred = getenv("_DD_LOAD_TEST_INTEGRATIONS");
     if (!test_deferred) {
         return;
     }
+    if (!ddtrace_initialize_new_dispatch_pool(TEST_INTEGRATION_POOL_ID, 2)) {
+        return;
+    }
 
-    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration", 1, 0);
-    DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK);
+    DDTRACE_DEFERRED_INTEGRATION_LOADER("test", "public_static_method", "load_test_integration", TEST_INTEGRATION_POOL_ID, 0);
+    DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK, TEST_INTEGRATION_POOL_ID, 1);
 }
 
 #endif

--- a/src/ext/php5/dispatch.c
+++ b/src/ext/php5/dispatch.c
@@ -20,8 +20,15 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 #endif
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    zval_dtor(&dispatch->function_name);
-    zval_dtor(&dispatch->callable);
+    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_dtor(&dispatch->function_name);
+        ZVAL_NULL(dispatch->function_name);
+    }
+
+    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_dtor(&dispatch->callable);
+        ZVAL_NULL(dispatch->callable);
+    }
 }
 
 void ddtrace_class_lookup_release_compat(void *zv) {
@@ -40,11 +47,6 @@ HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
 }
 
 zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
-    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->persistent);
-
-    memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
-
-    ddtrace_dispatch_copy(dispatch);
     return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/src/ext/php5/dispatch.c
+++ b/src/ext/php5/dispatch.c
@@ -20,14 +20,14 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 #endif
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+    if (Z_TYPE(dispatch->function_name) != IS_NULL) {
         zval_dtor(&dispatch->function_name);
-        ZVAL_NULL(dispatch->function_name);
+        ZVAL_NULL(&dispatch->function_name);
     }
 
-    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+    if (Z_TYPE(dispatch->callable) != IS_NULL) {
         zval_dtor(&dispatch->callable);
-        ZVAL_NULL(dispatch->callable);
+        ZVAL_NULL(&dispatch->callable);
     }
 }
 
@@ -46,7 +46,7 @@ HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
     return class_lookup;
 }
 
-zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
+zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch) {
     return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/src/ext/php5_4/dispatch.c
+++ b/src/ext/php5_4/dispatch.c
@@ -36,14 +36,14 @@ zend_function *ddtrace_ftable_get(const HashTable *table, zval *name) {
 }
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+    if (Z_TYPE(dispatch->function_name) != IS_NULL) {
         zval_dtor(&dispatch->function_name);
-        ZVAL_NULL(dispatch->function_name);
+        ZVAL_NULL(&dispatch->function_name);
     }
 
-    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+    if (Z_TYPE(dispatch->callable) != IS_NULL) {
         zval_dtor(&dispatch->callable);
-        ZVAL_NULL(dispatch->callable);
+        ZVAL_NULL(&dispatch->callable);
     }
 }
 

--- a/src/ext/php5_4/dispatch.c
+++ b/src/ext/php5_4/dispatch.c
@@ -36,8 +36,15 @@ zend_function *ddtrace_ftable_get(const HashTable *table, zval *name) {
 }
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    zval_dtor(&dispatch->function_name);
-    zval_dtor(&dispatch->callable);
+    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_dtor(&dispatch->function_name);
+        ZVAL_NULL(dispatch->function_name);
+    }
+
+    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_dtor(&dispatch->callable);
+        ZVAL_NULL(dispatch->callable);
+    }
 }
 
 void ddtrace_class_lookup_release_compat(void *zv) {
@@ -55,12 +62,7 @@ HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
     return class_lookup;
 }
 
-zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
-    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->persistent);
-
-    memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
-
-    ddtrace_dispatch_copy(dispatch);
+zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch) {
     return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/src/ext/php7/dispatch.c
+++ b/src/ext/php7/dispatch.c
@@ -12,15 +12,15 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
-        zval_ptr_dtor(&dispatch->function_name);
-        ZVAL_NULL(dispatch->function_name);
-    }
+    // if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+    zval_ptr_dtor(&dispatch->function_name);
+    ZVAL_NULL(&dispatch->function_name);
+    // }
 
-    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
-        zval_ptr_dtor(&dispatch->callable);
-        ZVAL_NULL(dispatch->callable);
-    }
+    // if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->callable) != IS_UNDEF) {
+    zval_ptr_dtor(&dispatch->callable);
+    ZVAL_NULL(&dispatch->callable);
+    // }
 }
 
 void ddtrace_class_lookup_release_compat(zval *zv) {
@@ -44,7 +44,7 @@ HashTable *ddtrace_new_class_lookup(zval *class_name) {
 #define DDTRACE_IS_ARRAY_PERSISTENT HASH_FLAG_PERSISTENT
 #endif
 
-zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
+zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch) {
     return zend_hash_update_ptr(lookup, Z_STR(dispatch->function_name), dispatch) != NULL;
 }
 

--- a/src/ext/php7/dispatch.c
+++ b/src/ext/php7/dispatch.c
@@ -12,15 +12,8 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    // if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
     zval_ptr_dtor(&dispatch->function_name);
-    ZVAL_NULL(&dispatch->function_name);
-    // }
-
-    // if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->callable) != IS_UNDEF) {
     zval_ptr_dtor(&dispatch->callable);
-    ZVAL_NULL(&dispatch->callable);
-    // }
 }
 
 void ddtrace_class_lookup_release_compat(zval *zv) {

--- a/src/ext/php7/dispatch.c
+++ b/src/ext/php7/dispatch.c
@@ -12,8 +12,15 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_dispatch_dtor(ddtrace_dispatch_t *dispatch) {
-    zval_ptr_dtor(&dispatch->function_name);
-    zval_ptr_dtor(&dispatch->callable);
+    if (Z_TYPE(dispatch->function_name) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_ptr_dtor(&dispatch->function_name);
+        ZVAL_NULL(dispatch->function_name);
+    }
+
+    if (Z_TYPE(dispatch->callable) != IS_NULL && Z_TYPE(dispatch->function_name) != IS_UNDEF) {
+        zval_ptr_dtor(&dispatch->callable);
+        ZVAL_NULL(dispatch->callable);
+    }
 }
 
 void ddtrace_class_lookup_release_compat(zval *zv) {
@@ -38,10 +45,6 @@ HashTable *ddtrace_new_class_lookup(zval *class_name) {
 #endif
 
 zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch_orig) {
-    ddtrace_dispatch_t *dispatch = pemalloc(sizeof(ddtrace_dispatch_t), lookup->u.flags & DDTRACE_IS_ARRAY_PERSISTENT);
-
-    memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
-    ddtrace_dispatch_copy(dispatch);
     return zend_hash_update_ptr(lookup, Z_STR(dispatch->function_name), dispatch) != NULL;
 }
 

--- a/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
@@ -20,5 +20,5 @@ test("exec_b");
 
 ?>
 --EXPECT--
-OLD HOOK METHOD exec_a
+NEW HOOK METHOD exec_a
 NEW HOOK METHOD exec_b

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once_from_different_hooks.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once_from_different_hooks.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Autoload intergations
+Builtin autoload loads only once even when multiple predeclared hooks were added
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
@@ -7,20 +7,26 @@ _DD_LOAD_TEST_INTEGRATIONS=1
 --FILE--
 <?php
 function load_test_integration(){
-    dd_trace_method("Test", "public_static_method", ['prehook' => function(){
-        echo "test_access hook" . PHP_EOL;
-    }]);
+    echo "autoload_attempted" . PHP_EOL;
 }
+
 class Test
 {
     public static function public_static_method()
     {
         echo "PUBLIC STATIC METHOD" . PHP_EOL;
     }
+
+    public static function second_public_static_method()
+    {
+        echo "SECOND PUBLIC STATIC METHOD" . PHP_EOL;
+    }
 }
 
 Test::public_static_method();
+Test::second_public_static_method();
 ?>
 --EXPECT--
-test_access hook
+autoload_attempted
 PUBLIC STATIC METHOD
+SECOND PUBLIC STATIC METHOD


### PR DESCRIPTION
### Description

This PR is meant to serve two purposes:
1) provide each dispatch with a unique identifier that can be cached in opcache and work across many versions
2) support deduplication of loader execution

Each integration (defined on C level) is meant to allocate a pool of dispatches - to be used to define integrations.
Currently only C level defined integrations are supported. 

It took me a few tries to get the approach that I think should serve well here, let me know what you think about it ( its still a WIP though, so no thorough review is necessary) 

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
