### PR TITLE
Disable tracer for good when DD_TRACE_ENABLED=false or cli and DD_TRACE_CLI_ENABLED=false

### DIFF
--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -280,14 +280,15 @@ static void dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
 static void dd_disable_by_configuration(TSRMLS_D) {
     if (!get_dd_trace_enabled()) {
         ddtrace_log_debugf("Tracing is disabled by user setting; disabling ddtrace");
-    } else if (dd_is_cli() && !get_dd_trace_cli_enabled()) {
-        ddtrace_log_debugf("CLI SAPI not explicitly enabled; disabling ddtrace");
-    } else {
-        // If we are in this branch, it means that we do not have to disable the tracer
+        DDTRACE_G(disable) = 1;
         return;
     }
 
-    DDTRACE_G(disable) = 1;
+    if (dd_is_cli() && !get_dd_trace_cli_enabled()) {
+        ddtrace_log_debugf("CLI SAPI not explicitly enabled; disabling ddtrace");
+        DDTRACE_G(disable) = 1;
+        return;
+    }
 }
 
 static PHP_MINIT_FUNCTION(ddtrace) {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -63,7 +63,7 @@ STD_PHP_INI_ENTRY("ddtrace.request_init_hook", "", PHP_INI_SYSTEM, OnUpdateStrin
 PHP_INI_END()
 
 static int ddtrace_startup(struct _zend_extension *extension) {
-    if (DDTRACE_G(disable) = 1) {
+    if (DDTRACE_G(disable)) {
         return SUCCESS;
     }
 
@@ -80,7 +80,7 @@ static int ddtrace_startup(struct _zend_extension *extension) {
 static void ddtrace_shutdown(struct _zend_extension *extension) {
     UNUSED(extension);
 
-    if (DDTRACE_G(disable) = 1) {
+    if (DDTRACE_G(disable)) {
         return;
     }
 


### PR DESCRIPTION
### Description

Before this PR, even when tracing was disabled, a few things happened, including spawning the background sender thread and initializing the internal handlers.

This is not only problematic in cases like the ones uncovered by https://github.com/DataDog/dd-trace-php/issues/1158, but it is also inconvenient because it increases the risks that we take when our tracer is installed but not used.

This PR applies the concept: "exit as soon as you can doing the least possible work".

**DRAFT**: this is still in draft, as more tests have to be added and some existing tested have to be adapted, but it is ready enough to receive feedback about the approach.

Relates to #1158.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
