### PR TITLE
Enable the BGS by default on PHP 5.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ aliases:
   - &STEP_EXT_INSTALL
     run:
       name: Build and install extension
-      command: make sudo install install_ini BUILD_DIR=tmp/build_extension
+      command: make sudo install install_ini BUILD_DIR=$(pwd)/tmp/build_extension
 
   - &STEP_COMPOSER_SELF_UPDATE
     run:
@@ -392,7 +392,7 @@ jobs:
           valgrind_config: << parameters.valgrind_config >>
       - run:
           name: Run extension tests with leak detection
-          command: make << parameters.unit_test_target >> BUILD_DIR=tmp/build_extension JUNIT_RESULTS_DIR=$(pwd)/test-results
+          command: make << parameters.unit_test_target >> BUILD_DIR=$(pwd)/tmp/build_extension JUNIT_RESULTS_DIR=$(pwd)/test-results
       - run:
           name: Run unit tests
           command: composer test-unit -- --log-junit test-results/php-unit/results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -959,6 +959,13 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 54 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test-web-54"
+          docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 72 web tests with nginx + FastCGI"
           resource_class: medium+
           sapi: cgi-fcgi

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -82,18 +82,6 @@ void ddtrace_config_shutdown(void);
 /* This should be at least an order of magnitude higher than the userland HTTP Transport default. */
 #define DD_TRACE_BGS_TIMEOUT 5000L
 
-/* There is an issue on PHP 5.4 that has been around for a while that was
- * exposed by the background sender getting enabled. We need to fix that, but
- * until then let's not enable BGS by default on < 5.6.
- *
- * We also don't enable the sandbox on PHP 5.4 yet.
- */
-#if PHP_VERSION_ID < 50600
-#define DD_TRACE_BGS_ENABLED false
-#else
-#define DD_TRACE_BGS_ENABLED true
-#endif
-
 #define DD_CONFIGURATION                                                                                             \
     CHAR(get_dd_trace_agent_url, "DD_TRACE_AGENT_URL", "")                                                           \
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
@@ -133,9 +121,9 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_trace_generate_root_span, "DD_TRACE_GENERATE_ROOT_SPAN", true)                                       \
     BOOL(get_dd_trace_sandbox_enabled, "DD_TRACE_SANDBOX_ENABLED", true)                                             \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", DD_TRACE_BGS_ENABLED,          \
+    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", true,                          \
          "use background thread to send traces to the agent")                                                        \
-    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", DD_TRACE_BGS_ENABLED,                                     \
+    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", true,                                                     \
          "use background sender (BGS) to send traces to the agent")                                                  \
     INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
     INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -4,9 +4,7 @@ Ensure we can read C configuration data
 DD_AGENT_HOST=some_known_host
 DD_TRACE_MEMORY_LIMIT=9999
 --FILE--
-
 <?php
-$bgsShouldBeEnabled = PHP_VERSION_ID >= 50600;
 echo dd_trace_env_config("DD_AGENT_HOST");
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_AGENT_PORT");
@@ -16,9 +14,9 @@ echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_DEBUG_CURL_OUTPUT") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=";
-echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
+echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_MEMORY_LIMIT");
 echo PHP_EOL;
@@ -35,12 +33,11 @@ echo PHP_EOL;
 echo dd_trace_env_config("trace.debug.curl.output") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo "trace.beta.send.traces.via.thread=";
-echo dd_trace_env_config("trace.beta.send.traces.via.thread") === $bgsShouldBeEnabled ? 'TRUE' : 'FALSE';
+echo dd_trace_env_config("trace.beta.send.traces.via.thread") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("trace.memory.limit");
 echo PHP_EOL;
 echo dd_trace_env_config("non.existing.entry") === NULL ? 'NULL' : 'NOT_NULL' ;
-
 ?>
 --EXPECT--
 some_known_host


### PR DESCRIPTION
### Description

This PR enables the background sender by default on PHP 5.4.

This also includes a fix to CI where the phpt tests would not properly report the exit code of `run-tests.php` when running it via `make` on PHP 5.4. Running `run-tests.php` directly fixes this bug as well as a number of other issues we've run into in the past with running the test runner through `make`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~ (Added "PHP 54 web tests with nginx + FastCGI" tests)

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
