### PR TITLE
remove non php7 code from ext/php7 folder

### DIFF
--- a/ext/php7/arrays.c
+++ b/ext/php7/arrays.c
@@ -2,57 +2,26 @@
 
 #include <php_version.h>
 
-#if PHP_VERSION_ID < 70000
-void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
-    HashPosition pos;
-    zval **operand;
-    size_t order = 0;
-    zend_hash_internal_pointer_reset_ex(input, &pos);
-    while (zend_hash_get_current_data_ex(input, (void **)&operand, &pos) == SUCCESS) {
-        callback(*operand, order++, context);
-        zend_hash_move_forward_ex(input, &pos);
-    }
-}
-#else
 void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
     zval *item = NULL;
     size_t order = 0;
     ZEND_HASH_FOREACH_VAL(input, item) { callback(item, order++, context); }
     ZEND_HASH_FOREACH_END();
 }
-#endif
 
 void *ddtrace_hash_find_ptr(const HashTable *ht, const char *str, size_t len) {
     void *result;
-#if PHP_VERSION_ID < 70000
-    void **rv = NULL;
-    result = zend_hash_find(ht, str, len, (void **)&rv) == SUCCESS ? *rv : NULL;
-#else
     result = zend_hash_str_find_ptr(ht, str, len);
-#endif
     return result;
 }
 
 void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len) {
     void *result;
-#if PHP_VERSION_ID < 70000
-    /* The code for the PHP 7 branch will also work on PHP 5, but if we do not
-     * call emalloc and free (even if we don't end up using it), then there is
-     * a memory leak reported by PHP 5.4 and 5.6:
-     *   - 5.4: https://app.circleci.com/jobs/github/DataDog/dd-trace-php/142159
-     *   - 5.6: https://app.circleci.com/jobs/github/DataDog/dd-trace-php/142298
-     * So we always use an emalloc path until this is resolved.
-     */
-    char *lc_str = zend_str_tolower_dup(str, len);
-    result = ddtrace_hash_find_ptr(ht, lc_str, len);
-    efree(lc_str);
-#else
     // Stack allocate small strings to improve performance
     ALLOCA_FLAG(use_heap)
     // zend_str_tolower_copy will add a null terminator; leave room for it
     char *lc_str = zend_str_tolower_copy(do_alloca(len + 1, use_heap), str, len);
     result = ddtrace_hash_find_ptr(ht, lc_str, len);
     free_alloca(lc_str, use_heap);
-#endif
     return result;
 }

--- a/ext/php7/auto_flush.h
+++ b/ext/php7/auto_flush.h
@@ -3,10 +3,6 @@
 
 #include <php.h>
 
-#if PHP_VERSION_ID < 50500
-int ddtrace_flush_tracer(void);
-#else
 ZEND_RESULT_CODE ddtrace_flush_tracer(void);
-#endif
 
 #endif  // DDTRACE_AUTO_FLUSH_H

--- a/ext/php7/comms_php.c
+++ b/ext/php7/comms_php.c
@@ -17,7 +17,7 @@ static void _comms_convert_append(zval *item, size_t offset, void *context) {
     zval converted;
     TSRMLS_FETCH();
 
-    PHP7_UNUSED(offset);
+    UNUSED(offset);
 
     ddtrace_convert_to_string(&converted, item TSRMLS_CC);
     *list = curl_slist_append(*list, Z_STRVAL(converted));

--- a/ext/php7/comms_php.c
+++ b/ext/php7/comms_php.c
@@ -17,7 +17,6 @@ static void _comms_convert_append(zval *item, size_t offset, void *context) {
     zval converted;
     TSRMLS_FETCH();
 
-    PHP5_UNUSED(offset);
     PHP7_UNUSED(offset);
 
     ddtrace_convert_to_string(&converted, item TSRMLS_CC);

--- a/ext/php7/compat_string.c
+++ b/ext/php7/compat_string.c
@@ -6,17 +6,6 @@
 
 #include "compatibility.h"
 
-#if PHP_VERSION_ID < 70000
-int ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
-    va_list arg;
-    int len;
-
-    va_start(arg, format);
-    len = vspprintf(message, max_len, format, arg);
-    va_end(arg);
-    return len;
-}
-#else
 size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
     va_list arg;
     size_t len;
@@ -26,18 +15,7 @@ size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
     va_end(arg);
     return len;
 }
-#endif
 
-#if PHP_VERSION_ID < 70000
-void ddtrace_downcase_zval(zval *src) {
-    if (!src || Z_TYPE_P(src) != IS_STRING) {
-        return;
-    }
-
-    zend_str_tolower(Z_STRVAL_P(src), Z_STRLEN_P(src));
-}
-
-#else
 void ddtrace_downcase_zval(zval *src) {
     if (!src || Z_TYPE_P(src) != IS_STRING) {
         return;
@@ -47,76 +25,7 @@ void ddtrace_downcase_zval(zval *src) {
     ZVAL_STR(src, zend_string_tolower(str));
     zend_string_release(str);
 }
-#endif
 
-#if PHP_VERSION_ID < 70000
-void ddtrace_convert_to_string(zval *dst, zval *src TSRMLS_DC) {
-    switch (Z_TYPE_P(src)) {
-        case IS_BOOL:
-            if (Z_LVAL_P(src)) {
-                ZVAL_STRING(dst, "(true)", 1);
-            } else {
-                ZVAL_STRING(dst, "(false)", 1);
-            }
-            break;
-
-        case IS_NULL:
-            ZVAL_STRING(dst, "(null)", 1);
-            break;
-
-        case IS_RESOURCE:
-            Z_STRLEN_P(dst) = ddtrace_spprintf(&Z_STRVAL_P(dst), 0, "Resource id #%ld", Z_LVAL_P(src));
-            break;
-
-        case IS_LONG:
-            Z_STRLEN_P(dst) = ddtrace_spprintf(&Z_STRVAL_P(dst), 0, "%ld", Z_LVAL_P(src));
-            break;
-
-        case IS_DOUBLE:
-            Z_STRLEN_P(dst) = ddtrace_spprintf(&Z_STRVAL_P(dst), 0, "%.*G", (int)EG(precision), Z_DVAL_P(src));
-            break;
-
-        case IS_ARRAY:
-            ZVAL_STRING(dst, "Array", 1);
-            break;
-
-        case IS_OBJECT: {
-            if (Z_OBJ_HANDLER_P(src, cast_object)) {
-                if (Z_OBJ_HANDLER_P(src, cast_object)(src, dst, IS_STRING TSRMLS_CC) == SUCCESS) {
-                    return;
-                }
-            } else if (Z_OBJ_HANDLER_P(src, get)) {
-                zval *newop = Z_OBJ_HANDLER_P(src, get)(src TSRMLS_CC);
-                if (Z_TYPE_P(newop) != IS_OBJECT) {
-                    /* for safety - avoid loop */
-                    ddtrace_convert_to_string(dst, newop TSRMLS_CC);
-
-                    // I think?
-                    zval_dtor(newop);
-                    return;
-                }
-            }
-
-            char *class_name;
-            zend_uint class_name_len;
-            Z_OBJ_HANDLER_P(src, get_class_name)(src, (const char **)&class_name, &class_name_len, 0 TSRMLS_CC);
-            Z_STRLEN_P(dst) = ddtrace_spprintf(&Z_STRVAL_P(dst), 0, "object(%s)#%d", class_name, Z_OBJ_HANDLE_P(src));
-            efree(class_name);
-            break;
-        }
-
-        case IS_CONSTANT:
-        case IS_STRING:
-            ZVAL_COPY_VALUE(dst, src);
-            zval_copy_ctor(dst);
-            return;
-
-            EMPTY_SWITCH_DEFAULT_CASE()
-    }
-    Z_TYPE_P(dst) = IS_STRING;
-}
-
-#else
 /* zend_operators.h wrongfully defines _convert_to_string, so use the ddtrace
  * prefix even though its private to this translation unit */
 static zend_string *_ddtrace_convert_to_string(zval *op) {
@@ -152,11 +61,6 @@ try_again:
 
         case IS_OBJECT: {
             zval tmp;
-#if PHP_VERSION_ID >= 80000
-            if (Z_OBJ_HT_P(op)->cast_object(Z_OBJ_P(op), &tmp, IS_STRING) == SUCCESS) {
-                return Z_STR(tmp);
-            }
-#else
             if (Z_OBJ_HT_P(op)->cast_object) {
                 if (Z_OBJ_HT_P(op)->cast_object(op, &tmp, IS_STRING) == SUCCESS) {
                     return Z_STR(tmp);
@@ -169,7 +73,6 @@ try_again:
                     return str;
                 }
             }
-#endif
             zend_string *class_name = Z_OBJ_HANDLER_P(op, get_class_name)(Z_OBJ_P(op));
             zend_string *message = strpprintf(0, "object(%s)#%d", ZSTR_VAL(class_name), Z_OBJ_HANDLE_P(op));
             zend_string_release(class_name);
@@ -195,4 +98,3 @@ void ddtrace_convert_to_string(zval *dst, zval *src) {
         ZVAL_NULL(dst);
     }
 }
-#endif

--- a/ext/php7/compat_string.h
+++ b/ext/php7/compat_string.h
@@ -9,11 +9,7 @@
 void ddtrace_downcase_zval(zval *src);
 
 // ddtrace_spprintf is a replacement for zend_spprintf, since it is not exported in many versions
-#if PHP_VERSION_ID < 70000
-int ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
-#else
 size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
-#endif
 
 /**
  * dst will be IS_STRING after the call; caller must dtor.

--- a/ext/php7/compatibility.h
+++ b/ext/php7/compatibility.h
@@ -15,15 +15,6 @@
 #endif
 #endif
 
-#if PHP_VERSION_ID >= 80000
-/* BC only */
-#define TSRMLS_D void
-#define TSRMLS_DC
-#define TSRMLS_C
-#define TSRMLS_CC
-#define TSRMLS_FETCH()
-#endif
-
 #define UNUSED_1(x) (void)(x)
 #define UNUSED_2(x, y) \
     do {               \
@@ -54,37 +45,18 @@
 #define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, _4, _5, ARITY, ...) UNUSED_##ARITY
 #define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 5, 4, 3, 2, 1)(__VA_ARGS__)
 
-#if PHP_VERSION_ID < 70000
-#define PHP5_UNUSED(...) UNUSED(__VA_ARGS__)
-#define PHP7_UNUSED(...) /* unused unused */
-#else
 #define PHP5_UNUSED(...) /* unused unused */
 #define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
-#endif
 
-#if PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70300
+#if PHP_VERSION_ID < 70300
 #define GC_ADDREF(x) (++GC_REFCOUNT(x))
 #define GC_DELREF(x) (--GC_REFCOUNT(x))
 #endif
 
-#if PHP_VERSION_ID < 70000
-#define ZVAL_VARARG_PARAM(list, arg_num) (*list[arg_num])
-#define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_BOOL && Z_LVAL_P(x) == 1)
-#define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c, 1)
-#else
 #define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c)
 #define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval*)list)[arg_num]))
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
-#endif
 
-#if PHP_VERSION_ID < 50600
-#define ZEND_ARG_VARIADIC_INFO(pass_by_ref, name)
-#endif
-
-#if PHP_VERSION_ID < 70000
-typedef zval ddtrace_exception_t;
-#else
 typedef zend_object ddtrace_exception_t;
-#endif
 
 #endif  // DD_COMPATIBILITY_H

--- a/ext/php7/compatibility.h
+++ b/ext/php7/compatibility.h
@@ -45,8 +45,6 @@
 #define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, _4, _5, ARITY, ...) UNUSED_##ARITY
 #define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 5, 4, 3, 2, 1)(__VA_ARGS__)
 
-#define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
-
 #if PHP_VERSION_ID < 70300
 #define GC_ADDREF(x) (++GC_REFCOUNT(x))
 #define GC_DELREF(x) (--GC_REFCOUNT(x))

--- a/ext/php7/compatibility.h
+++ b/ext/php7/compatibility.h
@@ -45,7 +45,6 @@
 #define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, _4, _5, ARITY, ...) UNUSED_##ARITY
 #define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 5, 4, 3, 2, 1)(__VA_ARGS__)
 
-#define PHP5_UNUSED(...) /* unused unused */
 #define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
 
 #if PHP_VERSION_ID < 70300

--- a/ext/php7/configuration.c
+++ b/ext/php7/configuration.c
@@ -173,10 +173,6 @@ bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D) {
 // Get env name for <PREFIX_><INTEGRATION><_SUFFIX> (i.e. <DD_TRACE_><LARAVEL><_ENABLED>)
 size_t ddtrace_config_integration_env_name(char* name, const char* prefix, ddtrace_integration* integration,
                                            const char* suffix) {
-#if PHP_VERSION_ID >= 70000
-    ZEND_ASSERT(strlen(prefix) <= DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN);
-    ZEND_ASSERT(strlen(suffix) <= DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN);
-#endif
     return (size_t)snprintf(name, DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1, "%s%s%s", prefix, integration->name_ucase,
                             suffix);
 }

--- a/ext/php7/configuration.c
+++ b/ext/php7/configuration.c
@@ -173,6 +173,8 @@ bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D) {
 // Get env name for <PREFIX_><INTEGRATION><_SUFFIX> (i.e. <DD_TRACE_><LARAVEL><_ENABLED>)
 size_t ddtrace_config_integration_env_name(char* name, const char* prefix, ddtrace_integration* integration,
                                            const char* suffix) {
+    ZEND_ASSERT(strlen(prefix) <= DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN);
+    ZEND_ASSERT(strlen(suffix) <= DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN);
     return (size_t)snprintf(name, DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1, "%s%s%s", prefix, integration->name_ucase,
                             suffix);
 }

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -201,9 +201,6 @@ ZEND_END_ARG_INFO()
 static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, sizeof(zend_ddtrace_globals)); }
 
 static PHP_GINIT_FUNCTION(ddtrace) {
-#ifdef ZTS
-    PHP5_UNUSED(TSRMLS_C);
-#endif
 #if defined(COMPILE_DL_DDTRACE) && defined(ZTS)
     ZEND_TSRMLS_CACHE_UPDATE();
 #endif
@@ -581,7 +578,6 @@ static bool ddtrace_should_warn_legacy(void) {
 }
 
 static PHP_FUNCTION(dd_trace) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *function = NULL;
     zval *class_name = NULL;
     zval *callable = NULL;
@@ -620,7 +616,6 @@ static PHP_FUNCTION(dd_trace) {
 }
 
 static PHP_FUNCTION(trace_method) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *class_name = NULL;
     zval *function = NULL;
     zval *tracing_closure = NULL;
@@ -747,8 +742,6 @@ static PHP_FUNCTION(hook_function) {
 }
 
 static PHP_FUNCTION(additional_trace_meta) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
-
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "")) {
         ddtrace_log_debug("Unexpected parameters to DDTrace\\additional_trace_meta");
         array_init(return_value);
@@ -760,7 +753,6 @@ static PHP_FUNCTION(additional_trace_meta) {
 }
 
 static PHP_FUNCTION(trace_function) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *function = NULL;
     zval *tracing_closure = NULL;
     zval *config_array = NULL;
@@ -800,20 +792,17 @@ static PHP_FUNCTION(trace_function) {
 }
 
 static PHP_FUNCTION(dd_trace_serialize_closed_spans) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
     ddtrace_serialize_closed_spans(return_value TSRMLS_CC);
 }
 
 // Invoke the function/method from the original context
 static PHP_FUNCTION(dd_trace_forward_call) {
-    PHP5_UNUSED(ht, return_value_ptr, this_ptr, return_value_used TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     RETURN_FALSE;
 }
 
 static PHP_FUNCTION(dd_trace_env_config) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     zval *env_name = NULL;
 
@@ -831,7 +820,6 @@ static PHP_FUNCTION(dd_trace_env_config) {
 
 // This function allows untracing a function.
 static PHP_FUNCTION(dd_untrace) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable) && DDTRACE_G(disable_in_current_request)) {
@@ -859,7 +847,6 @@ static PHP_FUNCTION(dd_untrace) {
 }
 
 static PHP_FUNCTION(dd_trace_disable_in_request) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     DDTRACE_G(disable_in_current_request) = 1;
@@ -868,7 +855,6 @@ static PHP_FUNCTION(dd_trace_disable_in_request) {
 }
 
 static PHP_FUNCTION(dd_trace_reset) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
@@ -881,7 +867,6 @@ static PHP_FUNCTION(dd_trace_reset) {
 
 /* {{{ proto string dd_trace_serialize_msgpack(array trace_array) */
 static PHP_FUNCTION(dd_trace_serialize_msgpack) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
@@ -902,7 +887,6 @@ static PHP_FUNCTION(dd_trace_serialize_msgpack) {
 
 // method used to be able to easily breakpoint the execution at specific PHP line in GDB
 static PHP_FUNCTION(dd_trace_noop) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
@@ -914,7 +898,6 @@ static PHP_FUNCTION(dd_trace_noop) {
 
 /* {{{ proto int dd_trace_dd_get_memory_limit() */
 static PHP_FUNCTION(dd_trace_dd_get_memory_limit) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
 
     RETURN_LONG(ddtrace_get_memory_limit(TSRMLS_C));
@@ -922,13 +905,11 @@ static PHP_FUNCTION(dd_trace_dd_get_memory_limit) {
 
 /* {{{ proto bool dd_trace_check_memory_under_limit() */
 static PHP_FUNCTION(dd_trace_check_memory_under_limit) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
     RETURN_BOOL(ddtrace_check_memory_under_limit(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     dd_tracer_circuit_breaker_register_error();
@@ -937,7 +918,6 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     dd_tracer_circuit_breaker_register_success();
@@ -946,14 +926,12 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_can_try) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     RETURN_BOOL(dd_tracer_circuit_breaker_can_try());
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     array_init_size(return_value, 5);
@@ -969,7 +947,6 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
 typedef zend_long ddtrace_zpplong_t;
 
 static PHP_FUNCTION(ddtrace_config_app_name) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string default_str = {
         .ptr = NULL,
         .len = 0,
@@ -1010,19 +987,16 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
 }
 
 static PHP_FUNCTION(ddtrace_config_distributed_tracing_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
     RETURN_BOOL(ddtrace_config_distributed_tracing_enabled(TSRMLS_C));
 }
 
 static PHP_FUNCTION(ddtrace_config_trace_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
     RETURN_BOOL(ddtrace_config_trace_enabled(TSRMLS_C));
 }
 
 static PHP_FUNCTION(ddtrace_config_integration_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     if (!ddtrace_config_trace_enabled(TSRMLS_C)) {
         RETURN_FALSE;
     }
@@ -1034,7 +1008,6 @@ static PHP_FUNCTION(ddtrace_config_integration_enabled) {
 }
 
 static PHP_FUNCTION(integration_analytics_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string integration;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &integration.ptr, &integration.len) != SUCCESS) {
         RETURN_NULL();
@@ -1043,7 +1016,6 @@ static PHP_FUNCTION(integration_analytics_enabled) {
 }
 
 static PHP_FUNCTION(integration_analytics_sample_rate) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string integration;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &integration.ptr, &integration.len) != SUCCESS) {
         RETURN_NULL();
@@ -1052,7 +1024,6 @@ static PHP_FUNCTION(integration_analytics_sample_rate) {
 }
 
 static PHP_FUNCTION(trigger_error) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string message;
     ddtrace_zpplong_t error_type;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &message.ptr, &message.len, &error_type) != SUCCESS) {
@@ -1085,7 +1056,6 @@ static PHP_FUNCTION(trigger_error) {
 }
 
 static PHP_FUNCTION(ddtrace_init) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     if (DDTRACE_G(request_init_hook_loaded) == 1) {
         RETURN_FALSE;
     }
@@ -1108,7 +1078,6 @@ static PHP_FUNCTION(ddtrace_init) {
 }
 
 static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     char *payload = NULL;
     ddtrace_zpplong_t num_traces = 0;
     ddtrace_zppstrlen_t payload_len = 0;
@@ -1126,8 +1095,6 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
 }
 
 static PHP_FUNCTION(dd_trace_buffer_span) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
     }
@@ -1151,7 +1118,6 @@ static PHP_FUNCTION(dd_trace_buffer_span) {
 }
 
 static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     RETURN_LONG(ddtrace_coms_trigger_writer_flush());
@@ -1160,7 +1126,6 @@ static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
 #define FUNCTION_NAME_MATCHES(function) ((sizeof(function) - 1) == fn_len && strncmp(fn, function, fn_len) == 0)
 
 static PHP_FUNCTION(dd_trace_internal_fn) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     PHP7_UNUSED(execute_data);
     zval ***params = NULL;
     uint32_t params_count = 0;
@@ -1231,7 +1196,6 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
 
 /* {{{ proto string dd_trace_set_trace_id() */
 static PHP_FUNCTION(dd_trace_set_trace_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     zval *trace_id = NULL;
@@ -1252,7 +1216,6 @@ static inline void return_span_id(zval *return_value, uint64_t id) {
 
 /* {{{ proto string dd_trace_push_span_id() */
 static PHP_FUNCTION(dd_trace_push_span_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     zval *existing_id = NULL;
@@ -1268,7 +1231,6 @@ static PHP_FUNCTION(dd_trace_push_span_id) {
 
 /* {{{ proto string dd_trace_pop_span_id() */
 static PHP_FUNCTION(dd_trace_pop_span_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     uint64_t id = ddtrace_pop_span_id(TSRMLS_C);
 
@@ -1295,7 +1257,6 @@ static PHP_FUNCTION(trace_id) {
 
 /* {{{ proto string dd_trace_closed_spans_count() */
 static PHP_FUNCTION(dd_trace_closed_spans_count) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     RETURN_LONG(DDTRACE_G(closed_spans_count));
 }
@@ -1314,20 +1275,17 @@ BOOL_T ddtrace_tracer_is_limited(TSRMLS_D) {
 
 /* {{{ proto string dd_trace_tracer_is_limited() */
 static PHP_FUNCTION(dd_trace_tracer_is_limited) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     RETURN_BOOL(ddtrace_tracer_is_limited(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 /* {{{ proto string dd_trace_compile_time_microseconds() */
 static PHP_FUNCTION(dd_trace_compile_time_microseconds) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
     RETURN_LONG(ddtrace_compile_time_get(TSRMLS_C));
 }
 
 static PHP_FUNCTION(startup_logs) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     PHP7_UNUSED(execute_data);
 
     smart_str buf = {0};

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -357,10 +357,6 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         ddtrace_startup_logging_first_rinit();
     }
 
-#if PHP_MAJOR_VERSION < 7
-    DDTRACE_G(should_warn_call_depth) = ddtrace_get_bool_config("DD_TRACE_WARN_CALL_STACK_DEPTH", TRUE TSRMLS_CC);
-#endif
-
     DDTRACE_G(request_init_hook_loaded) = 0;
     if (DDTRACE_G(request_init_hook) && DDTRACE_G(request_init_hook)[0]) {
         dd_request_init_hook_rinit(TSRMLS_C);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -6,11 +6,7 @@
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
-#if PHP_VERSION_ID >= 70000
 #include <Zend/zend_smart_str.h>
-#else
-#include <Zend/zend_builtin_functions.h>
-#endif
 #include <Zend/zend_vm.h>
 #include <inttypes.h>
 #include <php.h>
@@ -20,9 +16,6 @@
 
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
-#if PHP_VERSION_ID < 70000
-#include <ext/standard/php_smart_str.h>
-#endif
 
 #include "arrays.h"
 #include "auto_flush.h"
@@ -70,15 +63,9 @@ STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateStrin
 PHP_INI_END()
 
 static int ddtrace_startup(struct _zend_extension *extension) {
-#if PHP_VERSION_ID < 80000
     ddtrace_resource = zend_get_resource_handle(extension);
 #if PHP_VERSION_ID >= 70400
     ddtrace_op_array_extension = zend_get_op_array_extension_handle();
-#endif
-#else
-    UNUSED(extension);
-    ddtrace_resource = zend_get_resource_handle(PHP_DDTRACE_EXTNAME);
-    ddtrace_op_array_extension = zend_get_op_array_extension_handle(PHP_DDTRACE_EXTNAME);
 #endif
 
     ddtrace_excluded_modules_startup();
@@ -217,7 +204,7 @@ static PHP_GINIT_FUNCTION(ddtrace) {
 #ifdef ZTS
     PHP5_UNUSED(TSRMLS_C);
 #endif
-#if PHP_VERSION_ID >= 70000 && defined(COMPILE_DL_DDTRACE) && defined(ZTS)
+#if defined(COMPILE_DL_DDTRACE) && defined(ZTS)
     ZEND_TSRMLS_CACHE_UPDATE();
 #endif
     php_ddtrace_init_globals(ddtrace_globals);
@@ -245,7 +232,6 @@ static void dd_register_span_data_ce(TSRMLS_D) {
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
 }
 
-#if PHP_VERSION_ID >= 70000
 // SpanData::$name
 zval *ddtrace_spandata_property_name(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 0); }
 // SpanData::$resource
@@ -258,41 +244,6 @@ zval *ddtrace_spandata_property_type(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ
 zval *ddtrace_spandata_property_meta(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 4); }
 // SpanData::$metrics
 zval *ddtrace_spandata_property_metrics(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 5); }
-#endif
-
-#if PHP_VERSION_ID < 70000
-static zend_object_handlers ddtrace_fatal_error_handlers;
-/* The goal is to mimic zend_default_exception_new_ex except for adding
- * DEBUG_BACKTRACE_IGNORE_ARGS to zend_fetch_debug_backtrace. We don't want the
- * args as they could leak info, and the serializer will throw them away anyway.
- * Additionally, the tests leaked an argument in zend_fetch_debug_backtrace,
- * which was the straw to break the camel's back.
- */
-static zend_object_value ddtrace_fatal_error_new(zend_class_entry *class_type TSRMLS_DC) {
-    zval obj;
-    zend_object *object;
-    zval *trace;
-
-    Z_OBJVAL(obj) = zend_objects_new(&object, class_type TSRMLS_CC);
-    Z_OBJ_HT(obj) = &ddtrace_fatal_error_handlers;
-
-    object_properties_init(object, class_type);
-
-    ALLOC_ZVAL(trace);
-    Z_UNSET_ISREF_P(trace);
-    Z_SET_REFCOUNT_P(trace, 0);
-    zend_fetch_debug_backtrace(trace, 0, DEBUG_BACKTRACE_IGNORE_ARGS, 0 TSRMLS_CC);
-
-    zend_class_entry *exception_ce = zend_exception_get_default(TSRMLS_C);
-    zend_update_property_string(exception_ce, &obj, "file", sizeof("file") - 1,
-                                zend_get_executed_filename(TSRMLS_C) TSRMLS_CC);
-    zend_update_property_long(exception_ce, &obj, "line", sizeof("line") - 1,
-                              zend_get_executed_lineno(TSRMLS_C) TSRMLS_CC);
-    zend_update_property(exception_ce, &obj, "trace", sizeof("trace") - 1, trace TSRMLS_CC);
-
-    return Z_OBJVAL(obj);
-}
-#endif
 
 /* DDTrace\FatalError */
 zend_class_entry *ddtrace_ce_fatal_error;
@@ -300,15 +251,7 @@ zend_class_entry *ddtrace_ce_fatal_error;
 static void dd_register_fatal_error_ce(TSRMLS_D) {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, "DDTrace", "FatalError", NULL);
-#if PHP_VERSION_ID < 70000
-    ddtrace_ce_fatal_error = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
-    ddtrace_ce_fatal_error->create_object = ddtrace_fatal_error_new;
-    // these mimic zend_register_default_exception
-    memcpy(&ddtrace_fatal_error_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-    ddtrace_fatal_error_handlers.clone_obj = NULL;
-#else
     ddtrace_ce_fatal_error = zend_register_internal_class_ex(&ce, zend_ce_exception TSRMLS_CC);
-#endif
 }
 
 static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
@@ -485,11 +428,7 @@ static int datadog_info_print(const char *str TSRMLS_DC) { return php_output_wri
 static void _dd_info_tracer_config(void) {
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-#if PHP_VERSION_ID >= 70000
     php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", ZSTR_VAL(buf.s));
-#else
-    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", buf.c);
-#endif
     smart_str_free(&buf);
 }
 
@@ -515,7 +454,6 @@ static void _dd_info_diagnostics_table(TSRMLS_D) {
 
     ddtrace_startup_diagnostics(ht, false);
 
-#if PHP_VERSION_ID >= 70000
     zend_string *key;
     zval *val;
     ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
@@ -536,35 +474,6 @@ static void _dd_info_diagnostics_table(TSRMLS_D) {
         }
     }
     ZEND_HASH_FOREACH_END();
-#else
-    int key_type;
-    zval **val;
-    HashPosition pos;
-    char *key;
-    uint key_len;
-    ulong num_key;
-    zend_hash_internal_pointer_reset_ex(ht, &pos);
-    while (zend_hash_get_current_data_ex(ht, (void **)&val, &pos) == SUCCESS) {
-        key_type = zend_hash_get_current_key_ex(ht, &key, &key_len, &num_key, 0, &pos);
-        if (key_type == HASH_KEY_IS_STRING) {
-            switch (Z_TYPE_PP(val)) {
-                case IS_STRING:
-                    _dd_info_diagnostics_row(key, Z_STRVAL_PP(val) TSRMLS_CC);
-                    break;
-                case IS_NULL:
-                    _dd_info_diagnostics_row(key, "NULL" TSRMLS_CC);
-                    break;
-                case IS_BOOL:
-                    _dd_info_diagnostics_row(key, Z_BVAL_PP(val) ? "true" : "false" TSRMLS_CC);
-                    break;
-                default:
-                    _dd_info_diagnostics_row(key, "{unknown type}" TSRMLS_CC);
-                    break;
-            }
-        }
-        zend_hash_move_forward_ex(ht, &pos);
-    }
-#endif
 
     php_info_print_table_row(2, "Diagnostic checks", zend_hash_num_elements(ht) == 0 ? "passed" : "failed");
 
@@ -610,7 +519,6 @@ static BOOL_T _parse_config_array(zval *config_array, zval **tracing_closure, ui
         return FALSE;
     }
 
-#if PHP_VERSION_ID >= 70000
     zval *value;
     zend_string *key;
 
@@ -659,58 +567,6 @@ static BOOL_T _parse_config_array(zval *config_array, zval **tracing_closure, ui
         }
     }
     ZEND_HASH_FOREACH_END();
-#else
-    zval **value;
-    char *string_key;
-    uint str_len;
-    HashPosition iterator;
-    zend_ulong num_key;
-    int key_type;
-    HashTable *ht = Z_ARRVAL_P(config_array);
-
-    zend_hash_internal_pointer_reset_ex(ht, &iterator);
-    while (zend_hash_get_current_data_ex(ht, (void **)&value, &iterator) == SUCCESS) {
-        key_type = zend_hash_get_current_key_ex(ht, &string_key, &str_len, &num_key, 0, &iterator);
-        if (key_type != HASH_KEY_IS_STRING || !string_key) {
-            ddtrace_log_debug("Expected config_array to be an associative array");
-            return FALSE;
-        }
-        // TODO Optimize this
-        if (strcmp("posthook", string_key) == 0) {
-            if (Z_TYPE_PP(value) == IS_OBJECT && instanceof_function(Z_OBJCE_PP(value), zend_ce_closure TSRMLS_CC)) {
-                *tracing_closure = *value;
-                *options |= DDTRACE_DISPATCH_POSTHOOK;
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an instance of Closure", string_key);
-                return FALSE;
-            }
-        } else if (strcmp("prehook", string_key) == 0) {
-            ddtrace_log_debugf("'%s' not supported on PHP 5", string_key);
-            return FALSE;
-        } else if (strcmp("innerhook", string_key) == 0) {
-            if (Z_TYPE_PP(value) == IS_OBJECT && instanceof_function(Z_OBJCE_PP(value), zend_ce_closure TSRMLS_CC)) {
-                *tracing_closure = *value;
-                *options |= DDTRACE_DISPATCH_INNERHOOK;
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an instance of Closure", string_key);
-                return FALSE;
-            }
-        } else if (strcmp("instrument_when_limited", string_key) == 0) {
-            if (Z_TYPE_PP(value) == IS_LONG) {
-                if (Z_LVAL_PP(value)) {
-                    *options |= DDTRACE_DISPATCH_INSTRUMENT_WHEN_LIMITED;
-                }
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an int", string_key);
-                return FALSE;
-            }
-        } else {
-            ddtrace_log_debugf("Unknown option '%s' in config_array", string_key);
-            return FALSE;
-        }
-        zend_hash_move_forward_ex(ht, &iterator);
-    }
-#endif
     if (!*tracing_closure) {
         ddtrace_log_debug("Required key 'posthook', 'prehook' or 'innerhook' not found in config_array");
         return FALSE;
@@ -804,101 +660,6 @@ static PHP_FUNCTION(trace_method) {
     RETURN_BOOL(rv);
 }
 
-#if PHP_VERSION_ID < 70000
-/* Note that on PHP 5 we bind $this on the callbacks. If we don't then the VM
- * will set the static flag on the closure in certain circumstances. For
- * example, if a tracing closure is defined inside another closure that has a
- * scope, then the tracing closure will get created as static and will be
- * unable to bind to $this, as static closures cannot be bound to objects --
- * at least in PHP 5.
- *
- * In PHP 7 we don't bind $this as we want only public access.
- */
-static PHP_FUNCTION(hook_method) {
-    ddtrace_string classname = {.ptr = NULL, .len = 0};
-    ddtrace_string funcname = {.ptr = NULL, .len = 0};
-    zval *prehook = NULL, *posthook = NULL;
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
-
-    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "ss|O!O!", &classname.ptr,
-                                 &classname.len, &funcname.ptr, &funcname.len, &prehook, zend_ce_closure, &posthook,
-                                 zend_ce_closure) != SUCCESS) {
-        ddtrace_log_debug(
-            "Unable to parse parameters for DDTrace\\hook_method; expected "
-            "(string $class_name, string $method_name, ?Closure $prehook = NULL, ?Closure $posthook = NULL)");
-        RETURN_FALSE;
-    }
-
-    if (prehook && posthook) {
-        // both callbacks given; not yet supported
-        ddtrace_log_debug(
-            "DDTrace\\hook_method was given both prehook and posthook. This is not yet supported; ignoring call.");
-        RETURN_FALSE;
-    }
-
-    if (!prehook && !posthook) {
-        ddtrace_log_debug("DDTrace\\hook_method was given neither prehook nor posthook.");
-        RETURN_FALSE;
-    }
-
-    // at this point we know we have a posthook XOR posthook
-    zval *callable = prehook ?: posthook;
-    uint32_t options = (prehook ? DDTRACE_DISPATCH_PREHOOK : DDTRACE_DISPATCH_POSTHOOK) | DDTRACE_DISPATCH_NON_TRACING;
-
-    // todo: stop duplicating strings everywhere...
-    zval *class_name_zv = NULL, *method_name_zv = NULL;
-    MAKE_STD_ZVAL(class_name_zv);
-    MAKE_STD_ZVAL(method_name_zv);
-    ZVAL_STRINGL(class_name_zv, classname.ptr, classname.len, 1);
-    ZVAL_STRINGL(method_name_zv, funcname.ptr, funcname.len, 1);
-
-    zend_bool rv = ddtrace_trace(class_name_zv, method_name_zv, callable, options TSRMLS_CC);
-
-    zval_ptr_dtor(&method_name_zv);
-    zval_ptr_dtor(&class_name_zv);
-
-    RETURN_BOOL(rv);
-}
-
-static PHP_FUNCTION(hook_function) {
-    ddtrace_string funcname = {.ptr = NULL, .len = 0};
-    zval *prehook = NULL, *posthook = NULL;
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
-
-    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "s|O!O!", &funcname.ptr,
-                                 &funcname.len, &prehook, zend_ce_closure, &posthook, zend_ce_closure) != SUCCESS) {
-        ddtrace_log_debug(
-            "Unable to parse parameters for DDTrace\\hook_function; expected "
-            "(string $method_name, ?Closure $prehook = NULL, ?Closure $posthook = NULL)");
-        RETURN_FALSE;
-    }
-
-    if (prehook && posthook) {
-        // both callbacks given; not yet supported
-        ddtrace_log_debug(
-            "DDTrace\\hook_function was given both prehook and posthook. This is not yet supported; ignoring call.");
-        RETURN_FALSE;
-    }
-
-    if (!prehook && !posthook) {
-        ddtrace_log_debug("DDTrace\\hook_function was given neither prehook nor posthook.");
-        RETURN_FALSE;
-    }
-
-    // at this point we know we have a posthook XOR posthook
-    zval *callable = prehook ?: posthook;
-    uint32_t options = (prehook ? DDTRACE_DISPATCH_PREHOOK : DDTRACE_DISPATCH_POSTHOOK) | DDTRACE_DISPATCH_NON_TRACING;
-
-    zval *function_name_zv = NULL;
-    MAKE_STD_ZVAL(function_name_zv);
-    ZVAL_STRINGL(function_name_zv, funcname.ptr, funcname.len, 1);
-
-    zend_bool rv = ddtrace_trace(NULL, function_name_zv, callable, options TSRMLS_CC);
-
-    zval_ptr_dtor(&function_name_zv);
-    RETURN_BOOL(rv);
-}
-#else
 /*
  * In PHP 7 we don't bind $this as we want only public access.
  * In PHP 5 we have to bind $this; see PHP5's hook_method for details.
@@ -984,7 +745,6 @@ static PHP_FUNCTION(hook_function) {
 
     RETURN_BOOL(ddtrace_trace(NULL, &function_name_zv, callable, options TSRMLS_CC));
 }
-#endif
 
 static PHP_FUNCTION(additional_trace_meta) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
@@ -1092,11 +852,7 @@ static PHP_FUNCTION(dd_untrace) {
     }
 
     if (DDTRACE_G(function_lookup)) {
-#if PHP_VERSION_ID < 70000
-        zend_hash_del(DDTRACE_G(function_lookup), Z_STRVAL_P(function), Z_STRLEN_P(function));
-#else
         zend_hash_del(DDTRACE_G(function_lookup), Z_STR_P(function));
-#endif
     }
 
     RETURN_BOOL(1);
@@ -1210,11 +966,7 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
     return;
 }
 
-#if PHP_VERSION_ID < 70000
-typedef long ddtrace_zpplong_t;
-#else
 typedef zend_long ddtrace_zpplong_t;
-#endif
 
 static PHP_FUNCTION(ddtrace_config_app_name) {
     PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
@@ -1222,11 +974,6 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
         .ptr = NULL,
         .len = 0,
     };
-#if PHP_VERSION_ID < 70000
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &default_str.ptr, &default_str.len) != SUCCESS) {
-        RETURN_NULL();
-    }
-#else
     zend_string *default_zstr = NULL;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|S", &default_zstr) != SUCCESS) {
         RETURN_NULL();
@@ -1235,7 +982,6 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
         default_str.ptr = ZSTR_VAL(default_zstr);
         default_str.len = ZSTR_LEN(default_zstr);
     }
-#endif
 
     ddtrace_string app_name =
         ddtrace_string_getenv_multi(ZEND_STRL("DD_SERVICE"), ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
@@ -1252,16 +998,12 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
     }
 
     ddtrace_string trimmed = ddtrace_trim(app_name);
-#if PHP_VERSION_ID < 70000
-    RETVAL_STRINGL(trimmed.ptr, trimmed.len, 1);
-#else
     // Re-use and addref the default_zstr iff they match and trim didn't occur; copy otherwise
     if (default_zstr && trimmed.ptr == ZSTR_VAL(default_zstr) && trimmed.len == ZSTR_LEN(default_zstr)) {
         RETVAL_STR_COPY(default_zstr);
     } else {
         RETVAL_STRINGL(trimmed.ptr, trimmed.len);
     }
-#endif
     if (should_free_app_name) {
         efree(app_name.ptr);
     }
@@ -1485,11 +1227,6 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
             RETVAL_TRUE;
         }
     }
-#if PHP_VERSION_ID < 70000
-    if (params_count > 0) {
-        efree(params);
-    }
-#endif
 }
 
 /* {{{ proto string dd_trace_set_trace_id() */
@@ -1510,11 +1247,7 @@ static PHP_FUNCTION(dd_trace_set_trace_id) {
 static inline void return_span_id(zval *return_value, uint64_t id) {
     char buf[DD_TRACE_MAX_ID_LEN + 1];
     snprintf(buf, sizeof(buf), "%" PRIu64, id);
-#if PHP_VERSION_ID >= 70000
     RETURN_STRING(buf);
-#else
-    RETURN_STRING(buf, 1);
-#endif
 }
 
 /* {{{ proto string dd_trace_push_span_id() */
@@ -1599,12 +1332,7 @@ static PHP_FUNCTION(startup_logs) {
 
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-#if PHP_VERSION_ID >= 70000
     ZVAL_NEW_STR(return_value, buf.s);
-#else
-    ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
-    smart_str_free(&buf);
-#endif
 }
 
 static const zend_function_entry ddtrace_functions[] = {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -788,18 +788,18 @@ static PHP_FUNCTION(trace_function) {
 }
 
 static PHP_FUNCTION(dd_trace_serialize_closed_spans) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     ddtrace_serialize_closed_spans(return_value TSRMLS_CC);
 }
 
 // Invoke the function/method from the original context
 static PHP_FUNCTION(dd_trace_forward_call) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_FALSE;
 }
 
 static PHP_FUNCTION(dd_trace_env_config) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     zval *env_name = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &env_name) != SUCCESS) {
@@ -816,7 +816,7 @@ static PHP_FUNCTION(dd_trace_env_config) {
 
 // This function allows untracing a function.
 static PHP_FUNCTION(dd_untrace) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     if (DDTRACE_G(disable) && DDTRACE_G(disable_in_current_request)) {
         RETURN_BOOL(0);
@@ -843,7 +843,7 @@ static PHP_FUNCTION(dd_untrace) {
 }
 
 static PHP_FUNCTION(dd_trace_disable_in_request) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     DDTRACE_G(disable_in_current_request) = 1;
 
@@ -851,7 +851,7 @@ static PHP_FUNCTION(dd_trace_disable_in_request) {
 }
 
 static PHP_FUNCTION(dd_trace_reset) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -863,7 +863,7 @@ static PHP_FUNCTION(dd_trace_reset) {
 
 /* {{{ proto string dd_trace_serialize_msgpack(array trace_array) */
 static PHP_FUNCTION(dd_trace_serialize_msgpack) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -883,7 +883,7 @@ static PHP_FUNCTION(dd_trace_serialize_msgpack) {
 
 // method used to be able to easily breakpoint the execution at specific PHP line in GDB
 static PHP_FUNCTION(dd_trace_noop) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -894,19 +894,19 @@ static PHP_FUNCTION(dd_trace_noop) {
 
 /* {{{ proto int dd_trace_dd_get_memory_limit() */
 static PHP_FUNCTION(dd_trace_dd_get_memory_limit) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     RETURN_LONG(ddtrace_get_memory_limit(TSRMLS_C));
 }
 
 /* {{{ proto bool dd_trace_check_memory_under_limit() */
 static PHP_FUNCTION(dd_trace_check_memory_under_limit) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_BOOL(ddtrace_check_memory_under_limit(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     dd_tracer_circuit_breaker_register_error();
 
@@ -914,7 +914,7 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     dd_tracer_circuit_breaker_register_success();
 
@@ -922,13 +922,13 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_can_try) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     RETURN_BOOL(dd_tracer_circuit_breaker_can_try());
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     array_init_size(return_value, 5);
 
@@ -983,12 +983,12 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
 }
 
 static PHP_FUNCTION(ddtrace_config_distributed_tracing_enabled) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_BOOL(ddtrace_config_distributed_tracing_enabled(TSRMLS_C));
 }
 
 static PHP_FUNCTION(ddtrace_config_trace_enabled) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_BOOL(ddtrace_config_trace_enabled(TSRMLS_C));
 }
 
@@ -1114,7 +1114,7 @@ static PHP_FUNCTION(dd_trace_buffer_span) {
 }
 
 static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     RETURN_LONG(ddtrace_coms_trigger_writer_flush());
 }
@@ -1122,7 +1122,7 @@ static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
 #define FUNCTION_NAME_MATCHES(function) ((sizeof(function) - 1) == fn_len && strncmp(fn, function, fn_len) == 0)
 
 static PHP_FUNCTION(dd_trace_internal_fn) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     zval ***params = NULL;
     uint32_t params_count = 0;
 
@@ -1192,7 +1192,7 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
 
 /* {{{ proto string dd_trace_set_trace_id() */
 static PHP_FUNCTION(dd_trace_set_trace_id) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     zval *trace_id = NULL;
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &trace_id) == SUCCESS) {
@@ -1212,7 +1212,7 @@ static inline void return_span_id(zval *return_value, uint64_t id) {
 
 /* {{{ proto string dd_trace_push_span_id() */
 static PHP_FUNCTION(dd_trace_push_span_id) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     zval *existing_id = NULL;
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &existing_id) == SUCCESS) {
@@ -1227,7 +1227,7 @@ static PHP_FUNCTION(dd_trace_push_span_id) {
 
 /* {{{ proto string dd_trace_pop_span_id() */
 static PHP_FUNCTION(dd_trace_pop_span_id) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     uint64_t id = ddtrace_pop_span_id(TSRMLS_C);
 
     if (DDTRACE_G(span_ids_top) == NULL && get_dd_trace_auto_flush_enabled()) {
@@ -1253,7 +1253,7 @@ static PHP_FUNCTION(trace_id) {
 
 /* {{{ proto string dd_trace_closed_spans_count() */
 static PHP_FUNCTION(dd_trace_closed_spans_count) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_LONG(DDTRACE_G(closed_spans_count));
 }
 
@@ -1271,18 +1271,18 @@ BOOL_T ddtrace_tracer_is_limited(TSRMLS_D) {
 
 /* {{{ proto string dd_trace_tracer_is_limited() */
 static PHP_FUNCTION(dd_trace_tracer_is_limited) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_BOOL(ddtrace_tracer_is_limited(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 /* {{{ proto string dd_trace_compile_time_microseconds() */
 static PHP_FUNCTION(dd_trace_compile_time_microseconds) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
     RETURN_LONG(ddtrace_compile_time_get(TSRMLS_C));
 }
 
 static PHP_FUNCTION(startup_logs) {
-    PHP7_UNUSED(execute_data);
+    UNUSED(execute_data);
 
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);

--- a/ext/php7/ddtrace_string.c
+++ b/ext/php7/ddtrace_string.c
@@ -14,13 +14,7 @@ extern inline bool ddtrace_string_equals(ddtrace_string a, ddtrace_string b);
  * We aren't modifying anything, so we'll use const and just cast inside.
  */
 static const char *_dd_memnstr(const char *haystack, const char *needle, int needle_len, const char *end) {
-#if PHP_VERSION_ID < 50600
-    return zend_memnstr((char *)haystack, (char *)needle, needle_len, (char *)end);
-#elif PHP_VERSION_ID < 70000
-    return zend_memnstr((const char *)haystack, (const char *)needle, needle_len, (char *)end);
-#else
     return zend_memnstr((const char *)haystack, (const char *)needle, needle_len, (const char *)end);
-#endif
 }
 
 /**

--- a/ext/php7/ddtrace_string.h
+++ b/ext/php7/ddtrace_string.h
@@ -6,11 +6,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#if PHP_VERSION_ID < 70000
-typedef int ddtrace_zppstrlen_t;
-#else
 typedef size_t ddtrace_zppstrlen_t;
-#endif
 
 struct ddtrace_string {
     char *ptr;
@@ -21,11 +17,7 @@ typedef struct ddtrace_string ddtrace_string;
 #define DDTRACE_STRING_LITERAL(str) \
     (ddtrace_string) { .ptr = str, .len = sizeof(str) - 1 }
 
-#if PHP_VERSION_ID < 70000
-#define DDTRACE_STRING_ZVAL_L(zval_ptr, str) ZVAL_STRINGL(zval_ptr, str.ptr, str.len, 1)
-#else
 #define DDTRACE_STRING_ZVAL_L(zval_ptr, str) ZVAL_STRINGL(zval_ptr, str.ptr, str.len)
-#endif
 
 inline ddtrace_string ddtrace_string_cstring_ctor(char *ptr) {
     ddtrace_string string = {

--- a/ext/php7/dispatch.c
+++ b/ext/php7/dispatch.c
@@ -36,13 +36,8 @@ static bool dd_try_find_method_dispatch(zend_class_entry *class, zval *fname, dd
     }
     HashTable *class_lookup = NULL;
 
-#if PHP_VERSION_ID < 70000
-    const char *class_name = class->name;
-    size_t class_name_length = class->name_length;
-#else
     const char *class_name = ZSTR_VAL(class->name);
     size_t class_name_length = ZSTR_LEN(class->name);
-#endif
 
     class_lookup = ddtrace_hash_find_ptr_lc(DDTRACE_G(class_lookup), class_name, class_name_length);
     if (class_lookup) {
@@ -112,20 +107,6 @@ void ddtrace_dispatch_reset(TSRMLS_D) {
 static HashTable *_get_lookup_for_target(zval *class_name TSRMLS_DC) {
     HashTable *overridable_lookup = NULL;
     if (class_name && DDTRACE_G(class_lookup)) {
-#if PHP_VERSION_ID < 70000
-        // downcase the class name before lookup as class names are case insensitive.
-        zval *class_name_prev = class_name;
-        MAKE_STD_ZVAL(class_name);
-        ZVAL_STRINGL(class_name, Z_STRVAL_P(class_name_prev), Z_STRLEN_P(class_name_prev), 1);
-        ddtrace_downcase_zval(class_name);
-        overridable_lookup =
-            ddtrace_hash_find_ptr(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name));
-        if (!overridable_lookup) {
-            overridable_lookup = ddtrace_new_class_lookup(class_name TSRMLS_CC);
-        }
-        zval_ptr_dtor(&class_name);
-        class_name = class_name_prev;
-#else
         zend_string *class_name_lc = zend_string_tolower(Z_STR_P(class_name));
         overridable_lookup = zend_hash_find_ptr(DDTRACE_G(class_lookup), class_name_lc);
         if (!overridable_lookup) {
@@ -134,7 +115,6 @@ static HashTable *_get_lookup_for_target(zval *class_name TSRMLS_DC) {
             overridable_lookup = ddtrace_new_class_lookup(&tmp TSRMLS_CC);
         }
         zend_string_release(class_name_lc);
-#endif
     } else {
         overridable_lookup = DDTRACE_G(function_lookup);
     }

--- a/ext/php7/engine_api.c
+++ b/ext/php7/engine_api.c
@@ -56,12 +56,10 @@ ZEND_RESULT_CODE ddtrace_call_method(zend_object *obj, zend_class_entry *ce, zen
         .object = obj,
         .param_count = argc,
     };
-#if PHP_VERSION_ID < 80000
     /* Must be 0 to allow for by-ref args
      * BUT if you use by-ref args, you need to free the ref if it gets separated!
      */
     fci.no_separation = 0;
-#endif
     ZVAL_STR(&fci.function_name, method->common.function_name);
 
     zend_fcall_info_cache fcc = {
@@ -139,17 +137,10 @@ ZEND_RESULT_CODE ddtrace_call_function(zend_function **fn_proxy, const char *nam
 }
 
 void ddtrace_write_property(zval *obj, const char *prop, size_t prop_len, zval *value) {
-#if PHP_VERSION_ID < 80000
     zval member = ddtrace_zval_stringl(prop, prop_len);
     // the underlying API doesn't tell you if it worked _shrug_
     Z_OBJ_P(obj)->handlers->write_property(obj, &member, value, NULL);
     zend_string_release(Z_STR(member));
-#else
-    zend_string *member = zend_string_init(prop, prop_len, 0);
-    // the underlying API doesn't tell you if it worked _shrug_
-    Z_OBJ_P(obj)->handlers->write_property(Z_OBJ_P(obj), member, value, NULL);
-    zend_string_release(member);
-#endif
 }
 
 // Modeled after PHP's property_exists for the Z_TYPE_P(object) == IS_OBJECT case

--- a/ext/php7/engine_hooks.c
+++ b/ext/php7/engine_hooks.c
@@ -2,9 +2,6 @@
 
 #include <php.h>
 #include <time.h>
-#if PHP_VERSION_ID >= 80000
-#include <Zend/zend_observer.h>
-#endif
 
 #include "configuration.h"
 #include "ddtrace.h"
@@ -13,9 +10,7 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 static zend_op_array *(*_prev_compile_file)(zend_file_handle *file_handle, int type TSRMLS_DC);
-#if PHP_VERSION_ID < 80000
 void (*ddtrace_prev_error_cb)(DDTRACE_ERROR_CB_PARAMETERS);
-#endif
 
 void ddtrace_execute_internal_minit(void);
 void ddtrace_execute_internal_mshutdown(void);
@@ -31,22 +26,14 @@ void ddtrace_engine_hooks_minit(void) {
     ddtrace_opcode_minit();
     _compile_minit();
 
-#if PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 80000
     ddtrace_prev_error_cb = zend_error_cb;
     zend_error_cb = ddtrace_error_cb;
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    zend_observer_error_register(ddtrace_observer_error_cb);
-#endif
 }
 
 void ddtrace_engine_hooks_mshutdown(void) {
-#if PHP_VERSION_ID < 80000
     if (ddtrace_prev_error_cb == ddtrace_error_cb) {
         zend_error_cb = ddtrace_prev_error_cb;
     }
-#endif
 
     _compile_mshutdown();
     ddtrace_opcode_mshutdown();
@@ -87,33 +74,8 @@ void ddtrace_compile_time_reset(TSRMLS_D) { DDTRACE_G(compile_time_microseconds)
 int64_t ddtrace_compile_time_get(TSRMLS_D) { return DDTRACE_G(compile_time_microseconds); }
 
 extern inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error_handling_t mode TSRMLS_DC);
-#if PHP_VERSION_ID < 80000
 extern inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC);
-#else
-void ddtrace_restore_error_handling(ddtrace_error_handling *eh) {
-    if (PG(last_error_message)) {
-        if (PG(last_error_message) != eh->message) {
-            zend_string_release(PG(last_error_message));
-        }
-        if (PG(last_error_file) != eh->file) {
-            free(PG(last_error_file));
-        }
-    }
-    zend_restore_error_handling(&eh->error_handling TSRMLS_CC);
-    PG(last_error_type) = eh->type;
-    PG(last_error_message) = eh->message;
-    PG(last_error_file) = eh->file;
-    PG(last_error_lineno) = eh->lineno;
-    EG(error_reporting) = eh->error_reporting;
-}
-#endif
 extern inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC);
-#if PHP_VERSION_ID < 70000
-extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC);
-extern inline void ddtrace_maybe_clear_exception(TSRMLS_D);
-extern inline zval *ddtrace_exception_get_entry(zval *object, char *name, int name_len TSRMLS_DC);
-#else
 extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void);
 extern inline void ddtrace_maybe_clear_exception(void);
 extern inline zend_class_entry *ddtrace_get_exception_base(zval *object);
-#endif

--- a/ext/php7/engine_hooks.h
+++ b/ext/php7/engine_hooks.h
@@ -30,11 +30,7 @@ int64_t ddtrace_compile_time_get(TSRMLS_D);
 struct ddtrace_error_handling {
     int type;
     int lineno;
-#if PHP_VERSION_ID < 80000
     char *message;
-#else
-    zend_string *message;
-#endif
     char *file;
     int error_reporting;
     zend_error_handling error_handling;
@@ -44,9 +40,6 @@ typedef struct ddtrace_error_handling ddtrace_error_handling;
 struct ddtrace_sandbox_backup {
     ddtrace_error_handling eh;
     ddtrace_exception_t *exception, *prev_exception;
-#if PHP_VERSION_ID < 70000
-    zend_op *opline_before_exception;
-#endif
 };
 typedef struct ddtrace_sandbox_backup ddtrace_sandbox_backup;
 
@@ -65,7 +58,6 @@ inline void ddtrace_backup_error_handling(ddtrace_error_handling *eh, zend_error
     zend_replace_error_handling(mode, NULL, &eh->error_handling TSRMLS_CC);
 }
 
-#if PHP_VERSION_ID < 80000
 inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC) {
     if (PG(last_error_message)) {
         if (PG(last_error_message) != eh->message) {
@@ -82,55 +74,23 @@ inline void ddtrace_restore_error_handling(ddtrace_error_handling *eh TSRMLS_DC)
     PG(last_error_lineno) = eh->lineno;
     EG(error_reporting) = eh->error_reporting;
 }
-#else
-void ddtrace_restore_error_handling(ddtrace_error_handling *eh);
-#endif
 
-#if PHP_VERSION_ID < 70000
-inline void ddtrace_maybe_clear_exception(TSRMLS_D) {
-    if (EG(exception)) {
-        // Cannot use zend_clear_exception() in PHP 5 since there is no NULL check on the opline
-        zval_ptr_dtor(&EG(exception));
-        EG(exception) = NULL;
-        if (EG(prev_exception)) {
-            zval_ptr_dtor(&EG(prev_exception));
-            EG(prev_exception) = NULL;
-        }
-        if (EG(current_execute_data)) {
-            EG(current_execute_data)->opline = EG(opline_before_exception);
-        }
-    }
-}
-#else
 inline void ddtrace_maybe_clear_exception(void) {
     if (EG(exception)) {
         zend_clear_exception();
     }
 }
-#endif
 
-#if PHP_VERSION_ID < 70000
-inline ddtrace_sandbox_backup ddtrace_sandbox_begin(zend_op *opline_before_exception TSRMLS_DC) {
-#else
 inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void) {
-#endif
     ddtrace_sandbox_backup backup = {.exception = NULL, .prev_exception = NULL};
     if (EG(exception)) {
         backup.exception = EG(exception);
         backup.prev_exception = EG(prev_exception);
         EG(exception) = NULL;
         EG(prev_exception) = NULL;
-
-#if PHP_VERSION_ID < 70000
-        backup.opline_before_exception = opline_before_exception;
-#endif
     }
 
-#if PHP_VERSION_ID < 70000
-    zend_error_handling_t mode = EH_SUPPRESS;
-#else
     zend_error_handling_t mode = EH_THROW;
-#endif
 
     ddtrace_backup_error_handling(&backup.eh, mode TSRMLS_CC);
     return backup;
@@ -144,22 +104,12 @@ inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup TSRMLS_DC) {
         EG(exception) = backup->exception;
         EG(prev_exception) = backup->prev_exception;
 
-#if PHP_VERSION_ID < 70000
-        EG(opline_before_exception) = backup->opline_before_exception;
-#if PHP_VERSION_ID >= 50500
-        EG(current_execute_data)->opline = EG(exception_op);
-#endif
-#else
         zend_throw_exception_internal(NULL);
-#endif
     }
 }
 
-#if PHP_VERSION_ID >= 70000
 PHP_FUNCTION(ddtrace_internal_function_handler);
-#endif
 
-#if PHP_VERSION_ID < 80000
 #define DDTRACE_ERROR_CB_PARAMETERS \
     int type, const char *error_filename, const uint error_lineno, const char *format, va_list args
 
@@ -168,27 +118,11 @@ PHP_FUNCTION(ddtrace_internal_function_handler);
 extern void (*ddtrace_prev_error_cb)(DDTRACE_ERROR_CB_PARAMETERS);
 void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS);
 ddtrace_exception_t *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS TSRMLS_DC);
-#else
-void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
-#endif
 
 void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception);
 
-#if PHP_VERSION_ID < 70000
-void ddtrace_close_all_open_spans(TSRMLS_D);
-#else
 void ddtrace_close_all_open_spans(void);
-#endif
 
-#if PHP_VERSION_ID >= 80000
-inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
-    return (Z_OBJCE_P(object) == zend_ce_exception || instanceof_function_slow(Z_OBJCE_P(object), zend_ce_exception))
-               ? zend_ce_exception
-               : zend_ce_error;
-}
-#define GET_PROPERTY(object, id) \
-    zend_read_property_ex(ddtrace_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &rv)
-#elif PHP_VERSION_ID >= 70000
 inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
     return instanceof_function(Z_OBJCE_P(object), zend_ce_exception) ? zend_ce_exception : zend_ce_error;
 }
@@ -202,14 +136,6 @@ inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
 #else
 #define GET_PROPERTY(object, id) \
     zend_read_property_ex(ddtrace_get_exception_base(object), (object), ZSTR_KNOWN(id), 1, &rv)
-#endif
-#endif
-
-#if PHP_VERSION_ID < 70000
-inline zval *ddtrace_exception_get_entry(zval *object, char *name, int name_len TSRMLS_DC) {
-    zend_class_entry *exception_ce = zend_exception_get_default(TSRMLS_C);
-    return zend_read_property(exception_ce, object, name, name_len, 1 TSRMLS_CC);
-}
 #endif
 
 #endif  // DD_ENGINE_HOOKS_H

--- a/ext/php7/logging.h
+++ b/ext/php7/logging.h
@@ -5,12 +5,8 @@
 #include "configuration.h"
 
 inline void ddtrace_log_err(const char *message) {
-#if PHP_VERSION_ID < 80000
     TSRMLS_FETCH();
     php_log_err((char *)message TSRMLS_CC);
-#else
-    php_log_err(message);
-#endif
 }
 
 #define ddtrace_log_debugf(...)            \

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -81,13 +81,9 @@ static ZEND_RESULT_CODE dd_sandbox_fci_call(zend_execute_data *call, zend_fcall_
     va_list argv;
 
     va_start(argv, argc);
-#if PHP_VERSION_ID < 80000
     ret = zend_fcall_info_argv(fci, argc, &argv);
     // The only way we mess this up is by passing in argc < 0
     ZEND_ASSERT(ret == SUCCESS);
-#else
-    zend_fcall_info_argv(fci, (uint32_t)argc, &argv);
-#endif
     va_end(argv);
 
     ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
@@ -99,11 +95,7 @@ static ZEND_RESULT_CODE dd_sandbox_fci_call(zend_execute_data *call, zend_fcall_
 
         if (PG(last_error_message) && backup.eh.message != PG(last_error_message)) {
             char *error;
-#if PHP_VERSION_ID < 80000
             error = PG(last_error_message);
-#else
-            error = ZSTR_VAL(PG(last_error_message));
-#endif
             ddtrace_log_errf("Error raised in ddtrace's closure for %s%s%s(): %s in %s on line %d", scope, colon, name,
                              error, PG(last_error_file), PG(last_error_lineno));
         }
@@ -1147,7 +1139,6 @@ PHP_FUNCTION(ddtrace_internal_function_handler) {
     }
 }
 
-#if PHP_VERSION_ID < 80000
 zend_object *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS) {
     PHP7_UNUSED(error_filename, error_lineno);
 
@@ -1168,4 +1159,3 @@ zend_object *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS) {
 
     return Z_OBJ(ex);
 }
-#endif

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -749,7 +749,7 @@ static void dd_fcall_end_non_tracing_posthook(ddtrace_span_fci *span_fci, zval *
 }
 
 static void dd_fcall_end_tracing_prehook(ddtrace_span_fci *span_fci, zval *user_retval) {
-    PHP7_UNUSED(user_retval);
+    UNUSED(user_retval);
     dd_trace_stop_span_time(&span_fci->span);
 
     dd_set_default_properties();
@@ -757,7 +757,7 @@ static void dd_fcall_end_tracing_prehook(ddtrace_span_fci *span_fci, zval *user_
 }
 
 static void dd_fcall_end_non_tracing_prehook(ddtrace_span_fci *span_fci, zval *user_retval) {
-    PHP7_UNUSED(span_fci, user_retval);
+    UNUSED(span_fci, user_retval);
 
     ddtrace_drop_top_open_span();
 }
@@ -1140,7 +1140,7 @@ PHP_FUNCTION(ddtrace_internal_function_handler) {
 }
 
 zend_object *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS) {
-    PHP7_UNUSED(error_filename, error_lineno);
+    UNUSED(error_filename, error_lineno);
 
     zval ex;
     va_list args2;

--- a/ext/php7/random.c
+++ b/ext/php7/random.c
@@ -39,11 +39,7 @@ static inline uint64_t zval_to_uint64(zval *zid) {
         return 0U;
     }
     const char *id = Z_STRVAL_P(zid);
-#if PHP_VERSION_ID >= 70000
     size_t i = 0;
-#else
-    int i = 0;
-#endif
     for (; i < Z_STRLEN_P(zid); i++) {
         if (id[i] < '0' || id[i] > '9') {
             return 0U;

--- a/ext/php7/request_hooks.c
+++ b/ext/php7/request_hooks.c
@@ -14,118 +14,6 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
-#if PHP_VERSION_ID < 70000
-int dd_execute_php_file(const char *filename TSRMLS_DC) {
-    int filename_len = strlen(filename);
-    if (filename_len == 0) {
-        return FAILURE;
-    }
-    int dummy = 1;
-    zend_file_handle file_handle;
-    zend_op_array *new_op_array;
-    zval *result = NULL;
-    int ret;
-
-    BOOL_T rv = FALSE;
-
-    zval **original_return_value = EG(return_value_ptr_ptr);
-    zend_op **original_opline_ptr = EG(opline_ptr);
-    zend_op_array *original_active_op_array = EG(active_op_array);
-
-    ddtrace_error_handling eh_stream;
-    ddtrace_backup_error_handling(&eh_stream, EH_SUPPRESS TSRMLS_CC);
-    zend_bool _original_cg_multibyte = CG(multibyte);
-    CG(multibyte) = FALSE;
-
-    ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE TSRMLS_CC);
-
-    if (get_dd_trace_debug() && PG(last_error_message) && eh_stream.message != PG(last_error_message)) {
-        ddtrace_log_errf("Error raised while opening request-init-hook stream: %s in %s on line %d",
-                         PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
-    }
-
-    ddtrace_restore_error_handling(&eh_stream TSRMLS_CC);
-
-    if (ret == SUCCESS) {
-        if (!file_handle.opened_path) {
-            file_handle.opened_path = estrndup(filename, filename_len);
-        }
-        if (zend_hash_add(&EG(included_files), file_handle.opened_path, strlen(file_handle.opened_path) + 1,
-                          (void *)&dummy, sizeof(int), NULL) == SUCCESS) {
-            new_op_array = zend_compile_file(&file_handle, ZEND_REQUIRE TSRMLS_CC);
-            zend_destroy_file_handle(&file_handle TSRMLS_CC);
-        } else {
-            new_op_array = NULL;
-            zend_file_handle_dtor(&file_handle TSRMLS_CC);
-        }
-        if (new_op_array) {
-            EG(return_value_ptr_ptr) = &result;
-            EG(active_op_array) = new_op_array;
-            if (!EG(active_symbol_table)) {
-                zend_rebuild_symbol_table(TSRMLS_C);
-            }
-
-            ddtrace_error_handling eh;
-            ddtrace_backup_error_handling(&eh, EH_SUPPRESS TSRMLS_CC);
-
-            zend_try { zend_execute(new_op_array TSRMLS_CC); }
-#if PHP_VERSION_ID < 50600
-            // Cannot gracefully recover from fatal errors without crashing until PHP 5.6
-            zend_catch {
-                if (get_dd_trace_debug() && PG(last_error_message)) {
-                    ddtrace_log_errf("Unrecoverable error raised in request init hook: %s in %s on line %d",
-                                     PG(last_error_message), PG(last_error_file), PG(last_error_lineno));
-                }
-                zend_bailout();
-            }
-#endif
-            zend_end_try();
-
-            if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
-                ddtrace_log_errf("Error raised in request init hook: %s in %s on line %d", PG(last_error_message),
-                                 PG(last_error_file), PG(last_error_lineno));
-            }
-
-            ddtrace_restore_error_handling(&eh TSRMLS_CC);
-
-            destroy_op_array(new_op_array TSRMLS_CC);
-            efree(new_op_array);
-            if (!EG(exception)) {
-                if (EG(return_value_ptr_ptr) && *EG(return_value_ptr_ptr)) {
-                    zval_ptr_dtor(EG(return_value_ptr_ptr));
-                }
-            } else {
-                if (get_dd_trace_debug()) {
-                    zval *ex = EG(exception), *message = NULL;
-                    const char *type = Z_OBJCE_P(ex)->name;
-                    message = ddtrace_exception_get_entry(ex, ZEND_STRL("message") TSRMLS_CC);
-                    const char *msg = message && Z_TYPE_P(message) == IS_STRING
-                                          ? Z_STRVAL_P(message)
-                                          : "(internal error reading exception message)";
-                    ddtrace_log_errf("%s thrown in request init hook: %s", type, msg);
-                }
-                // Cannot use ddtrace_maybe_clear_exception() because it updates the opline to a dangling pointer
-                zval_ptr_dtor(&EG(exception));
-                EG(exception) = NULL;
-                if (EG(prev_exception)) {
-                    zval_ptr_dtor(&EG(prev_exception));
-                    EG(prev_exception) = NULL;
-                }
-            }
-            rv = TRUE;
-        }
-    } else {
-        ddtrace_log_debugf("Error opening request init hook: %s", filename);
-    }
-    CG(multibyte) = _original_cg_multibyte;
-
-    EG(return_value_ptr_ptr) = original_return_value;
-    EG(opline_ptr) = original_opline_ptr;
-    EG(active_op_array) = original_active_op_array;
-    return rv;
-}
-#else
-
 int dd_execute_php_file(const char *filename TSRMLS_DC) {
     int filename_len = strlen(filename);
     if (filename_len == 0) {
@@ -147,11 +35,7 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
 
     if (get_dd_trace_debug() && PG(last_error_message) && eh_stream.message != PG(last_error_message)) {
         char *error;
-#if PHP_VERSION_ID < 80000
         error = PG(last_error_message);
-#else
-        error = ZSTR_VAL(PG(last_error_message));
-#endif
         ddtrace_log_errf("Error raised while opening request-init-hook stream: %s in %s on line %d", error,
                          PG(last_error_file), PG(last_error_lineno));
     }
@@ -185,11 +69,7 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
 
             if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
                 char *error;
-#if PHP_VERSION_ID < 80000
                 error = PG(last_error_message);
-#else
-                error = ZSTR_VAL(PG(last_error_message));
-#endif
                 ddtrace_log_errf("Error raised in request init hook: %s in %s on line %d", error, PG(last_error_file),
                                  PG(last_error_lineno));
             }
@@ -225,7 +105,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
 
     return rv;
 }
-#endif
 
 int dd_execute_auto_prepend_file(char *auto_prepend_file TSRMLS_DC) {
     zend_file_handle prepend_file;
@@ -236,12 +115,6 @@ int dd_execute_auto_prepend_file(char *auto_prepend_file TSRMLS_DC) {
     prepend_file.type = ZEND_HANDLE_FILENAME;
     prepend_file.filename = auto_prepend_file;
     int ret = zend_execute_scripts(ZEND_REQUIRE TSRMLS_CC, NULL, 1, &prepend_file) == SUCCESS;
-#if PHP_VERSION_ID >= 80000
-    // Exit no longer calls zend_bailout in PHP 8, so we need to "rethrow" the exit
-    if (ret == 0) {
-        zend_throw_unwind_exit();
-    }
-#endif
     // EG(current_execute_data) = ex;
     return ret;
 }
@@ -256,11 +129,7 @@ void dd_request_init_hook_rinit(TSRMLS_D) {
 
     zval exists_flag;
     php_stat(DDTRACE_G(request_init_hook), strlen(DDTRACE_G(request_init_hook)), FS_EXISTS, &exists_flag TSRMLS_CC);
-#if PHP_VERSION_ID < 70000
-    if (!Z_BVAL(exists_flag)) {
-#else
     if (Z_TYPE(exists_flag) == IS_FALSE) {
-#endif
         ddtrace_log_debugf("Cannot open request init hook; file does not exist: '%s'", DDTRACE_G(request_init_hook));
         return;
     }

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -29,16 +29,6 @@ static void _free_span(ddtrace_span_fci *span_fci) {
         return;
     }
     ddtrace_span_t *span = &span_fci->span;
-#if PHP_VERSION_ID < 70000
-    if (span->span_data) {
-        zval_ptr_dtor(&span->span_data);
-        span->span_data = NULL;
-    }
-    if (span_fci->exception) {
-        zval_ptr_dtor(&span_fci->exception);
-        span_fci->exception = NULL;
-    }
-#else
     if (span->span_data) {
         zval_ptr_dtor(span->span_data);
         efree(span->span_data);
@@ -48,7 +38,6 @@ static void _free_span(ddtrace_span_fci *span_fci) {
         OBJ_RELEASE(span_fci->exception);
         span_fci->exception = NULL;
     }
-#endif
 
     efree(span_fci);
 }
@@ -97,12 +86,7 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
 
     ddtrace_span_t *span = &span_fci->span;
 
-    /* On PHP 5 object_init_ex does not set refcount to 1, but on PHP 7 it does */
-#if PHP_VERSION_ID < 70000
-    MAKE_STD_ZVAL(span->span_data);
-#else
     span->span_data = (zval *)ecalloc(1, sizeof(zval));
-#endif
     object_init_ex(span->span_data, ddtrace_ce_span_data);
 
     // Peek at the active span ID before we push a new one onto the stack

--- a/ext/php7/span.h
+++ b/ext/php7/span.h
@@ -31,9 +31,6 @@ struct ddtrace_span_fci {
     zend_execute_data *execute_data;
     struct ddtrace_dispatch_t *dispatch;
     ddtrace_exception_t *exception;
-#if PHP_VERSION_ID < 70000
-    ddtrace_execute_data dd_execute_data;
-#endif
     struct ddtrace_span_fci *next;
     ddtrace_span_t span;
 };

--- a/ext/php7/startup_logging.h
+++ b/ext/php7/startup_logging.h
@@ -1,14 +1,9 @@
 #ifndef DD_TRACE_STARTUP_LOGGING_H
 #define DD_TRACE_STARTUP_LOGGING_H
 
+#include <Zend/zend_smart_str.h>
 #include <php.h>
 #include <stdbool.h>
-
-#if PHP_VERSION_ID >= 70000
-#include <Zend/zend_smart_str.h>
-#else
-#include <ext/standard/php_smart_str.h>
-#endif
 
 /* Number of config & diagnostic values */
 #define DDTRACE_STARTUP_STAT_COUNT 43


### PR DESCRIPTION
### Description

Get rid of all non php7 code in `ext/php7`

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
