### PR TITLE
Add more tests for PHP 5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,6 +1298,18 @@ workflows:
           lib_curl_command: sudo apk update ; sudo apk add curl-dev
       - integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 55 Integration tests"
+          docker_image: "datadog/docker-library:ddtrace_alpine_php-5.5-debug"
+          integration_testsuite: "test-integrations-55"
+          lib_curl_command: |
+              sudo apk update
+              sudo apk add curl-dev cyrus-sasl-dev libmemcached-dev
+              echo "/usr" | sudo pecl install memcached-2.2.0
+              echo "extension=memcached.so" | sudo tee /usr/local/etc/php/conf.d/memcached.ini
+              echo "yes" | sudo pecl install mongo
+              echo "extension=mongo.so" | sudo tee /usr/local/etc/php/conf.d/mongo.ini
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 56 Integration tests"
           integration_testsuite: "test-integrations-56"
           docker_image: "datadog/docker-library:ddtrace_alpine_php-5.6-debug"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1264,6 +1264,10 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-5.4-debug-buster"
       - base_integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 55 base integration tests"
+          docker_image: "datadog/dd-trace-ci:php-5.5-debug-buster"
+      - base_integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 56 base integration tests"
           docker_image: "datadog/dd-trace-ci:php-5.6-debug-buster"
       - base_integration_tests:

--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -77,6 +77,7 @@ ext/date/tests/date_interval_create_from_date_string_nullparam.phpt
 ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
+ext/fileinfo/tests/bug68819_002.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt


### PR DESCRIPTION
### Description

This adds more tests for supporting PHP 5.5.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
