### PR TITLE
NullLogger is essential, not optional

### DIFF
--- a/bridge/_files.php
+++ b/bridge/_files.php
@@ -87,6 +87,7 @@ return [
     __DIR__ . '/../src/api/Log/LogLevel.php',
     __DIR__ . '/../src/api/Log/AbstractLogger.php',
     __DIR__ . '/../src/api/Log/ErrorLogLogger.php',
+    __DIR__ . '/../src/api/Log/NullLogger.php',
 
     __DIR__ . '/../src/DDTrace/Obfuscation.php',
     __DIR__ . '/../src/DDTrace/Format.php',

--- a/bridge/dd_register_optional_deps_autoloader.php
+++ b/bridge/dd_register_optional_deps_autoloader.php
@@ -20,7 +20,6 @@ class OptionalDepsAutoloader
         "DDTrace\\OpenTracer\\Scope" => 'DDTrace/OpenTracer/Scope.php',
         "DDTrace\\OpenTracer\\ScopeManager" => 'DDTrace/OpenTracer/ScopeManager.php',
         "DDTrace\\OpenTracer\\SpanContext" => 'DDTrace/OpenTracer/SpanContext.php',
-        "DDTrace\\Log\\NullLogger" => 'api/Log/NullLogger.php',
         "DDTrace\\NoopTracer" => 'api/NoopTracer.php',
         "DDTrace\\NoopSpan" => 'api/NoopSpan.php',
         "DDTrace\\NoopScope" => 'api/NoopScope.php',


### PR DESCRIPTION
### Description

Notably, PECL builds were failing when DD_TRACE_DEBUG=false (default)
was set because they would end up using NullLogger, but it couldn't
be found because it isn't shipped in the package.xml.

Maybe we should ship the optional files in src/api too, but at the
very least NullLogger isn't optional and should be included in
_files.php so it gets shipped in _generated.php.

Relates to #1090.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
