### PR TITLE
Make include paths relative to ext/

### DIFF
--- a/ext/php5/circuit_breaker.h
+++ b/ext/php5/circuit_breaker.h
@@ -4,7 +4,7 @@
 #include <stdatomic.h>
 #include <stdint.h>
 
-#include "../version.h"
+#include "ext/version.h"
 
 typedef struct dd_trace_circuit_breaker_t {
     _Atomic(uint32_t) consecutive_failures;

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "../version.h"
 #include "env_config.h"
+#include "ext/version.h"
 #include "random.h"
 
 extern zend_module_entry ddtrace_module_entry;

--- a/ext/php5/integrations/integrations.c
+++ b/ext/php5/integrations/integrations.c
@@ -1,7 +1,7 @@
 #include "integrations.h"
 
-#include "../configuration.h"
-#include "../ddtrace_string.h"
+#include "ext/php5/configuration.h"
+#include "ext/php5/ddtrace_string.h"
 
 #define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, integration_name)             \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \

--- a/ext/php5/integrations/integrations.h
+++ b/ext/php5/integrations/integrations.h
@@ -2,8 +2,8 @@
 #define DD_INTEGRATIONS_INTEGRATIONS_H
 #include <php.h>
 
-#include "../ddtrace_string.h"
-#include "../dispatch.h"
+#include "ext/php5/ddtrace_string.h"
+#include "ext/php5/dispatch.h"
 
 #define DDTRACE_LONGEST_INTEGRATION_NAME_LEN 13  // "zendframework" FTW!
 

--- a/ext/php5/php5/dispatch.c
+++ b/ext/php5/php5/dispatch.c
@@ -1,11 +1,11 @@
-#include "../dispatch.h"
+#include "ext/php5/dispatch.h"
 
 #include <Zend/zend_exceptions.h>
 #include <php.h>
 
 #include <ext/spl/spl_exceptions.h>
 
-#include "../ddtrace.h"
+#include "ext/php5/ddtrace.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 

--- a/ext/php5/php5/engine_hooks.c
+++ b/ext/php5/php5/engine_hooks.c
@@ -1,4 +1,4 @@
-#include "../engine_hooks.h"
+#include "ext/php5/engine_hooks.h"
 
 #include <Zend/zend.h>
 #include <Zend/zend_closures.h>
@@ -6,11 +6,11 @@
 #include <Zend/zend_interfaces.h>
 #include <php.h>
 
-#include "../compatibility.h"
-#include "../ddtrace.h"
-#include "../dispatch.h"
-#include "../logging.h"
-#include "../span.h"
+#include "ext/php5/compatibility.h"
+#include "ext/php5/ddtrace.h"
+#include "ext/php5/dispatch.h"
+#include "ext/php5/logging.h"
+#include "ext/php5/span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 

--- a/ext/php5/php5_4/auto_flush.c
+++ b/ext/php5/php5_4/auto_flush.c
@@ -1,3 +1,3 @@
-#include "../auto_flush.h"
+#include "ext/php5/auto_flush.h"
 
 int ddtrace_flush_tracer(void) { return SUCCESS; }

--- a/ext/php5/php5_4/dispatch.c
+++ b/ext/php5/php5_4/dispatch.c
@@ -1,11 +1,11 @@
-#include "../dispatch.h"
+#include "ext/php5/dispatch.h"
 
 #include <Zend/zend_exceptions.h>
 #include <php.h>
 
 #include <ext/spl/spl_exceptions.h>
 
-#include "../ddtrace.h"
+#include "ext/php5/ddtrace.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 

--- a/ext/php5/php5_4/engine_hooks.c
+++ b/ext/php5/php5_4/engine_hooks.c
@@ -1,4 +1,4 @@
-#include "../engine_hooks.h"
+#include "ext/php5/engine_hooks.h"
 
 #include <Zend/zend.h>
 #include <Zend/zend_exceptions.h>
@@ -7,11 +7,11 @@
 
 #include <ext/spl/spl_exceptions.h>
 
-#include "../compatibility.h"
-#include "../ddtrace.h"
-#include "../dispatch.h"
-#include "../logging.h"
-#include "../span.h"
+#include "ext/php5/compatibility.h"
+#include "ext/php5/ddtrace.h"
+#include "ext/php5/dispatch.h"
+#include "ext/php5/logging.h"
+#include "ext/php5/span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 

--- a/ext/php5/signals.c
+++ b/ext/php5/signals.c
@@ -9,9 +9,9 @@
 #include <php.h>
 #include <signal.h>
 
-#include "../version.h"
 #include "configuration.h"
 #include "ddtrace.h"
+#include "ext/version.h"
 #include "logging.h"
 
 #if defined HAVE_EXECINFO_H && defined backtrace_size_t && defined HAVE_BACKTRACE

--- a/ext/php5/startup_logging.c
+++ b/ext/php5/startup_logging.c
@@ -10,10 +10,10 @@
 #include <ext/standard/info.h>
 #include <ext/standard/php_smart_str.h>
 
-#include "../version.h"
 #include "coms.h"
 #include "configuration.h"
 #include "excluded_modules.h"
+#include "ext/version.h"
 #include "integrations/integrations.h"
 #include "logging.h"
 

--- a/ext/php7/circuit_breaker.h
+++ b/ext/php7/circuit_breaker.h
@@ -4,7 +4,7 @@
 #include <stdatomic.h>
 #include <stdint.h>
 
-#include "../version.h"
+#include "ext/version.h"
 
 typedef struct dd_trace_circuit_breaker_t {
     _Atomic(uint32_t) consecutive_failures;

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "../version.h"
 #include "env_config.h"
+#include "ext/version.h"
 #include "random.h"
 
 extern zend_module_entry ddtrace_module_entry;

--- a/ext/php7/integrations/integrations.c
+++ b/ext/php7/integrations/integrations.c
@@ -1,7 +1,7 @@
 #include "integrations.h"
 
-#include "../configuration.h"
-#include "../ddtrace_string.h"
+#include "ext/php7/configuration.h"
+#include "ext/php7/ddtrace_string.h"
 
 #define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, integration_name)             \
     ddtrace_hook_callable(DDTRACE_STRING_LITERAL(class), DDTRACE_STRING_LITERAL(fname), \

--- a/ext/php7/integrations/integrations.h
+++ b/ext/php7/integrations/integrations.h
@@ -2,8 +2,8 @@
 #define DD_INTEGRATIONS_INTEGRATIONS_H
 #include <php.h>
 
-#include "../ddtrace_string.h"
-#include "../dispatch.h"
+#include "ext/php7/ddtrace_string.h"
+#include "ext/php7/dispatch.h"
 
 #define DDTRACE_LONGEST_INTEGRATION_NAME_LEN 13  // "zendframework" FTW!
 

--- a/ext/php7/php7/dispatch.c
+++ b/ext/php7/php7/dispatch.c
@@ -1,13 +1,13 @@
-#include "../dispatch.h"
+#include "ext/php7/dispatch.h"
 
 #include <Zend/zend_exceptions.h>
 #include <php.h>
 
 #include <ext/spl/spl_exceptions.h>
 
-#include "../arrays.h"
-#include "../compatibility.h"
-#include "../ddtrace.h"
+#include "ext/php7/arrays.h"
+#include "ext/php7/compatibility.h"
+#include "ext/php7/ddtrace.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -1,4 +1,4 @@
-#include "../engine_hooks.h"
+#include "ext/php7/engine_hooks.h"
 
 #include <Zend/zend_closures.h>
 #include <Zend/zend_compile.h>
@@ -9,13 +9,13 @@
 
 #include <ext/spl/spl_exceptions.h>
 
-#include "../compatibility.h"
-#include "../ddtrace.h"
-#include "../dispatch.h"
-#include "../engine_api.h"
-#include "../env_config.h"
-#include "../logging.h"
-#include "../span.h"
+#include "ext/php7/compatibility.h"
+#include "ext/php7/ddtrace.h"
+#include "ext/php7/dispatch.h"
+#include "ext/php7/engine_api.h"
+#include "ext/php7/env_config.h"
+#include "ext/php7/logging.h"
+#include "ext/php7/span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 

--- a/ext/php7/signals.c
+++ b/ext/php7/signals.c
@@ -9,9 +9,9 @@
 #include <php.h>
 #include <signal.h>
 
-#include "../version.h"
 #include "configuration.h"
 #include "ddtrace.h"
+#include "ext/version.h"
 #include "logging.h"
 
 #if defined HAVE_EXECINFO_H && defined backtrace_size_t && defined HAVE_BACKTRACE

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -10,10 +10,10 @@
 
 #include <ext/standard/info.h>
 
-#include "../version.h"
 #include "coms.h"
 #include "configuration.h"
 #include "excluded_modules.h"
+#include "ext/version.h"
 #include "integrations/integrations.h"
 #include "logging.h"
 


### PR DESCRIPTION
### Description

This is a follow up PR to #1085 based on @morrisonlevi's suggestion to make the includes paths relative to the `ext/` directory vs relative to the current file path.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] ~~Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.~~
