### PR TITLE
Harden curl integration

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -197,6 +197,7 @@
             <file name="tests/ext/sandbox/distributed_tracing_curl_existing_headers_002.phpt" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing_curl_inject.inc" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing_curl_inject_exception.inc" role="test" />
+            <file name="tests/ext/sandbox/distributed_tracing_curl_missing_fn.phpt" role="test" />
             <file name="tests/ext/sandbox/distributed_tracing_curl_sandboxed.phpt" role="test" />
             <file name="tests/ext/sandbox/drop_spans.phpt" role="test" />
             <file name="tests/ext/sandbox/errors_are_flagged_from_userland.phpt" role="test" />

--- a/src/ext/php7/engine_api.c
+++ b/src/ext/php7/engine_api.c
@@ -2,6 +2,7 @@
 
 extern inline zval ddtrace_zval_long(zend_long num);
 extern inline zval ddtrace_zval_null(void);
+extern inline zval ddtrace_zval_undef(void);
 
 zval ddtrace_zval_stringl(const char *str, size_t len) {
     zval zv;

--- a/src/ext/php7/engine_api.h
+++ b/src/ext/php7/engine_api.h
@@ -35,6 +35,12 @@ inline zval ddtrace_zval_null(void) {
     return zv;
 }
 
+inline zval ddtrace_zval_undef(void) {
+    zval zv;
+    ZVAL_UNDEF(&zv);
+    return zv;
+}
+
 ZEND_RESULT_CODE ddtrace_call_method(zend_object *obj, zend_class_entry *ce, zend_function **fn_proxy,
                                      const char *fname, size_t fname_len, zval *retval, int argc, zval *argv);
 ZEND_RESULT_CODE ddtrace_call_function(zend_function **fn_proxy, const char *name, size_t name_len, zval *retval,

--- a/tests/ext/sandbox/distributed_tracing_curl_missing_fn.phpt
+++ b/tests/ext/sandbox/distributed_tracing_curl_missing_fn.phpt
@@ -1,0 +1,40 @@
+--TEST--
+If curl_inject_distributed_headers helper is missing, we don't sigsegv, right?
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 70000) die('skip: PHP 7 not supported'); ?>
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--INI--
+ddtrace.request_init_hook=
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+--FILE--
+<?php
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+    $span->name = 'curl_exec';
+});
+
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$response = curl_exec($ch);
+curl_close($ch);
+
+include 'distributed_tracing.inc';
+$headers = dt_decode_headers_from_httpbin($response);
+dt_dump_headers_from_httpbin($headers, [
+    'x-datadog-parent-id',
+    'x-datadog-origin',
+]);
+
+$spans = dd_trace_serialize_closed_spans();
+assert(isset($headers['x-datadog-parent-id']));
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+Warning: assert(): Assertion failed in %s on line %d
+Done.


### PR DESCRIPTION
### Description

As a follow-up to the feedback given in #1022 , this adds defensive initializations of local zvals in `php7/handlers_curl.c` and a test for a missing curl helper function on PHP 5. No issues were found.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
