### PR TITLE
Experimental support for PHP 8.0.0 RC 2

### DIFF
--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0rc1.tar.gz
-        phpSha256Hash: 19f859109540f6bc7f5bf4de71c1f363cd4f171a7c1f0e5f4f0abe5d40f271de
+        phpTarGzUrl: https://downloads.php.net/~pollita/php-8.0.0RC2.tar.gz
+        phpSha256Hash: 0cebc11c61c0f153bd866eab76c424404b3ccc779417cdfde1061e550c3e364c
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'


### PR DESCRIPTION
### Description

PHP 8.0.0 RC 2 was [released today](https://www.php.net/archive/2020.php#2020-10-16-1). \o/

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
