### PR TITLE
Add PHP 5.4 to PECL build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,7 +685,14 @@ jobs:
       - run:
           name: Run phpt tests with PECL
           command: |
-            sudo pecl run-tests <<# parameters.showdiff >> --showdiff <</ parameters.showdiff >> --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
+            TERM=dumb sudo pecl run-tests <<# parameters.showdiff >> --showdiff <</ parameters.showdiff >> --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
+      - run:
+          name: Gather .diff files for artifacts
+          command: |
+            mkdir -p /tmp/artifacts
+            find $(pecl config-get test_dir) -type f -name '*.diff' -exec cp --parents '{}' /tmp/artifacts \;
+          when: on_fail
+      - store_artifacts: { path: '/tmp/artifacts' }
 
   compile_extension:
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,9 @@ jobs:
     parameters:
       docker_image:
         type: string
+      showdiff:
+        type: boolean
+        default: true
     working_directory: ~/datadog
     executor:
       name: with_agent
@@ -682,7 +685,7 @@ jobs:
       - run:
           name: Run phpt tests with PECL
           command: |
-            sudo pecl run-tests --showdiff --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
+            sudo pecl run-tests <<# parameters.showdiff >> --showdiff <</ parameters.showdiff >> --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
 
   compile_extension:
     working_directory: ~/datadog
@@ -1016,6 +1019,12 @@ workflows:
           name: "php:7.3"
           docker_image: php:7.3
           package_type: deb
+      - pecl_tests:
+          requires: [ "Build PECL" ]
+          name: "PHP 54 PECL tests"
+          docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
+          # PHP 5.4's pecl doesn't support showdiff
+          showdiff: false
       - pecl_tests:
           requires: [ "Build PECL" ]
           name: "PHP 55 PECL tests"

--- a/config.m4
+++ b/config.m4
@@ -136,7 +136,10 @@ if test "$PHP_DDTRACE" != "no"; then
 
   if test $PHP_VERSION -lt 50500; then
     PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/php5_4])
-  elif test $PHP_VERSION -lt 70000; then
+  fi
+
+  dnl PHP 5.4 uses things from the php5 folder too
+  if test $PHP_VERSION -lt 70000; then
     PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/php5])
   elif test $PHP_VERSION -lt 80000; then
     PHP_ADD_BUILD_DIR([$ext_builddir/src/ext/php7])

--- a/package.xml
+++ b/package.xml
@@ -445,7 +445,7 @@
     <dependencies>
         <required>
             <php>
-                <min>5.5</min>
+                <min>5.4</min>
                 <max>7.4.99</max>
             </php>
             <pearinstaller>

--- a/tests/ext/call_user_func/namespaced-array.phpt
+++ b/tests/ext/call_user_func/namespaced-array.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Test that call_user_func_array can trace inside a namespace
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not yet supported'); ?>
 <?php if (PHP_MAJOR_VERSION != 5) die("skip: only supported on PHP 5 atm"); ?>
 --FILE--
 <?php

--- a/tests/ext/call_user_func/namespaced.phpt
+++ b/tests/ext/call_user_func/namespaced.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Test that call_user_func can trace inside a namespace
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not yet supported'); ?>
 <?php if (PHP_MAJOR_VERSION != 5) die("skip: only supported on PHP 5 atm"); ?>
 --FILE--
 <?php

--- a/tests/ext/call_user_func/not-namespaced-array.phpt
+++ b/tests/ext/call_user_func/not-namespaced-array.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test that call_user_func_array can trace in global scope
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die("skip: not supported on PHP 5.4"); ?>
 --FILE--
 <?php
 

--- a/tests/ext/call_user_func/not-namespaced.phpt
+++ b/tests/ext/call_user_func/not-namespaced.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test that call_user_func can trace in global scope
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die("skip: not supported on PHP 5.4"); ?>
 --FILE--
 <?php
 

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -4,7 +4,7 @@ Errors in request init hook do not affect error_get_last()
 DD_TRACE_DEBUG=1
 --INI--
 error_reporting=E_ALL
-ddtrace.request_init_hook=tests/ext/request-init-hook/raises_e_notice.php
+ddtrace.request_init_hook={PWD}/raises_e_notice.php
 --FILE--
 <?php
 var_dump(error_get_last());

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -4,12 +4,12 @@ Request init hook is confined to open_basedir
 DD_TRACE_DEBUG=1
 --INI--
 open_basedir=tests/ext/request-init-hook
-ddtrace.request_init_hook=tests/ext/includes/sanity_check.php
+ddtrace.request_init_hook={PWD}/../includes/sanity_check.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;
 
 ?>
---EXPECT--
-open_basedir restriction in effect; cannot open request init hook: 'tests/ext/includes/sanity_check.php'
+--EXPECTF--
+open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start

--- a/tests/ext/request-init-hook/request_init_hook_contains_non_printable_character.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_contains_non_printable_character.phpt
@@ -2,7 +2,7 @@
 Request init hook loads files without using multibyte flag
 --INI--
 zend.multibyte=1
-ddtrace.request_init_hook=tests/ext/request-init-hook/contains_binary_character.php
+ddtrace.request_init_hook={PWD}/contains_binary_character.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -3,12 +3,12 @@ Do not fail when PHP code couldn't be loaded
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
-ddtrace.request_init_hook=tests/ext/request-init-hook/this_file_doesnt_exist.php
+ddtrace.request_init_hook={PWD}/this_file_doesnt_exist.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;
 
 ?>
---EXPECT--
-Cannot open request init hook; file does not exist: 'tests/ext/request-init-hook/this_file_doesnt_exist.php'
+--EXPECTF--
+Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Request init hook ignores exceptions
 --INI--
-ddtrace.request_init_hook=tests/ext/request-init-hook/throws_exception.php
+ddtrace.request_init_hook={PWD}/throws_exception.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -3,7 +3,7 @@ Request init hook ignores fatal errors
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50600) die('skip: Cannot recover from fatal errors until PHP 5.6'); ?>
 --INI--
-ddtrace.request_init_hook=tests/ext/request-init-hook/raises_fatal_error.php
+ddtrace.request_init_hook={PWD}/raises_fatal_error.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors_php_54.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors_php_54.phpt
@@ -8,7 +8,7 @@ This test can be used to test manually.
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
-ddtrace.request_init_hook=tests/ext/request-init-hook/raises_fatal_error.php
+ddtrace.request_init_hook={PWD}/raises_fatal_error.php
 --FILE--
 <?php
 echo 'Request start' . PHP_EOL;

--- a/tests/ext/request-init-hook/run_file_before_request_handling.phpt
+++ b/tests/ext/request-init-hook/run_file_before_request_handling.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Prepend PHP code before the processing takes place and do not blacklist functionality on partial match
 --INI--
-ddtrace.request_init_hook=tests/ext/includes/sanity_check.php
+ddtrace.request_init_hook={PWD}/../includes/sanity_check.php
 --FILE--
 <?php
 echo "Request start" . PHP_EOL;

--- a/tests/ext/sandbox-prehook/php5_unsupported.phpt
+++ b/tests/ext/sandbox-prehook/php5_unsupported.phpt
@@ -1,7 +1,6 @@
 --TEST--
 [Prehook] Not supported on PHP 5
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip: PHP 5.4 not supported'); ?>
 <?php if (PHP_VERSION_ID >= 70000) die('skip: PHP 5 only test'); ?>
 --ENV--
 DD_TRACE_DEBUG=1

--- a/tests/ext/sandbox-regression/access_modifier_method_access_hook.phpt
+++ b/tests/ext/sandbox-regression/access_modifier_method_access_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Private and protected methods are called from a tracing closure
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Foo

--- a/tests/ext/sandbox-regression/access_modifier_property_access_hook.phpt
+++ b/tests/ext/sandbox-regression/access_modifier_property_access_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Private and protected properties are accessed from a tracing closure
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test

--- a/tests/ext/sandbox-regression/allow_overriding_before_overrided_methods_functions_are_defined.phpt
+++ b/tests/ext/sandbox-regression/allow_overriding_before_overrided_methods_functions_are_defined.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace a function and method before it is defined
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 DDTrace\trace_method("Test", "m", function($span, array $args, $retval) {

--- a/tests/ext/sandbox-regression/case_insensitive_method_hook.phpt
+++ b/tests/ext/sandbox-regression/case_insensitive_method_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace case-insensitive method from a child class
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Ancestor {

--- a/tests/ext/sandbox-regression/closure_accessing_outside_variables.phpt
+++ b/tests/ext/sandbox-regression/closure_accessing_outside_variables.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Tracing closure safely uses variables from outside scope
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 // variable present in outside scope

--- a/tests/ext/sandbox-regression/closure_set_inside_object_methods.phpt
+++ b/tests/ext/sandbox-regression/closure_set_inside_object_methods.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Tracing closure set from inside non-static method
 --DESCRIPTION--
 This differs from the original dd_trace() test in that it does not modify the original call arguments
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] dd_trace_tracer_is_limited() limits the tracer with a hard span limit
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum

--- a/tests/ext/sandbox-regression/destructor_called_when_this_gets_out_of_scope.phpt
+++ b/tests/ext/sandbox-regression/destructor_called_when_this_gets_out_of_scope.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Destructor is called when object goes out of scope
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/disable_tracing_disables_tracing.phpt
+++ b/tests/ext/sandbox-regression/disable_tracing_disables_tracing.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Disable tracing disables all tracing from happening
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/do_not_check_if_class_or_function_exists_by_default.phpt
+++ b/tests/ext/sandbox-regression/do_not_check_if_class_or_function_exists_by_default.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Do not throw exceptions when verifying if method or function exists
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/extension_disabled.phpt
+++ b/tests/ext/sandbox-regression/extension_disabled.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Tracing closures do not run when extension is disabled
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --INI--
 ddtrace.disable=true
 --FILE--

--- a/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
+++ b/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Method invoked via reflection correctly returns created object
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/method_returning_array.phpt
+++ b/tests/ext/sandbox-regression/method_returning_array.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Method can be traced and called from tracing closure
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/multiple_instrumentations.phpt
+++ b/tests/ext/sandbox-regression/multiple_instrumentations.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Multiple functions and methods are traced
 --DESCRIPTION--
 This differs from the original dd_trace() test in that it does not modify the original call arguments
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test_a($a){

--- a/tests/ext/sandbox-regression/namespaces.phpt
+++ b/tests/ext/sandbox-regression/namespaces.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Namespaced functions and methods are traced
 --DESCRIPTION--
 This differs from the original dd_trace() test in that the original call is always forwarded before the tracing closure is called
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 namespace Func {

--- a/tests/ext/sandbox-regression/overriding_construct.phpt
+++ b/tests/ext/sandbox-regression/overriding_construct.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace class constructor
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/overriding_method_defined_in_parent.phpt
+++ b/tests/ext/sandbox-regression/overriding_method_defined_in_parent.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace extended method when called from parent class
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Ancestor {

--- a/tests/ext/sandbox-regression/private_method_hook.phpt
+++ b/tests/ext/sandbox-regression/private_method_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace private method
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test

--- a/tests/ext/sandbox-regression/private_self_access.phpt
+++ b/tests/ext/sandbox-regression/private_self_access.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Tracing closure accesses private static method
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/protected_method_hook.phpt
+++ b/tests/ext/sandbox-regression/protected_method_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace protected method
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/recursion.phpt
+++ b/tests/ext/sandbox-regression/recursion.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Recursive calls will trace only outermost invocation
 --DESCRIPTION--
 This differs from the original dd_trace() test in that the original call is always forwarded before the tracing closure is called
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test($c, $end){

--- a/tests/ext/sandbox-regression/reset_configured_overrides.phpt
+++ b/tests/ext/sandbox-regression/reset_configured_overrides.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Traced functions and methods are untraced with reset
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/reset_function_tracing.phpt
+++ b/tests/ext/sandbox-regression/reset_function_tracing.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Untrace a function
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=spl_autoload_register
 --FILE--

--- a/tests/ext/sandbox-regression/return_value_passed.phpt
+++ b/tests/ext/sandbox-regression/return_value_passed.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Return value passed to tracing closure
 --DESCRIPTION--
 This differs from the original dd_trace() test in that it does not modify the original call arguments
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/simple_function_hook.phpt
+++ b/tests/ext/sandbox-regression/simple_function_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Userland function is traced
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test(){

--- a/tests/ext/sandbox-regression/simple_method_hook.phpt
+++ b/tests/ext/sandbox-regression/simple_method_hook.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Userland method is traced
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox-regression/throw_exception.phpt
+++ b/tests/ext/sandbox-regression/throw_exception.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Traced userland function catches and rethrows exception
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test($param = 2){

--- a/tests/ext/sandbox-regression/trace_method_or_function_that_will_exist_later.phpt
+++ b/tests/ext/sandbox-regression/trace_method_or_function_that_will_exist_later.phpt
@@ -1,7 +1,5 @@
 --TEST--
-[Sandbox regression] Methods and functions are traced before defined
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
+[Sandbox regression] Methods and functions are traced before definedx
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/trace_static_method.phpt
+++ b/tests/ext/sandbox-regression/trace_static_method.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Trace public static method
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_shouldn_t_be_freed.phpt
@@ -1,7 +1,5 @@
 --TEST--
 [Sandbox regression] Override traced function from within itself
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test($a){

--- a/tests/ext/sandbox-regression/variable_length_parameter_list.phpt
+++ b/tests/ext/sandbox-regression/variable_length_parameter_list.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Trace variadic functions and methods
 --DESCRIPTION--
 This differs from the original dd_trace() test in that it does not modify the original call arguments
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 function test($a, $b, $c){

--- a/tests/ext/sandbox-regression/with_params_method_hook.phpt
+++ b/tests/ext/sandbox-regression/with_params_method_hook.phpt
@@ -2,8 +2,6 @@
 [Sandbox regression] Trace method with params
 --DESCRIPTION--
 This differs from the original dd_trace() test in that it does not modify the original call arguments
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 class Test {

--- a/tests/ext/sandbox/preinitialized_tracing_of_method.phpt
+++ b/tests/ext/sandbox/preinitialized_tracing_of_method.phpt
@@ -2,8 +2,6 @@
 [Prehook regression] Trace public static method
 --ENV--
 _DD_LOAD_TEST_INTEGRATIONS=1
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/return_by_ref.phpt
+++ b/tests/ext/sandbox/return_by_ref.phpt
@@ -1,8 +1,5 @@
 --TEST--
 Functions that return by reference are instrumented
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip PHP 5.4 not supported'); ?>
-<?php if (PHP_VERSION_ID < 70000) die('skip: Unaltered VM dispatch required for return by ref on PHP 5'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/traced_internal_functions_override_01.phpt
+++ b/tests/ext/traced_internal_functions_override_01.phpt
@@ -2,8 +2,6 @@
 Ensure that if a user adds an internal function we already trace to traced internal functions list that it doesn't misbehave
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=header
---SKIPIF--
-<?php if (PHP_VERSION_ID < 50500) die('skip: requires DDTrace\\trace_function'); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
### Description

PECL can only do min-max for the required PHP version\*. Since we didn't support PHP 5.5 we couldn't support PHP 5.4 either. Now that we do support PHP 5.5 we can support PHP 5.4 too.

Also adjusts some tests to use relative directories for `request_init_hook`.
Also removes some SKIPIF sections for PHP 5.4.

\* It can do `exclude`s, but it seems we didn't know about this or the excludes were somehow undesirable (such as we may have had to list all PHP 5.5.Z versions in the exclude).

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
