### PR TITLE
More curl-multi scenarios in randomized tests

### DIFF
--- a/tests/randomized/app/src/RandomizedTests/Snippets.php
+++ b/tests/randomized/app/src/RandomizedTests/Snippets.php
@@ -175,6 +175,14 @@ class Snippets
             return;
         }
 
+        $version = curl_version();
+        if (!isset($version['version_number']) || $version['version_number'] < 0x072e00) {
+            /* CURLMOPT_PUSHFUNCTION is only available in curl v7.46.0
+             * @see https://github.com/php/php-src/blob/ce0bc58/ext/curl/interface.c#L1018
+             */
+            return;
+        }
+
         $mh = curl_multi_init();
 
         /* Set a CURLMOPT_PUSHFUNCTION callback.

--- a/tests/randomized/app/src/RandomizedTests/Snippets.php
+++ b/tests/randomized/app/src/RandomizedTests/Snippets.php
@@ -7,6 +7,8 @@ use GuzzleHttp\Client as GuzzleClient;
 
 class Snippets
 {
+    const CURL_MULTI_URL = 'httpbin/get?client=curl';
+
     public function availableIntegrations()
     {
         $all = [
@@ -14,7 +16,7 @@ class Snippets
             'guzzle' => 1,
             'memcached' => 1,
             'mysqli' => 1,
-            'curl' => 2,
+            'curl' => 7,
             'pdo' => 1,
             'phpredis' => 1,
         ];
@@ -61,15 +63,15 @@ class Snippets
     public function curlVariant2()
     {
         $ch1 = curl_init();
-        curl_setopt($ch1, CURLOPT_URL, 'httpbin/get?client=curl&multi');
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
         curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
 
         $ch2 = curl_init();
-        curl_setopt($ch2, CURLOPT_URL, 'httpbin/get?client=curl&multi');
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
         curl_setopt($ch2, CURLOPT_RETURNTRANSFER, 1);
 
         $ch3 = curl_init();
-        curl_setopt($ch3, CURLOPT_URL, 'httpbin/get?client=curl&multi');
+        curl_setopt($ch3, CURLOPT_URL, self::CURL_MULTI_URL);
         curl_setopt($ch3, CURLOPT_RETURNTRANSFER, 1);
 
         $mh = curl_multi_init();
@@ -85,6 +87,162 @@ class Snippets
         curl_multi_remove_handle($mh, $ch1);
         curl_multi_remove_handle($mh, $ch2);
         curl_multi_remove_handle($mh, $ch3);
+        curl_multi_close($mh);
+    }
+
+    public function curlVariant3()
+    {
+        # Call curl_multi_init() before curl_init()
+        $mh = curl_multi_init();
+
+        $ch1 = curl_init();
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+
+        $ch2 = curl_init();
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+
+        curl_multi_add_handle($mh, $ch1);
+        curl_multi_add_handle($mh, $ch2);
+
+        do {
+            curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($active > 0);
+
+        curl_multi_remove_handle($mh, $ch1);
+        curl_multi_remove_handle($mh, $ch2);
+
+        curl_multi_close($mh);
+    }
+
+    public function curlVariant4()
+    {
+        $mh = curl_multi_init();
+
+        $ch1 = curl_init();
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+
+        $ch2 = curl_init();
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+
+        curl_multi_add_handle($mh, $ch1);
+        curl_multi_add_handle($mh, $ch2);
+
+        do {
+            curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($active > 0);
+
+        # Do not call curl_multi_remove_handle()
+
+        curl_multi_close($mh);
+    }
+
+    public function curlVariant5()
+    {
+        $mh = curl_multi_init();
+
+        $ch1 = curl_init();
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+
+        $ch2 = curl_init();
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+
+        curl_multi_add_handle($mh, $ch1);
+        curl_multi_add_handle($mh, $ch2);
+
+        do {
+            curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($active > 0);
+
+        curl_multi_remove_handle($mh, $ch1);
+        curl_multi_remove_handle($mh, $ch2);
+
+        # Do not call curl_multi_close()
+    }
+
+    public function curlVariant6()
+    {
+        if (PHP_VERSION_ID <= 50500) {
+            # curl_multi_setopt() was added in PHP 5.5
+            return;
+        }
+
+        $mh = curl_multi_init();
+
+        /* Set a CURLMOPT_PUSHFUNCTION callback.
+         * I believe this will only be called for HTTP/2 requests which httpbin
+         * does not support. But we still want to test it since this closure is
+         * stored on the multi-handle and we want to make sure there are no
+         * dtor issues.
+         */
+        $callback = static function () {
+            return CURL_PUSH_OK;
+        };
+        curl_multi_setopt($mh, CURLMOPT_PUSHFUNCTION, $callback);
+
+        $ch1 = curl_init();
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+
+        $ch2 = curl_init();
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, 1);
+
+        curl_multi_add_handle($mh, $ch1);
+        curl_multi_add_handle($mh, $ch2);
+
+        do {
+            curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($active > 0);
+
+        curl_multi_remove_handle($mh, $ch1);
+        curl_multi_remove_handle($mh, $ch2);
+
+        curl_multi_close($mh);
+    }
+
+    public function curlVariant7()
+    {
+        $mh = curl_multi_init();
+
+        $ch1 = curl_init();
+        curl_setopt($ch1, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+
+        # Set a CURLOPT_WRITEFUNCTION callback
+        curl_setopt($ch1, CURLOPT_WRITEFUNCTION, function ($ch, $data) {
+            return \strlen($data);
+        });
+
+        $ch2 = curl_init();
+        curl_setopt($ch2, CURLOPT_URL, self::CURL_MULTI_URL);
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, 1);
+
+        # Set a CURLOPT_HEADERFUNCTION callback
+        curl_setopt($ch2, CURLOPT_HEADERFUNCTION, function ($ch, $data) {
+            return \strlen($data);
+        });
+
+        curl_multi_add_handle($mh, $ch1);
+        curl_multi_add_handle($mh, $ch2);
+
+        do {
+            curl_multi_exec($mh, $active);
+            curl_multi_select($mh);
+        } while ($active > 0);
+
+        curl_multi_remove_handle($mh, $ch1);
+        curl_multi_remove_handle($mh, $ch2);
+
         curl_multi_close($mh);
     }
 


### PR DESCRIPTION
### Description

This follow up PR to #1171 adds a few more scenarios to the randomized tests for the `curl_multi_*()` API.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- ~[ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.~
