### PR TITLE
Add functions for hashing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,7 +737,6 @@ jobs:
           name: Build and test Datadog::Arena
           command: |
             export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
-            cmake --version
             mkdir -p /tmp/build/DatadogArena
             cd /tmp/build/DatadogArena
             if [ -f "/etc/debian_version" ]
@@ -749,6 +748,23 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug \
               -DBUILD_TESTING=ON \
               ~/datadog/ext/DatadogArena
+            make -j
+            make test
+      - run:
+          name: Build and test Datadog::MemHash
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/DatadogMemHash
+            cd /tmp/build/DatadogMemHash
+            if [ -f "/etc/debian_version" ]
+            then
+              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+            fi
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              $toolchain \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_TESTING=ON \
+              ~/datadog/ext/DatadogMemHash
             make -j
             make test
 

--- a/ext/DatadogMemHash/CMakeLists.txt
+++ b/ext/DatadogMemHash/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.10)
+project(DatadogMemHash
+  LANGUAGES C CXX
+  VERSION 0.1.0
+)
+
+add_library(DatadogCxxMemHash INTERFACE)
+target_compile_features(DatadogCxxMemHash INTERFACE cxx_std_14)
+
+target_include_directories(DatadogCxxMemHash
+  INTERFACE
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+set_target_properties(DatadogCxxMemHash PROPERTIES
+  EXPORT_NAME CxxMemHash
+)
+
+add_library(DatadogCMemHash memhash.cc)
+target_compile_features(DatadogCMemHash
+  INTERFACE c_std_99
+)
+
+target_include_directories(DatadogCMemHash
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+set_target_properties(DatadogCMemHash PROPERTIES
+  OUTPUT_NAME datadog_memhash # It should be named libdatadog_memhash.{a,so}
+  VERSION ${PROJECT_VERSION}
+  EXPORT_NAME CMemHash
+)
+
+target_link_libraries(DatadogCMemHash PRIVATE DatadogCxxMemHash)
+
+#[[ We want to be able to use the namespaced name everywhere, including in this
+    project's tests; this is a pattern described in the talk Effective CMake
+    that enables it.
+#]]
+add_library(Datadog::CMemHash ALIAS DatadogCMemHash)
+add_library(Datadog::CxxMemHash ALIAS DatadogCxxMemHash)
+
+install(
+  TARGETS DatadogCMemHash DatadogCxxMemHash
+  EXPORT DatadogMemHashTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include
+  INCLUDES DESTINATION include
+)
+
+install(
+  EXPORT DatadogMemHashTargets
+  NAMESPACE Datadog::
+  DESTINATION share/cmake/DatadogMemHash
+)
+
+# This allows the exports to be used from the build tree, instead of only after installing
+export(
+  TARGETS DatadogCMemHash DatadogCxxMemHash
+  FILE DatadogMemHashExports.cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file("DatadogMemHashVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/DatadogMemHashVersion.cmake"
+  DESTINATION share/cmake/DatadogMemHash
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+# Add infrastructure for enabling tests
+option(BUILD_TESTING "Enable tests" OFF)
+include(CTest)
+if (${BUILD_TESTING})
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/ext/DatadogMemHash/README.md
+++ b/ext/DatadogMemHash/README.md
@@ -1,0 +1,34 @@
+# Datadog MemHash
+
+This exposes hashing functions for C99 and C++14 on 64-bit platforms:
+
+```c++
+// headers
+#include <datadog/memhash.h>
+#include <datadog/memhash.hh>
+
+// datadog/memhash.h
+uint64_t datadog_memhash(uint64_t size, const char str[]);
+uint64_t datadog_cantor_hash(uint64_t x, uint64_t y);
+
+// datadog/memhash.hh
+namespace datadog {
+uint64_t memhash(uint64_t size, const char str[]) noexcept;
+constexpr uint64_t cantor_hash(uint64_t x, uint64_t y) noexcept;
+}
+```
+
+Currently, `datadog::memhash` uses Murmur3¹.
+
+The CMake file exposes two targets:
+  - `Datadog::CMemHash`
+  - `Datadog::CxxMemHash`
+
+The C++ target is header-only, whereas the C API requires linking with
+`datadog_memhash`. It can be built as a shared library by setting the CMake
+option `BUILD_SHARED_LIBS=On`, or as a static library by setting it to `Off`.
+
+---
+
+¹ MurmurHash3 is in the public domain. It was written by Austin Appleby, who has
+disclaimed all copyrights to the source code.

--- a/ext/DatadogMemHash/include/datadog/memhash.h
+++ b/ext/DatadogMemHash/include/datadog/memhash.h
@@ -1,0 +1,10 @@
+#ifndef DATADOG_MEMHASH_H
+#define DATADOG_MEMHASH_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+uint64_t datadog_memhash(uint64_t size, const char str[]);
+uint64_t datadog_cantor_hash(uint64_t x, uint64_t y);
+
+#endif  // DATADOG_MEMHASH_H

--- a/ext/DatadogMemHash/include/datadog/memhash.hh
+++ b/ext/DatadogMemHash/include/datadog/memhash.hh
@@ -1,0 +1,168 @@
+#ifndef DATADOG_MEMHASH_HH
+#define DATADOG_MEMHASH_HH
+
+#include <cstdint>
+
+namespace datadog {
+
+namespace {
+
+constexpr uint64_t rotl64(uint64_t x, uint8_t r) { return (x << r) | (x >> (64u - r)); }
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+constexpr uint64_t fmix64(uint64_t k) noexcept {
+    k ^= k >> 33u;
+    k *= UINT64_C(0xff51afd7ed558ccd);
+    k ^= k >> 33u;
+    k *= UINT64_C(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33u;
+
+    return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128(const void *key, const uint64_t len, const uint32_t seed, void *out) noexcept {
+    auto *data = (const char *)key;
+    const uint64_t nblocks = len / 16u;
+
+    uint64_t h1 = seed;
+    uint64_t h2 = seed;
+
+    const uint64_t c1 = UINT64_C(0x87c37b91114253d5);
+    const uint64_t c2 = UINT64_C(0x4cf5ad432745937f);
+
+    //----------
+    // body
+
+    auto *blocks = (const uint64_t *)(key);
+
+    for (uint64_t i = 0; i < nblocks; i++) {
+        uint64_t k1 = blocks[(i * 2 + 0)];
+        uint64_t k2 = blocks[(i * 2 + 1)];
+
+        k1 *= c1;
+        k1 = rotl64(k1, 31);
+        k1 *= c2;
+        h1 ^= k1;
+
+        h1 = rotl64(h1, 27);
+        h1 += h2;
+        h1 = h1 * 5 + 0x52dce729;
+
+        k2 *= c2;
+        k2 = rotl64(k2, 33);
+        k2 *= c1;
+        h2 ^= k2;
+
+        h2 = rotl64(h2, 31);
+        h2 += h1;
+        h2 = h2 * 5 + 0x38495ab5;
+    }
+
+    //----------
+    // tail
+
+    auto *tail = (const uint8_t *)(data + nblocks * 16);
+
+    uint64_t k1 = 0;
+    uint64_t k2 = 0;
+
+    switch (len & 15u) {
+        case 15:
+            k2 ^= ((uint64_t)tail[14]) << 48u;
+        case 14:
+            k2 ^= ((uint64_t)tail[13]) << 40u;
+        case 13:
+            k2 ^= ((uint64_t)tail[12]) << 32u;
+        case 12:
+            k2 ^= ((uint64_t)tail[11]) << 24u;
+        case 11:
+            k2 ^= ((uint64_t)tail[10]) << 16u;
+        case 10:
+            k2 ^= ((uint64_t)tail[9]) << 8u;
+        case 9:
+            k2 ^= ((uint64_t)tail[8]) << 0u;
+            k2 *= c2;
+            k2 = rotl64(k2, 33);
+            k2 *= c1;
+            h2 ^= k2;
+
+        case 8:
+            k1 ^= ((uint64_t)tail[7]) << 56u;
+        case 7:
+            k1 ^= ((uint64_t)tail[6]) << 48u;
+        case 6:
+            k1 ^= ((uint64_t)tail[5]) << 40u;
+        case 5:
+            k1 ^= ((uint64_t)tail[4]) << 32u;
+        case 4:
+            k1 ^= ((uint64_t)tail[3]) << 24u;
+        case 3:
+            k1 ^= ((uint64_t)tail[2]) << 16u;
+        case 2:
+            k1 ^= ((uint64_t)tail[1]) << 8u;
+        case 1:
+            k1 ^= ((uint64_t)tail[0]) << 0u;
+            k1 *= c1;
+            k1 = rotl64(k1, 31);
+            k1 *= c2;
+            h1 ^= k1;
+    }
+
+    //----------
+    // finalization
+
+    h1 ^= len;
+    h2 ^= len;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+    h2 += h1;
+
+    ((uint64_t *)out)[0] = h1;
+    ((uint64_t *)out)[1] = h2;
+}
+
+template <uint64_t N>
+struct log2 {
+    constexpr static uint64_t value = 1 + log2<(N >> 1u)>::value;
+};
+
+template <>
+struct log2<1> {
+    constexpr static uint64_t value = 0;
+};
+
+}  // namespace
+
+inline uint64_t memhash(uint64_t size, const char str[]) noexcept {
+    uint64_t buffer[2] = {0, 0};
+    MurmurHash3_x64_128(str, size, 0, buffer);
+    return buffer[0];
+}
+
+/**
+ * Hashes two integers using the cantor pairing function:
+ *   https://en.wikipedia.org/wiki/Pairing_function#Cantor_pairing_function
+ *
+ * This hash is perfect until overflow occurs, and then there are repeating
+ * patterns due to the wrapped overflow. The hashes f(1, 2) and f(2, 1) are
+ * different.
+ *
+ * This makes it a good hash for two ints that are offsets into an array.
+ */
+constexpr uint64_t cantor_hash(uint64_t x, uint64_t y) noexcept {
+    return (x + y) * (x + y + 1) / 2 + y;
+}
+
+}  // namespace datadog
+
+#endif  // DATADOG_MEMHASH_HH

--- a/ext/DatadogMemHash/memhash.cc
+++ b/ext/DatadogMemHash/memhash.cc
@@ -1,0 +1,8 @@
+extern "C" {
+#include <datadog/memhash.h>
+}
+
+#include <datadog/memhash.hh>
+
+uint64_t datadog_memhash(uint64_t size, const char str[]) { return datadog::memhash(size, str); }
+uint64_t datadog_cantor_hash(uint64_t x, uint64_t y) { return datadog::cantor_hash(x, y); }

--- a/ext/DatadogMemHash/test/CMakeLists.txt
+++ b/ext/DatadogMemHash/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(Catch2 2.4 REQUIRED)
+
+include(Catch)
+
+add_library(catch2main main.cc)
+target_link_libraries(catch2main PUBLIC Catch2::Catch2)
+set_target_properties(catch2main PROPERTIES
+  CXX_STANDARD 11
+)
+
+add_executable(test_cantor cantor.cc)
+target_link_libraries(test_cantor PRIVATE catch2main Datadog::CxxMemHash)
+
+catch_discover_tests(test_cantor)

--- a/ext/DatadogMemHash/test/cantor.cc
+++ b/ext/DatadogMemHash/test/cantor.cc
@@ -1,0 +1,22 @@
+#include <catch2/catch.hpp>
+#include <datadog/memhash.hh>
+
+TEST_CASE("cantor tests", "[cantor_hash]") {
+    // clang-format off
+    uint64_t oracle[6][6] = {
+        {  0,   1,   3,   6,  10,  15},
+        {  2,   4,   7,  11,  16,  22},
+        {  5,   8,  12,  17,  23,  30},
+        {  9,  13,  18,  24,  31,  39},
+        { 14,  19,  25,  32,  40,  49},
+        { 20,  26,  33,  41,  50,  60},
+    };
+    // clang-format on
+
+    for (uint64_t y = 0; y < 6; ++y) {
+        for (uint64_t x = 0; x < 6; ++x) {
+            INFO("y,x=" << y << "," << x);
+            REQUIRE(oracle[y][x] == datadog::cantor_hash(x, y));
+        }
+    }
+}

--- a/ext/DatadogMemHash/test/main.cc
+++ b/ext/DatadogMemHash/test/main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,13 @@
             <!-- Shared -->
             <file name="ext/DatadogArena/arena.c" role="src" />
             <file name="ext/DatadogArena/datadog/arena.h" role="src" />
+
+            <file name="ext/DatadogMemHash/memhash.cc" role="src" />
+            <file name="ext/DatadogMemHash/include/datadog/memhash.h" role="src" />
+            <file name="ext/DatadogMemHash/include/datadog/memhash.hh" role="src" />
+            <file name="ext/DatadogMemHash/test/cantor.cc" role="test" />
+            <file name="ext/DatadogMemHash/test/main.cc" role="test" />
+
             <file name="ext/version.h" role="src" />
             <!-- Third party -->
             <file name="ext/vendor/mpack/AUTHORS.md" role="doc" />


### PR DESCRIPTION
### Description

This PR adds two functions for hashing:

1. `datadog::memhash`, which hashes linear bytes. Currently it uses the lower 64 bits of MurmurHash3's 128-bit hash. MurmurHash3 is in the public domain and the author has disclaimed any copyrights to it.
2. `datadog::cantor_hash`, which hashes two unsigned, 64-bit numbers using the [cantor pairing function](https://en.wikipedia.org/wiki/Pairing_function#Cantor_pairing_function). The hash of `(1, 2)` and `(2, 1)` are different. For small integers it forms a perfect hash; if the product of the two integers overflows then there can be collisions.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
