### PR TITLE
Disable instrumenting generators on PHP 5

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -242,6 +242,7 @@
             <file name="tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
             <file name="tests/ext/sandbox/generator.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_not_supported.phpt" role="test" />
+            <file name="tests/ext/sandbox/generator_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_with_exception.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_with_return.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_yield_from.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -98,8 +98,6 @@
             <file name="src/ext/compatibility.h" role="src" />
             <file name="src/ext/integrations/integrations.c" role="src" />
             <file name="src/ext/integrations/integrations.h" role="src" />
-            <file name="src/ext/integrations/elasticsearch.h" role="src" />
-            <file name="src/ext/integrations/test_integration.h" role="src" />
             <file name="src/ext/mpack/AUTHORS.md" role="doc" />
             <file name="src/ext/mpack/CHANGELOG.md" role="doc" />
             <file name="src/ext/mpack/README.md" role="doc" />

--- a/src/ext/php5/engine_hooks.c
+++ b/src/ext/php5/engine_hooks.c
@@ -592,6 +592,11 @@ static bool dd_try_fetch_user_dispatch(zend_execute_data *execute_data TSRMLS_DC
         return false;
     }
 
+    // Generators are not supported on PHP 5
+    if (op_array->fn_flags & ZEND_ACC_GENERATOR) {
+        return false;
+    }
+
     // we're not yet set-up to respect a cached dispatch; only a NOT_TRACED flag
     ddtrace_dispatch_t *dispatch = NULL;
     zend_function *fbc = (zend_function *)op_array;

--- a/tests/ext/sandbox/generator_php5.phpt
+++ b/tests/ext/sandbox/generator_php5.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Functions that return generators are not instrumented
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50500) die('skip: Generators were added in PHP 5.5'); ?>
+<?php if (PHP_VERSION_ID >= 70000) die('skip: Test is for PHP 5 only'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function getResults() {
+    for ($i = 10; $i < 13; $i++) {
+        yield $i;
+    }
+}
+
+function doSomething() {
+    $generator = getResults();
+    foreach ($generator as $value) {
+        echo $value . PHP_EOL;
+    }
+
+    return 'Done';
+}
+
+DDTrace\trace_function('getResults', function(SpanData $s, $a, $retval) {
+    $s->name = 'getResults';
+    $s->resource = $retval;
+});
+
+DDTrace\trace_function('doSomething', function(SpanData $s, $a, $retval) {
+    $s->name = 'doSomething';
+    $s->resource = $retval;
+});
+
+echo doSomething() . PHP_EOL;
+
+array_map(function($span) {
+    echo $span['name'];
+    echo isset($span['resource']) ? ', ' . $span['resource'] : '';
+    echo PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+?>
+--EXPECT--
+10
+11
+12
+Done
+doSomething, Done


### PR DESCRIPTION
### Description

Generators cannot be reliably instrumented on PHP 5 so this PR ensures that generators are never traced.

This PR also includes a tiny PECL build fix for files that were deleted in #1006.

### Reviewer checklist

- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
