### PR TITLE
[ddprof] Support v3 intake format; HTTP bugfixes

### DIFF
--- a/include/dd_send.h
+++ b/include/dd_send.h
@@ -69,7 +69,7 @@ extern const char *DDRC_table[];
   X(HOSTTAG,         host_tag,         3, "host",             1, "localhost")  \
   X(SERVICE,         service,          3, "service",          0, "myservice")  \
   X(LANGUAGE,        language,         3, "language",         1, "ILLEGAL")    \
-  X(RUNTIME,         runtime,          2, "runtime",          1, "ILLEGAL")    \
+  X(RUNTIME,         runtime,          2, "runtime",          0, NULL)         \
   X(SITE,            site,             3, "site",             0, NULL)         \
   X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")  \
   X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)         \

--- a/include/dd_send.h
+++ b/include/dd_send.h
@@ -17,11 +17,6 @@
   X(ERES,              "failed to receive response")                           \
   X(EDISCO,            "disconnected during operation")                        \
   X(EINVAL,            "invalid input value")                                  \
-  X(EARG_NOSTART,      "no start value given")                                 \
-  X(EARG_NOEND,        "no end value given")                                   \
-  X(EARG_NOHOST,       "no host value given")                                  \
-  X(EARG_NOLANG,       "no language value given")                              \
-  X(EARG_NOFAM,        "no family value given")                                \
   X(ETOOMANYPPROFS,    "too many pprofs (max 10)")                             \
   X(ESERIAL,           "couldn't serialize payload")                           \
   X(ENOT200,           "HTTP did not return 200 code")                         \
@@ -48,7 +43,7 @@ extern const char *DDRC_table[];
 #define DDRP_TYPE(a, b, c, d, e, f) c,
 #define DDRP_INTR(a, b, c, d, e, f) #b, // Introsection
 #define DDRP_REQD(a, b, c, d, e, f) e,
-#define DDRP_DFLT(a, b, c, d, e, f) (char*)f,
+#define DDRP_DFLT(a, b, c, d, e, f) f,
 
 // A - enum name
 // B - key name, also string representation
@@ -64,23 +59,23 @@ extern const char *DDRC_table[];
 // Accept-Encoding is a header
 // runtime-os is a tag[]
 //  A                B                 C  D                   E  F
-#define DDR_PARAMS(X)                                                               \
-  X(USERAGENT,       user_agent,       1, "User-Agent",       0, "ddprof")          \
-  X(ACCEPT,          accept,           1, "Accept",           0, "*/*")             \
-  X(APIKEY,          apikey,           1, "DD-API-KEY",       0, NULL)              \
-  X(ACCEPTENCODING,  accept_encoding,  0, "Accept-Encoding",  0, "gzip")            \
-  X(RECORDINGSTART,  start,            2, "start",            1, DDRC_EARG_NOSTART) \
-  X(RECORDINGEND,    end,              2, "end",              1, DDRC_EARG_NOEND)   \
-  X(HOSTTAG,         host_tag,         3, "host",             1, DDRC_EARG_NOHOST)  \
-  X(SERVICE,         service,          3, "service",          0, "myservice")       \
-  X(LANGUAGE,        language,         3, "language",         1, DDRC_EARG_NOLANG)  \
-  X(RUNTIME,         runtime,          2, "runtime",          0, NULL)              \
-  X(SITE,            site,             3, "site",             0, NULL)              \
-  X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")       \
-  X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)              \
-  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)              \
-  X(INTAKEVERSION,   intake_version,   2, "version",          0, "3")               \
-  X(FAMILY,          family,           2, "family",           1, DDRC_EARG_NOFAM)
+#define DDR_PARAMS(X)                                                          \
+  X(USERAGENT,       user_agent,       1, "User-Agent",       0, "ddprof")     \
+  X(ACCEPT,          accept,           1, "Accept",           0, "*/*")        \
+  X(APIKEY,          apikey,           1, "DD-API-KEY",       0, NULL)         \
+  X(ACCEPTENCODING,  accept_encoding,  0, "Accept-Encoding",  0, "gzip")       \
+  X(RECORDINGSTART,  start,            2, "start",            0, NULL)         \
+  X(RECORDINGEND,    end,              2, "end",              0, NULL)         \
+  X(HOSTTAG,         host_tag,         3, "host",             1, "localhost")  \
+  X(SERVICE,         service,          3, "service",          0, "myservice")  \
+  X(LANGUAGE,        language,         3, "language",         1, "ILLEGAL")    \
+  X(RUNTIME,         runtime,          2, "runtime",          0, NULL)         \
+  X(SITE,            site,             3, "site",             0, NULL)         \
+  X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")  \
+  X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)         \
+  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)         \
+  X(INTAKEVERSION,   intake_version,   2, "version",          0, "3")          \
+  X(FAMILY,          family,           2, "family",           0, "unknown")
 // clang-format on
 
 typedef enum DDRVals {

--- a/include/dd_send.h
+++ b/include/dd_send.h
@@ -64,16 +64,18 @@ extern const char *DDRC_table[];
   X(ACCEPT,          accept,           1, "Accept",           0, "*/*")        \
   X(APIKEY,          apikey,           1, "DD-API-KEY",       0, NULL)         \
   X(ACCEPTENCODING,  accept_encoding,  0, "Accept-Encoding",  0, "gzip")       \
-  X(RECORDINGSTART,  recording_start,  2, "recording-start",  0, NULL)         \
-  X(RECORDINGEND,    recording_end,    2, "recording-end",    0, NULL)         \
+  X(RECORDINGSTART,  start,            2, "start",            0, NULL)         \
+  X(RECORDINGEND,    end,              2, "end",              0, NULL)         \
   X(HOSTTAG,         host_tag,         3, "host",             1, "localhost")  \
   X(SERVICE,         service,          3, "service",          0, "myservice")  \
-  X(SITE,            site,             3, "site",             0, NULL)         \
   X(LANGUAGE,        language,         3, "language",         1, "ILLEGAL")    \
   X(RUNTIME,         runtime,          2, "runtime",          1, "ILLEGAL")    \
+  X(SITE,            site,             3, "site",             0, NULL)         \
   X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")  \
   X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)         \
-  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)
+  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)         \
+  X(INTAKEVERSION,   intake_version,   2, "version",          0, "3")          \
+  X(FAMILY,          family,           2, "family",           0, "unknown")
 // clang-format on
 
 typedef enum DDRVals {

--- a/include/dd_send.h
+++ b/include/dd_send.h
@@ -17,6 +17,11 @@
   X(ERES,              "failed to receive response")                           \
   X(EDISCO,            "disconnected during operation")                        \
   X(EINVAL,            "invalid input value")                                  \
+  X(EARG_NOSTART,      "no start value given")                                 \
+  X(EARG_NOEND,        "no end value given")                                   \
+  X(EARG_NOHOST,       "no host value given")                                  \
+  X(EARG_NOLANG,       "no language value given")                              \
+  X(EARG_NOFAM,        "no family value given")                                \
   X(ETOOMANYPPROFS,    "too many pprofs (max 10)")                             \
   X(ESERIAL,           "couldn't serialize payload")                           \
   X(ENOT200,           "HTTP did not return 200 code")                         \
@@ -43,7 +48,7 @@ extern const char *DDRC_table[];
 #define DDRP_TYPE(a, b, c, d, e, f) c,
 #define DDRP_INTR(a, b, c, d, e, f) #b, // Introsection
 #define DDRP_REQD(a, b, c, d, e, f) e,
-#define DDRP_DFLT(a, b, c, d, e, f) f,
+#define DDRP_DFLT(a, b, c, d, e, f) (char*)f,
 
 // A - enum name
 // B - key name, also string representation
@@ -59,23 +64,23 @@ extern const char *DDRC_table[];
 // Accept-Encoding is a header
 // runtime-os is a tag[]
 //  A                B                 C  D                   E  F
-#define DDR_PARAMS(X)                                                          \
-  X(USERAGENT,       user_agent,       1, "User-Agent",       0, "ddprof")     \
-  X(ACCEPT,          accept,           1, "Accept",           0, "*/*")        \
-  X(APIKEY,          apikey,           1, "DD-API-KEY",       0, NULL)         \
-  X(ACCEPTENCODING,  accept_encoding,  0, "Accept-Encoding",  0, "gzip")       \
-  X(RECORDINGSTART,  start,            2, "start",            0, NULL)         \
-  X(RECORDINGEND,    end,              2, "end",              0, NULL)         \
-  X(HOSTTAG,         host_tag,         3, "host",             1, "localhost")  \
-  X(SERVICE,         service,          3, "service",          0, "myservice")  \
-  X(LANGUAGE,        language,         3, "language",         1, "ILLEGAL")    \
-  X(RUNTIME,         runtime,          2, "runtime",          0, NULL)         \
-  X(SITE,            site,             3, "site",             0, NULL)         \
-  X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")  \
-  X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)         \
-  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)         \
-  X(INTAKEVERSION,   intake_version,   2, "version",          0, "3")          \
-  X(FAMILY,          family,           2, "family",           0, "unknown")
+#define DDR_PARAMS(X)                                                               \
+  X(USERAGENT,       user_agent,       1, "User-Agent",       0, "ddprof")          \
+  X(ACCEPT,          accept,           1, "Accept",           0, "*/*")             \
+  X(APIKEY,          apikey,           1, "DD-API-KEY",       0, NULL)              \
+  X(ACCEPTENCODING,  accept_encoding,  0, "Accept-Encoding",  0, "gzip")            \
+  X(RECORDINGSTART,  start,            2, "start",            1, DDRC_EARG_NOSTART) \
+  X(RECORDINGEND,    end,              2, "end",              1, DDRC_EARG_NOEND)   \
+  X(HOSTTAG,         host_tag,         3, "host",             1, DDRC_EARG_NOHOST)  \
+  X(SERVICE,         service,          3, "service",          0, "myservice")       \
+  X(LANGUAGE,        language,         3, "language",         1, DDRC_EARG_NOLANG)  \
+  X(RUNTIME,         runtime,          2, "runtime",          0, NULL)              \
+  X(SITE,            site,             3, "site",             0, NULL)              \
+  X(ENVIRONMENT,     environment,      3, "environment",      0, "prod-test")       \
+  X(PROFILERVERSION, profiler_version, 3, "profiler-version", 0, NULL)              \
+  X(RUNTIMEOS,       runtime_os,       0, "runtime-os",       0, NULL)              \
+  X(INTAKEVERSION,   intake_version,   2, "version",          0, "3")               \
+  X(FAMILY,          family,           2, "family",           1, DDRC_EARG_NOFAM)
 // clang-format on
 
 typedef enum DDRVals {

--- a/include/http.h
+++ b/include/http.h
@@ -19,7 +19,7 @@ bool SocketSetNonblocking(int, bool);
 \******************************************************************************/
 /*****************************  HTTP Connection  ******************************/
 typedef enum HttpConnState {
-  HCS_FREE,
+  HCS_FRESH,
   HCS_INIT,
   HCS_CONNECTED,
   HCS_SENDREC,
@@ -42,7 +42,7 @@ typedef enum HTTP_RET {
 typedef struct HttpConn {
   int fd;                // The file descriptor underneath this connection
   HttpConnState state;   // socket rather than HTTP
-  char mode;             // 0 - async, 1 - forced sync (blocking)tt
+  char mode;             // 0 - async, 1 - forced sync (blocking)
   struct addrinfo *addr; // cache
   bool addr_cached;
 } HttpConn;

--- a/src/dd_send.c
+++ b/src/dd_send.c
@@ -46,6 +46,8 @@ DDReq *DDR_init(DDReq *req) {
     if (!req)
       return NULL;
     req->ownership = 0x01;
+  } else {
+    req->owernship = 0;
   }
 
   req->as_header = as_init(NULL);

--- a/src/dd_send.c
+++ b/src/dd_send.c
@@ -172,14 +172,15 @@ int DDR_finalize(DDReq *req) {
     int j = DDR_idx[i];
     char *val = req->values[j];
 
-    // If we got a value, great!  If not, check for a default.  If there's
-    // no value and no default, skip this entry.
-    if (!val && DDR_defaults[j])
-      val = (char *)DDR_defaults[j];
-    else if (!val && !DDR_defaults[j] && DDR_reqd[i])
-      return DDRC_EINVAL;
-    else if (!val && !DDR_defaults[j])
-      continue;
+    // If the request specified a value, then use that.
+    if (!val) {
+      if (DDR_reqd[i])
+        return (long)DDR_defaults[j];
+      else if (DDR_defaults[j])
+        val = (char *)DDR_defaults[j];
+      else
+        continue;
+    }
     switch (DDR_types[j]) {
     case 0: // Skipit
       break;

--- a/src/dd_send.c
+++ b/src/dd_send.c
@@ -172,15 +172,14 @@ int DDR_finalize(DDReq *req) {
     int j = DDR_idx[i];
     char *val = req->values[j];
 
-    // If the request specified a value, then use that.
-    if (!val) {
-      if (DDR_reqd[i])
-        return (long)DDR_defaults[j];
-      else if (DDR_defaults[j])
-        val = (char *)DDR_defaults[j];
-      else
-        continue;
-    }
+    // If we got a value, great!  If not, check for a default.  If there's
+    // no value and no default, skip this entry.
+    if (!val && DDR_defaults[j])
+      val = (char *)DDR_defaults[j];
+    else if (!val && !DDR_defaults[j] && DDR_reqd[i])
+      return DDRC_EINVAL;
+    else if (!val && !DDR_defaults[j])
+      continue;
     switch (DDR_types[j]) {
     case 0: // Skipit
       break;

--- a/src/dd_send.c
+++ b/src/dd_send.c
@@ -47,7 +47,7 @@ DDReq *DDR_init(DDReq *req) {
       return NULL;
     req->ownership = 0x01;
   } else {
-    req->owernship = 0;
+    req->ownership = 0;
   }
 
   req->as_header = as_init(NULL);
@@ -161,7 +161,10 @@ int DDR_finalize(DDReq *req) {
   // Validate info for connection
   if (!req->host || !req->port)
     return DDRC_EINVAL;
-  as_sprintf(req->as_header, "POST %s HTTP/1.1\r\n", "/profiling/v1/input");
+  if (req->apikey)
+    as_sprintf(req->as_header, "POST %s HTTP/1.1\r\n", "/v1/input");
+  else
+    as_sprintf(req->as_header, "POST %s HTTP/1.1\r\n", "/profiling/v1/input");
   as_sprintf(req->as_header, "Host: %s:%s\r\n", req->host, req->port);
 
   // Populate header and body elements

--- a/src/http.c
+++ b/src/http.c
@@ -16,6 +16,11 @@
 
 #include "http.h"
 
+// We want to prevent the OS from sending us completely unnecessary signals.
+#ifdef __APPLE__
+#define MSG_NOSIGNAL 0
+#endif
+
 int SockSetBit(int fd, int bit, bool v) {
   return setsockopt(fd, IPPROTO_TCP, bit, (const void *)&(int){v}, sizeof(int));
 }
@@ -39,6 +44,11 @@ int TcpSockNew() {
     return close(fd), -1;
 #if __linux__
   if (-1 == SockSetBit(fd, TCP_QUICKACK, 1))
+    return close(fd), -1;
+#endif
+#if __APPLE__
+  if (-1 ==
+      setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&(int){1}, sizeof(int)))
     return close(fd), -1;
 #endif
   return fd;

--- a/src/pprof.c
+++ b/src/pprof.c
@@ -521,7 +521,7 @@ DProf *pprof_Init(DProf *dp, const char **sample_names,
       return NULL;
     dp->ownership = 1;
   } else {
-    dp->owernship = 0;
+    dp->ownership = 0;
   }
 
   PPProfile *pprof = &dp->pprof;

--- a/src/pprof.c
+++ b/src/pprof.c
@@ -520,6 +520,8 @@ DProf *pprof_Init(DProf *dp, const char **sample_names,
     if (!dp)
       return NULL;
     dp->ownership = 1;
+  } else {
+    dp->owernship = 0;
   }
 
   PPProfile *pprof = &dp->pprof;

--- a/src/string_table.c
+++ b/src/string_table.c
@@ -3,10 +3,6 @@
 
 #include "string_table.h"
 
-#ifdef D_SANITY_CHECKS
-#include <signal.h>
-#endif
-
 // ONLY FOR INTERNAL USE.  ONLY.
 #define STR_LEN_PTR(x) ((uint32_t *)&(x)[-4])
 #define STR_LEN(x) (*STR_LEN_PTR(x))
@@ -313,12 +309,9 @@ static ssize_t _StringTableArena_append(StringTableArena *sta,
   unsigned char *arena_ptr = dst + sizeof(uint32_t); // What we return
   uint32_t write_len = sz_val;                       // Size after padding
 
-#ifdef D_SANITY_CHECKS
-  if (STA_ALIGN(dst) != dst)
-    printf("NOT ALIGNED\n"), raise(SIGINT);
-  if (sz_total & STA_ALIGNMENT_MASK)
-    printf("LENGTH NOT ALIGNED\n"), raise(SIGINT);
-#endif
+  // Alignment checks
+  assert(STA_ALIGN(dst) == dst);
+  assert(!(sz_total & STA_ALIGNMENT_MASK));
 
   // Copy the 4-byte header (length) TODO this can overrun?
   memcpy(dst, &write_len, sizeof(uint32_t));


### PR DESCRIPTION
Various v3 intake format stuff.

### Description

dd_send should now support the v3 intake format.  We don't provide a v2 compatibility mode--just outright disable it.  It would be easy enough to add support again, but I see no reason to support a legacy interface.

Also the HTTP layer now:
 * uses Connection: close and do tail-closing for HTTP reqs
 * properly handles SIGPIPE (by not allowing it to be thrown!)
