### PR TITLE
Remove integrations that do not yet support PHP 8

### DIFF
--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -59,6 +59,23 @@ class IntegrationsLoader
     {
         $this->integrations = $integrations;
 
+        // Add integrations as they support PHP 8
+        if (\PHP_MAJOR_VERSION >= 8) {
+            $this->integrations[CodeIgniterIntegration::NAME] =
+                '\DDTrace\Integrations\CodeIgniter\V2\CodeIgniterIntegration';
+            $this->integrations[CurlIntegration::NAME] =
+                '\DDTrace\Integrations\Curl\CurlIntegration';
+            $this->integrations[EloquentIntegration::NAME] =
+                '\DDTrace\Integrations\Eloquent\EloquentIntegration';
+            $this->integrations[GuzzleIntegration::NAME] =
+                '\DDTrace\Integrations\Guzzle\GuzzleIntegration';
+            $this->integrations[LaravelIntegration::NAME] =
+                '\DDTrace\Integrations\Laravel\LaravelIntegration';
+            $this->integrations[MysqliIntegration::NAME] =
+                '\DDTrace\Integrations\Mysqli\MysqliIntegration';
+            return;
+        }
+
         $this->integrations[CakePHPIntegration::NAME] =
             '\DDTrace\Integrations\CakePHP\CakePHPIntegration';
         $this->integrations[CodeIgniterIntegration::NAME] =

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -147,12 +147,13 @@ final class IntegrationsLoaderTest extends BaseTestCase
 
     public function testWeDidNotForgetToRegisterALibraryForAutoLoading()
     {
-        if (Versions::phpVersionMatches('5.4')) {
-            $this->markTestSkipped('Sandboxed tests are skipped on PHP 5.4 so we cannot check for all integrations.');
-        }
-
         $expected = $this->normalize(glob(__DIR__ . '/../../../src/DDTrace/Integrations/*', GLOB_ONLYDIR));
 
+        /*
+         * We need a better way of validating loaded integrations:
+         * 0) that validates deferred-loaded integrations, and
+         * 1) does not require modifying this test.
+         */
         $excluded = [];
         if (\PHP_MAJOR_VERSION < 7) {
             $excluded[] = 'phpredis'; // PHP 7 only integration
@@ -167,6 +168,14 @@ final class IntegrationsLoaderTest extends BaseTestCase
             $excluded[] = 'wordpress';
             $excluded[] = 'yii';
         }
+        if (\PHP_MAJOR_VERSION >= 8) {
+            // Integrations that do not support PHP 8
+            $excluded[] = 'cakephp';
+            $excluded[] = 'lumen';
+            $excluded[] = 'mongo';
+            $excluded[] = 'symfony';
+            $excluded[] = 'zendframework';
+        }
         foreach ($excluded as $integrationToExclude) {
             $index = array_search($integrationToExclude, $expected, true);
             unset($expected[$index]);
@@ -178,8 +187,7 @@ final class IntegrationsLoaderTest extends BaseTestCase
         \ksort($integrations);
         $loaded = $this->normalize(array_keys($integrations));
 
-        // If this test fails you need to add an entry to IntegrationsLoader::LIBRARIES array.
-        $this->assertEquals(array_values($expected), array_values($loaded));
+        self::assertEquals(array_values($expected), array_values($loaded));
     }
 
     /**


### PR DESCRIPTION
### Description

To prevent accidentally loading an integration that does not have support for PHP 8, this PR removes them from the integration loaders. We will keep an eye out for PHP 8 support for each of these integrations and add them back to the loader once they become available.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
