### PR TITLE
Load WordPress 5 integration on PHP 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,7 @@ TEST_WEB_56 := \
 	test_web_symfony_34 \
 	test_web_yii_2 \
 	test_web_wordpress_48 \
+	test_web_wordpress_55 \
 	test_web_zend_1 \
 	test_web_custom
 

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -42,7 +42,7 @@ class WordPressIntegration extends Integration
                 return false;
             }
             $majorVersion = substr($GLOBALS['wp_version'], 0, 2);
-            if ('4.' === $majorVersion || ('5.' === $majorVersion && PHP_VERSION_ID >= 70000)) {
+            if ('4.' === $majorVersion || '5.' === $majorVersion) {
                 $loader = new WordPressIntegrationLoader();
                 $loader->load($integration);
             }


### PR DESCRIPTION
### Description

This reverts commit fd237bd17f2810db56fd6a7e43ce85a7da0d072e which was introduced in #1081. The suspected performance regressions were false-positives so we can enable WP 5 on PHP 5 again.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
