### PR TITLE
fix clang-format installation after circleci image update to buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,8 @@ jobs:
           command: |
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
               (
-                echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main"
-                echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main"
+                echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main"
+                echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main"
               ) | sudo tee /etc/apt/sources.list.d/llvm-toolchain.list
               sudo apt-get update
               sudo apt-get -y install clang-format


### PR DESCRIPTION
### Description

Image `circleci/php:7.2-cli-node-browsers` that we use in CI to run `clang-format` checks are on buster now, apparently from a while. Possibly, some cache recently expired in CircleCI and with the updates we are no longer able to install `clang-format` using the old repositories.

```
$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
This PR updates the llvm.org repositories urls for [buster/clang-format-12](https://apt.llvm.org/) based on the recommended urls from docs.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
