### PR TITLE
Fix off-by-one error with longest config name for integrations

### DIFF
--- a/src/ext/configuration.c
+++ b/src/ext/configuration.c
@@ -177,14 +177,14 @@ size_t ddtrace_config_integration_env_name(char* name, const char* prefix, ddtra
     ZEND_ASSERT(strlen(prefix) <= DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN);
     ZEND_ASSERT(strlen(suffix) <= DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN);
 #endif
-    return (size_t)snprintf(name, DDTRACE_LONGEST_INTEGRATION_ENV_LEN, "%s%s%s", prefix, integration->name_ucase,
+    return (size_t)snprintf(name, DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1, "%s%s%s", prefix, integration->name_ucase,
                             suffix);
 }
 
 // Get env value for <PREFIX_><INTEGRATION><_SUFFIX>
 ddtrace_string _dd_env_integration_value(const char* prefix, ddtrace_integration* integration,
                                          const char* suffix TSRMLS_DC) {
-    char name[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    char name[DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1];
     size_t len = ddtrace_config_integration_env_name(name, prefix, integration, suffix);
     return ddtrace_string_getenv(name, len TSRMLS_CC);
 }

--- a/src/ext/php5/startup_logging.c
+++ b/src/ext/php5/startup_logging.c
@@ -219,9 +219,9 @@ static void _dd_check_for_deprecated_env(HashTable *ht, const char *old_name, si
 }
 
 static void _dd_check_for_deprecated_integration_envs(HashTable *ht, ddtrace_integration *integration TSRMLS_DC) {
-    char old[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    char old[DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1];
     size_t old_len;
-    char new[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    char new[DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1];
     size_t new_len;
 
     old_len = ddtrace_config_integration_env_name(old, "DD_", integration, "_ANALYTICS_ENABLED");

--- a/src/ext/php7/startup_logging.c
+++ b/src/ext/php7/startup_logging.c
@@ -214,9 +214,9 @@ static void _dd_check_for_deprecated_env(HashTable *ht, const char *old_name, si
 }
 
 static void _dd_check_for_deprecated_integration_envs(HashTable *ht, ddtrace_integration *integration) {
-    char old[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    char old[DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1];
     size_t old_len;
-    char new[DDTRACE_LONGEST_INTEGRATION_ENV_LEN];
+    char new[DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1];
     size_t new_len;
 
     old_len = ddtrace_config_integration_env_name(old, "DD_", integration, "_ANALYTICS_ENABLED");


### PR DESCRIPTION
## Description

There was an off-by-one error that prevented `DD_TRACE_ELASTICSEARCH_ANALYTICS_SAMPLE_RATE` and `DD_TRACE_ZENDFRAMEWORK_ANALYTICS_SAMPLE_RATE` (added in `0.47.1`) from being read properly.

This PR fixes the issue and also adds tests for each integration's specific configuration. The tests also ensure that the integration has been added at the C level in response to [this CR comment](https://github.com/DataDog/dd-trace-php/pull/948#discussion_r465336826).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
