### PR TITLE
Release 0.48.3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -194,8 +194,9 @@
             <file name="tests/ext/sandbox/dd_trace_set_trace_id.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties_method.phpt" role="test" />
-            <file name="tests/ext/sandbox/deferred_load_using_function.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_attempt_loading_once.phpt" role="test" />
+            <file name="tests/ext/sandbox/deferred_load_missing_load_fn.phpt" role="test" />
+            <file name="tests/ext/sandbox/deferred_load_using_function.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_loading_helper.php" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing.inc" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing_curl.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -12,12 +12,12 @@
     </lead>
     <!-- **Automatically updated with pecl-build script** -->
     <!-- Date only needs to be set if it was packaged on a different day from release -->
-    <date>2020-09-10</date>
+    <date>2020-09-21</date>
     <version>
         <!-- **Automatically updated with pecl-build script** -->
         <!-- Version will be set from version.php or 0.0.0 for nightly builds -->
-        <release>0.48.2</release>
-        <api>0.48.2</api>
+        <release>0.48.3</release>
+        <api>0.48.3</api>
     </version>
     <stability>
         <release>stable</release>
@@ -25,13 +25,8 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-        ### Changed
-        - Update excluded modules #1011
-        - Deprecate dd-doctor.php #1014
-
         ### Fixed
-        - PHP 5.4 build in ZTS mode #1011
-        - Call ddtrace_engine_hooks_{rinit,rshutdown} #1013
+        - Fix sigsegv in deferred loading #1022
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -26,7 +26,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '0.48.2'; // Update ./version.php too
+    const VERSION = '0.48.3'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '0.48.2'; // Update Tracer::VERSION too
+return '0.48.3'; // Update Tracer::VERSION too

--- a/src/ext/php7/engine_api.c
+++ b/src/ext/php7/engine_api.c
@@ -89,9 +89,16 @@ ZEND_RESULT_CODE ddtrace_call_function(zend_function **fn_proxy, const char *nam
         zval fname = ddtrace_zval_stringl(name, name_len);
         zend_bool is_callable = zend_is_callable_ex(&fname, NULL, IS_CALLABLE_CHECK_SILENT, NULL, &fcc, NULL);
         zend_string_release(Z_STR(fname));
+
         if (UNEXPECTED(!is_callable)) {
+            /* zend_call_function undef's the retval; as a wrapper for it, this
+             * func should have the same invariant; a sigsegv occurred because
+             * of this.
+             */
+            ZVAL_UNDEF(retval);
             return FAILURE;
         }
+
         if (fn_proxy) {
             *fn_proxy = fcc.function_handler;
         }

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -170,7 +170,8 @@ static bool dd_should_trace_helper(zend_execute_data *call, zend_function *fbc, 
                                    scope ? "::" : "", Z_STRVAL(fname));
             }
 
-            zval retval, *integration = &dispatch->deferred_load_integration_name;
+            zval retval = {.u1.type_info = IS_UNDEF};
+            zval *integration = &dispatch->deferred_load_integration_name;
             zend_function **fn_proxy = &dd_integrations_load_deferred_integration;
             ddtrace_string loader = DDTRACE_STRING_LITERAL("ddtrace\\integrations\\load_deferred_integration");
             ZEND_RESULT_CODE status = ddtrace_call_function(fn_proxy, loader.ptr, loader.len, &retval, 1, integration);

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "0.48.2"
+#define PHP_DDTRACE_VERSION "0.48.3"
 #endif

--- a/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
+++ b/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
@@ -1,0 +1,45 @@
+--TEST--
+deferred loading doesn't trigger nor crash if DDTrace\Integrations\load_deferred_integration is missing
+----DESCRIPTION--
+This issue was reported in a GitHub issue:
+https://github.com/DataDog/dd-trace-php/issues/1021
+--SKIPIF--
+<?php if (PHP_MAJOR_VERSION < 7) die('skip: deferred loading not supported on PHP 5'); ?>
+--ENV--
+_DD_LOAD_TEST_INTEGRATIONS=1
+--INI--
+ddtrace.request_init_hook=
+--FILE--
+<?php
+
+namespace DDTrace\Test
+{
+    class TestSandboxedIntegration
+    {
+        const LOADED = 1;
+
+        function init()
+        {
+            echo "autoload_attempted" . PHP_EOL;
+            return self::LOADED;
+        }
+    }
+}
+
+namespace
+{
+    class Test
+    {
+        public static function public_static_method()
+        {
+            echo "PUBLIC STATIC METHOD" . PHP_EOL;
+        }
+    }
+
+    Test::public_static_method();
+    Test::public_static_method();
+}
+?>
+--EXPECT--
+PUBLIC STATIC METHOD
+PUBLIC STATIC METHOD


### PR DESCRIPTION
### Description

Fixes a segmentation fault in deferred loading; affects users calling these methods when ddtrace's request init hook is not run:

- `Redis::__construct`
- `Predis\Client::__construct`
- `Elasticsearch\Client::__construct`

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
