### PR TITLE
Update PHP 8 containers to RC 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1180,7 +1180,7 @@ workflows:
                 - php:7.2-fpm-alpine
                 - php:7.3-fpm-alpine
                 - php:7.4-fpm-alpine
-                - php:8.0.0RC2-fpm-alpine
+                - php:8.0.0RC3-fpm-alpine
       - pecl_tests:
           requires: [ "Build PECL" ]
           name: "PHP 54 PECL tests"

--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~pollita/php-8.0.0RC2.tar.gz
-        phpSha256Hash: 0cebc11c61c0f153bd866eab76c424404b3ccc779417cdfde1061e550c3e364c
+        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
+        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~pollita/php-8.0.0RC2.tar.gz
-        phpSha256Hash: 0cebc11c61c0f153bd866eab76c424404b3ccc779417cdfde1061e550c3e364c
+        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
+        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
 
   php-master:
     image: datadog/dd-trace-ci:php-master_buster

--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~pollita/php-8.0.0RC2.tar.gz
-        phpSha256Hash: 0cebc11c61c0f153bd866eab76c424404b3ccc779417cdfde1061e550c3e364c
+        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
+        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -7,6 +7,7 @@ Zend/tests/anon/007.phpt
 Zend/tests/anon/012.phpt
 Zend/tests/anon/013.phpt
 Zend/tests/arginfo_zpp_mismatch.phpt
+Zend/tests/arginfo_zpp_mismatch_strict.phpt
 Zend/tests/arrow_functions/005.phpt
 Zend/tests/assign_coalesce_001.phpt
 Zend/tests/assign_obj_ref_byval_function.phpt

--- a/dockerfiles/compile_extension/docker-compose.yml
+++ b/dockerfiles/compile_extension/docker-compose.yml
@@ -112,9 +112,9 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 8.0.0RC2
-        php_url: https://downloads.php.net/~pollita/php-8.0.0RC2.tar.gz
-        php_sha: 0cebc11c61c0f153bd866eab76c424404b3ccc779417cdfde1061e550c3e364c
+        php_version: 8.0.0RC3
+        php_url: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
+        php_sha: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
         php_api: 20200930
     command: build-dd-trace-php
     volumes:

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -489,6 +489,11 @@ final class PDOTest extends IntegrationTestCase
                     name varchar(100)
                 )
             ");
+            if (PHP_VERSION_ID >= 80000 && !$pdo->inTransaction()) {
+                // CREATE TABLE causes an implicit commit on PHP 8
+                // @see https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
+                $pdo->beginTransaction();
+            }
             $pdo->exec("INSERT INTO tests (id, name) VALUES (1, 'Tom')");
 
             $pdo->commit();
@@ -502,7 +507,11 @@ final class PDOTest extends IntegrationTestCase
             $pdo = $this->pdoInstance();
             $pdo->beginTransaction();
             $pdo->exec("DROP TABLE tests");
-            $pdo->commit();
+            if (PHP_VERSION_ID < 80000) {
+                // DROP TABLE causes an implicit commit on PHP 8
+                // @see https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
+                $pdo->commit();
+            }
             $pdo = null;
         });
     }

--- a/tests/xdebug/3.0.0beta1/request_init_hook.phpt
+++ b/tests/xdebug/3.0.0beta1/request_init_hook.phpt
@@ -19,12 +19,8 @@ array_map(function($span) {
 }, dd_trace_serialize_closed_spans());
 
 echo 'Done.' . PHP_EOL;
-
-// Note for later: Remove the "Xdebug: [Config]" error below when run-tests is updated
-// @see https://github.com/php/php-src/blob/b270081/run-tests.php#L892
 ?>
 --EXPECT--
-Xdebug: [Config] The setting 'xdebug.default_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.default_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
 Request init hook loaded.
 int(6)
 array_sum


### PR DESCRIPTION
### Description

Update PHP 8 containers to RC 3 which was [released on Oct 29](https://news-web.php.net/php.internals/112142).

This PR also fixes two recent changes that caused test failures for Xdebug (php/php-src#6324) and PDO (php/php-src#6355).

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
