### PR TITLE
Avoid repetition of same substitution pattern while writing randomized tests templates

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -33,7 +33,7 @@
         <exclude-pattern>tests/Integrations/PHPRedis/V5/*Test.php</exclude-pattern>
         <exclude-pattern>tests/randomized/analyze-results.php</exclude-pattern>
         <exclude-pattern>tests/randomized/generate-scenarios.php</exclude-pattern>
-        <exclude-pattern>tests/randomized/lib/RequestTargetsGenerator.php</exclude-pattern>
+        <exclude-pattern>tests/randomized/lib/*</exclude-pattern>
     </rule>
 
     <!-- PHP compatibility checks -->

--- a/tests/randomized/lib/ApacheConfigGenerator.php
+++ b/tests/randomized/lib/ApacheConfigGenerator.php
@@ -2,30 +2,31 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class ApacheConfigGenerator
 {
     public function generate($destination, array $envs, array $inis)
     {
-        $envsString = "";
+        $substitutions = [
+            'envs' => '',
+            'inis' => '',
+        ];
         foreach ($envs as $envName => $envValue) {
-            $envsString .= "    SetEnv $envName \"$envValue\"\n";
+            $substitutions['envs'] .= "    SetEnv $envName \"$envValue\"\n";
         }
-        $inisString = "";
         foreach ($inis as $iniName => $iniValue) {
             if (is_bool($iniValue)) {
-                $inisString .= sprintf("    php_admin_flag %s %s\n", $iniName, $iniValue ? 'on' : 'off');
+                $substitutions['inis'] .= sprintf("    php_admin_flag %s %s\n", $iniName, $iniValue ? 'on' : 'off');
             } else {
-                $inisString .= sprintf("    php_admin_value %s %s\n", $iniName, $iniValue);
+                $substitutions['inis'] .= sprintf("    php_admin_value %s %s\n", $iniName, $iniValue);
             }
         }
-        $template = \file_get_contents(__DIR__ . '/templates/apache.template.conf');
-        file_put_contents(
+
+        Utils::writeTemplate(
             $destination,
-            str_replace(
-                ['{{envs}}', '{{inis}}'],
-                [$envsString, $inisString],
-                $template
-            )
+            __DIR__ . '/templates/apache.template.conf',
+            $substitutions
         );
     }
 }

--- a/tests/randomized/lib/DockerComposeFileGenerator.php
+++ b/tests/randomized/lib/DockerComposeFileGenerator.php
@@ -2,25 +2,16 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class DockerComposeFileGenerator
 {
     public function generate($destination, array $substitutions)
     {
-        $needles = \array_map(
-            function ($key) {
-                return "{{{$key}}}";
-            },
-            array_keys($substitutions)
-        );
-        $replaces = array_values($substitutions);
-
-        file_put_contents(
+        Utils::writeTemplate(
             $destination,
-            \str_replace(
-                $needles,
-                $replaces,
-                file_get_contents(__DIR__ . '/templates/docker-compose.template.yml')
-            )
+            __DIR__ . '/templates/docker-compose.template.yml',
+            $substitutions
         );
     }
 }

--- a/tests/randomized/lib/EnvFileGenerator.php
+++ b/tests/randomized/lib/EnvFileGenerator.php
@@ -2,17 +2,18 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class EnvFileGenerator
 {
     public function generate($destination, $scenarioName)
     {
-        file_put_contents(
+        Utils::writeTemplate(
             $destination,
-            \str_replace(
-                ['{{scenario_name}}'],
-                [$scenarioName],
-                file_get_contents(__DIR__ . '/templates/.env.template')
-            )
+            __DIR__ . '/templates/.env.template',
+            [
+                'scenario_name' => $scenarioName,
+            ]
         );
     }
 }

--- a/tests/randomized/lib/MakefileGenerator.php
+++ b/tests/randomized/lib/MakefileGenerator.php
@@ -2,6 +2,8 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class MakefileGenerator
 {
     public function generate($destination, array $scenarioNames)
@@ -17,14 +19,13 @@ class MakefileGenerator
                 )
             )
         );
-        $template = \file_get_contents(__DIR__ . '/templates/Makefile.template');
-        file_put_contents(
+
+        Utils::writeTemplate(
             $destination,
-            str_replace(
-                ['{{test_targets}}'],
-                [$targetsString],
-                $template
-            )
+            __DIR__ . '/templates/Makefile.template',
+            [
+                'test_targets' => $targetsString,
+            ]
         );
     }
 }

--- a/tests/randomized/lib/MakefileScenarioGenerator.php
+++ b/tests/randomized/lib/MakefileScenarioGenerator.php
@@ -2,18 +2,18 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class MakefileScenarioGenerator
 {
     public function generate($destination, $scenarioName)
     {
-        $template = \file_get_contents(__DIR__ . '/templates/Makefile.scenario.template');
-        file_put_contents(
+        Utils::writeTemplate(
             $destination,
-            str_replace(
-                ['{{scenario_name}}'],
-                [$scenarioName],
-                $template
-            )
+            __DIR__ . '/templates/Makefile.scenario.template',
+            [
+                'scenario_name' => $scenarioName,
+            ]
         );
     }
 }

--- a/tests/randomized/lib/PhpFpmConfigGenerator.php
+++ b/tests/randomized/lib/PhpFpmConfigGenerator.php
@@ -2,30 +2,31 @@
 
 namespace RandomizedTests\Tooling;
 
+require_once __DIR__ . '/Utils.php';
+
 class PhpFpmConfigGenerator
 {
     public function generate($destination, array $envs, array $inis)
     {
-        $envsString = "";
+        $substitutions = [
+            'envs' => '',
+            'inis' => '',
+        ];
         foreach ($envs as $envName => $envValue) {
-            $envsString .= "env[$envName] = \"$envValue\"\n";
+            $substitutions['envs'] .= "env[$envName] = \"$envValue\"\n";
         }
-        $inisString = "";
         foreach ($inis as $iniName => $iniValue) {
             if (is_bool($iniValue)) {
-                $inisString .= sprintf("php_admin_flag[%s] = %s\n", $iniName, $iniValue ? 'on' : 'off');
+                $substitutions['inis'] .= sprintf("php_admin_flag[%s] = %s\n", $iniName, $iniValue ? 'on' : 'off');
             } else {
-                $inisString .= sprintf("php_admin_value[%s] = \"%s\"\n", $iniName, $iniValue);
+                $substitutions['inis'] .= sprintf("php_admin_value[%s] = \"%s\"\n", $iniName, $iniValue);
             }
         }
-        $template = \file_get_contents(__DIR__ . '/templates/php-fpm.template.conf');
-        file_put_contents(
+
+        Utils::writeTemplate(
             $destination,
-            str_replace(
-                ['{{envs}}', '{{inis}}'],
-                [$envsString, $inisString],
-                $template
-            )
+            __DIR__ . '/templates/php-fpm.template.conf',
+            $substitutions
         );
     }
 }

--- a/tests/randomized/lib/RequestTargetsGenerator.php
+++ b/tests/randomized/lib/RequestTargetsGenerator.php
@@ -2,7 +2,7 @@
 
 namespace RandomizedTests\Tooling;
 
-require_once __dir__ . '/Utils.php';
+require_once __DIR__ . '/Utils.php';
 
 use RandomizedTests\Tooling\Utils;
 

--- a/tests/randomized/lib/Utils.php
+++ b/tests/randomized/lib/Utils.php
@@ -14,4 +14,30 @@ class Utils
     {
         return rand(0, 100) <= $percent;
     }
+
+    /**
+     * Creates a $destination file from a template at $template after replacing $substitutions.
+     *
+     * @param string $destination Abs path to the file where the result will be saved.
+     * @param string $template Abs path of the template file containing mustache-like '{{name}}' substitutions.
+     * @param array $substitutions Associative array ['substitution_name' => 'substitution_value'].
+     */
+    public static function writeTemplate($destination, $template, array $substitutions = [])
+    {
+        $needles = \array_map(
+            function ($key) {
+                return "{{{$key}}}";
+            },
+            array_keys($substitutions)
+        );
+        $replaces = array_values($substitutions);
+        file_put_contents(
+            $destination,
+            \str_replace(
+                $needles,
+                $replaces,
+                \file_get_contents($template)
+            )
+        );
+    }
 }


### PR DESCRIPTION
### Description

This PR (a followup to #1153) moves some common patterns, specifically substitutions replacement in templates and final file generation, to a dedicated method shared across all template generators. This idea comes from [a very good point](https://github.com/DataDog/dd-trace-php/pull/1153#discussion_r581361649) made by @SammyK during a code review.

Here are a few design considerations. None of them is untouchable, of course:

- I didn't create a base generator class as I feel would have increased complexity not for a good reason, instead I created a utility function in `Utils`. If things get more complicated we can think if of an abstract base class.
- I did not use directly the utility function in `generate-scenario.php`. Instead I kept the generator even if the generator is just a proxy to the utility function. I made this decision so we do not leak the template name and location to the user.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
