### PR TITLE
Fix composer self-update on master properly handling cached directories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: "2.1"
 aliases:
 
   - &CACHE_COMPOSER_KEY
-    key: 'betav1-composer-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
+    key: 'betav1-composer-deps-version1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
 
   - &CACHE_NPM_KEY
     key: 'betav1-lint-deps-{{ checksum "composer.json" }}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: "2.1"
 aliases:
 
   - &CACHE_COMPOSER_KEY
-    key: 'betav1-composer-deps-version1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
+    key: 'betav2-composer-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
 
   - &CACHE_NPM_KEY
     key: 'betav1-lint-deps-{{ checksum "composer.json" }}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,10 +540,7 @@ jobs:
       - run:
           name: Run integration tests
           command: make test_integration PHPUNIT_OPTS="--log-junit test-results/php-integration/results.xml"
-      - save_cache:
-          <<: *INTEGRATION_COMPOSER_CACHE_KEY
-          paths:
-            - ~/.composer/cache
+      - <<: *STEP_COMPOSER_CACHE_SAVE
       - <<: *STEP_PERSIST_TO_WORKSPACE
       - <<: *STEP_STORE_TEST_RESULTS
 
@@ -592,10 +589,7 @@ jobs:
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts/
-      - save_cache:
-          <<: *INTEGRATION_COMPOSER_CACHE_KEY
-          paths:
-            - ~/.composer/cache
+      - <<: *STEP_COMPOSER_CACHE_SAVE
       - <<: *STEP_PERSIST_TO_WORKSPACE
 
   framework_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,8 +519,7 @@ jobs:
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - install_extension
-      - restore_cache: &INTEGRATION_COMPOSER_CACHE_KEY
-          key: 'betav1-composer-base-integration-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
+      - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_TESTS_UPDATE
@@ -574,8 +573,7 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - install_extension:
           lib_curl_command: << parameters.lib_curl_command >>
-      - restore_cache: &INTEGRATION_COMPOSER_CACHE_KEY
-          key: 'betav1-composer-integration-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}'
+      - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_TESTS_UPDATE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ aliases:
     save_cache:
       <<: *CACHE_COMPOSER_KEY
       paths:
-        - vendor/
+        - ~/.composer/cache
 
   - &STEP_COMPOSER_DISABLE_TLS
     run:
@@ -138,7 +138,6 @@ aliases:
     persist_to_workspace:
       root: '.'
       paths:
-      - vendor/
       - tmp/build_extension
 
   - &STEP_STORE_TEST_RESULTS
@@ -545,7 +544,6 @@ jobs:
       - save_cache:
           <<: *INTEGRATION_COMPOSER_CACHE_KEY
           paths:
-            - vendor/
             - ~/.composer/cache
       - <<: *STEP_PERSIST_TO_WORKSPACE
       - <<: *STEP_STORE_TEST_RESULTS
@@ -599,7 +597,6 @@ jobs:
       - save_cache:
           <<: *INTEGRATION_COMPOSER_CACHE_KEY
           paths:
-            - vendor/
             - ~/.composer/cache
       - <<: *STEP_PERSIST_TO_WORKSPACE
 


### PR DESCRIPTION
### Description

This PR:
 - disable caching of `vendor` folders, as speed p is provided by caching composer's cache folder and vendor files would be different for version to version in any case
 - updates the caching key version so we start from a clean cache on master, as some errors came up on master after we updated to composer 2

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
