### PR TITLE
Test Symfony 5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -707,6 +707,11 @@ test_web_symfony_51:
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_1 update
 	php tests/Frameworks/Symfony/Version_5_1/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V5_1)
+test_web_symfony_52:
+	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_2 update
+	php tests/Frameworks/Symfony/Version_5_2/bin/console cache:clear --no-warmup --env=prod
+	$(call run_tests,tests/Integrations/Symfony/V5_2)
+
 test_web_wordpress_48:
 	$(call run_tests,tests/Integrations/WordPress/V4_8)
 test_web_wordpress_55:

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,7 @@ TEST_WEB_72 := \
 	test_web_symfony_44 \
 	test_web_symfony_50 \
 	test_web_symfony_51 \
+	test_web_symfony_52 \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_yii_2 \
@@ -469,6 +470,7 @@ TEST_WEB_73 := \
 	test_web_symfony_44 \
 	test_web_symfony_50 \
 	test_web_symfony_51 \
+	test_web_symfony_52 \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_yii_2 \
@@ -506,6 +508,7 @@ TEST_WEB_74 := \
 	test_web_symfony_44 \
 	test_web_symfony_50 \
 	test_web_symfony_51 \
+	test_web_symfony_52 \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_yii_2 \
@@ -535,6 +538,7 @@ TEST_WEB_80 := \
 	test_web_slim_4 \
 	test_web_symfony_44 \
 	test_web_symfony_51 \
+	test_web_symfony_52 \
 	test_web_yii_2 \
 	test_web_custom
 

--- a/tests/Frameworks/Symfony/Version_5_2/src/Controller/CommonScenariosController.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Controller/CommonScenariosController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CommonScenariosController extends AbstractController
+{
+
+    /**
+     * @Route("/simple", name="simple")
+     */
+    public function simpleAction(Request $request)
+    {
+        // replace this example code with whatever you need
+        return new Response(
+            'Hi!'
+        );
+    }
+
+    /**
+     * @Route("/simple_view", name="simple_view")
+     */
+    public function simpleViewAction(Request $request)
+    {
+        // replace this example code with whatever you need
+        return $this->render('twig_template.html.twig', [
+            'base_dir' => realpath($this->getParameter('kernel.project_dir')).DIRECTORY_SEPARATOR,
+        ]);
+    }
+
+    /**
+     * @Route("/error", name="error")
+     * @throws \Exception
+     */
+    public function errorAction(Request $request)
+    {
+        throw new \Exception('An exception occurred');
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/templates/twig_template.html.twig
+++ b/tests/Frameworks/Symfony/Version_5_2/templates/twig_template.html.twig
@@ -1,0 +1,1 @@
+This is the view

--- a/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V5_2;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+class CommonScenariosTest extends WebFrameworkTestCase
+{
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_DEBUG' => 'true',
+            'DD_SERVICE' => 'test_symfony_52',
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSpecs
+     * @param RequestSpec $spec
+     * @param array $spanExpectations
+     * @throws \Exception
+     */
+    public function testScenario(RequestSpec $spec, array $spanExpectations)
+    {
+        $traces = $this->tracesFromWebRequest(function () use ($spec) {
+            $this->call($spec);
+        });
+
+        $this->assertFlameGraph($traces, $spanExpectations);
+    }
+
+    public function provideSpecs()
+    {
+        return $this->buildDataProvider(
+            [
+                'A simple GET request returning a string' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_52',
+                        'web',
+                        'simple'
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                        'symfony.route.name' => 'simple',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')
+                                ->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.request'),
+                                    SpanAssertion::exists('symfony.kernel.controller'),
+                                    SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::build(
+                                        'symfony.controller',
+                                        'test_symfony_52',
+                                        'web',
+                                        'App\Controller\CommonScenariosController::simpleAction'
+                                    )
+                                ]),
+                        ]),
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                    ]),
+                ],
+                'A simple GET request with a view' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_52',
+                        'web',
+                        'simple_view'
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
+                        'symfony.route.name' => 'simple_view',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view',
+                        'http.status_code' => '200',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_52',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::simpleViewAction'
+                                )->withChildren([
+                                    SpanAssertion::build(
+                                        'symfony.templating.render',
+                                        'test_symfony_52',
+                                        'web',
+                                        'Twig\Environment twig_template.html.twig'
+                                    )->withExactTags([]),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.response'),
+                                SpanAssertion::exists('symfony.kernel.finish_request'),
+                            ]),
+                        ]),
+                    ]),
+                ],
+                'A GET request with an exception' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_52',
+                        'web',
+                        'error'
+                    )->withExactTags([
+                        'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
+                        'symfony.route.name' => 'error',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error',
+                        'http.status_code' => '500',
+                    ])
+                    ->setError('Exception', 'An exception occurred')
+                    ->withExistingTagsNames(['error.stack'])
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')
+                        ->setError('Exception', 'An exception occurred')
+                        ->withExistingTagsNames(['error.stack'])
+                        ->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.controller'),
+                                SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                SpanAssertion::build(
+                                    'symfony.controller',
+                                    'test_symfony_52',
+                                    'web',
+                                    'App\Controller\CommonScenariosController::errorAction'
+                                )
+                                ->setError('Exception', 'An exception occurred')
+                                ->withExistingTagsNames(['error.stack']),
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.exception'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ],
+                'A GET request to a missing route' => [
+                    SpanAssertion::build(
+                        'symfony.request',
+                        'test_symfony_52',
+                        'web',
+                        'GET /does_not_exist'
+                    )->withExactTags([
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/does_not_exist',
+                        'http.status_code' => '404',
+                    ])->withChildren([
+                        SpanAssertion::exists('symfony.kernel.terminate'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                            SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                                SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
+                                    SpanAssertion::exists('symfony.kernel.finish_request'),
+                                    SpanAssertion::exists('symfony.kernel.response'),
+                                    SpanAssertion::exists('symfony.kernel.exception'),
+                                ]),
+                                SpanAssertion::exists('symfony.kernel.request')
+                                    ->setError(
+                                        'Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException',
+                                        'No route found for "GET /does_not_exist"'
+                                    )
+                                    ->withExistingTagsNames(['error.stack']),
+                            ]),
+                        ]),
+                    ]),
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V5_2;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+class TraceSearchConfigTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/public/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_ANALYTICS_ENABLED' => 'true',
+            'DD_SYMFONY_ANALYTICS_SAMPLE_RATE' => '0.3',
+        ]);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testScenario()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'symfony.request',
+                    'symfony',
+                    'web',
+                    'simple'
+                )->withExactTags([
+                    'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
+                    'symfony.route.name' => 'simple',
+                    'http.method' => 'GET',
+                    'http.url' => 'http://localhost:9999/simple',
+                    'http.status_code' => '200',
+                ])->withExactMetrics([
+                    '_dd1.sr.eausr' => 0.3,
+                    '_sampling_priority_v1' => 1,
+                ])->withChildren([
+                    SpanAssertion::exists('symfony.kernel.terminate'),
+                    SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
+                        SpanAssertion::exists('symfony.kernel.handle')->withChildren([
+                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.controller'),
+                            SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                            SpanAssertion::build(
+                                'symfony.controller',
+                                'symfony',
+                                'web',
+                                'App\Controller\CommonScenariosController::simpleAction'
+                            ),
+                            SpanAssertion::exists('symfony.kernel.response'),
+                            SpanAssertion::exists('symfony.kernel.finish_request'),
+                        ]),
+                    ]),
+                ]),
+            ]
+        );
+    }
+}

--- a/tooling/bin/install-xdebug.sh
+++ b/tooling/bin/install-xdebug.sh
@@ -11,6 +11,9 @@ case $(php-config --vernum | cut -c1-3) in
     506 ) xdebug_version="-2.5.5" ;;
     700 ) xdebug_version="-2.7.2" ;;
     701 ) xdebug_version="-2.8.1" ;;
+    702 ) xdebug_version="-2.9.8" ;;
+    703 ) xdebug_version="-2.9.8" ;;
+    704 ) xdebug_version="-2.9.8" ;;
 
     # Anything newer uses very under-development versions
     * )   xdebug_version="" ;;


### PR DESCRIPTION
### Description

This tests the Symfony 5.2 release. Note that some of the common scenarios results are slightly different because this doesn't install the web debug toolbar, so there is one less template render command.

This runs on PHP 7.2 - 7.4 and 8.0.

~Blocked on #1177 so it will be easier to review.~ Unblocked.

Relates to #1148.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
