### PR TITLE
Support service split by host in PHPRedis integration

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -264,6 +264,16 @@ function ddtrace_config_http_client_split_by_domain_enabled()
 }
 
 /**
+ * Set Redis client service name based on hostname
+ *
+ * @return bool
+ */
+function ddtrace_config_redis_client_split_by_host_enabled()
+{
+    return \_ddtrace_config_bool(\getenv('DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST'), false);
+}
+
+/**
  * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.
  * Motivation: We had users reporting that in some cases they have manual end-points that `echo` some content and
  * then just `exit(0)` at the end of action's method. While the shutdown hook that flushes traces would still be

--- a/src/private/functions.php
+++ b/src/private/functions.php
@@ -123,3 +123,23 @@ function _util_uri_apply_rules($uriPath, $incoming)
 
     return implode('/', $fragments);
 }
+
+/**
+ * Transform a host name (optionally with schema) or unix domain socket path into a service name-friendly string.
+ *
+ * @param string $hostOrUDS
+ * @return string
+ */
+function util_normalize_host_uds_as_service($hostOrUDS)
+{
+    if (null === $hostOrUDS) {
+        return '';
+    }
+
+    // Note, we do not use PHP's `parse_url()` because it would require tricks to be compatible with UDS file names.
+    $parts = \explode("://", $hostOrUDS);
+    $noSchema = count($parts) > 1 ? $parts[count($parts) - 1] : $hostOrUDS;
+    $noSpaces = \str_replace(' ', '', $noSchema);
+
+    return \trim(preg_replace('/[^a-zA-Z0-9.\_]+/', '-', $noSpaces), '- ');
+}

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -30,6 +30,14 @@ final class SpanChecker
     {
         $flattenTraces = $this->flattenTraces($traces);
         $actualGraph = $this->buildSpansGraph($flattenTraces);
+        if (\count($actualGraph) != \count($expectedFlameGraph)) {
+            TestCase::fail(\sprintf(
+                'Wrong number of root spans. Expected %d, actual: %s',
+                \count($expectedFlameGraph),
+                \count($actualGraph)
+            ));
+        }
+
         foreach ($expectedFlameGraph as $oneTrace) {
             if ($oneTrace->isToBeSkipped()) {
                 continue;

--- a/tests/Integrations/PHPRedis/PHPRedis3Test.php
+++ b/tests/Integrations/PHPRedis/PHPRedis3Test.php
@@ -41,6 +41,7 @@ class PHPRedis3Test extends IntegrationTestCase
         $this->redis->close();
         $this->redisSecondInstance->flushAll();
         $this->redisSecondInstance->close();
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST']);
         parent::ddTearDown();
     }
 
@@ -1783,6 +1784,66 @@ class PHPRedis3Test extends IntegrationTestCase
         ]);
     }
 
+    public function testSplitByDomainWhenError()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true']);
+        $redis = new \Redis();
+        $traces = $this->isolateTracer(function () use ($redis) {
+            try {
+                $redis->connect('non-existing-host');
+            } catch (Exception $e) {
+            }
+        });
+        $redis->close();
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build(
+                "Redis.connect",
+                'redis-non-existing-host',
+                'redis',
+                "Redis.connect"
+            )
+            ->setError()
+            ->withExistingTagsNames(['error.msg', 'error.stack'])
+            ->withExactTags([
+                'out.host' => 'non-existing-host',
+                'out.port' => $this->port,
+            ]),
+        ]);
+    }
+
+    public function testSplitByDomainWhenSuccess()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true']);
+        $redis = new \Redis();
+        $traces = $this->isolateTracer(function () use ($redis) {
+            $redis->connect($this->host);
+            $redis->set('key', 'value');
+        });
+        $redis->close();
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build(
+                "Redis.connect",
+                'redis-redis_integration',
+                'redis',
+                "Redis.connect"
+            )
+            ->withExactTags([
+                'out.host' => $this->host,
+                'out.port' => $this->port,
+            ]),
+            SpanAssertion::build(
+                "Redis.set",
+                'redis-redis_integration',
+                'redis',
+                "Redis.set"
+            )
+            ->withExactTags([
+                'redis.raw_command' => 'set key value',
+            ]),
+        ]);
+    }
 
     public function testSetGetWithBinarySafeStringsAsKey()
     {

--- a/tests/Integrations/PHPRedis/PHPRedis4Test.php
+++ b/tests/Integrations/PHPRedis/PHPRedis4Test.php
@@ -42,6 +42,7 @@ class PHPRedis4Test extends IntegrationTestCase
     {
         $this->redis->close();
         $this->redisSecondInstance->close();
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST']);
         parent::ddTearDown();
     }
 
@@ -2062,6 +2063,66 @@ class PHPRedis4Test extends IntegrationTestCase
         ]);
     }
 
+    public function testSplitByDomainWhenError()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true']);
+        $redis = new \Redis();
+        $traces = $this->isolateTracer(function () use ($redis) {
+            try {
+                $redis->connect('non-existing-host');
+            } catch (Exception $e) {
+            }
+        });
+        $redis->close();
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build(
+                "Redis.connect",
+                'redis-non-existing-host',
+                'redis',
+                "Redis.connect"
+            )
+            ->setError()
+            ->withExistingTagsNames(['error.msg', 'error.stack'])
+            ->withExactTags([
+                'out.host' => 'non-existing-host',
+                'out.port' => $this->port,
+            ]),
+        ]);
+    }
+
+    public function testSplitByDomainWhenSuccess()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true']);
+        $redis = new \Redis();
+        $traces = $this->isolateTracer(function () use ($redis) {
+            $redis->connect($this->host);
+            $redis->set('key', 'value');
+        });
+        $redis->close();
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build(
+                "Redis.connect",
+                'redis-redis_integration',
+                'redis',
+                "Redis.connect"
+            )
+            ->withExactTags([
+                'out.host' => $this->host,
+                'out.port' => $this->port,
+            ]),
+            SpanAssertion::build(
+                "Redis.set",
+                'redis-redis_integration',
+                'redis',
+                "Redis.set"
+            )
+            ->withExactTags([
+                'redis.raw_command' => 'set key value',
+            ]),
+        ]);
+    }
 
     public function testSetGetWithBinarySafeStringsAsKey()
     {

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -41,10 +41,11 @@ EOD;
         putenv('DD_TRACE_DEBUG');
         putenv('DD_TRACE_ENABLED');
         putenv('DD_TRACE_GLOBAL_TAGS');
+        putenv('DD_TRACE_PDO_ENABLED');
+        putenv('DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST');
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
         putenv('DD_TRACE_SLIM_ENABLED');
-        putenv('DD_TRACE_PDO_ENABLED');
         putenv('DD_VERSION');
     }
 
@@ -546,5 +547,26 @@ EOD;
         $this->assertSame(['/a/'], \ddtrace_config_path_fragment_regex());
         $this->assertSame(['path/*'], \ddtrace_config_path_mapping_incoming());
         $this->assertSame(['path/*'], \ddtrace_config_path_mapping_outgoing());
+    }
+
+    public function testRedisClientSplitHostNotSet()
+    {
+        $this->assertFalse(\ddtrace_config_redis_client_split_by_host_enabled());
+    }
+
+    public function testRedisClientSplitHostSetFalse()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=false',
+        ]);
+        $this->assertFalse(\ddtrace_config_redis_client_split_by_host_enabled());
+    }
+
+    public function testRedisClientSplitHostSetTrue()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true',
+        ]);
+        $this->assertTrue(\ddtrace_config_redis_client_split_by_host_enabled());
     }
 }

--- a/tests/Unit/private/UtilTest.php
+++ b/tests/Unit/private/UtilTest.php
@@ -35,6 +35,8 @@ class UtilTest extends BaseTestCase
             'without_schema' => ['example.com', 'example.com'],
             'trim' => ['   example   .com   ', 'example.com'],
 
+            // Do not remove schema extraction, as it is used by predis/phpredis
+            // https://github.com/phpredis/phpredis#connect-open
             'schema_http' => ['http://example.com', 'example.com'],
             'schema_https' => ['https://example.com', 'example.com'],
             'schema_tls' => ['tls://example.com', 'example.com'],

--- a/tests/Unit/private/UtilTest.php
+++ b/tests/Unit/private/UtilTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DDTrace\Tests\Unit\Private_;
+
+use DDTrace\Private_;
+use DDTrace\Tests\Common\BaseTestCase;
+
+class UtilTest extends BaseTestCase
+{
+    /**
+     * @dataProvider dataProviderHostUDSAsServiceNormalization
+     */
+    public function testDataProviderHostUDSAsServiceNormalization($hostOrUDS, $expected)
+    {
+        $this->assertSame(Private_\util_normalize_host_uds_as_service($hostOrUDS), $expected);
+    }
+
+    public function dataProviderHostUDSAsServiceNormalization()
+    {
+        return [
+            'empty' => ['', ''],
+            'null' => [null, ''],
+
+            'invalid_host' => ['invalid', 'invalid'],
+            // This is a best effort, where '.' is valid and all unexpected chars are replaced with -
+            'invalid_chars' => ['!in!!v@@@a.l/id', 'in-v-a.l-id'],
+
+            'ip_without_schema' => ['127.0.0.1', '127.0.0.1'],
+            'ip_without_schema_trailing_slash' => ['127.0.0.1/', '127.0.0.1'],
+            'ip_with_schema' => ['http://127.0.0.1', '127.0.0.1'],
+            'ip_with_schema_trailing_slash' => ['http://127.0.0.1/', '127.0.0.1'],
+
+            'underscores_preserved' => ['underscore_in_host_name', 'underscore_in_host_name'],
+
+            'without_schema' => ['example.com', 'example.com'],
+            'trim' => ['   example   .com   ', 'example.com'],
+
+            'schema_http' => ['http://example.com', 'example.com'],
+            'schema_https' => ['https://example.com', 'example.com'],
+            'schema_tls' => ['tls://example.com', 'example.com'],
+            'schema_ftp' => ['ftp://example.com', 'example.com'],
+
+            'uds' => ['/tmp/redis.sock', 'tmp-redis.sock'],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

This PR:
- introduces a new setting named `DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST`. Default value is `false`. It can be set to `true`;
- if the value of the above setting is `true`, then the service name for phpredis client spans is changed to `redis-<host>`. Example: `host=127.0.01 --> service=redis-127.0.0.1`, `host=some.host --> service=redis-some.host`;
- while this PR only applies to phpredis, we do not make a distinction between phpredis and predis while defining the service name, both will be prefixed by `redis-`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
