### PR TITLE
Let's try composer 2, again!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,12 @@ aliases:
   - &STEP_COMPOSER_SELF_UPDATE
     run:
       name: Upgrading composer
-      command: sudo composer self-update --no-interaction
+      command: |
+        # if the version is old enough, it won't understand --2 and will
+        # error out, but on a regular self-update it will go to v2.
+        # Versions 1.10.1+ will only go to the latest v1 on a normal
+        # self-update, so we do this combination to get everyone onto v2
+        sudo composer self-update --no-interaction && composer self-update --2 --no-interaction
 
   - &STEP_COMPOSER_UPDATE
     run:


### PR DESCRIPTION
### Description

Composer clients earlier than 1.10.1 will go directly to the latest
v2 on a `self-update`, but 1.x clients newer than this will only
update to the latest 1.x. The older clients will abort on --2 being
passed as they don't understand it, so we have to update twice.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.
