### PR TITLE
Only load WordPress 5 integration on PHP 7+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,6 @@ TEST_WEB_56 := \
 	test_web_symfony_34 \
 	test_web_yii_2 \
 	test_web_wordpress_48 \
-	test_web_wordpress_55 \
 	test_web_zend_1 \
 	test_web_custom
 

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -42,7 +42,7 @@ class WordPressIntegration extends Integration
                 return false;
             }
             $majorVersion = substr($GLOBALS['wp_version'], 0, 2);
-            if ('4.' === $majorVersion || '5.' === $majorVersion) {
+            if ('4.' === $majorVersion || ('5.' === $majorVersion && PHP_VERSION_ID >= 70000)) {
                 $loader = new WordPressIntegrationLoader();
                 $loader->load($integration);
             }


### PR DESCRIPTION
### Description

Due to some possible performance regressions discovered with WordPress 5 on PHP 5.6, this PR will only load the WP 5 integration on PHP 7+. Once the possible performance regressions have been validated/addressed, we can add the WP 5 integration back to PHP 5.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
