### PR TITLE
Consistent env vars: Support for DD_TRACE_<INTEGRATION>_<SUFFIX> env vars

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -5,6 +5,8 @@
 // \ddtrace_config_distributed_tracing_enabled()
 // \ddtrace_config_integration_enabled()
 // \ddtrace_config_trace_enabled()
+// \DDTrace\Config\integration_analytics_enabled()
+// \DDTrace\Config\integration_analytics_sample_rate()
 
 /**
  * Reads and normalizes a string configuration param, applying default value if appropriate.
@@ -331,18 +333,6 @@ function ddtrace_config_sampling_rules()
         ];
     }
     return $normalized;
-}
-
-function ddtrace_config_integration_analytics_enabled($name)
-{
-    $integrationNameForEnv = strtoupper(str_replace('-', '_', trim($name)));
-    return \_ddtrace_config_bool(\getenv("DD_${integrationNameForEnv}_ANALYTICS_ENABLED"), false);
-}
-
-function ddtrace_config_integration_analytics_sample_rate($name)
-{
-    $integrationNameForEnv = strtoupper(str_replace('-', '_', trim($name)));
-    return \_ddtrace_config_float(\getenv("DD_${integrationNameForEnv}_ANALYTICS_SAMPLE_RATE"), 1.0);
 }
 
 /**

--- a/src/DDTrace/Integrations/DefaultIntegrationConfiguration.php
+++ b/src/DDTrace/Integrations/DefaultIntegrationConfiguration.php
@@ -13,7 +13,7 @@ class DefaultIntegrationConfiguration extends AbstractIntegrationConfiguration
      */
     public function isTraceAnalyticsEnabled()
     {
-        if (\ddtrace_config_integration_analytics_enabled($this->integrationName)) {
+        if (\DDTrace\Config\integration_analytics_enabled($this->integrationName)) {
             return true;
         }
 
@@ -25,6 +25,6 @@ class DefaultIntegrationConfiguration extends AbstractIntegrationConfiguration
      */
     public function getTraceAnalyticsSampleRate()
     {
-        return \ddtrace_config_integration_analytics_sample_rate($this->integrationName);
+        return \DDTrace\Config\integration_analytics_sample_rate($this->integrationName);
     }
 }

--- a/src/api/Configuration.php
+++ b/src/api/Configuration.php
@@ -153,6 +153,9 @@ class Configuration extends AbstractConfiguration
      */
     public function isIntegrationEnabled($name)
     {
+        if (function_exists('ddtrace_config_integration_enabled')) {
+            return \ddtrace_config_integration_enabled($name);
+        }
         return $this->isEnabled() && !$this->inArray('integrations.disabled', $name);
     }
 

--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -230,15 +230,7 @@ bool ddtrace_config_integration_enabled_ex(ddtrace_integration_name integration_
 
 #define DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT false
 
-bool ddtrace_config_integration_analytics_enabled(ddtrace_string integration_str TSRMLS_DC) {
-    ddtrace_integration* integration = ddtrace_get_integration_from_string(integration_str);
-    if (integration == NULL) {
-        return DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT;
-    }
-    return ddtrace_config_integration_analytics_enabled_ex(integration->name TSRMLS_CC);
-}
-
-bool ddtrace_config_integration_analytics_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC) {
+static bool _dd_config_integration_analytics_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC) {
     bool result = DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT;
     ddtrace_integration* integration = &ddtrace_integrations[integration_name];
     ddtrace_string env_val;
@@ -266,17 +258,17 @@ bool ddtrace_config_integration_analytics_enabled_ex(ddtrace_integration_name in
     return result;
 }
 
-#define DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT 1.0
-
-double ddtrace_config_integration_analytics_sample_rate(ddtrace_string integration_str TSRMLS_DC) {
+bool ddtrace_config_integration_analytics_enabled(ddtrace_string integration_str TSRMLS_DC) {
     ddtrace_integration* integration = ddtrace_get_integration_from_string(integration_str);
     if (integration == NULL) {
-        return DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT;
+        return DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT;
     }
-    return ddtrace_config_integration_analytics_sample_rate_ex(integration->name TSRMLS_CC);
+    return _dd_config_integration_analytics_enabled_ex(integration->name TSRMLS_CC);
 }
 
-double ddtrace_config_integration_analytics_sample_rate_ex(ddtrace_integration_name integration_name TSRMLS_DC) {
+#define DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT 1.0
+
+static double _dd_config_integration_analytics_sample_rate_ex(ddtrace_integration_name integration_name TSRMLS_DC) {
     double result = DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT;
     ddtrace_integration* integration = &ddtrace_integrations[integration_name];
     ddtrace_string env_val;
@@ -302,6 +294,14 @@ double ddtrace_config_integration_analytics_sample_rate_ex(ddtrace_integration_n
         efree(env_val.ptr);
     }
     return result;
+}
+
+double ddtrace_config_integration_analytics_sample_rate(ddtrace_string integration_str TSRMLS_DC) {
+    ddtrace_integration* integration = ddtrace_get_integration_from_string(integration_str);
+    if (integration == NULL) {
+        return DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT;
+    }
+    return _dd_config_integration_analytics_sample_rate_ex(integration->name TSRMLS_CC);
 }
 
 bool ddtrace_config_trace_enabled(TSRMLS_D) {

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -6,6 +6,7 @@
 #include "compatibility.h"
 #include "ddtrace_string.h"
 #include "env_config.h"
+#include "integrations/integrations.h"
 
 /**
  * Returns true if `subject` matches "true" or "1".
@@ -30,8 +31,22 @@ bool ddtrace_config_env_bool(ddtrace_string env_name, bool default_value TSRMLS_
 bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D);
 bool ddtrace_config_trace_enabled(TSRMLS_D);
 
+#define DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN 10  // "DD_TRACE_" FTW!
+#define DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN 23  // "_ANALYTICS_SAMPLE_RATE" FTW!
+#define DDTRACE_LONGEST_INTEGRATION_ENV_LEN                                              \
+    (DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN + DDTRACE_LONGEST_INTEGRATION_NAME_LEN + \
+     DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN)
+
 // note: only call this if ddtrace_config_trace_enabled() returns true
 bool ddtrace_config_integration_enabled(ddtrace_string integration TSRMLS_DC);
+bool ddtrace_config_integration_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC);
+bool ddtrace_config_integration_analytics_enabled(ddtrace_string integration TSRMLS_DC);
+bool ddtrace_config_integration_analytics_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC);
+double ddtrace_config_integration_analytics_sample_rate(ddtrace_string integration TSRMLS_DC);
+double ddtrace_config_integration_analytics_sample_rate_ex(ddtrace_integration_name integration_name TSRMLS_DC);
+
+size_t ddtrace_config_integration_env_name(char *name, const char *prefix, ddtrace_integration *integration,
+                                           const char *suffix);
 
 inline ddtrace_string ddtrace_string_getenv(char *str, size_t len TSRMLS_DC) {
     return ddtrace_string_cstring_ctor(ddtrace_getenv(str, len TSRMLS_CC));

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -31,8 +31,8 @@ bool ddtrace_config_env_bool(ddtrace_string env_name, bool default_value TSRMLS_
 bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D);
 bool ddtrace_config_trace_enabled(TSRMLS_D);
 
-#define DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN 10  // "DD_TRACE_" FTW!
-#define DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN 23  // "_ANALYTICS_SAMPLE_RATE" FTW!
+#define DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN 9  // "DD_TRACE_" FTW!
+#define DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN 22  // "_ANALYTICS_SAMPLE_RATE" FTW!
 #define DDTRACE_LONGEST_INTEGRATION_ENV_LEN                                              \
     (DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN + DDTRACE_LONGEST_INTEGRATION_NAME_LEN + \
      DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN)
@@ -41,9 +41,7 @@ bool ddtrace_config_trace_enabled(TSRMLS_D);
 bool ddtrace_config_integration_enabled(ddtrace_string integration TSRMLS_DC);
 bool ddtrace_config_integration_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC);
 bool ddtrace_config_integration_analytics_enabled(ddtrace_string integration TSRMLS_DC);
-bool ddtrace_config_integration_analytics_enabled_ex(ddtrace_integration_name integration_name TSRMLS_DC);
 double ddtrace_config_integration_analytics_sample_rate(ddtrace_string integration TSRMLS_DC);
-double ddtrace_config_integration_analytics_sample_rate_ex(ddtrace_integration_name integration_name TSRMLS_DC);
 
 size_t ddtrace_config_integration_env_name(char *name, const char *prefix, ddtrace_integration *integration,
                                            const char *suffix);

--- a/src/ext/ddtrace.h
+++ b/src/ext/ddtrace.h
@@ -104,6 +104,7 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
 
 #define DDTRACE_FE(name, arg_info) DDTRACE_FENTRY(name, ZEND_FN(name), arg_info, 0)
 #define DDTRACE_NS_FE(name, arg_info) DDTRACE_RAW_FENTRY("DDTrace\\" #name, ZEND_FN(name), arg_info, 0)
+#define DDTRACE_SUB_NS_FE(ns, name, arg_info) DDTRACE_RAW_FENTRY("DDTrace\\" ns #name, ZEND_FN(name), arg_info, 0)
 #define DDTRACE_FALIAS(name, alias, arg_info) DDTRACE_FENTRY(name, ZEND_FN(alias), arg_info, 0)
 #define DDTRACE_FE_END ZEND_FE_END
 

--- a/src/ext/env_config.c
+++ b/src/ext/env_config.c
@@ -111,8 +111,13 @@ double ddtrace_get_double_config(char *name, double def TSRMLS_DC) {
     if (!env) {
         return def;
     }
+    double result = ddtrace_char_to_double(env, def);
+    free(env);
+    return result;
+}
 
-    char *endptr = env;
+double ddtrace_char_to_double(char *subject, double default_value) {
+    char *endptr = subject;
 
     // The strtod function is a bit tricky, so I've quoted docs to explain code
 
@@ -122,18 +127,16 @@ double ddtrace_get_double_config(char *name, double def TSRMLS_DC) {
      * value after the call.
      */
     errno = 0;
-    double result = strtod(env, &endptr);
+    double result = strtod(subject, &endptr);
 
     /* If endptr is not NULL, a pointer to the character after the last
      * character used in the conversion is stored in the location referenced
      * by endptr. If no conversion is performed, zero is returned and the value
      * of nptr is stored in the location referenced by endptr.
      */
-    int conversion_performed = endptr != env && errno == 0;
+    int conversion_performed = endptr != subject && errno == 0;
 
-    free(env);
-
-    return conversion_performed ? result : def;
+    return conversion_performed ? result : default_value;
 }
 
 char *ddtrace_get_c_string_config(char *name TSRMLS_DC) {

--- a/src/ext/env_config.h
+++ b/src/ext/env_config.h
@@ -28,6 +28,7 @@ char *ddtrace_get_c_string_config(char *name TSRMLS_DC);
 int64_t ddtrace_get_int_config(char *name, int64_t def TSRMLS_DC);
 uint32_t ddtrace_get_uint32_config(char *name, uint32_t def TSRMLS_DC);
 double ddtrace_get_double_config(char *name, double def TSRMLS_DC);
+double ddtrace_char_to_double(char *subject, double default_value);
 char *ddtrace_get_c_string_config_with_default(char *name, const char *def TSRMLS_DC);
 char *ddtrace_strdup(const char *source);
 

--- a/src/ext/integrations/elasticsearch.h
+++ b/src/ext/integrations/elasticsearch.h
@@ -7,8 +7,7 @@
     DDTRACE_DEFERRED_INTEGRATION_LOADER(class, method, "DDTrace\\Integrations\\ElasticSearch\\V1\\load")
 
 static inline void _dd_es_initialize_deferred_integration(TSRMLS_D) {
-    ddtrace_string elasticsearch = DDTRACE_STRING_LITERAL("elasticsearch");
-    if (!ddtrace_config_integration_enabled(elasticsearch TSRMLS_CC)) {
+    if (!ddtrace_config_integration_enabled_ex(DDTRACE_INTEGRATION_ELASTICSEARCH TSRMLS_CC)) {
         return;
     }
 

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -1,7 +1,49 @@
 #include "integrations.h"
 
+#include "ddtrace_string.h"
 #include "elasticsearch.h"
 #include "test_integration.h"
+
+ddtrace_integration ddtrace_integrations[] = {
+    {DDTRACE_INTEGRATION_CAKEPHP, "CAKEPHP", ZEND_STRL("cakephp")},
+    {DDTRACE_INTEGRATION_CODEIGNITER, "CODEIGNITER", ZEND_STRL("codeigniter")},
+    {DDTRACE_INTEGRATION_CURL, "CURL", ZEND_STRL("curl")},
+    {DDTRACE_INTEGRATION_ELASTICSEARCH, "ELASTICSEARCH", ZEND_STRL("elasticsearch")},
+    {DDTRACE_INTEGRATION_ELOQUENT, "ELOQUENT", ZEND_STRL("eloquent")},
+    {DDTRACE_INTEGRATION_GUZZLE, "GUZZLE", ZEND_STRL("guzzle")},
+    {DDTRACE_INTEGRATION_LARAVEL, "LARAVEL", ZEND_STRL("laravel")},
+    {DDTRACE_INTEGRATION_LUMEN, "LUMEN", ZEND_STRL("lumen")},
+    {DDTRACE_INTEGRATION_MEMCACHED, "MEMCACHED", ZEND_STRL("memcached")},
+    {DDTRACE_INTEGRATION_MONGO, "MONGO", ZEND_STRL("mongo")},
+    {DDTRACE_INTEGRATION_MYSQLI, "MYSQLI", ZEND_STRL("mysqli")},
+    {DDTRACE_INTEGRATION_PDO, "PDO", ZEND_STRL("pdo")},
+    {DDTRACE_INTEGRATION_PREDIS, "PREDIS", ZEND_STRL("predis")},
+    {DDTRACE_INTEGRATION_SLIM, "SLIM", ZEND_STRL("slim")},
+    {DDTRACE_INTEGRATION_SYMFONY, "SYMFONY", ZEND_STRL("symfony")},
+    {DDTRACE_INTEGRATION_WEB, "WEB", ZEND_STRL("web")},
+    {DDTRACE_INTEGRATION_WORDPRESS, "WORDPRESS", ZEND_STRL("wordpress")},
+    {DDTRACE_INTEGRATION_YII, "YII", ZEND_STRL("yii")},
+    {DDTRACE_INTEGRATION_ZENDFRAMEWORK, "ZENDFRAMEWORK", ZEND_STRL("zendframework")},
+};
+size_t ddtrace_integrations_len = 0;
+
+// Map of lowercase strings to the ddtrace_integration equivalent
+static HashTable _dd_string_to_integration_name_map;
+
+static void _dd_add_integration_to_map(char* name, size_t name_len, ddtrace_integration* integration);
+
+void ddtrace_integrations_minit(void) {
+    ddtrace_integrations_len = sizeof ddtrace_integrations / sizeof ddtrace_integrations[0];
+    zend_hash_init(&_dd_string_to_integration_name_map, ddtrace_integrations_len, NULL, NULL, 1);
+
+    for (size_t i = 0; i < ddtrace_integrations_len; ++i) {
+        char* name = ddtrace_integrations[i].name_lcase;
+        size_t name_len = ddtrace_integrations[i].name_len;
+        _dd_add_integration_to_map(name, name_len, &ddtrace_integrations[i]);
+    }
+}
+
+void ddtrace_integrations_mshutdown(void) { zend_hash_destroy(&_dd_string_to_integration_name_map); }
 
 #if PHP_VERSION_ID >= 70000
 #define DDTRACE_KNOWN_INTEGRATION(class_str, fname_str)                                         \
@@ -12,10 +54,8 @@ static void _dd_register_known_calls(void) {
     DDTRACE_KNOWN_INTEGRATION("wpdb", "query");
     DDTRACE_KNOWN_INTEGRATION("illuminate\\events\\dispatcher", "fire");
 }
-#endif
 
-void dd_integrations_initialize(TSRMLS_D) {
-#if PHP_VERSION_ID >= 70000
+void ddtrace_integrations_rinit(TSRMLS_D) {
     /* Due to negative lookup caching, we need to have a list of all things we
      * might instrument so that if a call is made to something we want to later
      * instrument but is not currently instrumented, that we don't cache this.
@@ -25,12 +65,39 @@ void dd_integrations_initialize(TSRMLS_D) {
      */
     _dd_register_known_calls();
 
+    _dd_es_initialize_deferred_integration(TSRMLS_C);
+    _dd_load_test_integrations(TSRMLS_C);
+}
+
+ddtrace_integration* ddtrace_get_integration_from_string(ddtrace_string integration) {
+    return zend_hash_str_find_ptr(&_dd_string_to_integration_name_map, integration.ptr, integration.len);
+}
+
+static void _dd_add_integration_to_map(char* name, size_t name_len, ddtrace_integration* integration) {
+    zend_hash_str_add_ptr(&_dd_string_to_integration_name_map, name, name_len, integration);
+    ZEND_ASSERT(strlen(integration->name_ucase) == name_len);
+    ZEND_ASSERT(DDTRACE_LONGEST_INTEGRATION_NAME_LEN >= name_len);
+}
+#else
+void ddtrace_integrations_rinit(TSRMLS_D) {
     /* In PHP 5.6 currently adding deferred integrations seem to trigger increase in heap
      * size - even though the memory usage is below the limit. We still can trigger memory
      * allocation error to be issued
      */
-
-    _dd_es_initialize_deferred_integration(TSRMLS_C);
-#endif
     _dd_load_test_integrations(TSRMLS_C);
 }
+
+ddtrace_integration *ddtrace_get_integration_from_string(ddtrace_string integration) {
+    ddtrace_integration **tmp;
+    if (zend_hash_find(&_dd_string_to_integration_name_map, integration.ptr, integration.len + 1, (void **)&tmp) ==
+        SUCCESS) {
+        return *tmp;
+    }
+    return NULL;
+}
+
+static void _dd_add_integration_to_map(char *name, size_t name_len, ddtrace_integration *integration) {
+    zend_hash_add(&_dd_string_to_integration_name_map, name, name_len + 1, (void **)&integration, sizeof(integration),
+                  NULL);
+}
+#endif

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -25,7 +25,7 @@ ddtrace_integration ddtrace_integrations[] = {
     {DDTRACE_INTEGRATION_YII, "YII", ZEND_STRL("yii")},
     {DDTRACE_INTEGRATION_ZENDFRAMEWORK, "ZENDFRAMEWORK", ZEND_STRL("zendframework")},
 };
-size_t ddtrace_integrations_len = 0;
+size_t ddtrace_integrations_len = sizeof ddtrace_integrations / sizeof ddtrace_integrations[0];
 
 // Map of lowercase strings to the ddtrace_integration equivalent
 static HashTable _dd_string_to_integration_name_map;
@@ -33,7 +33,6 @@ static HashTable _dd_string_to_integration_name_map;
 static void _dd_add_integration_to_map(char* name, size_t name_len, ddtrace_integration* integration);
 
 void ddtrace_integrations_minit(void) {
-    ddtrace_integrations_len = sizeof ddtrace_integrations / sizeof ddtrace_integrations[0];
     zend_hash_init(&_dd_string_to_integration_name_map, ddtrace_integrations_len, NULL, NULL, 1);
 
     for (size_t i = 0; i < ddtrace_integrations_len; ++i) {

--- a/src/ext/integrations/integrations.h
+++ b/src/ext/integrations/integrations.h
@@ -5,7 +5,7 @@
 #include "ddtrace_string.h"
 #include "dispatch.h"
 
-#define DDTRACE_LONGEST_INTEGRATION_NAME_LEN 14  // "zendframework" FTW!
+#define DDTRACE_LONGEST_INTEGRATION_NAME_LEN 13  // "zendframework" FTW!
 
 typedef enum {
     DDTRACE_INTEGRATION_CAKEPHP,

--- a/src/ext/integrations/integrations.h
+++ b/src/ext/integrations/integrations.h
@@ -5,6 +5,41 @@
 #include "ddtrace_string.h"
 #include "dispatch.h"
 
+#define DDTRACE_LONGEST_INTEGRATION_NAME_LEN 14  // "zendframework" FTW!
+
+typedef enum {
+    DDTRACE_INTEGRATION_CAKEPHP,
+    DDTRACE_INTEGRATION_CODEIGNITER,
+    DDTRACE_INTEGRATION_CURL,
+    DDTRACE_INTEGRATION_ELASTICSEARCH,
+    DDTRACE_INTEGRATION_ELOQUENT,
+    DDTRACE_INTEGRATION_GUZZLE,
+    DDTRACE_INTEGRATION_LARAVEL,
+    DDTRACE_INTEGRATION_LUMEN,
+    DDTRACE_INTEGRATION_MEMCACHED,
+    DDTRACE_INTEGRATION_MONGO,
+    DDTRACE_INTEGRATION_MYSQLI,
+    DDTRACE_INTEGRATION_PDO,
+    DDTRACE_INTEGRATION_PREDIS,
+    DDTRACE_INTEGRATION_SLIM,
+    DDTRACE_INTEGRATION_SYMFONY,
+    DDTRACE_INTEGRATION_WEB,
+    DDTRACE_INTEGRATION_WORDPRESS,
+    DDTRACE_INTEGRATION_YII,
+    DDTRACE_INTEGRATION_ZENDFRAMEWORK,
+} ddtrace_integration_name;
+
+struct ddtrace_integration {
+    ddtrace_integration_name name;
+    char *name_ucase;
+    char *name_lcase;
+    size_t name_len;
+};
+typedef struct ddtrace_integration ddtrace_integration;
+
+extern ddtrace_integration ddtrace_integrations[];
+extern size_t ddtrace_integrations_len;
+
 /**
  * DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, loader_function)
  * this makro will assign a loader function for each Class, Method/Function combination
@@ -43,5 +78,10 @@
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \
                           DDTRACE_STRING_LITERAL(callable), options TSRMLS_CC)
 
-void dd_integrations_initialize(TSRMLS_D);
-#endif
+void ddtrace_integrations_minit(void);
+void ddtrace_integrations_mshutdown(void);
+void ddtrace_integrations_rinit(TSRMLS_D);
+
+ddtrace_integration *ddtrace_get_integration_from_string(ddtrace_string integration);
+
+#endif  // DD_INTEGRATIONS_INTEGRATIONS_H

--- a/src/ext/php7/startup_logging.c
+++ b/src/ext/php7/startup_logging.c
@@ -12,6 +12,7 @@
 
 #include "coms.h"
 #include "configuration.h"
+#include "integrations/integrations.h"
 #include "logging.h"
 #include "version.h"
 
@@ -188,6 +189,45 @@ static bool _dd_file_exists(const char *file) {
 
 static bool _dd_open_basedir_allowed(const char *file) { return (php_check_open_basedir_ex(file, 0) != -1); }
 
+#define DD_ENV_DEPRECATION_MESSAGE "'%s=%s' is deprecated, use %s instead."
+
+static void _dd_check_for_deprecated_env(HashTable *ht, const char *old_name, size_t old_name_len, const char *new_name,
+                                         size_t new_name_len) {
+    ddtrace_string val = ddtrace_string_getenv((char *)old_name, old_name_len);
+    if (val.len) {
+        size_t messsage_len = sizeof(DD_ENV_DEPRECATION_MESSAGE) + old_name_len + val.len + new_name_len;
+        zend_string *message = zend_string_alloc(messsage_len, 0);
+        int actual_len =
+            snprintf(ZSTR_VAL(message), messsage_len, DD_ENV_DEPRECATION_MESSAGE, old_name, val.ptr, new_name);
+
+        if (actual_len > 0) {
+            ZSTR_VAL(message)[actual_len] = '\0';
+            ZSTR_LEN(message) = actual_len;
+            _dd_add_assoc_zstring(ht, old_name, old_name_len, message);
+        } else {
+            zend_string_free(message);
+        }
+    }
+    if (val.ptr) {
+        efree(val.ptr);
+    }
+}
+
+static void _dd_check_for_deprecated_integration_envs(HashTable *ht, ddtrace_integration *integration) {
+    char old[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    size_t old_len;
+    char new[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    size_t new_len;
+
+    old_len = ddtrace_config_integration_env_name(old, "DD_", integration, "_ANALYTICS_ENABLED");
+    new_len = ddtrace_config_integration_env_name(new, "DD_TRACE_", integration, "_ANALYTICS_ENABLED");
+    _dd_check_for_deprecated_env(ht, old, old_len, new, new_len);
+
+    old_len = ddtrace_config_integration_env_name(old, "DD_", integration, "_ANALYTICS_SAMPLE_RATE");
+    new_len = ddtrace_config_integration_env_name(new, "DD_TRACE_", integration, "_ANALYTICS_SAMPLE_RATE");
+    _dd_check_for_deprecated_env(ht, old, old_len, new, new_len);
+}
+
 /* Supported zval types for diagnostics: string, bool, null
  * To support other types, update:
  *     - ddtrace.c:_dd_info_diagnostics_table(); PHP info output
@@ -223,21 +263,22 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
     //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_incoming_error"), ""); // TODO Parse at C level
     //_dd_add_assoc_string(ht, ZEND_STRL("uri_mapping_outgoing_error"), ""); // TODO Parse at C level
 
-    char *old_service = get_dd_service_name();
-    if (strcmp(old_service, "") != 0) {
-        _dd_add_assoc_string(ht, ZEND_STRL("service_name"), old_service);
-        _dd_add_assoc_string(ht, ZEND_STRL("service_name_error"),
-                             "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead.");
-    }
-    free(old_service);
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("DD_SERVICE_NAME"), ZEND_STRL("DD_SERVICE"));
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("DD_TRACE_APP_NAME"), ZEND_STRL("DD_SERVICE"));
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("ddtrace_app_name"), ZEND_STRL("DD_SERVICE"));
 
-    char *old_tags = get_dd_trace_global_tags();
-    if (strcmp(old_tags, "") != 0) {
-        _dd_add_assoc_string(ht, ZEND_STRL("global_tags"), old_tags);
-        _dd_add_assoc_string(ht, ZEND_STRL("global_tags_error"),
-                             "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead.");
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("DD_TRACE_GLOBAL_TAGS"), ZEND_STRL("DD_TAGS"));
+    _dd_check_for_deprecated_env(
+        ht, ZEND_STRL("DD_TRACE_RESOURCE_URI_MAPPING"),
+        ZEND_STRL("DD_TRACE_RESOURCE_URI_MAPPING_INCOMING and DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING"));
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("DD_SAMPLING_RATE"), ZEND_STRL("DD_TRACE_SAMPLE_RATE"));
+
+    _dd_check_for_deprecated_env(ht, ZEND_STRL("DD_INTEGRATIONS_DISABLED"),
+                                 ZEND_STRL("DD_TRACE_[INTEGRATION]_ENABLED=false"));
+
+    for (size_t i = 0; i < ddtrace_integrations_len; ++i) {
+        _dd_check_for_deprecated_integration_envs(ht, &ddtrace_integrations[i]);
     }
-    free(old_tags);
 }
 
 static void _dd_json_escape_string(smart_str *buf, const char *val, size_t len) {

--- a/tests/Unit/Integrations/DefaultIntegrationConfigurationTest.php
+++ b/tests/Unit/Integrations/DefaultIntegrationConfigurationTest.php
@@ -11,68 +11,101 @@ final class DefaultIntegrationConfigurationTest extends BaseTestCase
     {
         parent::setUp();
         putenv('DD_TRACE_ANALYTICS_ENABLED');
-        putenv('DD_DUMMY_ANALYTICS_ENABLED');
-        putenv('DD_DUMMY_ANALYTICS_SAMPLE_RATE');
+        putenv('DD_TRACE_PDO_ANALYTICS_ENABLED');
+        putenv('DD_TRACE_PDO_ANALYTICS_SAMPLE_RATE');
+        putenv('DD_PDO_ANALYTICS_ENABLED');
+        putenv('DD_PDO_ANALYTICS_SAMPLE_RATE');
     }
 
     public function testTraceAnalyticsOffByDefault()
     {
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertFalse($conf->isTraceAnalyticsEnabled());
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertFalse($conf->isTraceAnalyticsEnabled());
     }
 
     public function testTraceAnalyticsIfIntegrationEnabled()
     {
-        putenv('DD_DUMMY_ANALYTICS_ENABLED=true');
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertTrue($conf->isTraceAnalyticsEnabled());
+        putenv('DD_TRACE_PDO_ANALYTICS_ENABLED=true');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
+    }
+
+    public function testTraceAnalyticsIfIntegrationEnabledDeprecated()
+    {
+        putenv('DD_PDO_ANALYTICS_ENABLED=true');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
+    }
+
+    public function testTraceAnalyticsIfIntegrationEnabledWithDeprecatedPrecedence()
+    {
+        putenv('DD_PDO_ANALYTICS_ENABLED=false');
+        putenv('DD_TRACE_PDO_ANALYTICS_ENABLED=true');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
     }
 
     public function testTraceAnalyticsGlobalEnabledAndNotRequiresExplicit()
     {
         putenv('DD_TRACE_ANALYTICS_ENABLED=true');
-        $conf = new DefaultIntegrationConfiguration('dummy', false);
-        $this->assertTrue($conf->isTraceAnalyticsEnabled());
+        $conf = new DefaultIntegrationConfiguration('pdo', false);
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
     }
 
     public function testTraceAnalyticsGlobalEnabledAndRequiresExplicit()
     {
         putenv('DD_TRACE_ANALYTICS_ENABLED=true');
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertFalse($conf->isTraceAnalyticsEnabled());
-    }
-
-    public function testTraceAnalyticsIntegrationEnabledAndRequiresExplicit()
-    {
-        putenv('DD_DUMMY_ANALYTICS_ENABLED=true');
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertTrue($conf->isTraceAnalyticsEnabled());
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertFalse($conf->isTraceAnalyticsEnabled());
     }
 
     public function testTraceAnalyticsGlobalDisabledIntegrationEnabledRequiresExplicit()
     {
         putenv('DD_TRACE_ANALYTICS_ENABLED=false');
-        putenv('DD_DUMMY_ANALYTICS_ENABLED=true');
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertTrue($conf->isTraceAnalyticsEnabled());
+        putenv('DD_TRACE_PDO_ANALYTICS_ENABLED=true');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
+    }
+
+    public function testTraceAnalyticsGlobalDisabledIntegrationEnabledRequiresExplicitDeprecated()
+    {
+        putenv('DD_TRACE_ANALYTICS_ENABLED=false');
+        putenv('DD_PDO_ANALYTICS_ENABLED=true');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertTrue($conf->isTraceAnalyticsEnabled());
     }
 
     public function testTraceAnalyticsSampleRateDefaultTo1()
     {
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertEquals(1.0, $conf->getTraceAnalyticsSampleRate());
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertEquals(1.0, $conf->getTraceAnalyticsSampleRate());
     }
 
     public function testTraceAnalyticsSampleRateCanBeSet()
     {
-        putenv('DD_DUMMY_ANALYTICS_SAMPLE_RATE=0.3');
-        $conf = new DefaultIntegrationConfiguration('dummy');
-        $this->assertEquals(0.3, $conf->getTraceAnalyticsSampleRate());
+        putenv('DD_TRACE_PDO_ANALYTICS_SAMPLE_RATE=0.3');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertEquals(0.3, $conf->getTraceAnalyticsSampleRate());
+    }
+
+    public function testTraceAnalyticsSampleRateCanBeSetDeprecated()
+    {
+        putenv('DD_PDO_ANALYTICS_SAMPLE_RATE=0.3');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertEquals(0.3, $conf->getTraceAnalyticsSampleRate());
+    }
+
+    public function testTraceAnalyticsSampleRateCanBeSetWithDeprecatedPrecedence()
+    {
+        putenv('DD_TRACE_PDO_ANALYTICS_SAMPLE_RATE=0.2');
+        putenv('DD_PDO_ANALYTICS_SAMPLE_RATE=0.4');
+        $conf = new DefaultIntegrationConfiguration('pdo');
+        self::assertEquals(0.2, $conf->getTraceAnalyticsSampleRate());
     }
 
     public function testTraceAnalyticsOffIfGlobalAndIntegrationNotSetAndNotRequiresExplicit()
     {
-        $conf = new DefaultIntegrationConfiguration('dummy', false);
-        $this->assertFalse($conf->isTraceAnalyticsEnabled());
+        $conf = new DefaultIntegrationConfiguration('pdo', false);
+        self::assertFalse($conf->isTraceAnalyticsEnabled());
     }
 }

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -44,7 +44,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
     public function testSingleIntegrationLoadingCanBeDisabled()
     {
         putenv('DD_TRACE_ENABLED=1');
-        putenv('DD_INTEGRATIONS_DISABLED=integration_1');
+        putenv('DD_INTEGRATIONS_DISABLED=pdo');
         Configuration::replace(\Mockery::mock('\DDTrace\Configuration', [
             'isDebugModeEnabled' => false,
             'isSandboxEnabled' => false,
@@ -56,7 +56,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         putenv('DD_INTEGRATIONS_DISABLED');
         putenv('DD_TRACE_ENABLED');
 
-        $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('integration_1'));
+        $this->assertSame(Integration::NOT_LOADED, $loader->getLoadingStatus('pdo'));
     }
 
     public function testIntegrationsAreLoaded()

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -3,8 +3,6 @@ Startup logging diagnostics
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
 <?php include 'startup_logging_skipif.inc'; ?>
---ENV--
-DD_TRACE_DEBUG=1
 --FILE--
 <?php
 include_once 'startup_logging.inc';
@@ -13,9 +11,11 @@ $args = [
     '-dddtrace.request_init_hook=' . __DIR__ . '/includes/request_init_hook.inc',
 ];
 $env = [
+    'DD_TRACE_DEBUG=1',
     'DD_AGENT_HOST=invalid_host',
     'DD_SERVICE_NAME=foo_service',
     'DD_TRACE_GLOBAL_TAGS=foo_tag',
+    'DD_TRACE_RESOURCE_URI_MAPPING=/foo',
 ];
 $logs = dd_get_startup_logs($args, $env);
 
@@ -23,10 +23,9 @@ dd_dump_startup_logs($logs, [
     'agent_error',
     'open_basedir_init_hook_allowed',
     'open_basedir_container_tagging_allowed',
-    'service_name',
-    'service_name_error',
-    'global_tags',
-    'global_tags_error',
+    'DD_SERVICE_NAME',
+    'DD_TRACE_GLOBAL_TAGS',
+    'DD_TRACE_RESOURCE_URI_MAPPING',
     'agent_url',
     'ddtrace.request_init_hook',
     'open_basedir_configured',
@@ -36,10 +35,9 @@ dd_dump_startup_logs($logs, [
 agent_error: "%s"
 open_basedir_init_hook_allowed: false
 open_basedir_container_tagging_allowed: false
-service_name: "foo_service"
-service_name_error: "Usage of DD_SERVICE_NAME is deprecated, use DD_SERVICE instead."
-global_tags: "foo_tag"
-global_tags_error: "Usage of DD_TRACE_GLOBAL_TAGS is deprecated, use DD_TAGS instead."
+DD_SERVICE_NAME: "'DD_SERVICE_NAME=foo_service' is deprecated, use DD_SERVICE instead."
+DD_TRACE_GLOBAL_TAGS: "'DD_TRACE_GLOBAL_TAGS=foo_tag' is deprecated, use DD_TAGS instead."
+DD_TRACE_RESOURCE_URI_MAPPING: "'DD_TRACE_RESOURCE_URI_MAPPING=/foo' is deprecated, use DD_TRACE_RESOURCE_URI_MAPPING_INCOMING and DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING instead."
 agent_url: "http://invalid_host:8126"
 ddtrace.request_init_hook: "%s/includes/request_init_hook.inc"
 open_basedir_configured: true


### PR DESCRIPTION
### Description

This PR normalizes usage of integration-specific environment variable names to be consistent with other tracers.

| Old Name  | New Name |
| ------------- | ------------- |
| `DD_<INTEGRATION>_ANALYTICS_ENABLED` | `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`  |
| `DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE `  | `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE `  |
| `DD_INTEGRATIONS_DISABLED` | `DD_TRACE_<INTEGRATION>_ENABLED` |

For example, to disable the `pdo` and `laravel` integrations before this PR:

```
# Deprecated
DD_INTEGRATIONS_DISABLED=pdo,laravel
```

Starting from 0.47.1:

```
DD_TRACE_PDO_ENABLED=false
DD_TRACE_LARAVEL_ENABLED=false
```

The old names will continue to work but are deprecated and may be removed in a future release.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
