### PR TITLE
Sandbox flush in limited mode on PHP 5.4

### DIFF
--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -40,15 +40,6 @@ final class Bootstrap
             }
         };
 
-        // TO BE REMOVED as part of APMPHP-381
-        if (PHP_VERSION_ID < 50500) {
-            if (\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN')) {
-                self::initRootSpan($tracer);
-                register_shutdown_function($flushTracer);
-            }
-            return;
-        }
-
         \DDTrace\trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', [
             'instrument_when_limited' => 1,
             'posthook' => $flushTracer,

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -29,21 +29,14 @@ final class Bootstrap
 
         $tracer = self::resetTracer();
 
-        $flushTracer = function () {
-            dd_trace_disable_in_request(); //disable function tracing to speedup shutdown
-
+        \DDTrace\hook_method('DDTrace\\Bootstrap', 'flushTracerShutdown', null, function () {
             $tracer = GlobalTracer::get();
             $scopeManager = $tracer->getScopeManager();
             $scopeManager->close();
             if (!\dd_trace_env_config('DD_TRACE_AUTO_FLUSH_ENABLED')) {
                 $tracer->flush();
             }
-        };
-
-        \DDTrace\trace_method('DDTrace\\Bootstrap', 'flushTracerShutdown', [
-            'instrument_when_limited' => 1,
-            'posthook' => $flushTracer,
-        ]);
+        });
 
         if (\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN')) {
             self::initRootSpan($tracer);


### PR DESCRIPTION
### Description

Enable sandboxed writing of traces when reached spans limit on php 5.4 now that 5.4 is sandboxed

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
