### PR TITLE
Release 0.48.1

### DIFF
--- a/.circleci/valgrind/valgrind_musl_suppressions.lib
+++ b/.circleci/valgrind/valgrind_musl_suppressions.lib
@@ -154,3 +154,17 @@
     fun:execute_ex
     fun:ddtrace_execute_ex
 }
+{
+    <PHP 5.4 leaks at request timeout>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:_emalloc
+    fun:compile_file
+    fun:phar_compile_file
+    fun:_dd_compile_file
+    fun:zend_execute_scripts
+    fun:php_execute_script
+    fun:do_cli
+    fun:main
+}

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,12 @@ install_all: install install_ini
 
 test_c: export DD_TRACE_CLI_ENABLED=1
 test_c: $(SO_FILE)
+	export USE_TRACKED_ALLOC=1; \
 	$(MAKE) -C $(BUILD_DIR) test TESTS="-q --show-all $(TESTS)"
 
 test_c_mem: export DD_TRACE_CLI_ENABLED=1
 test_c_mem: $(SO_FILE)
+	export USE_TRACKED_ALLOC=1; \
 	$(MAKE) -C $(BUILD_DIR) test TESTS="-q --show-all -m $(TESTS)"
 
 test_c_asan: export DD_TRACE_CLI_ENABLED=1

--- a/package.xml
+++ b/package.xml
@@ -440,6 +440,7 @@ All calls to `DDTrace\trace_function` or `DDTrace\trace_method` functions need t
             <file name="tests/ext/get_memory_limit_unlimited_set_by_absolute.phpt" role="test" />
             <file name="tests/ext/get_memory_limit_unlimited_set_by_percentage.phpt" role="test" />
             <file name="tests/ext/read_c_configuration.phpt" role="test" />
+            <file name="tests/ext/request_timeout_01.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
             <file name="tests/ext/startup_logging.inc" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -344,7 +344,14 @@ All calls to `DDTrace\trace_function` or `DDTrace\trace_method` functions need t
             <file name="tests/ext/sandbox/safe_to_string_metadata.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_properties.phpt" role="test" />
-            <file name="tests/ext/sandbox/spans_out_of_sync.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_01.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_03_php5.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_03_php7.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_04_php5.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_04_php7.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_05.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_06.phpt" role="test" />
             <file name="tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt" role="test" />
             <file name="tests/ext/sandbox/variadic_args_internal.phpt" role="test" />
             <file name="tests/ext/sandbox/variadic_no_args.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -12,12 +12,12 @@
     </lead>
     <!-- **Automatically updated with pecl-build script** -->
     <!-- Date only needs to be set if it was packaged on a different day from release -->
-    <date>2020-08-25</date>
+    <date>2020-08-31</date>
     <version>
         <!-- **Automatically updated with pecl-build script** -->
         <!-- Version will be set from version.php or 0.0.0 for nightly builds -->
-        <release>0.48.0</release>
-        <api>0.48.0</api>
+        <release>0.48.1</release>
+        <api>0.48.1</api>
     </version>
     <stability>
         <release>stable</release>
@@ -25,44 +25,10 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-## Important!
-The legacy API for custom instrumentation `dd_trace()` is now a no-op in this release. See the [upgrade guide](https://docs.datadoghq.com/tracing/custom_instrumentation/php/?tab=tracingfunctioncalls#legacy-api-upgrade-guide) for instructions on upgrading.
-
-The way PHP 5.4 and 5.6 hook into the engine has changed. Please read [deep call stacks on PHP 5](https://docs.datadoghq.com/tracing/troubleshooting/php_5_deep_call_stacks/) for more information on potential issues.
-
-All calls to `DDTrace\trace_function` or `DDTrace\trace_method` functions need to happen before the first invocation of the target e.g. `DDTrace\trace_function('foo', ...)` should be done before `foo` is called for the first time. In the future this may need to be done before the target is even defined. This was previously noted in 0.45.0, but is now enforced for all PHP versions.
-
-
-### Added
-
-- Deferred initialization of integrations, and matching integration to a callable at compile time #891 #972
-- Test for non-zero durations #950
-- Add support for PHPRedis 3 extension on PHP 7 #948
-- Add support for PHPRedis 4 extension on PHP 7 #982
-- Add support for PHPRedis 5 extension on PHP 7 #983
-- Add non-tracing API (hook_function/hook_method) #984
-
-### Changed
-
-- Improve CGI usage in test suite #952 (thank you @remicollet!)
-- Remove `ddtrace.strict_mode` INI setting #955
-- Sandbox PHP 5.6 using `zend_execute_ex` + `zend_execute_internal` #970
-- Package `_generated.php` with PECL #980
-- Move startup logs behind debug mode #986
-- Split PHP 7's opcode handlers for previous case #987
-- Sandbox PHP 5.4, cache negative lookups on PHP 5, and delete integrations using dd_trace #988
-- Cleanup PHP 7 curl handlers #989
-- Update dd_trace warning for being a no-op #990
-- Defer loading of PHPRedis #992
-- Defer loading of Predis #994
-
 ### Fixed
-
-- Compatibility issues with PECL #845 (thank you @remicollet!)
-- Fix package.xml validation for PECL #954
-- Removed obsolete pre-integrations loading check from dd-doctor.php #956
-- Fix off-by-one error with longest config name for integrations #985
-
+- Symfony HttpException with status less than 500 should not be considered an error #995, #1002 (thanks, @franek!)
+- Block Zend signals from background sender thread #1000
+- Fix out-of-sync issue if span stack is closed while a closure is running #1001
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonySandboxedIntegration.php
@@ -144,10 +144,12 @@ class SymfonySandboxedIntegration extends SandboxedIntegration
         );
 
         // Handling exceptions
-        $exceptionHandlingTracer = function (SpanData $span, $args) use ($integration) {
+        $exceptionHandlingTracer = function (SpanData $span, $args, $retval) use ($integration) {
             $span->name = $span->resource = 'symfony.kernel.handleException';
             $span->service = $integration->appName;
-            $integration->symfonyRequestSpan->setError($args[0]);
+            if (!(isset($retval) && \method_exists($retval, 'getStatusCode') && $retval->getStatusCode() < 500)) {
+                $integration->symfonyRequestSpan->setError($args[0]);
+            }
         };
         // Symfony 4.3-
         \DDTrace\trace_method('Symfony\Component\HttpKernel\HttpKernel', 'handleException', $exceptionHandlingTracer);

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -26,7 +26,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '0.48.0'; // Update ./version.php too
+    const VERSION = '0.48.1'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '0.48.0'; // Update Tracer::VERSION too
+return '0.48.1'; // Update Tracer::VERSION too

--- a/src/ext/php5_4/engine_hooks.c
+++ b/src/ext/php5_4/engine_hooks.c
@@ -284,6 +284,12 @@ static void dd_set_default_properties(ddtrace_span_fci *span_fci, zend_function 
 
 static void dd_tracing_posthook_impl(zend_function *fbc, ddtrace_span_fci *span_fci, zval *return_value TSRMLS_DC) {
     bool keep_span = dd_tracing_posthook_impl_impl(fbc, span_fci, return_value TSRMLS_CC);
+
+    if (span_fci != DDTRACE_G(open_spans_top)) {
+        // This can happen if the tracer flushes while an internal span is active
+        return;
+    }
+
     if (keep_span) {
         dd_set_default_properties(span_fci, fbc TSRMLS_CC);
         ddtrace_close_span(TSRMLS_C);

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "0.48.0"
+#define PHP_DDTRACE_VERSION "0.48.1"
 #endif

--- a/tests/Frameworks/TestScenarios.php
+++ b/tests/Frameworks/TestScenarios.php
@@ -12,6 +12,7 @@ class TestScenarios
             GetSpec::create('A simple GET request returning a string', '/simple'),
             GetSpec::create('A simple GET request with a view', '/simple_view'),
             GetSpec::create('A GET request with an exception', '/error')->expectStatusCode(500),
+            GetSpec::create('A GET request to a missing route', '/does_not_exist'),
         ];
     }
 }

--- a/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
+++ b/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
@@ -35,6 +35,11 @@ trait CommonScenariosDataProviderTrait
 
         // We expect that all the scenarios that we defined have a corresponding expectation to serve
         $unexpectedRequest = array_diff($allRequestNames, $allExpectationNames);
+        // Note to team for later: Add 404 checks to all frameworks
+        $i = array_search('A GET request to a missing route', $unexpectedRequest, true);
+        if ($i !== false) {
+            unset($unexpectedRequest[$i]);
+        }
         if ($unexpectedRequest) {
             throw new PHPUnit_Framework_ExpectationFailedException(
                 'Found the following scenarios not having any expectation defined: '
@@ -44,7 +49,15 @@ trait CommonScenariosDataProviderTrait
 
         $dataProvider = [];
         foreach ($scenarios as $request) {
-            $dataProvider[$request->getName()] = [ $request, $definedExpectations[$request->getName()] ];
+            $key = $request->getName();
+            if (!isset($definedExpectations[$key])) {
+                error_log('This framework is missing the following scenario test: ' . $key);
+                continue;
+            }
+            $dataProvider[$key] = [
+                $request,
+                $definedExpectations[$key]
+            ];
         }
 
         return $dataProvider;

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -126,6 +126,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'symfony',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -129,6 +129,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'symfony',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -131,6 +131,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_34',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -140,6 +140,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                     SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_40',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -140,6 +140,37 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                     SpanAssertion::exists('symfony.kernel.terminate')->skipIf(static::IS_SANDBOX),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_42',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_4/CommonScenariosSandboxedTest.php
+++ b/tests/Integrations/Symfony/V4_4/CommonScenariosSandboxedTest.php
@@ -138,6 +138,37 @@ class CommonScenariosSandboxedTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_44',
+                        'web',
+                        'GET /does_not_exist'
+                    )
+                        ->withExactTags([
+                            'http.method' => 'GET',
+                            'http.url' => 'http://localhost:9999/does_not_exist',
+                            'http.status_code' => '404',
+                        ])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.exception'),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                ],
             ]
         );
     }

--- a/tests/ext/request_timeout_01.phpt
+++ b/tests/ext/request_timeout_01.phpt
@@ -1,0 +1,31 @@
+--TEST--
+A PHP request timeout does not leak/segfault (run with leak detection)
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+max_execution_time=1
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo 'Shutdown' . PHP_EOL;
+});
+
+function makeFatalError() {
+    // Trigger a fatal error (hit the max execution time)
+    while(1) {}
+    return 42;
+}
+
+function main() {
+    var_dump(array_sum([1, 99]));
+    makeFatalError();
+    echo 'You should not see this.' . PHP_EOL;
+}
+
+main();
+?>
+--EXPECTF--
+int(100)
+
+%s Maximum execution time of 1 second exceeded in %s on line %d
+Shutdown

--- a/tests/ext/sandbox/spans_out_of_sync_01.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [internal]
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'dd_trace_serialize_closed_spans';
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_02.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Gracefully handle out-of-sync spans
+Gracefully handle out-of-sync spans from traced function [internal][default properties]
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
@@ -9,7 +9,6 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
 // when this closure runs, DDTrace\SpanData will have been freed already.
 DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
     echo 'You should not see this.' . PHP_EOL;
-    $span->name = 'dd_trace_serialize_closed_spans';
 });
 
 var_dump(dd_trace_serialize_closed_spans());

--- a/tests/ext/sandbox/spans_out_of_sync_03_php5.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_03_php5.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [user]
+--ENV--
+DD_TRACE_DEBUG=1
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION !== 5) die('skip: php 5 required'); ?>
+--FILE--
+<?php
+
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'shutdown_and_flush';
+});
+
+function shutdown_and_flush() {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+array(0) {
+}
+Cannot run tracing closure for shutdown_and_flush(); spans out of sync
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_03_php7.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_03_php7.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [user]
+--ENV--
+DD_TRACE_DEBUG=1
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION !== 7) die('skip: php 7 required'); ?>
+--FILE--
+<?php
+
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'shutdown_and_flush';
+});
+
+function shutdown_and_flush() {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_04_php5.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_04_php5.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [user][default properties]
+--ENV--
+DD_TRACE_DEBUG=1
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION !== 5) die('skip: php 5 required'); ?>
+--FILE--
+<?php
+
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+function shutdown_and_flush() {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+array(0) {
+}
+Cannot run tracing closure for shutdown_and_flush(); spans out of sync
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_04_php7.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_04_php7.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [user][default properties]
+--ENV--
+DD_TRACE_DEBUG=1
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION !== 7) die('skip: php 7 required'); ?>
+--FILE--
+<?php
+
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+function shutdown_and_flush() {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_05.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user]
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    $span->name = 'shutdown_and_flush';
+
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_06.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user][default properties]
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Fixed
- Symfony HttpException with status less than 500 should not be considered an error #995, #1002 (thanks, @franek!)
- Block Zend signals from background sender thread #1000
- Fix out-of-sync issue if span stack is closed while a closure is running #1001

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
