### PR TITLE
Package _generated.php with PECL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,6 +609,47 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - run: sh dockerfiles/verify_packages/verify_<< parameters.package_type >>.sh
 
+  pecl_build:
+    working_directory: ~/datadog
+    executor:
+      name: with_agent
+      docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_COMPOSER_INSTALL
+      - run:
+          name: Make PECL build
+          command: |
+            tooling/bin/pecl-build
+            mkdir -p ./pecl && cp datadog_trace-*.tgz ./pecl
+      #- store_artifacts:
+      #    path: pecl
+      - persist_to_workspace:
+          root: .
+          paths: [pecl]
+
+  pecl_tests:
+    parameters:
+      docker_image:
+        type: string
+    working_directory: ~/datadog
+    executor:
+      name: with_agent
+      docker_image: << parameters.docker_image >>
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Install from PECL build
+          command: |
+            cp ./pecl/datadog_trace-*.tgz ./datadog_trace.tgz
+            sudo pecl install datadog_trace.tgz
+            echo "extension=ddtrace.so" | sudo tee /usr/local/etc/php/conf.d/ddtrace.ini
+            php --ri=ddtrace
+      - run:
+          name: Run phpt tests with PECL
+          command: |
+            sudo pecl run-tests --showdiff --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
+
   compile_extension:
     working_directory: ~/datadog
     parameters:
@@ -687,6 +728,7 @@ jobs:
           command: make packages
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
+      - store_artifacts: { path: 'pecl', destination: '/pecl' }
       - persist_to_workspace:
           root: '.'
           paths: ['./build/packages', 'dockerfiles/verify_packages']
@@ -797,6 +839,9 @@ workflows:
           docker_image: "circleci/php:7.4-zts"
           lib_curl_command: sudo apt update; sudo apt -y install libcurl4-nss-dev
           so_suffix: "20190902-zts"
+      - pecl_build:
+          requires: [ 'Prepare Code' ]
+          name: "Build PECL"
       - "package extension":
           requires:
             - "Compile PHP 54"
@@ -812,6 +857,7 @@ workflows:
             - "Compile PHP 72-zts"
             - "Compile PHP 73-zts"
             - "Compile PHP 74-zts"
+            - "Build PECL"
       - "package verification":
           requires:
             - "package extension"
@@ -886,6 +932,30 @@ workflows:
           name: "php:7.3"
           docker_image: php:7.3
           package_type: deb
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 56 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-5.6-debug-buster"
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 70 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-7.0-debug-buster"
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 71 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-7.1-debug-buster"
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 72 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-7.2-debug-buster"
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 73 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-7.3-debug-buster"
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 74 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 72 web tests with nginx + FastCGI"

--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,12 @@
         <email>sammyk@php.net</email>
         <active>yes</active>
     </lead>
+    <!-- **Automatically updated with pecl-build script** -->
+    <!-- Date only needs to be set if it was packaged on a different day from release -->
     <date>${date}</date>
     <version>
+        <!-- **Automatically updated with pecl-build script** -->
+        <!-- Version will be set from version.php or 0.0.0 for nightly builds -->
         <release>${version}</release>
         <api>${version}</api>
     </version>
@@ -23,6 +27,7 @@
     <notes>${notes}</notes>
     <contents>
         <dir name="/">
+            <!-- Source files -->
             <file name="m4/ax_execinfo.m4" role="src" />
             <file name="m4/polyfill.m4" role="src" />
             <file name="src/dogstatsd/client.c" role="src" />
@@ -80,8 +85,6 @@
             <file name="src/ext/startup_logging.h" role="src" />
             <file name="src/ext/version.h" role="src" />
             <file name="src/ext/compatibility.h" role="src" />
-            <file name="src/ext/integrations/deferred.c" role="src" />
-            <file name="src/ext/integrations/deferred.h" role="src" />
             <file name="src/ext/integrations/integrations.c" role="src" />
             <file name="src/ext/integrations/integrations.h" role="src" />
             <file name="src/ext/integrations/elasticsearch.h" role="src" />
@@ -127,154 +130,8 @@
             <file name="src/ext/php7/startup_logging.c" role="src" />
             <file name="src/ext/third-party/mt19937-64.c" role="src" />
             <file name="src/ext/third-party/mt19937-64.h" role="src" />
-            <dir name="src">
-                <dir name="DDTrace">
-                    <file name="version.php" role="php" />
-                    <file name="Sampling/Sampler.php" role="php" />
-                    <file name="Sampling/ConfigurableSampler.php" role="php" />
-                    <file name="Sampling/AlwaysKeepSampler.php" role="php" />
-                    <file name="Sampling/PrioritySampling.php" role="php" />
-                    <file name="Data/SpanContext.php" role="php" />
-                    <file name="Data/Span.php" role="php" />
-                    <file name="StartSpanOptionsFactory.php" role="php" />
-                    <file name="GlobalTracer.php" role="php" />
-                    <file name="NoopSpan.php" role="php" />
-                    <file name="Configuration.php" role="php" />
-                    <file name="Obfuscation.php" role="php" />
-                    <file name="Propagator.php" role="php" />
-                    <file name="try_catch_finally.php" role="php" />
-                    <file name="Encoders/MessagePack.php" role="php" />
-                    <file name="Encoders/SpanEncoder.php" role="php" />
-                    <file name="Encoders/Noop.php" role="php" />
-                    <file name="Encoders/Json.php" role="php" />
-                    <file name="Encoder.php" role="php" />
-                    <file name="OpenTracer/ScopeManager.php" role="php" />
-                    <file name="OpenTracer/SpanContext.php" role="php" />
-                    <file name="OpenTracer/Tracer.php" role="php" />
-                    <file name="OpenTracer/Scope.php" role="php" />
-                    <file name="OpenTracer/Span.php" role="php" />
-                    <file name="NoopTracer.php" role="php" />
-                    <file name="StartSpanOptions.php" role="php" />
-                    <file name="Propagators/CurlHeadersMap.php" role="php" />
-                    <file name="Propagators/TextMap.php" role="php" />
-                    <file name="Propagators/Noop.php" role="php" />
-                    <file name="ScopeManager.php" role="php" />
-                    <file name="NoopScopeManager.php" role="php" />
-                    <file name="Util/ContainerInfo.php" role="php" />
-                    <file name="Util/ArrayKVStore.php" role="php" />
-                    <file name="Util/CodeTracer.php" role="php" />
-                    <file name="Util/Runtime.php" role="php" />
-                    <file name="Util/ObjectKVStore.php" role="php" />
-                    <file name="Util/TryCatchFinally.php" role="php" />
-                    <file name="Util/Versions.php" role="php" />
-                    <file name="SpanContext.php" role="php" />
-                    <file name="Integrations/AbstractIntegrationConfiguration.php" role="php" />
-                    <file name="Integrations/Eloquent/EloquentIntegration.php" role="php" />
-                    <file name="Integrations/Eloquent/EloquentSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Lumen/V5/LumenIntegrationLoader.php" role="php" />
-                    <file name="Integrations/Lumen/LumenIntegration.php" role="php" />
-                    <file name="Integrations/SandboxedIntegration.php" role="php" />
-                    <file name="Integrations/IntegrationsLoader.php" role="php" />
-                    <file name="Integrations/Laravel/V5/LaravelIntegrationLoader.php" role="php" />
-                    <file name="Integrations/Laravel/LaravelIntegration.php" role="php" />
-                    <file name="Integrations/Laravel/V4/LaravelIntegration.php" role="php" />
-                    <file name="Integrations/Laravel/V4/LaravelProvider.php" role="php" />
-                    <file name="Integrations/Laravel/LaravelSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Predis/PredisIntegration.php" role="php" />
-                    <file name="Integrations/Predis/PredisSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Web/WebIntegration.php" role="php" />
-                    <file name="Integrations/ElasticSearch/V1/ElasticSearchIntegration.php" role="php" />
-                    <file name="Integrations/ElasticSearch/V1/ElasticSearchCommon.php" role="php" />
-                    <file name="Integrations/ElasticSearch/V1/ElasticSearchSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Curl/CurlSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Curl/CurlIntegration.php" role="php" />
-                    <file name="Integrations/Mysqli/MysqliSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Mysqli/MysqliIntegration.php" role="php" />
-                    <file name="Integrations/Mysqli/MysqliCommon.php" role="php" />
-                    <file name="Integrations/DefaultIntegrationConfiguration.php" role="php" />
-                    <file name="Integrations/Memcached/MemcachedIntegration.php" role="php" />
-                    <file name="Integrations/Memcached/MemcachedSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Integration.php" role="php" />
-                    <file name="Integrations/WordPress/WordPressSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/WordPress/V4/WordPressIntegrationLoader.php" role="php" />
-                    <file name="Integrations/Slim/SlimIntegration.php" role="php" />
-                    <file name="Integrations/Slim/V3/SlimIntegrationLoader.php" role="php" />
-                    <file name="Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Mongo/MongoIntegration.php" role="php" />
-                    <file name="Integrations/Mongo/MongoClientIntegration.php" role="php" />
-                    <file name="Integrations/Mongo/MongoCollectionIntegration.php" role="php" />
-                    <file name="Integrations/Mongo/MongoDBIntegration.php" role="php" />
-                    <file name="Integrations/Mongo/MongoSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/PDO/PDOSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/PDO/PDOIntegration.php" role="php" />
-                    <file name="Integrations/CakePHP/CakePHPIntegration.php" role="php" />
-                    <file name="Integrations/CakePHP/V2/CakePHPIntegrationLoader.php" role="php" />
-                    <file name="Integrations/Guzzle/GuzzleSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Guzzle/GuzzleIntegration.php" role="php" />
-                    <file name="Integrations/ZendFramework/V1/TraceRequest.php" role="php" />
-                    <file name="Integrations/ZendFramework/V1/Ddtrace.php" role="php" />
-                    <file name="Integrations/ZendFramework/ZendFrameworkIntegration.php" role="php" />
-                    <file name="Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Symfony/SymfonySandboxedIntegration.php" role="php" />
-                    <file name="Integrations/Symfony/V3/SymfonyBundle.php" role="php" />
-                    <file name="Integrations/Symfony/SymfonyIntegration.php" role="php" />
-                    <file name="Integrations/Symfony/V4/SymfonyBundle.php" role="php" />
-                    <file name="Integrations/Yii/V2/YiiIntegrationLoader.php" role="php" />
-                    <file name="Integrations/Yii/YiiSandboxedIntegration.php" role="php" />
-                    <file name="Format.php" role="php" />
-                    <file name="Obfuscation/WildcardToRegex.php" role="php" />
-                    <file name="Log/InterpolateTrait.php" role="php" />
-                    <file name="Log/AbstractLogger.php" role="php" />
-                    <file name="Log/Logger.php" role="php" />
-                    <file name="Log/LoggerInterface.php" role="php" />
-                    <file name="Log/LoggingTrait.php" role="php" />
-                    <file name="Log/LogLevel.php" role="php" />
-                    <file name="Log/PsrLogger.php" role="php" />
-                    <file name="Log/ErrorLogLogger.php" role="php" />
-                    <file name="Log/NullLogger.php" role="php" />
-                    <file name="Tracer.php" role="php" />
-                    <file name="Configuration/Registry.php" role="php" />
-                    <file name="Configuration/AbstractConfiguration.php" role="php" />
-                    <file name="Configuration/EnvVariableRegistry.php" role="php" />
-                    <file name="Exceptions/InvalidSpanArgument.php" role="php" />
-                    <file name="Exceptions/InvalidSpanOption.php" role="php" />
-                    <file name="Exceptions/UnsupportedFormat.php" role="php" />
-                    <file name="Exceptions/InvalidReferencesSet.php" role="php" />
-                    <file name="Exceptions/InvalidReferenceArgument.php" role="php" />
-                    <file name="Transport.php" role="php" />
-                    <file name="Transport/Stream.php" role="php" />
-                    <file name="Transport/Http.php" role="php" />
-                    <file name="Transport/Noop.php" role="php" />
-                    <file name="Bootstrap.php" role="php" />
-                    <file name="NoopSpanContext.php" role="php" />
-                    <file name="Scope.php" role="php" />
-                    <file name="Processing/TraceAnalyticsProcessor.php" role="php" />
-                    <file name="Reference.php" role="php" />
-                    <file name="Type.php" role="php" />
-                    <file name="Span.php" role="php" />
-                    <file name="Contracts/ScopeManager.php" role="php" />
-                    <file name="Contracts/SpanContext.php" role="php" />
-                    <file name="Contracts/Tracer.php" role="php" />
-                    <file name="Contracts/Scope.php" role="php" />
-                    <file name="Contracts/Span.php" role="php" />
-                    <file name="Time.php" role="php" />
-                    <file name="autoload.php" role="php" />
-                    <file name="Http/Request.php" role="php" />
-                    <file name="Http/Urls.php" role="php" />
-                    <file name="Tag.php" role="php" />
-                    <file name="NoopScope.php" role="php" />
-                </dir> <!-- ddtrace -->
-            </dir> <!-- src -->
-            <dir name="bridge">
-                <file name="dd_autoloader.php" role="php" />
-                <file name="dd_init.php" role="php" />
-                <file name="dd_optional_deps_autoloader.php" role="php" />
-                <file name="dd_require_all.php" role="php" />
-                <file name="dd_required_deps_autoloader.php" role="php" />
-                <file name="dd_wrap_autoloader.php" role="php" />
-                <file name="functions.php" role="php" />
-            </dir>
 
+            <!-- Tests -->
             <file name="tests/ext/call_user_func/namespaced-array.phpt" role="test" />
             <file name="tests/ext/call_user_func/namespaced.phpt" role="test" />
             <file name="tests/ext/call_user_func/not-namespaced-array.phpt" role="test" />
@@ -352,7 +209,6 @@
             <file name="tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_handled_in_multicatch.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_handled_with_finally.phpt" role="test" />
-            <file name="tests/ext/sandbox/exception_handling_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_handling.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_is_defined.phpt" role="test" />
             <file name="tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
@@ -501,6 +357,8 @@
             <file name="tests/ext/startup_logging_skipif.inc" role="test" />
             <file name="tests/ext/traced_internal_functions_override_01.phpt" role="test" />
             <file name="tests/ext/traced_internal_functions_override_02.phpt" role="test" />
+
+            <!-- Docs -->
             <file name="CHANGELOG.md" role="doc" />
             <file name="config.m4" role="src" />
             <file name="LICENSE" role="doc" />
@@ -509,6 +367,16 @@
             <file name="NOTICE" role="doc" />
             <file name="README.md" role="doc" />
             <file name="UPGRADE-0.10.md" role="doc" />
+
+            <!-- PHP files -->
+            <!-- Include any files from ./bridge that are not referenced in ./bridge/_files.php -->
+            <!-- Make sure to update <filelist> below too -->
+            <file name="bridge/_generated.php" role="php" />
+            <file name="bridge/autoload.php" role="php" />
+            <file name="bridge/dd_init.php" role="php" />
+            <file name="bridge/dd_register_optional_deps_autoloader.php" role="php" />
+            <file name="bridge/dd_wrap_autoloader.php" role="php" />
+            <file name="bridge/php5.php" role="php" />
         </dir>
     </contents>
     <dependencies>
@@ -527,149 +395,13 @@
     </dependencies>
     <providesextension>ddtrace</providesextension>
     <extsrcrelease>
-        <configureoption name="enable-ddtrace-debug" default="no" prompt="Enable internal debugging in ddtrace" />
         <filelist>
-          <install as="datadog_trace/src/DDTrace/version.php"  name="src/DDTrace/version.php" />
-          <install as="datadog_trace/src/DDTrace/Sampling/Sampler.php"  name="src/DDTrace/Sampling/Sampler.php" />
-          <install as="datadog_trace/src/DDTrace/Sampling/ConfigurableSampler.php"  name="src/DDTrace/Sampling/ConfigurableSampler.php" />
-          <install as="datadog_trace/src/DDTrace/Sampling/AlwaysKeepSampler.php"  name="src/DDTrace/Sampling/AlwaysKeepSampler.php" />
-          <install as="datadog_trace/src/DDTrace/Sampling/PrioritySampling.php"  name="src/DDTrace/Sampling/PrioritySampling.php" />
-          <install as="datadog_trace/src/DDTrace/Data/SpanContext.php"  name="src/DDTrace/Data/SpanContext.php" />
-          <install as="datadog_trace/src/DDTrace/Data/Span.php"  name="src/DDTrace/Data/Span.php" />
-          <install as="datadog_trace/src/DDTrace/StartSpanOptionsFactory.php"  name="src/DDTrace/StartSpanOptionsFactory.php" />
-          <install as="datadog_trace/src/DDTrace/GlobalTracer.php"  name="src/DDTrace/GlobalTracer.php" />
-          <install as="datadog_trace/src/DDTrace/NoopSpan.php"  name="src/DDTrace/NoopSpan.php" />
-          <install as="datadog_trace/src/DDTrace/Configuration.php"  name="src/DDTrace/Configuration.php" />
-          <install as="datadog_trace/src/DDTrace/Obfuscation.php"  name="src/DDTrace/Obfuscation.php" />
-          <install as="datadog_trace/src/DDTrace/Propagator.php"  name="src/DDTrace/Propagator.php" />
-          <install as="datadog_trace/src/DDTrace/try_catch_finally.php"  name="src/DDTrace/try_catch_finally.php" />
-          <install as="datadog_trace/src/DDTrace/Encoders/MessagePack.php"  name="src/DDTrace/Encoders/MessagePack.php" />
-          <install as="datadog_trace/src/DDTrace/Encoders/SpanEncoder.php"  name="src/DDTrace/Encoders/SpanEncoder.php" />
-          <install as="datadog_trace/src/DDTrace/Encoders/Noop.php"  name="src/DDTrace/Encoders/Noop.php" />
-          <install as="datadog_trace/src/DDTrace/Encoders/Json.php"  name="src/DDTrace/Encoders/Json.php" />
-          <install as="datadog_trace/src/DDTrace/Encoder.php"  name="src/DDTrace/Encoder.php" />
-          <install as="datadog_trace/src/DDTrace/OpenTracer/ScopeManager.php"  name="src/DDTrace/OpenTracer/ScopeManager.php" />
-          <install as="datadog_trace/src/DDTrace/OpenTracer/SpanContext.php"  name="src/DDTrace/OpenTracer/SpanContext.php" />
-          <install as="datadog_trace/src/DDTrace/OpenTracer/Tracer.php"  name="src/DDTrace/OpenTracer/Tracer.php" />
-          <install as="datadog_trace/src/DDTrace/OpenTracer/Scope.php"  name="src/DDTrace/OpenTracer/Scope.php" />
-          <install as="datadog_trace/src/DDTrace/OpenTracer/Span.php"  name="src/DDTrace/OpenTracer/Span.php" />
-          <install as="datadog_trace/src/DDTrace/NoopTracer.php"  name="src/DDTrace/NoopTracer.php" />
-          <install as="datadog_trace/src/DDTrace/StartSpanOptions.php"  name="src/DDTrace/StartSpanOptions.php" />
-          <install as="datadog_trace/src/DDTrace/Propagators/CurlHeadersMap.php"  name="src/DDTrace/Propagators/CurlHeadersMap.php" />
-          <install as="datadog_trace/src/DDTrace/Propagators/TextMap.php"  name="src/DDTrace/Propagators/TextMap.php" />
-          <install as="datadog_trace/src/DDTrace/Propagators/Noop.php"  name="src/DDTrace/Propagators/Noop.php" />
-          <install as="datadog_trace/src/DDTrace/ScopeManager.php"  name="src/DDTrace/ScopeManager.php" />
-          <install as="datadog_trace/src/DDTrace/NoopScopeManager.php"  name="src/DDTrace/NoopScopeManager.php" />
-          <install as="datadog_trace/src/DDTrace/Util/ContainerInfo.php"  name="src/DDTrace/Util/ContainerInfo.php" />
-          <install as="datadog_trace/src/DDTrace/Util/ArrayKVStore.php"  name="src/DDTrace/Util/ArrayKVStore.php" />
-          <install as="datadog_trace/src/DDTrace/Util/CodeTracer.php"  name="src/DDTrace/Util/CodeTracer.php" />
-          <install as="datadog_trace/src/DDTrace/Util/Runtime.php"  name="src/DDTrace/Util/Runtime.php" />
-          <install as="datadog_trace/src/DDTrace/Util/ObjectKVStore.php"  name="src/DDTrace/Util/ObjectKVStore.php" />
-          <install as="datadog_trace/src/DDTrace/Util/TryCatchFinally.php"  name="src/DDTrace/Util/TryCatchFinally.php" />
-          <install as="datadog_trace/src/DDTrace/Util/Versions.php"  name="src/DDTrace/Util/Versions.php" />
-          <install as="datadog_trace/src/DDTrace/SpanContext.php"  name="src/DDTrace/SpanContext.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/AbstractIntegrationConfiguration.php"  name="src/DDTrace/Integrations/AbstractIntegrationConfiguration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Eloquent/EloquentIntegration.php"  name="src/DDTrace/Integrations/Eloquent/EloquentIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php"  name="src/DDTrace/Integrations/Eloquent/EloquentSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php"  name="src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Lumen/LumenIntegration.php"  name="src/DDTrace/Integrations/Lumen/LumenIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/SandboxedIntegration.php"  name="src/DDTrace/Integrations/SandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/IntegrationsLoader.php"  name="src/DDTrace/Integrations/IntegrationsLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php"  name="src/DDTrace/Integrations/Laravel/V5/LaravelIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Laravel/LaravelIntegration.php"  name="src/DDTrace/Integrations/Laravel/LaravelIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Laravel/V4/LaravelIntegration.php"  name="src/DDTrace/Integrations/Laravel/V4/LaravelIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php"  name="src/DDTrace/Integrations/Laravel/V4/LaravelProvider.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php"  name="src/DDTrace/Integrations/Laravel/LaravelSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Predis/PredisIntegration.php"  name="src/DDTrace/Integrations/Predis/PredisIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Predis/PredisSandboxedIntegration.php"  name="src/DDTrace/Integrations/Predis/PredisSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Web/WebIntegration.php"  name="src/DDTrace/Integrations/Web/WebIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php"  name="src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchCommon.php"  name="src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchCommon.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchSandboxedIntegration.php"  name="src/DDTrace/Integrations/ElasticSearch/V1/ElasticSearchSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php"  name="src/DDTrace/Integrations/Curl/CurlSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Curl/CurlIntegration.php"  name="src/DDTrace/Integrations/Curl/CurlIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php"  name="src/DDTrace/Integrations/Mysqli/MysqliSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php"  name="src/DDTrace/Integrations/Mysqli/MysqliIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mysqli/MysqliCommon.php"  name="src/DDTrace/Integrations/Mysqli/MysqliCommon.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/DefaultIntegrationConfiguration.php"  name="src/DDTrace/Integrations/DefaultIntegrationConfiguration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php"  name="src/DDTrace/Integrations/Memcached/MemcachedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php"  name="src/DDTrace/Integrations/Memcached/MemcachedSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Integration.php"  name="src/DDTrace/Integrations/Integration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php"  name="src/DDTrace/Integrations/WordPress/WordPressSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php"  name="src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Slim/SlimIntegration.php"  name="src/DDTrace/Integrations/Slim/SlimIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Slim/V3/SlimIntegrationLoader.php"  name="src/DDTrace/Integrations/Slim/V3/SlimIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php"  name="src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mongo/MongoIntegration.php"  name="src/DDTrace/Integrations/Mongo/MongoIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mongo/MongoClientIntegration.php"  name="src/DDTrace/Integrations/Mongo/MongoClientIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php"  name="src/DDTrace/Integrations/Mongo/MongoCollectionIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mongo/MongoDBIntegration.php"  name="src/DDTrace/Integrations/Mongo/MongoDBIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php"  name="src/DDTrace/Integrations/Mongo/MongoSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php"  name="src/DDTrace/Integrations/PDO/PDOSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/PDO/PDOIntegration.php"  name="src/DDTrace/Integrations/PDO/PDOIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php"  name="src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php"  name="src/DDTrace/Integrations/CakePHP/V2/CakePHPIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php"  name="src/DDTrace/Integrations/Guzzle/GuzzleSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php"  name="src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php"  name="src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php"  name="src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php"  name="src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php"  name="src/DDTrace/Integrations/ZendFramework/ZendFrameworkSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php"  name="src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php"  name="src/DDTrace/Integrations/Symfony/V3/SymfonyBundle.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php"  name="src/DDTrace/Integrations/Symfony/SymfonyIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php"  name="src/DDTrace/Integrations/Symfony/V4/SymfonyBundle.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php"  name="src/DDTrace/Integrations/Yii/V2/YiiIntegrationLoader.php" />
-          <install as="datadog_trace/src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php"  name="src/DDTrace/Integrations/Yii/YiiSandboxedIntegration.php" />
-          <install as="datadog_trace/src/DDTrace/Format.php"  name="src/DDTrace/Format.php" />
-          <install as="datadog_trace/src/DDTrace/Obfuscation/WildcardToRegex.php"  name="src/DDTrace/Obfuscation/WildcardToRegex.php" />
-          <install as="datadog_trace/src/DDTrace/Log/InterpolateTrait.php"  name="src/DDTrace/Log/InterpolateTrait.php" />
-          <install as="datadog_trace/src/DDTrace/Log/AbstractLogger.php"  name="src/DDTrace/Log/AbstractLogger.php" />
-          <install as="datadog_trace/src/DDTrace/Log/Logger.php"  name="src/DDTrace/Log/Logger.php" />
-          <install as="datadog_trace/src/DDTrace/Log/LoggerInterface.php"  name="src/DDTrace/Log/LoggerInterface.php" />
-          <install as="datadog_trace/src/DDTrace/Log/LoggingTrait.php"  name="src/DDTrace/Log/LoggingTrait.php" />
-          <install as="datadog_trace/src/DDTrace/Log/LogLevel.php"  name="src/DDTrace/Log/LogLevel.php" />
-          <install as="datadog_trace/src/DDTrace/Log/PsrLogger.php"  name="src/DDTrace/Log/PsrLogger.php" />
-          <install as="datadog_trace/src/DDTrace/Log/ErrorLogLogger.php"  name="src/DDTrace/Log/ErrorLogLogger.php" />
-          <install as="datadog_trace/src/DDTrace/Log/NullLogger.php"  name="src/DDTrace/Log/NullLogger.php" />
-          <install as="datadog_trace/src/DDTrace/Tracer.php"  name="src/DDTrace/Tracer.php" />
-          <install as="datadog_trace/src/DDTrace/Configuration/Registry.php"  name="src/DDTrace/Configuration/Registry.php" />
-          <install as="datadog_trace/src/DDTrace/Configuration/AbstractConfiguration.php"  name="src/DDTrace/Configuration/AbstractConfiguration.php" />
-          <install as="datadog_trace/src/DDTrace/Configuration/EnvVariableRegistry.php"  name="src/DDTrace/Configuration/EnvVariableRegistry.php" />
-          <install as="datadog_trace/src/DDTrace/Exceptions/InvalidSpanArgument.php"  name="src/DDTrace/Exceptions/InvalidSpanArgument.php" />
-          <install as="datadog_trace/src/DDTrace/Exceptions/InvalidSpanOption.php"  name="src/DDTrace/Exceptions/InvalidSpanOption.php" />
-          <install as="datadog_trace/src/DDTrace/Exceptions/UnsupportedFormat.php"  name="src/DDTrace/Exceptions/UnsupportedFormat.php" />
-          <install as="datadog_trace/src/DDTrace/Exceptions/InvalidReferencesSet.php"  name="src/DDTrace/Exceptions/InvalidReferencesSet.php" />
-          <install as="datadog_trace/src/DDTrace/Exceptions/InvalidReferenceArgument.php"  name="src/DDTrace/Exceptions/InvalidReferenceArgument.php" />
-          <install as="datadog_trace/src/DDTrace/Transport.php"  name="src/DDTrace/Transport.php" />
-          <install as="datadog_trace/src/DDTrace/Transport/Stream.php"  name="src/DDTrace/Transport/Stream.php" />
-          <install as="datadog_trace/src/DDTrace/Transport/Http.php"  name="src/DDTrace/Transport/Http.php" />
-          <install as="datadog_trace/src/DDTrace/Transport/Noop.php"  name="src/DDTrace/Transport/Noop.php" />
-          <install as="datadog_trace/src/DDTrace/Bootstrap.php"  name="src/DDTrace/Bootstrap.php" />
-          <install as="datadog_trace/src/DDTrace/NoopSpanContext.php"  name="src/DDTrace/NoopSpanContext.php" />
-          <install as="datadog_trace/src/DDTrace/Scope.php"  name="src/DDTrace/Scope.php" />
-          <install as="datadog_trace/src/DDTrace/Processing/TraceAnalyticsProcessor.php"  name="src/DDTrace/Processing/TraceAnalyticsProcessor.php" />
-          <install as="datadog_trace/src/DDTrace/Reference.php"  name="src/DDTrace/Reference.php" />
-          <install as="datadog_trace/src/DDTrace/Type.php"  name="src/DDTrace/Type.php" />
-          <install as="datadog_trace/src/DDTrace/Span.php"  name="src/DDTrace/Span.php" />
-          <install as="datadog_trace/src/DDTrace/Contracts/ScopeManager.php"  name="src/DDTrace/Contracts/ScopeManager.php" />
-          <install as="datadog_trace/src/DDTrace/Contracts/SpanContext.php"  name="src/DDTrace/Contracts/SpanContext.php" />
-          <install as="datadog_trace/src/DDTrace/Contracts/Tracer.php"  name="src/DDTrace/Contracts/Tracer.php" />
-          <install as="datadog_trace/src/DDTrace/Contracts/Scope.php"  name="src/DDTrace/Contracts/Scope.php" />
-          <install as="datadog_trace/src/DDTrace/Contracts/Span.php"  name="src/DDTrace/Contracts/Span.php" />
-          <install as="datadog_trace/src/DDTrace/Time.php"  name="src/DDTrace/Time.php" />
-          <install as="datadog_trace/src/DDTrace/autoload.php"  name="src/DDTrace/autoload.php" />
-          <install as="datadog_trace/src/DDTrace/Http/Request.php"  name="src/DDTrace/Http/Request.php" />
-          <install as="datadog_trace/src/DDTrace/Http/Urls.php"  name="src/DDTrace/Http/Urls.php" />
-          <install as="datadog_trace/src/DDTrace/Tag.php"  name="src/DDTrace/Tag.php" />
-          <install as="datadog_trace/src/DDTrace/NoopScope.php"  name="src/DDTrace/NoopScope.php" />
-          <install as="datadog_trace/bridge/dd_init.php"  name="bridge/dd_init.php" />
-          <install as="datadog_trace/bridge/functions.php"  name="bridge/functions.php" />
-          <install as="datadog_trace/bridge/dd_wrap_autoloader.php"  name="bridge/dd_wrap_autoloader.php" />
-          <install as="datadog_trace/bridge/dd_required_deps_autoloader.php"  name="bridge/dd_required_deps_autoloader.php" />
-          <install as="datadog_trace/bridge/dd_autoloader.php"  name="bridge/dd_autoloader.php" />
-          <install as="datadog_trace/bridge/dd_optional_deps_autoloader.php"  name="bridge/dd_optional_deps_autoloader.php" />
-          <install as="datadog_trace/bridge/dd_require_all.php"  name="bridge/dd_require_all.php" />
+            <install as="datadog_trace/bridge/_generated.php" name="bridge/_generated.php" />
+            <install as="datadog_trace/bridge/autoload.php" name="bridge/autoload.php" />
+            <install as="datadog_trace/bridge/dd_init.php" name="bridge/dd_init.php" />
+            <install as="datadog_trace/bridge/dd_register_optional_deps_autoloader.php" name="bridge/dd_register_optional_deps_autoloader.php" />
+            <install as="datadog_trace/bridge/dd_wrap_autoloader.php" name="bridge/dd_wrap_autoloader.php" />
+            <install as="datadog_trace/bridge/php5.php" name="bridge/php5.php" />
         </filelist>
     </extsrcrelease>
 </package>

--- a/tooling/bin/pecl-build
+++ b/tooling/bin/pecl-build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -f ./bridge/_generated.php
+composer compile
+
+# PECL doesn't like the "-nightly" part of the nightly version number so we have to change it
+dd_version=$(php -r "echo (include 'src/DDTrace/version.php') !== '1.0.0-nightly' ?: '0.0.0';")
+sed -e "s/\${version}/${dd_version}/g" -e "s/\${date}/$(date +%Y-%m-%d)/g" -i package.xml
+
+pear package-validate package.xml
+pear package


### PR DESCRIPTION
### Description

This PR improves and automates several aspects of PECL builds:

- Adds the `_generated.php` file as part of the PECL build
- Adds a PECL build (`pecl/datadog_trace-<version>.tgz`) as part of `package extension` in CI **(do not build PECL packages with `pear package` directly)**
- Runs the phpt tests from the PECL build on all supported PHP versions via `pecl run-tests`
- `package.xml` is automatically updated for `<version>` and `<date>` when the package is built

I've updated the release notes with this information.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
