### PR TITLE
Add Slim 3 to PHP 5.5's test suite

### DIFF
--- a/.circleci/php-5.5_web.txt
+++ b/.circleci/php-5.5_web.txt
@@ -3,6 +3,7 @@ cakephp-28-suite
 codeigniter-22-test
 laravel-42-suite
 lumen-52-suite
+slim-312-suite
 symfony-23-suite
 symfony-28-suite
 symfony-30-suite

--- a/composer.json
+++ b/composer.json
@@ -290,6 +290,7 @@
             "@cakephp-28-update",
             "@laravel-42-update",
             "@lumen-52-update",
+            "@slim-312-update",
             "@symfony-23-update",
             "@symfony-28-update",
             "@symfony-30-update",
@@ -304,6 +305,7 @@
             "@codeigniter-22-test",
             "@laravel-42-test",
             "@lumen-52-test",
+            "@slim-312-test",
             "@symfony-23-test",
             "@symfony-28-test",
             "@symfony-30-test",
@@ -570,6 +572,7 @@
 
         "slim-312-update": "@composer --working-dir=tests/Frameworks/Slim/Version_3_12 update",
         "slim-312-test": "@composer test -- --testsuite=slim-312-test",
+        "slim-312-suite": ["@slim-312-update", "@slim-312-test"],
 
         "symfony-23-update": [
             "@composer --working-dir=tests/Frameworks/Symfony/Version_2_3 update"

--- a/tests/Frameworks/Slim/Version_3_12/composer.json
+++ b/tests/Frameworks/Slim/Version_3_12/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.5",
         "monolog/monolog": "^1.17",
         "slim/php-view": "^2.0",
         "slim/slim": "^3.1",
         "slim/twig-view": "^2.5"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.0"
+        "phpunit/phpunit": ">=4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -5,7 +5,6 @@ namespace DDTrace\Tests\Integrations\Slim\V3_12;
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
-use DDTrace\Util\Versions;
 
 final class CommonScenariosTest extends WebFrameworkTestCase
 {
@@ -38,9 +37,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
 
     public function provideSpecs()
     {
-        if (Versions::phpVersionMatches('5.6')) {
+        if (\PHP_MAJOR_VERSION < 7) {
             // Controller's __invoke method is not traced until we support tracing prehook
-            // zend_execute_internals so some metadata is missing in 5.6, e.g. controller name.
+            // zend_execute_internals so some metadata is missing in 5, e.g. controller name.
             return $this->buildDataProvider(
                 [
                     'A simple GET request returning a string' => [


### PR DESCRIPTION
### Description

This is a follow-up PR to Support PHP 5.5 #1008 that adds Slim 3 to the test suites for PHP 5.5.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
