### PR TITLE
[PHP 8] Second custom pre-RC5 build

### DIFF
--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       args:
         phpVersion: 8.0
         phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
-        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0
+        phpSha256Hash: 9597c3497f6afa05e13db1e69e86e53bcfc19ad9581c30384be0f7f8f55c3eae

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       args:
         phpVersion: 8.0
         phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
-        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0
+        phpSha256Hash: 9597c3497f6afa05e13db1e69e86e53bcfc19ad9581c30384be0f7f8f55c3eae
 
   php-master:
     image: datadog/dd-trace-ci:php-master_buster

--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       args:
         phpVersion: 8.0
         phpTarGzUrl: https://github.com/SammyK/php-src/archive/sammyk/php8.0.0-pre-rc5.tar.gz
-        phpSha256Hash: 97f42abb17a116ff6b37c47be1e8852034dcd331ab5e150ebb6a8fbf64df5de0
+        phpSha256Hash: 9597c3497f6afa05e13db1e69e86e53bcfc19ad9581c30384be0f7f8f55c3eae
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'


### PR DESCRIPTION
### Description

This PR is a follow up to #1093 that adds php/php-src#6422 to the PHP 8 containers. That PR fixes a number of issues with passing the correct return value to the end handlers.

These changes will be landing in [RC5 next week](https://github.com/php/php-src/pull/6377#issuecomment-726107473).

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] ~~Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.~~
