### PR TITLE
Attach fatal errors to all open internal spans

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -237,6 +237,7 @@
             <file name="tests/ext/sandbox/fatal_errors_are_tracked_003_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_are_tracked_003_php7.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_are_tracked_004.phpt" role="test" />
+            <file name="tests/ext/sandbox/fatal_errors_are_tracked_005.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
             <file name="tests/ext/sandbox/generator.phpt" role="test" />

--- a/src/ext/engine_hooks.h
+++ b/src/ext/engine_hooks.h
@@ -171,6 +171,8 @@ ddtrace_exception_t *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETE
 void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
 #endif
 
+void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception);
+
 #if PHP_VERSION_ID < 70000
 void ddtrace_close_all_open_spans(TSRMLS_D);
 #else

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -182,8 +182,8 @@ static ZEND_RESULT_CODE ddtrace_copy_function_args(zval *args, void **p) {
     return SUCCESS;
 }
 
-static void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
-    if (exception) {
+void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
+    if (exception && !span_fci->exception) {
         MAKE_STD_ZVAL(span_fci->exception);
         ZVAL_COPY_VALUE(span_fci->exception, exception);
         zval_copy_ctor(span_fci->exception);

--- a/src/ext/php5_4/engine_hooks.c
+++ b/src/ext/php5_4/engine_hooks.c
@@ -142,8 +142,8 @@ typedef void (*dd_execute_hook)(zend_op_array *op_array TSRMLS_DC);
 
 static void (*dd_prev_execute)(zend_op_array *op_array TSRMLS_DC);
 
-static void dd_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
-    if (exception) {
+void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
+    if (exception && !span_fci->exception) {
         MAKE_STD_ZVAL(span_fci->exception);
         ZVAL_COPY_VALUE(span_fci->exception, exception);
         zval_copy_ctor(span_fci->exception);
@@ -158,7 +158,7 @@ static bool dd_tracing_posthook_impl_impl(zend_function *fbc, ddtrace_span_fci *
     ddtrace_dispatch_t *dispatch = span_fci->dispatch;
 
     dd_trace_stop_span_time(span);
-    dd_span_attach_exception(span_fci, EG(exception));
+    ddtrace_span_attach_exception(span_fci, EG(exception));
 
     if (UNEXPECTED(!span_data || !return_value)) {
         if (get_dd_trace_debug()) {

--- a/src/ext/php7/engine_hooks.c
+++ b/src/ext/php7/engine_hooks.c
@@ -353,7 +353,7 @@ static void dd_copy_posthook_args(zval *args, zend_execute_data *call) {
     }
 }
 
-static void dd_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
+void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception) {
     if (exception && span_fci->exception == NULL) {
         GC_ADDREF(exception);
         span_fci->exception = exception;
@@ -730,7 +730,7 @@ static ZEND_RESULT_CODE dd_do_hook_function_posthook(zend_execute_data *call, dd
 
 static void dd_fcall_end_tracing_posthook(ddtrace_span_fci *span_fci, zval *user_retval) {
     ddtrace_dispatch_t *dispatch = span_fci->dispatch;
-    dd_span_attach_exception(span_fci, EG(exception));
+    ddtrace_span_attach_exception(span_fci, EG(exception));
 
     dd_trace_stop_span_time(&span_fci->span);
 
@@ -1054,9 +1054,7 @@ static int dd_handle_exception_handler(zend_execute_data *execute_data) {
         ZVAL_NULL(&retval);
         // The catching frame's span will get closed by the return handler so we leave it open
         if (dd_is_catching_frame(execute_data) == false) {
-            if (EG(exception)) {
-                dd_span_attach_exception(span_fci, EG(exception));
-            }
+            ddtrace_span_attach_exception(span_fci, EG(exception));
             dd_observer_end(NULL, span_fci, &retval);
         }
     }

--- a/tests/ext/sandbox/fatal_errors_are_tracked_005.phpt
+++ b/tests/ext/sandbox/fatal_errors_are_tracked_005.phpt
@@ -1,0 +1,52 @@
+--TEST--
+All open internal spans are marked with the fatal error
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,DDTrace\Testing\trigger_error
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die("skip: PHP 5.4 does not support close-at-exit functionality"); ?>
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo 'Shutdown' . PHP_EOL;
+    foreach (dd_trace_serialize_closed_spans() as $span) {
+        echo $span['name'] . PHP_EOL;
+        if (isset($span['error']) && $span['error'] === 1) {
+            echo $span['meta']['error.type'] . PHP_EOL;
+            echo $span['meta']['error.msg'] . PHP_EOL;
+            echo $span['meta']['error.stack'] . PHP_EOL;
+        }
+    }
+});
+
+function main()
+{
+    var_dump(array_sum([1, 99]));
+    DDTrace\Testing\trigger_error('My foo error', E_USER_ERROR);
+    echo 'You should not see this.' . PHP_EOL;
+}
+
+// let's test defaults
+DDTrace\trace_function('main', function (DDTrace\SpanData $span) {});
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {});
+DDTrace\trace_function('DDTrace\\Testing\\trigger_error', function (DDTrace\SpanData $span) {});
+
+main();
+?>
+--EXPECTF--
+int(100)
+
+%s My foo error in %s on line %d
+Shutdown
+main
+E_USER_ERROR
+My foo error
+#0 %s(%d): DDTrace\Testing\trigger_error()
+#1 %s(%d): main()
+#2 {main}
+DDTrace\Testing\trigger_error
+E_USER_ERROR
+My foo error
+#0 %s(%d): DDTrace\Testing\trigger_error()
+#1 %s(%d): main()
+#2 {main}
+array_sum


### PR DESCRIPTION
### Description

Previously fatal errors were attached only to the top-most open internal span. In this case, "internal" means traced by `DDTrace\trace_method` or `DDTrace\trace_function`; it doesn't apply to spans made through Open Tracing or the `DDTrace\Tracer` API which notably includes the root span when `DD_TRACE_GENERATE_ROOT_SPAN` is on (it defaults to on).

Also avoid installing `ddtrace_error_cb` on PHP 5.4 as this feature it isn't supported yet.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
