### PR TITLE
XFAIL unreliable string shuffle test on PHP 5.4

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -229,6 +229,7 @@ ext/standard/tests/serialize/bug64146.phpt
 ext/standard/tests/serialize/bug67072_2.phpt
 ext/standard/tests/serialize/bug68976.phpt
 ext/standard/tests/serialize/serialization_objects_007.phpt
+ext/standard/tests/strings/004.phpt
 ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/substr_compare.phpt
 ext/standard/tests/time/strptime_basic.phpt


### PR DESCRIPTION
### Description

This string tests is unreliable on PHP 5.4. For PHP 5.5 this test was relaxed:
php/php-src@09b92a3a542455651016afe1bc9854e52b4673c3

This has failed in CI from time to time, so let's xfail it.

### Readiness checklist
- [x] ~Changelog has been added to the release document.~
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
