### PR TITLE
Add consecutive bitfield alignment to clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,5 @@
 BasedOnStyle: LLVM
 AlignOperands: DontAlign
 AllowShortBlocksOnASingleLine: true
+AlignConsecutiveBitFields: true
 ---


### PR DESCRIPTION
Several of the shared libraries pack optional parameters into bitfields.  I don't anticipate these to change too often, but when they do it's nice to be able to eyeball the diffs, which is a little harder to do when the indentations are all over the place.

### Description
This is a stylistic change for the build system.  Just an idea.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
