### PR TITLE
Fix sigsegv in deferred loading

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -186,8 +186,9 @@
             <file name="tests/ext/sandbox/dd_trace_set_trace_id.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties_method.phpt" role="test" />
-            <file name="tests/ext/sandbox/deferred_load_using_function.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_attempt_loading_once.phpt" role="test" />
+            <file name="tests/ext/sandbox/deferred_load_missing_load_fn.phpt" role="test" />
+            <file name="tests/ext/sandbox/deferred_load_using_function.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_loading_helper.php" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing.inc" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing_curl.phpt" role="test" />

--- a/src/ext/php7/engine_api.c
+++ b/src/ext/php7/engine_api.c
@@ -89,9 +89,16 @@ ZEND_RESULT_CODE ddtrace_call_function(zend_function **fn_proxy, const char *nam
         zval fname = ddtrace_zval_stringl(name, name_len);
         zend_bool is_callable = zend_is_callable_ex(&fname, NULL, IS_CALLABLE_CHECK_SILENT, NULL, &fcc, NULL);
         zend_string_release(Z_STR(fname));
+
         if (UNEXPECTED(!is_callable)) {
+            /* zend_call_function undef's the retval; as a wrapper for it, this
+             * func should have the same invariant; a sigsegv occurred because
+             * of this.
+             */
+            ZVAL_UNDEF(retval);
             return FAILURE;
         }
+
         if (fn_proxy) {
             *fn_proxy = fcc.function_handler;
         }

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -170,7 +170,8 @@ static bool dd_should_trace_helper(zend_execute_data *call, zend_function *fbc, 
                                    scope ? "::" : "", Z_STRVAL(fname));
             }
 
-            zval retval, *integration = &dispatch->deferred_load_integration_name;
+            zval retval = {.u1.type_info = IS_UNDEF};
+            zval *integration = &dispatch->deferred_load_integration_name;
             zend_function **fn_proxy = &dd_integrations_load_deferred_integration;
             ddtrace_string loader = DDTRACE_STRING_LITERAL("ddtrace\\integrations\\load_deferred_integration");
             ZEND_RESULT_CODE status = ddtrace_call_function(fn_proxy, loader.ptr, loader.len, &retval, 1, integration);

--- a/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
+++ b/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
@@ -1,0 +1,45 @@
+--TEST--
+deferred loading doesn't trigger nor crash if DDTrace\Integrations\load_deferred_integration is missing
+----DESCRIPTION--
+This issue was reported in a GitHub issue:
+https://github.com/DataDog/dd-trace-php/issues/1021
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION < 7) die('skip: deferred loading not supported on PHP 5'); ?>
+--ENV--
+_DD_LOAD_TEST_INTEGRATIONS=1
+--INI--
+ddtrace.request_init_hook=
+--FILE--
+<?php
+
+namespace DDTrace\Test
+{
+    class TestSandboxedIntegration
+    {
+        const LOADED = 1;
+
+        function init()
+        {
+            echo "autoload_attempted" . PHP_EOL;
+            return self::LOADED;
+        }
+    }
+}
+
+namespace
+{
+    class Test
+    {
+        public static function public_static_method()
+        {
+            echo "PUBLIC STATIC METHOD" . PHP_EOL;
+        }
+    }
+
+    Test::public_static_method();
+    Test::public_static_method();
+}
+?>
+--EXPECT--
+PUBLIC STATIC METHOD
+PUBLIC STATIC METHOD


### PR DESCRIPTION
### Description

A user encountered this in #1021. In the case the loading function couldn't be found the `zval retval` would be un-initialized and then sigsegv would occur when trying to `zval_ptr_dtor` it. I initialized the local variable, but also changed `ddtrace_call_function` to initialize the retval like `zend_call_function` would, which contributed to the bug occurring.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
