### PR TITLE
Call ddtrace_engine_hooks_{rinit,rshutdown}

### DIFF
--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -354,6 +354,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         dd_request_init_hook_rinit(TSRMLS_C);
     }
 
+    ddtrace_engine_hooks_rinit(TSRMLS_C);
     ddtrace_bgs_log_rinit(PG(error_log));
     ddtrace_dispatch_init(TSRMLS_C);
     ddtrace_distributed_tracing_rinit(TSRMLS_C);
@@ -388,6 +389,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_engine_hooks_rshutdown(TSRMLS_C);
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown(TSRMLS_C);
 


### PR DESCRIPTION
### Description

These were added, but then never called :facepalm:

Honestly, we were unlucky that tests did not catch this. This means
that most of the time the function used the same address in subsequent
requests.

I also don't know how to add a test for this, as I don't know how to
force the address to change.

I believe issue #1012 is caused by this, but have not confirmed it yet.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
