### PR TITLE
Add configured http headers to root span

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -50,4 +50,5 @@
     <exclude-pattern>tests/overhead/*</exclude-pattern>
     <exclude-pattern>tests/Frameworks/*/Version_*/*</exclude-pattern>
     <exclude-pattern>tests/AutoInstrumentation</exclude-pattern>
+    <exclude-pattern>tmp</exclude-pattern>
 </ruleset>

--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -365,6 +365,6 @@ function ddtrace_config_http_headers()
         function ($header) {
             return \strtolower($header);
         },
-        \_ddtrace_config_indexed_array(\getenv('DD_TRACE_HTTP_HEADERS'), [])
+        \_ddtrace_config_indexed_array(\getenv('DD_TRACE_HEADER_TAGS'), [])
     );
 }

--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -355,3 +355,16 @@ function ddtrace_config_service_mapping()
 {
     return \_ddtrace_config_associative_array(\getenv('DD_SERVICE_MAPPING'), []);
 }
+
+/**
+ * Returns the list of header names to be added as a tag to the root span. Header names are converted to lowercase.
+ */
+function ddtrace_config_http_headers()
+{
+    return array_map(
+        function ($header) {
+            return \strtolower($header);
+        },
+        \_ddtrace_config_indexed_array(\getenv('DD_TRACE_HTTP_HEADERS'), [])
+    );
+}

--- a/tests/Frameworks/Custom/Version_Not_Autoloaded/Headers/index.php
+++ b/tests/Frameworks/Custom/Version_Not_Autoloaded/Headers/index.php
@@ -1,0 +1,6 @@
+<?php
+
+header('tHird-HEaDer   : separated: with  : colon     ');
+header('should-not-be-included: a value');
+
+echo "web page";

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\NotAutoloaded;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Not_Autoloaded/Headers/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE' => 'my-service',
+            'DD_TRACE_HTTP_HEADERS' => '  fIrSt-HEADER   ,  SECOND-header  , third-HEADER , FORTH-HEADER',
+        ]);
+    }
+
+    public function testSelectedHeadersAreIncluded()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create(
+                'First request: Startup logs test',
+                '/',
+                [
+                    'first-Header: some value: with colon',
+                    'FORTH-header: 123',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'web.request',
+                    'my-service',
+                    'web',
+                    'GET /'
+                )->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/',
+                    'http.status_code' => 200,
+                    'http.request.headers.first-header' => 'some value: with colon',
+                    'http.request.headers.forth-header' => '123',
+                    'http.response.headers.third-header' => 'separated: with  : colon',
+                ]),
+            ]
+        );
+    }
+}

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -17,7 +17,7 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'my-service',
-            'DD_TRACE_HTTP_HEADERS' => '  fIrSt-HEADER   ,  SECOND-header  , third-HEADER , FORTH-HEADER',
+            'DD_TRACE_HEADER_TAGS' => '  fIrSt-HEADER   ,  SECOND-header  , third-HEADER , FORTH-HEADER',
         ]);
     }
 

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\NotAutoloaded;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class HttpHeadersNotConfiguredTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Not_Autoloaded/Headers/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_SERVICE' => 'my-service',
+        ]);
+    }
+
+    public function testSelectedHeadersAreIncluded()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $spec = GetSpec::create(
+                'First request: Startup logs test',
+                '/',
+                [
+                    'first-Header: some value: with colon',
+                    'FORTH-header: 123',
+                ]
+            );
+            $this->call($spec);
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'web.request',
+                    'my-service',
+                    'web',
+                    'GET /'
+                )->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/',
+                    'http.status_code' => 200,
+                ]),
+            ]
+        );
+    }
+}

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -46,6 +46,7 @@ EOD;
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
         putenv('DD_TRACE_SLIM_ENABLED');
+        putenv('DD_TRACE_HTTP_HEADERS');
         putenv('DD_VERSION');
     }
 
@@ -448,15 +449,15 @@ EOD;
             ],
             'one service mapping' => [
                 'service1:service2',
-                [ 'service1' => 'service2' ],
+                ['service1' => 'service2'],
             ],
             'multiple service mappings' => [
                 'service1:service2,service3:service4',
-                [ 'service1' => 'service2', 'service3' => 'service4' ],
+                ['service1' => 'service2', 'service3' => 'service4'],
             ],
             'tolerant to extra whitespace' => [
                 'service1 :    service2 ,         service3 : service4                    ',
-                [ 'service1' => 'service2', 'service3' => 'service4' ],
+                ['service1' => 'service2', 'service3' => 'service4'],
             ],
         ];
     }
@@ -568,5 +569,28 @@ EOD;
             'DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST=true',
         ]);
         $this->assertTrue(\ddtrace_config_redis_client_split_by_host_enabled());
+    }
+
+    public function testHttpHeadersDefaultsToEmpty()
+    {
+        $this->assertEmpty(\ddtrace_config_http_headers());
+    }
+
+    public function testHttpHeadersCanSetOne()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_HTTP_HEADERS=A-Header',
+        ]);
+        $this->assertSame(['a-header'], \ddtrace_config_http_headers());
+    }
+
+    public function testHttpHeadersCanSetMultiple()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_HTTP_HEADERS=A-Header   ,Any-Name    ,    cOn7aining-!spe_cial?:ch/ars    ',
+        ]);
+        // Same behavior as python tracer:
+        // https://github.com/DataDog/dd-trace-py/blob/f1298cb8100f146059f978b58c88641bd7424af8/ddtrace/http/headers.py
+        $this->assertSame(['a-header', 'any-name', 'con7aining-!spe_cial?:ch/ars'], \ddtrace_config_http_headers());
     }
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -46,7 +46,7 @@ EOD;
         putenv('DD_TRACE_SAMPLE_RATE');
         putenv('DD_TRACE_SAMPLING_RULES');
         putenv('DD_TRACE_SLIM_ENABLED');
-        putenv('DD_TRACE_HTTP_HEADERS');
+        putenv('DD_TRACE_HEADER_TAGS');
         putenv('DD_VERSION');
     }
 
@@ -579,7 +579,7 @@ EOD;
     public function testHttpHeadersCanSetOne()
     {
         $this->putEnvAndReloadConfig([
-            'DD_TRACE_HTTP_HEADERS=A-Header',
+            'DD_TRACE_HEADER_TAGS=A-Header',
         ]);
         $this->assertSame(['a-header'], \ddtrace_config_http_headers());
     }
@@ -587,7 +587,7 @@ EOD;
     public function testHttpHeadersCanSetMultiple()
     {
         $this->putEnvAndReloadConfig([
-            'DD_TRACE_HTTP_HEADERS=A-Header   ,Any-Name    ,    cOn7aining-!spe_cial?:ch/ars    ',
+            'DD_TRACE_HEADER_TAGS=A-Header   ,Any-Name    ,    cOn7aining-!spe_cial?:ch/ars    ',
         ]);
         // Same behavior as python tracer:
         // https://github.com/DataDog/dd-trace-py/blob/f1298cb8100f146059f978b58c88641bd7424af8/ddtrace/http/headers.py


### PR DESCRIPTION
### Description

This PR adds the possibility to define a list of http headers names that are set on the root span.
Headers values are separated by request and response headers and the configuration variable is unique. 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
