### PR TITLE
Skip bug 64146 on PHP 5.5

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -229,6 +229,7 @@ ext/standard/tests/serialize/bug21957.phpt
 ext/standard/tests/serialize/bug27469.phpt
 ext/standard/tests/serialize/bug30234.phpt
 ext/standard/tests/serialize/bug62836_1.phpt
+ext/standard/tests/serialize/bug64146.phpt
 ext/standard/tests/serialize/bug67072_2.phpt
 ext/standard/tests/serialize/bug68976.phpt
 ext/standard/tests/serialize/bug70219_1.phpt


### PR DESCRIPTION
There are multiple serialization bugs fixed in PHP 5.6 and 7.0 that
affect this test. I thought I already committed this one, but it
failed recently so I guess not.

### Readiness checklist
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
