### PR TITLE
Update Jessie package verification

### DIFF
--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -1,4 +1,4 @@
-JESSIE_PHP_VERSIONS:=5.6.jessie 7.0.jessie 7.1.jessie 7.2.jessie
+JESSIE_PHP_VERSIONS:=5.6.jessie # We don't test PHP 7 on Jessie; PHP packages on sury.org went EOL June 30, 2020
 STRETCH_PHP_VERSIONS:=5.6.stretch 7.0.stretch 7.1.stretch 7.2.stretch
 CENTOS6_PHP_VERSIONS:=5.4.centos6 5.6.centos6 7.0.centos6 7.1.centos6 7.2.centos6
 CENTOS7_PHP_VERSIONS:=5.4.centos7 5.6.centos7 7.0.centos7 7.1.centos7 7.2.centos7 #7.3.centos7

--- a/dockerfiles/verify_packages/debian_jessie/Dockerfile
+++ b/dockerfiles/verify_packages/debian_jessie/Dockerfile
@@ -1,14 +1,13 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get -y install apt-transport-https lsb-release ca-certificates
-RUN apt-get install curl -y
-RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
-RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list
-RUN apt-get update
+# Sury.org no longer provides PHP packages for Jessie
+# https://www.linuxcompatible.org/story/suryorg-has-discontinued-debian-8-support/
+# So we just test the PHP version in the default repo (5.6)
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y install curl php5
+
 ADD build/packages /packages
-
-ARG php_version
-RUN apt-get -y --force-yes install php${php_version}
-
-RUN dpkg -i /packages/*.deb
-RUN php -m | grep ddtrace
+RUN set -eux; \
+    dpkg -i /packages/*.deb; \
+    php -m | grep ddtrace


### PR DESCRIPTION
### Description

PHP packages on sury.org went EOL on June 30, 2020 and our `package verification` checks have failed ever since. This PR updates the Jessie package verification to use the PHP available in the default repo (PHP 5.6).

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- ~[ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.~
