### PR TITLE
Fix linting + xfail a flaky test

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.6.list
+++ b/dockerfiles/ci/xfail_tests/5.6.list
@@ -264,6 +264,7 @@ ext/standard/tests/serialize/bug70219_1.phpt
 ext/standard/tests/serialize/serialization_objects_007.phpt
 ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/substr_compare.phpt
+sapi/cli/tests/upload_2G.phpt
 tests/basic/027.phpt
 tests/classes/__call_004.phpt
 tests/classes/__call_005.phpt

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -1638,10 +1638,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_SUB_NS_FE("Testing\\", trigger_error, arginfo_ddtrace_testing_trigger_error),
     DDTRACE_FE_END};
 
-static const zend_module_dep ddtrace_deps[] = {
-    ZEND_MOD_REQUIRED("curl")
-    ZEND_MOD_END
-};
+static const zend_module_dep ddtrace_deps[] = {ZEND_MOD_REQUIRED("curl") ZEND_MOD_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX,
                                           NULL,


### PR DESCRIPTION
### Description

Just a quick cleanup PR to fix linting on PHP 8 and xfail a flaky test on PHP 5.6 (already on the xfail list for PHP 7+).