### PR TITLE
Always run build_package workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -854,13 +854,7 @@ workflows:
 
   build_packages:
     jobs:
-      - "Prepare Code":
-          filters:
-            tags:
-              only: /(^build$)|(^[v]?[0-9]+(\.[0-9]+)*$)/
-            branches:
-              # Always build on master and on release branches
-              only: /^.*(master|build|[0-9]+.[0-9]+.[0-9]+|ddtrace-[0-9]+.[0-9]+).*$/
+      - "Prepare Code"
       - compile_extension:
           name: "Compile PHP 54"
           docker_image: "datadog/docker-library:ddtrace_centos_6_php_5_4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1105,14 +1105,14 @@ workflows:
           name: "PHP 55 custom autoloaded web tests with nginx + PHP-FPM"
           resource_class: medium+
           sapi: fpm-fcgi
-          integration_testsuite: "custom-framework-autoloaded-suite"
+          integration_testsuite: "test_web_custom"
           docker_image: "datadog/dd-trace-ci:php-5.5-debug-buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 74 custom autoloaded web tests with nginx + PHP-FPM"
           resource_class: medium+
           sapi: fpm-fcgi
-          integration_testsuite: "custom-framework-autoloaded-suite"
+          integration_testsuite: "test_web_custom"
           docker_image: "datadog/dd-trace-ci:php-7.4-debug-buster"
 
   build:


### PR DESCRIPTION
### Description

This PR enable running `build_package` workflow always, to make sure that if something is merged into master, it has no failing tests. In addition to that, this PR fixes naming of a test suite that changes in the transition from composer-based test execution to make-based execution.

As a separate effort, we must reduce CI times, as part of a different effort.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
