### PR TITLE
[Tracer] Add runtime id, components, and plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,6 +900,24 @@ jobs:
             make -j
             make test
 
+      - run:
+          name: Build and test Datadog::PHP::Components
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/DatadogPHPComponents
+            cd /tmp/build/DatadogPHPComponents
+            if [ -f "/etc/debian_version" ]
+            then
+              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+            fi
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              $toolchain \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_TESTING=ON \
+              ~/datadog/components
+            make -j
+            make test
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -1063,7 +1081,7 @@ workflows:
                 - "datadog/dd-trace-ci:alpine"
                 - "datadog/dd-trace-ci:buster"
               cmake_version:
-                - "3.10.3"
+                - "3.13.5"
                 - "3.18.4"
               catch2_version:
                 - "2.4.2"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
-C_FILES := $(shell find ext src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
+C_FILES := $(shell find components ext plugins src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 INIT_HOOK_TEST_FILES := $(shell find tests/C2PHP -name '*.phpt' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 M4_FILES := $(shell find m4 -name '*.m4*' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Need CMake 3.13 for installing targets from subdirectories
+cmake_minimum_required(VERSION 3.13)
+
+project(DatadogPHPComponents
+  VERSION 0.1.0
+  LANGUAGES C
+)
+
+option(BUILD_COMPONENTS_TESTING "Enable tests" OFF)
+if (${BUILD_COMPONENTS_TESTING})
+  # Tests uses the C++ testing framework Catch2
+  enable_language(CXX)
+
+  # The Catch2::Catch2 target has been available since 2.1.2
+  # dd-trace-cpp uses Catch2 2.4 at this time, so we can require at least 2.4
+  find_package(Catch2 2.4 REQUIRED)
+
+  #[[ This file takes a while to build, so we do it once here and every test
+      executable can link to it to save time.
+  ]]
+  add_library(catch2_main catch2_main.cc)
+  target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
+  target_compile_features(catch2_main PUBLIC cxx_std_11)
+
+  include(Catch)
+  enable_testing()
+endif()
+
+include(GNUInstallDirs)
+
+add_subdirectory(string_view)
+add_subdirectory(uuid)
+
+add_library(DatadogPHPComponents INTERFACE)
+
+target_link_libraries(DatadogPHPComponents
+  INTERFACE DatadogPHPStringView DatadogPHPUUID
+)
+
+install(
+  TARGETS DatadogPHPComponents DatadogPHPStringView DatadogPHPUUID
+  EXPORT DatadogPHPComponentsTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT DatadogPHPComponentsTargets
+  FILE DatadogPHPComponentsTargets.cmake
+  NAMESPACE Datadog::PHP::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)

--- a/components/catch2_main.cc
+++ b/components/catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(DatadogPHPStringView string_view.c)
+
+target_include_directories(DatadogPHPStringView
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(DatadogPHPStringView
+  PUBLIC c_std_99
+)
+
+set_target_properties(DatadogPHPStringView PROPERTIES
+  OUTPUT_NAME datadog_php_string_view
+  VERSION ${PROJECT_VERSION}
+)
+
+add_library(Datadog::PHP::StringView
+  ALIAS DatadogPHPStringView
+)
+
+if (${BUILD_COMPONENTS_TESTING})
+  add_subdirectory(test)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/string_view/
+)

--- a/components/string_view/string_view.c
+++ b/components/string_view/string_view.c
@@ -1,0 +1,15 @@
+#include "string_view.h"
+
+#include <string.h>
+
+datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]) {
+    datadog_php_string_view string_view = {
+        .len = cstr ? strlen(cstr) : 0,
+        .ptr = cstr,
+    };
+    return string_view;
+}
+
+bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b) {
+    return a.len == b.len && (a.ptr == b.ptr || memcmp(a.ptr, b.ptr, b.len) == 0);
+}

--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -1,0 +1,40 @@
+#ifndef DATADOG_PHP_STRING_VIEW_H
+#define DATADOG_PHP_STRING_VIEW_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * A string view is a non-owning view into another string. The original string
+ * should not be changed from the view.
+ */
+typedef struct datadog_php_string_view {
+    size_t len;
+    const char *ptr;
+} datadog_php_string_view;
+
+/* Used to initialize an empty string e.g.
+ *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+ */
+#define DATADOG_PHP_STRING_VIEW_INIT \
+    { 0, NULL }
+
+/**
+ * Creates a string view from a C string, which is an array of characters which
+ * is terminated by a null string. Derives the length from strlen. `cstr` may be
+ * null, in which case the `.len` will be 0.
+ * @param cstr
+ * @return
+ */
+datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]);
+
+/**
+ * Compares the views `a` and `b` for equality. Note that the `.ptr` value of
+ * the views will be ignored when `.len` is 0.
+ * @param a
+ * @param b
+ * @return
+ */
+bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b);
+
+#endif  // DATADOG_PHP_STRING_VIEW_H

--- a/components/string_view/test/CMakeLists.txt
+++ b/components/string_view/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(string_view string_view.cc)
+
+target_link_libraries(string_view
+  PUBLIC catch2_main Datadog::PHP::StringView
+)
+
+catch_discover_tests(string_view)

--- a/components/string_view/test/string_view.cc
+++ b/components/string_view/test/string_view.cc
@@ -1,0 +1,59 @@
+extern "C" {
+#include "string_view/string_view.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("string_view init", "[string_view]") {
+    datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+
+    REQUIRE(str.len == 0);
+    REQUIRE(str.ptr == NULL);
+}
+
+TEST_CASE("string_view cstrings", "[string_view]") {
+    datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+    REQUIRE(empty.len == 0);
+    REQUIRE(empty.ptr[0] == '\0');
+
+    datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+    REQUIRE(nil.len == 0);
+    REQUIRE(nil.ptr == NULL);
+
+    datadog_php_string_view abc = datadog_php_string_view_from_cstr("abc");
+    REQUIRE(abc.len == 3);
+    REQUIRE(memcmp(abc.ptr, "abc", 3) == 0);
+
+    const char buff[5] = "four";
+    datadog_php_string_view four = datadog_php_string_view_from_cstr(buff);
+    REQUIRE(four.len == 4);
+    REQUIRE((const void*)four.ptr == (const void*)&buff);
+}
+
+TEST_CASE("string_view empty equal", "[string_view]") {
+    datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+    REQUIRE(empty.len == 0);
+    REQUIRE(empty.ptr[0] == '\0');
+
+    datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+    REQUIRE(nil.len == 0);
+    REQUIRE(nil.ptr == NULL);
+
+    REQUIRE(datadog_php_string_view_equal(empty, nil));
+}
+
+TEST_CASE("string_view equal", "[string_view]") {
+    const char buff1[] = "asdf";
+    char buff2[sizeof buff1];
+    memcpy((void*)buff2, buff1, sizeof buff1);
+
+    datadog_php_string_view str1 = datadog_php_string_view_from_cstr(buff1);
+    datadog_php_string_view str2 = datadog_php_string_view_from_cstr(buff2);
+
+    REQUIRE(datadog_php_string_view_equal(str1, str2));
+
+    // identity cases
+    REQUIRE(datadog_php_string_view_equal(str1, str1));
+    REQUIRE(datadog_php_string_view_equal(str2, str2));
+}

--- a/components/uuid/CMakeLists.txt
+++ b/components/uuid/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(DatadogPHPUUID uuid.c)
+
+target_include_directories(DatadogPHPUUID
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(DatadogPHPUUID
+  PUBLIC c_std_11
+)
+
+set_target_properties(DatadogPHPUUID PROPERTIES
+  OUTPUT_NAME datadog_php_uuid
+  VERSION ${PROJECT_VERSION}
+)
+
+add_library(Datadog::PHP::UUID
+  ALIAS DatadogPHPUUID
+)
+
+if (${BUILD_COMPONENTS_TESTING})
+  add_subdirectory(test)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/uuid.h
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uuid/
+)

--- a/components/uuid/test/CMakeLists.txt
+++ b/components/uuid/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(uuid uuid.cc)
+
+target_link_libraries(uuid
+  PUBLIC catch2_main Datadog::PHP::UUID
+)
+
+catch_discover_tests(uuid)

--- a/components/uuid/test/uuid.cc
+++ b/components/uuid/test/uuid.cc
@@ -1,0 +1,85 @@
+extern "C" {
+#include "uuid/uuid.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("uuid encode32 nil", "[uuid]") {
+    datadog_php_uuid uuid;
+    datadog_php_uuid_default_ctor(&uuid);
+
+    alignas(16) char dest[32];
+    datadog_php_uuid_encode32(uuid, dest);
+
+    alignas(16) char expect[33] = "00000000000000000000000000000000";
+    REQUIRE(memcmp(expect, dest, 32) == 0);
+}
+
+TEST_CASE("uuid encode32", "[uuid]") {
+    datadog_php_uuid uuid = {
+        {29, 202, 33, 60, 217, 201, 77, 49, 162, 30, 13, 192, 25, 215, 90, 236},
+    };
+
+    alignas(32) char dest[32];
+    datadog_php_uuid_encode32(uuid, dest);
+
+    alignas(32) char expect[33] = "1dca213cd9c94d31a21e0dc019d75aec";
+    REQUIRE(memcmp(expect, dest, 32) == 0);
+}
+
+TEST_CASE("uuid encode36", "[uuid]") {
+    datadog_php_uuid uuid = {
+        {190, 40, 194, 233, 78, 82, 76, 113, 164, 20, 69, 167, 221, 234, 5, 240},
+    };
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuid, dest);
+
+    alignas(32) char expect[37] = "be28c2e9-4e52-4c71-a414-45a7ddea05f0";
+    REQUIRE(memcmp(expect, dest, 36) == 0);
+}
+
+TEST_CASE("uuidv4 encode36 easy", "[uuid]") {
+    // this byte pattern is already a valid UUIDv4, so we won't change it
+    alignas(16) uint8_t bytes[16] = {190, 40, 194, 233, 78, 82, 76, 113, 164, 20, 69, 167, 221, 234, 5, 240};
+    datadog_php_uuid uuidv4;
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect[37] = "be28c2e9-4e52-4c71-a414-45a7ddea05f0";
+    REQUIRE(memcmp(expect, dest, 36) == 0);
+}
+
+TEST_CASE("uuidv4 encode36 bytes 6", "[uuid]") {
+    datadog_php_uuid uuidv4;
+
+    /* These tests are valid UUIDv4s except for byte 6, which we are testing
+     * that it alters correctly.
+     */
+
+    /* byte 6 is 10111111; upper bits are flipped, lower all 1s which shouldn't
+     * change at all.
+     */
+    alignas(16) uint8_t bytes[16] = {190, 40, 194, 233, 78, 82, 191, 113, 164, 20, 69, 167, 221, 234, 5, 240};
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect1[37] = "be28c2e9-4e52-4f71-a414-45a7ddea05f0";
+    REQUIRE(memcmp(expect1, dest, 36) == 0);
+
+    /* byte 6 is 10110000; upper bits are flipped, lower all 0s which shouldn't
+     * change at all.
+     */
+    bytes[6] = 176;
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect2[37] = "be28c2e9-4e52-4071-a414-45a7ddea05f0";
+    REQUIRE(memcmp(expect2, dest, 36) == 0);
+}

--- a/components/uuid/uuid.c
+++ b/components/uuid/uuid.c
@@ -1,0 +1,131 @@
+#include "uuid.h"
+
+/* The nibble_to_hex function is by Wojciech Muła. It is a SIMD friendly way to
+ * hex encode half a byte. It has BSD 2-clause "Simplified" license:
+Copyright (c) 2005-2016, Wojciech Muła
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+static char nibble_to_hex(uint8_t byte) {
+    byte &= 15u;
+
+    const char corr = 'a' - '0' - 10;
+    const char c = byte + '0';
+
+    uint8_t tmp = 128 - 10 + byte;
+    uint8_t msb = tmp & 0x80;
+
+    uint8_t mask = msb - (msb >> 7);  // 0x7f or 0x00
+
+    return c + (mask & corr);
+}
+
+void datadog_php_uuid_default_ctor(datadog_php_uuid *uuid) {
+    for (unsigned i = 0; i != 16; ++i) {
+        uuid->data[i] = 0;
+    }
+}
+
+void datadog_php_uuidv4_bytes_ctor(datadog_php_uuid *uuid, const uint8_t src[]) {
+    for (unsigned i = 0; i != 16; ++i) {
+        uuid->data[i] = src[i];
+    }
+
+    /* See RFC 4122, section 4.4
+     * Algorithms for Creating a UUID from Truly Random or Pseudo-Random Numbers
+     */
+
+    /* Set the four most significant bits (bits 12 through 15) of the
+     * time_hi_and_version field to the 4-bit version number from
+     * Section 4.1.3.
+     * ----
+     * We want this pattern, where X preserves what is there.
+     * 0100XXXX
+     */
+    uuid->data[6] = 0x40 | (uuid->data[6] & 0xf);
+
+    /* Set the two most significant bits (bits 6 and 7) of the
+     * clock_seq_hi_and_reserved to zero and one, respectively.
+     * -----
+     * We want this pattern, where X preserves what is there.
+     * 10XXXXXX
+     */
+    uuid->data[8] = 0x80 | (uuid->data[8] & 0x3f);
+}
+
+void datadog_php_uuid_encode32(datadog_php_uuid uuid, char *dest) {
+    char *out = dest;
+#if __clang__
+#pragma clang loop vectorize(enable)
+#endif
+    for (unsigned i = 0; i < 16; ++i, out += 2) {
+        uint8_t in = uuid.data[i];
+        char first = nibble_to_hex(in >> UINT8_C(4));
+        char second = nibble_to_hex(in & UINT8_C(15));
+        *out = first;
+        *(out + 1) = second;
+    }
+}
+
+/**
+ * Encodes the `uuid` into a 36 character ASCII string as defined by RFC 4122
+ * (https://tools.ietf.org/html/rfc4122#section-4.1), and stores the result in
+ * `dest`.
+ *
+ * @param dest A buffer at least 36 chars in length.
+ * @param uuid The UUID to encode.
+ */
+void datadog_php_uuid_encode36(datadog_php_uuid uuid, char *dest) {
+    /* This could be more efficient if we didn't call to encode32 and then
+     * fix it up after, but this is not performance sensitive.
+     */
+    _Alignas(16) char src[32];
+    datadog_php_uuid_encode32(uuid, src);
+
+    unsigned dest_offset = 0, src_offset = 0;
+    for (unsigned i = 0; i++ != 8; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 12; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+}

--- a/components/uuid/uuid.h
+++ b/components/uuid/uuid.h
@@ -1,0 +1,45 @@
+#ifndef DATADOG_PHP_UUID
+#define DATADOG_PHP_UUID
+
+#include <stdint.h>
+
+typedef struct datadog_php_uuid {
+    // Since this is a 16-byte type, let's use a 16 byte alignment
+    _Alignas(16) uint8_t data[16];
+} datadog_php_uuid;
+
+#define DATADOG_PHP_UUID_INIT                              \
+    {                                                      \
+        { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } \
+    }
+
+void datadog_php_uuid_default_ctor(datadog_php_uuid *);
+
+/**
+ * Creates a UUIDv4 from the provided bytes. This decouples the UUIDv4
+ * invariants from the algorithm that generates random numbers, so be cautious
+ * that you pass random bytes to it (or are testing specific bit patterns).
+ *
+ * @param uuid
+ * @param src At least 16 random bytes
+ */
+void datadog_php_uuidv4_bytes_ctor(datadog_php_uuid *uuid, const uint8_t src[]);
+
+/**
+ * Encodes the `uuidv4` into a 32 character ASCII string.
+ * @param uuid The UUIDv4 to encode.
+ * @param dest A buffer at least 32 chars in length.
+ */
+void datadog_php_uuid_encode32(datadog_php_uuid uuid, char *dest);
+
+/**
+ * Encodes the `uuidv4` into a 36 character ASCII string as defined by RFC 4122
+ * (https://tools.ietf.org/html/rfc4122#section-4.1), and stores the result in
+ * `dest`.
+ *
+ * @param uuid The UUIDv4 to encode.
+ * @param dest A buffer at least 36 chars in length.
+ */
+void datadog_php_uuid_encode36(datadog_php_uuid uuid, char *dest);
+
+#endif  // DATADOG_PHP_UUID

--- a/config.m4
+++ b/config.m4
@@ -40,6 +40,14 @@ if test "$PHP_DDTRACE" != "no"; then
     src/dogstatsd/client.c \
   "
 
+  DD_TRACE_COMPONENT_SOURCES="\
+    components/uuid/uuid.c \
+  "
+
+  DD_TRACE_PLUGIN_SOURCES="\
+    plugins/runtime_id_plugin/runtime_id_plugin.c \
+  "
+
   PHP_VERSION_ID=$($PHP_CONFIG --vernum)
 
   if test $PHP_VERSION_ID -lt 50500; then
@@ -184,7 +192,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
   fi
 
-  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
+  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_COMPONENT_SOURCES $DD_TRACE_PLUGIN_SOURCES $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
   PHP_ADD_BUILD_DIR($ext_builddir/ext, 1)
 
   PHP_CHECK_LIBRARY(rt, shm_open,
@@ -199,6 +207,12 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir])
   PHP_ADD_INCLUDE([$ext_srcdir/ext])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/components])
+  PHP_ADD_BUILD_DIR([$ext_builddir/components])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/plugins])
+  PHP_ADD_BUILD_DIR([$ext_builddir/plugins])
 
   PHP_ADD_INCLUDE([$ext_srcdir/ext/vendor])
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/vendor])

--- a/plugins/plugin/plugin.h
+++ b/plugins/plugin/plugin.h
@@ -1,0 +1,54 @@
+#ifndef DATADOG_PHP_PLUGIN_H
+#define DATADOG_PHP_PLUGIN_H
+
+#include <stdbool.h>
+
+// forward declare this so this isn't tied to a specific PHP header
+struct _zend_extension;
+
+/**
+ * PLUGIN_FAILURE means something failed, but it doesn't think the failure is
+ * significant enough to abort loading/request; maybe just that feature won't
+ * work.
+ * DATADOG_PHP_PLUGIN_DISABLE_PLUGIN means serious failure occurred and the
+ * plugins recommends the extension disable itself.
+ */
+enum datadog_php_plugin_result {
+    DATADOG_PHP_PLUGIN_SUCCESS = 0,
+    DATADOG_PHP_PLUGIN_FAILURE,
+    DATADOG_PHP_PLUGIN_DISABLE_PLUGIN,
+};
+
+/* Plugins MUST set .minit and/or .startup; all other function pointers are
+ * optional. If .minit or .startup doesn't return SUCCESS then no other hooks
+ * will get called, _including the shutdown hooks_, so be sure to clean up
+ * anything you need to before returning from .minit or .startup in this case.
+ * There's a similar story for .activate and .rinit; if you return anything
+ * but SUCCESS then clean up the request globals, because .rshutdown and
+ * .deactivate will not be called.
+ */
+typedef struct datadog_php_plugin {
+    // PHP lifecycle hooks {{{
+    enum datadog_php_plugin_result (*minit)(int type, int module_number);
+    enum datadog_php_plugin_result (*startup)(struct _zend_extension);
+
+    enum datadog_php_plugin_result (*activate)(void);
+    enum datadog_php_plugin_result (*rinit)(int type, int module_number);
+
+    /* The upstream hooks here have return values, but the return value has been
+     * ignored since at least PHP 5.4, so we just return void.
+     */
+    void (*rshutdown)(int type, int module_number);
+    void (*deactivate_func_t)(void);
+
+    void (*mshutdown)(int type, int module_number);
+    void (*shutdown)(struct _zend_extension);
+    // }}} PHP lifecycle hooks
+
+    // Tracer lifecycle hooks {{{
+    // begin?
+    // post-flush?
+    // }}}
+} datadog_php_plugin;
+
+#endif  // DATADOG_PHP_PLUGIN_H

--- a/plugins/runtime_id_plugin/runtime_id_plugin.c
+++ b/plugins/runtime_id_plugin/runtime_id_plugin.c
@@ -1,0 +1,36 @@
+#include "runtime_id_plugin.h"
+
+#include <sodium.h>
+
+#include "uuid/uuid.h"
+
+datadog_php_uuid runtime_id = DATADOG_PHP_UUID_INIT;
+
+typedef enum datadog_php_plugin_result plugin_result_t;
+
+static plugin_result_t datadog_php_runtime_id_plugin_minit(int type, int module_number) {
+    (void)type;
+    (void)module_number;
+
+    if (sodium_init() == -1) {
+        return DATADOG_PHP_PLUGIN_FAILURE;
+    }
+
+    _Alignas(16) uint8_t bytes[16];
+    randombytes_buf(bytes, sizeof bytes);
+
+    datadog_php_uuidv4_bytes_ctor(&runtime_id, bytes);
+
+    return DATADOG_PHP_PLUGIN_SUCCESS;
+}
+
+static void datadog_php_runtime_id_plugin_mshutdown(int type, int module_number) {
+    (void)type;
+    (void)module_number;
+    randombytes_close();
+}
+
+datadog_php_plugin datadog_php_runtime_id_plugin = {
+    .minit = datadog_php_runtime_id_plugin_minit,
+    .mshutdown = datadog_php_runtime_id_plugin_mshutdown,
+};

--- a/plugins/runtime_id_plugin/runtime_id_plugin.h
+++ b/plugins/runtime_id_plugin/runtime_id_plugin.h
@@ -1,0 +1,8 @@
+#ifndef DATADOG_PHP_RUNTIME_ID_PLUGIN_H
+#define DATADOG_PHP_RUNTIME_ID_PLUGIN_H
+
+#include "plugin/plugin.h"
+
+extern datadog_php_plugin datadog_php_runtime_id_plugin;
+
+#endif  // DATADOG_PHP_RUNTIME_ID_PLUGIN_H


### PR DESCRIPTION
### Description

Adds top-level directories components and plugins. Components have
a single public header and their own tests. Plugins are a type of
component that are coupled to the PHP lifecycle.

The runtime id is used to associate traces to other data. It is
unique per process and should be regenerated after a fork. The
profiler will use the runtime id to associate profiles to traces.

This adds a dependency on libsodium for generating random bytes.
I expect many CI jobs will fail because of this.

This bumps the minimum version of CMake required to 3.13. The
specific feature needed is:
 - The install(TARGETS) command learned to install targets created
   outside the current directory.

This is used to install all components from the common
components/CMakeLists.txt.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.
