### PR TITLE
Build on PHP 8.0.0 RC 1 (without a shippable build)

### DIFF
--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         #   phpVersion: 8.0-custom
         #   phpTarGzUrl: https://github.com/<org>/<repo>/archive/<branch-or-tag-name>.tar.gz
         phpVersion: 8.0
-        phpTarGzUrl: https://github.com/php/php-src/archive/php-8.0.0beta4.tar.gz
+        phpTarGzUrl: https://github.com/php/php-src/archive/php-8.0.0rc1.tar.gz
 
   php-master:
     image: datadog/dd-trace-ci:php-master_buster

--- a/src/ext/ddtrace.c
+++ b/src/ext/ddtrace.c
@@ -70,10 +70,15 @@ STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateStrin
 PHP_INI_END()
 
 static int ddtrace_startup(struct _zend_extension *extension) {
+#if PHP_VERSION_ID < 80000
     ddtrace_resource = zend_get_resource_handle(extension);
-
 #if PHP_VERSION_ID >= 70400
     ddtrace_op_array_extension = zend_get_op_array_extension_handle();
+#endif
+#else
+    UNUSED(extension);
+    ddtrace_resource = zend_get_resource_handle(PHP_DDTRACE_EXTNAME);
+    ddtrace_op_array_extension = zend_get_op_array_extension_handle(PHP_DDTRACE_EXTNAME);
 #endif
 
     ddtrace_excluded_modules_startup();
@@ -82,8 +87,7 @@ static int ddtrace_startup(struct _zend_extension *extension) {
 }
 
 static void ddtrace_shutdown(struct _zend_extension *extension) {
-    PHP5_UNUSED(extension);
-    PHP7_UNUSED(extension);
+    UNUSED(extension);
 
     ddtrace_internal_handlers_shutdown();
 }

--- a/src/ext/engine_hooks.c
+++ b/src/ext/engine_hooks.c
@@ -129,6 +129,8 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
 }
 #else
 void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message) {
+    UNUSED(error_filename, error_lineno);
+
     ddtrace_span_fci *span = DDTRACE_G(open_spans_top);
     if (span && (type == E_ERROR || type == E_CORE_ERROR || type == E_USER_ERROR)) {
         zval ex, tmp;

--- a/src/ext/php5_4/engine_hooks.c
+++ b/src/ext/php5_4/engine_hooks.c
@@ -566,7 +566,7 @@ typedef void (*dd_execute_internal_hook)(zend_execute_data *execute_data_ptr, in
 static void dd_internal_tracing_prehook(zend_execute_data *execute_data_ptr, int return_value_used TSRMLS_DC,
                                         ddtrace_dispatch_t *dispatch) {
     // todo: add support for tracing prehook for PHP 5.4
-    PHP5_UNUSED(dispatch);
+    UNUSED(dispatch);
     dd_prev_execute_internal(execute_data_ptr, return_value_used TSRMLS_CC);
 }
 
@@ -643,13 +643,13 @@ void ddtrace_opcode_mshutdown(void) {}
 
 void ddtrace_engine_hooks_rinit(TSRMLS_D) {
 #if ZTS
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
 }
 
 void ddtrace_engine_hooks_rshutdown(TSRMLS_D) {
 #if ZTS
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
 }
 
@@ -673,14 +673,17 @@ void ddtrace_execute_internal_mshutdown(void) {
 
 // TODO: can we support close-at-exit and by extension fatal errors on PHP 5.4?
 zval *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS TSRMLS_DC) {
-    PHP5_UNUSED(DDTRACE_ERROR_CB_PARAM_PASSTHRU TSRMLS_CC);
+    UNUSED(DDTRACE_ERROR_CB_PARAM_PASSTHRU);
+#if ZTS
+    UNUSED(TSRMLS_C);
+#endif
 
     return NULL;
 }
 
 void ddtrace_close_all_open_spans(TSRMLS_D) {
 #if ZTS
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
     ddtrace_log_debug("Request to close all open spans ignored; not supported on PHP 5.4 (yet, anyway)");
 }


### PR DESCRIPTION
### Description

This updates the PHP 8 container to 8.0.0 RC 1 and fixes two `ZEND_API` changes. This PR does not include a shippable build of ddtrace on RC 1. That will come in a future PR.

This PR also fixes a build error on PHP 5.4 ZTS and cleans up a small section of `UNUSED` macro usage.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- ~[ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.~ Does not include a shippable build.
