### PR TITLE
Deprecate dd-doctor.php

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,22 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Bug description
+<!-- A clear and concise description of the bug. -->
 
-**PHP Info**
-- Output of `php -v`
-- Output of `php -m`
+### PHP version
+<!-- Output of `php -v` -->
 
-**OS Info**
-- Output of `cat /etc/os-release | grep -E "(NAME)|(VERSION)"`
+### Installed extensions
+<!-- Output of `php -m` -->
 
-**Output of dd-doctor**
-- Deploy `dd-doctor` to your root folder `curl https://raw.githubusercontent.com/DataDog/dd-trace-php/master/src/dd-doctor.php -o <path-to-webroot>/<some-random-name>.php`
-- Access it at `http://your-host/<some-random-name>.php`
-- Paste here the output
-- Remember to remove the file `<path-to-webroot>/<some-random-name>.php` when you are done.
+### OS info
+<!-- Output of `cat /etc/os-release | grep -E "(NAME)|(VERSION)"` -->
 
-**If you are upgrading**
+### Diagnostics and configuration
 
-If you are upgrading from a previous version that did not show the bug, please provide us with the version number.
+#### Output of phpinfo() (ddtrace >= 0.47.0)
+<!-- Remove this section if the installed version of ddtrace is < 0.47.0 -->
+
+<!-- 1. Create a `phpinfo()` page: `<?php phpinfo(); ?>` and load the page from a web browser -->
+<!-- 2. Scroll down to the "ddtrace" section -->
+<!-- 2a. Take a screenshot of the whole "ddtrace" section and drag the image into this text box to attach the screenshot -->
+<!-- 2b. OR copy the "DATADOG TRACER CONFIGURATION" JSON and the "Diagnostics" section and paste them here  -->
+
+<!-- If this issue is related to the CLI SAPI, copy the output of `php --ri=ddtrace` and paste it here. -->
+
+#### Output of dd-doctor (ddtrace < 0.47.0)
+<!-- Remove this section if the installed version of ddtrace is >= 0.47.0 -->
+
+<!-- 1. Deploy `dd-doctor.php` to your root folder `curl https://raw.githubusercontent.com/DataDog/dd-trace-php/master/src/dd-doctor.php -o <path-to-webroot>/<some-random-name>.php` -->
+<!-- 2. Access it at `http://your-host/<some-random-name>.php` -->
+<!-- 3. Paste the output here -->
+<!-- 4. Remember to remove the file `<path-to-webroot>/<some-random-name>.php` when you are done -->
+
+### Upgrading info
+<!-- Remove this section if you did not upgrade ddtrace and/or PHP -->
+
+<!-- If you are upgrading from a previous version of ddtrace and/or PHP, please provide the previously installed version number(s) here. -->

--- a/src/dd-doctor.php
+++ b/src/dd-doctor.php
@@ -180,6 +180,23 @@ render('PHP version and SAPI', PHP_VERSION . ' - ' . PHP_SAPI);
 renderSuccessOrFailure('ddtrace extension installed', extension_loaded('ddtrace') || extension_loaded('dd_trace'));
 $versionInstalled = phpversion('ddtrace') ?: false;
 render('ddtrace version (installed)', $versionInstalled);
+
+if (extension_loaded('ddtrace') && version_compare(phpversion('ddtrace'), '0.47.0', '>=')) {
+    echo PHP_EOL . PHP_EOL;
+    echo '******************************************************' . PHP_EOL;
+    echo '** WARNING: The dd-doctor.php script is deprecated. **' . PHP_EOL;
+    echo '******************************************************' . PHP_EOL;
+    echo 'Please refer to the "ddtrace" section of a phpinfo() page:' . PHP_EOL;
+    echo PHP_EOL;
+    echo escape('    <?php phpinfo(); ?>') . PHP_EOL;
+    echo PHP_EOL;
+    echo 'For the CLI SAPI, please refer to the extension information from:' . PHP_EOL;
+    echo PHP_EOL;
+    echo '    $ php --ri=ddtrace' . PHP_EOL;
+    echo PHP_EOL;
+    exit(0);
+}
+
 $versionConst = defined('DD_TRACE_VERSION') ? DD_TRACE_VERSION : false;
 render('ddtrace version (const)', $versionConst);
 $initHook = ini_get('ddtrace.request_init_hook');


### PR DESCRIPTION
### Description

Deprecates `dd-doctor.php` in favor of using `phpinfo()` for troubleshooting. Also updates the GitHub issue template to refer to a `phpinfo()` page.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
