### PR TITLE
Update PHP language xfail lists

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -259,6 +259,7 @@ tests/classes/autoload_020.phpt
 tests/classes/clone_001.phpt
 tests/classes/clone_002.phpt
 tests/classes/clone_004.phpt
+tests/lang/045.phpt
 tests/lang/type_hints_002.phpt
 tests/output/ob_start_basic_002.phpt
 tests/run-test/test005.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -42,6 +42,7 @@ Zend/tests/bug75420.5.phpt
 Zend/tests/bug75420.6.phpt
 Zend/tests/bug75420.8.phpt
 Zend/tests/bug78999.phpt
+Zend/tests/bug79778.phpt
 Zend/tests/class_alias_020.phpt
 Zend/tests/class_name_as_scalar.phpt
 Zend/tests/closure_058.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -51,6 +51,9 @@ Zend/tests/bug78182.phpt
 Zend/tests/bug78644.phpt
 Zend/tests/bug78999.phpt
 Zend/tests/bug79155.phpt
+Zend/tests/bug79778.phpt
+Zend/tests/bug79862.phpt
+Zend/tests/bug80037.phpt
 Zend/tests/class_alias_020.phpt
 Zend/tests/class_name_as_scalar.phpt
 Zend/tests/closure_058.phpt
@@ -223,6 +226,7 @@ ext/reflection/tests/ReflectionReference_bug78263.phpt
 ext/reflection/tests/bug39884.phpt
 ext/reflection/tests/bug46103.phpt
 ext/reflection/tests/bug69802.phpt
+ext/reflection/tests/bug79683.phpt
 ext/reflection/tests/traits004.phpt
 ext/session/tests/003.phpt
 ext/session/tests/004.phpt
@@ -334,6 +338,7 @@ ext/standard/tests/array/array_unique_variation3.phpt
 ext/standard/tests/array/array_walk_closure.phpt
 ext/standard/tests/array/arsort_object1.phpt
 ext/standard/tests/array/arsort_object2.phpt
+ext/standard/tests/array/bug79839.phpt
 ext/standard/tests/array/compact_this.phpt
 ext/standard/tests/array/uasort_object1.phpt
 ext/standard/tests/assert/assert_variation.phpt


### PR DESCRIPTION
### Description

Locally I updated PHP 7.2, 7.3, and 7.4 buster containers to the latest versions. All of these tests fail because a specific object ID is tested.

The PHP 5.5 test is one that happens in a 1 second request time limit. If it triggers in a memory routine then it is corrupted and sigsegvs in the next memory operation. This is why newer PHP versions (I think PHP 7.1+?) use a different mechanism for timeout handling.

### Readiness checklist
- [x] ~Changelog has been added to the release document.~
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] ~Changelog has been added to the release document.~
