### PR TITLE
Fix pecl-build for real releases

### DIFF
--- a/tooling/bin/pecl-build
+++ b/tooling/bin/pecl-build
@@ -6,7 +6,7 @@ rm -f ./bridge/_generated.php
 composer compile
 
 # PECL doesn't like the "-nightly" part of the nightly version number so we have to change it
-dd_version=$(php -r "echo (include 'src/DDTrace/version.php') !== '1.0.0-nightly' ?: '0.0.0';")
+dd_version=$(php -r "echo str_replace('1.0.0-nightly', '0.0.0', require 'src/DDTrace/version.php');")
 sed -e "s/\${version}/${dd_version}/g" -e "s/\${date}/$(date +%Y-%m-%d)/g" -i package.xml
 
 pear package-validate package.xml


### PR DESCRIPTION
### Description

This was cherry-picked from the 0.48.0 release PR #997. It fixes the build for real releases.

Although the existing tests are adequate, should we persist the artifact in the CI job?

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests are adequate.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
