### PR TITLE
[Profiler] Run .clang-format on everything; adjust style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,5 @@
 ---
-BasedOnStyle: Google
----
-Language: Cpp
-ColumnLimit: 80
-IndentWidth: 4
-AccessModifierOffset: 0
-BreakConstructorInitializers: AfterColon
+BasedOnStyle: LLVM
+AlignOperands: DontAlign
+AllowShortBlocksOnASingleLine: true
 ---

--- a/src/arena.c
+++ b/src/arena.c
@@ -10,68 +10,68 @@ extern inline char *ddprof_arena_try_alloc(ddprof_arena *arena, size_t size);
 
 /* prefer powers of 2 */
 ddprof_arena *ddprof_arena_create(size_t size) {
-    size_t aligned = DDPROF_ARENA_ALIGNED_SIZE(sizeof(ddprof_arena));
-    size = size > aligned ? size : aligned;
-    ddprof_arena *arena = (ddprof_arena *)calloc(1, size);
+  size_t aligned = DDPROF_ARENA_ALIGNED_SIZE(sizeof(ddprof_arena));
+  size = size > aligned ? size : aligned;
+  ddprof_arena *arena = (ddprof_arena *)calloc(1, size);
 
-    arena->ptr = (char *)arena + aligned;
-    arena->end = (char *)arena + size;
-    arena->prev = NULL;
+  arena->ptr = (char *)arena + aligned;
+  arena->end = (char *)arena + size;
+  arena->prev = NULL;
 
-    return arena;
+  return arena;
 }
 
 void ddprof_arena_grow(ddprof_arena **arena_ptr, size_t min_size) {
-    ddprof_arena *arena = *arena_ptr;
-    size_t prev_size = arena->end - (char *)arena;
-    min_size += DDPROF_ARENA_ALIGNED_SIZE(sizeof(ddprof_arena));
-    size_t size = prev_size > min_size ? prev_size : min_size;
-    // todo: align min_size to a power of 2 if it doesn't fit?
+  ddprof_arena *arena = *arena_ptr;
+  size_t prev_size = arena->end - (char *)arena;
+  min_size += DDPROF_ARENA_ALIGNED_SIZE(sizeof(ddprof_arena));
+  size_t size = prev_size > min_size ? prev_size : min_size;
+  // todo: align min_size to a power of 2 if it doesn't fit?
 
-    ddprof_arena *new_arena = ddprof_arena_create(size);
-    new_arena->prev = *arena_ptr;
-    *arena_ptr = new_arena;
+  ddprof_arena *new_arena = ddprof_arena_create(size);
+  new_arena->prev = *arena_ptr;
+  *arena_ptr = new_arena;
 }
 
 void ddprof_arena_destroy(ddprof_arena *arena) {
-    do {
-        ddprof_arena *prev = arena->prev;
-        free(arena);
-        arena = prev;
-    } while (arena);
+  do {
+    ddprof_arena *prev = arena->prev;
+    free(arena);
+    arena = prev;
+  } while (arena);
 }
 
 char *ddprof_arena_checkpoint(ddprof_arena *arena) { return arena->ptr; }
 
 static ddprof_arena *dd_arena_restore(ddprof_arena *arena, char *checkpoint) {
-    if (arena) {
-        /* Hand-waving a bit, but comparing pointers from different allocations
-         * is undefined behavior. Comparing uintptr_ts is implementation defined
-         * behavior; a step up.
-         */
-        uintptr_t begin = (uintptr_t)arena;
-        uintptr_t end = (uintptr_t)arena->end;
-        uintptr_t ptr = (uintptr_t)checkpoint;
-        if (begin <= ptr && ptr <= end) {
-            arena->ptr = checkpoint;
-        } else {
-            ddprof_arena *root = dd_arena_restore(arena->prev, checkpoint);
-            /* If the checkpoint is found in a previous arena then delete this
-             * arena; return the new root upwards.
-             */
-            if (root) {
-                arena->prev = NULL;
-                free(arena);
-            }
-            return root;
-        }
+  if (arena) {
+    /* Hand-waving a bit, but comparing pointers from different allocations
+     * is undefined behavior. Comparing uintptr_ts is implementation defined
+     * behavior; a step up.
+     */
+    uintptr_t begin = (uintptr_t)arena;
+    uintptr_t end = (uintptr_t)arena->end;
+    uintptr_t ptr = (uintptr_t)checkpoint;
+    if (begin <= ptr && ptr <= end) {
+      arena->ptr = checkpoint;
+    } else {
+      ddprof_arena *root = dd_arena_restore(arena->prev, checkpoint);
+      /* If the checkpoint is found in a previous arena then delete this
+       * arena; return the new root upwards.
+       */
+      if (root) {
+        arena->prev = NULL;
+        free(arena);
+      }
+      return root;
     }
-    return arena;
+  }
+  return arena;
 }
 
 void ddprof_arena_restore(ddprof_arena **arena_ptr, char *checkpoint) {
-    ddprof_arena *root = dd_arena_restore(*arena_ptr, checkpoint);
-    if (root) {
-        *arena_ptr = root;
-    }
+  ddprof_arena *root = dd_arena_restore(*arena_ptr, checkpoint);
+  if (root) {
+    *arena_ptr = root;
+  }
 }

--- a/src/native/dictionary.c
+++ b/src/native/dictionary.c
@@ -3,7 +3,9 @@
 #include "dictionary.h"
 
 // Globals
-void* dictionary_dflt_na = (void*)&(uint64_t){0}; // random pointer...  TODO this needs a whole strategy for deserialization
+
+// random pointer...  TODO this needs a whole strategy for deserialization
+void *dictionary_dflt_na = (void *)&(uint64_t){0};
 
 // TODO
 // * this and string_table should have parameter-by-parameter defaulting.  We
@@ -11,17 +13,19 @@ void* dictionary_dflt_na = (void*)&(uint64_t){0}; // random pointer...  TODO thi
 //   value denoting "default".
 
 // ---- Forward decl of purely internal functions
-static char _dictionary_values_resize(Dictionary*);
-static char _dictionary_insert(Dictionary*, ssize_t, void*, size_t);
+static char _dictionary_values_resize(Dictionary *);
+static char _dictionary_insert(Dictionary *, ssize_t, void *, size_t);
 
-Dictionary* dictionary_init(Dictionary* dict, DictionaryOptions* opts) {
-  static DictionaryOptions default_opts = {.hash=1, .alloc=1, .logging=0, .copy=1};
+Dictionary *dictionary_init(Dictionary *dict, DictionaryOptions *opts) {
+  static DictionaryOptions default_opts = {
+      .hash = 1, .alloc = 1, .logging = 0, .copy = 1};
   char clear_dict = 0;
-  if(!opts) opts = &default_opts;
-  if(!dict) {
-    clear_dict=1;
+  if (!opts)
+    opts = &default_opts;
+  if (!dict) {
+    clear_dict = 1;
     dict = calloc(1, sizeof(Dictionary));
-    if(!dict)
+    if (!dict)
       return NULL;
   }
 
@@ -32,55 +36,63 @@ Dictionary* dictionary_init(Dictionary* dict, DictionaryOptions* opts) {
   // case there's no way to know the disposition of the previous dictionary, so
   // focus on initializing it in a referentially safe way
   dict->values_reserved = DIC_ARENA_NELEM;
-  dict->values = calloc(dict->values_reserved, sizeof(void*));
-  if(!dict->values) {
+  dict->values = calloc(dict->values_reserved, sizeof(void *));
+  if (!dict->values) {
     dict->values = NULL;
-    if(clear_dict) free(dict);
+    if (clear_dict)
+      free(dict);
     return NULL;
   }
 
   // This is not configurable
-  if(!stringtable_init((StringTable*)dict, (StringTableOptions*)opts)) {
+  if (!stringtable_init((StringTable *)dict, (StringTableOptions *)opts)) {
     free(dict->values);
-    if(clear_dict) free(dict);
+    if (clear_dict)
+      free(dict);
     return NULL;
   }
 
   return dict;
 }
 
-void dictionary_free(Dictionary* dict) {
-  StringTable* st = (StringTable*)dict;
-  if(!dict) return;
-  if(dict->copy_vals) {
-    for(uint32_t i=0; i < st->nodes->entry_capacity; i++) {
-      if(!st->nodes->entry[i]) continue;
+void dictionary_free(Dictionary *dict) {
+  StringTable *st = (StringTable *)dict;
+  if (!dict)
+    return;
+  if (dict->copy_vals) {
+    for (uint32_t i = 0; i < st->nodes->entry_capacity; i++) {
+      if (!st->nodes->entry[i])
+        continue;
       size_t idx = st->nodes->entry[i]->idx;
-      if(dict->values[idx] && dict->values[idx] != DICT_NA) {
+      if (dict->values[idx] && dict->values[idx] != DICT_NA) {
         free(dict->values[idx]);
         dict->values[idx] = NULL;
       }
     }
   }
 
-  if(dict->values) free(dict->values);
+  if (dict->values)
+    free(dict->values);
 
   stringtable_free(st);
 }
 
-void* dictionary_get(Dictionary* dict, unsigned char* key, size_t sz_key) {
-  ssize_t idx = stringtable_lookup((StringTable*)dict, key, sz_key, NULL);
-  if(-1 == idx) return DICT_NA;
+void *dictionary_get(Dictionary *dict, unsigned char *key, size_t sz_key) {
+  ssize_t idx = stringtable_lookup((StringTable *)dict, key, sz_key, NULL);
+  if (-1 == idx)
+    return DICT_NA;
   return dict->values[idx];
 }
 
-void* dictionary_get_cstr(Dictionary* dict, char* key) {
-  return dictionary_get(dict, (unsigned char*)key, strlen(key));
+void *dictionary_get_cstr(Dictionary *dict, char *key) {
+  return dictionary_get(dict, (unsigned char *)key, strlen(key));
 }
 
-char _dictionary_values_resize(Dictionary* dict) {
-  void** values_resize_buf = realloc(dict->values, 2*dict->values_reserved*sizeof(void*));
-  if(!values_resize_buf) return -1;
+char _dictionary_values_resize(Dictionary *dict) {
+  void **values_resize_buf =
+      realloc(dict->values, 2 * dict->values_reserved * sizeof(void *));
+  if (!values_resize_buf)
+    return -1;
 
   memset(&values_resize_buf[dict->values_reserved], 0, dict->values_reserved);
   dict->values_reserved *= 2;
@@ -88,29 +100,33 @@ char _dictionary_values_resize(Dictionary* dict) {
   return 0;
 }
 
-/*
- *  The next time I write this, I'm going to replace the void* with a fat pointer in order to
- *  properly represent length.  That way, I can avoid heap allocations when the user
- *  is just adding any kind of 64-bit type.
+/* The next time I write this, I'm going to replace the void* with a fat
+ * pointer in order to properly represent length.  That way, I can avoid heap
+ * allocations when the user is just adding any kind of 64-bit type.
  */
-static char _dictionary_insert(Dictionary* dict, ssize_t idx, void* val, size_t sz_val) {
-  if(idx < 0)        return -1; // We don't create the entries here
-  if(val && !sz_val) return -1; // Paradox.  NOT a delete operation.
-  if(!val && !sz_val) val = DICT_NA; // Say what you mean or error?  Hard to say.
+static char _dictionary_insert(Dictionary *dict, ssize_t idx, void *val,
+                               size_t sz_val) {
+  if (idx < 0)
+    return -1; // We don't create the entries here
+  if (val && !sz_val)
+    return -1; // Paradox.  NOT a delete operation.
+  if (!val && !sz_val)
+    val = DICT_NA; // Say what you mean or error?  Hard to say.
 
   // Do we need to resize?
-  while(idx >= dict->values_reserved) {
-    if(-1 == _dictionary_values_resize(dict)) return -1;
+  while (idx >= dict->values_reserved) {
+    if (-1 == _dictionary_values_resize(dict))
+      return -1;
   }
 
   // Intern or reference the value, clearing the old one if semantically valid
-  if(dict->copy_vals) {
-    if(dict->values[idx] && dict->values[idx] != DICT_NA) {
+  if (dict->copy_vals) {
+    if (dict->values[idx] && dict->values[idx] != DICT_NA) {
       free(dict->values[idx]);
       dict->values[idx] = NULL;
     }
 
-    if(val != DICT_NA) {
+    if (val != DICT_NA) {
       dict->values[idx] = calloc(1, sz_val);
       memcpy(dict->values[idx], val, sz_val);
     } else {
@@ -124,14 +140,15 @@ static char _dictionary_insert(Dictionary* dict, ssize_t idx, void* val, size_t 
   return 0;
 }
 
-ssize_t dictionary_add(Dictionary* dict, unsigned char* key, size_t sz_key, void* val, size_t sz_val) {
-  ssize_t idx = stringtable_lookup((StringTable*)dict, key, sz_key, NULL);
+ssize_t dictionary_add(Dictionary *dict, unsigned char *key, size_t sz_key,
+                       void *val, size_t sz_val) {
+  ssize_t idx = stringtable_lookup((StringTable *)dict, key, sz_key, NULL);
 
   // If the value is NA or the idx is -1, we want to insert the value
-  if(-1 == idx || dict->values[idx] == DICT_NA) {
-    if(-1 == idx)
-      idx = stringtable_add((StringTable*)dict, key, sz_key);
-    if(-1 == _dictionary_insert(dict, idx, val, sz_val))
+  if (-1 == idx || dict->values[idx] == DICT_NA) {
+    if (-1 == idx)
+      idx = stringtable_add((StringTable *)dict, key, sz_key);
+    if (-1 == _dictionary_insert(dict, idx, val, sz_val))
       return -1;
     return idx;
   }
@@ -139,33 +156,38 @@ ssize_t dictionary_add(Dictionary* dict, unsigned char* key, size_t sz_key, void
   return -1;
 }
 
-ssize_t dictionary_put(Dictionary* dict, unsigned char* key, size_t sz_key, void* val, size_t sz_val) {
-  ssize_t idx = stringtable_lookup((StringTable*)dict, key, sz_key, NULL);
+ssize_t dictionary_put(Dictionary *dict, unsigned char *key, size_t sz_key,
+                       void *val, size_t sz_val) {
+  ssize_t idx = stringtable_lookup((StringTable *)dict, key, sz_key, NULL);
 
-  if(-1 == idx)
-    idx = stringtable_add((StringTable*)dict, key, sz_key);
-  if(-1 == _dictionary_insert(dict, idx, val, sz_val))
+  if (-1 == idx)
+    idx = stringtable_add((StringTable *)dict, key, sz_key);
+  if (-1 == _dictionary_insert(dict, idx, val, sz_val))
     return -1;
   return idx;
 }
 
-ssize_t dictionary_add_cstr(Dictionary* dict, char* key, void* val, size_t sz_val) {
-  return dictionary_add(dict, (unsigned char*)key, strlen(key), val, sz_val);
+ssize_t dictionary_add_cstr(Dictionary *dict, char *key, void *val,
+                            size_t sz_val) {
+  return dictionary_add(dict, (unsigned char *)key, strlen(key), val, sz_val);
 }
 
-ssize_t dictionary_put_cstr(Dictionary* dict, char* key, void* val, size_t sz_val) {
-  return dictionary_put(dict, (unsigned char*)key, strlen(key), val, sz_val);
+ssize_t dictionary_put_cstr(Dictionary *dict, char *key, void *val,
+                            size_t sz_val) {
+  return dictionary_put(dict, (unsigned char *)key, strlen(key), val, sz_val);
 }
 
-ssize_t dictionary_del(Dictionary* dict, unsigned char* key, size_t sz_key) {
-  ssize_t idx = stringtable_lookup((StringTable*)dict, key, sz_key, NULL);
-  if(-1 == idx) return -1;
-  if(dict->copy_vals) free(dict->values[idx]);
+ssize_t dictionary_del(Dictionary *dict, unsigned char *key, size_t sz_key) {
+  ssize_t idx = stringtable_lookup((StringTable *)dict, key, sz_key, NULL);
+  if (-1 == idx)
+    return -1;
+  if (dict->copy_vals)
+    free(dict->values[idx]);
   dict->values[idx] = DICT_NA;
 
   return idx;
 }
 
-ssize_t dictionary_del_cstr(Dictionary* dict, char* key) {
-  return dictionary_del(dict, (unsigned char*)key, strlen(key));
+ssize_t dictionary_del_cstr(Dictionary *dict, char *key) {
+  return dictionary_del(dict, (unsigned char *)key, strlen(key));
 }

--- a/src/native/pprof.c
+++ b/src/native/pprof.c
@@ -11,33 +11,39 @@
 #ifndef DBG_PRINT_ENABLE
 #define DBG_PRINT_ENABLE 0
 #endif
-#define DBG_PRINT(...) do{if(DBG_PRINT_ENABLE) printf("<%s:%d> %s", __FILE__, __LINE__, __VA_ARGS__);} while(0)
+#define DBG_PRINT(...)                                                         \
+  do {                                                                         \
+    if (DBG_PRINT_ENABLE)                                                      \
+      printf("<%s:%d> %s", __FILE__, __LINE__, __VA_ARGS__);                   \
+  } while (0)
 
 // TODO unused vars should only happen when the consistency of the API forces
 //      an unnecessary object to be passed, and even then should be scrutinized.
 //      Check to make sure these are necessary.
 #ifdef KNOCKOUT_UNUSED
-#  define UNUSED(x) (void)(x)
+#define UNUSED(x) (void)(x)
 #else
-#  define UNUSED(x) do {} while(0)
+#define UNUSED(x)                                                              \
+  do {                                                                         \
+  } while (0)
 #endif
 
-#define pprofgrow(x, N, M)                                             \
-  __extension__ ({                                                     \
-    int __rc = 0;                                                      \
-    if (!(N)%(M)) {                                                    \
-      DBG_PRINT("Resizing " #x);                                       \
-      __typeof__(x) _buf = calloc((N) + (M), sizeof(__typeof__(x)));   \
-      if (!_buf) __rc = -1;                                            \
-      if (x) {                                                         \
-        memcpy(_buf, (x), (N)*sizeof(__typeof__(x)));                  \
-        free(x);                                                       \
-      }                                                                \
-      (x) = _buf;                                                      \
-    }                                                                  \
-    __rc;                                                              \
+#define pprofgrow(x, N, M)                                                     \
+  __extension__({                                                              \
+    int __rc = 0;                                                              \
+    if (!(N) % (M)) {                                                          \
+      DBG_PRINT("Resizing " #x);                                               \
+      __typeof__(x) _buf = calloc((N) + (M), sizeof(__typeof__(x)));           \
+      if (!_buf)                                                               \
+        __rc = -1;                                                             \
+      if (x) {                                                                 \
+        memcpy(_buf, (x), (N) * sizeof(__typeof__(x)));                        \
+        free(x);                                                               \
+      }                                                                        \
+      (x) = _buf;                                                              \
+    }                                                                          \
+    __rc;                                                                      \
   })
-
 
 /******************************************************************************\
 |*                            String Table (Vocab)                            *|
@@ -46,22 +52,23 @@
 //    here as a horrible baseline.
 #define VOCAB_SZ 4096
 
-size_t addToVocab(char* str, char*** _st, size_t* _sz_st) {
-  if(!str) str="";
-  char** st    = *_st;
+size_t addToVocab(char *str, char ***_st, size_t *_sz_st) {
+  if (!str)
+    str = "";
+  char **st = *_st;
   size_t sz_st = *_sz_st;
 
   // Does this string already exist in the table?
-  for(size_t i = 0; i < sz_st; i++)
-    if(!strcmp(st[i], str))
+  for (size_t i = 0; i < sz_st; i++)
+    if (!strcmp(st[i], str))
       return i;
 
   // We have a new string.  Resize the string table if needed.
-  if(!(sz_st%VOCAB_SZ)) {
+  if (!(sz_st % VOCAB_SZ)) {
     DBG_PRINT("Resizing vocab");
-    char** buf = calloc(sz_st + VOCAB_SZ, sizeof(char*));
-    if(!buf) {}  // TODO do something?
-    memcpy(buf, st, sz_st*sizeof(char*));
+    char **buf = calloc(sz_st + VOCAB_SZ, sizeof(char *));
+    if (!buf) {} // TODO do something?
+    memcpy(buf, st, sz_st * sizeof(char *));
     free(*_st);
     st = *_st = buf;
   }
@@ -71,54 +78,55 @@ size_t addToVocab(char* str, char*** _st, size_t* _sz_st) {
   return sz_st;
 }
 
-uint64_t vocab_intern(void* state, char* str) {
-  PPProfile* pprof = (PPProfile*)state;
+uint64_t vocab_intern(void *state, char *str) {
+  PPProfile *pprof = (PPProfile *)state;
   return addToVocab(str, &pprof->string_table, &pprof->n_string_table);
 }
 
-char** vocab_get_table(void* state) {
-  PPProfile* pprof = (PPProfile*)state;
+char **vocab_get_table(void *state) {
+  PPProfile *pprof = (PPProfile *)state;
   return pprof->string_table;
 }
 
-size_t vocab_get_size(void* state) {
-  PPProfile* pprof = (PPProfile*)state;
+size_t vocab_get_size(void *state) {
+  PPProfile *pprof = (PPProfile *)state;
   return pprof->n_string_table;
 }
-
 
 /******************************************************************************\
 |*                       String Table (string_table.h)                        *|
 \******************************************************************************/
-uint64_t pprof_stringtable_intern(void* state, char* str) {
-  return stringtable_add_cstr((StringTable*)state, str);
+uint64_t pprof_stringtable_intern(void *state, char *str) {
+  return stringtable_add_cstr((StringTable *)state, str);
 }
 
-char** pprof_stringtable_gettable(void* state) {
-  return (char**)((StringTable*)state)->arena->entry;
+char **pprof_stringtable_gettable(void *state) {
+  return (char **)((StringTable *)state)->arena->entry;
 }
 
-size_t pprof_stringtable_size(void* state) {
-  return ((StringTable*)state)->arena->entry_idx;
+size_t pprof_stringtable_size(void *state) {
+  return ((StringTable *)state)->arena->entry_idx;
 }
 
-size_t pprof_strIntern(DProf* dp, char* str) {
+size_t pprof_strIntern(DProf *dp, char *str) {
   return dp->intern_string(dp->string_table_data, str);
 }
-
 
 /******************************************************************************\
 |*                                   DProf                                    *|
 \******************************************************************************/
 // Forward decl of purely internal functions
-static uint64_t _pprof_mapNew(DProf*, uint64_t, uint64_t, uint64_t, uint64_t, int64_t);
-static uint64_t _pprof_funNew(DProf*, int64_t, int64_t, int64_t, int64_t);
-static uint64_t _pprof_lineNew(DProf*, PPLocation*, uint64_t, int64_t);
-static char _pprof_mapFree(PPMapping**, size_t);
+static uint64_t _pprof_mapNew(DProf *, uint64_t, uint64_t, uint64_t, uint64_t,
+                              int64_t);
+static uint64_t _pprof_funNew(DProf *, int64_t, int64_t, int64_t, int64_t);
+static uint64_t _pprof_lineNew(DProf *, PPLocation *, uint64_t, int64_t);
+static char _pprof_mapFree(PPMapping **, size_t);
 
 // ---- Implementation
-static uint64_t _pprof_mapNew(DProf* dp, uint64_t map_start, uint64_t map_end, uint64_t map_off, uint64_t id_filename, int64_t build) {
-  PPProfile* pprof = &dp->pprof;
+static uint64_t _pprof_mapNew(DProf *dp, uint64_t map_start, uint64_t map_end,
+                              uint64_t map_off, uint64_t id_filename,
+                              int64_t build) {
+  PPProfile *pprof = &dp->pprof;
   uint64_t id = pprof->n_mapping;
 
   // Resize if needed
@@ -126,14 +134,14 @@ static uint64_t _pprof_mapNew(DProf* dp, uint64_t map_start, uint64_t map_end, u
 
   // Initialize this mapping
   pprof->mapping[id] = calloc(1, sizeof(PPMapping));
-  if(!pprof->mapping[id]) {} // TODO error
+  if (!pprof->mapping[id]) {} // TODO error
   perftools__profiles__mapping__init(pprof->mapping[id]);
 
   // Populate specific mapping
-  pprof->mapping[id]->id = id+1;
+  pprof->mapping[id]->id = id + 1;
   pprof->mapping[id]->memory_start = map_start;
   pprof->mapping[id]->memory_limit = map_end;
-  pprof->mapping[id]->file_offset  = map_off;
+  pprof->mapping[id]->file_offset = map_off;
   pprof->mapping[id]->filename = id_filename;
   pprof->mapping[id]->build_id = build;
 
@@ -146,29 +154,33 @@ static uint64_t _pprof_mapNew(DProf* dp, uint64_t map_start, uint64_t map_end, u
   return id;
 }
 
-char isEqualMapping(uint64_t map_start, uint64_t map_end, uint64_t map_off, int64_t id_filename, int64_t build, PPMapping* B) {
-  return id_filename == B->filename   &&
-         build == B->build_id         &&
-         map_end == B->memory_limit   &&
-         map_start == B->memory_start &&
-         map_off == B->file_offset;
+char isEqualMapping(uint64_t map_start, uint64_t map_end, uint64_t map_off,
+                    int64_t id_filename, int64_t build, PPMapping *B) {
+  return id_filename == B->filename && build == B->build_id &&
+      map_end == B->memory_limit && map_start == B->memory_start &&
+      map_off == B->file_offset;
 }
 
 // Returns the ID of the mapping
 // NOTE that this is different from the index of the mapping in the pprof
-uint64_t pprof_mapAdd(DProf* dp, uint64_t map_start, uint64_t map_end, uint64_t map_off, const char* filename, const char* build) {
-  PPProfile* pprof = &dp->pprof;
+uint64_t pprof_mapAdd(DProf *dp, uint64_t map_start, uint64_t map_end,
+                      uint64_t map_off, const char *filename,
+                      const char *build) {
+  PPProfile *pprof = &dp->pprof;
   uint64_t id_filename = pprof_strIntern(dp, filename);
   uint64_t id_build = pprof_strIntern(dp, build);
 
-  for(size_t i=0; i < pprof->n_mapping; i++)
-    if(isEqualMapping(map_start, map_end, map_off, id_filename, id_build, pprof->mapping[i]))
-      return i+1;
-  return _pprof_mapNew(dp, map_start, map_end, map_off, id_filename, id_build)+1;
+  for (size_t i = 0; i < pprof->n_mapping; i++)
+    if (isEqualMapping(map_start, map_end, map_off, id_filename, id_build,
+                       pprof->mapping[i]))
+      return i + 1;
+  return _pprof_mapNew(dp, map_start, map_end, map_off, id_filename, id_build) +
+      1;
 }
 
-static uint64_t _pprof_lineNew(DProf* dp, PPLocation* loc, uint64_t id_function, int64_t line) {
-UNUSED(dp);
+static uint64_t _pprof_lineNew(DProf *dp, PPLocation *loc, uint64_t id_function,
+                               int64_t line) {
+  UNUSED(dp);
   uint64_t id = loc->n_line;
 
   // Initialize
@@ -176,11 +188,11 @@ UNUSED(dp);
 
   // Take care of this element
   loc->line[id] = calloc(1, sizeof(PPLine));
-  if(!loc->line[id]) {} // TODO error
+  if (!loc->line[id]) {} // TODO error
   perftools__profiles__line__init(loc->line[id]);
 
   // Populate this entry
-  loc->line[id]->line        = line;
+  loc->line[id]->line = line;
   loc->line[id]->function_id = id_function;
 
   // Done!
@@ -190,20 +202,25 @@ UNUSED(dp);
 
 // Returns the ID of the line
 // NOTE that this is different from the index of the line in the location
-uint64_t pprof_lineAdd(DProf* dp, PPLocation* loc, uint64_t id_function, int64_t line) {
-  for(size_t i = 0; i < loc->n_line; i++)
-    if(id_function == loc->line[i]->function_id && line == loc->line[i]->line)
-      return i+1;
+uint64_t pprof_lineAdd(DProf *dp, PPLocation *loc, uint64_t id_function,
+                       int64_t line) {
+  for (size_t i = 0; i < loc->n_line; i++)
+    if (id_function == loc->line[i]->function_id && line == loc->line[i]->line)
+      return i + 1;
 
-  return _pprof_lineNew(dp, loc, id_function, line)+1;
+  return _pprof_lineNew(dp, loc, id_function, line) + 1;
 }
 
-char isEqualFunction(int64_t id_name, int64_t id_system_name, int64_t id_filename, PPFunction* B) {
-  return id_name == B->name && id_system_name == B->system_name && id_filename == B->filename;
+char isEqualFunction(int64_t id_name, int64_t id_system_name,
+                     int64_t id_filename, PPFunction *B) {
+  return id_name == B->name && id_system_name == B->system_name &&
+      id_filename == B->filename;
 }
 
-static uint64_t _pprof_funNew(DProf* dp, int64_t id_name, int64_t id_system_name, int64_t id_filename, int64_t start_line) {
-  PPProfile* pprof = &dp->pprof;
+static uint64_t _pprof_funNew(DProf *dp, int64_t id_name,
+                              int64_t id_system_name, int64_t id_filename,
+                              int64_t start_line) {
+  PPProfile *pprof = &dp->pprof;
   uint64_t id = pprof->n_function;
 
   // Initialize or grow if needed
@@ -211,11 +228,11 @@ static uint64_t _pprof_funNew(DProf* dp, int64_t id_name, int64_t id_system_name
 
   // Initialize this function
   pprof->function[id] = calloc(1, sizeof(PPFunction));
-  if(!pprof->function[id]) {} // TODO error
+  if (!pprof->function[id]) {} // TODO error
   perftools__profiles__function__init(pprof->function[id]);
 
   // Populate a new function
-  pprof->function[id]->id = id+1;
+  pprof->function[id]->id = id + 1;
   pprof->function[id]->name = id_name;
   pprof->function[id]->system_name = id_system_name;
   pprof->function[id]->filename = id_filename;
@@ -226,26 +243,34 @@ static uint64_t _pprof_funNew(DProf* dp, int64_t id_name, int64_t id_system_name
   return id;
 }
 
-uint64_t pprof_funAdd(DProf* dp, const char* name, const char* system_name, const char* filename, int64_t start_line) {
-  PPProfile* pprof = &dp->pprof;
+uint64_t pprof_funAdd(DProf *dp, const char *name, const char *system_name,
+                      const char *filename, int64_t start_line) {
+  PPProfile *pprof = &dp->pprof;
   int64_t id_name = pprof_strIntern(dp, name);
   int64_t id_system_name = pprof_strIntern(dp, system_name);
   int64_t id_filename = pprof_strIntern(dp, filename);
 
   for (size_t i = 0; i < pprof->n_function; i++)
-    if (isEqualFunction(id_name, id_system_name, id_filename, pprof->function[i]))
-      return i+1;
-  return _pprof_funNew(dp, id_name, id_system_name, id_filename, start_line)+1;
+    if (isEqualFunction(id_name, id_system_name, id_filename,
+                        pprof->function[i]))
+      return i + 1;
+  return _pprof_funNew(dp, id_name, id_system_name, id_filename, start_line) +
+      1;
 }
 
-static uint64_t _pprof_locNew(DProf* dp, uint64_t id_mapping, uint64_t addr, const uint64_t *functions, const int64_t *lines, size_t n_functions) {
-  PPProfile* pprof = &dp->pprof;
+static uint64_t _pprof_locNew(DProf *dp, uint64_t id_mapping, uint64_t addr,
+                              const uint64_t *functions, const int64_t *lines,
+                              size_t n_functions) {
+  PPProfile *pprof = &dp->pprof;
   uint64_t id = pprof->n_location;
 
   // Early sanity checks
-  if (!n_functions) return 0;
-  if (!functions)   return 0;
-  if (!lines)       return 0;
+  if (!n_functions)
+    return 0;
+  if (!functions)
+    return 0;
+  if (!lines)
+    return 0;
 
   // Initialize or grow if needed
   pprofgrow(pprof->location, pprof->n_location, DPROF_CHUNK_SZ);
@@ -256,7 +281,7 @@ static uint64_t _pprof_locNew(DProf* dp, uint64_t id_mapping, uint64_t addr, con
   perftools__profiles__location__init(pprof->location[id]);
 
   // Populate
-  pprof->location[id]->id = id+1;
+  pprof->location[id]->id = id + 1;
   pprof->location[id]->mapping_id = id_mapping;
   pprof->location[id]->address = addr;
 
@@ -266,10 +291,10 @@ static uint64_t _pprof_locNew(DProf* dp, uint64_t id_mapping, uint64_t addr, con
   // Done!
   pprof->n_location++;
   return id;
-
 }
 
-static bool isEqualLine(const PPLine *line, uint64_t function_id, int64_t lineno) {
+static bool isEqualLine(const PPLine *line, uint64_t function_id,
+                        int64_t lineno) {
   uint64_t fid_a = line->function_id, fid_b = function_id;
   int64_t line_a = line->line, line_b = lineno;
   return !((fid_a ^ fid_b) | (line_a ^ line_b));
@@ -278,9 +303,12 @@ static bool isEqualLine(const PPLine *line, uint64_t function_id, int64_t lineno
 static bool isEqualLocation(const PPLocation *location, uint64_t mapping_id,
                             uint64_t addr, const uint64_t *functions,
                             const int64_t *lines, size_t n_functions) {
-  if (location->mapping_id != mapping_id) return false;
-  if (location->address != addr) return false;
-  if (location->n_line != n_functions) return false;
+  if (location->mapping_id != mapping_id)
+    return false;
+  if (location->address != addr)
+    return false;
+  if (location->n_line != n_functions)
+    return false;
 
   for (size_t i = 0; i < n_functions; ++i) {
     if (!isEqualLine(location->line[i], functions[i], lines[i])) {
@@ -291,38 +319,42 @@ static bool isEqualLocation(const PPLocation *location, uint64_t mapping_id,
   return true;
 }
 
-static PPLocation *findLocation(DProf* dp, uint64_t id_mapping, uint64_t addr,
+static PPLocation *findLocation(DProf *dp, uint64_t id_mapping, uint64_t addr,
                                 const uint64_t *functions, const int64_t *lines,
                                 size_t n_functions) {
-  PPProfile* pprof = &dp->pprof;
+  PPProfile *pprof = &dp->pprof;
   for (size_t i = 0; i < pprof->n_location; ++i) {
     PPLocation *location = pprof->location[i];
-    if (isEqualLocation(location, id_mapping, addr, functions, lines, n_functions)) {
+    if (isEqualLocation(location, id_mapping, addr, functions, lines,
+                        n_functions)) {
       return location;
     }
   }
   return NULL;
 }
 
-uint64_t pprof_locAdd(DProf* dp, uint64_t id_mapping, uint64_t addr,
+uint64_t pprof_locAdd(DProf *dp, uint64_t id_mapping, uint64_t addr,
                       const uint64_t *functions, const int64_t *lines,
                       size_t n_functions) {
-  PPLocation *location = findLocation(dp, id_mapping, addr, functions, lines, n_functions);
+  PPLocation *location =
+      findLocation(dp, id_mapping, addr, functions, lines, n_functions);
   return (location)
-    ? location->id
-    : _pprof_locNew(dp, id_mapping, addr, functions, lines, n_functions) + 1;
+      ? location->id
+      : _pprof_locNew(dp, id_mapping, addr, functions, lines, n_functions) + 1;
 }
 
 static bool isEqualSample(const PPSample *B, const uint64_t *loc, size_t nloc) {
-  if (nloc != B->n_location_id) return false;
+  if (nloc != B->n_location_id)
+    return false;
   for (size_t i = 0; i != nloc; i++) {
-    if (loc[i] != B->location_id[i]) return false;
+    if (loc[i] != B->location_id[i])
+      return false;
   }
   return true;
 }
 
-static PPSample *findSample(DProf* dp, uint64_t* loc, size_t nloc) {
-  PPProfile* pprof = &dp->pprof;
+static PPSample *findSample(DProf *dp, uint64_t *loc, size_t nloc) {
+  PPProfile *pprof = &dp->pprof;
   for (size_t i = 0; i != pprof->n_sample; ++i) {
     PPSample *sample = pprof->sample[i];
     if (isEqualSample(sample, loc, nloc)) {
@@ -332,14 +364,18 @@ static PPSample *findSample(DProf* dp, uint64_t* loc, size_t nloc) {
   return NULL;
 }
 
-char pprof_sampleAdd(DProf* dp, int64_t* val, size_t nval, uint64_t* loc, size_t nloc) {
-  PPProfile* pprof = &dp->pprof;
+char pprof_sampleAdd(DProf *dp, int64_t *val, size_t nval, uint64_t *loc,
+                     size_t nloc) {
+  PPProfile *pprof = &dp->pprof;
   uint64_t id = pprof->n_sample;
 
   // Early sanity checks
-  if (nval != pprof->n_sample_type) return -1;  // pprof and user disagree
-  if (!val) return -1; // samples are null
-  if (!nloc || !loc) return -1; // no locations
+  if (nval != pprof->n_sample_type)
+    return -1; // pprof and user disagree
+  if (!val)
+    return -1; // samples are null
+  if (!nloc || !loc)
+    return -1; // no locations
 
   PPSample *sample = findSample(dp, loc, nloc);
   if (sample) {
@@ -355,40 +391,40 @@ char pprof_sampleAdd(DProf* dp, int64_t* val, size_t nval, uint64_t* loc, size_t
 
   // Initialize this sample
   pprof->sample[id] = calloc(1, sizeof(PPSample));
-  if(!pprof->sample[id]) {} // TODO error
+  if (!pprof->sample[id]) {} // TODO error
   perftools__profiles__sample__init(pprof->sample[id]);
 
   // Populate the sample value.  First, validate and allocate
   pprof->sample[id]->n_value = nval;
   pprof->sample[id]->value = calloc(nval, sizeof(int64_t));
   if (!pprof->sample[id]->value) {} // TODO error
-  memcpy(pprof->sample[id]->value, val, nval*sizeof(*val));
+  memcpy(pprof->sample[id]->value, val, nval * sizeof(*val));
 
   // Populate the location IDs
   pprof->sample[id]->n_location_id = nloc;
   pprof->sample[id]->location_id = calloc(nloc, sizeof(uint64_t));
   if (!pprof->sample[id]->location_id) {} // TODO error
-  memcpy(pprof->sample[id]->location_id, loc, nloc*sizeof(*loc));
+  memcpy(pprof->sample[id]->location_id, loc, nloc * sizeof(*loc));
 
   // We're done!
   pprof->n_sample++;
   return 0;
 }
 
-char pprof_sampleFree(PPSample** sample, size_t sz) {
-  if(!sample) // TODO is this an error?
+char pprof_sampleFree(PPSample **sample, size_t sz) {
+  if (!sample) // TODO is this an error?
     return 0;
 
-  for(size_t i=0; i<sz; i++) {
-    if(!sample[i])
+  for (size_t i = 0; i < sz; i++) {
+    if (!sample[i])
       continue;
 
-    if(sample[i]->location_id) {
+    if (sample[i]->location_id) {
       free(sample[i]->location_id);
       sample[i]->location_id = NULL;
     }
 
-    if(sample[i]->value) {
+    if (sample[i]->value) {
       free(sample[i]->value);
       sample[i]->value = NULL;
     }
@@ -401,50 +437,58 @@ char pprof_sampleFree(PPSample** sample, size_t sz) {
   return 0;
 }
 
-void pprof_timeUpdate(DProf* dp) {
-  if(!dp) return;
+void pprof_timeUpdate(DProf *dp) {
+  if (!dp)
+    return;
   struct timeval tv = {0};
   gettimeofday(&tv, NULL);
-  pprof_timeSet(dp, (tv.tv_sec*1000*1000 + tv.tv_usec)*1000);
+  pprof_timeSet(dp, (tv.tv_sec * 1000 * 1000 + tv.tv_usec) * 1000);
 }
 
-void pprof_durationUpdate(DProf* dp) {
-  if(!dp) return;
+void pprof_durationUpdate(DProf *dp) {
+  if (!dp)
+    return;
   struct timeval tv = {0};
   gettimeofday(&tv, NULL);
-  pprof_durationSet(dp, (tv.tv_sec*1000*1000 + tv.tv_usec)*1000 - dp->pprof.time_nanos);
+  pprof_durationSet(
+      dp, (tv.tv_sec * 1000 * 1000 + tv.tv_usec) * 1000 - dp->pprof.time_nanos);
 }
 
-char pprof_Init(DProf* dp, const char** sample_names, const char** sample_units, size_t n_sampletypes) {
-  PPProfile* pprof = &dp->pprof;
+char pprof_Init(DProf *dp, const char **sample_names, const char **sample_units,
+                size_t n_sampletypes) {
+  PPProfile *pprof = &dp->pprof;
   // Early sanity checks
-  if (!sample_names || !sample_units || 2>n_sampletypes) return -1;
+  if (!sample_names || !sample_units || 2 > n_sampletypes)
+    return -1;
 
   // Define the appropriate internment strategy
-  switch(dp->table_type) {
-    case 0:
-      dp->intern_string     = vocab_intern;
-      dp->string_table      = vocab_get_table;
-      dp->string_table_size = vocab_get_size;
-      dp->string_table_data = pprof;
-      break;
-    default: // Error, default to best implementation so far
-    case 1:
-      dp->intern_string     = pprof_stringtable_intern;
-      dp->string_table      = pprof_stringtable_gettable;
-      dp->string_table_size = pprof_stringtable_size;
-      dp->string_table_data = stringtable_init(NULL, &(StringTableOptions){.hash=1, .logging=0});
-      ((StringTable*)dp->string_table_data)->logging = 1; // TODO make this configurable
-      break;
+  switch (dp->table_type) {
+  case 0:
+    dp->intern_string = vocab_intern;
+    dp->string_table = vocab_get_table;
+    dp->string_table_size = vocab_get_size;
+    dp->string_table_data = pprof;
+    break;
+  default: // Error, default to best implementation so far
+  case 1:
+    dp->intern_string = pprof_stringtable_intern;
+    dp->string_table = pprof_stringtable_gettable;
+    dp->string_table_size = pprof_stringtable_size;
+    dp->string_table_data =
+        stringtable_init(NULL, &(StringTableOptions){.hash = 1, .logging = 0});
+
+    // TODO make this configurable
+    ((StringTable *)dp->string_table_data)->logging = 1;
+    break;
   }
 
   // Initialize the top-level container and the type holders
   perftools__profiles__profile__init(pprof);
-  pprof_strIntern(dp,""); // Initialize
+  pprof_strIntern(dp, ""); // Initialize
 
   // Initialize sample_type
-  pprof->sample_type = calloc(n_sampletypes,sizeof(PPValueType*));
-  if(!pprof->sample_type) {} // TODO error
+  pprof->sample_type = calloc(n_sampletypes, sizeof(PPValueType *));
+  if (!pprof->sample_type) {} // TODO error
   pprof->n_sample_type = n_sampletypes;
   pprof->n_sample = 0;
 
@@ -459,8 +503,8 @@ char pprof_Init(DProf* dp, const char** sample_names, const char** sample_units,
   }
 
   // Initialize period_type
-  pprof->period_type = calloc(1,sizeof(PPValueType));
-  if(!pprof->period_type) {} // TODO error
+  pprof->period_type = calloc(1, sizeof(PPValueType));
+  if (!pprof->period_type) {} // TODO error
   perftools__profiles__value_type__init(pprof->period_type);
   pprof->period_type->type = pprof->sample_type[1]->type;
   pprof->period_type->unit = pprof->sample_type[1]->unit;
@@ -468,14 +512,14 @@ char pprof_Init(DProf* dp, const char** sample_names, const char** sample_units,
   return 0;
 }
 
-static char _pprof_mapFree(PPMapping** map, size_t sz) {
-  if(!map)    // TODO err?
+static char _pprof_mapFree(PPMapping **map, size_t sz) {
+  if (!map) // TODO err?
     return 0;
 
   // TODO when we change all mappings to get allocated into a common arena,
   // update this
-  for(size_t i=0; i<sz; i++)
-    if(map[i]) {
+  for (size_t i = 0; i < sz; i++)
+    if (map[i]) {
       free(map[i]);
       map[i] = NULL;
     }
@@ -485,13 +529,13 @@ static char _pprof_mapFree(PPMapping** map, size_t sz) {
   return 0;
 }
 
-char pprof_lineFree(PPLine** line, size_t sz) {
-  if(!line)
+char pprof_lineFree(PPLine **line, size_t sz) {
+  if (!line)
     return 0;
 
   // TODO refactor when ready
-  for(size_t i=0; i<sz; i++)
-    if(line[i]) {
+  for (size_t i = 0; i < sz; i++)
+    if (line[i]) {
       free(line[i]);
       line[i] = NULL;
     }
@@ -501,13 +545,13 @@ char pprof_lineFree(PPLine** line, size_t sz) {
   return 0;
 }
 
-char pprof_locFree(PPLocation** loc, size_t sz) {
-  if(!loc)
+char pprof_locFree(PPLocation **loc, size_t sz) {
+  if (!loc)
     return 0;
 
   // TODO refactor when ready
-  for(size_t i=0; i<sz; i++)
-    if(loc[i]) {
+  for (size_t i = 0; i < sz; i++)
+    if (loc[i]) {
       pprof_lineFree(loc[i]->line, loc[i]->n_line);
       loc[i]->line = NULL;
       free(loc[i]);
@@ -519,13 +563,13 @@ char pprof_locFree(PPLocation** loc, size_t sz) {
   return 0;
 }
 
-char pprof_funFree(PPFunction** fun, size_t sz) {
-  if(!fun)
+char pprof_funFree(PPFunction **fun, size_t sz) {
+  if (!fun)
     return 0;
 
   // TODO refactor when ready
-  for(size_t i=0; i<sz; i++)
-    if(fun[i]) {
+  for (size_t i = 0; i < sz; i++)
+    if (fun[i]) {
       free(fun[i]);
       fun[i] = NULL;
     }
@@ -535,12 +579,12 @@ char pprof_funFree(PPFunction** fun, size_t sz) {
   return 0;
 }
 
-char pprof_sampleClear(DProf* dp) {
-  PPProfile* pprof = &dp->pprof;
-  if(!pprof)
+char pprof_sampleClear(DProf *dp) {
+  PPProfile *pprof = &dp->pprof;
+  if (!pprof)
     return 0;
 
-  if(pprof->sample)
+  if (pprof->sample)
     pprof_sampleFree(pprof->sample, pprof->n_sample);
   pprof->sample = NULL;
   pprof->n_sample = 0;
@@ -548,14 +592,14 @@ char pprof_sampleClear(DProf* dp) {
   return 0;
 }
 
-char pprof_Free(DProf* dp) {
-  PPProfile* pprof = &dp->pprof;
-  if(!pprof)   // Is this an error?
+char pprof_Free(DProf *dp) {
+  PPProfile *pprof = &dp->pprof;
+  if (!pprof) // Is this an error?
     return 0;
 
-  if(pprof->sample_type) {
-    for(size_t i=0; i<pprof->n_sample_type; i++)
-      if(pprof->sample_type[i]) {
+  if (pprof->sample_type) {
+    for (size_t i = 0; i < pprof->n_sample_type; i++)
+      if (pprof->sample_type[i]) {
         free(pprof->sample_type[i]);
         pprof->sample_type[i] = NULL;
       }
@@ -563,36 +607,36 @@ char pprof_Free(DProf* dp) {
     pprof->sample_type = NULL;
   }
 
-  if(pprof->period_type) {
+  if (pprof->period_type) {
     free(pprof->period_type);
     pprof->period_type = NULL;
   }
 
-  if(pprof->mapping) {
+  if (pprof->mapping) {
     _pprof_mapFree(pprof->mapping, pprof->n_mapping);
     pprof->mapping = NULL;
   }
 
-  if(pprof->location) {
+  if (pprof->location) {
     pprof_locFree(pprof->location, pprof->n_location);
     pprof->location = NULL;
   }
 
-  if(pprof->function) {
+  if (pprof->function) {
     pprof_funFree(pprof->function, pprof->n_function);
     pprof->function = NULL;
   }
 
-  if(pprof->sample) {
+  if (pprof->sample) {
     pprof_sampleFree(pprof->sample, pprof->n_sample);
     pprof->sample = NULL;
   }
 
-  switch(dp->table_type) {
+  switch (dp->table_type) {
   case 0:
-    if(pprof->string_table) {
-      for(size_t i=0; i<pprof->n_string_table; i++)
-        if(pprof->string_table[i]) {
+    if (pprof->string_table) {
+      for (size_t i = 0; i < pprof->n_string_table; i++)
+        if (pprof->string_table[i]) {
           free(pprof->string_table[i]);
           pprof->string_table[i] = NULL;
         }
@@ -606,29 +650,29 @@ char pprof_Free(DProf* dp) {
     break;
   }
 
-  if(pprof->comment) {
+  if (pprof->comment) {
     free(pprof->comment);
     pprof->comment = NULL;
   }
   return 0;
 }
 
-
 /******************************************************************************\
 |*                        Compression Helper Functions                        *|
 \******************************************************************************/
-void GZip(char* file, const char* data, const size_t sz_data) {
+void GZip(char *file, const char *data, const size_t sz_data) {
   gzFile fi = gzopen(file, "wb9");
   gzwrite(fi, data, sz_data);
   gzclose(fi);
-  struct stat st = {0}; stat(file, &st);
+  struct stat st = {0};
+  stat(file, &st);
 }
 
-size_t pprof_zip(DProf* dp, unsigned char* ret, const size_t sz_packed) {
-  PPProfile* pprof = &dp->pprof;
+size_t pprof_zip(DProf *dp, unsigned char *ret, const size_t sz_packed) {
+  PPProfile *pprof = &dp->pprof;
   // Assumes the ret buffer has already been sized to at least sz_packed
   // Serialized pprof
-  void* packed = malloc(sz_packed); // TODO check for err?
+  void *packed = malloc(sz_packed); // TODO check for err?
   perftools__profiles__profile__pack(pprof, packed);
   memset(ret, 0, sz_packed);
 
@@ -637,7 +681,8 @@ size_t pprof_zip(DProf* dp, unsigned char* ret, const size_t sz_packed) {
                  .avail_out = sz_packed,
                  .next_in = packed,
                  .next_out = ret};
-  deflateInit2(&zs, Z_BEST_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+  deflateInit2(&zs, Z_BEST_COMPRESSION, Z_DEFLATED, 15 + 16, 8,
+               Z_DEFAULT_STRATEGY);
   deflate(&zs, Z_FINISH);
   deflateEnd(&zs);
   free(packed);

--- a/src/native/proto/.clang-format
+++ b/src/native/proto/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/src/native/string_table.c
+++ b/src/native/string_table.c
@@ -3,16 +3,16 @@
 #include "string_table.h"
 
 #ifdef D_SANITY_CHECKS
-  #include <signal.h>
+#include <signal.h>
 #endif
 
 // ONLY FOR INTERNAL USE.  ONLY.
-#define STR_LEN_PTR(x) ((uint32_t*)&(x)[-4])
+#define STR_LEN_PTR(x) ((uint32_t *)&(x)[-4])
 #define STR_LEN(x) (*STR_LEN_PTR(x))
 
 #ifdef D_LOGGING_ENABLE
-#include <unistd.h>
 #include <stdio.h>
+#include <unistd.h>
 #endif
 
 /* TODO
@@ -26,14 +26,13 @@
 \******************************************************************************/
 // ---- djb2
 // NB, this is not a sophisticated hashing strategy.
-uint32_t djb2_hash(unsigned char* str, size_t len) {
+uint32_t djb2_hash(unsigned char *str, size_t len) {
   uint32_t ret = 5381;
 
-  for(;len;len--)
+  for (; len; len--)
     ret = ((ret << 5) + ret) + *str++;
   return ret;
 }
-
 
 // The below section as per https://github.com/wangyi-fudan/wyhash
 /******************************************************************************\
@@ -43,72 +42,115 @@ uint32_t djb2_hash(unsigned char* str, size_t len) {
 #include <stdint.h>
 #include <string.h>
 #ifndef WYHASH32_BIG_ENDIAN
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return v;}
+static inline unsigned _wyr32(const uint8_t *p) {
+  unsigned v;
+  memcpy(&v, p, 4);
+  return v;
+}
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
+static inline unsigned _wyr32(const uint8_t *p) {
+  unsigned v;
+  memcpy(&v, p, 4);
+  return __builtin_bswap32(v);
+}
 #elif defined(_MSC_VER)
-static inline unsigned _wyr32(const uint8_t *p) { unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v);}
+static inline unsigned _wyr32(const uint8_t *p) {
+  unsigned v;
+  memcpy(&v, p, 4);
+  return _byteswap_ulong(v);
+}
 #endif
-static inline unsigned _wyr24(const uint8_t *p, unsigned k) { return (((unsigned)p[0])<<16)|(((unsigned)p[k>>1])<<8)|p[k-1];}
-static inline void _wymix32(unsigned  *A,  unsigned  *B){
-  uint64_t  c=*A^0x53c5ca59u;  c*=*B^0x74743c1bu;
-  *A=(unsigned)c;
-  *B=(unsigned)(c>>32);
+static inline unsigned _wyr24(const uint8_t *p, unsigned k) {
+  return (((unsigned)p[0]) << 16) | (((unsigned)p[k >> 1]) << 8) | p[k - 1];
+}
+static inline void _wymix32(unsigned *A, unsigned *B) {
+  uint64_t c = *A ^ 0x53c5ca59u;
+  c *= *B ^ 0x74743c1bu;
+  *A = (unsigned)c;
+  *B = (unsigned)(c >> 32);
 }
 static inline unsigned wyhash32(const void *key, uint64_t len, unsigned seed) {
-  const uint8_t *p=(const uint8_t *)key; uint64_t i=len;
-  unsigned see1=(unsigned)len; seed^=(unsigned)(len>>32); _wymix32(&seed, &see1);
-  for(;i>8;i-=8,p+=8){  seed^=_wyr32(p); see1^=_wyr32(p+4); _wymix32(&seed, &see1); }
-  if(i>=4){ seed^=_wyr32(p); see1^=_wyr32(p+i-4); } else if (i) seed^=_wyr24(p,i);
-  _wymix32(&seed, &see1); _wymix32(&seed, &see1); return seed^see1;
+  const uint8_t *p = (const uint8_t *)key;
+  uint64_t i = len;
+  unsigned see1 = (unsigned)len;
+  seed ^= (unsigned)(len >> 32);
+  _wymix32(&seed, &see1);
+  for (; i > 8; i -= 8, p += 8) {
+    seed ^= _wyr32(p);
+    see1 ^= _wyr32(p + 4);
+    _wymix32(&seed, &see1);
+  }
+  if (i >= 4) {
+    seed ^= _wyr32(p);
+    see1 ^= _wyr32(p + i - 4);
+  } else if (i)
+    seed ^= _wyr24(p, i);
+  _wymix32(&seed, &see1);
+  _wymix32(&seed, &see1);
+  return seed ^ see1;
 }
-static inline uint64_t wyrand(uint64_t *seed){
-  *seed+=0xa0761d6478bd642full;
-  uint64_t  see1=*seed^0xe7037ed1a0b428dbull;
-  see1*=(see1>>32)|(see1<<32);
-  return  (*seed*((*seed>>32)|(*seed<<32)))^((see1>>32)|(see1<<32));
+static inline uint64_t wyrand(uint64_t *seed) {
+  *seed += 0xa0761d6478bd642full;
+  uint64_t see1 = *seed ^ 0xe7037ed1a0b428dbull;
+  see1 *= (see1 >> 32) | (see1 << 32);
+  return (*seed * ((*seed >> 32) | (*seed << 32))) ^
+      ((see1 >> 32) | (see1 << 32));
 }
-static inline unsigned wy32x32(unsigned a,  unsigned  b) { _wymix32(&a,&b); _wymix32(&a,&b); return a^b;  }
-static inline float wy2u01(unsigned r) { const float _wynorm=1.0f/(1ull<<23); return (r>>9)*_wynorm;}
-static inline float wy2gau(unsigned r) { const float _wynorm=1.0f/(1ull<<9); return ((r&0x3ff)+((r>>10)&0x3ff)+((r>>20)&0x3ff))*_wynorm-3.0f;}
+static inline unsigned wy32x32(unsigned a, unsigned b) {
+  _wymix32(&a, &b);
+  _wymix32(&a, &b);
+  return a ^ b;
+}
+static inline float wy2u01(unsigned r) {
+  const float _wynorm = 1.0f / (1ull << 23);
+  return (r >> 9) * _wynorm;
+}
+static inline float wy2gau(unsigned r) {
+  const float _wynorm = 1.0f / (1ull << 9);
+  return ((r & 0x3ff) + ((r >> 10) & 0x3ff) + ((r >> 20) & 0x3ff)) * _wynorm -
+      3.0f;
+}
 
-static inline unsigned wyhash32(const void*, uint64_t, unsigned);
-uint32_t wyhash_hash(unsigned char* str, size_t len) {
+static inline unsigned wyhash32(const void *, uint64_t, unsigned);
+uint32_t wyhash_hash(unsigned char *str, size_t len) {
   static unsigned seed = 3913693727; // random large 32-bit prime
-  return wyhash32((const void*)str, len, seed);
+  return wyhash32((const void *)str, len, seed);
 }
 /******************************************************************************\
 |*                   End of Inlined wyhash32 Implementation                   *|
 \******************************************************************************/
 
-
 /******************************************************************************\
 |*                           Internal Declarations                            *|
 \******************************************************************************/
-static StringTableArena* _StringTableArena_init(StringTableArena*);
-//static char _StringTableArena_expand(StringTableArena*);
-static void _StringTableArena_free(StringTableArena*);
-static char _StringTableArena_reserve(StringTableArena*, size_t);
-//static unsigned char*_StringTableArena_insert(StringTableArena*, unsigned char*, size_t);
+static StringTableArena *_StringTableArena_init(StringTableArena *);
+// static char _StringTableArena_expand(StringTableArena*);
+static void _StringTableArena_free(StringTableArena *);
+static char _StringTableArena_reserve(StringTableArena *, size_t);
+// static unsigned char*_StringTableArena_insert(StringTableArena*, unsigned
+// char*, size_t);
 
-static StringTableNodes* _StringTableNodes_init(StringTableNodes*);
-//static char _StringTableNodes_expand(StringTableNodes*);
-static void _StringTableNodes_free(StringTableNodes*);
-static char _StringTableNodes_reserve(StringTableNodes*);
-//static char _StringTableNodes_insert(StringTableNodes*, unsigned char*, ssize_t);
-static StringTableNode* _StringTableNodes_get(StringTableNodes*, unsigned char*, size_t, uint32_t*, HashFun);
+static StringTableNodes *_StringTableNodes_init(StringTableNodes *);
+// static char _StringTableNodes_expand(StringTableNodes*);
+static void _StringTableNodes_free(StringTableNodes *);
+static char _StringTableNodes_reserve(StringTableNodes *);
+// static char _StringTableNodes_insert(StringTableNodes*, unsigned char*,
+// ssize_t);
+static StringTableNode *_StringTableNodes_get(StringTableNodes *,
+                                              unsigned char *, size_t,
+                                              uint32_t *, HashFun);
 
-//static char _StringTable_table_init(StringTable*);
-//static char _StringTable_table_expand(StringTable*);
-//static void _StringTable_table_free(StringTable*);
-//static ssize_t _StringTable_table_add(StringTable*, unsigned char*);
-
+// static char _StringTable_table_init(StringTable*);
+// static char _StringTable_table_expand(StringTable*);
+// static void _StringTable_table_free(StringTable*);
+// static ssize_t _StringTable_table_add(StringTable*, unsigned char*);
 
 /******************************************************************************\
 |*                              StringTableArena                              *|
 \******************************************************************************/
 #define STA_ALIGNMENT_MASK 15ull
-#define STA_ALIGN(x) ((__typeof__(x))(((uint64_t)(x)+STA_ALIGNMENT_MASK) &~STA_ALIGNMENT_MASK))
+#define STA_ALIGN(x)                                                           \
+  ((__typeof__(x))(((uint64_t)(x) + STA_ALIGNMENT_MASK) & ~STA_ALIGNMENT_MASK))
 
 /*******************************************************************************
  * Initializes a StringTableArena.
@@ -118,16 +160,19 @@ static StringTableNode* _StringTableNodes_get(StringTableNodes*, unsigned char*,
  *            internal.  Internal objects are freed by the library on
  *            _StringTableArena_free().
  ******************************************************************************/
-static StringTableArena* _StringTableArena_init(StringTableArena* sta) {
-  unsigned char* sta_buf = calloc(1, ST_ARENA_SIZE);
-  if(!sta_buf) goto STA_INIT_CLEANUP00;
+static StringTableArena *_StringTableArena_init(StringTableArena *sta) {
+  unsigned char *sta_buf = calloc(1, ST_ARENA_SIZE);
+  if (!sta_buf)
+    goto STA_INIT_CLEANUP00;
 
-  unsigned char** entry_buf = calloc(sizeof(unsigned char*), ST_ARENA_NELEM);
-  if(!entry_buf) goto STA_INIT_CLEANUP01;
+  unsigned char **entry_buf = calloc(sizeof(unsigned char *), ST_ARENA_NELEM);
+  if (!entry_buf)
+    goto STA_INIT_CLEANUP01;
 
-  if(!sta) {
+  if (!sta) {
     sta = calloc(1, sizeof(StringTableArena));
-    if(!sta) goto STA_INIT_CLEANUP02;
+    if (!sta)
+      goto STA_INIT_CLEANUP02;
     sta->ownership = 1;
   }
 
@@ -151,7 +196,6 @@ STA_INIT_CLEANUP00:
   return NULL;
 }
 
-
 /*******************************************************************************
  * Frees a StringTableArena.
  *
@@ -161,10 +205,10 @@ STA_INIT_CLEANUP00:
  *
  * @param sta An initialized StringTableArena
  ******************************************************************************/
-static void _StringTableArena_free(StringTableArena* sta) {
-  for(int i=0; i<32; i++)
-    if(sta->regions[i])
-      free(sta->regions[i]), sta->regions[i]=NULL;
+static void _StringTableArena_free(StringTableArena *sta) {
+  for (int i = 0; i < 32; i++)
+    if (sta->regions[i])
+      free(sta->regions[i]), sta->regions[i] = NULL;
 
   free(sta->entry);
 
@@ -176,7 +220,7 @@ static void _StringTableArena_free(StringTableArena* sta) {
   sta->entry_capacity = 0;
   sta->entry_idx = 0;
 
-  if(sta->ownership)
+  if (sta->ownership)
     free(sta);
 }
 
@@ -185,11 +229,12 @@ static void _StringTableArena_free(StringTableArena* sta) {
  *
  * @param sta An initialized StringTableArena
  ******************************************************************************/
-static char _StringTableArena_expandar(StringTableArena* sta) {
+static char _StringTableArena_expandar(StringTableArena *sta) {
   // NB, there are various inefficiencies with this implementation for multi-
   // scale allocations.  TODO
-  unsigned char* buf = calloc(2*sizeof(unsigned char), sta->capacity);
-  if(!buf) return -1;
+  unsigned char *buf = calloc(2 * sizeof(unsigned char), sta->capacity);
+  if (!buf)
+    return -1;
 
   sta->arena = buf;
   sta->regions[sta->filled_regions++] = buf;
@@ -203,15 +248,16 @@ static char _StringTableArena_expandar(StringTableArena* sta) {
  *
  * @param sta An initialized StringTableArena
  ******************************************************************************/
-static char _StringTableArena_expandcap(StringTableArena* sta) {
-  unsigned char** buf = realloc(sta->entry, 2*sizeof(unsigned char*)*sta->entry_capacity);
-  if(!buf) return -1;
+static char _StringTableArena_expandcap(StringTableArena *sta) {
+  unsigned char **buf =
+      realloc(sta->entry, 2 * sizeof(unsigned char *) * sta->entry_capacity);
+  if (!buf)
+    return -1;
 
   sta->entry = buf;
   sta->entry_capacity *= 2;
   return 0;
 }
-
 
 // TODO something is wrong with these reservation functions
 
@@ -230,16 +276,20 @@ static char _StringTableArena_expandcap(StringTableArena* sta) {
  *
  * @param length how much space is requested
  ******************************************************************************/
-static char _StringTableArena_reserve(StringTableArena* sta, size_t length) {
-  if(length > ST_ARENA_SIZE) return -1; // Will not grant oversized reservations
+static char _StringTableArena_reserve(StringTableArena *sta, size_t length) {
+  if (length > ST_ARENA_SIZE)
+    return -1; // Will not grant oversized reservations
 
   // Check whether the arena has capacity
-  if(STA_ALIGN(sta->arena_off + length + 1  + sizeof(uint32_t)) >= sta->capacity)
-    if(_StringTableArena_expandar(sta)) return -1;
+  if (STA_ALIGN(sta->arena_off + length + 1 + sizeof(uint32_t)) >=
+      sta->capacity)
+    if (_StringTableArena_expandar(sta))
+      return -1;
 
   // Check whether the entries has capacity
-  if(sta->entry_idx >= sta->entry_capacity)
-    if(_StringTableArena_expandcap(sta)) return -1;
+  if (sta->entry_idx >= sta->entry_capacity)
+    if (_StringTableArena_expandcap(sta))
+      return -1;
 
   return 0;
 }
@@ -261,33 +311,35 @@ static char _StringTableArena_reserve(StringTableArena* sta, size_t length) {
  * @param sz_val the size of the value in bytes.  Does not need to be aligned
  *        size, as that is handled during append
  ******************************************************************************/
-static ssize_t _StringTableArena_append(StringTableArena* sta, unsigned char* val, size_t sz_val) {
+static ssize_t _StringTableArena_append(StringTableArena *sta,
+                                        unsigned char *val, size_t sz_val) {
   // If the total size exceeds the minimum arena size, then we could either
   // silently truncate or we could throw an error.  Right now, we silently
   // truncate.  TODO OOB logs
   // ASSERT ?alloc aligns to word-boundaries, which should be true on x86_64
   size_t sz_total = STA_ALIGN(sz_val + sizeof(uint32_t) + 1);
-  if(sz_total > ST_ARENA_SIZE)
+  if (sz_total > ST_ARENA_SIZE)
     sz_val = ST_ARENA_SIZE; // if we subtract 5 bytes, it'll just realign
 
   // Ensure we have enough space for both the arena and the entries
-  if(-1 == _StringTableArena_reserve(sta, sz_val))
+  if (-1 == _StringTableArena_reserve(sta, sz_val))
     return -1;
 
   // Compute several constants related to setting up the arena
-  unsigned char* dst = &sta->arena[sta->arena_off];   // Top of the object
-  unsigned char* arena_ptr = dst + sizeof(uint32_t);  // What we return
-  uint32_t write_len = sz_val;                        // Size after padding
+  unsigned char *dst = &sta->arena[sta->arena_off];  // Top of the object
+  unsigned char *arena_ptr = dst + sizeof(uint32_t); // What we return
+  uint32_t write_len = sz_val;                       // Size after padding
 
 #ifdef D_SANITY_CHECKS
-  if(STA_ALIGN(dst) != dst)
+  if (STA_ALIGN(dst) != dst)
     printf("NOT ALIGNED\n"), raise(SIGINT);
-  if(sz_total & STA_ALIGNMENT_MASK)
+  if (sz_total & STA_ALIGNMENT_MASK)
     printf("LENGTH NOT ALIGNED\n"), raise(SIGINT);
 #endif
 
   // Copy the 4-byte header (length) TODO this can overrun?
-  memcpy(dst, &write_len, sizeof(uint32_t));  dst += sizeof(uint32_t);
+  memcpy(dst, &write_len, sizeof(uint32_t));
+  dst += sizeof(uint32_t);
 
   // Copy the string (either whole or truncated)
   memcpy(dst, val, sz_val);
@@ -303,7 +355,6 @@ static ssize_t _StringTableArena_append(StringTableArena* sta, unsigned char* va
   return ret;
 }
 
-
 /******************************************************************************\
 |*                              StringTableNodes                              *|
 \******************************************************************************/
@@ -314,21 +365,25 @@ static ssize_t _StringTableArena_append(StringTableArena* sta, unsigned char* va
  *
  * @param stn An uninitialized StringTableNodes object
  ******************************************************************************/
-static StringTableNodes* _StringTableNodes_init(StringTableNodes* stn) {
-  StringTableNode* stn_buf = calloc(sizeof(StringTableNode), ST_ARENA_NELEM);
-  if(!stn_buf) goto STN_INIT_CLEANUP00;
+static StringTableNodes *_StringTableNodes_init(StringTableNodes *stn) {
+  StringTableNode *stn_buf = calloc(sizeof(StringTableNode), ST_ARENA_NELEM);
+  if (!stn_buf)
+    goto STN_INIT_CLEANUP00;
 
-  StringTableNode** entry_buf = calloc(sizeof(StringTableNode*), ST_ARENA_NELEM);
-  if(!entry_buf) goto STN_INIT_CLEANUP01;
+  StringTableNode **entry_buf =
+      calloc(sizeof(StringTableNode *), ST_ARENA_NELEM);
+  if (!entry_buf)
+    goto STN_INIT_CLEANUP01;
 
-  if(!stn) {
+  if (!stn) {
     stn = calloc(1, sizeof(StringTableNodes));
-    if(!stn) goto STN_INIT_CLEANUP02;
+    if (!stn)
+      goto STN_INIT_CLEANUP02;
     stn->ownership = 1;
   }
 
   stn->arena = stn_buf;
-  stn->sz_region[0]   = ST_ARENA_NELEM;
+  stn->sz_region[0] = ST_ARENA_NELEM;
   stn->regions[0] = stn_buf;
   stn->capacity = ST_ARENA_NELEM;
   stn->arena_off = 0;
@@ -356,9 +411,10 @@ STN_INIT_CLEANUP00:
  *
  * @param stn An initialized StringTableNodes
  ******************************************************************************/
-static void _StringTableNodes_free(StringTableNodes* stn) {
-  for(int i=0; i<32; i++)
-    if(stn->regions[i]) free(stn->regions[i]), stn->regions[i]=NULL;
+static void _StringTableNodes_free(StringTableNodes *stn) {
+  for (int i = 0; i < 32; i++)
+    if (stn->regions[i])
+      free(stn->regions[i]), stn->regions[i] = NULL;
 
   free(stn->entry);
 
@@ -370,7 +426,7 @@ static void _StringTableNodes_free(StringTableNodes* stn) {
   stn->entry_capacity = 0;
   stn->entry_count = 0;
 
-  if(stn->ownership)
+  if (stn->ownership)
     free(stn);
 }
 
@@ -379,9 +435,10 @@ static void _StringTableNodes_free(StringTableNodes* stn) {
  *
  * @param stn An initialized StringTableNodes
  ******************************************************************************/
-static char _StringTableNodes_expandar(StringTableNodes* stn) {
-  StringTableNode* buf = calloc(2*sizeof(StringTableNode), stn->capacity);
-  if(!buf) return -1;
+static char _StringTableNodes_expandar(StringTableNodes *stn) {
+  StringTableNode *buf = calloc(2 * sizeof(StringTableNode), stn->capacity);
+  if (!buf)
+    return -1;
 
   stn->arena = buf;
   stn->capacity *= 2;
@@ -401,26 +458,30 @@ static char _StringTableNodes_expandar(StringTableNodes* stn) {
  *
  * @param stn An initialized StringTableNodes
  ******************************************************************************/
-static char _StringTableNodes_expandcap(StringTableNodes* stn) {
-  StringTableNode** buf = calloc(2*stn->entry_capacity, sizeof(StringTableNode*));
-  if(!buf) return -1;
+static char _StringTableNodes_expandcap(StringTableNodes *stn) {
+  StringTableNode **buf =
+      calloc(2 * stn->entry_capacity, sizeof(StringTableNode *));
+  if (!buf)
+    return -1;
   stn->entry_capacity *= 2;
   stn->entry_count = 0;
 
   // Iterate through the regions, re-inserting every individual element...
-  StringTableNode* node = NULL;
+  StringTableNode *node = NULL;
   uint32_t hash_val;
-  for(uint64_t i = 0; i < stn->filled_regions; i++) {
-    for(uint32_t j = 0; j < stn->sz_region[i]; j++) {
+  for (uint64_t i = 0; i < stn->filled_regions; i++) {
+    for (uint32_t j = 0; j < stn->sz_region[i]; j++) {
       node = &stn->regions[i][j];
-      if(!node->value) continue;
+      if (!node->value)
+        continue;
       node->next = NULL;
       hash_val = wyhash_hash(node->value, STR_LEN(node->value));
       uint32_t idx = hash_val & (stn->entry_capacity - 1);
-      StringTableNode* that_node = buf[idx];
+      StringTableNode *that_node = buf[idx];
 
-      if(that_node) {
-        while(that_node->next) that_node = that_node->next;
+      if (that_node) {
+        while (that_node->next)
+          that_node = that_node->next;
         that_node->next = node;
       } else {
         stn->entry_count++;
@@ -434,7 +495,6 @@ static char _StringTableNodes_expandcap(StringTableNodes* stn) {
   return 0;
 }
 
-
 /*******************************************************************************
  * Reserve space on a StringTableNodes object
  *
@@ -444,12 +504,14 @@ static char _StringTableNodes_expandcap(StringTableNodes* stn) {
  *
  * @param stn An initialized StringTableNodes
  ******************************************************************************/
-static char _StringTableNodes_reserve(StringTableNodes* stn) {
-  if(stn->arena_off >= stn->capacity)
-    if(_StringTableNodes_expandar(stn)) return -1;
+static char _StringTableNodes_reserve(StringTableNodes *stn) {
+  if (stn->arena_off >= stn->capacity)
+    if (_StringTableNodes_expandar(stn))
+      return -1;
 
-  if(stn->entry_count*2 > stn->entry_capacity)
-    if(_StringTableNodes_expandcap(stn)) return -1;
+  if (stn->entry_count * 2 > stn->entry_capacity)
+    if (_StringTableNodes_expandcap(stn))
+      return -1;
   return 0;
 }
 
@@ -472,20 +534,22 @@ static char _StringTableNodes_reserve(StringTableNodes* stn) {
  *            underlying function is not currently a property of the
  *            StringTableNodes object, but rather the containing struct.
  *****************************************************************************/
-inline static StringTableNode* _StringTableNodes_get(StringTableNodes* stn, unsigned char* val, size_t sz_val, uint32_t* hash, HashFun fun) {
+inline static StringTableNode *
+_StringTableNodes_get(StringTableNodes *stn, unsigned char *val, size_t sz_val,
+                      uint32_t *hash, HashFun fun) {
   uint32_t hash_val;
 
-  if(hash)
+  if (hash)
     hash_val = *hash;
-  else if(fun)
+  else if (fun)
     hash_val = fun(val, sz_val);
   else
     return NULL; // No hash and can't compute it
 
   // Now look it up
-  StringTableNode* node = stn->entry[hash_val & (stn->entry_capacity - 1)];
-  while(node) {
-    if(sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val)) {
+  StringTableNode *node = stn->entry[hash_val & (stn->entry_capacity - 1)];
+  while (node) {
+    if (sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val)) {
       return node;
     }
     node = node->next;
@@ -497,21 +561,22 @@ inline static StringTableNode* _StringTableNodes_get(StringTableNodes* stn, unsi
 /******************************************************************************\
 |*                                 Public API                                 *|
 \******************************************************************************/
-ssize_t stringtable_add(StringTable* st, unsigned char* val, size_t sz_val) {
+ssize_t stringtable_add(StringTable *st, unsigned char *val, size_t sz_val) {
   // Compute hash
   uint32_t hash_val;
   uint64_t stashed_capacity = st->nodes->entry_capacity;
-  if(!st->hash_fun) return -1;
+  if (!st->hash_fun)
+    return -1;
   hash_val = st->hash_fun(val, sz_val);
 
   // Now we can hash into a node to see whether one exists
-  StringTableNode* node = st->nodes->entry[hash_val & (stashed_capacity - 1)];
-  StringTableNode* node_prev = NULL;
+  StringTableNode *node = st->nodes->entry[hash_val & (stashed_capacity - 1)];
+  StringTableNode *node_prev = NULL;
 
   // Either find a matching node and return the index or run into an empty node
   // and quit.
-  while(node) {
-    if(sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val))
+  while (node) {
+    if (sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val))
       return node->idx;
     node_prev = node;
     node = node->next;
@@ -520,21 +585,21 @@ ssize_t stringtable_add(StringTable* st, unsigned char* val, size_t sz_val) {
   // Node doesn't exist, which means the value is novel in the arena and thus
   // needs to be added.  We start out by reserving enough room for both the
   // string arena itself and for the hashtable nodes.  If
-  if(-1 == _StringTableArena_reserve(st->arena, sz_val))
+  if (-1 == _StringTableArena_reserve(st->arena, sz_val))
     return -1;
-  if(-1 == _StringTableNodes_reserve(st->nodes))
+  if (-1 == _StringTableNodes_reserve(st->nodes))
     return -1;
 
   // It's possible that we rehashed in the last step, so refresh the lookup
   // because the capacity may have changed
-  if(stashed_capacity != st->nodes->entry_capacity) {
+  if (stashed_capacity != st->nodes->entry_capacity) {
     node = st->nodes->entry[hash_val & (st->nodes->entry_capacity - 1)];
     node_prev = NULL;
 
-    // Either find a matching node and return the index or run into an empty node
-    // and quit.
-    while(node) {
-      if(sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val))
+    // Either find a matching node and return the index or run into an empty
+    // node and quit.
+    while (node) {
+      if (sz_val == STR_LEN(node->value) && !memcmp(val, node->value, sz_val))
         return node->idx;
       node_prev = node;
       node = node->next;
@@ -543,10 +608,10 @@ ssize_t stringtable_add(StringTable* st, unsigned char* val, size_t sz_val) {
 
   // Now add the object into the arena and check consistency
   ssize_t arena_idx = _StringTableArena_append(st->arena, val, sz_val);
-  if(-1 == arena_idx)
+  if (-1 == arena_idx)
     return -1;
-  unsigned char* arena_ptr = st->arena->entry[arena_idx];
-  if(!arena_ptr)
+  unsigned char *arena_ptr = st->arena->entry[arena_idx];
+  if (!arena_ptr)
     return -1;
 
   // At this point, we have what we need to populate a node and we've reserved
@@ -559,7 +624,7 @@ ssize_t stringtable_add(StringTable* st, unsigned char* val, size_t sz_val) {
   // Now we need to either add the node to the entries or as a child of a
   // different node.  When we looked it up, we kept track of whether we
   // terminated immediately or after visiting a parent.
-  if(!node_prev) {
+  if (!node_prev) {
     st->nodes->entry_count++;
     st->nodes->entry[hash_val & (st->nodes->entry_capacity - 1)] = node;
   } else {
@@ -569,14 +634,16 @@ ssize_t stringtable_add(StringTable* st, unsigned char* val, size_t sz_val) {
   return node->idx;
 }
 
-StringTable* stringtable_init(StringTable* ret, StringTableOptions* opts) {
-  static StringTableOptions default_opts = {.hash=1, .logging=0};
-  if(!opts) opts = &default_opts;
+StringTable *stringtable_init(StringTable *ret, StringTableOptions *opts) {
+  static StringTableOptions default_opts = {.hash = 1, .logging = 0};
+  if (!opts)
+    opts = &default_opts;
 
   // If the user gave us a NULL pointer, then return a substantial one
-  if(!ret) {
+  if (!ret) {
     ret = calloc(1, sizeof(StringTable));
-    if(!ret) goto STRING_TABLE_INIT_CLEANUP00;
+    if (!ret)
+      goto STRING_TABLE_INIT_CLEANUP00;
     ret->ownership = 1;
   }
 
@@ -585,15 +652,17 @@ StringTable* stringtable_init(StringTable* ret, StringTableOptions* opts) {
   ret->hash_fun = opts->hash ? wyhash_hash : djb2_hash;
 
   // Run internal initializers
-  if(!(ret->arena = _StringTableArena_init(NULL))) goto STRING_TABLE_INIT_CLEANUP01;
-  if(!(ret->nodes = _StringTableNodes_init(NULL))) goto STRING_TABLE_INIT_CLEANUP02;
+  if (!(ret->arena = _StringTableArena_init(NULL)))
+    goto STRING_TABLE_INIT_CLEANUP01;
+  if (!(ret->nodes = _StringTableNodes_init(NULL)))
+    goto STRING_TABLE_INIT_CLEANUP02;
 
   return ret;
 
 STRING_TABLE_INIT_CLEANUP02:
   _StringTableArena_free(ret->arena);
 STRING_TABLE_INIT_CLEANUP01:
-  if(ret->ownership) {
+  if (ret->ownership) {
     free(ret);
     ret = NULL;
   }
@@ -601,28 +670,32 @@ STRING_TABLE_INIT_CLEANUP00:
   return NULL;
 }
 
-void stringtable_free(StringTable* st) {
-  _StringTableArena_free(st->arena); st->arena = NULL;
-  _StringTableNodes_free(st->nodes); st->nodes = NULL;
+void stringtable_free(StringTable *st) {
+  _StringTableArena_free(st->arena);
+  st->arena = NULL;
+  _StringTableNodes_free(st->nodes);
+  st->nodes = NULL;
 
-  if(st->ownership)
+  if (st->ownership)
     free(st);
 }
 
-ssize_t stringtable_lookup(StringTable* st, unsigned char* val, size_t sz_val, uint32_t* hash) {
-  StringTableNode* node = _StringTableNodes_get(st->nodes, val, sz_val, hash, st->hash_fun);
+ssize_t stringtable_lookup(StringTable *st, unsigned char *val, size_t sz_val,
+                           uint32_t *hash) {
+  StringTableNode *node =
+      _StringTableNodes_get(st->nodes, val, sz_val, hash, st->hash_fun);
 
   return (!node) ? -1 : node->idx;
 }
 
-unsigned char* stringtable_get(StringTable* st, ssize_t idx) {
+unsigned char *stringtable_get(StringTable *st, ssize_t idx) {
   return st->arena->entry[idx];
 }
 
-ssize_t stringtable_lookup_cstr(StringTable* st, char* str) {
-  return stringtable_lookup(st, (unsigned char*)str, strlen(str), NULL);
+ssize_t stringtable_lookup_cstr(StringTable *st, char *str) {
+  return stringtable_lookup(st, (unsigned char *)str, strlen(str), NULL);
 }
 
-ssize_t stringtable_add_cstr(StringTable* st, char* str){
-  return stringtable_add(st, (unsigned char*)str, strlen(str));
+ssize_t stringtable_add_cstr(StringTable *st, char *str) {
+  return stringtable_add(st, (unsigned char *)str, strlen(str));
 }


### PR DESCRIPTION
### Description

This adjusts the `.clang-format` file and runs it across the project. A few notes on options:

- `AlignOperands: DontAlign` is there mostly because it formats ternary statements quite poorly without it.
- `AllowShortBlocksOnASingleLine: true` is supposed to permit things like `if (cond) { return; }` on a single line, but it doesn't seem to work most of the time.

Let me know if you see anything related to code style you don't like and I can try to adjust the options more.