### PR TITLE
Remove query string when new resource mapper is used

### DIFF
--- a/src/private/functions.php
+++ b/src/private/functions.php
@@ -53,6 +53,9 @@ function _util_uri_apply_rules($uriPath, $incoming)
         return '/';
     }
 
+    // Removing query string
+    $uriPath = strstr($uriPath, '?', true) ? : $uriPath;
+
     // We always expect leading slash if it is a pure path, while urls with RFC3986 complaint schemes are preserved.
     // See: https://tools.ietf.org/html/rfc3986#page-17
     if ($uriPath[0] !== '/' && 1 !== \preg_match('/^[a-z][a-zA-Z0-9+\-.]+:\/\//', $uriPath)) {

--- a/tests/Unit/private/UriTest.php
+++ b/tests/Unit/private/UriTest.php
@@ -486,4 +486,16 @@ class UriTest extends BaseTestCase
             \DDtrace\Private_\util_uri_normalize_outgoing_path('/int/123/nested/some')
         );
     }
+
+    public function testQueryStringIsRemoved()
+    {
+        $this->assertSame(
+            '/int/?/nested/some',
+            \DDtrace\Private_\util_uri_normalize_incoming_path('/int/123/nested/some?key=value')
+        );
+        $this->assertSame(
+            '/int/?/nested/some',
+            \DDtrace\Private_\util_uri_normalize_outgoing_path('/int/123/nested/some?key=value')
+        );
+    }
 }

--- a/tests/overhead/docker-compose.yml
+++ b/tests/overhead/docker-compose.yml
@@ -2,23 +2,23 @@ version: '3.6'
 
 services:
 
-  # nginx:
-  #   image: overhead-nginx
-  #   ports:
-  #     # no tracer
-  #     - 8886:8886
-  #     # current master on GitHub
-  #     - 8887:8887
-  #     # current local head
-  #     - 8888:8888
-  #     # a specific release, set DD_TRACER_LIBRARY_VERSION=X.Y.Z in service
-  #     # 'php-fpm-release'
-  #     - 8889:8889
-  #   depends_on:
-  #     - php-fpm-notracer
-  #     - php-fpm-master
-  #     - php-fpm-release
-  #     - php-fpm-head
+  nginx:
+    image: overhead-nginx
+    ports:
+      # no tracer
+      - 8886:8886
+      # current master on GitHub
+      - 8887:8887
+      # current local head
+      - 8888:8888
+      # a specific release, set DD_TRACER_LIBRARY_VERSION=X.Y.Z in service
+      # 'php-fpm-release'
+      - 8889:8889
+    depends_on:
+      - php-fpm-notracer
+      - php-fpm-master
+      - php-fpm-release
+      - php-fpm-head
 
   php-fpm-notracer:
     image: overhead-php-fpm-notracer


### PR DESCRIPTION
### Description

The old uri to resource mapper used to both normalize a uri AND remove the query string param.
The new one only currently normalizes the uri.

This creates problems in generic web tracing as the uri is used as part of the resource name.

This PR adds removal of query string from resource uri.

With fix

![image](https://user-images.githubusercontent.com/2952352/88671684-e3230500-d0e6-11ea-88ec-a05d67f9ac5c.png)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
