### PR TITLE
Trace Symfony controller and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,7 @@ TEST_WEB_71 := \
 	test_web_symfony_30 \
 	test_web_symfony_33 \
 	test_web_symfony_34 \
+	test_web_symfony_40 \
 	test_web_symfony_42 \
 	test_web_yii_2 \
 	test_web_wordpress_48 \
@@ -403,6 +404,7 @@ TEST_WEB_73 := \
 	test_web_lumen_56 \
 	test_web_lumen_58 \
 	test_web_slim_312 \
+	test_web_symfony_34 \
 	test_web_symfony_40 \
 	test_web_symfony_42 \
 	test_web_symfony_44 \
@@ -433,6 +435,7 @@ TEST_WEB_74 := \
 	test_web_lumen_56 \
 	test_web_lumen_58 \
 	test_web_slim_312 \
+	test_web_symfony_34 \
 	test_web_symfony_40 \
 	test_web_symfony_42 \
 	test_web_symfony_44 \

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -103,7 +103,7 @@ class SymfonyIntegration extends Integration
         $integration->symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $integration->appName);
         $integration->addTraceAnalyticsIfEnabledLegacy($integration->symfonyRequestSpan);
 
-        // Move this to its own integration
+        /* Move this to its own integration
         $doctrineRepositories = [];
         \DDTrace\hook_method(
             'Doctrine\\Bundle\\DoctrineBundle\\Repository\\ServiceEntityRepository',
@@ -142,6 +142,7 @@ class SymfonyIntegration extends Integration
                 }
             }
         );
+         */
 
         \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\HttpKernel',

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -41,14 +41,42 @@ class SymfonyIntegration extends Integration
     {
         $integration = $this;
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
+            'Symfony\Component\HttpKernel\Kernel',
+            '__construct',
+            function () {
+                \DDTrace\trace_method(
+                    'Symfony\Component\HttpKernel\Kernel',
+                    'handle',
+                    function (SpanData $span) {
+                        $span->name = 'symfony.httpkernel.kernel.handle';
+                        $span->resource = \get_class($this);
+                        $span->type = Type::WEB_SERVLET;
+                        $span->service = \ddtrace_config_app_name('symfony');
+                    }
+                );
+
+                \DDTrace\trace_method(
+                    'Symfony\Component\HttpKernel\Kernel',
+                    'boot',
+                    function (SpanData $span) {
+                        $span->name = 'symfony.httpkernel.kernel.boot';
+                        $span->resource = \get_class($this);
+                        $span->type = Type::WEB_SERVLET;
+                        $span->service = \ddtrace_config_app_name('symfony');
+                    }
+                );
+            }
+        );
+
+        \DDTrace\hook_method(
             'Symfony\Component\HttpKernel\HttpKernel',
             '__construct',
             function () use ($integration) {
                 $tracer = GlobalTracer::get();
                 $scope = $tracer->getRootScope();
                 if (!$scope) {
-                    return false;
+                    return;
                 }
                 /** @var Span $symfonyRequestSpan */
                 $integration->symfonyRequestSpan = $scope->getSpan();
@@ -58,11 +86,10 @@ class SymfonyIntegration extends Integration
                         && Versions::versionMatches('2', \Symfony\Component\HttpKernel\Kernel::VERSION)
                 ) {
                     $integration->loadSymfony2($integration);
-                    return false;
+                    return;
                 }
 
                 $integration->loadSymfony($integration);
-                return false;
             }
         );
 
@@ -75,6 +102,46 @@ class SymfonyIntegration extends Integration
         $integration->symfonyRequestSpan->overwriteOperationName('symfony.request');
         $integration->symfonyRequestSpan->setTag(Tag::SERVICE_NAME, $integration->appName);
         $integration->addTraceAnalyticsIfEnabledLegacy($integration->symfonyRequestSpan);
+
+        // Move this to its own integration
+        $doctrineRepositories = [];
+        \DDTrace\hook_method(
+            'Doctrine\\Bundle\\DoctrineBundle\\Repository\\ServiceEntityRepository',
+            '__construct',
+            function ($object, $class) use (&$doctrineRepositories) {
+                if (isset($object) && \is_object($object)) {
+                    $class = \get_class($object);
+                }
+
+                if (isset($doctrineRepositories[$class])) {
+                    return;
+                }
+
+                $doctrineRepositories[$class] = null;
+
+                $rc = new \ReflectionClass($class);
+                $methods = $rc->getMethods(\ReflectionMethod::IS_PUBLIC);
+                foreach ($methods as $method) {
+                    $methodname = $method->name;
+                    // Skip magic methods and other functions prefixed with _
+                    if (\strlen($methodname) === 0 || $methodname[0] === '_') {
+                        continue;
+                    }
+
+                    \DDTrace\trace_method(
+                        $class,
+                        $methodname,
+                        function (SpanData $span) use ($class, $methodname) {
+                            $replaced = \str_replace('\\', '.', $class);
+                            $span->name = "{$replaced}.{$methodname}";
+                            $span->resource = "{$class}::{$methodname}";
+                            $span->type = Type::WEB_SERVLET;
+                            $span->service = \ddtrace_config_app_name('doctrine');
+                        }
+                    );
+                }
+            }
+        );
 
         \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\HttpKernel',
@@ -132,6 +199,41 @@ class SymfonyIntegration extends Integration
                         // Invalid API usage
                         return false;
                     }
+
+                    // trace the container itself
+                    if ($eventName === 'kernel.controller' && \method_exists($event, 'getController')) {
+                        $controller = $event->getController();
+                        if (!($controller instanceof \Closure)) {
+                            if (\is_callable($controller, false, $controllerName) && $controllerName !== null) {
+                                if (\strpos($controllerName, '::') > 0) {
+                                    list($class, $method) = \explode('::', $controllerName);
+                                    if (isset($class, $method)) {
+                                        \DDTrace\trace_method(
+                                            $class,
+                                            $method,
+                                            function (SpanData $span) use ($controllerName, $integration) {
+                                                $span->name = 'symfony.controller';
+                                                $span->resource = $controllerName;
+                                                $span->type = Type::WEB_SERVLET;
+                                                $span->service = $integration->appName;
+                                            }
+                                        );
+                                    }
+                                } else {
+                                    \DDTrace\trace_function(
+                                        $controllerName,
+                                        function (SpanData $span) use ($controllerName, $integration) {
+                                            $span->name = 'symfony.controller';
+                                            $span->resource = $controllerName;
+                                            $span->type = Type::WEB_SERVLET;
+                                            $span->service = $integration->appName;
+                                        }
+                                    );
+                                }
+                            }
+                        }
+                    }
+
                     $span->name = $span->resource = 'symfony.' . $eventName;
                     $span->service = $integration->appName;
                     if ($event === null) {

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -33,6 +33,10 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => '/app.php',
                 'http.status_code' => '200',
+            ])->withChildren([
+                SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                ]),
             ]),
         ]);
     }

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -33,6 +33,10 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => '/app.php',
                 'http.status_code' => '200',
+            ])->withChildren([
+                SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                ]),
             ]),
         ]);
     }

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -38,24 +38,30 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleAction'
+                                )->skipIf(\PHP_MAJOR_VERSION !== 5), // call_user_func_array
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -63,32 +69,44 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
                                     SpanAssertion::build(
                                         'symfony.templating.render',
                                         'symfony',
                                         'web',
                                         'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                                    )
-                                        ->withExactTags([
-                                        ]),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                                    )->withExactTags([]),
+                                ])
+                                ->skipIf(\PHP_MAJOR_VERSION !== 5), // call_user_func_array
+                                SpanAssertion::build(
+                                    'symfony.templating.render',
+                                    'symfony',
+                                    'web',
+                                    'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
+                                )->withExactTags([])->skipIf(\PHP_MAJOR_VERSION === 5),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -96,33 +114,41 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'error'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
-                            'symfony.route.name' => 'error',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500',
-                        ])
-                        ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack'])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('symfony.templating.render'),
-                                                ]),
-                                            SpanAssertion::exists('symfony.kernel.response'),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
-                                        ]),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])
+                    ->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::errorAction'
+                                )
+                                ->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack'])
+                                ->skipIf(\PHP_MAJOR_VERSION !== 5), // call_user_func_array
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A GET request to a missing route' => [
                     SpanAssertion::build(
@@ -130,14 +156,13 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'GET /does_not_exist'
-                    )
-                        ->withExactTags([
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/does_not_exist',
-                            'http.status_code' => '404',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -154,6 +179,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     ->withExistingTagsNames(['error.stack']),
                             ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -38,28 +38,33 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                            ->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
-                                SpanAssertion::exists('symfony.kernel.controller'),
-                                SpanAssertion::exists('symfony.kernel.response'),
-                                SpanAssertion::exists('symfony.kernel.finish_request'),
-                            ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
+                )->withExactTags([
+                    'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                        SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::build(
+                                'symfony.controller',
+                                'symfony',
+                                'web',
+                                'AppBundle\Controller\CommonScenariosController::simpleAction'
+                            )->skipIf(\PHP_MAJOR_VERSION !== 5), // call_user_func_array
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ]),
                     ]),
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                ]),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -38,25 +38,31 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleAction'
+                                ),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -64,33 +70,38 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
                                     SpanAssertion::build(
                                         'symfony.templating.render',
                                         'symfony',
                                         'web',
                                         'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                                    )
-                                        ->withExactTags([
-                                        ]),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    )->withExactTags([]),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -98,34 +109,41 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'error'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
-                            'symfony.route.name' => 'error',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500',
-                        ])
-                        ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack'])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('symfony.templating.render'),
-                                                ]),
-                                            SpanAssertion::exists('symfony.kernel.response'),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
-                                        ]),
+                    )->withExactTags([
+                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])
+                    ->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::errorAction'
+                                )
+                                ->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack']),
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request to a missing route' => [
                     SpanAssertion::build(
@@ -133,14 +151,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'symfony',
                         'web',
                         'GET /does_not_exist'
-                    )
-                        ->withExactTags([
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/does_not_exist',
-                            'http.status_code' => '404',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -157,6 +175,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     ->withExistingTagsNames(['error.stack']),
                             ]),
                         ]),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -38,29 +38,33 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                            ->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
-                                SpanAssertion::exists('symfony.kernel.controller'),
-                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                SpanAssertion::exists('symfony.kernel.response'),
-                                SpanAssertion::exists('symfony.kernel.finish_request'),
-                            ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
+                )->withExactTags([
+                    'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                        SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),SpanAssertion::build(
+                                'symfony.controller',
+                                'symfony',
+                                'web',
+                                'AppBundle\Controller\CommonScenariosController::simpleAction'
+                            ),
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ]),
                     ]),
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                ]),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -32,22 +32,28 @@ class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
                 'symfony',
                 'web',
                 'terminated_by_exit'
-            )
-                ->withExactTags([
-                    'symfony.route.action' => 'AppBundle\Controller\HomeController@actionBeingTerminatedByExit',
-                    'symfony.route.name' => 'terminated_by_exit',
-                    'http.method' => 'GET',
-                    'http.url' => 'http://localhost:9999/terminated_by_exit',
-                    'http.status_code' => '200',
-                ])
-                ->withChildren([
-                    SpanAssertion::exists('symfony.kernel.handle')
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
-                            SpanAssertion::exists('symfony.kernel.controller'),
-                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                        ]),
+            )->withExactTags([
+                'symfony.route.action' => 'AppBundle\Controller\HomeController@actionBeingTerminatedByExit',
+                'symfony.route.name' => 'terminated_by_exit',
+                'http.method' => 'GET',
+                'http.url' => 'http://localhost:9999/terminated_by_exit',
+                'http.status_code' => '200',
+            ])->withChildren([
+                SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                    SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.kernel.request'),
+                        SpanAssertion::exists('symfony.kernel.controller'),
+                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                        SpanAssertion::build(
+                            'symfony.controller',
+                            'symfony',
+                            'web',
+                            'AppBundle\Controller\HomeController::actionBeingTerminatedByExit'
+                        ),
+                    ]),
                 ]),
+            ]),
         ]);
     }
 }

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -52,14 +52,22 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
                     ])->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                            ->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.request'),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_34',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleAction'
+                                ),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
+                        ]),
                         SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
                 ],
@@ -76,20 +84,29 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
                     ])->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
-                            SpanAssertion::exists('symfony.kernel.controller'),
-                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                            SpanAssertion::build(
-                                'symfony.templating.render',
-                                'test_symfony_34',
-                                'web',
-                                'Twig\Environment twig_template.html.twig'
-                            )->withExactTags([
-                            ]),
-                            SpanAssertion::exists('symfony.kernel.response'),
-                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::build(
+                                        'symfony.controller',
+                                        'test_symfony_34',
+                                        'web',
+                                        'AppBundle\Controller\CommonScenariosController::simpleViewAction'
+                                    )->withChildren([
+                                        SpanAssertion::build(
+                                            'symfony.templating.render',
+                                            'test_symfony_34',
+                                            'web',
+                                            'Twig\Environment twig_template.html.twig'
+                                        )->withExactTags([]),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
                         ]),
                         SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
@@ -111,21 +128,29 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack'])
                         ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                                SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.request'),
                                     SpanAssertion::exists('symfony.kernel.controller'),
                                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('symfony.templating.render'),
-                                                ]),
-                                            SpanAssertion::exists('symfony.kernel.response'),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::build(
+                                        'symfony.controller',
+                                        'test_symfony_34',
+                                        'web',
+                                        'AppBundle\Controller\CommonScenariosController::errorAction'
+                                    )
+                                    ->setError('Exception', 'An exception occurred')
+                                    ->withExistingTagsNames(['error.stack']),
+                                    SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                        SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                            SpanAssertion::exists('symfony.templating.render'),
                                         ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    ]),
                                 ]),
+                            ]),
                             SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
@@ -142,22 +167,25 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '404',
                         ])
                         ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
-                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                            SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                                SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                            SpanAssertion::exists('symfony.templating.render'),
+                                        ]),
                                     ]),
-                                ]),
-                                SpanAssertion::exists('symfony.kernel.request')
+                                    SpanAssertion::exists('symfony.kernel.request')
                                     ->setError(
                                         'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
                                         'No route found for "GET /does_not_exist"'
                                     )
                                     ->withExistingTagsNames(['error.stack']),
+                                ]),
                             ]),
+                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
                 ],
             ]

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -25,33 +25,38 @@ class TemplateEnginesTest extends WebFrameworkTestCase
                 'symfony',
                 'web',
                 'alternate_templating'
-            )
-                ->withExactTags([
-                    'symfony.route.action' => 'AppBundle\Controller\HomeController@indexAction',
-                    'symfony.route.name' => 'alternate_templating',
-                    'http.method' => 'GET',
-                    'http.url' => 'http://localhost:9999/alternate_templating',
-                    'http.status_code' => '200',
-                ])
-                ->withChildren([
-                    SpanAssertion::exists('symfony.kernel.handle')
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
-                            SpanAssertion::exists('symfony.kernel.controller'),
-                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+            )->withExactTags([
+                'symfony.route.action' => 'AppBundle\Controller\HomeController@indexAction',
+                'symfony.route.name' => 'alternate_templating',
+                'http.method' => 'GET',
+                'http.url' => 'http://localhost:9999/alternate_templating',
+                'http.status_code' => '200',
+            ])->withChildren([
+                SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                    SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.kernel.request'),
+                        SpanAssertion::exists('symfony.kernel.controller'),
+                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                        SpanAssertion::build(
+                            'symfony.controller',
+                            'symfony',
+                            'web',
+                            'AppBundle\Controller\HomeController::indexAction'
+                        )->withChildren([
                             SpanAssertion::build(
                                 'symfony.templating.render',
                                 'symfony',
                                 'web',
                                 'Symfony\Component\Templating\PhpEngine php_template.template.php'
-                            )
-                                ->withExactTags([
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.response'),
-                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                            )->withExactTags([]),
                         ]),
-                    SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.kernel.response'),
+                        SpanAssertion::exists('symfony.kernel.finish_request'),
+                    ]),
                 ]),
+                SpanAssertion::exists('symfony.kernel.terminate'),
+            ]),
         ]);
     }
 }

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -38,29 +38,35 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
+                )->withExactTags([
+                    'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')
                             ->withChildren([
                                 SpanAssertion::exists('symfony.kernel.request'),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'AppBundle\Controller\CommonScenariosController::simpleAction'
+                                ),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                ]),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -46,25 +46,31 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_40',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_40',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleAction'
+                                ),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -72,33 +78,38 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_40',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_40',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
                                     SpanAssertion::build(
                                         'symfony.templating.render',
                                         'test_symfony_40',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )
-                                        ->withExactTags([
-                                        ]),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    )->withExactTags([]),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -106,34 +117,41 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_40',
                         'web',
                         'error'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
-                            'symfony.route.name' => 'error',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500',
-                        ])
-                        ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack'])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('symfony.templating.render'),
-                                                ]),
-                                            SpanAssertion::exists('symfony.kernel.response'),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
-                                        ]),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])
+                    ->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_40',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::errorAction'
+                                )
+                                ->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack']),
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request to a missing route' => [
                     SpanAssertion::build(
@@ -141,14 +159,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_40',
                         'web',
                         'GET /does_not_exist'
-                    )
-                        ->withExactTags([
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/does_not_exist',
-                            'http.status_code' => '404',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -158,13 +176,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.request')
-                                    ->setError(
-                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
-                                        'No route found for "GET /does_not_exist"'
-                                    )
-                                    ->withExistingTagsNames(['error.stack']),
+                                ->setError(
+                                    'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                    'No route found for "GET /does_not_exist"'
+                                )
+                                ->withExistingTagsNames(['error.stack']),
                             ]),
                         ]),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -38,29 +38,34 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                            ->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
-                                SpanAssertion::exists('symfony.kernel.controller'),
-                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                SpanAssertion::exists('symfony.kernel.response'),
-                                SpanAssertion::exists('symfony.kernel.finish_request'),
-                            ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
+                )->withExactTags([
+                    'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                        SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                            SpanAssertion::build(
+                                'symfony.controller',
+                                'symfony',
+                                'web',
+                                'App\Controller\CommonScenariosController::simpleAction'
+                            ),
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ]),
                     ]),
+                ]),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -46,25 +46,31 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_42',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
-                                ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_42',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleAction'
+                                )
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -72,33 +78,38 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_42',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_42',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
                                     SpanAssertion::build(
                                         'symfony.templating.render',
                                         'test_symfony_42',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )
-                                        ->withExactTags([
-                                        ]),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    )->withExactTags([]),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -106,34 +117,39 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_42',
                         'web',
                         'error'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
-                            'symfony.route.name' => 'error',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500',
-                        ])
-                        ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack'])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception')
-                                                ->withChildren([
-                                                    SpanAssertion::exists('symfony.templating.render'),
-                                                ]),
-                                            SpanAssertion::exists('symfony.kernel.response'),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
-                                        ]),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_42',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::errorAction'
+                                )->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack']),
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render'),
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request to a missing route' => [
                     SpanAssertion::build(
@@ -141,14 +157,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_42',
                         'web',
                         'GET /does_not_exist'
-                    )
-                        ->withExactTags([
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/does_not_exist',
-                            'http.status_code' => '404',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -165,6 +181,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     ->withExistingTagsNames(['error.stack']),
                             ]),
                         ]),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -39,29 +39,35 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
+                )->withExactTags([
+                    'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ]) ->withChildren([
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')
                             ->withChildren([
                                 SpanAssertion::exists('symfony.kernel.request'),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'symfony',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleAction'
+                                ),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
                     ]),
+                ]),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
@@ -47,15 +47,16 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_44',
                         'web',
                         'simple'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                            'symfony.route.name' => 'simple',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple',
-                            'http.status_code' => '200',
-                        ])
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')
                                 ->withChildren([
                                     SpanAssertion::exists('symfony.kernel.request'),
@@ -63,9 +64,16 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::build(
+                                        'symfony.controller',
+                                        'test_symfony_44',
+                                        'web',
+                                        'App\Controller\CommonScenariosController::simpleAction'
+                                    )
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
                         ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
@@ -73,33 +81,38 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_44',
                         'web',
                         'simple_view'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
-                            'symfony.route.name' => 'simple_view',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view',
-                            'http.status_code' => '200',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_44',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
                                     SpanAssertion::build(
                                         'symfony.templating.render',
                                         'test_symfony_44',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )
-                                        ->withExactTags([
-                                        ]),
-                                    SpanAssertion::exists('symfony.kernel.response'),
-                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    )->withExactTags([]),
                                 ]),
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
@@ -107,33 +120,44 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_44',
                         'web',
                         'error'
-                    )
-                        ->withExactTags([
-                            'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
-                            'symfony.route.name' => 'error',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error',
-                            'http.status_code' => '500',
-                        ])
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])
+                    ->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack'])
                         ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.handle')
-                                ->withChildren([
-                                    SpanAssertion::exists('symfony.kernel.request'),
-                                    SpanAssertion::exists('symfony.kernel.controller'),
-                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                    SpanAssertion::exists('symfony.kernel.handleException')
-                                        ->withChildren([
-                                            SpanAssertion::exists('symfony.kernel.exception'),
-                                            SpanAssertion::exists('symfony.kernel.response')->withChildren([
-                                                SpanAssertion::exists('symfony.templating.render')
-                                            ]),
-                                            SpanAssertion::exists('symfony.kernel.finish_request'),
-                                        ]),
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_44',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::errorAction'
+                                )
+                                ->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack']),
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception'),
+                                    SpanAssertion::exists('symfony.kernel.response')->withChildren([
+                                        SpanAssertion::exists('symfony.templating.render')
+                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
                                 ]),
-                                SpanAssertion::exists('symfony.kernel.terminate'),
+                            ]),
                         ]),
+                    ]),
                 ],
                 'A GET request to a missing route' => [
                     SpanAssertion::build(
@@ -141,14 +165,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'test_symfony_44',
                         'web',
                         'GET /does_not_exist'
-                    )
-                        ->withExactTags([
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/does_not_exist',
-                            'http.status_code' => '404',
-                        ])
-                        ->withChildren([
-                            SpanAssertion::exists('symfony.kernel.terminate'),
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -165,6 +189,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     ->withExistingTagsNames(['error.stack']),
                             ]),
                         ]),
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
@@ -38,29 +38,34 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'symfony',
                     'web',
                     'simple'
-                )
-                    ->withExactTags([
-                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
-                        'symfony.route.name' => 'simple',
-                        'http.method' => 'GET',
-                        'http.url' => 'http://localhost:9999/simple',
-                        'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_sampling_priority_v1' => 1,
-                    ])
-                    ->withChildren([
-                        SpanAssertion::exists('symfony.kernel.handle')
-                            ->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
-                                SpanAssertion::exists('symfony.kernel.controller'),
-                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                SpanAssertion::exists('symfony.kernel.response'),
-                                SpanAssertion::exists('symfony.kernel.finish_request'),
-                            ]),
-                        SpanAssertion::exists('symfony.kernel.terminate'),
+                )->withExactTags([
+                    'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                        SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                            SpanAssertion::build(
+                                'symfony.controller',
+                                'symfony',
+                                'web',
+                                'App\Controller\CommonScenariosController::simpleAction'
+                            ),
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ]),
                     ]),
+                ]),
             ]
         );
     }


### PR DESCRIPTION
### Description

This adds the following enhancements:

- Trace the Symfony controller as `symfony.controller`, attaching the method name as the resource. Note that this doesn't work with controllers that are closures, only other forms of callables. Also, some versions of Symfony call this with `call_user_func` or `call_user_func_array`, and sometimes it's fully qualified and sometimes it's not. I point this out because on PHP 7 it matters; if it's unqualified then it won't be traced.
- Trace the main HttpKernel\Kernel's methods `boot` and `handle`.
- Move `Symfony\Component\HttpKernel\HttpKernel::__construct` to the non-tracing prehook API.
- Trace public methods of Doctrine Repository classes. This will probably be split off of this PR in its final form, but it was really satisfying to see it in the demo app. In the screenshot below, the spans that start with `App` underneath `symfony.controller App\Controller\BlogController::index` are the ones belonging to Doctrine. Edit: this piece has been removed from this PR.

![Screenshot of Symfony demo app with changes from the initial PR](https://user-images.githubusercontent.com/253316/95690925-704f0380-0bd8-11eb-89b1-35b05778a716.png)


### Readiness checklist
- [x] Changelog has been added to the release document.  
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
