### PR TITLE
Fix Symfony 4.0 composer update issue in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -569,6 +569,7 @@ test_web_symfony_34:
 	php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V3_4)
 test_web_symfony_40:
+	# Trick to have symfony 4.0 update process not to fail because of an error related to monolog dependencies.
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 update --no-scripts
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 update
 	php tests/Frameworks/Symfony/Version_4_0/bin/console cache:clear --no-warmup --env=prod

--- a/Makefile
+++ b/Makefile
@@ -569,6 +569,7 @@ test_web_symfony_34:
 	php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V3_4)
 test_web_symfony_40:
+	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 update --no-scripts
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 update
 	php tests/Frameworks/Symfony/Version_4_0/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V4_0)
@@ -590,7 +591,6 @@ test_web_zend_1:
 test_web_custom:
 	$(COMPOSER) --working-dir=tests/Frameworks/Custom/Version_Autoloaded update
 	$(call run_tests,--testsuite=custom-framework-autoloading-test)
-
 
 test_scenario_%:
 	$(Q) $(COMPOSER_TESTS) scenario $*


### PR DESCRIPTION
### Description

Some release of symfony/flex's recipes or dependencies (I believe around monolog but I was not able to track it down to the rela cause) is causing the `cache:clear` post install to fail with an error `"excluded_http_codes" cannot be used as your version of Monolog bridge does not support it.`. Attempts based on issues in various symfony recipes did not work.
Only trick that worked is running composer update once with `--no-script` (so cache clear is not run) and once without it, so all the post-update scripts required by symfony is executed.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
