### PR TITLE
Symfony HttpException with status <500 should not be considered as error

### DIFF
--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -147,7 +147,9 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         $exceptionHandlingTracer = function (SpanData $span, $args) use ($integration) {
             $span->name = $span->resource = 'symfony.kernel.handleException';
             $span->service = $integration->appName;
-            $integration->symfonyRequestSpan->setError($args[0]);
+            if (!($args[0] instanceof Symfony\Component\HttpKernel\Exception\HttpExceptionInterface && $args[0] < 500)) {
+                $integration->symfonyRequestSpan->setError($args[0]);
+            }
         };
         // Symfony 4.3-
         \DDTrace\trace_method('Symfony\Component\HttpKernel\HttpKernel', 'handleException', $exceptionHandlingTracer);


### PR DESCRIPTION
### Description

A better Symfony instrument has been added to Symfony 4.4.
However, HttpException with HTTP Status 400, 404, ... are considered as error for Datadog.
They should not be considered as errors but as normal usage.
I propose this PR in order to modify this behavior.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.