### PR TITLE
Attach fatal errors to userland root span on PHP 5

### DIFF
--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -246,22 +246,6 @@ static void dd_register_span_data_ce(TSRMLS_D) {
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
 }
 
-#if PHP_VERSION_ID >= 70000
-// SpanData::$name
-zval *ddtrace_spandata_property_name(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 0); }
-// SpanData::$resource
-zval *ddtrace_spandata_property_resource(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 1); }
-// SpanData::$service
-zval *ddtrace_spandata_property_service(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 2); }
-// SpanData::$type
-zval *ddtrace_spandata_property_type(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 3); }
-// SpanData::$meta
-zval *ddtrace_spandata_property_meta(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 4); }
-// SpanData::$metrics
-zval *ddtrace_spandata_property_metrics(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 5); }
-#endif
-
-#if PHP_VERSION_ID < 70000
 static zend_object_handlers ddtrace_fatal_error_handlers;
 /* The goal is to mimic zend_default_exception_new_ex except for adding
  * DEBUG_BACKTRACE_IGNORE_ARGS to zend_fetch_debug_backtrace. We don't want the
@@ -293,7 +277,6 @@ static zend_object_value ddtrace_fatal_error_new(zend_class_entry *class_type TS
 
     return Z_OBJVAL(obj);
 }
-#endif
 
 /* DDTrace\FatalError */
 zend_class_entry *ddtrace_ce_fatal_error;
@@ -301,15 +284,11 @@ zend_class_entry *ddtrace_ce_fatal_error;
 static void dd_register_fatal_error_ce(TSRMLS_D) {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "DDTrace", "FatalError", NULL);
-#if PHP_VERSION_ID < 70000
     ddtrace_ce_fatal_error = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
     ddtrace_ce_fatal_error->create_object = ddtrace_fatal_error_new;
     // these mimic zend_register_default_exception
     memcpy(&ddtrace_fatal_error_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     ddtrace_fatal_error_handlers.clone_obj = NULL;
-#else
-    ddtrace_ce_fatal_error = zend_register_internal_class_ex(&ce, zend_ce_exception TSRMLS_CC);
-#endif
 }
 
 static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -15,15 +15,6 @@ extern zend_class_entry *ddtrace_ce_fatal_error;
 typedef struct ddtrace_span_ids_t ddtrace_span_ids_t;
 typedef struct ddtrace_span_fci ddtrace_span_fci;
 
-#if PHP_VERSION_ID >= 70000
-zval *ddtrace_spandata_property_name(zval *spandata);
-zval *ddtrace_spandata_property_resource(zval *spandata);
-zval *ddtrace_spandata_property_service(zval *spandata);
-zval *ddtrace_spandata_property_type(zval *spandata);
-zval *ddtrace_spandata_property_meta(zval *spandata);
-zval *ddtrace_spandata_property_metrics(zval *spandata);
-#endif
-
 BOOL_T ddtrace_tracer_is_limited(TSRMLS_D);
 
 // clang-format off
@@ -45,8 +36,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     char *dogstatsd_port;
     char *dogstatsd_buffer;
 
-    // PHP 7 uses ZEND_TLS for these
-#if PHP_VERSION_ID < 70000
     // Distributed tracing & curl
     HashTable *dt_http_saved_curl_headers;
     zend_bool back_up_http_headers;
@@ -62,7 +51,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 
     // ext/curl's list entry resource type
     int le_curl;
-#endif
 
     uint64_t trace_id;
     ddtrace_span_ids_t *span_ids_top;
@@ -92,13 +80,7 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
  * defines these macros without the comma in the definition site, so that it
  * exists at the usage site.
  */
-#if PHP_VERSION_ID < 70000
 #define DDTRACE_ARG_INFO_SIZE(arg_info) ((zend_uint)(sizeof(arg_info) / sizeof(struct _zend_arg_info) - 1))
-#elif PHP_VERSION_ID < 80100
-#define DDTRACE_ARG_INFO_SIZE(arg_info) ((uint32_t)(sizeof(arg_info) / sizeof(struct _zend_internal_arg_info) - 1))
-#else
-#error Check if ZEND_FENTRY has changed in PHP 8.1 and if we need to update the macros
-#endif
 
 #define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
     { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }

--- a/ext/php5/engine_hooks.c
+++ b/ext/php5/engine_hooks.c
@@ -2,9 +2,6 @@
 
 #include <php.h>
 #include <time.h>
-#if PHP_VERSION_ID >= 80000
-#include <Zend/zend_observer.h>
-#endif
 
 #include "configuration.h"
 #include "ddtrace.h"
@@ -13,9 +10,7 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 static zend_op_array *(*_prev_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
-#if PHP_VERSION_ID < 80000
 void (*ddtrace_prev_error_cb)(DDTRACE_ERROR_CB_PARAMETERS);
-#endif
 
 void ddtrace_execute_internal_minit(void);
 void ddtrace_execute_internal_mshutdown(void);
@@ -31,23 +26,16 @@ void ddtrace_engine_hooks_minit(void) {
     ddtrace_opcode_minit();
     _compile_minit();
 
-#if PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 80000
+#if PHP_VERSION_ID >= 50500
     ddtrace_prev_error_cb = zend_error_cb;
     zend_error_cb = ddtrace_error_cb;
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    zend_observer_error_register(ddtrace_observer_error_cb);
 #endif
 }
 
 void ddtrace_engine_hooks_mshutdown(void) {
-#if PHP_VERSION_ID < 80000
     if (ddtrace_prev_error_cb == ddtrace_error_cb) {
         zend_error_cb = ddtrace_prev_error_cb;
     }
-#endif
-
     _compile_mshutdown();
     ddtrace_opcode_mshutdown();
     ddtrace_execute_internal_mshutdown();
@@ -87,33 +75,8 @@ void ddtrace_compile_time_reset(TSRMLS_D) { DDTRACE_G(compile_time_microseconds)
 int64_t ddtrace_compile_time_get(TSRMLS_D) { return DDTRACE_G(compile_time_microseconds); }
 
 extern inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC);
-#if PHP_VERSION_ID < 80000
 extern inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC);
-#else
-void ddtrace_restore_error_handling(ddtrace_error_handling *eh) {
-    if (PG(last_error_message)) {
-        if (PG(last_error_message) != eh->message) {
-            zend_string_release(PG(last_error_message));
-        }
-        if (PG(last_error_file) != eh->file) {
-            free(PG(last_error_file));
-        }
-    }
-    zend_restore_error_handling(&eh->error_handling TSRMLS_CC);
-    PG(last_error_type) = eh->type;
-    PG(last_error_message) = eh->message;
-    PG(last_error_file) = eh->file;
-    PG(last_error_lineno) = eh->lineno;
-    EG(error_reporting) = eh->error_reporting;
-}
-#endif
 extern inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC);
-#if PHP_VERSION_ID < 70000
 extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC);
 extern inline void ddtrace_maybe_clear_exception(TSRMLS_D);
 extern inline zval *ddtrace_exception_get_entry(zval *object, char *name, int name_len TSRMLS_DC);
-#else
-extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void);
-extern inline void ddtrace_maybe_clear_exception(void);
-extern inline zend_class_entry *ddtrace_get_exception_base(zval *object);
-#endif

--- a/ext/php5/engine_hooks.h
+++ b/ext/php5/engine_hooks.h
@@ -12,11 +12,6 @@
 
 extern int ddtrace_resource;
 
-#if PHP_VERSION_ID >= 70400
-extern int ddtrace_op_array_extension;
-#define DDTRACE_OP_ARRAY_EXTENSION(op_array) ZEND_OP_ARRAY_EXTENSION(op_array, ddtrace_op_array_extension)
-#endif
-
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
@@ -30,11 +25,7 @@ int64_t ddtrace_compile_time_get(TSRMLS_D);
 struct ddtrace_error_handling {
     int type;
     int lineno;
-#if PHP_VERSION_ID < 80000
     char *message;
-#else
-    zend_string *message;
-#endif
     char *file;
     int error_reporting;
     zend_error_handling error_handling;
@@ -44,9 +35,7 @@ typedef struct ddtrace_error_handling ddtrace_error_handling;
 struct ddtrace_sandbox_backup {
     ddtrace_error_handling eh;
     ddtrace_exception_t *exception, *prev_exception;
-#if PHP_VERSION_ID < 70000
     zend_op *opline_before_exception;
-#endif
 };
 typedef struct ddtrace_sandbox_backup ddtrace_sandbox_backup;
 
@@ -65,7 +54,6 @@ inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error
     zend_replace_error_handling(mode, NULL, &eh->error_handling TSRMLS_CC);
 }
 
-#if PHP_VERSION_ID < 80000
 inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC) {
     if (PG(last_error_message)) {
         if (PG(last_error_message) != eh->message) {
@@ -82,11 +70,7 @@ inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC)
     PG(last_error_lineno) = eh->lineno;
     EG(error_reporting) = eh->error_reporting;
 }
-#else
-void ddtrace_restore_error_handling(ddtrace_error_handling *eh);
-#endif
 
-#if PHP_VERSION_ID < 70000
 inline void ddtrace_maybe_clear_exception(TSRMLS_D) {
     if (EG(exception)) {
         // Cannot use zend_clear_exception() in PHP 5 since there is no NULL check on the opline
@@ -101,37 +85,18 @@ inline void ddtrace_maybe_clear_exception(TSRMLS_D) {
         }
     }
 }
-#else
-inline void ddtrace_maybe_clear_exception(void) {
-    if (EG(exception)) {
-        zend_clear_exception();
-    }
-}
-#endif
 
-#if PHP_VERSION_ID < 70000
 inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC) {
-#else
-inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void) {
-#endif
     ddtrace_sandbox_backup backup = {.exception = NULL, .prev_exception = NULL};
     if (EG(exception)) {
         backup.exception = EG(exception);
         backup.prev_exception = EG(prev_exception);
         EG(exception) = NULL;
         EG(prev_exception) = NULL;
-
-#if PHP_VERSION_ID < 70000
         backup.opline_before_exception = opline_before_exception;
-#endif
     }
 
-#if PHP_VERSION_ID < 70000
     zend_error_handling_t mode = EH_SUPPRESS;
-#else
-    zend_error_handling_t mode = EH_THROW;
-#endif
-
     ddtrace_backup_error_handling(&backup.eh, mode TSRMLS_CC);
     return backup;
 }
@@ -144,22 +109,13 @@ inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC) {
         EG(exception) = backup->exception;
         EG(prev_exception) = backup->prev_exception;
 
-#if PHP_VERSION_ID < 70000
         EG(opline_before_exception) = backup->opline_before_exception;
 #if PHP_VERSION_ID >= 50500
         EG(current_execute_data)->opline = EG(exception_op);
 #endif
-#else
-        zend_throw_exception_internal(NULL);
-#endif
     }
 }
 
-#if PHP_VERSION_ID >= 70000
-PHP_FUNCTION(ddtrace_internal_function_handler);
-#endif
-
-#if PHP_VERSION_ID < 80000
 #define DDTRACE_ERROR_CB_PARAMETERS \
     int type, const char *error_filename, const uint error_lineno, const char *format, va_list args
 
@@ -168,48 +124,13 @@ PHP_FUNCTION(ddtrace_internal_function_handler);
 extern void (*ddtrace_prev_error_cb)(DDTRACE_ERROR_CB_PARAMETERS);
 void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS);
 ddtrace_exception_t *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS TSRMLS_DC);
-#else
-void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
-#endif
 
 void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception);
-
-#if PHP_VERSION_ID < 70000
 void ddtrace_close_all_open_spans(TSRMLS_D);
-#else
-void ddtrace_close_all_open_spans(void);
-#endif
 
-#if PHP_VERSION_ID >= 80000
-inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
-    return (Z_OBJCE_P(object) == zend_ce_exception || instanceof_function_slow(Z_OBJCE_P(object), zend_ce_exception))
-               ? zend_ce_exception
-               : zend_ce_error;
-}
-#define GET_PROPERTY(object, id) \
-    zend_read_property_ex(ddtrace_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &rv)
-#elif PHP_VERSION_ID >= 70000
-inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
-    return instanceof_function(Z_OBJCE_P(object), zend_ce_exception) ? zend_ce_exception : zend_ce_error;
-}
-#if PHP_VERSION_ID < 70100
-#define ZEND_STR_MESSAGE "message"
-#define GET_PROPERTY(object, name) \
-    zend_read_property(ddtrace_get_exception_base(object), (object), name, sizeof(name) - 1, 1, &rv)
-#elif PHP_VERSION_ID < 70200
-#define GET_PROPERTY(object, id) \
-    zend_read_property_ex(ddtrace_get_exception_base(object), (object), CG(known_strings)[id], 1, &rv)
-#else
-#define GET_PROPERTY(object, id) \
-    zend_read_property_ex(ddtrace_get_exception_base(object), (object), ZSTR_KNOWN(id), 1, &rv)
-#endif
-#endif
-
-#if PHP_VERSION_ID < 70000
 inline zval *ddtrace_exception_get_entry(zval *object, char *name, int name_len TSRMLS_DC) {
     zend_class_entry *exception_ce = zend_exception_get_default(TSRMLS_C);
     return zend_read_property(exception_ce, object, name, name_len, 1 TSRMLS_CC);
 }
-#endif
 
 #endif  // DD_ENGINE_HOOKS_H

--- a/ext/php5/span.h
+++ b/ext/php5/span.h
@@ -31,9 +31,7 @@ struct ddtrace_span_fci {
     zend_execute_data *execute_data;
     struct ddtrace_dispatch_t *dispatch;
     ddtrace_exception_t *exception;
-#if PHP_VERSION_ID < 70000
     ddtrace_execute_data dd_execute_data;
-#endif
     struct ddtrace_span_fci *next;
     ddtrace_span_t span;
 };

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -100,10 +100,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         // CodeIgniter's error handler does not adjust the status code
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'Error_::index',
-                    ])->ifPhpVersionNotMatch('5', function (SpanAssertion $assertion) {
-                        // Automatic error attachement to root span in case of PHP < 7 is still under development.
+                    ])->ifPhpVersionNotMatch('5.4', function (SpanAssertion $assertion) {
+                        // Automatic error attachment to root span in case of PHP 5.4 is still under development.
+                        $message = PHP_MAJOR_VERSION >= 7
+                            ? "Uncaught Exception: datadog in %s:%d"
+                            : "Uncaught exception 'Exception' with message 'datadog' in %s:%d";
                         $assertion
-                            ->setError("E_ERROR", "Uncaught Exception: datadog in %s:%d")
+                            ->setError("E_ERROR", $message)
                             ->withExistingTagsNames(['error.stack']);
                     })->withChildren([
                         SpanAssertion::build(

--- a/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
+++ b/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
@@ -26,8 +26,8 @@ final class FatalErrorTest extends WebFrameworkTestCase
 
     public function testScenario()
     {
-        if (\PHP_MAJOR_VERSION !== 7) {
-            $this->markTestSkipped('Fatal errors on the root span only work on PHP 7');
+        if (\PHP_VERSION_ID < 50500) {
+            self::markTestSkipped('Fatal errors on the root span only work on PHP 5.5+');
         }
         $traces = $this->tracesFromWebRequest(function () {
             $spec = GetSpec::create('Fatal error tracking', '/fatal');

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -217,14 +217,15 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/error',
                         // WordPress doesn't appear to automatically set the proper error code
                         'http.status_code' => '200',
-                    ])
-                    ->ifPhpVersionNotMatch('5', function (SpanAssertion $assertion) {
-                        // Automatic error attachement to root span in case of PHP < 7 is still under development.
+                    ])->ifPhpVersionNotMatch('5.4', function (SpanAssertion $assertion) {
+                        // Automatic error attachment to root span in case of PHP 5.4 is still under development.
+                        $message = PHP_MAJOR_VERSION >= 7
+                            ? "Uncaught Exception: Oops! in %s:%d"
+                            : "Uncaught exception 'Exception' with message 'Oops!' in %s:%d";
                         $assertion
-                            ->setError("E_ERROR", "Uncaught Exception: Oops! in %s:%d")
+                            ->setError("E_ERROR", $message)
                             ->withExistingTagsNames(['error.stack']);
-                    })
-                    ->withChildren([
+                    })->withChildren([
                         SpanAssertion::exists('WP.main')
                             // There's no way to propagate this to the root span in userland yet
                             ->setError('Exception', 'Oops!')

--- a/tests/Integrations/WordPress/V5_5/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V5_5/CommonScenariosTest.php
@@ -242,10 +242,13 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/error',
                         // WordPress doesn't appear to automatically set the proper error code
                         'http.status_code' => '200',
-                    ])->ifPhpVersionNotMatch('5', function (SpanAssertion $assertion) {
-                        // Automatic error attachement to root span in case of PHP < 7 is still under development.
+                    ])->ifPhpVersionNotMatch('5.4', function (SpanAssertion $assertion) {
+                        // Automatic error attachment to root span in case of PHP 5.4 is still under development.
+                        $message = PHP_MAJOR_VERSION >= 7
+                            ? "Uncaught Exception: Oops! in %s:%d"
+                            : "Uncaught exception 'Exception' with message 'Oops!' in %s:%d";
                         $assertion
-                            ->setError("E_ERROR", "Uncaught Exception: Oops! in %s:%d")
+                            ->setError("E_ERROR", $message)
                             ->withExistingTagsNames(['error.stack']);
                     })->withChildren([
                         SpanAssertion::exists('WP.main')


### PR DESCRIPTION
### Description

This is a followup PR to #1040 that attaches fatal errors to root spans created in userland for PHP 5.6 and 5.5.

As mentioned in #1034, PHP 5.4 is still not supported.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
