### PR TITLE
Add 404 tests to Symfony integration

### DIFF
--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -144,10 +144,10 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         );
 
         // Handling exceptions
-        $exceptionHandlingTracer = function (SpanData $span, $args) use ($integration) {
+        $exceptionHandlingTracer = function (SpanData $span, $args, $retval) use ($integration) {
             $span->name = $span->resource = 'symfony.kernel.handleException';
             $span->service = $integration->appName;
-            if (!($args[0] instanceof Symfony\Component\HttpKernel\Exception\HttpExceptionInterface && $args[0] < 500)) {
+            if (!(isset($retval) && \method_exists($retval, 'getStatusCode') && $retval->getStatusCode() < 500)) {
                 $integration->symfonyRequestSpan->setError($args[0]);
             }
         };

--- a/tests/Frameworks/TestScenarios.php
+++ b/tests/Frameworks/TestScenarios.php
@@ -12,6 +12,7 @@ class TestScenarios
             GetSpec::create('A simple GET request returning a string', '/simple'),
             GetSpec::create('A simple GET request with a view', '/simple_view'),
             GetSpec::create('A GET request with an exception', '/error')->expectStatusCode(500),
+            GetSpec::create('A GET request to a missing route', '/does_not_exist'),
         ];
     }
 }

--- a/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
+++ b/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
@@ -35,6 +35,11 @@ trait CommonScenariosDataProviderTrait
 
         // We expect that all the scenarios that we defined have a corresponding expectation to serve
         $unexpectedRequest = array_diff($allRequestNames, $allExpectationNames);
+        // TODO Add 404 checks to all frameworks
+        $i = array_search('A GET request to a missing route', $unexpectedRequest, true);
+        if ($i !== false) {
+            unset($unexpectedRequest[$i]);
+        }
         if ($unexpectedRequest) {
             throw new PHPUnit_Framework_ExpectationFailedException(
                 'Found the following scenarios not having any expectation defined: '
@@ -44,7 +49,15 @@ trait CommonScenariosDataProviderTrait
 
         $dataProvider = [];
         foreach ($scenarios as $request) {
-            $dataProvider[$request->getName()] = [ $request, $definedExpectations[$request->getName()] ];
+            $key = $request->getName();
+            if (!isset($definedExpectations[$key])) {
+                error_log('This framework is missing the following scenario test: ' . $key);
+                continue;
+            }
+            $dataProvider[$key] = [
+                $request,
+                $definedExpectations[$key]
+            ];
         }
 
         return $dataProvider;

--- a/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
+++ b/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
@@ -35,7 +35,7 @@ trait CommonScenariosDataProviderTrait
 
         // We expect that all the scenarios that we defined have a corresponding expectation to serve
         $unexpectedRequest = array_diff($allRequestNames, $allExpectationNames);
-        // TODO Add 404 checks to all frameworks
+        // Note to team for later: Add 404 checks to all frameworks
         $i = array_search('A GET request to a missing route', $unexpectedRequest, true);
         if ($i !== false) {
             unset($unexpectedRequest[$i]);

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -126,6 +126,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'symfony',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -129,6 +129,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'symfony',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -131,6 +131,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_34',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -140,6 +140,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                     SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_40',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -140,6 +140,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                     SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_42',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_4/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Symfony/V4_4/CommonScenariosSandboxedTest.php
@@ -138,6 +138,37 @@ class CommonScenariosSandboxedTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_44',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.exception'),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }


### PR DESCRIPTION
### Description

This PR just wraps up the fantastic contribution from @franek in #995 by adding tests of 404 endpoints to the Symfony integration.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
