### PR TITLE
Add PHP-FPM test runner to web tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/artifacts
-            find ~/datadog/tests -type f -name 'nginx_*.log' -o -name 'dd_php_error.log' -exec cp --parents '{}' /tmp/artifacts \;
+            find ~/datadog/tests -type f -name 'phpunit_error.log' -o -name 'nginx_*.log' -o -name 'php_fpm_*.log' -o -name 'dd_php_error.log' -exec cp --parents '{}' /tmp/artifacts \;
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts/
@@ -882,6 +882,13 @@ workflows:
           resource_class: medium+
           sapi: cgi-fcgi
           integration_testsuite: "test-web-74"
+          docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
+          name: "PHP 74 custom autoloaded web tests with nginx + PHP-FPM"
+          resource_class: medium+
+          sapi: fpm-fcgi
+          integration_testsuite: "custom-framework-autoloaded-suite"
           docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
   build:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ error.log
 dd_php_error.log
 nginx.pid
 nginx_*.log
+php_fpm_*.log
+phpunit_error.log
 libtool
 ltmain.sh
 missing

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -302,6 +302,7 @@ final class SpanChecker
                     isset($span['meta']['http.status_code']) ? $span['meta']['http.status_code'] : '',
                     $namePrefix . "Wrong value for 'status code'. "
                         . "Expected: $expectedStatusCode. Actual: $actualStatusCode"
+                        . print_r($span, true)
                 );
             }
         }
@@ -313,12 +314,12 @@ final class SpanChecker
         TestCase::assertSame(
             $exp->getOperationName(),
             isset($span['name']) ? $span['name'] : '',
-            $namePrefix . "Wrong value for 'operation name'"
+            $namePrefix . "Wrong value for 'operation name': " . print_r($span, true)
         );
         TestCase::assertSame(
             $exp->hasError(),
             isset($span['error']) && 1 === $span['error'],
-            $namePrefix . "Wrong value for 'error'"
+            $namePrefix . "Wrong value for 'error': " . print_r($span, true)
         );
         if ($exp->getExactTags() !== SpanAssertion::NOT_TESTED) {
             $filtered = [];
@@ -383,21 +384,21 @@ final class SpanChecker
             TestCase::assertEquals(
                 $metrics,
                 isset($span['metrics']) ? $span['metrics'] : [],
-                $namePrefix . "Wrong value for 'metrics'"
+                $namePrefix . "Wrong value for 'metrics' " . print_r($span, true)
             );
         }
         if ($exp->getService() != SpanAssertion::NOT_TESTED) {
             TestCase::assertSame(
                 $exp->getService(),
                 isset($span['service']) ? $span['service'] : '',
-                $namePrefix . "Wrong value for 'service'"
+                $namePrefix . "Wrong value for 'service' " . print_r($span, true)
             );
         }
         if ($exp->getType() != SpanAssertion::NOT_TESTED) {
             TestCase::assertSame(
                 $exp->getType(),
                 isset($span['type']) ? $span['type'] : '',
-                $namePrefix . "Wrong value for 'type'"
+                $namePrefix . "Wrong value for 'type' " . print_r($span, true)
             );
         }
         if ($exp->getResource() != SpanAssertion::NOT_TESTED) {
@@ -405,7 +406,8 @@ final class SpanChecker
             $actualResource = isset($span['resource']) ? $span['resource'] : '';
             TestCase::assertTrue(
                 $this->exactWildcardsMatches($expectedResource, $actualResource),
-                $namePrefix . "Wrong value for 'resource'. Exp: '$expectedResource' - Act: '$actualResource'"
+                $namePrefix . "Wrong value for 'resource'. Exp: '$expectedResource' - Act: '$actualResource' "
+                . print_r($span, true)
             );
         }
     }

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -195,7 +195,13 @@ trait TracerTestTrait
             // Retrieving data
             $response = curl_exec($curl);
             if (!$response) {
-                \usleep(50 * 1000); // Waiting for 50 ms
+                // PHP-FPM requests are much slower in the container
+                // Temporary workaround until we get a proper test runner
+                \usleep(
+                    'fpm-fcgi' === \getenv('DD_TRACE_TEST_SAPI')
+                        ? 500 * 1000 // 500 ms for PHP-FPM
+                        : 50 * 1000 // 50 ms for other SAPIs
+                );
                 continue;
             } else {
                 break;

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -17,6 +17,8 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
 
     const PORT = 9999;
 
+    const ERROR_LOG_NAME = 'phpunit_error.log';
+
     /**
      * @var WebServer|null
      */
@@ -24,6 +26,10 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
+        $index = static::getAppIndexScript();
+        if ($index) {
+            ini_set('error_log', dirname($index) . '/' . static::ERROR_LOG_NAME);
+        }
         parent::setUpBeforeClass();
         static::setUpWebServer();
     }
@@ -51,7 +57,6 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     protected static function getEnvs()
     {
         $envs = [
-            'DD_AUTOLOAD_NO_COMPILE' => getenv('DD_AUTOLOAD_NO_COMPILE'),
             'DD_TEST_INTEGRATION' => 'true',
             'DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS' => 1,
             // Short flush interval by default or our tests will take all day
@@ -146,6 +151,9 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
                 // sleep for 100 milliseconds before trying again
                 \usleep(100 * 1000);
             } else {
+                // See phpunit_error.log in CircleCI artifacts
+                error_log("[request] '{$method} {$url}' (attempt #{$i})");
+                error_log("[response] {$response}");
                 break;
             }
         }

--- a/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarInvalidTest.php
+++ b/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarInvalidTest.php
@@ -7,6 +7,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class AgentUrlEnvVarInvalidTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';

--- a/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarTest.php
+++ b/tests/Integrations/Custom/Autoloaded/AgentUrlEnvVarTest.php
@@ -7,6 +7,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class AgentUrlEnvVarTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';

--- a/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
+++ b/tests/Integrations/Custom/Autoloaded/BackgroundSenderLogTest.php
@@ -8,6 +8,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 final class BackgroundSenderLogTest extends WebFrameworkTestCase
 {
     const BGS_FLUSH_INTERVAL_MS = 500;
+    const IS_SANDBOX = true;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -9,6 +9,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 final class CircuitBreakerTest extends WebFrameworkTestCase
 {
     const FLUSH_INTERVAL_MS = 500;
+    const IS_SANDBOX = true;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
@@ -7,6 +7,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class CompileTimeDisabledTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
@@ -7,6 +7,7 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class CompileTimeEnabledTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
 
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -8,6 +8,8 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class TraceSearchConfigTest extends WebFrameworkTestCase
 {
+    const IS_SANDBOX = true;
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';

--- a/tests/Nginx/nginx-default.conf
+++ b/tests/Nginx/nginx-default.conf
@@ -17,8 +17,8 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log {{root_path}}/nginx_access.log;
-    error_log {{root_path}}/nginx_error.log;
+    access_log {{access_log}};
+    error_log {{error_log}};
 
     gzip on;
 

--- a/tests/Sapi/CliServer/CliServer.php
+++ b/tests/Sapi/CliServer/CliServer.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace DDTrace\Tests\Sapi\CliServer;
+
+use DDTrace\Tests\Integrations\CLI\EnvSerializer;
+use DDTrace\Tests\Integrations\CLI\IniSerializer;
+use DDTrace\Tests\Sapi\Sapi;
+use Symfony\Component\Process\Process;
+
+final class CliServer implements Sapi
+{
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var int
+     */
+    private $port;
+
+    /**
+     * @var string
+     */
+    private $indexFile;
+
+    /**
+     * @var array
+     */
+    private $envs;
+
+    /**
+     * @var array
+     */
+    private $inis;
+
+    /**
+     * @param string $indexFile
+     * @param string $host
+     * @param int $port
+     * @param array $envs
+     * @param array $inis
+     */
+    public function __construct($indexFile, $host, $port, array $envs = [], array $inis = [])
+    {
+        $this->indexFile = $indexFile;
+        $this->host = $host;
+        $this->port = $port;
+        $this->envs = $envs;
+        $this->inis = $inis;
+    }
+
+    public function start()
+    {
+        /**
+         * If a router is provided to the built-in web server (the index file),
+         * the request init hook (which hooks auto_prepend_file) will not run.
+         * If there is no router, the script is run with php_execute_script():
+         * @see https://heap.space/xref/PHP-7.4/sapi/cli/php_cli_server.c?r=58b17906#2077
+         * This runs the auto_prepend_file as expected. However, if a router is present,
+         * zend_execute_scripts() will be used instead:
+         * @see https://heap.space/xref/PHP-7.4/sapi/cli/php_cli_server.c?r=58b17906#2202
+         * As a result auto_prepend_file (and the request init hook) is not executed.
+         */
+        $cmd = sprintf(
+            'php %s -S %s:%d -t %s', // . ' %s'
+            new IniSerializer($this->inis),
+            $this->host,
+            $this->port,
+            dirname($this->indexFile)
+            //$this->indexFile
+        );
+        $envs = new EnvSerializer($this->envs);
+        $processCmd = "$envs exec $cmd";
+
+        // See phpunit_error.log in CircleCI artifacts
+        error_log("[cli-server] Starting: '{$processCmd}'");
+        if (isset($this->inis['error_log'])) {
+            error_log("[cli-server] Error log: '" . realpath($this->inis['error_log']) . "'");
+        }
+
+        $this->process = new Process($processCmd);
+        $this->process->start();
+    }
+
+    public function stop()
+    {
+        error_log("[cli-server] Stopping...");
+        $this->process->stop(0);
+    }
+
+    public function isFastCgi()
+    {
+        return false;
+    }
+}

--- a/tests/Sapi/PhpCgi/PhpCgi.php
+++ b/tests/Sapi/PhpCgi/PhpCgi.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace DDTrace\Tests\Sapi\PhpCgi;
+
+use DDTrace\Tests\Integrations\CLI\EnvSerializer;
+use DDTrace\Tests\Integrations\CLI\IniSerializer;
+use DDTrace\Tests\Sapi\Sapi;
+use Symfony\Component\Process\Process;
+
+final class PhpCgi implements Sapi
+{
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var int
+     */
+    private $port;
+
+    /**
+     * @var array
+     */
+    private $envs;
+
+    /**
+     * @var array
+     */
+    private $inis;
+
+    /**
+     * @param string $host
+     * @param int $port
+     * @param array $envs
+     * @param array $inis
+     */
+    public function __construct($host, $port, array $envs = [], array $inis = [])
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->envs = $envs;
+        $this->inis = $inis;
+    }
+
+    public function start()
+    {
+        $cmd = sprintf(
+            'php-cgi %s -b %s:%d',
+            new IniSerializer($this->inis),
+            $this->host,
+            $this->port
+        );
+        $envs = new EnvSerializer($this->envs);
+        $processCmd = "$envs exec $cmd";
+
+        // See phpunit_error.log in CircleCI artifacts
+        error_log("[php-cgi] Starting: '{$processCmd}'");
+        if (isset($this->inis['error_log'])) {
+            error_log("[php-cgi] Error log: '" . realpath($this->inis['error_log']) . "'");
+        }
+
+        $this->process = new Process($processCmd);
+        $this->process->start();
+    }
+
+    public function stop()
+    {
+        error_log("[php-cgi] Stopping...");
+        $this->process->stop(0);
+    }
+
+    public function isFastCgi()
+    {
+        return true;
+    }
+}

--- a/tests/Sapi/PhpFpm/PhpFpm.php
+++ b/tests/Sapi/PhpFpm/PhpFpm.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace DDTrace\Tests\Sapi\PhpFpm;
+
+use DDTrace\Tests\Sapi\Sapi;
+use Symfony\Component\Process\Process;
+
+final class PhpFpm implements Sapi
+{
+    const ERROR_LOG = 'php_fpm_error.log';
+
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var array
+     */
+    private $envs;
+
+    /**
+     * @var array
+     */
+    private $inis;
+
+    /**
+     * @var string
+     */
+    private $configFile;
+
+    /**
+     * @param string $rootPath
+     * @param string $host
+     * @param int $port
+     * @param array $envs
+     * @param array $inis
+     */
+    public function __construct($rootPath, $host, $port, array $envs = [], array $inis = [])
+    {
+        $this->envs = $envs;
+        $this->inis = $inis;
+
+        $replacements = [
+            '{{fcgi_host}}' => $host,
+            '{{fcgi_port}}' => $port,
+            '{{envs}}' => $this->envsForConfFile(),
+            '{{inis}}' => $this->inisForConfFile(),
+            '{{error_log}}' => $rootPath . '/' . self::ERROR_LOG,
+        ];
+        $configContent = str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            file_get_contents(__DIR__ . '/www.conf')
+        );
+
+        $this->configFile = sys_get_temp_dir() . uniqid('/www-conf-', true);
+
+        // This gets logged to phpunit_error.log (check CircleCI artifacts)
+        error_log("[php-fpm] Generated config file '{$this->configFile}'");
+        error_log("[php-fpm] Error log: '" . $replacements['{{error_log}}'] . "'");
+        error_log("[php-fpm]\n{$configContent}");
+
+        if (false === file_put_contents($this->configFile, $configContent)) {
+            throw new \Exception('Error creating temp PHP-FPM config file: ' . $this->configFile);
+        }
+    }
+
+    public function start()
+    {
+        $cmd = sprintf(
+            'exec php-fpm -p %s --fpm-config %s -F',
+            __DIR__,
+            $this->configFile
+        );
+
+        // See phpunit_error.log in CircleCI artifacts
+        error_log("[php-fpm] Starting: '{$cmd}'");
+
+        $this->process = new Process($cmd);
+        $this->process->start();
+    }
+
+    public function stop()
+    {
+        error_log("[php-fpm] Stopping...");
+        $this->process->stop(0);
+        // Waiting 200 ms for PHP-FPM to give the socket back
+        \usleep(200 * 1000);
+    }
+
+    public function isFastCgi()
+    {
+        return true;
+    }
+
+    private function envsForConfFile()
+    {
+        $lines = [];
+        foreach ($this->envs as $name => $value) {
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+            // PHP-FPM thinks that "false" is an empty value and will fail on startup with:
+            // ERROR: [%s:%d] empty value
+            if ('false' === $value) {
+                $value = '0';
+            }
+            if ('' !== $value) {
+                $lines[] = sprintf('env[%s] = %s', $name, $value);
+            }
+        }
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function inisForConfFile()
+    {
+        $lines = [];
+        foreach ($this->inis as $name => $value) {
+            switch ($value) {
+                case '0':
+                case '1':
+                case 'true':
+                case 'false':
+                case 'on':
+                case 'off':
+                case 'yes':
+                case 'no':
+                    $lines[] = sprintf('php_admin_flag[%s] = %s', $name, $value);
+                    break;
+                default:
+                    $lines[] = sprintf('php_admin_value[%s] = %s', $name, $value);
+                    break;
+            }
+        }
+        return implode(PHP_EOL, $lines);
+    }
+
+    public function __destruct()
+    {
+        if ($this->configFile) {
+            unlink($this->configFile);
+        }
+    }
+}

--- a/tests/Sapi/PhpFpm/www.conf
+++ b/tests/Sapi/PhpFpm/www.conf
@@ -1,0 +1,13 @@
+[global]
+error_log = {{error_log}}
+
+[www]
+listen = {{fcgi_host}}:{{fcgi_port}}
+
+pm = static
+pm.max_children = 1
+catch_workers_output = yes
+
+{{envs}}
+
+{{inis}}

--- a/tests/Sapi/Sapi.php
+++ b/tests/Sapi/Sapi.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DDTrace\Tests\Sapi;
+
+interface Sapi
+{
+    /**
+     * Start the SAPI process
+     */
+    public function start();
+
+    /**
+     * Stop the SAPI process
+     */
+    public function stop();
+
+    /**
+     * Whether or not SAPI runs as FastCGI
+     */
+    public function isFastCgi();
+}


### PR DESCRIPTION
### Description

This PR adds a PHP-FPM test runner to the web server tests in CircleCI. As of right now it only runs the custom web framework tests on PHP 7.4 since the test runner is quite slow. We will add more and make speed improvements going forward.

This also includes a refactoring of the existing web SAPI test runners. And also adds a new `phpunit_error.log` to the CircleCI artifacts for more visibility on failed web tests.

### Readiness checklist
- ~~[ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.~~
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
