### PR TITLE
 Support PsrHttpServerMiddleware for Slim 4

### DIFF
--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -64,6 +64,7 @@ class SlimIntegration extends Integration
                         }
                     });
 
+                    /* Blocked: https://datadoghq.atlassian.net/browse/APMPHP-553
                     \DDTrace\hook_method(
                         'Slim\\Middleware\\ErrorMiddleware',
                         'handleException',
@@ -76,6 +77,7 @@ class SlimIntegration extends Integration
                             }
                         }
                     );
+                     */
                 }
 
                 if ('3' === $majorVersion) {

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -35,6 +35,56 @@ final class CommonScenariosTest extends WebFrameworkTestCase
         $this->assertFlameGraph($traces, $spanExpectations);
     }
 
+    private function wrapMiddleware(array $children, array $setError = []): SpanAssertion
+    {
+        if (!empty($setError)) {
+            return SpanAssertion::build(
+                'slim.middleware',
+                'slim_test_app',
+                'web',
+                'Slim\\Middleware\\ErrorMiddleware'
+            )->withChildren([
+                SpanAssertion::build(
+                    'slim.middleware',
+                    'slim_test_app',
+                    'web',
+                    'Slim\Middleware\RoutingMiddleware'
+                )->withChildren([
+                    SpanAssertion::build(
+                        'slim.middleware',
+                        'slim_test_app',
+                        'web',
+                        'Slim\\Views\\TwigMiddleware'
+                    )
+                    ->withChildren($children)
+                    ->withExistingTagsNames(['error.stack'])
+                    ->setError(...$setError)
+                ])->withExistingTagsNames(['error.stack'])->setError(...$setError),
+            ])/* ->setError(...$setError) ; no error on ErrorMiddleware*/;
+        } else {
+            return SpanAssertion::build(
+                'slim.middleware',
+                'slim_test_app',
+                'web',
+                'Slim\\Middleware\\ErrorMiddleware'
+            )->withChildren([
+                SpanAssertion::build(
+                    'slim.middleware',
+                    'slim_test_app',
+                    'web',
+                    'Slim\Middleware\RoutingMiddleware'
+                )->withChildren([
+                    SpanAssertion::build(
+                        'slim.middleware',
+                        'slim_test_app',
+                        'web',
+                        'Slim\\Views\\TwigMiddleware'
+                    )->withChildren($children)
+                ]),
+            ]);
+        }
+    }
+
     public function provideSpecs()
     {
         return $this->buildDataProvider(
@@ -52,14 +102,16 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
                     ])->withChildren([
-                        SpanAssertion::build(
-                            'slim.route',
-                            'slim_test_app',
-                            'web',
-                            'Closure::__invoke'
-                        )->withExactTags([
-                            'slim.route.name' => 'simple-route',
-                        ])
+                        $this->wrapMiddleware([
+                            SpanAssertion::build(
+                                'slim.route',
+                                'slim_test_app',
+                                'web',
+                                'Closure::__invoke'
+                            )->withExactTags([
+                                'slim.route.name' => 'simple-route',
+                            ])
+                        ]),
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -74,21 +126,23 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
                     ])->withChildren([
-                        SpanAssertion::build(
-                            'slim.route',
-                            'slim_test_app',
-                            'web',
-                            'Closure::__invoke'
-                        )->withChildren([
+                        $this->wrapMiddleware([
                             SpanAssertion::build(
-                                'slim.view',
+                                'slim.route',
                                 'slim_test_app',
                                 'web',
-                                'simple_view.phtml'
-                            )->withExactTags([
-                                'slim.view' => 'simple_view.phtml',
-                            ])
-                        ])
+                                'Closure::__invoke'
+                            )->withChildren([
+                                SpanAssertion::build(
+                                    'slim.view',
+                                    'slim_test_app',
+                                    'web',
+                                    'simple_view.phtml'
+                                )->withExactTags([
+                                    'slim.view' => 'simple_view.phtml',
+                                ]),
+                            ]),
+                        ]),
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -102,17 +156,23 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ])->setError(null, null)
-                        ->withChildren([
-                            SpanAssertion::build(
-                                'slim.route',
-                                'slim_test_app',
-                                'web',
-                                'Closure::__invoke'
-                            )->withExistingTagsNames([
-                                'error.stack'
-                            ])->setError(null, 'Foo error')
-                        ]),
+                    ])->withExistingTagsNames(['error.stack'])
+                    ->setError(null, 'Foo error')
+                    ->withChildren([
+                        $this->wrapMiddleware(
+                            [
+                                SpanAssertion::build(
+                                    'slim.route',
+                                    'slim_test_app',
+                                    'web',
+                                    'Closure::__invoke'
+                                )->withExistingTagsNames([
+                                    'error.stack'
+                                ])->setError(null, 'Foo error')
+                            ],
+                            [null, 'Foo error']
+                        )
+                    ]),
                 ],
             ]
         );

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -156,8 +156,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ])->withExistingTagsNames(['error.stack'])
-                    ->setError(null, 'Foo error')
+                    ])
+                    ->setError(null, null)
                     ->withChildren([
                         $this->wrapMiddleware(
                             [


### PR DESCRIPTION
### Description

Adds support for some of Slim 4's middleware implementations; it doesn't support all forms because our tracer doesn't support tracing closures and anonymous classes (at least, not statically).

![app datadoghq com_apm_trace_3342428958159249758_colorBy=service env=none graphType=flamegraph shouldShowLegend=true sort=time spanID=1653738486728196359 spanViewType=metadata](https://user-images.githubusercontent.com/253316/110216064-48ec2200-7e6a-11eb-82ed-6f5f66138067.png)

This PR previously had support for Slim 4's error handler. Support for the Slim 4 error handler has been disabled and will be re-enabled in another PR.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
