### PR TITLE
Add StringTable component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -750,6 +750,7 @@ jobs:
             tar -xf ../v<< parameters.catch2_version >>.tar.gz --strip 1
             cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2
             cmake --build build/ --target install
+
       - run:
           name: Build and test Datadog::Arena
           command: |
@@ -763,10 +764,12 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               $toolchain \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_TESTING=ON \
+              -DCMAKE_INSTALL_PREFIX=/opt/libdatadog \
+              -DBUILD_ARENA_TESTING=ON \
               ~/datadog/ext/DatadogArena
-            make -j
+            make -j all install
             make test
+
       - run:
           name: Build and test Datadog::MemHash
           command: |
@@ -780,9 +783,30 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               $toolchain \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_TESTING=ON \
+              -DCMAKE_INSTALL_PREFIX=/opt/libdatadog \
+              -DBUILD_MEMHASH_TESTING=ON \
               ~/datadog/ext/DatadogMemHash
-            make -j
+            make -j all install
+            make test
+
+      - run:
+          name: Build and test Datadog::StringTable
+          command: |
+            ls -R /opt/libdatadog
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/DatadogStringTable
+            cd /tmp/build/DatadogStringTable
+            if [ -f "/etc/debian_version" ]
+            then
+              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+            fi
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              $toolchain \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_INSTALL_PREFIX=/opt/libdatadog \
+              -DBUILD_STRINGTABLE_TESTING=ON \
+              ~/datadog/ext/DatadogStringTable
+            make -j all install
             make test
 
   compile_alpine:

--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,6 @@ BasedOnStyle: Google
 Language: Cpp
 ColumnLimit: 120
 IndentWidth: 4
+AccessModifierOffset: 0
+BreakConstructorInitializers: AfterColon
 ---

--- a/ext/DatadogArena/CMakeLists.txt
+++ b/ext/DatadogArena/CMakeLists.txt
@@ -27,11 +27,41 @@ set_target_properties(DatadogArena PROPERTIES
 add_library(Datadog::Arena ALIAS DatadogArena)
 
 # Add infrastructure for enabling tests
-option(BUILD_TESTING "Enable tests" ON)
-include(CTest)
-if (${BUILD_TESTING})
+option(BUILD_ARENA_TESTING "Enable tests" OFF)
+if (${BUILD_ARENA_TESTING})
   enable_testing()
   add_subdirectory(test)
 endif()
 
-# todo: add stuff for installing the library
+install(
+  TARGETS DatadogArena
+  EXPORT DatadogArenaTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include
+  INCLUDES DESTINATION include
+)
+
+install(
+  EXPORT DatadogArenaTargets
+  NAMESPACE Datadog::
+  DESTINATION share/cmake/DatadogArena
+)
+
+export(
+  TARGETS DatadogArena
+  FILE DatadogArenaExports.cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file("DatadogArenaVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/DatadogArenaVersion.cmake"
+  DESTINATION share/cmake/DatadogArena
+)

--- a/ext/DatadogMemHash/CMakeLists.txt
+++ b/ext/DatadogMemHash/CMakeLists.txt
@@ -82,8 +82,8 @@ install(
 )
 
 # Add infrastructure for enabling tests
-option(BUILD_MEMHHASH_TESTING "Enable tests" OFF)
-if (${BUILD_MEMHHASH_TESTING})
+option(BUILD_MEMHASH_TESTING "Enable tests" OFF)
+if (${BUILD_MEMHASH_TESTING})
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/ext/DatadogMemHash/CMakeLists.txt
+++ b/ext/DatadogMemHash/CMakeLists.txt
@@ -82,9 +82,8 @@ install(
 )
 
 # Add infrastructure for enabling tests
-option(BUILD_TESTING "Enable tests" OFF)
-include(CTest)
-if (${BUILD_TESTING})
+option(BUILD_MEMHHASH_TESTING "Enable tests" OFF)
+if (${BUILD_MEMHHASH_TESTING})
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/ext/DatadogStringTable/CMakeLists.txt
+++ b/ext/DatadogStringTable/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.10)
+project(DatadogStringTable
+  LANGUAGES C CXX
+  VERSION 0.1.0
+)
+
+# We try to use installed versions first; fallback to relative directories
+find_package(DatadogArena QUIET)
+if (NOT DatadogArena_FOUND)
+  add_subdirectory(../DatadogArena DatadogArena)
+endif ()
+
+find_package(DatadogMemHash QUIET)
+if (NOT DatadogMemHash_FOUND)
+  add_subdirectory(../DatadogMemHash DatadogMemHash)
+endif ()
+
+add_library(DatadogStringTable  string_table.cc)
+target_compile_features(DatadogStringTable PUBLIC cxx_std_14)
+
+target_include_directories(DatadogStringTable
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+target_link_libraries(DatadogStringTable
+  PUBLIC Datadog::Arena
+  PRIVATE Datadog::CxxMemHash
+)
+
+set_target_properties(DatadogStringTable PROPERTIES
+  EXPORT_NAME StringTable
+)
+
+set_target_properties(DatadogStringTable PROPERTIES
+  OUTPUT_NAME datadog_stringtable # It should be named libdatadog_stringtable.{a,so}
+  VERSION ${PROJECT_VERSION}
+  EXPORT_NAME StringTable
+)
+
+#[[ We want to be able to use the namespaced name everywhere, including in this
+    project's tests; this is a pattern described in the talk Effective CMake
+    that enables it.
+#]]
+add_library(Datadog::StringTable ALIAS DatadogStringTable)
+
+install(
+  TARGETS DatadogStringTable
+  EXPORT DatadogStringTableTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include
+  INCLUDES DESTINATION include
+)
+
+install(
+  EXPORT DatadogStringTableTargets
+  NAMESPACE Datadog::
+  DESTINATION share/cmake/DatadogStringTable
+)
+
+# This allows the exports to be used from the build tree, instead of only after installing
+export(
+  TARGETS DatadogStringTable
+  FILE DatadogStringTableExports.cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file("DatadogStringTableVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/DatadogStringTableVersion.cmake"
+  DESTINATION share/cmake/DatadogStringTable
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+# Add infrastructure for enabling tests
+option(BUILD_STRINGTABLE_TESTING "Enable tests" OFF)
+if (${BUILD_STRINGTABLE_TESTING})
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/ext/DatadogStringTable/include/datadog/hashed_string.hh
+++ b/ext/DatadogStringTable/include/datadog/hashed_string.hh
@@ -1,0 +1,47 @@
+#ifndef DATADOG_HASHED_STRING_HH
+#define DATADOG_HASHED_STRING_HH
+
+#include <cstddef>
+#include <cstring>
+#include <functional>
+
+namespace datadog {
+
+class hashed_string {
+    std::size_t hash_;
+    std::size_t size_;
+    const char *data_;
+
+    public:
+    constexpr hashed_string() noexcept : hash_{0}, size_{0}, data_{nullptr} {}
+
+    /* Be responsible with the hashes passed in; they should be generated using
+     * the same hash function as the other constructors.
+     */
+    constexpr hashed_string(std::size_t h, std::size_t s, const char *p) noexcept : hash_{h}, size_{s}, data_{p} {}
+
+    hashed_string(std::size_t len, const char *ptr) noexcept;
+
+    constexpr std::size_t hash() const noexcept { return hash_; }
+    constexpr std::size_t size() const noexcept { return size_; }
+    constexpr const char *data() const noexcept { return data_; }
+};
+
+constexpr bool operator==(const hashed_string &lhs, const hashed_string &rhs) noexcept {
+    return lhs.size() == rhs.size() && (lhs.data() == rhs.data() || memcmp(lhs.data(), rhs.data(), lhs.size()) == 0);
+}
+
+}  // namespace datadog
+
+namespace std {
+
+template <>
+struct hash<datadog::hashed_string> {
+    constexpr std::size_t operator()(const datadog::hashed_string &hashed_string) const noexcept {
+        return hashed_string.hash();
+    }
+};
+
+}  // namespace std
+
+#endif  // DATADOG_HASHED_STRING_HH

--- a/ext/DatadogStringTable/include/datadog/interned_string.hh
+++ b/ext/DatadogStringTable/include/datadog/interned_string.hh
@@ -1,0 +1,35 @@
+#ifndef DATADOG_INTERNED_STRING_HH
+#define DATADOG_INTERNED_STRING_HH
+
+#include <cstddef>
+
+namespace datadog {
+
+struct interned_string {
+    std::size_t hash;
+    std::size_t offset;
+    std::size_t size;
+    char data[1];  // struct hack, ahoy!
+
+    // not copyable nor move-able due to struct hack
+    interned_string(const interned_string &) = delete;
+    interned_string(interned_string &&) = delete;
+    interned_string &operator=(const interned_string &) = delete;
+    interned_string &operator=(interned_string &&) = delete;
+};
+
+// interned_strings compare by address, not contents
+constexpr bool operator==(interned_string &lhs, interned_string &rhs) { return &lhs == &rhs; }
+
+}  // namespace datadog
+
+namespace std {
+
+template <>
+class hash<datadog::interned_string> {
+    constexpr std::size_t operator()(const datadog::interned_string &string) const noexcept { return string.hash; }
+};
+
+}  // namespace std
+
+#endif  // DATADOG_INTERNED_STRING_HH

--- a/ext/DatadogStringTable/include/datadog/string_table.hh
+++ b/ext/DatadogStringTable/include/datadog/string_table.hh
@@ -1,0 +1,91 @@
+#ifndef DATADOG_STRING_TABLE_HH
+#define DATADOG_STRING_TABLE_HH
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+extern "C" {
+#include <datadog/arena.h>
+}
+
+#include "hashed_string.hh"
+#include "interned_string.hh"
+
+namespace datadog {
+
+class string_table {
+    datadog_arena **arena;  // does not own the arena
+    std::unordered_map<hashed_string, std::size_t> map;
+    std::vector<const char *> vector;
+
+    public:
+    // string tables aren't copyable
+    string_table(const string_table &) = delete;
+    string_table &operator=(const string_table &) = delete;
+
+    // they are move-able
+    string_table(string_table &&) noexcept;
+    string_table &operator=(string_table &&) noexcept;
+
+    explicit string_table(datadog_arena **arena) noexcept;
+
+    ~string_table();
+
+    interned_string &intern(hashed_string);
+    interned_string &intern(interned_string &);
+
+    std::size_t size() const noexcept;
+
+    interned_string &operator[](std::size_t offset) noexcept;
+    const interned_string &operator[](std::size_t offset) const noexcept;
+
+    void swap(string_table &other) noexcept;
+
+    inline const char *const *data() const noexcept { return vector.data(); }
+};
+
+inline string_table::string_table(string_table &&) noexcept = default;
+inline string_table &string_table::operator=(string_table &&) noexcept = default;
+
+inline string_table::string_table(datadog_arena **a) noexcept : arena{a}, map{}, vector{} {
+    // the empty string is _always_ offset 0
+    auto &interned = intern({0, nullptr});
+    assert(interned.offset == 0);
+}
+
+inline interned_string &string_table::intern(interned_string &interned) {
+    hashed_string hashed{interned.hash, interned.size, &interned.data[0]};
+    return intern(hashed);
+}
+
+inline string_table::~string_table() = default;
+
+inline std::size_t string_table::size() const noexcept {
+    assert(vector.size() == map.size());
+    return vector.size();
+}
+
+inline interned_string &string_table::operator[](std::size_t offset) noexcept {
+    assert(offset < size());
+    char *addr = const_cast<char *>(vector[offset] - offsetof(interned_string, data));
+    return *reinterpret_cast<interned_string *>(addr);
+}
+
+inline const interned_string &string_table::operator[](std::size_t offset) const noexcept {
+    assert(offset < size());
+    const char *addr = vector[offset] - offsetof(interned_string, data);
+    return *reinterpret_cast<const interned_string *>(addr);
+}
+
+inline void string_table::swap(string_table &other) noexcept {
+    vector.swap(other.vector);
+    map.swap(other.map);
+}
+
+}  // namespace datadog
+
+#endif  // DATADOG_STRING_TABLE_HH

--- a/ext/DatadogStringTable/string_table.cc
+++ b/ext/DatadogStringTable/string_table.cc
@@ -1,0 +1,38 @@
+#include "datadog/string_table.hh"
+
+#include <datadog/memhash.hh>
+
+namespace datadog {
+
+hashed_string::hashed_string(std::size_t len, const char *ptr) noexcept :
+    hashed_string{datadog::memhash(len, ptr), len, ptr} {}
+
+interned_string &string_table::intern(hashed_string hashed) {
+    constexpr auto data_offset = offsetof(interned_string, data);
+    std::size_t size = hashed.size();
+
+    auto iter = map.find(hashed);
+    if (iter == map.end()) {
+        /* We add +1 for the null terminator. It's not required, but makes
+         * working with it easier, as debuggers Just Work.
+         */
+        auto *addr = datadog_arena_alloc(arena, data_offset + size + 1);
+        auto *interned = reinterpret_cast<interned_string *>(addr);
+        interned->hash = hashed.hash();
+        interned->offset = vector.size();
+        interned->size = size;
+        memcpy(&interned->data[0], hashed.data(), size);
+        interned->data[size] = '\0';
+
+        vector.push_back(&interned->data[0]);
+
+        hashed_string updated_hash_string{hashed.hash(), interned->size, &interned->data[0]};
+        map.emplace(updated_hash_string, interned->offset);
+        return *interned;
+    }
+
+    char *addr = const_cast<char *>(vector[iter->second] - data_offset);
+    return *reinterpret_cast<interned_string *>(addr);
+}
+
+}  // namespace datadog

--- a/ext/DatadogStringTable/test/CMakeLists.txt
+++ b/ext/DatadogStringTable/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(Catch2 2.4 REQUIRED)
+
+include(Catch)
+
+add_library(catch2main main.cc)
+target_link_libraries(catch2main PUBLIC Catch2::Catch2)
+set_target_properties(catch2main PROPERTIES
+  CXX_STANDARD 11
+)
+
+add_executable(test_string_table string_table.cc)
+target_link_libraries(test_string_table PRIVATE catch2main Datadog::StringTable Datadog::CxxMemHash)
+
+catch_discover_tests(test_string_table)

--- a/ext/DatadogStringTable/test/main.cc
+++ b/ext/DatadogStringTable/test/main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/ext/DatadogStringTable/test/string_table.cc
+++ b/ext/DatadogStringTable/test/string_table.cc
@@ -1,0 +1,111 @@
+#include <catch2/catch.hpp>
+#include <datadog/memhash.hh>
+#include <datadog/string_table.hh>
+#include <string>
+
+using datadog::interned_string;
+using datadog::string_table;
+
+TEST_CASE("string_table defaults", "[string_table]") {
+    datadog_arena *arena = datadog_arena_create(4096);
+    string_table string_table{&arena};
+
+    // string_table has an empty string at offset 0 (unless the table is dtor'd)
+    REQUIRE(string_table.size() == 1);
+
+    interned_string &interned = string_table[0];
+    REQUIRE(interned.size == 0);
+    REQUIRE(interned.offset == 0);
+    REQUIRE(interned.hash == datadog::memhash(0, nullptr));
+
+    std::string empty_string{};
+    auto &empty2 = string_table.intern({empty_string.size(), empty_string.data()});
+    REQUIRE(&empty2 == &interned);
+
+    const char empty_cstr[] = "";
+    auto &empty3 = string_table.intern({0, empty_cstr});
+    REQUIRE(&empty3 == &interned);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("string_table basics", "[string_table]") {
+    datadog_arena *arena = datadog_arena_create(4096);
+    string_table string_table{&arena};
+
+    std::string datadog = "datadog";
+    interned_string &interned = string_table.intern({datadog.size(), datadog.data()});
+
+    REQUIRE(interned.size == datadog.size());
+    REQUIRE(interned.offset == 1);  // remember, there is an empty string at 0
+    REQUIRE(interned.hash == datadog::memhash(datadog.size(), datadog.data()));
+
+    interned_string &again = string_table.intern({datadog.size(), datadog.data()});
+    REQUIRE(&interned == &again);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("intern a few strings", "[string_table]") {
+    datadog_arena *arena = datadog_arena_create(4096);
+    string_table string_table{&arena};
+
+    for (int i = 0; i < 10; ++i) {
+        std::string input = std::to_string(i * 9973);
+        interned_string &interned = string_table.intern({input.size(), input.data()});
+
+        REQUIRE(interned.size == input.size());
+
+        // remember, there is an empty string at 0
+        REQUIRE(interned.offset == i + 1);
+        REQUIRE(interned.hash == datadog::memhash(input.size(), input.data()));
+    }
+
+    REQUIRE(string_table.size() == 11);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("intern a moderate number of strings", "[string_table]") {
+    datadog_arena *arena = datadog_arena_create(4096);
+    string_table string_table{&arena};
+
+    for (int i = 0; i < 100; ++i) {
+        std::string input = std::to_string(i * 9973);
+        interned_string &interned = string_table.intern({input.size(), input.data()});
+
+        REQUIRE(interned.size == input.size());
+
+        // remember, there is an empty string at 0
+        REQUIRE(interned.offset == i + 1);
+        REQUIRE(interned.hash == datadog::memhash(input.size(), input.data()));
+    }
+
+    REQUIRE(string_table.size() == 101);
+
+    datadog_arena_destroy(arena);
+}
+
+TEST_CASE("intern strings of different lengths", "[string_table]") {
+    /* With a max_len of 512 and storing strings of length 0 .. 512, we will
+     * easily exceed the starting arena size of 8192, so this will also test
+     * some string_table interactions with the arena.
+     */
+    size_t max_len = 512;
+    datadog_arena *arena = datadog_arena_create(8192);
+    string_table string_table{&arena};
+
+    for (size_t i = 1; i < max_len + 1; ++i) {
+        auto input = std::string(i, '.');
+        interned_string &interned = string_table.intern({input.size(), input.data()});
+
+        REQUIRE(interned.size == input.size());
+
+        REQUIRE(interned.offset == i);
+        REQUIRE(interned.hash == datadog::memhash(input.size(), input.data()));
+    }
+
+    REQUIRE(string_table.size() == max_len + 1);
+
+    datadog_arena_destroy(arena);
+}


### PR DESCRIPTION
### Description

The StringTable is responsible for de-duplicating strings, and also storing them in a way so that they are accessible through a contiguous buffer. This should be useful for both the tracer and the profiler.

It's written C++. I had to adjust the `.clang-format` rules for this so that it plays nice with EditorConfig on certain C++ features. It uses the previously added [MemHash](#1107) and [Arena](#1068) components. I had to rename some cmake variables so that tests aren't built by default for Arena and MemHash when building tests for StringTable. Arena and MemHash are installed into `/opt/libdatadog` so StringTable can find them (in CI, not in the package).

One implementation detail I'm not sure of is actually storing the hash. If an interned string is used as a string key into a hash table, having that hash cached is great. However, it adds 8 bytes per string, which can be high overhead for short strings in particular. For now I decided to keep it, but we can revisit the balance with concrete data.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.
