### PR TITLE
Block Zend signals from background sender thread

### DIFF
--- a/.circleci/valgrind/valgrind_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_musl_suppressions.lib
@@ -154,3 +154,17 @@
     fun:execute_ex
     fun:ddtrace_execute_ex
 }
+{
+    <PHP 5.4 leaks at request timeout>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:_emalloc
+    fun:compile_file
+    fun:phar_compile_file
+    fun:_dd_compile_file
+    fun:zend_execute_scripts
+    fun:php_execute_script
+    fun:do_cli
+    fun:main
+}

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test_c: $(SO_FILE)
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
 	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
+	export USE_TRACKED_ALLOC=1; \
 	\
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
 	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all $(TESTS)
@@ -62,6 +63,7 @@ test_c_mem: $(SO_FILE)
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
 	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
+	export USE_TRACKED_ALLOC=1; \
 	\
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
 	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all -m $(TESTS)

--- a/package.xml
+++ b/package.xml
@@ -401,6 +401,7 @@
             <file name="tests/ext/get_memory_limit_unlimited_set_by_absolute.phpt" role="test" />
             <file name="tests/ext/get_memory_limit_unlimited_set_by_percentage.phpt" role="test" />
             <file name="tests/ext/read_c_configuration.phpt" role="test" />
+            <file name="tests/ext/request_timeout_01.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
             <file name="tests/ext/startup_logging.inc" role="test" />

--- a/tests/ext/request_timeout_01.phpt
+++ b/tests/ext/request_timeout_01.phpt
@@ -1,0 +1,31 @@
+--TEST--
+A PHP request timeout does not leak/segfault (run with leak detection)
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+max_execution_time=1
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo 'Shutdown' . PHP_EOL;
+});
+
+function makeFatalError() {
+    // Trigger a fatal error (hit the max execution time)
+    while(1) {}
+    return 42;
+}
+
+function main() {
+    var_dump(array_sum([1, 99]));
+    makeFatalError();
+    echo 'You should not see this.' . PHP_EOL;
+}
+
+main();
+?>
+--EXPECTF--
+int(100)
+
+%s Maximum execution time of 1 second exceeded in %s on line %d
+Shutdown


### PR DESCRIPTION
### Description

If the background thread is delivered these signals then it probably results in a crash. PHP 7.0 is the only version I could trigger an issue on; PHP 5 and PHP 7.1+ don't seem to trigger it.

Notably, PHP uses SIGPROF on Linux to trigger the timeout (this is a gross abuse of this signal, imo, but that's out of our control). If the background thread intercepts this signal it will badly crash.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.