### PR TITLE
Add PHP 5.5-debug-buster image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
   '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
   '5.5': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5' }
   '5.5-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5-debug' }
+  '5.5-debug-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.5-debug-buster' }
   '5.6':
     <<: *base_php_service
     image: datadog/dd-trace-ci:php-dev-5.6


### PR DESCRIPTION
### Description

This is in preparation of supporting PHP 5.5. The corresponding docker image PR is DataDog/dd-trace-ci#25.

### Readiness checklist
- [x] ~Changelog has been added to the release document.~
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] ~Milestone is set.~
- [x] ~Changelog has been added to the release document.~
