### PR TITLE
add missing dependency on curl extension for PHP 8

### DIFF
--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -1638,7 +1638,14 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_SUB_NS_FE("Testing\\", trigger_error, arginfo_ddtrace_testing_trigger_error),
     DDTRACE_FE_END};
 
-zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER,
+static const zend_module_dep ddtrace_deps[] = {
+    ZEND_MOD_REQUIRED("curl")
+    ZEND_MOD_END
+};
+
+zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX,
+                                          NULL,
+                                          ddtrace_deps,
                                           PHP_DDTRACE_EXTNAME,
                                           ddtrace_functions,
                                           PHP_MINIT(ddtrace),


### PR DESCRIPTION
Without **curl** extension, extension load fails with "undefined symbol: curl_multi_ce" (PHP 8 only , build with --enable-rtld-now) so will segfault on standard build when curl extension is build shared and not loaded.

PHP 5 and 7 are not affected as this symbol is not used