### PR TITLE
Defer loading of Predis integration

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -107,6 +107,7 @@ class IntegrationsLoader
         if (\PHP_MAJOR_VERSION >= 7) {
             unset($this->integrations[ElasticSearchSandboxedIntegration::NAME]);
             unset($this->integrations[PHPRedisSandboxedIntegration::NAME]);
+            unset($this->integrations[PredisSandboxedIntegration::NAME]);
         }
     }
 

--- a/src/ext/integrations/integrations.c
+++ b/src/ext/integrations/integrations.c
@@ -63,13 +63,22 @@ static void dd_register_known_calls(TSRMLS_D) {
 
 #if PHP_VERSION_ID >= 70000
 
-static void dd_set_up_deferred_loading_phpredis() {
-    if (!ddtrace_config_integration_enabled_ex(DDTRACE_INTEGRATION_PHPREDIS TSRMLS_CC)) {
+static void dd_set_up_deferred_loading_phpredis(void) {
+    if (!ddtrace_config_integration_enabled_ex(DDTRACE_INTEGRATION_PHPREDIS)) {
         return;
     }
 
     DDTRACE_DEFERRED_INTEGRATION_LOADER("Redis", "__construct",
                                         "DDTrace\\Integrations\\PHPRedis\\PHPRedisSandboxedIntegration");
+}
+
+static void dd_set_up_deferred_loading_predis(void) {
+    if (!ddtrace_config_integration_enabled_ex(DDTRACE_INTEGRATION_PREDIS)) {
+        return;
+    }
+
+    DDTRACE_DEFERRED_INTEGRATION_LOADER("Predis\\Client", "__construct",
+                                        "DDTrace\\Integrations\\Predis\\PredisSandboxedIntegration");
 }
 
 void ddtrace_integrations_rinit(TSRMLS_D) {
@@ -78,6 +87,7 @@ void ddtrace_integrations_rinit(TSRMLS_D) {
     _dd_es_initialize_deferred_integration(TSRMLS_C);
     _dd_load_test_integrations(TSRMLS_C);
     dd_set_up_deferred_loading_phpredis();
+    dd_set_up_deferred_loading_predis();
 }
 
 ddtrace_integration* ddtrace_get_integration_from_string(ddtrace_string integration) {

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -165,8 +165,10 @@ final class IntegrationsLoaderTest extends BaseTestCase
         if (\PHP_MAJOR_VERSION < 7) {
             $excluded[] = 'phpredis'; // PHP 7 only integration
         } else {
-            $excluded[] = 'elasticsearch'; // Deferred loading integration
-            $excluded[] = 'phpredis'; // Deferred loading integration
+            // Deferred loading integrations
+            $excluded[] = 'elasticsearch';
+            $excluded[] = 'phpredis';
+            $excluded[] = 'predis';
         }
         foreach ($excluded as $integrationToExclude) {
             $index = array_search($integrationToExclude, $expected, true);


### PR DESCRIPTION
### Description

This loads the Predis integration once `Predis\Client::__construct` is called. This way if a request doesn't use the predis integration then it isn't loaded (less cost).

It also does some minor cleanup on the deferred loading of phpredis integration impl too.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
