### PR TITLE
do not keep alive connections while executing randomized testing

### DIFF
--- a/tests/randomized/docker/run.sh
+++ b/tests/randomized/docker/run.sh
@@ -5,5 +5,5 @@ set -e
 bash /scripts/prepare.sh
 
 echo "Starting load"
-vegeta -cpus=1 attack -format=http -targets=/vegeta-request-targets.txt -duration=${DURATION:-30s} -keepalive=true -max-workers=10 -workers=10 -rate=0 | tee results.bin | vegeta report --type=json --output=/results/results.json
+vegeta -cpus=1 attack -format=http -targets=/vegeta-request-targets.txt -duration=${DURATION:-30s} -keepalive=false -max-workers=10 -workers=10 -rate=0 | tee results.bin | vegeta report --type=json --output=/results/results.json
 echo "Done loading"


### PR DESCRIPTION
### Description

A degree of flakiness in randomized testing was observed regardless of the tracer installed or not.

A typical error that is a false positive is [this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5231/workflows/c839b1ba-0e9e-4f07-ab5e-9d304e121c01) where a EOF error is generated by vegeta supposedly when the server close the connection due to high traffic.

Searching online it seems that this is generated when the Go's http client receive a response with `Keep-Alive` and then the server closes the connection, for other reasons.

In order to increase stability we set to false the `-keepalive` flag in vegeta and observe flakiness in the next few pushes.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
