### PR TITLE
Add DatadogArena and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,6 +693,48 @@ jobs:
           when: on_fail
       - store_artifacts: { path: '/tmp/artifacts' }
 
+  DatadogArena:
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+      cmake_version:
+        type: string
+      catch2_version:
+        type: string
+    docker:
+      - image: << parameters.docker_image >>
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Install cmake << parameters.cmake_version >>
+          command: |
+            cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+            mkdir -p /opt/cmake/<< parameters.cmake_version >>
+            cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
+            rm -f /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+      - run:
+          name: Install Catch2
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            cd /tmp
+            curl -OL https://github.com/catchorg/Catch2/archive/v<< parameters.catch2_version >>.tar.gz
+            mkdir catch2
+            cd catch2
+            tar -xf ../v<< parameters.catch2_version >>.tar.gz --strip 1
+            cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2
+            cmake --build build/ --target install
+      - run:
+          name: Build and test Datadog::Arena
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            cmake --version
+            mkdir -p /tmp/build/DatadogArena
+            cd /tmp/build/DatadogArena
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON ~/datadog/ext/DatadogArena
+            make -j
+            make test
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -851,6 +893,25 @@ jobs:
 
 workflows:
   version: 2
+
+  components:
+    jobs:
+      # We need to prepare code because centos 6's git is too old for CircleCI, true story:
+      # > error: unknown switch `B'
+      - "Prepare Code"
+      - DatadogArena:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              docker_image:
+                # Don't need PHP, just basic toolchain
+                - "datadog/dd-trace-ci:php-8.0_centos-6"
+              cmake_version:
+                - "3.10.3"
+                - "3.18.4"
+              catch2_version:
+                - "2.4.2"
+                - "2.13.3"
 
   build_packages:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,7 +693,7 @@ jobs:
           when: on_fail
       - store_artifacts: { path: '/tmp/artifacts' }
 
-  DatadogArena:
+  ExtensionComponents:
     working_directory: ~/datadog
     parameters:
       docker_image:
@@ -709,10 +709,21 @@ jobs:
       - run:
           name: Install cmake << parameters.cmake_version >>
           command: |
-            cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
-            mkdir -p /opt/cmake/<< parameters.cmake_version >>
-            cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
-            rm -f /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+            if [ -e /etc/alpine-release ]
+            then
+              # We build from source on Alpine (slow)
+              mkdir -p /tmp/cmake /opt/cmake/<< parameters.cmake_version >>
+              cd /tmp/cmake
+              curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>.tar.gz
+              tar -xf *.tar.gz --strip 1
+              ./bootstrap --prefix=/opt/cmake/<< parameters.cmake_version >> --parallel=2 && make -j 2 && make install
+            else
+              # We use prebuilt Linux packages everywhere else (fast)
+              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+              mkdir -p /opt/cmake/<< parameters.cmake_version >>
+              cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
+            fi
+
       - run:
           name: Install Catch2
           command: |
@@ -899,13 +910,15 @@ workflows:
       # We need to prepare code because centos 6's git is too old for CircleCI, true story:
       # > error: unknown switch `B'
       - "Prepare Code"
-      - DatadogArena:
+      - ExtensionComponents:
           requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               docker_image:
                 # Don't need PHP, just basic toolchain
                 - "datadog/dd-trace-ci:php-8.0_centos-6"
+                - "datadog/dd-trace-ci:alpine"
+                - "datadog/dd-trace-ci:buster"
               cmake_version:
                 - "3.10.3"
                 - "3.18.4"

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,8 @@ block_comment_end = */
 
 [*Makefile]
 indent_style = tab
+
+[CMakeLists.txt]
+indent_size = 2
+block_comment_start = #[[
+block_comment_end = #]]

--- a/ext/DatadogArena/CMakeLists.txt
+++ b/ext/DatadogArena/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.10)
+# todo: once this has been shipped without defects, bump this to 1.0.0
+project(DatadogArena
+  VERSION 0.9.0
+  LANGUAGES C
+)
+
+add_library(DatadogArena arena.c)
+target_include_directories(DatadogArena PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>
+  $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(DatadogArena PRIVATE c_std_11)
+
+set_target_properties(DatadogArena PROPERTIES
+  # It should be named libdatadog_arena.{a,so}, not libDatadogArena.{a,so}
+  OUTPUT_NAME datadog_arena
+  PUBLIC_HEADER datadog/arena.h
+  VERSION ${PROJECT_VERSION}
+)
+
+#[[
+  We want to be able to use the namespaced name everywhere, including in this project's tests;
+  this is a pattern described in the talk Effective CMake
+#]]
+add_library(Datadog::Arena ALIAS DatadogArena)
+
+# Add infrastructure for enabling tests
+option(BUILD_TESTING "Enable tests" ON)
+include(CTest)
+if (${BUILD_TESTING})
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
+# todo: add stuff for installing the library

--- a/ext/DatadogArena/arena.c
+++ b/ext/DatadogArena/arena.c
@@ -1,0 +1,59 @@
+#include "datadog/arena.h"
+
+#include <stdlib.h>
+
+_Static_assert(sizeof(size_t) == 8, "Unexpected size_t size");
+
+extern inline char *datadog_arena_alloc(datadog_arena **arena_ptr, size_t size);
+extern inline bool datadog_arena_try_alloc(datadog_arena *arena, size_t size, char **result);
+
+/* prefer powers of 2 */
+datadog_arena *datadog_arena_create(size_t size) {
+    datadog_arena *arena = (datadog_arena *)calloc(1, size);
+
+    size_t aligned = DATADOG_ARENA_ALIGNED_SIZE(sizeof(datadog_arena));
+    arena->ptr = (char *)arena + aligned;
+    arena->end = (char *)arena + size;
+    arena->prev = NULL;
+
+    return arena;
+}
+
+void datadog_arena_grow(datadog_arena **arena_ptr, size_t min_size) {
+    datadog_arena *arena = *arena_ptr;
+    size_t prev_size = arena->end - (char *)arena;
+    min_size += DATADOG_ARENA_ALIGNED_SIZE(sizeof(datadog_arena));
+    size_t size = prev_size > min_size ? prev_size : min_size;
+    // todo: align min_size to a power of 2 if it doesn't fit?
+
+    datadog_arena *new_arena = datadog_arena_create(size);
+    new_arena->prev = *arena_ptr;
+    *arena_ptr = new_arena;
+}
+
+void datadog_arena_destroy(datadog_arena *arena) {
+    do {
+        datadog_arena *prev = arena->prev;
+        free(arena);
+        arena = prev;
+    } while (arena);
+}
+
+char *datadog_arena_checkpoint(datadog_arena *arena) { return arena->ptr; }
+
+// todo: what to do when checkpoint isn't found in arena?
+void datadog_arena_restore(datadog_arena **arena_ptr, char *checkpoint) {
+    datadog_arena *arena = *arena_ptr;
+
+    while (arena) {
+        if ((char *)arena <= checkpoint && checkpoint <= arena->end) {
+            arena->ptr = checkpoint;
+            break;
+        } else {
+            datadog_arena *prev = arena->prev;
+            free(arena);
+            arena = prev;
+        }
+    }
+    *arena_ptr = arena;
+}

--- a/ext/DatadogArena/datadog/arena.h
+++ b/ext/DatadogArena/datadog/arena.h
@@ -1,0 +1,70 @@
+#ifndef DATADOG_ARENA_H
+#define DATADOG_ARENA_H 1
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct datadog_arena {
+    char *ptr, *end;
+    struct datadog_arena *prev;
+};
+typedef struct datadog_arena datadog_arena;
+
+/* Aligns allocations to 8 byte boundaries */
+#define DATADOG_ARENA_ALIGNMENT UINT64_C(8)
+#define DATADOG_ARENA_ALIGNMENT_MASK ~(DATADOG_ARENA_ALIGNMENT - 1)
+
+#define DATADOG_ARENA_ALIGNED_SIZE(size) (((size) + DATADOG_ARENA_ALIGNMENT - 1) & DATADOG_ARENA_ALIGNMENT_MASK)
+
+/* prefer powers of 2 */
+datadog_arena *datadog_arena_create(size_t size);
+
+void datadog_arena_grow(datadog_arena **arena_ptr, size_t min_size);
+
+void datadog_arena_destroy(datadog_arena *arena);
+
+/* We want the main allocation code to be inlined; one of the reasons for using
+ * an arena is for performance.
+ */
+inline char *datadog_arena_alloc(datadog_arena **arena_ptr, size_t size) {
+    datadog_arena *arena = *arena_ptr;
+    size = DATADOG_ARENA_ALIGNED_SIZE(size);
+
+    if (size > (size_t)(arena->end - arena->ptr)) {
+        datadog_arena_grow(arena_ptr, size);
+    }
+
+    char *ptr = arena->ptr;
+    arena->ptr += size;
+    return ptr;
+}
+
+/* Try to allocate `size` memory without growing the arena.
+ * If the allocation fits, return true and set *result to the pointer.
+ * If it does not fit, return false and do not set *result.
+ */
+inline bool datadog_arena_try_alloc(datadog_arena *arena, size_t size, char **result) {
+    size = DATADOG_ARENA_ALIGNED_SIZE(size);
+    if (size > (size_t)(arena->end - arena->ptr)) {
+        return false;
+    }
+
+    *result = arena->ptr;
+    arena->ptr += size;
+    return true;
+}
+
+/* Checkpointing allows you to save a position in the arena, then to later
+ * free any memory after the checkpoint.
+ * Example where it may be useful: serialization. You can checkpoint,
+ * serialize, transfer, then rewind back.
+ */
+char *datadog_arena_checkpoint(datadog_arena *arena);
+
+/* The checkpoint must exist in the arena or the arena's prev (recursively).
+ * If it doesn't the behavior is undefined.
+ */
+void datadog_arena_restore(datadog_arena **arena_ptr, char *checkpoint);
+
+#endif  // DATADOG_ARENA_H

--- a/ext/DatadogArena/test/CMakeLists.txt
+++ b/ext/DatadogArena/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+enable_language(CXX)
+
+# The Catch2::Catch2 target has been available since 2.1.2
+# dd-trace-cpp uses Catch2 2.4 at this time, so we can require at least 2.4
+find_package(Catch2 2.4 REQUIRED)
+
+include(Catch)
+
+add_library(catch2main main.cc)
+target_link_libraries(catch2main PUBLIC Catch2::Catch2)
+target_compile_features(catch2main PUBLIC cxx_std_11)
+
+add_executable(arena arena.cc)
+target_link_libraries(arena PUBLIC catch2main Datadog::Arena)
+
+catch_discover_tests(arena)

--- a/ext/DatadogArena/test/arena.cc
+++ b/ext/DatadogArena/test/arena.cc
@@ -1,0 +1,96 @@
+extern "C" {
+#include <datadog/arena.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("basic arena creation", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(1024);
+    REQUIRE(arena->ptr > (char *)arena);
+    REQUIRE((void *)arena->ptr ==
+            (void *)((char *)arena + sizeof(datadog_arena)));
+    REQUIRE(arena->ptr < arena->end);
+    REQUIRE(arena->end - (char *)arena == 1024);
+    REQUIRE(arena->prev == nullptr);
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("basic arena alignment", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(1024);
+    char *checkpoint = datadog_arena_checkpoint(arena);
+    datadog_arena_alloc(&arena, 1);
+    REQUIRE((void *)datadog_arena_checkpoint(arena) ==
+            (void *)(checkpoint + DATADOG_ARENA_ALIGNMENT));
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("basic arena growth", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(1024);
+    datadog_arena *first_arena = arena;
+
+    // arena size 1024 cannot fit 512 x2 because of arena struct overhead
+    datadog_arena_alloc(&arena, 512);
+    datadog_arena_alloc(&arena, 512);
+
+    REQUIRE(arena->prev == first_arena);
+    REQUIRE((void *)arena->ptr ==
+            (void *)((char *)arena + sizeof(datadog_arena)));
+    REQUIRE(arena->end - (char *)arena == 1024);
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("arena try alloc", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(1024);
+    datadog_arena *first_arena = arena;
+
+    char *ptr;
+    REQUIRE(datadog_arena_try_alloc(arena, 512, &ptr));
+    REQUIRE((void *)ptr == (void *)((char *)arena + sizeof(datadog_arena)));
+
+    char *ptr_backup = ptr;
+    char *checkpoint = datadog_arena_checkpoint(arena);
+    // arena size 1024 cannot fit 512 x2 because of arena struct overhead
+    REQUIRE(!datadog_arena_try_alloc(arena, 512, &ptr));
+
+    REQUIRE(arena == first_arena);
+    REQUIRE((void *)checkpoint == (void *)datadog_arena_checkpoint(arena));
+    REQUIRE((void *)ptr == (void *)ptr_backup);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("arena basic checkpoint and restore", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(1024);
+    datadog_arena *first_arena = arena;
+
+    char *checkpoint = datadog_arena_checkpoint(arena);
+    datadog_arena_alloc(&arena, 512);
+    // ensure we didn't accidentally grow
+    REQUIRE(arena == first_arena);
+
+    datadog_arena_restore(&arena, checkpoint);
+    REQUIRE((void *)arena->ptr == (void *)checkpoint);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("arena growing checkpoint and restore", "[arena]") {
+    datadog_arena *arena = datadog_arena_create(512);
+
+    datadog_arena_alloc(&arena, 256);
+
+    datadog_arena *first_arena = arena;
+    char *checkpoint = datadog_arena_checkpoint(arena);
+    datadog_arena_alloc(&arena, 256);
+
+    // make sure we grew
+    REQUIRE(arena != first_arena);
+    REQUIRE(arena->prev == first_arena);
+
+    datadog_arena_restore(&arena, checkpoint);
+    // make sure we rewound
+    REQUIRE(arena == first_arena);
+    REQUIRE((void *)arena->ptr == (void *)checkpoint);
+
+    datadog_arena_destroy(arena);
+}

--- a/ext/DatadogArena/test/main.cc
+++ b/ext/DatadogArena/test/main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
### Description

This adds an arena allocator `datadog_arena` similar to PHP's `zend_arena`. Critically it is not tied to _any_ PHPisms at all so it can be used across all PHP versions. This allocator doesn't support deallocating individual objects; it frees all its memory at once. There is also a checkpoint/restore API so you can save the current allocator position and then rewind to the same spot (caller is responsible for making sure conflicting checkpoint/restores nor frees happen between checkpoint/restore).

In particular arena allocators are good for serializing variable-length data which is then transferred and freed. This pattern comes up in both the tracer and the profiler.

Tests are written using the Catch2 library and uses the CMake build system. The arena simple enough that it can be integrated directly using whatever build system we want; if we don't count tests it's just two files, `arena.c` and `datadog/arena.h`.

------

One thing I encountered while writing this is that in buster containers we don't have write access to `/opt` as the `circleci` user, which means we must use `sudo` there. However, `sudo` doesn't exist in the CentOS containers. This is annoying and I plan to push changes to the buster containers soon that add ownership of `/opt` to `circleci`, but we should also probably get `sudo` + `circleci` into the CentOS containers too. Without these changes it makes it difficult to write scripts or commands that work across the different containers.

Another thing is that `eclint` should probably be an inclusion list instead of an exclusion list -- at this point it seems we exclude far more directories than we lint...

### Readiness checklist
- [x] ~Changelog has been added to the release document.~ This doesn't actually get used anywhere yet -- just the library and tests.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [x] ~Changelog has been added to the release document.~
