### PR TITLE
Make execution of ext tests locally faster and easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ BUILD_SUFFIX := extension
 BUILD_DIR := $(PROJECT_ROOT)/tmp/build_$(BUILD_SUFFIX)
 SO_FILE := $(BUILD_DIR)/modules/ddtrace.so
 WALL_FLAGS := -Wall -Wextra
-CFLAGS := -O2 $(WALL_FLAGS)
+EXTRA_CFLAGS :=
+CFLAGS := -O2 $(EXTRA_CFLAGS) $(WALL_FLAGS)
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
@@ -17,10 +18,13 @@ C_FILES := $(shell find ext src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ pr
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 M4_FILES := $(shell find m4 -name '*.m4*' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 
-ALL_FILES := $(C_FILES) $(TEST_FILES) $(BUILD_DIR)/config.m4 $(M4_FILES)
+$(BUILD_DIR)/tests/%: tests/%
+	$(Q) echo Copying tests/$* to $@
+	$(Q) mkdir -p $(dir $@)
+	$(Q) cp -a tests/$* $@
 
 $(BUILD_DIR)/%: %
-	$(Q) echo Copying $* to build dir
+	$(Q) echo Copying $* to $@
 	$(Q) mkdir -p $(dir $@)
 	$(Q) cp -a $* $@
 
@@ -36,7 +40,7 @@ $(BUILD_DIR)/configure: $(BUILD_DIR)/config.m4
 $(BUILD_DIR)/Makefile: $(BUILD_DIR)/configure
 	$(Q) (cd $(BUILD_DIR); ./configure)
 
-$(SO_FILE): $(ALL_FILES) $(BUILD_DIR)/Makefile
+$(SO_FILE): $(C_FILES) $(BUILD_DIR)/Makefile
 	$(Q) $(MAKE) -C $(BUILD_DIR) CFLAGS="$(CFLAGS)"
 
 install: $(SO_FILE)
@@ -50,17 +54,15 @@ install_ini: $(INI_FILE)
 install_all: install install_ini
 
 test_c: export DD_TRACE_CLI_ENABLED=1
-test_c: $(SO_FILE)
+test_c: $(SO_FILE) $(TEST_FILES)
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
 	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
 	export USE_TRACKED_ALLOC=1; \
-	\
-	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
 	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all $(TESTS)
 
 test_c_mem: export DD_TRACE_CLI_ENABLED=1
-test_c_mem: $(SO_FILE)
+test_c_mem: $(SO_FILE) $(TEST_FILES)
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
 	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
@@ -70,7 +72,7 @@ test_c_mem: $(SO_FILE)
 	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all -m $(TESTS)
 
 test_c_asan: export DD_TRACE_CLI_ENABLED=1
-test_c_asan: $(SO_FILE)
+test_c_asan: $(SO_FILE) $(TEST_FILES)
 	( \
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
@@ -81,7 +83,7 @@ test_c_asan: $(SO_FILE)
 	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all --asan $(TESTS); \
 	)
 
-test_extension_ci: $(SO_FILE)
+test_extension_ci: $(SO_FILE) $(TEST_FILES)
 	( \
 	set -xe; \
 	export REPORT_EXIT_STATUS=1; \
@@ -101,6 +103,7 @@ dist_clean:
 
 clean:
 	$(MAKE) -C $(BUILD_DIR) clean
+	$(Q) rm -f $(SO_FILE)
 	$(Q) rm -f composer.lock
 
 sudo:


### PR DESCRIPTION
### Description

As part of every execution, before we copied ALL files (sources, tests, .m4) and run a complete build even if only one single test file changed, not a source file. With this PR we separate the concept of source files and test files.

When a test file changes, the file is only automatically copied to `tmp/build_extension/tests/ext/**` and a build is NOT done.
When a source file changes, the file is copied to `tmp/build_extension/**` and a build IS done automatically.

Now developers can run `make test_c TESTS=tests/ext/some_thing.phpt` and the quickest possible process will be executed, only building if necessary.

Note that the `EXTRA_CFLAG` variable is provided to provide extra CFLAGS, e.g. `EXTRA_CFLAGS=-g`.

Limitations:
  - When a `.h` file changes, it is automatically copied to the build directory but a build it NOT done.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
