### PR TITLE
Add back support for trace analytics to curl integration

### DIFF
--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -42,13 +42,16 @@ final class CurlIntegration extends Integration
             return Integration::NOT_LOADED;
         }
 
+        $integration = $this;
+
         \DDTrace\trace_function('curl_exec', [
             // the ddtrace extension will handle distributed headers
             'instrument_when_limited' => 0,
-            'posthook' => function (SpanData $span, $args, $retval) {
+            'posthook' => function (SpanData $span, $args, $retval) use ($integration) {
                 $span->name = $span->resource = 'curl_exec';
                 $span->type = Type::HTTP_CLIENT;
                 $span->service = 'curl';
+                $integration->addTraceAnalyticsIfEnabled($span);
 
                 if (!isset($args[0])) {
                     return;


### PR DESCRIPTION
### Description

As part of release 0.43.0 we sandboxed curl on php 7. We missed enabling
trace analytics.

This PR restore trace analytics on curl.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
