### PR TITLE
Add sources for Symfony 5.2 framework

### DIFF
--- a/tests/Frameworks/README.md
+++ b/tests/Frameworks/README.md
@@ -150,6 +150,19 @@ Link: https://symfony.com/doc/5.1/setup.html
 
     $ composer create-project symfony/website-skeleton Version_5_1 "5.1.*"
 
+### Symfony 5.2
+
+For Symfony 5.2 I intentionally installed the symfony/skeleton instead of the
+full web skeleton; this removes dependencies we do not use like doctrine/dbal.
+We had troubles with installing compatible versions of these unused dependencies
+in the past.
+Link: https://symfony.com/doc/5.2/setup.html
+
+    $ composer create-project symfony/skeleton Version_5_2 "5.2.*"
+    $ cd Version_5_2
+    $ composer require doctrine/annotations
+    $ composer require symfony/twig-bundle
+
 ## Custom frameworks
 
 These aren't real frameworks, but they represent unsupported frameworks and custom frameworks.

--- a/tests/Frameworks/Symfony/Version_5_2/.env
+++ b/tests/Frameworks/Symfony/Version_5_2/.env
@@ -1,0 +1,19 @@
+# In all environments, the following files are loaded if they exist,
+# the latter taking precedence over the former:
+#
+#  * .env                contains default values for the environment variables needed by the app
+#  * .env.local          uncommitted file with local overrides
+#  * .env.$APP_ENV       committed environment-specific defaults
+#  * .env.$APP_ENV.local uncommitted environment-specific overrides
+#
+# Real environment variables win over .env files.
+#
+# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE NOR IN ANY OTHER COMMITTED FILES.
+#
+# Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
+# https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
+
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=c8db676eda45ca0ed2cd13c0df87072e
+###< symfony/framework-bundle ###

--- a/tests/Frameworks/Symfony/Version_5_2/.gitignore
+++ b/tests/Frameworks/Symfony/Version_5_2/.gitignore
@@ -1,0 +1,10 @@
+
+###> symfony/framework-bundle ###
+/.env.local
+/.env.local.php
+/.env.*.local
+/config/secrets/prod/prod.decrypt.private.php
+/public/bundles/
+/var/
+/vendor/
+###< symfony/framework-bundle ###

--- a/tests/Frameworks/Symfony/Version_5_2/bin/console
+++ b/tests/Frameworks/Symfony/Version_5_2/bin/console
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
+
+if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
+}
+
+set_time_limit(0);
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+}
+
+$input = new ArgvInput();
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+}
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$application = new Application($kernel);
+$application->run($input);

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -1,0 +1,61 @@
+{
+    "type": "project",
+    "license": "proprietary",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": ">=7.2.5",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "doctrine/annotations": "^1.12",
+        "symfony/console": "5.2.*",
+        "symfony/dotenv": "5.2.*",
+        "symfony/flex": "^1.3.1",
+        "symfony/framework-bundle": "5.2.*",
+        "symfony/twig-bundle": "5.2.*",
+        "symfony/yaml": "5.2.*"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
+    },
+    "replace": {
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php72": "*"
+    },
+    "scripts": {
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    },
+    "conflict": {
+        "symfony/symfony": "*"
+    },
+    "extra": {
+        "symfony": {
+            "allow-contrib": false,
+            "require": "5.2.*"
+        }
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/config/bundles.php
+++ b/tests/Frameworks/Symfony/Version_5_2/config/bundles.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+];

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/cache.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/cache.yaml
@@ -1,0 +1,19 @@
+framework:
+    cache:
+        # Unique name of your app: used to compute stable namespaces for cache keys.
+        #prefix_seed: your_vendor_name/app_name
+
+        # The "app" cache stores to the filesystem by default.
+        # The data in this cache should persist between deploys.
+        # Other options include:
+
+        # Redis
+        #app: cache.adapter.redis
+        #default_redis_provider: redis://localhost
+
+        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+        #app: cache.adapter.apcu
+
+        # Namespaced pools use the above "app" backend by default
+        #pools:
+            #my.dedicated.cache: null

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/framework.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/framework.yaml
@@ -1,0 +1,17 @@
+# see https://symfony.com/doc/current/reference/configuration/framework.html
+framework:
+    secret: '%env(APP_SECRET)%'
+    #csrf_protection: true
+    #http_method_override: true
+
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+
+    #esi: true
+    #fragments: true
+    php_errors:
+        log: true

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/prod/routing.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/prod/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: null

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/routing.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/routing.yaml
@@ -1,0 +1,7 @@
+framework:
+    router:
+        utf8: true
+
+        # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
+        # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
+        #default_uri: http://localhost

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/test/framework.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/test/framework.yaml
@@ -1,0 +1,4 @@
+framework:
+    test: true
+    session:
+        storage_id: session.storage.mock_file

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/test/twig.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/test/twig.yaml
@@ -1,0 +1,2 @@
+twig:
+    strict_variables: true

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/twig.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/twig.yaml
@@ -1,0 +1,2 @@
+twig:
+    default_path: '%kernel.project_dir%/templates'

--- a/tests/Frameworks/Symfony/Version_5_2/config/preload.php
+++ b/tests/Frameworks/Symfony/Version_5_2/config/preload.php
@@ -1,0 +1,5 @@
+<?php
+
+if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
+    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+}

--- a/tests/Frameworks/Symfony/Version_5_2/config/routes.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/routes.yaml
@@ -1,0 +1,3 @@
+#index:
+#    path: /
+#    controller: App\Controller\DefaultController::index

--- a/tests/Frameworks/Symfony/Version_5_2/config/routes/annotations.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/routes/annotations.yaml
@@ -1,0 +1,7 @@
+controllers:
+    resource: ../../src/Controller/
+    type: annotation
+
+kernel:
+    resource: ../../src/Kernel.php
+    type: annotation

--- a/tests/Frameworks/Symfony/Version_5_2/config/routes/dev/framework.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/routes/dev/framework.yaml
@@ -1,0 +1,3 @@
+_errors:
+    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+    prefix: /_error

--- a/tests/Frameworks/Symfony/Version_5_2/config/services.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/services.yaml
@@ -1,0 +1,31 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/'
+        exclude:
+            - '../src/DependencyInjection/'
+            - '../src/Entity/'
+            - '../src/Kernel.php'
+            - '../src/Tests/'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    App\Controller\:
+        resource: '../src/Controller/'
+        tags: ['controller.service_arguments']
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/tests/Frameworks/Symfony/Version_5_2/public/index.php
+++ b/tests/Frameworks/Symfony/Version_5_2/public/index.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Kernel;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    Debug::enable();
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);

--- a/tests/Frameworks/Symfony/Version_5_2/src/Kernel.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Kernel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/services.yaml');
+            $container->import('../config/{services}_'.$this->environment.'.yaml');
+        } elseif (is_file($path = \dirname(__DIR__).'/config/services.php')) {
+            (require $path)($container->withPath($path), $this);
+        }
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/routes.yaml');
+        } elseif (is_file($path = \dirname(__DIR__).'/config/routes.php')) {
+            (require $path)($routes->withPath($path), $this);
+        }
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/templates/base.html.twig
+++ b/tests/Frameworks/Symfony/Version_5_2/templates/base.html.twig
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        {# Run `composer require symfony/webpack-encore-bundle`
+           and uncomment the following Encore helpers to start using Symfony UX #}
+        {% block stylesheets %}
+            {#{{ encore_entry_link_tags('app') }}#}
+        {% endblock %}
+
+        {% block javascripts %}
+            {#{{ encore_entry_script_tags('app') }}#}
+        {% endblock %}
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
### Description

This uses symfony/skeleton instead of symfony/web-skeleton to have
fewer unused dependencies, which have caused dependency issues
in the past when trying to run tests on a wide range of PHP versions.

Add doctrine/annotations for routing. Symfony 5.2 now supports PHP 8
attributes for routing, but since we need this to work on PHP 7.2-7.4
we use annotations.

Add symfony/twig-bundle for testing Twig integration.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Will be tested in another PR.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
