### PR TITLE
[PHP 8] Custom pre-RC5 build

### DIFF
--- a/dockerfiles/ci/alpine/Dockerfile
+++ b/dockerfiles/ci/alpine/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
     apk add --no-cache \
         argon2-dev \
         autoconf \
+        bison \
         bash \
         ca-certificates \
         coreutils \

--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
-        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
+        phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
+        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
-        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
+        phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
+        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0
 
   php-master:
     image: datadog/dd-trace-ci:php-master_buster

--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.gz
-        phpSha256Hash: c651a10058840abd44f99a8aed0446f102291d1408f2299790b919634689b5cd
+        phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
+        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'

--- a/dockerfiles/ci/centos/6/php-8.0/Dockerfile
+++ b/dockerfiles/ci/centos/6/php-8.0/Dockerfile
@@ -18,6 +18,7 @@ RUN set -eux; \
         scl-utils \
         unzip \
         vim \
+        xz \
         zlib-devel; \
     yum install -y devtoolset-7; \
     yum clean all;
@@ -46,6 +47,14 @@ RUN set -eux; \
 # No package 'oniguruma' found
     /root/download-src.sh oniguruma https://github.com/kkos/oniguruma/releases/download/v6.9.5_rev1/onig-6.9.5-rev1.tar.gz; \
     cd "${SRC_DIR}/oniguruma"; \
+    ./configure && make && make install; \
+# bison 3.0.0 or later is required to generate PHP parsers
+    /root/download-src.sh bison https://ftp.gnu.org/gnu/bison/bison-3.7.3.tar.gz; \
+    cd "${SRC_DIR}/bison"; \
+    ./configure && make && make install; \
+# re2c 0.13.4 is required to generate PHP lexers
+    /root/download-src.sh re2c https://github.com/skvadrik/re2c/releases/download/2.0.3/re2c-2.0.3.tar.xz; \
+    cd "${SRC_DIR}/re2c"; \
     ./configure && make && make install;
 
 # CMake 3.0.2 or higher is required.  You are running version 2.8.12.2
@@ -79,7 +88,8 @@ RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
     (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
-    rm -f /tmp/php.tar.gz;
+    rm -f /tmp/php.tar.gz; \
+    ${PHP_SRC_DIR}/buildconf --force;
 
 ENV PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -447,6 +447,7 @@ ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/tokenizer/tests/PhpToken_constructor.phpt
 ext/tokenizer/tests/PhpToken_getAll.phpt
+ext/tokenizer/tests/PhpToken_tokenize.phpt
 ext/zip/tests/bug38943.phpt
 ext/zip/tests/bug38943_2.phpt
 sapi/cli/tests/upload_2G.phpt


### PR DESCRIPTION
### Description

It looks like we might get a PHP 8.0.0 RC5 release [next week](https://github.com/php/php-src/pull/6377#issuecomment-725574878). (Thanks again @carusogabriel!) Ahead of the release, this PR updates the Alpine, Buster, and CentOS 6 containers with a custom build that includes php/php-src#6377, php/php-src#6421, and a [Dmitry JIT fix](https://github.com/php/php-src/commit/11c4821ba968d2a39310851ab89d673c553b72f3) to the observer API.

This will unblock #1089 to allow continued development of the observer API refactor.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
