### PR TITLE
[Tracer] Add component system, string_view and sapi components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,6 +900,24 @@ jobs:
             make -j
             make test
 
+      - run:
+          name: Build and test Datadog::Php::Components
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/datadog_php_components
+            cd /tmp/build/datadog_php_components
+            if [ -f "/etc/debian_version" ]
+            then
+              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+            fi
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              $toolchain \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_COMPONENTS_TESTING=ON \
+              ~/datadog/components
+            make -j all
+            make test
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -1063,11 +1081,10 @@ workflows:
                 - "datadog/dd-trace-ci:alpine"
                 - "datadog/dd-trace-ci:buster"
               cmake_version:
-                - "3.10.3"
-                - "3.18.4"
+                - "3.14.7"
+                - "3.19.6"
               catch2_version:
-                - "2.4.2"
-                - "2.13.3"
+                - "2.13.4"
 
   build_packages:
     jobs:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
-C_FILES := $(shell find ext src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
+C_FILES := $(shell find components ext src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 INIT_HOOK_TEST_FILES := $(shell find tests/C2PHP -name '*.phpt' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 M4_FILES := $(shell find m4 -name '*.m4*' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,44 @@
+#[[ Need CMake 3.14 so that `install(TARGETS)` uses better defaults, which
+    saves us from repeating configuration in every file (and must be the same).
+]]
+cmake_minimum_required(VERSION 3.14)
+
+project(datadog-php-components
+  VERSION 0.1.0
+  LANGUAGES C
+)
+
+option(BUILD_COMPONENTS_TESTING "Enable tests" OFF)
+if (${BUILD_COMPONENTS_TESTING})
+  # Tests uses the C++ testing framework Catch2
+  enable_language(CXX)
+
+  # The Catch2::Catch2 target has been available since 2.1.2
+  # We are unsure of the true minimum, but have tested 2.4
+  find_package(Catch2 2.4 REQUIRED)
+
+  #[[ This file takes a while to build, so we do it once here and every test
+      executable can link to it to save time.
+  ]]
+  add_library(catch2_main catch2_main.cc)
+  target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
+  target_compile_features(catch2_main PUBLIC cxx_std_11)
+
+  include(Catch)
+  enable_testing()
+endif()
+
+include(GNUInstallDirs)
+
+add_library(datadog_php_components INTERFACE)
+
+add_subdirectory(string_view)
+
+# sapi depends on string_view
+add_subdirectory(sapi)
+
+install(EXPORT DatadogPhpComponentsTargets
+  FILE DatadogPhpComponentsTargets.cmake
+  NAMESPACE Datadog::Php::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)

--- a/components/catch2_main.cc
+++ b/components/catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/components/sapi/CMakeLists.txt
+++ b/components/sapi/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_library(datadog_php_sapi sapi.c)
+
+target_include_directories(datadog_php_sapi
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(datadog_php_sapi
+  PUBLIC c_std_99
+)
+
+set_target_properties(datadog_php_sapi PROPERTIES
+  EXPORT_NAME Sapi
+  VERSION ${PROJECT_VERSION}
+)
+
+target_link_libraries(datadog_php_sapi
+  PUBLIC Datadog::Php::StringView
+)
+
+add_library(Datadog::Php::Sapi
+  ALIAS datadog_php_sapi
+)
+
+if (${BUILD_COMPONENTS_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sapi.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sapi/
+)
+
+target_link_libraries(datadog_php_components
+  INTERFACE datadog_php_sapi
+)
+
+install(TARGETS datadog_php_sapi
+  EXPORT DatadogPhpComponentsTargets
+)

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -1,0 +1,33 @@
+#include "sapi/sapi.h"
+
+#include <string.h>
+
+typedef datadog_php_sapi sapi_t;
+typedef datadog_php_string_view string_view_t;
+
+#define SV(cstr) DATADOG_PHP_STRING_VIEW_LITERAL(cstr)
+
+sapi_t datadog_php_sapi_from_name(string_view_t module) {
+    struct {
+        string_view_t str;
+        sapi_t type;
+    } sapis[] = {
+        {SV("apache2handler"), DATADOG_PHP_SAPI_APACHE2HANDLER},
+        {SV("cgi-fcgi"), DATADOG_PHP_SAPI_CGI_FCGI},
+        {SV("cli"), DATADOG_PHP_SAPI_CLI},
+        {SV("cli-server"), DATADOG_PHP_SAPI_CLI_SERVER},
+        {SV("embed"), DATADOG_PHP_SAPI_EMBED},
+        {SV("fpm-fcgi"), DATADOG_PHP_SAPI_FPM_FCGI},
+        {SV("litespeed"), DATADOG_PHP_SAPI_LITESPEED},
+        {SV("phpdbg"), DATADOG_PHP_SAPI_PHPDBG},
+    };
+
+    unsigned n_sapis = sizeof sapis / sizeof *sapis;
+    for (unsigned i = 0; i != n_sapis; ++i) {
+        if (datadog_php_string_view_equal(module, sapis[i].str)) {
+            return sapis[i].type;
+        }
+    }
+
+    return DATADOG_PHP_SAPI_UNKNOWN;
+}

--- a/components/sapi/sapi.h
+++ b/components/sapi/sapi.h
@@ -1,0 +1,20 @@
+#ifndef DATADOG_PHP_SAPI_H
+#define DATADOG_PHP_SAPI_H
+
+#include "string_view/string_view.h"
+
+typedef enum {
+    DATADOG_PHP_SAPI_UNKNOWN = 0,
+    DATADOG_PHP_SAPI_APACHE2HANDLER,
+    DATADOG_PHP_SAPI_CGI_FCGI,
+    DATADOG_PHP_SAPI_CLI,
+    DATADOG_PHP_SAPI_CLI_SERVER,
+    DATADOG_PHP_SAPI_EMBED,
+    DATADOG_PHP_SAPI_LITESPEED,
+    DATADOG_PHP_SAPI_FPM_FCGI,
+    DATADOG_PHP_SAPI_PHPDBG,
+} datadog_php_sapi;
+
+datadog_php_sapi datadog_php_sapi_from_name(datadog_php_string_view module);
+
+#endif  // DATADOG_PHP_SAPI_H

--- a/components/sapi/tests/CMakeLists.txt
+++ b/components/sapi/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(sapi sapi.cc)
+
+target_link_libraries(sapi
+  PUBLIC catch2_main Datadog::Php::Sapi
+)
+
+catch_discover_tests(sapi)

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -1,0 +1,57 @@
+extern "C" {
+#include "sapi/sapi.h"
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("recongize real sapis", "[sapi]") {
+    // these strings were taken from the PHP 8.0's sapi/ folder
+    struct {
+        const char *name;
+        datadog_php_sapi sapi;
+    } cases[] = {
+        {"apache2handler", DATADOG_PHP_SAPI_APACHE2HANDLER},
+        {"cgi-fcgi", DATADOG_PHP_SAPI_CGI_FCGI},
+        {"cli", DATADOG_PHP_SAPI_CLI},
+        {"cli-server", DATADOG_PHP_SAPI_CLI_SERVER},
+        {"embed", DATADOG_PHP_SAPI_EMBED},
+        {"fpm-fcgi", DATADOG_PHP_SAPI_FPM_FCGI},
+        {"litespeed", DATADOG_PHP_SAPI_LITESPEED},
+        {"phpdbg", DATADOG_PHP_SAPI_PHPDBG},
+    };
+
+    unsigned n_sapis = sizeof cases / sizeof *cases;
+    for (unsigned i = 0; i != n_sapis; ++i) {
+        datadog_php_string_view view = datadog_php_string_view_from_cstr(cases[i].name);
+        datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
+
+        REQUIRE(sapi == cases[i].sapi);
+    }
+}
+
+TEST_CASE("unknown sapis", "[sapi]") {
+    /* These used to be SAPIs, but have since been removed. I think that makes
+     * them good testing canidates for unknown SAPIs.
+     */
+    const char *cases[] = {
+        "aolserver",
+        "caudium",
+
+        // The fact "Continuity" is upper-cased gave me a giggle
+        "Continuity",
+
+        "isapi",
+        "nsapi",
+        "pi3web",
+        "roxen",
+        "webjames",
+    };
+
+    unsigned n_sapis = sizeof cases / sizeof *cases;
+    for (unsigned i = 0; i != n_sapis; ++i) {
+        datadog_php_string_view view = datadog_php_string_view_from_cstr(cases[i]);
+        datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
+
+        REQUIRE(sapi == DATADOG_PHP_SAPI_UNKNOWN);
+    }
+}

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_library(datadog_php_string_view string_view.c)
+
+target_include_directories(datadog_php_string_view
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(datadog_php_string_view
+  PUBLIC c_std_99
+)
+
+set_target_properties(datadog_php_string_view PROPERTIES
+  EXPORT_NAME StringView
+  VERSION ${PROJECT_VERSION}
+)
+
+add_library(Datadog::Php::StringView
+  ALIAS datadog_php_string_view
+)
+
+if (${BUILD_COMPONENTS_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/string_view/
+)
+
+target_link_libraries(datadog_php_components
+  INTERFACE datadog_php_string_view
+)
+
+install(TARGETS datadog_php_string_view
+  EXPORT DatadogPhpComponentsTargets
+)

--- a/components/string_view/string_view.c
+++ b/components/string_view/string_view.c
@@ -1,0 +1,15 @@
+#include "string_view.h"
+
+#include <string.h>
+
+datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]) {
+    datadog_php_string_view string_view = {
+        .len = cstr ? strlen(cstr) : 0,
+        .ptr = cstr,
+    };
+    return string_view;
+}
+
+bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b) {
+    return a.len == b.len && (a.ptr == b.ptr || memcmp(a.ptr, b.ptr, b.len) == 0);
+}

--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -1,0 +1,41 @@
+#ifndef DATADOG_PHP_STRING_VIEW_H
+#define DATADOG_PHP_STRING_VIEW_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * A string view is a non-owning view into another string. The original string
+ * should not be changed from the view.
+ */
+typedef struct datadog_php_string_view {
+    size_t len;
+    const char *ptr;
+} datadog_php_string_view;
+
+/* Used to initialize an empty string e.g.
+ *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+ */
+#define DATADOG_PHP_STRING_VIEW_INIT \
+    { 0, NULL }
+
+/* Initialize from a string literal e.g.
+ *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_LITERAL("hello");
+ */
+#define DATADOG_PHP_STRING_VIEW_LITERAL(cstr) \
+    { sizeof(cstr) - 1, cstr }
+
+/**
+ * Creates a string view from a C string, which is an array of char which is
+ * terminated by a null byte. Derives the length from strlen. `cstr` may be
+ * null, in which case the `.len` will be 0.
+ */
+datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]);
+
+/**
+ * Compares the views `a` and `b` for equality. Note that the `.ptr` value of
+ * the views will be ignored when `.len` is 0.
+ */
+bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b);
+
+#endif  // DATADOG_PHP_STRING_VIEW_H

--- a/components/string_view/tests/CMakeLists.txt
+++ b/components/string_view/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(string_view string_view.cc)
+
+target_link_libraries(string_view
+  PUBLIC catch2_main Datadog::Php::StringView
+)
+
+catch_discover_tests(string_view)

--- a/components/string_view/tests/string_view.cc
+++ b/components/string_view/tests/string_view.cc
@@ -1,0 +1,59 @@
+extern "C" {
+#include "string_view/string_view.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("string_view init", "[string_view]") {
+    datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+
+    REQUIRE(str.len == 0);
+    REQUIRE(str.ptr == NULL);
+}
+
+TEST_CASE("string_view cstrings", "[string_view]") {
+    datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+    REQUIRE(empty.len == 0);
+    REQUIRE(empty.ptr[0] == '\0');
+
+    datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+    REQUIRE(nil.len == 0);
+    REQUIRE(nil.ptr == NULL);
+
+    datadog_php_string_view abc = datadog_php_string_view_from_cstr("abc");
+    REQUIRE(abc.len == 3);
+    REQUIRE(memcmp(abc.ptr, "abc", 3) == 0);
+
+    const char buff[5] = "four";
+    datadog_php_string_view four = datadog_php_string_view_from_cstr(buff);
+    REQUIRE(four.len == 4);
+    REQUIRE((const void*)four.ptr == (const void*)&buff);
+}
+
+TEST_CASE("string_view empty equal", "[string_view]") {
+    datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+    REQUIRE(empty.len == 0);
+    REQUIRE(empty.ptr[0] == '\0');
+
+    datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+    REQUIRE(nil.len == 0);
+    REQUIRE(nil.ptr == NULL);
+
+    REQUIRE(datadog_php_string_view_equal(empty, nil));
+}
+
+TEST_CASE("string_view equal", "[string_view]") {
+    const char buff1[] = "asdf";
+    char buff2[sizeof buff1];
+    memcpy((void*)buff2, buff1, sizeof buff1);
+
+    datadog_php_string_view str1 = datadog_php_string_view_from_cstr(buff1);
+    datadog_php_string_view str2 = datadog_php_string_view_from_cstr(buff2);
+
+    REQUIRE(datadog_php_string_view_equal(str1, str2));
+
+    // identity cases
+    REQUIRE(datadog_php_string_view_equal(str1, str1));
+    REQUIRE(datadog_php_string_view_equal(str2, str2));
+}

--- a/config.m4
+++ b/config.m4
@@ -40,6 +40,11 @@ if test "$PHP_DDTRACE" != "no"; then
     src/dogstatsd/client.c \
   "
 
+  DD_TRACE_COMPONENT_SOURCES="\
+    components/sapi/sapi.c \
+    components/string_view/string_view.c \
+  "
+
   PHP_VERSION_ID=$($PHP_CONFIG --vernum)
 
   if test $PHP_VERSION_ID -lt 50500; then
@@ -184,7 +189,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
   fi
 
-  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
+  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_COMPONENT_SOURCES $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
   PHP_ADD_BUILD_DIR($ext_builddir/ext, 1)
 
   PHP_CHECK_LIBRARY(rt, shm_open,
@@ -199,6 +204,11 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir])
   PHP_ADD_INCLUDE([$ext_srcdir/ext])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/components])
+  PHP_ADD_BUILD_DIR([$ext_builddir/components])
+  PHP_ADD_BUILD_DIR([$ext_builddir/components/sapi])
+  PHP_ADD_BUILD_DIR([$ext_builddir/components/string_view])
 
   PHP_ADD_INCLUDE([$ext_srcdir/ext/vendor])
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/vendor])

--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -69,6 +69,7 @@ ext/date/tests/date_default_timezone_set-1.phpt
 ext/date/tests/date_diff1.phpt
 ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/test-parse-from-format.phpt
+ext/fileinfo/tests/bug68819_002.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -39,6 +39,7 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
+#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"
@@ -272,14 +273,26 @@ static void dd_register_fatal_error_ce(TSRMLS_D) {
     ddtrace_fatal_error_handlers.clone_obj = NULL;
 }
 
-static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
-    if (strcmp("fpm-fcgi", sapi_module.name) == 0 || strcmp("apache2handler", sapi_module.name) == 0 ||
-        strcmp("cli", sapi_module.name) == 0 || strcmp("cli-server", sapi_module.name) == 0 ||
-        strcmp("cgi-fcgi", sapi_module.name) == 0) {
-        return;
+static bool dd_is_compatible_sapi(datadog_php_string_view module_name) {
+    switch (datadog_php_sapi_from_name(module_name)) {
+        case DATADOG_PHP_SAPI_APACHE2HANDLER:
+        case DATADOG_PHP_SAPI_CGI_FCGI:
+        case DATADOG_PHP_SAPI_CLI:
+        case DATADOG_PHP_SAPI_CLI_SERVER:
+        case DATADOG_PHP_SAPI_FPM_FCGI:
+            return true;
+
+        default:
+            return false;
     }
-    ddtrace_log_debugf("Incompatible SAPI detected '%s'; disabling ddtrace", sapi_module.name);
-    DDTRACE_G(disable) = 1;
+}
+
+static void dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
+    datadog_php_string_view module_name = datadog_php_string_view_from_cstr(sapi_module.name);
+    if (UNEXPECTED(!dd_is_compatible_sapi(module_name))) {
+        ddtrace_log_debugf("Incompatible SAPI detected '%s'; disabling ddtrace", sapi_module.name);
+        DDTRACE_G(disable) = 1;
+    }
 }
 
 static PHP_MINIT_FUNCTION(ddtrace) {
@@ -289,7 +302,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 
     // config initialization needs to be at the top
     ddtrace_initialize_config(TSRMLS_C);
-    _dd_disable_if_incompatible_sapi_detected(TSRMLS_C);
+    dd_disable_if_incompatible_sapi_detected(TSRMLS_C);
     atomic_init(&ddtrace_first_rinit, 1);
     atomic_init(&ddtrace_warn_legacy_api, 1);
 

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -38,6 +38,7 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
+#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"
@@ -251,14 +252,26 @@ static void dd_register_fatal_error_ce(TSRMLS_D) {
     ddtrace_ce_fatal_error = zend_register_internal_class_ex(&ce, zend_ce_exception TSRMLS_CC);
 }
 
-static void _dd_disable_if_incompatible_sapi_detected(TSRMLS_D) {
-    if (strcmp("fpm-fcgi", sapi_module.name) == 0 || strcmp("apache2handler", sapi_module.name) == 0 ||
-        strcmp("cli", sapi_module.name) == 0 || strcmp("cli-server", sapi_module.name) == 0 ||
-        strcmp("cgi-fcgi", sapi_module.name) == 0) {
-        return;
+static bool dd_is_compatible_sapi(datadog_php_string_view module_name) {
+    switch (datadog_php_sapi_from_name(module_name)) {
+        case DATADOG_PHP_SAPI_APACHE2HANDLER:
+        case DATADOG_PHP_SAPI_CGI_FCGI:
+        case DATADOG_PHP_SAPI_CLI:
+        case DATADOG_PHP_SAPI_CLI_SERVER:
+        case DATADOG_PHP_SAPI_FPM_FCGI:
+            return true;
+
+        default:
+            return false;
     }
-    ddtrace_log_debugf("Incompatible SAPI detected '%s'; disabling ddtrace", sapi_module.name);
-    DDTRACE_G(disable) = 1;
+}
+
+static void dd_disable_if_incompatible_sapi_detected(void) {
+    datadog_php_string_view module_name = datadog_php_string_view_from_cstr(sapi_module.name);
+    if (UNEXPECTED(!dd_is_compatible_sapi(module_name))) {
+        ddtrace_log_debugf("Incompatible SAPI detected '%s'; disabling ddtrace", sapi_module.name);
+        DDTRACE_G(disable) = 1;
+    }
 }
 
 static PHP_MINIT_FUNCTION(ddtrace) {
@@ -268,7 +281,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 
     // config initialization needs to be at the top
     ddtrace_initialize_config(TSRMLS_C);
-    _dd_disable_if_incompatible_sapi_detected(TSRMLS_C);
+    dd_disable_if_incompatible_sapi_detected();
     atomic_init(&ddtrace_first_rinit, 1);
     atomic_init(&ddtrace_warn_legacy_api, 1);
 

--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,12 @@
     <notes>${notes}</notes>
     <contents>
         <dir name="/">
+            <!-- components -->
+            <file name="components/sapi/sapi.c" role="src" />
+            <file name="components/sapi/sapi.h" role="src" />
+            <file name="components/string_view/string_view.c" role="src" />
+            <file name="components/string_view/string_view.h" role="src" />
+
             <!-- Shared -->
             <file name="ext/DatadogArena/arena.c" role="src" />
             <file name="ext/DatadogArena/datadog/arena.h" role="src" />


### PR DESCRIPTION
### Description

Adds top-level directory components. Components have a single
public header and their own tests.

This bumps the minimum version of CMake required to 3.14. The
specific feature needed is:

> The install(TARGETS) command learned how to install to an
> appropriate default directory for a given target type, based on
> variables from the GNUInstallDirs module and built-in defaults,
> in lieu of a DESTINATION argument.

This is so each component doesn't have to copy/paste the same config
and keep it in sync.

This also drops the older Catch2 version; it was not being done
for any specific reason.

Put bad test on PHP 5.4 into xfail; already xfail this on PHP 5.5.
php/php-src@471540d

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
