### PR TITLE
Properly group traces sent in batch during long running scripts

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -23,6 +23,7 @@
     </rule>
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>bridge/dd_init.php</exclude-pattern>
+        <exclude-pattern>tests/Integration/LongRunning/long_running_script_manual.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/PHPRedis/PHPRedis5Test.php</exclude-pattern>
     </rule>
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -1262,7 +1262,7 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
     }
 
     bool result = ddtrace_send_traces_via_thread(num_traces, curl_headers, payload, payload_len TSRMLS_CC);
-    _ddtrace_prepare_for_new_trace();
+    _ddtrace_prepare_for_new_trace(TSRMLS_C);
     RETURN_BOOL(result);
 }
 

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -89,6 +89,9 @@ static void ddtrace_shutdown(struct _zend_extension *extension) {
 static void ddtrace_activate(void) {}
 static void ddtrace_deactivate(void) {}
 
+// prepare the tracer state to start handling a new trace
+void _ddtrace_prepare_for_new_trace();
+
 static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   PHP_DDTRACE_VERSION,
                                                   "Datadog",
@@ -377,7 +380,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     // Reset compile time after request init hook has compiled
     ddtrace_compile_time_reset(TSRMLS_C);
 
-    DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id();
+    _ddtrace_prepare_for_new_trace();
 
     return SUCCESS;
 }
@@ -1259,7 +1262,7 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
     }
 
     bool result = ddtrace_send_traces_via_thread(num_traces, curl_headers, payload, payload_len TSRMLS_CC);
-    DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id();
+    _ddtrace_prepare_for_new_trace();
     RETURN_BOOL(result);
 }
 
@@ -1548,3 +1551,9 @@ ZEND_GET_MODULE(ddtrace)
 ZEND_TSRMLS_CACHE_DEFINE();
 #endif
 #endif
+
+// the following operations are performed in order to put the tracer in a state when a new trace can be started:
+//   - set a new trace (group) id
+void _ddtrace_prepare_for_new_trace() {
+    DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id();
+}

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -90,7 +90,7 @@ static void ddtrace_activate(void) {}
 static void ddtrace_deactivate(void) {}
 
 // prepare the tracer state to start handling a new trace
-void _ddtrace_prepare_for_new_trace(TSRMLS_D);
+static void dd_prepare_for_new_trace(TSRMLS_D);
 
 static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   PHP_DDTRACE_VERSION,
@@ -380,7 +380,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     // Reset compile time after request init hook has compiled
     ddtrace_compile_time_reset(TSRMLS_C);
 
-    _ddtrace_prepare_for_new_trace(TSRMLS_C);
+    dd_prepare_for_new_trace(TSRMLS_C);
 
     return SUCCESS;
 }
@@ -1262,7 +1262,7 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
     }
 
     bool result = ddtrace_send_traces_via_thread(num_traces, curl_headers, payload, payload_len TSRMLS_CC);
-    _ddtrace_prepare_for_new_trace(TSRMLS_C);
+    dd_prepare_for_new_trace(TSRMLS_C);
     RETURN_BOOL(result);
 }
 
@@ -1554,4 +1554,4 @@ ZEND_TSRMLS_CACHE_DEFINE();
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id
-void _ddtrace_prepare_for_new_trace(TSRMLS_D) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
+static void dd_prepare_for_new_trace(TSRMLS_D) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -1254,11 +1254,13 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
 
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "las", &num_traces, &curl_headers,
                                  &payload, &payload_len) == FAILURE) {
-        ddtrace_log_debug("dd_trace_send_traces_via_thread() expects url, http headers, and http body");
+        ddtrace_log_debug("dd_trace_send_traces_via_thread() expects trace count, http headers, and http body");
         RETURN_FALSE
     }
 
-    RETURN_BOOL(ddtrace_send_traces_via_thread(num_traces, curl_headers, payload, payload_len TSRMLS_CC));
+    bool result = ddtrace_send_traces_via_thread(num_traces, curl_headers, payload, payload_len TSRMLS_CC);
+    DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id();
+    RETURN_BOOL(result);
 }
 
 static PHP_FUNCTION(dd_trace_buffer_span) {

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -1554,6 +1554,4 @@ ZEND_TSRMLS_CACHE_DEFINE();
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id
-void _ddtrace_prepare_for_new_trace() {
-    DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id();
-}
+void _ddtrace_prepare_for_new_trace() { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -90,7 +90,7 @@ static void ddtrace_activate(void) {}
 static void ddtrace_deactivate(void) {}
 
 // prepare the tracer state to start handling a new trace
-void _ddtrace_prepare_for_new_trace();
+void _ddtrace_prepare_for_new_trace(TSRMLS_D);
 
 static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   PHP_DDTRACE_VERSION,
@@ -380,7 +380,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     // Reset compile time after request init hook has compiled
     ddtrace_compile_time_reset(TSRMLS_C);
 
-    _ddtrace_prepare_for_new_trace();
+    _ddtrace_prepare_for_new_trace(TSRMLS_C);
 
     return SUCCESS;
 }
@@ -1554,4 +1554,4 @@ ZEND_TSRMLS_CACHE_DEFINE();
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id
-void _ddtrace_prepare_for_new_trace() { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
+void _ddtrace_prepare_for_new_trace(TSRMLS_D) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }

--- a/tests/Common/CLITestCase.php
+++ b/tests/Common/CLITestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\CLI;
+namespace DDTrace\Tests\Common;
 
 use DDTrace\Tests\Common\AgentReplayerTrait;
 use DDTrace\Tests\Common\IntegrationTestCase;

--- a/tests/Common/CLITestCase.php
+++ b/tests/Common/CLITestCase.php
@@ -33,7 +33,6 @@ abstract class CLITestCase extends IntegrationTestCase
             // Uncomment to see debug-level messages
             //'DD_TRACE_DEBUG' => 'true',
             'DD_TEST_INTEGRATION' => 'true',
-            'DD_TRACE_ENCODER' => 'json',
         ];
         return $envs;
     }
@@ -46,14 +45,14 @@ abstract class CLITestCase extends IntegrationTestCase
     protected static function getInis()
     {
         return [
-            'ddtrace.request_init_hook' => __DIR__ . '/../../../bridge/dd_wrap_autoloader.php',
+            'ddtrace.request_init_hook' => __DIR__ . '/../../bridge/dd_wrap_autoloader.php',
             // Enabling `strict_mode` disables debug mode
             //'ddtrace.strict_mode' => '1',
         ];
     }
 
     /**
-     * Run a command from the CLI
+     * Run a command from the CLI and return the generated traces.
      *
      * @param string $arguments
      * @param array $overrideEnvs
@@ -61,12 +60,25 @@ abstract class CLITestCase extends IntegrationTestCase
      */
     public function getTracesFromCommand($arguments = '', $overrideEnvs = [])
     {
+        return $this->loadTraces($this->getAgentRequestFromCommand($arguments, $overrideEnvs));
+    }
+
+    /**
+     * Run a command from the CLI and return the raw response.
+     *
+     * @param string $arguments
+     * @param array $overrideEnvs
+     * @return array | null
+     */
+    public function getAgentRequestFromCommand($arguments = '', $overrideEnvs = [])
+    {
         $envs = (string) new EnvSerializer(array_merge([], static::getEnvs(), $overrideEnvs));
         $inis = (string) new IniSerializer(static::getInis());
         $script = escapeshellarg($this->getScriptLocation());
         $arguments = escapeshellarg($arguments);
-        `$envs php $inis $script $arguments`;
-        return $this->loadTrace();
+        $commandToExecute = "$envs php $inis $script $arguments";
+        `$commandToExecute`;
+        return $this->getLastAgentRequest();
     }
 
     /**
@@ -74,9 +86,8 @@ abstract class CLITestCase extends IntegrationTestCase
      *
      * @return array
      */
-    private function loadTrace()
+    private function loadTraces($request)
     {
-        $request = $this->getLastAgentRequest();
         if (!isset($request['body'])) {
             return [];
         }

--- a/tests/Common/EnvSerializer.php
+++ b/tests/Common/EnvSerializer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\CLI;
+namespace DDTrace\Tests\Common;
 
 /**
  * Serialize an associative array into env var string for CLI commands

--- a/tests/Common/IniSerializer.php
+++ b/tests/Common/IniSerializer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\CLI;
+namespace DDTrace\Tests\Common;
 
 /**
  * Serialize an associative array into INI string for CLI SAPI

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -13,6 +13,10 @@ final class LongRunningScriptTest extends CLITestCase
 
     public function testMultipleTracesFromLongRunningScriptSetCorrectTraceCountHeader()
     {
+        if (5 === \PHP_MAJOR_VERSION) {
+            $this->markTestSkipped('We do not officially support and test long running scripts on PHP 5');
+            return;
+        }
         $agentRequest = $this->getAgentRequestFromCommand('', [
             'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
             'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DDTrace\Tests\Integration\LongRunning;
+
+use DDTrace\Tests\Common\CLITestCase;
+
+final class LongRunningScriptTest extends CLITestCase
+{
+
+    protected function getScriptLocation()
+    {
+        return __DIR__ . '/long_running_script_manual.php';
+    }
+
+    public function testMultipleTracesFromLongRunningScriptSetCorrectTraceCountHeader()
+    {
+        $agentRequest = $this->getAgentRequestFromCommand('', [
+            'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
+            'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
+            'DD_TRACE_BGS_TIMEOUT' => 3000,
+        ]);
+
+        $this->assertSame('3', $agentRequest['headers']['X-Datadog-Trace-Count']);
+        $this->assertCount(3, json_decode($agentRequest['body'], true));
+    }
+}

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -6,7 +6,6 @@ use DDTrace\Tests\Common\CLITestCase;
 
 final class LongRunningScriptTest extends CLITestCase
 {
-
     protected function getScriptLocation()
     {
         return __DIR__ . '/long_running_script_manual.php';

--- a/tests/Integration/LongRunning/long_running_script_manual.php
+++ b/tests/Integration/LongRunning/long_running_script_manual.php
@@ -14,11 +14,6 @@ function do_manual_instrumentation()
     $rootSpan->setTag(Tag::RESOURCE_NAME, "sub-resource");
     $subSpan->finish();
     $rootSpan->finish();
-
-    if (PHP_MAJOR_VERSION === 5) {
-        // Auto flushing is not yet supported on PHP 5.
-        $tracer->flush();
-    }
 }
 
 // Sending multiple traces

--- a/tests/Integration/LongRunning/long_running_script_manual.php
+++ b/tests/Integration/LongRunning/long_running_script_manual.php
@@ -1,0 +1,22 @@
+<?php
+
+use DDTrace\GlobalTracer;
+use DDTrace\Tag;
+
+function do_manual_instrumentation()
+{
+    $tracer = GlobalTracer::get();
+    $rootSpan = $tracer->startActiveSpan("root-operation")->getSpan();
+    $rootSpan->setTag(Tag::SERVICE_NAME, "long-running-service");
+    $rootSpan->setTag(Tag::RESOURCE_NAME, "root-resource");
+
+    $subSpan = $tracer->startActiveSpan('sub-operation')->getSpan();
+    $rootSpan->setTag(Tag::RESOURCE_NAME, "sub-resource");
+    $subSpan->finish();
+    $rootSpan->finish();
+}
+
+// Sending multiple traces
+do_manual_instrumentation();
+do_manual_instrumentation();
+do_manual_instrumentation();

--- a/tests/Integration/LongRunning/long_running_script_manual.php
+++ b/tests/Integration/LongRunning/long_running_script_manual.php
@@ -16,6 +16,7 @@ function do_manual_instrumentation()
     $rootSpan->finish();
 
     if (PHP_MAJOR_VERSION === 5) {
+        // Auto flushing is not yet supported on PHP 5.
         $tracer->flush();
     }
 }

--- a/tests/Integration/LongRunning/long_running_script_manual.php
+++ b/tests/Integration/LongRunning/long_running_script_manual.php
@@ -14,9 +14,15 @@ function do_manual_instrumentation()
     $rootSpan->setTag(Tag::RESOURCE_NAME, "sub-resource");
     $subSpan->finish();
     $rootSpan->finish();
+
+    if (PHP_MAJOR_VERSION === 5) {
+        $tracer->flush();
+    }
 }
 
 // Sending multiple traces
 do_manual_instrumentation();
 do_manual_instrumentation();
 do_manual_instrumentation();
+
+error_log('Script is done');

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integrations\CLI\CakePHP\V2_8;
 
 use DDTrace\Tests\Common\SpanAssertion;
-use DDTrace\Tests\Integrations\CLI\CLITestCase;
+use DDTrace\Tests\Common\CLITestCase;
 
 class CommonScenariosTest extends CLITestCase
 {

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integrations\CLI\Custom\Autoloaded;
 
 use DDTrace\Tests\Common\SpanAssertion;
-use DDTrace\Tests\Integrations\CLI\CLITestCase;
+use DDTrace\Tests\Common\CLITestCase;
 
 final class CommonScenariosTest extends CLITestCase
 {

--- a/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integrations\CLI\Custom\Autoloaded;
 
 use DDTrace\Tests\Common\SpanAssertion;
-use DDTrace\Tests\Integrations\CLI\CLITestCase;
+use DDTrace\Tests\Common\CLITestCase;
 
 final class NoRootSpanTest extends CLITestCase
 {

--- a/tests/Integrations/CLI/Custom/NotAutoloaded/NotAutoloadedTestCase.php
+++ b/tests/Integrations/CLI/Custom/NotAutoloaded/NotAutoloadedTestCase.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integrations\CLI\Custom\NotAutoloaded;
 
 use DDTrace\Tests\Common\SpanAssertion;
-use DDTrace\Tests\Integrations\CLI\CLITestCase;
+use DDTrace\Tests\Common\CLITestCase;
 
 final class NotAutoloadedTestCase extends CLITestCase
 {

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\Integrations\CLI\Laravel\V5_8;
 
 use DDTrace\Tests\Common\SpanAssertion;
-use DDTrace\Tests\Integrations\CLI\CLITestCase;
+use DDTrace\Tests\Common\CLITestCase;
 
 class CommonScenariosTest extends CLITestCase
 {

--- a/tests/Sapi/CliServer/CliServer.php
+++ b/tests/Sapi/CliServer/CliServer.php
@@ -2,8 +2,8 @@
 
 namespace DDTrace\Tests\Sapi\CliServer;
 
-use DDTrace\Tests\Integrations\CLI\EnvSerializer;
-use DDTrace\Tests\Integrations\CLI\IniSerializer;
+use DDTrace\Tests\Common\EnvSerializer;
+use DDTrace\Tests\Common\IniSerializer;
 use DDTrace\Tests\Sapi\Sapi;
 use Symfony\Component\Process\Process;
 

--- a/tests/Sapi/PhpCgi/PhpCgi.php
+++ b/tests/Sapi/PhpCgi/PhpCgi.php
@@ -2,8 +2,8 @@
 
 namespace DDTrace\Tests\Sapi\PhpCgi;
 
-use DDTrace\Tests\Integrations\CLI\EnvSerializer;
-use DDTrace\Tests\Integrations\CLI\IniSerializer;
+use DDTrace\Tests\Common\EnvSerializer;
+use DDTrace\Tests\Common\IniSerializer;
 use DDTrace\Tests\Sapi\Sapi;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
### Description

By default the background sender enqueue traces and sends them every 5 seconds (or when necessary if they are piling up). Spans are grouped together (and traces counted) based on a group id that was reset in the RINIT. Problem is: for long running scripts RINIT is run only once and we were sending all traces correctly, but header `X-Datadog-Trace-Count: 1` caused only the first trace (every 5 seconds) to be decoded.

This PR add state reset after traces are sent to the background sender and the script is ready to handle a new trace.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
