### PR TITLE
Added DD_TRACE_QUERY_STRING_RESOURCE_PARAMS option

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -240,6 +240,14 @@ function ddtrace_config_path_fragment_regex()
 /**
  * @return string[]
  */
+function ddtrace_config_path_query_resource_params()
+{
+    return \_ddtrace_config_indexed_array(\getenv('DD_TRACE_QUERY_STRING_RESOURCE_PARAMS'), []);
+}
+
+/**
+ * @return string[]
+ */
 function ddtrace_config_path_mapping_incoming()
 {
     return \_ddtrace_config_indexed_array(\getenv('DD_TRACE_RESOURCE_URI_MAPPING_INCOMING'), []);

--- a/tests/Unit/private/UriTest.php
+++ b/tests/Unit/private/UriTest.php
@@ -487,6 +487,22 @@ class UriTest extends BaseTestCase
         );
     }
 
+    public function testQueryStringHasParams()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_QUERY_STRING_RESOURCE_PARAMS=foo',
+        ]);
+
+        $this->assertSame(
+            '/int/?/nested/some?foo=value',
+            \DDtrace\Private_\util_uri_normalize_incoming_path('/int/123/nested/some?foo=value&bar=value')
+        );
+        $this->assertSame(
+            '/int/?/nested/some?foo=value',
+            \DDtrace\Private_\util_uri_normalize_outgoing_path('/int/123/nested/some?foo=value&bar=value')
+        );
+    }
+
     public function testQueryStringIsRemoved()
     {
         $this->assertSame(


### PR DESCRIPTION
### Description
Added `DD_TRACE_QUERY_STRING_RESOURCE_PARAMS` array option to keep selected query string attributes in the uri 
 to resource mapper.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
