### PR TITLE
Remove non php5 code from ext/php5 folder

### DIFF
--- a/ext/php5/arrays.c
+++ b/ext/php5/arrays.c
@@ -2,7 +2,6 @@
 
 #include <php_version.h>
 
-#if PHP_VERSION_ID < 70000
 void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
     HashPosition pos;
     zval **operand;
@@ -13,29 +12,16 @@ void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *contex
         zend_hash_move_forward_ex(input, &pos);
     }
 }
-#else
-void ddtrace_array_walk(HashTable *input, ddtrace_walk_fn callback, void *context) {
-    zval *item = NULL;
-    size_t order = 0;
-    ZEND_HASH_FOREACH_VAL(input, item) { callback(item, order++, context); }
-    ZEND_HASH_FOREACH_END();
-}
-#endif
 
 void *ddtrace_hash_find_ptr(const HashTable *ht, const char *str, size_t len) {
     void *result;
-#if PHP_VERSION_ID < 70000
     void **rv = NULL;
     result = zend_hash_find(ht, str, len, (void **)&rv) == SUCCESS ? *rv : NULL;
-#else
-    result = zend_hash_str_find_ptr(ht, str, len);
-#endif
     return result;
 }
 
 void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len) {
     void *result;
-#if PHP_VERSION_ID < 70000
     /* The code for the PHP 7 branch will also work on PHP 5, but if we do not
      * call emalloc and free (even if we don't end up using it), then there is
      * a memory leak reported by PHP 5.4 and 5.6:
@@ -46,13 +32,5 @@ void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len)
     char *lc_str = zend_str_tolower_dup(str, len);
     result = ddtrace_hash_find_ptr(ht, lc_str, len);
     efree(lc_str);
-#else
-    // Stack allocate small strings to improve performance
-    ALLOCA_FLAG(use_heap)
-    // zend_str_tolower_copy will add a null terminator; leave room for it
-    char *lc_str = zend_str_tolower_copy(do_alloca(len + 1, use_heap), str, len);
-    result = ddtrace_hash_find_ptr(ht, lc_str, len);
-    free_alloca(lc_str, use_heap);
-#endif
     return result;
 }

--- a/ext/php5/comms_php.c
+++ b/ext/php5/comms_php.c
@@ -17,8 +17,7 @@ static void _comms_convert_append(zval *item, size_t offset, void *context) {
     zval converted;
     TSRMLS_FETCH();
 
-    PHP5_UNUSED(offset);
-    PHP7_UNUSED(offset);
+    UNUSED(offset);
 
     ddtrace_convert_to_string(&converted, item TSRMLS_CC);
     *list = curl_slist_append(*list, Z_STRVAL(converted));

--- a/ext/php5/compat_string.c
+++ b/ext/php5/compat_string.c
@@ -6,7 +6,6 @@
 
 #include "compatibility.h"
 
-#if PHP_VERSION_ID < 70000
 int ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
     va_list arg;
     int len;
@@ -16,19 +15,7 @@ int ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
     va_end(arg);
     return len;
 }
-#else
-size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...) {
-    va_list arg;
-    size_t len;
 
-    va_start(arg, format);
-    len = vspprintf(message, max_len, format, arg);
-    va_end(arg);
-    return len;
-}
-#endif
-
-#if PHP_VERSION_ID < 70000
 void ddtrace_downcase_zval(zval *src) {
     if (!src || Z_TYPE_P(src) != IS_STRING) {
         return;
@@ -37,19 +24,6 @@ void ddtrace_downcase_zval(zval *src) {
     zend_str_tolower(Z_STRVAL_P(src), Z_STRLEN_P(src));
 }
 
-#else
-void ddtrace_downcase_zval(zval *src) {
-    if (!src || Z_TYPE_P(src) != IS_STRING) {
-        return;
-    }
-    zend_string *str = Z_STR_P(src);
-
-    ZVAL_STR(src, zend_string_tolower(str));
-    zend_string_release(str);
-}
-#endif
-
-#if PHP_VERSION_ID < 70000
 void ddtrace_convert_to_string(zval *dst, zval *src TSRMLS_DC) {
     switch (Z_TYPE_P(src)) {
         case IS_BOOL:
@@ -115,84 +89,3 @@ void ddtrace_convert_to_string(zval *dst, zval *src TSRMLS_DC) {
     }
     Z_TYPE_P(dst) = IS_STRING;
 }
-
-#else
-/* zend_operators.h wrongfully defines _convert_to_string, so use the ddtrace
- * prefix even though its private to this translation unit */
-static zend_string *_ddtrace_convert_to_string(zval *op) {
-try_again:
-    switch (Z_TYPE_P(op)) {
-        case IS_UNDEF:
-            return zend_string_init("(undef)", sizeof("(undef)") - 1, 0);
-
-        case IS_NULL:
-            return zend_string_init("(null)", sizeof("(null)") - 1, 0);
-
-        case IS_FALSE:
-            return zend_string_init("(false)", sizeof("(false)") - 1, 0);
-
-        case IS_TRUE:
-            return zend_string_init("(true)", sizeof("(true)") - 1, 0);
-
-        case IS_RESOURCE:
-            return strpprintf(0, "Resource id #" ZEND_LONG_FMT, (zend_long)Z_RES_HANDLE_P(op));
-
-        case IS_LONG:
-            return zend_long_to_str(Z_LVAL_P(op));
-
-        case IS_DOUBLE:
-            return strpprintf(0, "%.*G", (int)EG(precision), Z_DVAL_P(op));
-
-        case IS_ARRAY:
-#if PHP_VERSION_ID < 70400
-            return zend_string_init("Array", sizeof("Array") - 1, 0);
-#else
-            return ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED);
-#endif
-
-        case IS_OBJECT: {
-            zval tmp;
-#if PHP_VERSION_ID >= 80000
-            if (Z_OBJ_HT_P(op)->cast_object(Z_OBJ_P(op), &tmp, IS_STRING) == SUCCESS) {
-                return Z_STR(tmp);
-            }
-#else
-            if (Z_OBJ_HT_P(op)->cast_object) {
-                if (Z_OBJ_HT_P(op)->cast_object(op, &tmp, IS_STRING) == SUCCESS) {
-                    return Z_STR(tmp);
-                }
-            } else if (Z_OBJ_HT_P(op)->get) {
-                zval *z = Z_OBJ_HT_P(op)->get(op, &tmp);
-                if (Z_TYPE_P(z) != IS_OBJECT) {
-                    zend_string *str = _ddtrace_convert_to_string(z);
-                    zval_ptr_dtor(z);
-                    return str;
-                }
-            }
-#endif
-            zend_string *class_name = Z_OBJ_HANDLER_P(op, get_class_name)(Z_OBJ_P(op));
-            zend_string *message = strpprintf(0, "object(%s)#%d", ZSTR_VAL(class_name), Z_OBJ_HANDLE_P(op));
-            zend_string_release(class_name);
-            return message;
-        }
-
-        case IS_REFERENCE:
-            op = Z_REFVAL_P(op);
-            goto try_again;
-
-        case IS_STRING:
-            return zend_string_copy(Z_STR_P(op));
-
-            EMPTY_SWITCH_DEFAULT_CASE()
-    }
-}
-
-void ddtrace_convert_to_string(zval *dst, zval *src) {
-    zend_string *str = _ddtrace_convert_to_string(src);
-    if (str) {
-        ZVAL_STR(dst, str);
-    } else {
-        ZVAL_NULL(dst);
-    }
-}
-#endif

--- a/ext/php5/compat_string.h
+++ b/ext/php5/compat_string.h
@@ -9,11 +9,7 @@
 void ddtrace_downcase_zval(zval *src);
 
 // ddtrace_spprintf is a replacement for zend_spprintf, since it is not exported in many versions
-#if PHP_VERSION_ID < 70000
 int ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
-#else
-size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
-#endif
 
 /**
  * dst will be IS_STRING after the call; caller must dtor.

--- a/ext/php5/compatibility.h
+++ b/ext/php5/compatibility.h
@@ -15,15 +15,6 @@
 #endif
 #endif
 
-#if PHP_VERSION_ID >= 80000
-/* BC only */
-#define TSRMLS_D void
-#define TSRMLS_DC
-#define TSRMLS_C
-#define TSRMLS_CC
-#define TSRMLS_FETCH()
-#endif
-
 #define UNUSED_1(x) (void)(x)
 #define UNUSED_2(x, y) \
     do {               \
@@ -54,37 +45,14 @@
 #define _GET_UNUSED_MACRO_OF_ARITY(_1, _2, _3, _4, _5, ARITY, ...) UNUSED_##ARITY
 #define UNUSED(...) _GET_UNUSED_MACRO_OF_ARITY(__VA_ARGS__, 5, 4, 3, 2, 1)(__VA_ARGS__)
 
-#if PHP_VERSION_ID < 70000
-#define PHP5_UNUSED(...) UNUSED(__VA_ARGS__)
-#define PHP7_UNUSED(...) /* unused unused */
-#else
-#define PHP5_UNUSED(...) /* unused unused */
-#define PHP7_UNUSED(...) UNUSED(__VA_ARGS__)
-#endif
-
-#if PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70300
-#define GC_ADDREF(x) (++GC_REFCOUNT(x))
-#define GC_DELREF(x) (--GC_REFCOUNT(x))
-#endif
-
-#if PHP_VERSION_ID < 70000
 #define ZVAL_VARARG_PARAM(list, arg_num) (*list[arg_num])
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_BOOL && Z_LVAL_P(x) == 1)
 #define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c, 1)
-#else
-#define COMPAT_RETVAL_STRING(c) RETVAL_STRING(c)
-#define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval*)list)[arg_num]))
-#define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
-#endif
 
 #if PHP_VERSION_ID < 50600
 #define ZEND_ARG_VARIADIC_INFO(pass_by_ref, name)
 #endif
 
-#if PHP_VERSION_ID < 70000
 typedef zval ddtrace_exception_t;
-#else
-typedef zend_object ddtrace_exception_t;
-#endif
 
 #endif  // DD_COMPATIBILITY_H

--- a/ext/php5/configuration.c
+++ b/ext/php5/configuration.c
@@ -173,10 +173,6 @@ bool ddtrace_config_distributed_tracing_enabled(TSRMLS_D) {
 // Get env name for <PREFIX_><INTEGRATION><_SUFFIX> (i.e. <DD_TRACE_><LARAVEL><_ENABLED>)
 size_t ddtrace_config_integration_env_name(char* name, const char* prefix, ddtrace_integration* integration,
                                            const char* suffix) {
-#if PHP_VERSION_ID >= 70000
-    ZEND_ASSERT(strlen(prefix) <= DDTRACE_LONGEST_INTEGRATION_ENV_PREFIX_LEN);
-    ZEND_ASSERT(strlen(suffix) <= DDTRACE_LONGEST_INTEGRATION_ENV_SUFFIX_LEN);
-#endif
     return (size_t)snprintf(name, DDTRACE_LONGEST_INTEGRATION_ENV_LEN + 1, "%s%s%s", prefix, integration->name_ucase,
                             suffix);
 }

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -3,14 +3,10 @@
 #endif
 #include <SAPI.h>
 #include <Zend/zend.h>
+#include <Zend/zend_builtin_functions.h>
 #include <Zend/zend_closures.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
-#if PHP_VERSION_ID >= 70000
-#include <Zend/zend_smart_str.h>
-#else
-#include <Zend/zend_builtin_functions.h>
-#endif
 #include <Zend/zend_vm.h>
 #include <inttypes.h>
 #include <php.h>
@@ -20,9 +16,7 @@
 
 #include <ext/spl/spl_exceptions.h>
 #include <ext/standard/info.h>
-#if PHP_VERSION_ID < 70000
 #include <ext/standard/php_smart_str.h>
-#endif
 
 #include "arrays.h"
 #include "auto_flush.h"
@@ -70,16 +64,7 @@ STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateStrin
 PHP_INI_END()
 
 static int ddtrace_startup(struct _zend_extension *extension) {
-#if PHP_VERSION_ID < 80000
     ddtrace_resource = zend_get_resource_handle(extension);
-#if PHP_VERSION_ID >= 70400
-    ddtrace_op_array_extension = zend_get_op_array_extension_handle();
-#endif
-#else
-    UNUSED(extension);
-    ddtrace_resource = zend_get_resource_handle(PHP_DDTRACE_EXTNAME);
-    ddtrace_op_array_extension = zend_get_op_array_extension_handle(PHP_DDTRACE_EXTNAME);
-#endif
 
     ddtrace_excluded_modules_startup();
     ddtrace_internal_handlers_startup();
@@ -215,10 +200,7 @@ static void php_ddtrace_init_globals(zend_ddtrace_globals *ng) { memset(ng, 0, s
 
 static PHP_GINIT_FUNCTION(ddtrace) {
 #ifdef ZTS
-    PHP5_UNUSED(TSRMLS_C);
-#endif
-#if PHP_VERSION_ID >= 70000 && defined(COMPILE_DL_DDTRACE) && defined(ZTS)
-    ZEND_TSRMLS_CACHE_UPDATE();
+    UNUSED(TSRMLS_C);
 #endif
     php_ddtrace_init_globals(ddtrace_globals);
 }
@@ -396,9 +378,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         ddtrace_startup_logging_first_rinit();
     }
 
-#if PHP_MAJOR_VERSION < 7
     DDTRACE_G(should_warn_call_depth) = ddtrace_get_bool_config("DD_TRACE_WARN_CALL_STACK_DEPTH", TRUE TSRMLS_CC);
-#endif
 
     DDTRACE_G(request_init_hook_loaded) = 0;
     if (DDTRACE_G(request_init_hook) && DDTRACE_G(request_init_hook)[0]) {
@@ -463,11 +443,7 @@ static int datadog_info_print(const char *str TSRMLS_DC) { return php_output_wri
 static void _dd_info_tracer_config(void) {
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-#if PHP_VERSION_ID >= 70000
-    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", ZSTR_VAL(buf.s));
-#else
     php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", buf.c);
-#endif
     smart_str_free(&buf);
 }
 
@@ -493,28 +469,6 @@ static void _dd_info_diagnostics_table(TSRMLS_D) {
 
     ddtrace_startup_diagnostics(ht, false);
 
-#if PHP_VERSION_ID >= 70000
-    zend_string *key;
-    zval *val;
-    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
-        switch (Z_TYPE_P(val)) {
-            case IS_STRING:
-                _dd_info_diagnostics_row(ZSTR_VAL(key), Z_STRVAL_P(val) TSRMLS_CC);
-                break;
-            case IS_NULL:
-                _dd_info_diagnostics_row(ZSTR_VAL(key), "NULL" TSRMLS_CC);
-                break;
-            case IS_TRUE:
-            case IS_FALSE:
-                _dd_info_diagnostics_row(ZSTR_VAL(key), Z_TYPE_P(val) == IS_TRUE ? "true" : "false" TSRMLS_CC);
-                break;
-            default:
-                _dd_info_diagnostics_row(ZSTR_VAL(key), "{unknown type}" TSRMLS_CC);
-                break;
-        }
-    }
-    ZEND_HASH_FOREACH_END();
-#else
     int key_type;
     zval **val;
     HashPosition pos;
@@ -542,7 +496,6 @@ static void _dd_info_diagnostics_table(TSRMLS_D) {
         }
         zend_hash_move_forward_ex(ht, &pos);
     }
-#endif
 
     php_info_print_table_row(2, "Diagnostic checks", zend_hash_num_elements(ht) == 0 ? "passed" : "failed");
 
@@ -588,56 +541,6 @@ static BOOL_T _parse_config_array(zval *config_array, zval **tracing_closure, ui
         return FALSE;
     }
 
-#if PHP_VERSION_ID >= 70000
-    zval *value;
-    zend_string *key;
-
-    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARRVAL_P(config_array), key, value) {
-        if (!key) {
-            ddtrace_log_debug("Expected config_array to be an associative array");
-            return FALSE;
-        }
-        // TODO Optimize this
-        if (strcmp("posthook", ZSTR_VAL(key)) == 0) {
-            if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), zend_ce_closure)) {
-                *tracing_closure = value;
-                *options |= DDTRACE_DISPATCH_POSTHOOK;
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an instance of Closure", ZSTR_VAL(key));
-                return FALSE;
-            }
-        } else if (strcmp("prehook", ZSTR_VAL(key)) == 0) {
-            if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), zend_ce_closure)) {
-                *tracing_closure = value;
-                *options |= DDTRACE_DISPATCH_PREHOOK;
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an instance of Closure", ZSTR_VAL(key));
-                return FALSE;
-            }
-        } else if (strcmp("innerhook", ZSTR_VAL(key)) == 0) {
-            if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), zend_ce_closure)) {
-                *tracing_closure = value;
-                *options |= DDTRACE_DISPATCH_INNERHOOK;
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an instance of Closure", ZSTR_VAL(key));
-                return FALSE;
-            }
-        } else if (strcmp("instrument_when_limited", ZSTR_VAL(key)) == 0) {
-            if (Z_TYPE_P(value) == IS_LONG) {
-                if (Z_LVAL_P(value)) {
-                    *options |= DDTRACE_DISPATCH_INSTRUMENT_WHEN_LIMITED;
-                }
-            } else {
-                ddtrace_log_debugf("Expected '%s' to be an int", ZSTR_VAL(key));
-                return FALSE;
-            }
-        } else {
-            ddtrace_log_debugf("Unknown option '%s' in config_array", ZSTR_VAL(key));
-            return FALSE;
-        }
-    }
-    ZEND_HASH_FOREACH_END();
-#else
     zval **value;
     char *string_key;
     uint str_len;
@@ -688,7 +591,6 @@ static BOOL_T _parse_config_array(zval *config_array, zval **tracing_closure, ui
         }
         zend_hash_move_forward_ex(ht, &iterator);
     }
-#endif
     if (!*tracing_closure) {
         ddtrace_log_debug("Required key 'posthook', 'prehook' or 'innerhook' not found in config_array");
         return FALSE;
@@ -703,7 +605,7 @@ static bool ddtrace_should_warn_legacy(void) {
 }
 
 static PHP_FUNCTION(dd_trace) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *function = NULL;
     zval *class_name = NULL;
     zval *callable = NULL;
@@ -742,7 +644,7 @@ static PHP_FUNCTION(dd_trace) {
 }
 
 static PHP_FUNCTION(trace_method) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *class_name = NULL;
     zval *function = NULL;
     zval *tracing_closure = NULL;
@@ -782,7 +684,6 @@ static PHP_FUNCTION(trace_method) {
     RETURN_BOOL(rv);
 }
 
-#if PHP_VERSION_ID < 70000
 /* Note that on PHP 5 we bind $this on the callbacks. If we don't then the VM
  * will set the static flag on the closure in certain circumstances. For
  * example, if a tracing closure is defined inside another closure that has a
@@ -796,7 +697,7 @@ static PHP_FUNCTION(hook_method) {
     ddtrace_string classname = {.ptr = NULL, .len = 0};
     ddtrace_string funcname = {.ptr = NULL, .len = 0};
     zval *prehook = NULL, *posthook = NULL;
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
 
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "ss|O!O!", &classname.ptr,
                                  &classname.len, &funcname.ptr, &funcname.len, &prehook, zend_ce_closure, &posthook,
@@ -841,7 +742,7 @@ static PHP_FUNCTION(hook_method) {
 static PHP_FUNCTION(hook_function) {
     ddtrace_string funcname = {.ptr = NULL, .len = 0};
     zval *prehook = NULL, *posthook = NULL;
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
 
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "s|O!O!", &funcname.ptr,
                                  &funcname.len, &prehook, zend_ce_closure, &posthook, zend_ce_closure) != SUCCESS) {
@@ -876,96 +777,9 @@ static PHP_FUNCTION(hook_function) {
     zval_ptr_dtor(&function_name_zv);
     RETURN_BOOL(rv);
 }
-#else
-/*
- * In PHP 7 we don't bind $this as we want only public access.
- * In PHP 5 we have to bind $this; see PHP5's hook_method for details.
- */
-static PHP_FUNCTION(hook_method) {
-    zend_string *class_name = NULL, *method_name = NULL;
-    zval *prehook = NULL, *posthook = NULL;
-
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 2, 4)
-    // clang-format off
-        Z_PARAM_STR(class_name)
-        Z_PARAM_STR(method_name)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_OBJECT_OF_CLASS_EX(prehook, zend_ce_closure, 1, 0)
-        Z_PARAM_OBJECT_OF_CLASS_EX(posthook, zend_ce_closure, 1, 0)
-    // clang-format on
-    ZEND_PARSE_PARAMETERS_END_EX({
-        ddtrace_log_debug(
-            "Unable to parse parameters for DDTrace\\hook_method; expected "
-            "(string $class_name, string $method_name, ?Closure $prehook = NULL, ?Closure $posthook = NULL)");
-    });
-
-    if (prehook && posthook) {
-        // both callbacks given; not yet supported
-        ddtrace_log_debug(
-            "DDTrace\\hook_method was given both prehook and posthook. This is not yet supported; ignoring call.");
-        RETURN_FALSE;
-    }
-
-    if (!prehook && !posthook) {
-        ddtrace_log_debug("DDTrace\\hook_method was given neither prehook nor posthook.");
-        RETURN_FALSE;
-    }
-
-    // at this point we know we have a posthook XOR posthook
-    zval *callable = prehook ?: posthook;
-    uint32_t options = (prehook ? DDTRACE_DISPATCH_PREHOOK : DDTRACE_DISPATCH_POSTHOOK) | DDTRACE_DISPATCH_NON_TRACING;
-
-    // massage zend_string * into zval
-    zval class_name_zv, method_name_zv;
-    ZVAL_STR(&class_name_zv, class_name);
-    ZVAL_STR(&method_name_zv, method_name);
-
-    RETURN_BOOL(ddtrace_trace(&class_name_zv, &method_name_zv, callable, options TSRMLS_CC));
-}
-
-static PHP_FUNCTION(hook_function) {
-    zend_string *function_name = NULL;
-    zval *prehook = NULL, *posthook = NULL;
-
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 1, 3)
-    // clang-format off
-        Z_PARAM_STR(function_name)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_OBJECT_OF_CLASS_EX(prehook, zend_ce_closure, 1, 0)
-        Z_PARAM_OBJECT_OF_CLASS_EX(posthook, zend_ce_closure, 1, 0)
-    // clang-format on
-    ZEND_PARSE_PARAMETERS_END_EX({
-        ddtrace_log_debug(
-            "Unable to parse parameters for DDTrace\\hook_function; expected "
-            "(string $function_name, ?Closure $prehook = NULL, ?Closure $posthook = NULL)");
-    });
-
-    if (prehook && posthook) {
-        // both callbacks given; not yet supported
-        ddtrace_log_debug(
-            "DDTrace\\hook_function was given both prehook and posthook. This is not yet supported; ignoring call.");
-        RETURN_FALSE;
-    }
-
-    if (!prehook && !posthook) {
-        ddtrace_log_debug("DDTrace\\hook_function was given neither prehook nor posthook.");
-        RETURN_FALSE;
-    }
-
-    // at this point we know we have a posthook XOR posthook
-    zval *callable = prehook ?: posthook;
-    uint32_t options = (prehook ? DDTRACE_DISPATCH_PREHOOK : DDTRACE_DISPATCH_POSTHOOK) | DDTRACE_DISPATCH_NON_TRACING;
-
-    // massage zend_string * into zval
-    zval function_name_zv;
-    ZVAL_STR(&function_name_zv, function_name);
-
-    RETURN_BOOL(ddtrace_trace(NULL, &function_name_zv, callable, options TSRMLS_CC));
-}
-#endif
 
 static PHP_FUNCTION(additional_trace_meta) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
 
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "")) {
         ddtrace_log_debug("Unexpected parameters to DDTrace\\additional_trace_meta");
@@ -978,7 +792,7 @@ static PHP_FUNCTION(additional_trace_meta) {
 }
 
 static PHP_FUNCTION(trace_function) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr);
+    UNUSED(return_value_used, this_ptr, return_value_ptr);
     zval *function = NULL;
     zval *tracing_closure = NULL;
     zval *config_array = NULL;
@@ -1018,21 +832,18 @@ static PHP_FUNCTION(trace_function) {
 }
 
 static PHP_FUNCTION(dd_trace_serialize_closed_spans) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_serialize_closed_spans(return_value TSRMLS_CC);
 }
 
 // Invoke the function/method from the original context
 static PHP_FUNCTION(dd_trace_forward_call) {
-    PHP5_UNUSED(ht, return_value_ptr, this_ptr, return_value_used TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(ht, return_value_ptr, this_ptr, return_value_used TSRMLS_CC);
     RETURN_FALSE;
 }
 
 static PHP_FUNCTION(dd_trace_env_config) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     zval *env_name = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &env_name) != SUCCESS) {
@@ -1049,8 +860,7 @@ static PHP_FUNCTION(dd_trace_env_config) {
 
 // This function allows untracing a function.
 static PHP_FUNCTION(dd_untrace) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     if (DDTRACE_G(disable) && DDTRACE_G(disable_in_current_request)) {
         RETURN_BOOL(0);
@@ -1070,19 +880,14 @@ static PHP_FUNCTION(dd_untrace) {
     }
 
     if (DDTRACE_G(function_lookup)) {
-#if PHP_VERSION_ID < 70000
         zend_hash_del(DDTRACE_G(function_lookup), Z_STRVAL_P(function), Z_STRLEN_P(function));
-#else
-        zend_hash_del(DDTRACE_G(function_lookup), Z_STR_P(function));
-#endif
     }
 
     RETURN_BOOL(1);
 }
 
 static PHP_FUNCTION(dd_trace_disable_in_request) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     DDTRACE_G(disable_in_current_request) = 1;
 
@@ -1090,8 +895,7 @@ static PHP_FUNCTION(dd_trace_disable_in_request) {
 }
 
 static PHP_FUNCTION(dd_trace_reset) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -1103,8 +907,7 @@ static PHP_FUNCTION(dd_trace_reset) {
 
 /* {{{ proto string dd_trace_serialize_msgpack(array trace_array) */
 static PHP_FUNCTION(dd_trace_serialize_msgpack) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -1124,8 +927,7 @@ static PHP_FUNCTION(dd_trace_serialize_msgpack) {
 
 // method used to be able to easily breakpoint the execution at specific PHP line in GDB
 static PHP_FUNCTION(dd_trace_noop) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -1136,22 +938,19 @@ static PHP_FUNCTION(dd_trace_noop) {
 
 /* {{{ proto int dd_trace_dd_get_memory_limit() */
 static PHP_FUNCTION(dd_trace_dd_get_memory_limit) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
 
     RETURN_LONG(ddtrace_get_memory_limit(TSRMLS_C));
 }
 
 /* {{{ proto bool dd_trace_check_memory_under_limit() */
 static PHP_FUNCTION(dd_trace_check_memory_under_limit) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     RETURN_BOOL(ddtrace_check_memory_under_limit(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     dd_tracer_circuit_breaker_register_error();
 
@@ -1159,8 +958,7 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_error) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     dd_tracer_circuit_breaker_register_success();
 
@@ -1168,15 +966,13 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_register_success) {
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_can_try) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     RETURN_BOOL(dd_tracer_circuit_breaker_can_try());
 }
 
 static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     array_init_size(return_value, 5);
 
@@ -1188,32 +984,17 @@ static PHP_FUNCTION(dd_tracer_circuit_breaker_info) {
     return;
 }
 
-#if PHP_VERSION_ID < 70000
 typedef long ddtrace_zpplong_t;
-#else
-typedef zend_long ddtrace_zpplong_t;
-#endif
 
 static PHP_FUNCTION(ddtrace_config_app_name) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string default_str = {
         .ptr = NULL,
         .len = 0,
     };
-#if PHP_VERSION_ID < 70000
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &default_str.ptr, &default_str.len) != SUCCESS) {
         RETURN_NULL();
     }
-#else
-    zend_string *default_zstr = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|S", &default_zstr) != SUCCESS) {
-        RETURN_NULL();
-    }
-    if (default_zstr) {
-        default_str.ptr = ZSTR_VAL(default_zstr);
-        default_str.len = ZSTR_LEN(default_zstr);
-    }
-#endif
 
     ddtrace_string app_name =
         ddtrace_string_getenv_multi(ZEND_STRL("DD_SERVICE"), ZEND_STRL("DD_SERVICE_NAME") TSRMLS_CC);
@@ -1230,35 +1011,24 @@ static PHP_FUNCTION(ddtrace_config_app_name) {
     }
 
     ddtrace_string trimmed = ddtrace_trim(app_name);
-#if PHP_VERSION_ID < 70000
     RETVAL_STRINGL(trimmed.ptr, trimmed.len, 1);
-#else
-    // Re-use and addref the default_zstr iff they match and trim didn't occur; copy otherwise
-    if (default_zstr && trimmed.ptr == ZSTR_VAL(default_zstr) && trimmed.len == ZSTR_LEN(default_zstr)) {
-        RETVAL_STR_COPY(default_zstr);
-    } else {
-        RETVAL_STRINGL(trimmed.ptr, trimmed.len);
-    }
-#endif
     if (should_free_app_name) {
         efree(app_name.ptr);
     }
 }
 
 static PHP_FUNCTION(ddtrace_config_distributed_tracing_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     RETURN_BOOL(ddtrace_config_distributed_tracing_enabled(TSRMLS_C));
 }
 
 static PHP_FUNCTION(ddtrace_config_trace_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     RETURN_BOOL(ddtrace_config_trace_enabled(TSRMLS_C));
 }
 
 static PHP_FUNCTION(ddtrace_config_integration_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     if (!ddtrace_config_trace_enabled(TSRMLS_C)) {
         RETURN_FALSE;
     }
@@ -1270,7 +1040,7 @@ static PHP_FUNCTION(ddtrace_config_integration_enabled) {
 }
 
 static PHP_FUNCTION(integration_analytics_enabled) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string integration;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &integration.ptr, &integration.len) != SUCCESS) {
         RETURN_NULL();
@@ -1279,7 +1049,7 @@ static PHP_FUNCTION(integration_analytics_enabled) {
 }
 
 static PHP_FUNCTION(integration_analytics_sample_rate) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string integration;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &integration.ptr, &integration.len) != SUCCESS) {
         RETURN_NULL();
@@ -1288,7 +1058,7 @@ static PHP_FUNCTION(integration_analytics_sample_rate) {
 }
 
 static PHP_FUNCTION(trigger_error) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     ddtrace_string message;
     ddtrace_zpplong_t error_type;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &message.ptr, &message.len, &error_type) != SUCCESS) {
@@ -1321,7 +1091,7 @@ static PHP_FUNCTION(trigger_error) {
 }
 
 static PHP_FUNCTION(ddtrace_init) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     if (DDTRACE_G(request_init_hook_loaded) == 1) {
         RETURN_FALSE;
     }
@@ -1344,7 +1114,7 @@ static PHP_FUNCTION(ddtrace_init) {
 }
 
 static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     char *payload = NULL;
     ddtrace_zpplong_t num_traces = 0;
     ddtrace_zppstrlen_t payload_len = 0;
@@ -1362,7 +1132,7 @@ static PHP_FUNCTION(dd_trace_send_traces_via_thread) {
 }
 
 static PHP_FUNCTION(dd_trace_buffer_span) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     if (DDTRACE_G(disable)) {
         RETURN_BOOL(0);
@@ -1387,8 +1157,7 @@ static PHP_FUNCTION(dd_trace_buffer_span) {
 }
 
 static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     RETURN_LONG(ddtrace_coms_trigger_writer_flush());
 }
@@ -1396,8 +1165,7 @@ static PHP_FUNCTION(dd_trace_coms_trigger_writer_flush) {
 #define FUNCTION_NAME_MATCHES(function) ((sizeof(function) - 1) == fn_len && strncmp(fn, function, fn_len) == 0)
 
 static PHP_FUNCTION(dd_trace_internal_fn) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
     zval ***params = NULL;
     uint32_t params_count = 0;
 
@@ -1463,17 +1231,14 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
             RETVAL_TRUE;
         }
     }
-#if PHP_VERSION_ID < 70000
     if (params_count > 0) {
         efree(params);
     }
-#endif
 }
 
 /* {{{ proto string dd_trace_set_trace_id() */
 static PHP_FUNCTION(dd_trace_set_trace_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     zval *trace_id = NULL;
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &trace_id) == SUCCESS) {
@@ -1488,17 +1253,12 @@ static PHP_FUNCTION(dd_trace_set_trace_id) {
 static inline void return_span_id(zval *return_value, uint64_t id) {
     char buf[DD_TRACE_MAX_ID_LEN + 1];
     snprintf(buf, sizeof(buf), "%" PRIu64, id);
-#if PHP_VERSION_ID >= 70000
-    RETURN_STRING(buf);
-#else
     RETURN_STRING(buf, 1);
-#endif
 }
 
 /* {{{ proto string dd_trace_push_span_id() */
 static PHP_FUNCTION(dd_trace_push_span_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     zval *existing_id = NULL;
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "|z!", &existing_id) == SUCCESS) {
@@ -1513,8 +1273,7 @@ static PHP_FUNCTION(dd_trace_push_span_id) {
 
 /* {{{ proto string dd_trace_pop_span_id() */
 static PHP_FUNCTION(dd_trace_pop_span_id) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     uint64_t id = ddtrace_pop_span_id(TSRMLS_C);
 
     if (DDTRACE_G(span_ids_top) == NULL && get_dd_trace_auto_flush_enabled()) {
@@ -1540,8 +1299,7 @@ static PHP_FUNCTION(trace_id) {
 
 /* {{{ proto string dd_trace_closed_spans_count() */
 static PHP_FUNCTION(dd_trace_closed_spans_count) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     RETURN_LONG(DDTRACE_G(closed_spans_count));
 }
 
@@ -1559,30 +1317,23 @@ BOOL_T ddtrace_tracer_is_limited(TSRMLS_D) {
 
 /* {{{ proto string dd_trace_tracer_is_limited() */
 static PHP_FUNCTION(dd_trace_tracer_is_limited) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     RETURN_BOOL(ddtrace_tracer_is_limited(TSRMLS_C) == TRUE ? 1 : 0);
 }
 
 /* {{{ proto string dd_trace_compile_time_microseconds() */
 static PHP_FUNCTION(dd_trace_compile_time_microseconds) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
     RETURN_LONG(ddtrace_compile_time_get(TSRMLS_C));
 }
 
 static PHP_FUNCTION(startup_logs) {
-    PHP5_UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
-    PHP7_UNUSED(execute_data);
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht TSRMLS_CC);
 
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-#if PHP_VERSION_ID >= 70000
-    ZVAL_NEW_STR(return_value, buf.s);
-#else
     ZVAL_STRINGL(return_value, buf.c, buf.len, 1);
     smart_str_free(&buf);
-#endif
 }
 
 static const zend_function_entry ddtrace_functions[] = {

--- a/ext/php5/ddtrace_string.h
+++ b/ext/php5/ddtrace_string.h
@@ -6,11 +6,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#if PHP_VERSION_ID < 70000
 typedef int ddtrace_zppstrlen_t;
-#else
-typedef size_t ddtrace_zppstrlen_t;
-#endif
 
 struct ddtrace_string {
     char *ptr;
@@ -21,11 +17,7 @@ typedef struct ddtrace_string ddtrace_string;
 #define DDTRACE_STRING_LITERAL(str) \
     (ddtrace_string) { .ptr = str, .len = sizeof(str) - 1 }
 
-#if PHP_VERSION_ID < 70000
 #define DDTRACE_STRING_ZVAL_L(zval_ptr, str) ZVAL_STRINGL(zval_ptr, str.ptr, str.len, 1)
-#else
-#define DDTRACE_STRING_ZVAL_L(zval_ptr, str) ZVAL_STRINGL(zval_ptr, str.ptr, str.len)
-#endif
 
 inline ddtrace_string ddtrace_string_cstring_ctor(char *ptr) {
     ddtrace_string string = {

--- a/ext/php5/dispatch.h
+++ b/ext/php5/dispatch.h
@@ -65,7 +65,6 @@ void ddtrace_dispatch_init(TSRMLS_D);
 void ddtrace_dispatch_destroy(TSRMLS_D);
 void ddtrace_dispatch_reset(TSRMLS_D);
 
-#if PHP_VERSION_ID < 70000
 
 #undef EX
 #define EX(element) ((execute_data)->element)
@@ -87,12 +86,6 @@ void ddtrace_dispatch_reset(TSRMLS_D);
 void ddtrace_class_lookup_release_compat(void *zv);
 
 #define ddtrace_zval_ptr_dtor(x) zval_dtor(x)
-#else
-void ddtrace_class_lookup_release_compat(zval *zv);
-
-#define ddtrace_zval_ptr_dtor(x) zval_ptr_dtor(x)
-#define INIT_ZVAL(x) ZVAL_NULL(&x)
-#endif
 
 HashTable *ddtrace_new_class_lookup(zval *clazz TSRMLS_DC);
 zend_bool ddtrace_dispatch_store(HashTable *class_lookup, ddtrace_dispatch_t *dispatch);

--- a/ext/php5/dispatch.h
+++ b/ext/php5/dispatch.h
@@ -65,7 +65,6 @@ void ddtrace_dispatch_init(TSRMLS_D);
 void ddtrace_dispatch_destroy(TSRMLS_D);
 void ddtrace_dispatch_reset(TSRMLS_D);
 
-
 #undef EX
 #define EX(element) ((execute_data)->element)
 

--- a/ext/php5/handlers_internal.c
+++ b/ext/php5/handlers_internal.c
@@ -2,12 +2,12 @@
 
 #include "compatibility.h"
 
-void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) { PHP5_UNUSED(ht, fname); }
+void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname) { UNUSED(ht, fname); }
 void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]) {
-    PHP5_UNUSED(ht, functions_len, functions);
+    UNUSED(ht, functions_len, functions);
 }
 void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, ddtrace_string methods[]) {
-    PHP5_UNUSED(Class, methods_len, methods);
+    UNUSED(Class, methods_len, methods);
 }
 
 void ddtrace_curl_handlers_startup(void);

--- a/ext/php5/integrations/integrations.c
+++ b/ext/php5/integrations/integrations.c
@@ -53,13 +53,13 @@ size_t ddtrace_integrations_len = sizeof ddtrace_integrations / sizeof ddtrace_i
 // Map of lowercase strings to the ddtrace_integration equivalent
 static HashTable _dd_string_to_integration_name_map;
 
-static void _dd_add_integration_to_map(char* name, size_t name_len, ddtrace_integration* integration);
+static void _dd_add_integration_to_map(char *name, size_t name_len, ddtrace_integration *integration);
 
 void ddtrace_integrations_minit(void) {
     zend_hash_init(&_dd_string_to_integration_name_map, ddtrace_integrations_len, NULL, NULL, 1);
 
     for (size_t i = 0; i < ddtrace_integrations_len; ++i) {
-        char* name = ddtrace_integrations[i].name_lcase;
+        char *name = ddtrace_integrations[i].name_lcase;
         size_t name_len = ddtrace_integrations[i].name_len;
         _dd_add_integration_to_map(name, name_len, &ddtrace_integrations[i]);
     }
@@ -84,7 +84,7 @@ static void dd_register_known_calls(TSRMLS_D) {
 }
 
 static void dd_load_test_integrations(TSRMLS_D) {
-    char* test_deferred = getenv("_DD_LOAD_TEST_INTEGRATIONS");
+    char *test_deferred = getenv("_DD_LOAD_TEST_INTEGRATIONS");
     if (!test_deferred) {
         return;
     }

--- a/ext/php5/integrations/integrations.c
+++ b/ext/php5/integrations/integrations.c
@@ -93,58 +93,6 @@ static void dd_load_test_integrations(TSRMLS_D) {
     DDTRACE_INTEGRATION_TRACE("test", "automaticaly_traced_method", "tracing_function", DDTRACE_DISPATCH_POSTHOOK);
 }
 
-#if PHP_VERSION_ID >= 70000
-static void dd_set_up_deferred_loading_by_method(ddtrace_integration_name name, ddtrace_string Class,
-                                                 ddtrace_string method, ddtrace_string integration) {
-    if (!ddtrace_config_integration_enabled_ex(name)) {
-        return;
-    }
-
-    ddtrace_hook_callable(Class, method, integration, DDTRACE_DISPATCH_DEFERRED_LOADER);
-}
-
-void ddtrace_integrations_rinit(TSRMLS_D) {
-    dd_register_known_calls();
-    dd_load_test_integrations(TSRMLS_C);
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_ELASTICSEARCH, "elasticsearch\\client", "__construct",
-                                         "DDTrace\\Integrations\\ElasticSearch\\V1\\ElasticSearchIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_MEMCACHED, "Memcached", "__construct",
-                                         "DDTrace\\Integrations\\Memcached\\MemcachedIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_PDO, "PDO", "__construct",
-                                         "DDTrace\\Integrations\\PDO\\PDOIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_PHPREDIS, "Redis", "__construct",
-                                         "DDTrace\\Integrations\\PHPRedis\\PHPRedisIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_PHPREDIS, "RedisCluster", "__construct",
-                                         "DDTrace\\Integrations\\PHPRedis\\PHPRedisIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_PREDIS, "Predis\\Client", "__construct",
-                                         "DDTrace\\Integrations\\Predis\\PredisIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_SLIM, "Slim\\App", "__construct",
-                                         "DDTrace\\Integrations\\Slim\\SlimIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_WORDPRESS, "Requests", "set_certificate_path",
-                                         "DDTrace\\Integrations\\WordPress\\WordPressIntegration");
-
-    DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_YII, "yii\\di\\Container", "__construct",
-                                         "DDTrace\\Integrations\\Yii\\YiiIntegration");
-}
-
-ddtrace_integration* ddtrace_get_integration_from_string(ddtrace_string integration) {
-    return zend_hash_str_find_ptr(&_dd_string_to_integration_name_map, integration.ptr, integration.len);
-}
-
-static void _dd_add_integration_to_map(char* name, size_t name_len, ddtrace_integration* integration) {
-    zend_hash_str_add_ptr(&_dd_string_to_integration_name_map, name, name_len, integration);
-    ZEND_ASSERT(strlen(integration->name_ucase) == name_len);
-    ZEND_ASSERT(DDTRACE_LONGEST_INTEGRATION_NAME_LEN >= name_len);
-}
-#else
 void ddtrace_integrations_rinit(TSRMLS_D) {
     /* In PHP 5.6 currently adding deferred integrations seem to trigger increase in heap
      * size - even though the memory usage is below the limit. We still can trigger memory
@@ -168,4 +116,3 @@ static void _dd_add_integration_to_map(char *name, size_t name_len, ddtrace_inte
     zend_hash_add(&_dd_string_to_integration_name_map, name, name_len + 1, (void **)&integration, sizeof(integration),
                   NULL);
 }
-#endif

--- a/ext/php5/logging.h
+++ b/ext/php5/logging.h
@@ -5,12 +5,8 @@
 #include "configuration.h"
 
 inline void ddtrace_log_err(const char *message) {
-#if PHP_VERSION_ID < 80000
     TSRMLS_FETCH();
     php_log_err((char *)message TSRMLS_CC);
-#else
-    php_log_err(message);
-#endif
 }
 
 #define ddtrace_log_debugf(...)            \

--- a/ext/php5/php5/engine_hooks.c
+++ b/ext/php5/php5/engine_hooks.c
@@ -784,18 +784,18 @@ void ddtrace_execute_internal_mshutdown(void) {
 
 void ddtrace_engine_hooks_rinit(TSRMLS_D) {
 #if ZTS
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
 }
 
 void ddtrace_engine_hooks_rshutdown(TSRMLS_D) {
 #if ZTS
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
 }
 
 zval *ddtrace_make_exception_from_error(DDTRACE_ERROR_CB_PARAMETERS TSRMLS_DC) {
-    PHP5_UNUSED(error_filename, error_lineno);
+    UNUSED(error_filename, error_lineno);
 
     zval *exception, *message_zv, *code_zv;
     MAKE_STD_ZVAL(exception);

--- a/ext/php5/random.c
+++ b/ext/php5/random.c
@@ -39,11 +39,7 @@ static inline uint64_t zval_to_uint64(zval *zid) {
         return 0U;
     }
     const char *id = Z_STRVAL_P(zid);
-#if PHP_VERSION_ID >= 70000
-    size_t i = 0;
-#else
     int i = 0;
-#endif
     for (; i < Z_STRLEN_P(zid); i++) {
         if (id[i] < '0' || id[i] > '9') {
             return 0U;

--- a/ext/php5/request_hooks.c
+++ b/ext/php5/request_hooks.c
@@ -14,7 +14,6 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
-#if PHP_VERSION_ID < 70000
 int dd_execute_php_file(const char *filename TSRMLS_DC) {
     int filename_len = strlen(filename);
     if (filename_len == 0) {
@@ -124,108 +123,6 @@ int dd_execute_php_file(const char *filename TSRMLS_DC) {
     EG(active_op_array) = original_active_op_array;
     return rv;
 }
-#else
-
-int dd_execute_php_file(const char *filename TSRMLS_DC) {
-    int filename_len = strlen(filename);
-    if (filename_len == 0) {
-        return FAILURE;
-    }
-    zval dummy;
-    zend_file_handle file_handle;
-    zend_op_array *new_op_array;
-    zval result;
-    int ret, rv = FALSE;
-
-    ddtrace_error_handling eh_stream;
-    // Using an EH_THROW here causes a non-recoverable zend_bailout()
-    ddtrace_backup_error_handling(&eh_stream, EH_NORMAL);
-    zend_bool _original_cg_multibyte = CG(multibyte);
-    CG(multibyte) = FALSE;
-
-    ret = php_stream_open_for_zend_ex(filename, &file_handle, USE_PATH | STREAM_OPEN_FOR_INCLUDE);
-
-    if (get_dd_trace_debug() && PG(last_error_message) && eh_stream.message != PG(last_error_message)) {
-        char *error;
-#if PHP_VERSION_ID < 80000
-        error = PG(last_error_message);
-#else
-        error = ZSTR_VAL(PG(last_error_message));
-#endif
-        ddtrace_log_errf("Error raised while opening request-init-hook stream: %s in %s on line %d", error,
-                         PG(last_error_file), PG(last_error_lineno));
-    }
-
-    ddtrace_restore_error_handling(&eh_stream);
-
-    if (!EG(exception) && ret == SUCCESS) {
-        zend_string *opened_path;
-        if (!file_handle.opened_path) {
-            file_handle.opened_path = zend_string_init(filename, filename_len, 0);
-        }
-        opened_path = zend_string_copy(file_handle.opened_path);
-        ZVAL_NULL(&dummy);
-
-        if (zend_hash_add(&EG(included_files), opened_path, &dummy)) {
-            new_op_array = zend_compile_file(&file_handle, ZEND_REQUIRE);
-            zend_destroy_file_handle(&file_handle);
-        } else {
-            new_op_array = NULL;
-            zend_file_handle_dtor(&file_handle);
-        }
-
-        zend_string_release(opened_path);
-        if (new_op_array) {
-            ZVAL_UNDEF(&result);
-
-            ddtrace_error_handling eh;
-            ddtrace_backup_error_handling(&eh, EH_THROW);
-
-            zend_execute(new_op_array, &result);
-
-            if (get_dd_trace_debug() && PG(last_error_message) && eh.message != PG(last_error_message)) {
-                char *error;
-#if PHP_VERSION_ID < 80000
-                error = PG(last_error_message);
-#else
-                error = ZSTR_VAL(PG(last_error_message));
-#endif
-                ddtrace_log_errf("Error raised in request init hook: %s in %s on line %d", error, PG(last_error_file),
-                                 PG(last_error_lineno));
-            }
-
-            ddtrace_restore_error_handling(&eh);
-
-            destroy_op_array(new_op_array);
-            efree(new_op_array);
-            if (!EG(exception)) {
-                zval_ptr_dtor(&result);
-            } else if (get_dd_trace_debug()) {
-                zend_object *ex = EG(exception);
-
-                const char *type = ex->ce->name->val;
-                zval rv, obj;
-                ZVAL_OBJ(&obj, ex);
-                zval *message = GET_PROPERTY(&obj, ZEND_STR_MESSAGE);
-                const char *msg = Z_TYPE_P(message) == IS_STRING ? Z_STR_P(message)->val
-                                                                 : "(internal error reading exception message)";
-                ddtrace_log_errf("%s thrown in request init hook: %s", type, msg);
-                if (message == &rv) {
-                    zval_dtor(message);
-                }
-            }
-            ddtrace_maybe_clear_exception();
-            rv = TRUE;
-        }
-    } else {
-        ddtrace_maybe_clear_exception();
-        ddtrace_log_debugf("Error opening request init hook: %s", filename);
-    }
-    CG(multibyte) = _original_cg_multibyte;
-
-    return rv;
-}
-#endif
 
 int dd_execute_auto_prepend_file(char *auto_prepend_file TSRMLS_DC) {
     zend_file_handle prepend_file;
@@ -236,12 +133,6 @@ int dd_execute_auto_prepend_file(char *auto_prepend_file TSRMLS_DC) {
     prepend_file.type = ZEND_HANDLE_FILENAME;
     prepend_file.filename = auto_prepend_file;
     int ret = zend_execute_scripts(ZEND_REQUIRE TSRMLS_CC, NULL, 1, &prepend_file) == SUCCESS;
-#if PHP_VERSION_ID >= 80000
-    // Exit no longer calls zend_bailout in PHP 8, so we need to "rethrow" the exit
-    if (ret == 0) {
-        zend_throw_unwind_exit();
-    }
-#endif
     // EG(current_execute_data) = ex;
     return ret;
 }
@@ -256,11 +147,7 @@ void dd_request_init_hook_rinit(TSRMLS_D) {
 
     zval exists_flag;
     php_stat(DDTRACE_G(request_init_hook), strlen(DDTRACE_G(request_init_hook)), FS_EXISTS, &exists_flag TSRMLS_CC);
-#if PHP_VERSION_ID < 70000
     if (!Z_BVAL(exists_flag)) {
-#else
-    if (Z_TYPE(exists_flag) == IS_FALSE) {
-#endif
         ddtrace_log_debugf("Cannot open request init hook; file does not exist: '%s'", DDTRACE_G(request_init_hook));
         return;
     }

--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -167,10 +167,10 @@ static void _add_assoc_zval_copy(zval *el, const char *name, zval *prop) {
  * @see https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_exceptions.c#L543-L605
  */
 static int _trace_string(zval **frame TSRMLS_DC, int num_args, va_list args, zend_hash_key *hash_key) {
-    PHP5_UNUSED(hash_key);
+    UNUSED(hash_key);
 #ifdef ZTS
     /* This arg is required for the zend_hash_apply_with_arguments function signature, but we don't need it */
-    PHP5_UNUSED(TSRMLS_C);
+    UNUSED(TSRMLS_C);
 #endif
 
     char *s_tmp, **str;

--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -29,7 +29,6 @@ static void _free_span(ddtrace_span_fci *span_fci) {
         return;
     }
     ddtrace_span_t *span = &span_fci->span;
-#if PHP_VERSION_ID < 70000
     if (span->span_data) {
         zval_ptr_dtor(&span->span_data);
         span->span_data = NULL;
@@ -38,17 +37,6 @@ static void _free_span(ddtrace_span_fci *span_fci) {
         zval_ptr_dtor(&span_fci->exception);
         span_fci->exception = NULL;
     }
-#else
-    if (span->span_data) {
-        zval_ptr_dtor(span->span_data);
-        efree(span->span_data);
-        span->span_data = NULL;
-    }
-    if (span_fci->exception) {
-        OBJ_RELEASE(span_fci->exception);
-        span_fci->exception = NULL;
-    }
-#endif
 
     efree(span_fci);
 }
@@ -98,11 +86,7 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
     ddtrace_span_t *span = &span_fci->span;
 
     /* On PHP 5 object_init_ex does not set refcount to 1, but on PHP 7 it does */
-#if PHP_VERSION_ID < 70000
     MAKE_STD_ZVAL(span->span_data);
-#else
-    span->span_data = (zval *)ecalloc(1, sizeof(zval));
-#endif
     object_init_ex(span->span_data, ddtrace_ce_span_data);
 
     // Peek at the active span ID before we push a new one onto the stack

--- a/ext/php5/startup_logging.h
+++ b/ext/php5/startup_logging.h
@@ -4,11 +4,7 @@
 #include <php.h>
 #include <stdbool.h>
 
-#if PHP_VERSION_ID >= 70000
-#include <Zend/zend_smart_str.h>
-#else
 #include <ext/standard/php_smart_str.h>
-#endif
 
 /* Number of config & diagnostic values */
 #define DDTRACE_STARTUP_STAT_COUNT 43


### PR DESCRIPTION
### Description

Get rid of all non php5 code in `ext/php5`

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
