### PR TITLE
Update containers to PHP 8.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1220,7 +1220,7 @@ workflows:
                 - php:7.2-fpm-alpine
                 - php:7.3-fpm-alpine
                 - php:7.4-fpm-alpine
-                - php:8.0.0RC4-fpm-alpine # Add RC5 when available
+                - php:8.0-rc-fpm-alpine
       - pecl_tests:
           requires: [ "Build PECL" ]
           name: "PHP 54 PECL tests"
@@ -1440,7 +1440,7 @@ workflows:
           requires: [ 'Prepare Code' ]
           name: "PHP 80 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
-          xdebug_version_one: "3.0.0beta1"
+          xdebug_version_one: "3.0.0"
       - placeholder:
           requires: [ 'Prepare Code' ]
           name: Language tests

--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://github.com/php/php-src/archive/php-8.0.0RC5.tar.gz
-        phpSha256Hash: ec5836f816e17fd8a281f671bb247b4c420f8de23fb425d599877cd911a54230
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.0.tar.gz
+        phpSha256Hash: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71

--- a/dockerfiles/ci/alpine/php-8.0/Dockerfile
+++ b/dockerfiles/ci/alpine/php-8.0/Dockerfile
@@ -74,12 +74,12 @@ RUN set -eux; \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
         #yes 'no' | pecl install memcached; \ # TODO Does not support PHP 8 yet
-        #pecl install mongodb; \ # TODO Does not support PHP 8 yet
-        pecl install redis-5.3.2RC2; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
+        pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
+        pecl install redis-5.3.2; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
-        pecl install xdebug-3.0.0beta1; \
+        pecl install xdebug-3.0.0; \
         cd $(php-config --extension-dir); \
-        mv xdebug.so xdebug-3.0.0beta1.so; \
+        mv xdebug.so xdebug-3.0.0.so; \
     done;
 
 RUN set -eux; \
@@ -87,10 +87,10 @@ RUN set -eux; \
 # Causes error: "_tsrm_ls_cache: initial-exec TLS resolves to dynamic definition"
     rm /opt/php/8.0-debug-zts/conf.d/apcu.ini; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug; \
+    switch-php ${PHP_VERSION}-debug;
+
 # Install Composer
-    curl -q https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer | \
-    sudo php -- --filename=composer --install-dir=/usr/local/bin;
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://github.com/php/php-src/archive/php-8.0.0RC5.tar.gz
-        phpSha256Hash: ec5836f816e17fd8a281f671bb247b4c420f8de23fb425d599877cd911a54230
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.0.tar.gz
+        phpSha256Hash: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
 
   php-master:
     image: datadog/dd-trace-ci:php-master_buster

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile
@@ -72,20 +72,20 @@ RUN set -eux; \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
         #yes 'no' | pecl install memcached; \ # TODO Does not support PHP 8 yet
-        #pecl install mongodb; \ # TODO Does not support PHP 8 yet
-        pecl install redis-5.3.2RC2; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
+        pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
+        pecl install redis-5.3.2; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
-        pecl install xdebug-3.0.0beta1; \
+        pecl install xdebug-3.0.0; \
         cd $(php-config --extension-dir); \
-        mv xdebug.so xdebug-3.0.0beta1.so; \
+        mv xdebug.so xdebug-3.0.0.so; \
     done;
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug; \
+    switch-php ${PHP_VERSION}-debug;
+
 # Install Composer
-    curl -q https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer | \
-    sudo php -- --filename=composer --install-dir=/usr/local/bin;
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://github.com/php/php-src/archive/php-8.0.0RC5.tar.gz
-        phpSha256Hash: ec5836f816e17fd8a281f671bb247b4c420f8de23fb425d599877cd911a54230
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.0.tar.gz
+        phpSha256Hash: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'

--- a/dockerfiles/compile_extension/docker-compose.yml
+++ b/dockerfiles/compile_extension/docker-compose.yml
@@ -112,9 +112,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 8.0.0RC5
-        php_url: https://github.com/php/php-src/archive/php-8.0.0RC5.tar.gz
-        php_sha: ec5836f816e17fd8a281f671bb247b4c420f8de23fb425d599877cd911a54230
+        php_version: 8.0.0
+        php_sha: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
         php_api: 20200930
     command: build-dd-trace-php
     volumes:

--- a/tests/xdebug/3.0.0/request_init_hook.phpt
+++ b/tests/xdebug/3.0.0/request_init_hook.phpt
@@ -10,7 +10,7 @@ ddtrace.request_init_hook={PWD}/../fake_request_init_hook.inc
 ddtrace.traced_internal_functions=array_sum
 --FILE--
 <?php
-if (!extension_loaded('xdebug') || version_compare(phpversion('xdebug'), '3.0.0beta1') < 0) die('Xdebug 3.0.0+ required');
+if (!extension_loaded('xdebug') || version_compare(phpversion('xdebug'), '3.0.0') < 0) die('Xdebug 3.0.0+ required');
 
 var_dump(array_sum([1, 2, 3]));
 


### PR DESCRIPTION
### Description

PHP 8 is [GA](https://www.php.net/releases/8.0/en.php). 🎉 

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
