### PR TITLE
Fix ElasticSearch integration fallback to legacy

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -97,11 +97,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\CodeIgniter\V2\CodeIgniterSandboxedIntegration';
             $this->integrations[CurlSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Curl\CurlSandboxedIntegration';
-            // for PHP 7.0+ use C level integration autoloader
-            if (\PHP_MAJOR_VERSION < 7) {
-                $this->integrations[ElasticSearchSandboxedIntegration::NAME] =
-                    '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration';
-            }
+            $this->integrations[ElasticSearchSandboxedIntegration::NAME] =
+                '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchSandboxedIntegration';
             $this->integrations[EloquentSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\Eloquent\EloquentSandboxedIntegration';
             $this->integrations[GuzzleSandboxedIntegration::NAME] =
@@ -134,6 +131,11 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Yii\YiiSandboxedIntegration';
             $this->integrations[ZendFrameworkSandboxedIntegration::NAME] =
                 '\DDTrace\Integrations\ZendFramework\ZendFrameworkSandboxedIntegration';
+        }
+
+        // For PHP 7.0+ use C level deferred integration loader
+        if (\PHP_MAJOR_VERSION >= 7) {
+            unset($this->integrations[ElasticSearchSandboxedIntegration::NAME]);
         }
     }
 

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -160,15 +160,18 @@ final class IntegrationsLoaderTest extends BaseTestCase
         }
 
         $expected = $this->normalize(glob(__DIR__ . '/../../../src/DDTrace/Integrations/*', GLOB_ONLYDIR));
+
+        $excluded = [];
         if (\PHP_MAJOR_VERSION < 7) {
-            $php7plusOnly = [
-                'phpredis',
-            ];
-            foreach ($php7plusOnly as $integrationToExclude) {
-                $index = array_search($integrationToExclude, $expected);
-                unset($expected[$index]);
-            }
+            $excluded[] = 'phpredis'; // PHP 7 only integration
+        } else {
+            $excluded[] = 'elasticsearch'; // Deferred loading integration
         }
+        foreach ($excluded as $integrationToExclude) {
+            $index = array_search($integrationToExclude, $expected, true);
+            unset($expected[$index]);
+        }
+
         \ksort($expected);
 
         $integrations = IntegrationsLoader::get()->getIntegrations();


### PR DESCRIPTION
### Description

This is a tiny followup PR to #891 to prevent the ElasticSearch integration from falling back to non-sandboxed version on PHP 7. The deferred integration loading feature hasn't been released yet.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- ~~[ ] Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
