### PR TITLE
Refactor the PHP 8 exception serialization

### DIFF
--- a/ext/php8/engine_api.h
+++ b/ext/php8/engine_api.h
@@ -47,13 +47,13 @@ inline zval ddtrace_zval_undef(void) {
     return zv;
 }
 
-ZEND_RESULT_CODE ddtrace_call_method(zend_object *obj, zend_class_entry *ce, zend_function **fn_proxy,
-                                     const char *fname, size_t fname_len, zval *retval, int argc, zval *argv);
-ZEND_RESULT_CODE ddtrace_call_function(zend_function **fn_proxy, const char *name, size_t name_len, zval *retval,
-                                       int argc, ...);
+zend_result ddtrace_call_method(zend_object *obj, zend_class_entry *ce, zend_function **fn_proxy, const char *fname,
+                                size_t fname_len, zval *retval, int argc, zval *argv);
+zend_result ddtrace_call_function(zend_function **fn_proxy, const char *name, size_t name_len, zval *retval, int argc,
+                                  ...);
 
 void ddtrace_write_property(zval *obj, const char *prop, size_t prop_len, zval *value);
 bool ddtrace_property_exists(zval *object, zval *property);
-ZEND_RESULT_CODE ddtrace_read_property(zval *dest, zval *obj, const char *prop, size_t prop_len);
+zend_result ddtrace_read_property(zval *dest, zval *obj, const char *prop, size_t prop_len);
 
 #endif  // DDTRACE_ENGINE_API_H

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -385,7 +385,7 @@ final class PDOTest extends IntegrationTestCase
             try {
                 $pdo = $this->pdoInstance();
                 $stmt = $pdo->prepare($query);
-                $stmt->execute([1]);
+                $stmt->execute();
                 $stmt->fetchAll();
                 $stmt->closeCursor();
                 $stmt = null;
@@ -412,7 +412,7 @@ final class PDOTest extends IntegrationTestCase
                 $pdo = $this->pdoInstance();
                 $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
                 $stmt = $pdo->prepare($query);
-                $stmt->execute([1]);
+                $stmt->execute();
                 $stmt->fetchAll();
                 $stmt->closeCursor();
                 $stmt = null;


### PR DESCRIPTION
### Description

This is now based on the PHP 8.0 version of
Exception::getTraceAsString.

Also patch up PDO exception tests. In 8.0.1 PHP fixed a bug:
php/php-src@ccb7f1c7d8518dc4548273a5acd578c57d47cc0c

In our tests it manifests as:
> SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens

This isn't what we are testing, so let's fix it so when we upgrade
our container it doesn't start failing.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document.
