### PR TITLE
Assert both 0 and 1 work as values for DD_TRACE_SAMPLE_RATE

### DIFF
--- a/tests/Unit/Sampling/ConfigurableSamplerTest.php
+++ b/tests/Unit/Sampling/ConfigurableSamplerTest.php
@@ -53,9 +53,13 @@ final class ConfigurableSamplerTest extends BaseTestCase
         return [
             // Edges
             [0.0, 0.0, 0.0],
+            // 0% provided as int.
+            [0, 0.0, 0.0],
             [1.0, 1.0, 1.0],
             [100, 1.0, 1.0],
             [-20, 0.0, 0.0],
+            // 100% provided as int.
+            [1, 1.00, 1.00],
 
             // Common cases
             [0.5, 0.47, 0.53],


### PR DESCRIPTION
### Description

This PR adds a test to assert that both `0` and `1` work as values for `DD_TRACE_SAMPLE_RATE`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
