### PR TITLE
invoke make generate in overhead measurement sample app

### DIFF
--- a/tests/overhead/dockerfiles/Dockerfile_73_fpm_head
+++ b/tests/overhead/dockerfiles/Dockerfile_73_fpm_head
@@ -6,6 +6,7 @@ ADD ./ /dd-trace-php
 
 WORKDIR /dd-trace-php
 
-RUN composer install
+RUN composer update
 RUN composer install-ext
+RUN make generate
 RUN echo "ddtrace.request_init_hook=/dd-trace-php/bridge/dd_wrap_autoloader.php" >> /usr/local/etc/php/conf.d/ddtrace.ini

--- a/tests/overhead/dockerfiles/Dockerfile_73_fpm_master
+++ b/tests/overhead/dockerfiles/Dockerfile_73_fpm_master
@@ -8,6 +8,7 @@ RUN git clone https://github.com/DataDog/dd-trace-php.git \
     --depth 1 \
     /dd-trace-php
 
-RUN composer --working-dir=/dd-trace-php install
+RUN composer --working-dir=/dd-trace-php update
 RUN composer --working-dir=/dd-trace-php install-ext
+RUN make generate
 RUN echo "ddtrace.request_init_hook=/dd-trace-php/bridge/dd_wrap_autoloader.php" >> /usr/local/etc/php/conf.d/ddtrace.ini


### PR DESCRIPTION
### Description

Starting from #1039 we need two steps to have a fully functional local working environment:
- install extension
- generate the `_generated.php` file

They cannot be done in the same composer command as the library we use to do that is not compatible with PHP 8.

This PR add the file generation to the master and head images in the `test/overhead` sample app.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
