### PR TITLE
Slim 4 integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,7 @@ TEST_WEB_72 := \
 	test_web_lumen_56 \
 	test_web_lumen_58 \
 	test_web_slim_312 \
+	test_web_slim_4 \
 	test_web_symfony_23 \
 	test_web_symfony_28 \
 	test_web_symfony_30 \
@@ -461,6 +462,7 @@ TEST_WEB_73 := \
 	test_web_lumen_56 \
 	test_web_lumen_58 \
 	test_web_slim_312 \
+	test_web_slim_4 \
 	test_web_symfony_34 \
 	test_web_symfony_40 \
 	test_web_symfony_42 \
@@ -497,6 +499,7 @@ TEST_WEB_74 := \
 	test_web_lumen_56 \
 	test_web_lumen_58 \
 	test_web_slim_312 \
+	test_web_slim_4 \
 	test_web_symfony_34 \
 	test_web_symfony_40 \
 	test_web_symfony_42 \
@@ -524,6 +527,7 @@ TEST_WEB_80 := \
 	test_web_codeigniter_22 \
 	test_web_laravel_8x \
 	test_web_slim_312 \
+	test_web_slim_4 \
 	test_web_yii_2 \
 	test_web_custom
 	#test_web_symfony_51 ; will work eventually; currently hung on: doctrine/doctrine-migrations-bundle
@@ -654,6 +658,9 @@ test_web_lumen_58:
 test_web_slim_312:
 	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_3_12 update
 	$(call run_tests,--testsuite=slim-312-test)
+test_web_slim_4:
+	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_4 update
+	$(call run_tests,--testsuite=slim-4-test)
 test_web_symfony_23:
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_2_3 update
 	$(call run_tests,tests/Integrations/Symfony/V2_3)

--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -84,7 +84,6 @@ class SlimIntegration extends Integration
                     $rootSpan->setTag(Tag::HTTP_URL, (string) $request->getUri());
 
                     if ('4' === $majorVersion) {
-                        $rootSpan->setTag('slim.route', $callableName);
                         $span->name = 'slim.route';
 
                         $route = $request->getAttribute(RouteContext::ROUTE);
@@ -92,6 +91,7 @@ class SlimIntegration extends Integration
                             $routeName = $route->getName();
                             if ($routeName) {
                                 $span->meta['slim.route.name'] = $routeName;
+                                $rootSpan->setTag('slim.route.name', $routeName);
                             }
                         }
                     } else {

--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -85,6 +85,7 @@ class SlimIntegration extends Integration
 
                     if ('4' === $majorVersion) {
                         $span->name = 'slim.route';
+                        $rootSpan->setTag('slim.route.handler', $callableName);
 
                         $route = $request->getAttribute(RouteContext::ROUTE);
                         if ($route && $route instanceof \Slim\Interfaces\RouteInterface) {

--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -7,8 +7,8 @@ use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
-use DDTrace\Util\Versions;
 use Psr\Http\Message\ServerRequestInterface;
+use Slim\Routing\RouteContext;
 
 class SlimIntegration extends Integration
 {
@@ -40,41 +40,41 @@ class SlimIntegration extends Integration
             '__construct',
             null,
             function ($app) use ($integration, $appName) {
-                // At the moment we only report internals of Slim 3.*
                 $majorVersion = substr($app::VERSION, 0, 1);
-                if ('3' !== $majorVersion) {
+                if ('3' !== $majorVersion && '4' !== $majorVersion) {
                     return;
                 }
 
                 // Overwrite root span info
                 $rootSpan = GlobalTracer::get()->getRootScope()->getSpan();
                 $integration->addTraceAnalyticsIfEnabledLegacy($rootSpan);
-                $rootSpan->overwriteOperationName('slim.request');
                 $rootSpan->setTag(Tag::SERVICE_NAME, $appName);
 
-                // Hook into the router to extract the proper route name
-                \DDTrace\hook_method(
-                    'Slim\Router',
-                    'lookupRoute',
-                    null,
-                    function ($router, $scope, $args, $return) use ($rootSpan) {
-                        /** @var \Slim\Interfaces\RouteInterface $route */
-                        $route = $return;
-                        $rootSpan->setTag(
-                            Tag::RESOURCE_NAME,
-                            $_SERVER['REQUEST_METHOD'] . ' ' . ($route->getName() ?: $route->getPattern())
-                        );
-                    }
-                );
+                if ('3' === $majorVersion) {
+                    $rootSpan->overwriteOperationName('slim.request');
+
+                    // Hook into the router to extract the proper route name
+                    \DDTrace\hook_method(
+                        'Slim\\Router',
+                        'lookupRoute',
+                        null,
+                        function ($router, $scope, $args, $return) use ($rootSpan) {
+                            /** @var \Slim\Interfaces\RouteInterface $route */
+                            $route = $return;
+                            $rootSpan->setTag(
+                                Tag::RESOURCE_NAME,
+                                $_SERVER['REQUEST_METHOD'] . ' ' . ($route->getName() ?: $route->getPattern())
+                            );
+                        }
+                    );
+                }
 
                 // Providing info about the controller
-                $traceControllers = function (SpanData $span, $args) use ($rootSpan, $appName) {
+                $traceControllers = function (SpanData $span, $args) use ($rootSpan, $appName, $majorVersion) {
                     $callable = $args[0];
                     $callableName = '{unknown callable}';
                     \is_callable($callable, false, $callableName);
-                    $rootSpan->setTag('slim.route.controller', $callableName);
 
-                    $span->name = 'slim.route.controller';
                     $span->resource = $callableName ?: 'controller';
                     $span->type = Type::WEB_SERVLET;
                     $span->service = $appName;
@@ -82,6 +82,22 @@ class SlimIntegration extends Integration
                     /** @var ServerRequestInterface $request */
                     $request = $args[1];
                     $rootSpan->setTag(Tag::HTTP_URL, (string) $request->getUri());
+
+                    if ('4' === $majorVersion) {
+                        $rootSpan->setTag('slim.route', $callableName);
+                        $span->name = 'slim.route';
+
+                        $route = $request->getAttribute(RouteContext::ROUTE);
+                        if ($route && $route instanceof \Slim\Interfaces\RouteInterface) {
+                            $routeName = $route->getName();
+                            if ($routeName) {
+                                $span->meta['slim.route.name'] = $routeName;
+                            }
+                        }
+                    } else {
+                        $rootSpan->setTag('slim.route.controller', $callableName);
+                        $span->name = 'slim.route.controller';
+                    }
                 };
 
                 // If the tracer ever supports tracing an interface, we should trace the following:

--- a/tests/Frameworks/README.md
+++ b/tests/Frameworks/README.md
@@ -82,6 +82,10 @@ In order to generate the sample Slim Framework apps we used the default commands
 
     $ composer create-project slim/slim-skeleton Version_3_12 "3.12.*"
 
+### Slim 4.x
+
+    $ composer create-project slim/slim-skeleton Version_4 "4.*"
+
 ## Symfony
 
 In order to generate the sample Symfony apps we used the default commands from the framework's 'Getting started' guides.

--- a/tests/Frameworks/Slim/Version_4/.coveralls.yml
+++ b/tests/Frameworks/Slim/Version_4/.coveralls.yml
@@ -1,0 +1,1 @@
+json_path: coveralls-upload.json

--- a/tests/Frameworks/Slim/Version_4/.gitignore
+++ b/tests/Frameworks/Slim/Version_4/.gitignore
@@ -1,0 +1,7 @@
+.idea/
+.vscode/
+/coverage/
+/vendor/
+/logs/*
+!/logs/README.md
+.phpunit.result.cache

--- a/tests/Frameworks/Slim/Version_4/.travis.yml
+++ b/tests/Frameworks/Slim/Version_4/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+dist: trusty
+
+matrix:
+  include:
+  - php: 7.2
+  - php: 7.3
+  - php: 7.4
+    env: ANALYSIS='true'
+  - php: nightly
+
+  allow_failures:
+  - php: nightly
+
+before_script:
+- composer require php-coveralls/php-coveralls:^2.1.0
+- composer install -n
+
+script:
+- if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+
+after_success:
+- if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/php-coveralls --coverage_clover=clover.xml -v ; fi

--- a/tests/Frameworks/Slim/Version_4/CONTRIBUTING.md
+++ b/tests/Frameworks/Slim/Version_4/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# How to Contribute
+
+## Pull Requests
+
+1. Fork the Slim Skeleton repository
+2. Create a new branch for each feature or improvement
+3. Send a pull request from each feature branch to the **4.x** branch
+
+It is very important to separate new features or improvements into separate feature branches, and to send a
+pull request for each branch. This allows us to review and pull in new features or improvements individually.
+
+## Style Guide
+
+All pull requests must adhere to the [PSR-2 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).

--- a/tests/Frameworks/Slim/Version_4/README.md
+++ b/tests/Frameworks/Slim/Version_4/README.md
@@ -1,0 +1,42 @@
+# Slim Framework 4 Skeleton Application
+
+[![Coverage Status](https://coveralls.io/repos/github/slimphp/Slim-Skeleton/badge.svg?branch=master)](https://coveralls.io/github/slimphp/Slim-Skeleton?branch=master)
+
+Use this skeleton application to quickly setup and start working on a new Slim Framework 4 application. This application uses the latest Slim 4 with Slim PSR-7 implementation and PHP-DI container implementation. It also uses the Monolog logger.
+
+This skeleton application was built for Composer. This makes setting up a new Slim Framework application quick and easy.
+
+## Install the Application
+
+Run this command from the directory in which you want to install your new Slim Framework application.
+
+```bash
+composer create-project slim/slim-skeleton [my-app-name]
+```
+
+Replace `[my-app-name]` with the desired directory name for your new application. You'll want to:
+
+* Point your virtual host document root to your new application's `public/` directory.
+* Ensure `logs/` is web writable.
+
+To run the application in development, you can run these commands 
+
+```bash
+cd [my-app-name]
+composer start
+```
+
+Or you can use `docker-compose` to run the app with `docker`, so you can run these commands:
+```bash
+cd [my-app-name]
+docker-compose up -d
+```
+After that, open `http://localhost:8080` in your browser.
+
+Run this command in the application directory to run the test suite
+
+```bash
+composer test
+```
+
+That's it! Now go build something cool.

--- a/tests/Frameworks/Slim/Version_4/app/dependencies.php
+++ b/tests/Frameworks/Slim/Version_4/app/dependencies.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use DI\ContainerBuilder;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Processor\UidProcessor;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+return function (ContainerBuilder $containerBuilder) {
+    $containerBuilder->addDefinitions([
+        LoggerInterface::class => function (ContainerInterface $c) {
+            $settings = $c->get('settings');
+
+            $loggerSettings = $settings['logger'];
+            $logger = new Logger($loggerSettings['name']);
+
+            $processor = new UidProcessor();
+            $logger->pushProcessor($processor);
+
+            $handler = new StreamHandler($loggerSettings['path'], $loggerSettings['level']);
+            $logger->pushHandler($handler);
+
+            return $logger;
+        },
+    ]);
+};

--- a/tests/Frameworks/Slim/Version_4/app/middleware.php
+++ b/tests/Frameworks/Slim/Version_4/app/middleware.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use App\Application\Middleware\SessionMiddleware;
+use Slim\App;
+
+return function (App $app) {
+    $app->add(SessionMiddleware::class);
+};

--- a/tests/Frameworks/Slim/Version_4/app/repositories.php
+++ b/tests/Frameworks/Slim/Version_4/app/repositories.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use App\Domain\User\UserRepository;
+use App\Infrastructure\Persistence\User\InMemoryUserRepository;
+use DI\ContainerBuilder;
+
+return function (ContainerBuilder $containerBuilder) {
+    // Here we map our UserRepository interface to its in memory implementation
+    $containerBuilder->addDefinitions([
+        UserRepository::class => \DI\autowire(InMemoryUserRepository::class),
+    ]);
+};

--- a/tests/Frameworks/Slim/Version_4/app/routes.php
+++ b/tests/Frameworks/Slim/Version_4/app/routes.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use App\Application\Actions\User\ListUsersAction;
+use App\Application\Actions\User\ViewUserAction;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\App;
+use Slim\Interfaces\RouteCollectorProxyInterface as Group;
+
+return function (App $app) {
+    $app->options('/{routes:.*}', function (Request $request, Response $response) {
+        // CORS Pre-Flight OPTIONS Request Handler
+        return $response;
+    });
+
+    $app->get('/', function (Request $request, Response $response) {
+        $response->getBody()->write('Hello world!');
+        return $response;
+    });
+
+    $app->group('/users', function (Group $group) {
+        $group->get('', ListUsersAction::class);
+        $group->get('/{id}', ViewUserAction::class);
+    });
+};

--- a/tests/Frameworks/Slim/Version_4/app/routes.php
+++ b/tests/Frameworks/Slim/Version_4/app/routes.php
@@ -32,7 +32,7 @@ return function (App $app) {
     })->setName('simple-route');
 
     // Create Twig
-    $twig = Twig::create(__DIR__ . '/../templates'/*, ['cache' => 'path/to/cache']*/);
+    $twig = Twig::create(__DIR__ . '/../templates');
 
     // Add Twig-View Middleware
     $app->add(TwigMiddleware::create($app, $twig));

--- a/tests/Frameworks/Slim/Version_4/app/routes.php
+++ b/tests/Frameworks/Slim/Version_4/app/routes.php
@@ -7,6 +7,8 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
+use Slim\Views\Twig;
+use Slim\Views\TwigMiddleware;
 
 return function (App $app) {
     $app->options('/{routes:.*}', function (Request $request, Response $response) {
@@ -22,5 +24,25 @@ return function (App $app) {
     $app->group('/users', function (Group $group) {
         $group->get('', ListUsersAction::class);
         $group->get('/{id}', ViewUserAction::class);
+    });
+
+    $app->get('/simple', function (Request $request, Response $response, $args) {
+        $response->getBody()->write("Simple :)\n");
+        return $response;
+    })->setName('simple-route');
+
+    // Create Twig
+    $twig = Twig::create(__DIR__ . '/../templates'/*, ['cache' => 'path/to/cache']*/);
+
+    // Add Twig-View Middleware
+    $app->add(TwigMiddleware::create($app, $twig));
+
+    $app->get('/simple_view', function (Request $request, Response $response) {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'simple_view.phtml');
+    });
+
+    $app->get('/error', function (Request $request, Response $response, $args) {
+        throw new \Exception('Foo error');
     });
 };

--- a/tests/Frameworks/Slim/Version_4/app/settings.php
+++ b/tests/Frameworks/Slim/Version_4/app/settings.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use DI\ContainerBuilder;
+use Monolog\Logger;
+
+return function (ContainerBuilder $containerBuilder) {
+    // Global Settings Object
+    $containerBuilder->addDefinitions([
+        'settings' => [
+            'displayErrorDetails' => true, // Should be set to false in production
+            'logger' => [
+                'name' => 'slim-app',
+                'path' => isset($_ENV['docker']) ? 'php://stdout' : __DIR__ . '/../logs/app.log',
+                'level' => Logger::DEBUG,
+            ],
+        ],
+    ]);
+};

--- a/tests/Frameworks/Slim/Version_4/composer.json
+++ b/tests/Frameworks/Slim/Version_4/composer.json
@@ -1,0 +1,54 @@
+{
+    "name": "slim/slim-skeleton",
+    "description": "A Slim Framework skeleton application for rapid development",
+    "keywords": [
+        "microframework",
+        "rest",
+        "router",
+        "psr7"
+    ],
+    "homepage": "http://github.com/slimphp/Slim-Skeleton",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Josh Lockhart",
+            "email": "info@joshlockhart.com",
+            "homepage": "http://www.joshlockhart.com/"
+        },
+        {
+            "name": "Pierre Berube",
+            "email": "pierre@lgse.com",
+            "homepage": "http://www.lgse.com/"
+        }
+    ],
+    "require": {
+        "php": "^7.2 | ^8.0",
+        "ext-json": "*",
+        "monolog/monolog": "^2.0",
+        "php-di/php-di": "^6.1",
+        "slim/psr7": "^1.1",
+        "slim/slim": "^4.5",
+        "slim/twig-view": "^3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5"
+    },
+    "config": {
+        "process-timeout": 0,
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "start": "php -S localhost:8080 -t public",
+        "test": "phpunit"
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/docker-compose.yml
+++ b/tests/Frameworks/Slim/Version_4/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+
+volumes:
+    logs:
+        driver: local
+
+services:
+    slim:
+        image: php:7-alpine
+        working_dir: /var/www
+        command: php -S 0.0.0.0:8080 -t public
+        environment:
+            docker: "true"
+        ports:
+            - 8080:8080
+        volumes:
+            - .:/var/www
+            - logs:/var/www/logs

--- a/tests/Frameworks/Slim/Version_4/logs/README.md
+++ b/tests/Frameworks/Slim/Version_4/logs/README.md
@@ -1,0 +1,1 @@
+Your Slim Framework application's log files will be written to this directory.

--- a/tests/Frameworks/Slim/Version_4/phpunit.xml
+++ b/tests/Frameworks/Slim/Version_4/phpunit.xml
@@ -1,0 +1,27 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="tests/bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Frameworks/Slim/Version_4/public/.htaccess
+++ b/tests/Frameworks/Slim/Version_4/public/.htaccess
@@ -1,0 +1,21 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # Some hosts may require you to use the `RewriteBase` directive.
+  # Determine the RewriteBase automatically and set it as environment variable.
+  # If you are using Apache aliases to do mass virtual hosting or installed the
+  # project in a subdirectory, the base path will be prepended to allow proper
+  # resolution of the index.php file and to redirect to the correct URI. It will
+  # work in environments without path prefix as well, providing a safe, one-size
+  # fits all solution. But as you do not need it in this case, you can comment
+  # the following 2 lines to eliminate the overhead.
+  RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
+  RewriteRule ^(.*) - [E=BASE:%1]
+  
+  # If the above doesn't work you might need to set the `RewriteBase` directive manually, it should be the
+  # absolute physical path to the directory that contains this htaccess file.
+  # RewriteBase /
+
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteRule ^ index.php [QSA,L]
+</IfModule>

--- a/tests/Frameworks/Slim/Version_4/public/index.php
+++ b/tests/Frameworks/Slim/Version_4/public/index.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+use App\Application\Handlers\HttpErrorHandler;
+use App\Application\Handlers\ShutdownHandler;
+use App\Application\ResponseEmitter\ResponseEmitter;
+use DI\ContainerBuilder;
+use Slim\Factory\AppFactory;
+use Slim\Factory\ServerRequestCreatorFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Instantiate PHP-DI ContainerBuilder
+$containerBuilder = new ContainerBuilder();
+
+if (false) { // Should be set to true in production
+	$containerBuilder->enableCompilation(__DIR__ . '/../var/cache');
+}
+
+// Set up settings
+$settings = require __DIR__ . '/../app/settings.php';
+$settings($containerBuilder);
+
+// Set up dependencies
+$dependencies = require __DIR__ . '/../app/dependencies.php';
+$dependencies($containerBuilder);
+
+// Set up repositories
+$repositories = require __DIR__ . '/../app/repositories.php';
+$repositories($containerBuilder);
+
+// Build PHP-DI Container instance
+$container = $containerBuilder->build();
+
+// Instantiate the app
+AppFactory::setContainer($container);
+$app = AppFactory::create();
+$callableResolver = $app->getCallableResolver();
+
+// Register middleware
+$middleware = require __DIR__ . '/../app/middleware.php';
+$middleware($app);
+
+// Register routes
+$routes = require __DIR__ . '/../app/routes.php';
+$routes($app);
+
+/** @var bool $displayErrorDetails */
+$displayErrorDetails = $container->get('settings')['displayErrorDetails'];
+
+// Create Request object from globals
+$serverRequestCreator = ServerRequestCreatorFactory::create();
+$request = $serverRequestCreator->createServerRequestFromGlobals();
+
+// Create Error Handler
+$responseFactory = $app->getResponseFactory();
+$errorHandler = new HttpErrorHandler($callableResolver, $responseFactory);
+
+// Create Shutdown Handler
+$shutdownHandler = new ShutdownHandler($request, $errorHandler, $displayErrorDetails);
+register_shutdown_function($shutdownHandler);
+
+// Add Routing Middleware
+$app->addRoutingMiddleware();
+
+// Add Error Middleware
+$errorMiddleware = $app->addErrorMiddleware($displayErrorDetails, false, false);
+$errorMiddleware->setDefaultErrorHandler($errorHandler);
+
+// Run App & Emit Response
+$response = $app->handle($request);
+$responseEmitter = new ResponseEmitter();
+$responseEmitter->emit($response);

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/Action.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/Action.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions;
+
+use App\Domain\DomainException\DomainRecordNotFoundException;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpBadRequestException;
+use Slim\Exception\HttpNotFoundException;
+
+abstract class Action
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
+     * @var array
+     */
+    protected $args;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Request  $request
+     * @param Response $response
+     * @param array    $args
+     * @return Response
+     * @throws HttpNotFoundException
+     * @throws HttpBadRequestException
+     */
+    public function __invoke(Request $request, Response $response, $args): Response
+    {
+        $this->request = $request;
+        $this->response = $response;
+        $this->args = $args;
+
+        try {
+            return $this->action();
+        } catch (DomainRecordNotFoundException $e) {
+            throw new HttpNotFoundException($this->request, $e->getMessage());
+        }
+    }
+
+    /**
+     * @return Response
+     * @throws DomainRecordNotFoundException
+     * @throws HttpBadRequestException
+     */
+    abstract protected function action(): Response;
+
+    /**
+     * @return array|object
+     * @throws HttpBadRequestException
+     */
+    protected function getFormData()
+    {
+        $input = json_decode(file_get_contents('php://input'));
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new HttpBadRequestException($this->request, 'Malformed JSON input.');
+        }
+
+        return $input;
+    }
+
+    /**
+     * @param  string $name
+     * @return mixed
+     * @throws HttpBadRequestException
+     */
+    protected function resolveArg(string $name)
+    {
+        if (!isset($this->args[$name])) {
+            throw new HttpBadRequestException($this->request, "Could not resolve argument `{$name}`.");
+        }
+
+        return $this->args[$name];
+    }
+
+    /**
+     * @param  array|object|null $data
+     * @return Response
+     */
+    protected function respondWithData($data = null, int $statusCode = 200): Response
+    {
+        $payload = new ActionPayload($statusCode, $data);
+
+        return $this->respond($payload);
+    }
+
+    /**
+     * @param ActionPayload $payload
+     * @return Response
+     */
+    protected function respond(ActionPayload $payload): Response
+    {
+        $json = json_encode($payload, JSON_PRETTY_PRINT);
+        $this->response->getBody()->write($json);
+
+        return $this->response
+                    ->withHeader('Content-Type', 'application/json')
+                    ->withStatus($payload->getStatusCode());
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/ActionError.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/ActionError.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions;
+
+use JsonSerializable;
+
+class ActionError implements JsonSerializable
+{
+    public const BAD_REQUEST = 'BAD_REQUEST';
+    public const INSUFFICIENT_PRIVILEGES = 'INSUFFICIENT_PRIVILEGES';
+    public const NOT_ALLOWED = 'NOT_ALLOWED';
+    public const NOT_IMPLEMENTED = 'NOT_IMPLEMENTED';
+    public const RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND';
+    public const SERVER_ERROR = 'SERVER_ERROR';
+    public const UNAUTHENTICATED = 'UNAUTHENTICATED';
+    public const VALIDATION_ERROR = 'VALIDATION_ERROR';
+    public const VERIFICATION_ERROR = 'VERIFICATION_ERROR';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @param string        $type
+     * @param string|null   $description
+     */
+    public function __construct(string $type, ?string $description)
+    {
+        $this->type = $type;
+        $this->description = $description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     * @return self
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string|null $description
+     * @return self
+     */
+    public function setDescription(?string $description = null): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $payload = [
+            'type' => $this->type,
+            'description' => $this->description,
+        ];
+
+        return $payload;
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/ActionPayload.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/ActionPayload.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions;
+
+use JsonSerializable;
+
+class ActionPayload implements JsonSerializable
+{
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @var array|object|null
+     */
+    private $data;
+
+    /**
+     * @var ActionError|null
+     */
+    private $error;
+
+    /**
+     * @param int                   $statusCode
+     * @param array|object|null     $data
+     * @param ActionError|null      $error
+     */
+    public function __construct(
+        int $statusCode = 200,
+        $data = null,
+        ?ActionError $error = null
+    ) {
+        $this->statusCode = $statusCode;
+        $this->data = $data;
+        $this->error = $error;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return array|null|object
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return ActionError|null
+     */
+    public function getError(): ?ActionError
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $payload = [
+            'statusCode' => $this->statusCode,
+        ];
+
+        if ($this->data !== null) {
+            $payload['data'] = $this->data;
+        } elseif ($this->error !== null) {
+            $payload['error'] = $this->error;
+        }
+
+        return $payload;
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/ListUsersAction.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/ListUsersAction.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions\User;
+
+use Psr\Http\Message\ResponseInterface as Response;
+
+class ListUsersAction extends UserAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function action(): Response
+    {
+        $users = $this->userRepository->findAll();
+
+        $this->logger->info("Users list was viewed.");
+
+        return $this->respondWithData($users);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/UserAction.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/UserAction.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions\User;
+
+use App\Application\Actions\Action;
+use App\Domain\User\UserRepository;
+use Psr\Log\LoggerInterface;
+
+abstract class UserAction extends Action
+{
+    /**
+     * @var UserRepository
+     */
+    protected $userRepository;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param UserRepository  $userRepository
+     */
+    public function __construct(LoggerInterface $logger, UserRepository $userRepository)
+    {
+        parent::__construct($logger);
+        $this->userRepository = $userRepository;
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/ViewUserAction.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Actions/User/ViewUserAction.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Actions\User;
+
+use Psr\Http\Message\ResponseInterface as Response;
+
+class ViewUserAction extends UserAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function action(): Response
+    {
+        $userId = (int) $this->resolveArg('id');
+        $user = $this->userRepository->findUserOfId($userId);
+
+        $this->logger->info("User of id `${userId}` was viewed.");
+
+        return $this->respondWithData($user);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Handlers/HttpErrorHandler.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Handlers/HttpErrorHandler.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Handlers;
+
+use App\Application\Actions\ActionError;
+use App\Application\Actions\ActionPayload;
+use Exception;
+use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Exception\HttpBadRequestException;
+use Slim\Exception\HttpException;
+use Slim\Exception\HttpForbiddenException;
+use Slim\Exception\HttpMethodNotAllowedException;
+use Slim\Exception\HttpNotFoundException;
+use Slim\Exception\HttpNotImplementedException;
+use Slim\Exception\HttpUnauthorizedException;
+use Slim\Handlers\ErrorHandler as SlimErrorHandler;
+use Throwable;
+
+class HttpErrorHandler extends SlimErrorHandler
+{
+    /**
+     * @inheritdoc
+     */
+    protected function respond(): Response
+    {
+        $exception = $this->exception;
+        $statusCode = 500;
+        $error = new ActionError(
+            ActionError::SERVER_ERROR,
+            'An internal error has occurred while processing your request.'
+        );
+
+        if ($exception instanceof HttpException) {
+            $statusCode = $exception->getCode();
+            $error->setDescription($exception->getMessage());
+
+            if ($exception instanceof HttpNotFoundException) {
+                $error->setType(ActionError::RESOURCE_NOT_FOUND);
+            } elseif ($exception instanceof HttpMethodNotAllowedException) {
+                $error->setType(ActionError::NOT_ALLOWED);
+            } elseif ($exception instanceof HttpUnauthorizedException) {
+                $error->setType(ActionError::UNAUTHENTICATED);
+            } elseif ($exception instanceof HttpForbiddenException) {
+                $error->setType(ActionError::INSUFFICIENT_PRIVILEGES);
+            } elseif ($exception instanceof HttpBadRequestException) {
+                $error->setType(ActionError::BAD_REQUEST);
+            } elseif ($exception instanceof HttpNotImplementedException) {
+                $error->setType(ActionError::NOT_IMPLEMENTED);
+            }
+        }
+
+        if (
+            !($exception instanceof HttpException)
+            && ($exception instanceof Exception || $exception instanceof Throwable)
+            && $this->displayErrorDetails
+        ) {
+            $error->setDescription($exception->getMessage());
+        }
+
+        $payload = new ActionPayload($statusCode, null, $error);
+        $encodedPayload = json_encode($payload, JSON_PRETTY_PRINT);
+
+        $response = $this->responseFactory->createResponse($statusCode);
+        $response->getBody()->write($encodedPayload);
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Handlers/ShutdownHandler.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Handlers/ShutdownHandler.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Handlers;
+
+use App\Application\ResponseEmitter\ResponseEmitter;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\HttpInternalServerErrorException;
+
+class ShutdownHandler
+{
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var HttpErrorHandler
+     */
+    private $errorHandler;
+
+    /**
+     * @var bool
+     */
+    private $displayErrorDetails;
+
+    /**
+     * ShutdownHandler constructor.
+     *
+     * @param Request       $request
+     * @param $errorHandler $errorHandler
+     * @param bool          $displayErrorDetails
+     */
+    public function __construct(
+        Request $request,
+        HttpErrorHandler $errorHandler,
+        bool $displayErrorDetails
+    ) {
+        $this->request = $request;
+        $this->errorHandler = $errorHandler;
+        $this->displayErrorDetails = $displayErrorDetails;
+    }
+
+    public function __invoke()
+    {
+        $error = error_get_last();
+        if ($error) {
+            $errorFile = $error['file'];
+            $errorLine = $error['line'];
+            $errorMessage = $error['message'];
+            $errorType = $error['type'];
+            $message = 'An error while processing your request. Please try again later.';
+
+            if ($this->displayErrorDetails) {
+                switch ($errorType) {
+                    case E_USER_ERROR:
+                        $message = "FATAL ERROR: {$errorMessage}. ";
+                        $message .= " on line {$errorLine} in file {$errorFile}.";
+                        break;
+
+                    case E_USER_WARNING:
+                        $message = "WARNING: {$errorMessage}";
+                        break;
+
+                    case E_USER_NOTICE:
+                        $message = "NOTICE: {$errorMessage}";
+                        break;
+
+                    default:
+                        $message = "ERROR: {$errorMessage}";
+                        $message .= " on line {$errorLine} in file {$errorFile}.";
+                        break;
+                }
+            }
+
+            $exception = new HttpInternalServerErrorException($this->request, $message);
+            $response = $this->errorHandler->__invoke($this->request, $exception, $this->displayErrorDetails, false, false);
+
+            $responseEmitter = new ResponseEmitter();
+            $responseEmitter->emit($response);
+        }
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/Middleware/SessionMiddleware.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/Middleware/SessionMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+
+class SessionMiddleware implements Middleware
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            session_start();
+            $request = $request->withAttribute('session', $_SESSION);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Application/ResponseEmitter/ResponseEmitter.php
+++ b/tests/Frameworks/Slim/Version_4/src/Application/ResponseEmitter/ResponseEmitter.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Application\ResponseEmitter;
+
+use Psr\Http\Message\ResponseInterface;
+use Slim\ResponseEmitter as SlimResponseEmitter;
+
+class ResponseEmitter extends SlimResponseEmitter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function emit(ResponseInterface $response): void
+    {
+        // This variable should be set to the allowed host from which your API can be accessed with
+        $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';
+
+        $response = $response
+            ->withHeader('Access-Control-Allow-Credentials', 'true')
+            ->withHeader('Access-Control-Allow-Origin', $origin)
+            ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization')
+            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+            ->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->withAddedHeader('Cache-Control', 'post-check=0, pre-check=0')
+            ->withHeader('Pragma', 'no-cache');
+
+        if (ob_get_contents()) {
+            ob_clean();
+        }
+
+        parent::emit($response);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Domain/DomainException/DomainException.php
+++ b/tests/Frameworks/Slim/Version_4/src/Domain/DomainException/DomainException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\DomainException;
+
+use Exception;
+
+abstract class DomainException extends Exception
+{
+}

--- a/tests/Frameworks/Slim/Version_4/src/Domain/DomainException/DomainRecordNotFoundException.php
+++ b/tests/Frameworks/Slim/Version_4/src/Domain/DomainException/DomainRecordNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\DomainException;
+
+class DomainRecordNotFoundException extends DomainException
+{
+}

--- a/tests/Frameworks/Slim/Version_4/src/Domain/User/User.php
+++ b/tests/Frameworks/Slim/Version_4/src/Domain/User/User.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\User;
+
+use JsonSerializable;
+
+class User implements JsonSerializable
+{
+    /**
+     * @var int|null
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $username;
+
+    /**
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @var string
+     */
+    private $lastName;
+
+    /**
+     * @param int|null  $id
+     * @param string    $username
+     * @param string    $firstName
+     * @param string    $lastName
+     */
+    public function __construct(?int $id, string $username, string $firstName, string $lastName)
+    {
+        $this->id = $id;
+        $this->username = strtolower($username);
+        $this->firstName = ucfirst($firstName);
+        $this->lastName = ucfirst($lastName);
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->id,
+            'username' => $this->username,
+            'firstName' => $this->firstName,
+            'lastName' => $this->lastName,
+        ];
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/src/Domain/User/UserNotFoundException.php
+++ b/tests/Frameworks/Slim/Version_4/src/Domain/User/UserNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\User;
+
+use App\Domain\DomainException\DomainRecordNotFoundException;
+
+class UserNotFoundException extends DomainRecordNotFoundException
+{
+    public $message = 'The user you requested does not exist.';
+}

--- a/tests/Frameworks/Slim/Version_4/src/Domain/User/UserRepository.php
+++ b/tests/Frameworks/Slim/Version_4/src/Domain/User/UserRepository.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\User;
+
+interface UserRepository
+{
+    /**
+     * @return User[]
+     */
+    public function findAll(): array;
+
+    /**
+     * @param int $id
+     * @return User
+     * @throws UserNotFoundException
+     */
+    public function findUserOfId(int $id): User;
+}

--- a/tests/Frameworks/Slim/Version_4/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
+++ b/tests/Frameworks/Slim/Version_4/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\User;
+
+use App\Domain\User\User;
+use App\Domain\User\UserNotFoundException;
+use App\Domain\User\UserRepository;
+
+class InMemoryUserRepository implements UserRepository
+{
+    /**
+     * @var User[]
+     */
+    private $users;
+
+    /**
+     * InMemoryUserRepository constructor.
+     *
+     * @param array|null $users
+     */
+    public function __construct(array $users = null)
+    {
+        $this->users = $users ?? [
+            1 => new User(1, 'bill.gates', 'Bill', 'Gates'),
+            2 => new User(2, 'steve.jobs', 'Steve', 'Jobs'),
+            3 => new User(3, 'mark.zuckerberg', 'Mark', 'Zuckerberg'),
+            4 => new User(4, 'evan.spiegel', 'Evan', 'Spiegel'),
+            5 => new User(5, 'jack.dorsey', 'Jack', 'Dorsey'),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAll(): array
+    {
+        return array_values($this->users);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserOfId(int $id): User
+    {
+        if (!isset($this->users[$id])) {
+            throw new UserNotFoundException();
+        }
+
+        return $this->users[$id];
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/templates/simple_view.phtml
+++ b/tests/Frameworks/Slim/Version_4/templates/simple_view.phtml
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Simple View Example :: Slim Framework</title>
+    </head>
+    <body>
+        <h1>Simple View</h1>
+        <p>Hello.</p>
+    </body>
+</html>

--- a/tests/Frameworks/Slim/Version_4/tests/Application/Actions/ActionTest.php
+++ b/tests/Frameworks/Slim/Version_4/tests/Application/Actions/ActionTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Application\Actions;
+
+use App\Application\Actions\Action;
+use App\Application\Actions\ActionPayload;
+use DateTimeImmutable;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Log\LoggerInterface;
+use Tests\TestCase;
+
+class ActionTest extends TestCase
+{
+    public function testActionSetsHttpCodeInRespond()
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        $logger = $container->get(LoggerInterface::class);
+
+        $testAction = new class($logger) extends Action {
+            public function __construct(
+                LoggerInterface $loggerInterface
+            ) {
+                parent::__construct($loggerInterface);
+            }
+
+            public function action() :Response
+            {
+                return $this->respond(
+                    new ActionPayload(
+                        202,
+                        [
+                            'willBeDoneAt' => (new DateTimeImmutable())->format(DateTimeImmutable::ATOM)
+                        ]
+                    )
+                );
+            }
+        };
+
+        $app->get('/test-action-response-code', $testAction);
+        $request = $this->createRequest('GET', '/test-action-response-code');
+        $response = $app->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+    }
+
+    public function testActionSetsHttpCodeRespondData()
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        $logger = $container->get(LoggerInterface::class);
+
+        $testAction = new class($logger) extends Action {
+            public function __construct(
+                LoggerInterface $loggerInterface
+            ) {
+                parent::__construct($loggerInterface);
+            }
+
+            public function action() :Response
+            {
+                return $this->respondWithData(
+                    [
+                        'willBeDoneAt' => (new DateTimeImmutable())->format(DateTimeImmutable::ATOM)
+                    ],
+                    202
+                );
+            }
+        };
+
+        $app->get('/test-action-response-code', $testAction);
+        $request = $this->createRequest('GET', '/test-action-response-code');
+        $response = $app->handle($request);
+
+        $this->assertEquals(202, $response->getStatusCode());
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/Application/Actions/User/ListUserActionTest.php
+++ b/tests/Frameworks/Slim/Version_4/tests/Application/Actions/User/ListUserActionTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Application\Actions\User;
+
+use App\Application\Actions\ActionPayload;
+use App\Domain\User\UserRepository;
+use App\Domain\User\User;
+use DI\Container;
+use Tests\TestCase;
+
+class ListUserActionTest extends TestCase
+{
+    public function testAction()
+    {
+        $app = $this->getAppInstance();
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $user = new User(1, 'bill.gates', 'Bill', 'Gates');
+
+        $userRepositoryProphecy = $this->prophesize(UserRepository::class);
+        $userRepositoryProphecy
+            ->findAll()
+            ->willReturn([$user])
+            ->shouldBeCalledOnce();
+
+        $container->set(UserRepository::class, $userRepositoryProphecy->reveal());
+
+        $request = $this->createRequest('GET', '/users');
+        $response = $app->handle($request);
+
+        $payload = (string) $response->getBody();
+        $expectedPayload = new ActionPayload(200, [$user]);
+        $serializedPayload = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $this->assertEquals($serializedPayload, $payload);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/Application/Actions/User/ViewUserActionTest.php
+++ b/tests/Frameworks/Slim/Version_4/tests/Application/Actions/User/ViewUserActionTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Application\Actions\User;
+
+use App\Application\Actions\ActionError;
+use App\Application\Actions\ActionPayload;
+use App\Application\Handlers\HttpErrorHandler;
+use App\Domain\User\User;
+use App\Domain\User\UserNotFoundException;
+use App\Domain\User\UserRepository;
+use DI\Container;
+use Slim\Middleware\ErrorMiddleware;
+use Tests\TestCase;
+
+class ViewUserActionTest extends TestCase
+{
+    public function testAction()
+    {
+        $app = $this->getAppInstance();
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $user = new User(1, 'bill.gates', 'Bill', 'Gates');
+
+        $userRepositoryProphecy = $this->prophesize(UserRepository::class);
+        $userRepositoryProphecy
+            ->findUserOfId(1)
+            ->willReturn($user)
+            ->shouldBeCalledOnce();
+
+        $container->set(UserRepository::class, $userRepositoryProphecy->reveal());
+
+        $request = $this->createRequest('GET', '/users/1');
+        $response = $app->handle($request);
+
+        $payload = (string) $response->getBody();
+        $expectedPayload = new ActionPayload(200, $user);
+        $serializedPayload = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $this->assertEquals($serializedPayload, $payload);
+    }
+
+    public function testActionThrowsUserNotFoundException()
+    {
+        $app = $this->getAppInstance();
+
+        $callableResolver = $app->getCallableResolver();
+        $responseFactory = $app->getResponseFactory();
+
+        $errorHandler = new HttpErrorHandler($callableResolver, $responseFactory);
+        $errorMiddleware = new ErrorMiddleware($callableResolver, $responseFactory, true, false ,false);
+        $errorMiddleware->setDefaultErrorHandler($errorHandler);
+
+        $app->add($errorMiddleware);
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $userRepositoryProphecy = $this->prophesize(UserRepository::class);
+        $userRepositoryProphecy
+            ->findUserOfId(1)
+            ->willThrow(new UserNotFoundException())
+            ->shouldBeCalledOnce();
+
+        $container->set(UserRepository::class, $userRepositoryProphecy->reveal());
+
+        $request = $this->createRequest('GET', '/users/1');
+        $response = $app->handle($request);
+
+        $payload = (string) $response->getBody();
+        $expectedError = new ActionError(ActionError::RESOURCE_NOT_FOUND, 'The user you requested does not exist.');
+        $expectedPayload = new ActionPayload(404, null, $expectedError);
+        $serializedPayload = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $this->assertEquals($serializedPayload, $payload);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/Domain/User/UserTest.php
+++ b/tests/Frameworks/Slim/Version_4/tests/Domain/User/UserTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Domain\User;
+
+use App\Domain\User\User;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    public function userProvider()
+    {
+        return [
+            [1, 'bill.gates', 'Bill', 'Gates'],
+            [2, 'steve.jobs', 'Steve', 'Jobs'],
+            [3, 'mark.zuckerberg', 'Mark', 'Zuckerberg'],
+            [4, 'evan.spiegel', 'Evan', 'Spiegel'],
+            [5, 'jack.dorsey', 'Jack', 'Dorsey'],
+        ];
+    }
+
+    /**
+     * @dataProvider userProvider
+     * @param $id
+     * @param $username
+     * @param $firstName
+     * @param $lastName
+     */
+    public function testGetters($id, $username, $firstName, $lastName)
+    {
+        $user = new User($id, $username, $firstName, $lastName);
+
+        $this->assertEquals($id, $user->getId());
+        $this->assertEquals($username, $user->getUsername());
+        $this->assertEquals($firstName, $user->getFirstName());
+        $this->assertEquals($lastName, $user->getLastName());
+    }
+
+    /**
+     * @dataProvider userProvider
+     * @param $id
+     * @param $username
+     * @param $firstName
+     * @param $lastName
+     */
+    public function testJsonSerialize($id, $username, $firstName, $lastName)
+    {
+        $user = new User($id, $username, $firstName, $lastName);
+
+        $expectedPayload = json_encode([
+            'id' => $id,
+            'username' => $username,
+            'firstName' => $firstName,
+            'lastName' => $lastName,
+        ]);
+
+        $this->assertEquals($expectedPayload, json_encode($user));
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/Infrastructure/Persistence/User/InMemoryUserRepositoryTest.php
+++ b/tests/Frameworks/Slim/Version_4/tests/Infrastructure/Persistence/User/InMemoryUserRepositoryTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Infrastructure\Persistence\User;
+
+use App\Domain\User\User;
+use App\Domain\User\UserNotFoundException;
+use App\Infrastructure\Persistence\User\InMemoryUserRepository;
+use Tests\TestCase;
+
+class InMemoryUserRepositoryTest extends TestCase
+{
+    public function testFindAll()
+    {
+        $user = new User(1, 'bill.gates', 'Bill', 'Gates');
+
+        $userRepository = new InMemoryUserRepository([1 => $user]);
+
+        $this->assertEquals([$user], $userRepository->findAll());
+    }
+
+    public function testFindAllUsersByDefault()
+    {
+        $users = [
+            1 => new User(1, 'bill.gates', 'Bill', 'Gates'),
+            2 => new User(2, 'steve.jobs', 'Steve', 'Jobs'),
+            3 => new User(3, 'mark.zuckerberg', 'Mark', 'Zuckerberg'),
+            4 => new User(4, 'evan.spiegel', 'Evan', 'Spiegel'),
+            5 => new User(5, 'jack.dorsey', 'Jack', 'Dorsey'),
+        ];
+
+        $userRepository = new InMemoryUserRepository();
+
+        $this->assertEquals(array_values($users), $userRepository->findAll());
+    }
+
+    public function testFindUserOfId()
+    {
+        $user = new User(1, 'bill.gates', 'Bill', 'Gates');
+
+        $userRepository = new InMemoryUserRepository([1 => $user]);
+
+        $this->assertEquals($user, $userRepository->findUserOfId(1));
+    }
+
+    public function testFindUserOfIdThrowsNotFoundException()
+    {
+        $userRepository = new InMemoryUserRepository([]);
+        $this->expectException(UserNotFoundException::class);
+        $userRepository->findUserOfId(1);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/TestCase.php
+++ b/tests/Frameworks/Slim/Version_4/tests/TestCase.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use DI\ContainerBuilder;
+use Exception;
+use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\App;
+use Slim\Factory\AppFactory;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request as SlimRequest;
+use Slim\Psr7\Uri;
+
+class TestCase extends PHPUnit_TestCase
+{
+    /**
+     * @return App
+     * @throws Exception
+     */
+    protected function getAppInstance(): App
+    {
+        // Instantiate PHP-DI ContainerBuilder
+        $containerBuilder = new ContainerBuilder();
+
+        // Container intentionally not compiled for tests.
+
+        // Set up settings
+        $settings = require __DIR__ . '/../app/settings.php';
+        $settings($containerBuilder);
+
+        // Set up dependencies
+        $dependencies = require __DIR__ . '/../app/dependencies.php';
+        $dependencies($containerBuilder);
+
+        // Set up repositories
+        $repositories = require __DIR__ . '/../app/repositories.php';
+        $repositories($containerBuilder);
+
+        // Build PHP-DI Container instance
+        $container = $containerBuilder->build();
+
+        // Instantiate the app
+        AppFactory::setContainer($container);
+        $app = AppFactory::create();
+
+        // Register middleware
+        $middleware = require __DIR__ . '/../app/middleware.php';
+        $middleware($app);
+
+        // Register routes
+        $routes = require __DIR__ . '/../app/routes.php';
+        $routes($app);
+
+        return $app;
+    }
+
+    /**
+     * @param string $method
+     * @param string $path
+     * @param array  $headers
+     * @param array  $cookies
+     * @param array  $serverParams
+     * @return Request
+     */
+    protected function createRequest(
+        string $method,
+        string $path,
+        array $headers = ['HTTP_ACCEPT' => 'application/json'],
+        array $cookies = [],
+        array $serverParams = []
+    ): Request {
+        $uri = new Uri('', '', 80, $path);
+        $handle = fopen('php://temp', 'w+');
+        $stream = (new StreamFactory())->createStreamFromResource($handle);
+
+        $h = new Headers();
+        foreach ($headers as $name => $value) {
+            $h->addHeader($name, $value);
+        }
+
+        return new SlimRequest($method, $uri, $h, $cookies, $serverParams, $stream);
+    }
+}

--- a/tests/Frameworks/Slim/Version_4/tests/bootstrap.php
+++ b/tests/Frameworks/Slim/Version_4/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+

--- a/tests/Frameworks/Slim/Version_4/var/cache/.gitignore
+++ b/tests/Frameworks/Slim/Version_4/var/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -46,7 +46,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'GET /simple'
                     )->withExactTags([
-                        'slim.route' => 'Closure::__invoke',
+                        'slim.route.name' => 'simple-route',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
@@ -68,7 +68,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'GET /simple_view'
                     )->withExactTags([
-                        'slim.route' => 'Closure::__invoke',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
@@ -97,7 +96,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'GET /error'
                     )->withExactTags([
-                        'slim.route' => 'Closure::__invoke',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Slim\V4;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+final class CommonScenariosTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Slim/Version_4/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE' => 'slim_test_app',
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSpecs
+     * @param RequestSpec $spec
+     * @param array $spanExpectations
+     * @throws \Exception
+     */
+    public function testScenario(RequestSpec $spec, array $spanExpectations)
+    {
+        $traces = $this->tracesFromWebRequest(function () use ($spec) {
+            $this->call($spec);
+        });
+
+        $this->assertFlameGraph($traces, $spanExpectations);
+    }
+
+    public function provideSpecs()
+    {
+        return $this->buildDataProvider(
+            [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'slim_test_app',
+                        'web',
+                        'GET /simple'
+                    )->withExactTags([
+                        'slim.route' => 'Closure::__invoke',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'slim.route',
+                            'slim_test_app',
+                            'web',
+                            'Closure::__invoke'
+                        )->withExactTags([
+                            'slim.route.name' => 'simple-route',
+                        ])
+                    ]),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'slim_test_app',
+                        'web',
+                        'GET /simple_view'
+                    )->withExactTags([
+                        'slim.route' => 'Closure::__invoke',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'slim.route',
+                            'slim_test_app',
+                            'web',
+                            'Closure::__invoke'
+                        )->withChildren([
+                            SpanAssertion::build(
+                                'slim.view',
+                                'slim_test_app',
+                                'web',
+                                'simple_view.phtml'
+                            )->withExactTags([
+                                'slim.view' => 'simple_view.phtml',
+                            ])
+                        ])
+                    ]),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'web.request',
+                        'slim_test_app',
+                        'web',
+                        'GET /error'
+                    )->withExactTags([
+                        'slim.route' => 'Closure::__invoke',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])->setError(null, null)
+                        ->withChildren([
+                            SpanAssertion::build(
+                                'slim.route',
+                                'slim_test_app',
+                                'web',
+                                'Closure::__invoke'
+                            )->withExistingTagsNames([
+                                'error.stack'
+                            ])->setError(null, 'Foo error')
+                        ]),
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -47,6 +47,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'GET /simple'
                     )->withExactTags([
                         'slim.route.name' => 'simple-route',
+                        'slim.route.handler' => 'Closure::__invoke',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
@@ -68,6 +69,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'GET /simple_view'
                     )->withExactTags([
+                        'slim.route.handler' => 'Closure::__invoke',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
@@ -96,6 +98,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'GET /error'
                     )->withExactTags([
+                        'slim.route.handler' => 'Closure::__invoke',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -42,6 +42,9 @@
         <testsuite name="slim-312-test">
             <directory>./Integrations/Slim/V3_12</directory>
         </testsuite>
+        <testsuite name="slim-4-test">
+            <directory>./Integrations/Slim/V4</directory>
+        </testsuite>
         <testsuite name="custom-framework-autoloading-test">
             <directory>./Integrations/Custom/Autoloaded</directory>
             <directory>./Integrations/Custom/NotAutoloaded</directory>


### PR DESCRIPTION
### Description

This PR adds support for Slim 4. It differs from the Slim 3 integration in the following ways:

0. The span names default to `web.request` instead of `slim.request` to be consistent with other integrations.
1. The route name (if not empty) is attached to the `slim.route` span as metadata instead of changing the root span resource name.
2. Slim doesn't have controllers so there are no references to a controller in the Slim 4 integration.

<img width="1343" alt="Screen Shot 2021-01-25 at 2 27 30 PM" src="https://user-images.githubusercontent.com/578780/105773944-8d0a0f80-5f19-11eb-9323-8f95dafb2dfd.png">

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
