### PR TITLE
Import framework tests suite from dd-trace-ci to dd-trace-php

### DIFF
--- a/dockerfiles/frameworks/Makefile
+++ b/dockerfiles/frameworks/Makefile
@@ -18,9 +18,21 @@ else
 	curl -L -o "$@" "https://github.com/DataDog/dd-trace-php/releases/download/$(VERSION_TO_INSTALL)/datadog-php-tracer_$(VERSION_TO_INSTALL)_amd64.deb"
 endif
 
-.PHONY: build_file_server
+.PHONY: build_file_server publish_file_server
 build_file_server: $(DDTRACE_DEB)
 	@docker-compose -f $(ROOT_DIR)/nginx_file_server.yml build --no-cache nginx_file_server
+publish_file_server: $(DDTRACE_DEB)
+	@docker-compose -f $(ROOT_DIR)/nginx_file_server.yml push nginx_file_server
+
+build: build_file_server $(addprefix build_framework_,$(DDTRACE_TARGETS))
+
+publish: build $(addprefix publish_framework_,$(DDTRACE_TARGETS)) publish_file_server
+
+build_framework_%:
+	@docker-compose -f $(ROOT_DIR)/$(*).yml build $(*)
+
+publish_framework_%:
+	@docker-compose -f $(ROOT_DIR)/$(*).yml push $(*)
 
 .PHONY: clean
 clean:

--- a/dockerfiles/frameworks/README.md
+++ b/dockerfiles/frameworks/README.md
@@ -1,0 +1,45 @@
+# Framework tests how to
+
+This folders contains definitions for the frameworks' test suites we run in CI and the companion environements configured to run such test suites.
+
+From now on, snipptes this document assumes this folder as the working directory.
+
+## Publish the images
+
+In order to run in CI, images are required to be available from docker hub.
+
+In order to build and publish all the required images, run the following command.
+
+```
+$ make publish
+```
+
+In order to only build locally all the required images, run the following command.
+
+```
+$ make build
+```
+
+In order to build and publish a specific framework image, run the following command.
+
+```
+# make publish_framework_<name>
+$ make publish_framework_predis3
+```
+
+In order to only build locally a specific framework image, run the following command.
+
+```
+# make build_framework_<name>
+$ make build_framework_predis3
+```
+
+In order to run a specific framework test suite
+
+```
+# With the tracer installed
+$ make predis3
+
+# Without the tracer installed
+$ make predis3_no_ddtrace
+```

--- a/dockerfiles/frameworks/contrib/Dockerfile
+++ b/dockerfiles/frameworks/contrib/Dockerfile
@@ -1,0 +1,219 @@
+FROM debian:buster AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -xe; \
+  apt-get update; \
+  apt-get install -y curl gnupg vim zip git; \
+  echo "deb https://packages.sury.org/php/ buster main" | tee /etc/apt/sources.list.d/php.list; \
+  curl -L -o - https://packages.sury.org/php/apt.gpg | apt-key add -;\
+  apt-get update; \
+  apt-get clean; \
+  git config --global user.email "example@example.com"; \
+  git config --global user.name "Patch Maker";
+
+RUN set -xe; \
+    apt-get update; \
+    apt-get install -y $(for V in 5.6 7.0 7.1 7.2 7.3; do \
+        echo \
+        php${V}-fpm \
+        php${V}-apcu \
+        php${V}-ctype \
+        php${V}-curl \
+        php${V}-dom \
+        php${V}-gd \
+        php${V}-iconv \
+        php${V}-imagick \
+        php${V}-json \
+        php${V}-intl \
+        php${V}-fileinfo\
+        php${V}-mbstring \
+        php${V}-opcache \
+        php${V}-pdo \
+        php${V}-mysqli \
+        php${V}-xml \
+        php${V}-phar \
+        php${V}-tokenizer \
+        php${V}-simplexml \
+        php${V}-xdebug \
+        php${V}-zip \
+        php${V}-xmlwriter \
+        php${V}-mysql \
+        php${V}-sqlite3 \
+        php${V}-memcached \
+        php${V}-amqp \
+        php${V}-dev \
+        # php${V}-pear \
+        php${V}-bcmath; \
+    done; \
+    ); \
+    apt-get clean;
+
+RUN set -xe; \
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');";\
+    php -r "if (hash_file('sha384', 'composer-setup.php') === '$(curl -L -o - https://composer.github.io/installer.sig)') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"; \
+    php composer-setup.php; \
+    php -r "unlink('composer-setup.php');"; \
+    mv composer.phar /usr/local/bin/composer;
+
+ADD switch_php.sh /usr/local/bin/switch_php
+
+RUN set -xe; \
+    for V in 7.0 7.1 7.2 7.3; do \
+      switch_php ${V}; \
+      rm /usr/share/php/.registry/.channel.pecl.php.net/redis.reg || true; \
+      pecl install redis; \
+    done
+
+ENV COMPOSER_MEMORY_LIMIT -1
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD flow/20-redis.ini /etc/php/7.3/cli/conf.d/20-redis.ini
+ADD flow/20-redis.ini /etc/php/7.2/cli/conf.d/20-redis.ini
+ADD flow/20-redis.ini /etc/php/7.1/cli/conf.d/20-redis.ini
+ADD flow/20-redis.ini /etc/php/7.0/cli/conf.d/20-redis.ini
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+CMD [ "bash" ]
+
+# FROM base AS symfony
+# ENV COMPOSER_MEMORY_LIMIT -1
+# ARG SYMFONY_VERSION_TAG=v4.3.4
+
+# RUN set -xe; \
+#     git clone --depth 1 --branch ${SYMFONY_VERSION_TAG} https://github.com/symfony/symfony /home/symfony; \
+#     cd /home/symfony; \
+#     composer update --prefer-dist; \
+#     php ./phpunit install
+
+# WORKDIR /home/symfony/
+# ADD symfony/${SYMFONY_VERSION_TAG}.patch ./
+# RUN set -xe; \
+#     # add vendor to git to allow easy patching of vendor files too
+#     git add -f vendor; \
+#     git commit -m "vendor"; \
+#     git apply *.patch
+
+# ENV SYMFONY_DEPRECATIONS_HELPER=disabled=1
+# ADD symfony/run.sh ./
+# CMD [ "./run.sh" ]
+
+FROM base AS laravel
+ARG LARAVEL_VERSION_TAG=v5.8.17
+RUN set -xe; \
+    git clone --depth 1 --branch ${LARAVEL_VERSION_TAG} https://github.com/laravel/framework /home/laravel; \
+    cd /home/laravel; \
+    export COMPOSER_MEMORY_LIMIT=-1; \
+    composer install --prefer-dist
+
+WORKDIR /home/laravel
+ADD laravel/patch.patch ./
+ENV DD_SERVICE=laravel
+RUN set -xe; \
+    git apply *.patch
+
+CMD ["php", "./vendor/bin/phpunit", "-v"]
+
+FROM base AS flow
+ARG FLOW_VERSION_TAG=5.2.6
+ARG FLOW_BUILD_TOOLS_VERISON=5.2
+RUN set -xe; \
+    git clone https://github.com/neos/flow-development-distribution.git -b ${FLOW_BUILD_TOOLS_VERISON} /home/flow; \
+    cd /home/flow; \
+    composer update --no-progress --no-interaction
+
+WORKDIR /home/flow
+RUN set -xe; \
+    mkdir -p ../../neos/; \
+    git clone --depth 1 --branch ${FLOW_VERSION_TAG} https://github.com/neos/flow-development-collection ../../neos/flow-development-collection; \
+    export NEOS_TARGET_REPOSITORY=neos/flow-development-collection; \
+    export NEOS_TARGET_VERSION=5.2; \
+    export TRAVIS_REPO_SLUG=neos/flow-development-collection; \
+    php Build/BuildEssentials/TravisCi/ComposerManifestUpdater.php .
+RUN set -xe; \
+    sed -e 's/dev-travis as //g' -i composer.json; \
+    composer update --no-progress --no-interaction; \
+    rm -f Configuration/Routes.yaml; \
+    cp Configuration/Settings.yaml.example Configuration/Settings.yaml; \
+    set -e 's/127.0.0.1/mysql/g' -i Configuration/Settings.yaml; \
+    Build/BuildEssentials/TravisCi/SetupDatabase.sh; \
+    cp Configuration/Settings.yaml Configuration/Testing/; \
+    FLOW_CONTEXT=Testing/Behat ./flow behat:setup;
+RUN set -xe; \
+  apt-get update; \
+  apt-get install -y default-mysql-client;
+
+RUN set -xe; \
+    rm -rf ./Packages/Application/Neos.Behat/.git \
+    ./Packages/Application/Neos.Welcome/.git \
+    ./Packages/Framework/.git \
+    ./Build/BuildEssentials/.git \
+    ./Build/Behat/vendor/behat/mink-extension/.git \
+    ./Build/Behat/vendor/behat/behat/.git; \
+    git add -f Build; \
+    git add -f Packages; \
+    git commit -m "pre patch"
+
+ADD flow/30.tz.ini /etc/php/7.3/cli/conf.d/30-tz.ini
+ADD flow/30.tz.ini /etc/php/7.2/cli/conf.d/30-tz.ini
+ADD flow/30.tz.ini /etc/php/7.1/cli/conf.d/30-tz.ini
+ADD flow/30.tz.ini /etc/php/7.0/cli/conf.d/30-tz.ini
+ADD flow/Settings.yaml Configuration/Settings.yaml
+ADD flow/Settings.yaml Configuration/Testing/Settings.yaml
+ADD flow/run.sh ./
+ADD flow/patch.patch ./
+
+RUN set -xe; \
+    git apply *.patch
+
+CMD [ "./run.sh" ]
+
+FROM base AS wordpress
+ENV DD_SERVICE=wordpress
+ARG WORDPRESS_VERSION_TAG=4.8.10
+RUN set -xe; \
+  apt-get update; \
+  apt-get install -y default-mysql-client; \
+  apt-get clean
+
+RUN set -xe; \
+    git clone --depth 1 --branch ${WORDPRESS_VERSION_TAG} git://develop.git.wordpress.org/ /home/wordpress; \
+    cd /home/wordpress; \
+    switch_php 5.6; \
+    composer require --dev phpunit/phpunit ^5
+
+WORKDIR /home/wordpress
+ADD wordpress/wp-tests-config.php ./
+ADD wordpress/run.sh ./
+ADD wordpress/${WORDPRESS_VERSION_TAG}.patch ./
+
+RUN set -xe; \
+    git apply *.patch
+
+CMD [ "./run.sh" ]
+
+########################################################################################################################
+## phpredis/phpredis frameworks tests
+########################################################################################################################
+FROM base AS phpredis
+ARG PHPREDIS_VERSION_TAG
+
+RUN set -xe; \
+    git clone --depth 1 --branch ${PHPREDIS_VERSION_TAG} https://github.com/phpredis/phpredis.git \
+        /home/phpredis-${PHPREDIS_VERSION_TAG};
+
+WORKDIR /home/phpredis-${PHPREDIS_VERSION_TAG}
+
+ENV DD_SERVICE=phpredis-${PHPREDIS_VERSION_TAG}
+
+# Installing the correct version of redis
+RUN pecl uninstall redis
+RUN printf 'no' | pecl install -f redis-${PHPREDIS_VERSION_TAG}
+
+# Applying patches
+ADD phpredis/${PHPREDIS_VERSION_TAG}/patch.patch /home/phpredis-${PHPREDIS_VERSION_TAG}/patch.patch
+RUN set -xe; \
+    git apply *.patch
+
+WORKDIR /home/phpredis-${PHPREDIS_VERSION_TAG}
+ADD phpredis/${PHPREDIS_VERSION_TAG}/run.sh ./run.sh
+CMD [ "./run.sh" ]

--- a/dockerfiles/frameworks/contrib/entrypoint.sh
+++ b/dockerfiles/frameworks/contrib/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+if [[ -z "$NO_DDTRACE" ]]; then
+    curl -o /tmp/ddtrace.deb http://nginx_file_server/ddtrace.deb
+    dpkg -i /tmp/ddtrace.deb
+
+    export DD_TRACE_CLI_ENABLED=true
+fi
+exec "$@"

--- a/dockerfiles/frameworks/contrib/flow/20-redis.ini
+++ b/dockerfiles/frameworks/contrib/flow/20-redis.ini
@@ -1,0 +1,1 @@
+extension=redis.so

--- a/dockerfiles/frameworks/contrib/flow/30.tz.ini
+++ b/dockerfiles/frameworks/contrib/flow/30.tz.ini
@@ -1,0 +1,1 @@
+date.timezone = "Europe/Warsaw"

--- a/dockerfiles/frameworks/contrib/flow/Settings.yaml
+++ b/dockerfiles/frameworks/contrib/flow/Settings.yaml
@@ -1,0 +1,8 @@
+Neos:
+  Flow:
+    persistence:
+      backendOptions:
+        host: 'mysql'
+        driver: pdo_mysql
+        user: 'root'
+        dbname: 'flow_functional_testing'

--- a/dockerfiles/frameworks/contrib/flow/patch.patch
+++ b/dockerfiles/frameworks/contrib/flow/patch.patch
@@ -1,0 +1,24 @@
+From fd067df8bd662dc792be644abdecd051217f6996 Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Mon, 2 Sep 2019 10:34:42 +0000
+Subject: [PATCH] patch
+
+---
+ .../Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php          | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/Packages/Framework/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php b/Packages/Framework/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
+index 9a3d185..5c004e7 100644
+--- a/Packages/Framework/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
++++ b/Packages/Framework/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
+@@ -273,8 +273,5 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
+     {
+         $testString = 'кириллическийПуть/кириллическоеИмя.расширение';
+         $this->assertEquals('кириллическийПуть', Functions::pathinfo($testString, PATHINFO_DIRNAME), 'pathinfo() did not return the correct dirname for a unicode path.');
+-        $this->assertEquals('кириллическоеИмя.расширение', Functions::pathinfo($testString, PATHINFO_BASENAME), 'pathinfo() did not return the correct basename for a unicode path.');
+-        $this->assertEquals('расширение', Functions::pathinfo($testString, PATHINFO_EXTENSION), 'pathinfo() did not return the correct extension for a unicode path.');
+-        $this->assertEquals('кириллическоеИмя', Functions::pathinfo($testString, PATHINFO_FILENAME), 'pathinfo() did not return the correct filename for a unicode path.');
+     }
+ }
+--
+2.20.1

--- a/dockerfiles/frameworks/contrib/flow/run.sh
+++ b/dockerfiles/frameworks/contrib/flow/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+switch_php 7.1
+
+for cnt in {1..100}; do
+    mysql -h mysql -e 'CREATE DATABASE IF NOT EXISTS flow_functional_testing;' && break || true
+    sleep 1
+done
+
+
+bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/UnitTests.xml
+bin/phpunit --colors --stop-on-failure -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml --testsuite "Framework tests"

--- a/dockerfiles/frameworks/contrib/laravel/patch.patch
+++ b/dockerfiles/frameworks/contrib/laravel/patch.patch
@@ -1,0 +1,100 @@
+From 1bf80d0ca795752fb134033ae9ed054681c7a34e Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Mon, 2 Sep 2019 14:25:02 +0000
+Subject: [PATCH] patch
+
+---
+ tests/Database/DatabaseConnectionTest.php      | 5 +++--
+ tests/Database/DatabaseEloquentBuilderTest.php | 1 +
+ tests/Filesystem/FilesystemTest.php            | 2 ++
+ tests/Redis/RedisConnectionTest.php            | 4 ++++
+ 4 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/tests/Database/DatabaseConnectionTest.php b/tests/Database/DatabaseConnectionTest.php
+index f727d3d..35d668d 100755
+--- a/tests/Database/DatabaseConnectionTest.php
++++ b/tests/Database/DatabaseConnectionTest.php
+@@ -123,10 +123,11 @@ class DatabaseConnectionTest extends TestCase
+         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'rowCount', 'bindValue'])->getMock();
+         $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
+         $statement->expects($this->once())->method('execute');
+-        $statement->expects($this->once())->method('rowCount')->will($this->returnValue(['boom']));
++        $statement->expects($this->any())->method('rowCount')->will($this->returnValue(['boom']));
+         $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue($statement));
+         $mock = $this->getMockConnection(['prepareBindings'], $pdo);
+-        $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['foo' => 'bar']))->will($this->returnValue(['foo' => 'bar']));
++	//$mock->expects($this->twice())->method('prepareBindings')->with($this->equalTo(['foo' => 'bar']))->will($this->returnValue(['foo' => 'bar']));
++	$mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['foo' => 'bar']))->will($this->returnValue(['foo' => 'bar']));
+         $results = $mock->update('foo', ['foo' => 'bar']);
+         $this->assertEquals(['boom'], $results);
+         $log = $mock->getQueryLog();
+diff --git a/tests/Database/DatabaseEloquentBuilderTest.php b/tests/Database/DatabaseEloquentBuilderTest.php
+index 2fdbba2..87533b8 100755
+--- a/tests/Database/DatabaseEloquentBuilderTest.php
++++ b/tests/Database/DatabaseEloquentBuilderTest.php
+@@ -1199,6 +1199,7 @@ class DatabaseEloquentBuilderTest extends TestCase
+     {
+         $query = m::mock(BaseBuilder::class);
+         $query->shouldReceive('from')->with('foo_table');
++        $query->shouldReceive('toSql')->zeroOrMoreTimes();
+
+         return $query;
+     }
+diff --git a/tests/Filesystem/FilesystemTest.php b/tests/Filesystem/FilesystemTest.php
+index 84d09bf..28b6ec8 100755
+--- a/tests/Filesystem/FilesystemTest.php
++++ b/tests/Filesystem/FilesystemTest.php
+@@ -362,6 +362,7 @@ class FilesystemTest extends TestCase
+
+     public function testIsWritable()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         file_put_contents($this->tempDir.'/foo.txt', 'foo');
+         $files = new Filesystem;
+         @chmod($this->tempDir.'/foo.txt', 0444);
+@@ -372,6 +373,7 @@ class FilesystemTest extends TestCase
+
+     public function testIsReadable()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         file_put_contents($this->tempDir.'/foo.txt', 'foo');
+         $files = new Filesystem;
+         // chmod is noneffective on Windows
+diff --git a/tests/Redis/RedisConnectionTest.php b/tests/Redis/RedisConnectionTest.php
+index d014ac1..316ddb7 100644
+--- a/tests/Redis/RedisConnectionTest.php
++++ b/tests/Redis/RedisConnectionTest.php
+@@ -227,6 +227,7 @@ class RedisConnectionTest extends TestCase
+
+     public function test_it_calculates_intersection_of_sorted_sets_and_stores()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         foreach ($this->connections() as $redis) {
+             $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+             $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+@@ -256,6 +257,7 @@ class RedisConnectionTest extends TestCase
+
+     public function test_it_calculates_union_of_sorted_sets_and_stores()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         foreach ($this->connections() as $redis) {
+             $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+             $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+@@ -288,6 +290,7 @@ class RedisConnectionTest extends TestCase
+
+     public function test_it_returns_range_in_sorted_set()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         foreach ($this->connections() as $redis) {
+             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+             $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
+@@ -301,6 +304,7 @@ class RedisConnectionTest extends TestCase
+
+     public function test_it_returns_rev_range_in_sorted_set()
+     {
++        return $this->markTestIncomplete("incompatible environment");
+         foreach ($this->connections() as $redis) {
+             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+             $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
+--
+2.20.1

--- a/dockerfiles/frameworks/contrib/phpredis/3.1.6/patch.patch
+++ b/dockerfiles/frameworks/contrib/phpredis/3.1.6/patch.patch
@@ -1,0 +1,59 @@
+diff --git a/tests/RedisTest.php b/tests/RedisTest.php
+index 24f01d7..dc4b637 100644
+--- a/tests/RedisTest.php
++++ b/tests/RedisTest.php
+@@ -442,7 +442,7 @@ class Redis_Test extends TestSuite
+     public function testExpireAt() {
+         $this->redis->del('key');
+         $this->redis->set('key', 'value');
+-        $now = time(NULL);
++        $now = time();
+         $this->redis->expireAt('key', $now + 1);
+         $this->assertEquals('value', $this->redis->get('key'));
+         sleep(2);
+@@ -4363,10 +4363,10 @@ class Redis_Test extends TestSuite
+         $this->redis->rpush('{eval-key}-list', 'c');
+
+         // Make a set
+-        $this->redis->del('{eval-key}-set');
+-        $this->redis->sadd('{eval-key}-set', 'd');
+-        $this->redis->sadd('{eval-key}-set', 'e');
+-        $this->redis->sadd('{eval-key}-set', 'f');
++        $this->redis->del('{eval-key}-zset');
++        $this->redis->zadd('{eval-key}-zset', 0, 'd');
++        $this->redis->zadd('{eval-key}-zset', 1, 'e');
++        $this->redis->zadd('{eval-key}-zset', 2, 'f');
+
+         // Basic keys
+         $this->redis->set('{eval-key}-str1', 'hello, world');
+@@ -4376,9 +4376,9 @@ class Redis_Test extends TestSuite
+         $list = $this->redis->eval("return redis.call('lrange', KEYS[1], 0, -1)", Array('{eval-key}-list'), 1);
+         $this->assertTrue($list === Array('a','b','c'));
+
+-        // Use a script to return our set
+-        $set = $this->redis->eval("return redis.call('smembers', KEYS[1])", Array('{eval-key}-set'), 1);
+-        $this->assertTrue($set == Array('d','e','f'));
++        // Use a script to return our zset
++        $zset = $this->redis->eval("return redis.call('zrange', KEYS[1], 0, -1)", Array('{eval-key}-zset'), 1);
++        $this->assertTrue($zset == Array('d','e','f'));
+
+         // Test an empty MULTI BULK response
+         $this->redis->del('{eval-key}-nolist');
+@@ -4394,7 +4394,7 @@ class Redis_Test extends TestSuite
+                     redis.call('get', '{eval-key}-str2'),
+                     redis.call('lrange', 'not-any-kind-of-list', 0, -1),
+                     {
+-                        redis.call('smembers','{eval-key}-set'),
++                        redis.call('zrange','{eval-key}-zset', 0, -1),
+                         redis.call('lrange', '{eval-key}-list', 0, -1)
+                     }
+                 }
+@@ -4414,7 +4414,7 @@ class Redis_Test extends TestSuite
+         );
+
+         // Now run our script, and check our values against each other
+-        $eval_result = $this->redis->eval($nested_script, Array('{eval-key}-str1', '{eval-key}-str2', '{eval-key}-set', '{eval-key}-list'), 4);
++        $eval_result = $this->redis->eval($nested_script, Array('{eval-key}-str1', '{eval-key}-str2', '{eval-key}-zset', '{eval-key}-list'), 4);
+         $this->assertTrue(is_array($eval_result) && count($this->array_diff_recursive($eval_result, $expected)) == 0);
+
+         /*

--- a/dockerfiles/frameworks/contrib/phpredis/3.1.6/run.sh
+++ b/dockerfiles/frameworks/contrib/phpredis/3.1.6/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+switch_php 7.3
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class Redis
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class RedisArray

--- a/dockerfiles/frameworks/contrib/phpredis/4.3.0/patch.patch
+++ b/dockerfiles/frameworks/contrib/phpredis/4.3.0/patch.patch
@@ -1,0 +1,72 @@
+From 3e4efcf86d0df40a90a53b42378ca3092f34d823 Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Wed, 5 Aug 2020 15:02:17 +0000
+Subject: [PATCH] patch
+
+---
+ tests/RedisTest.php | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/tests/RedisTest.php b/tests/RedisTest.php
+index 7dcd17f..981bf95 100644
+--- a/tests/RedisTest.php
++++ b/tests/RedisTest.php
+@@ -5757,6 +5757,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_savedToRedis()
+     {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+
+         $sessionId = $this->generateSessionId();
+@@ -5778,7 +5779,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockingDisabledByDefault()
+     {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 5, true, 300, false);
+         usleep(100000);
+@@ -5805,7 +5807,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lock_ttlMaxExecutionTime()
+     {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('skipping because session is not properly setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true, 2);
+         usleep(100000);
+@@ -5821,7 +5824,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lock_ttlLockExpire()
+     {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true, 300, true, null, -1, 2);
+         usleep(100000);
+@@ -5837,7 +5841,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockHoldCheckBeforeWrite_otherProcessHasLock()
+     {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 2, true, 300, true, null, -1, 1, 'firstProcess');
+         usleep(1500000); // 1.5 sec
+@@ -6211,7 +6216,7 @@ class Redis_Test extends TestSuite
+                         $cmd .= ' --define extension=igbinary.so';
+                     }
+                     if (!$redis) {
+-                        $cmd .= ' --define extension=' . dirname(__DIR__) . '/modules/redis.so';
++                        $cmd .= ' --define extension=redis.so';
+                     }
+                 }
+             }
+--
+2.20.1

--- a/dockerfiles/frameworks/contrib/phpredis/4.3.0/run.sh
+++ b/dockerfiles/frameworks/contrib/phpredis/4.3.0/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+switch_php 7.3
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class Redis
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class RedisArray

--- a/dockerfiles/frameworks/contrib/phpredis/5.3.1/patch.patch
+++ b/dockerfiles/frameworks/contrib/phpredis/5.3.1/patch.patch
@@ -1,0 +1,228 @@
+From 473e293458ab9462375ad1e43d05048bcb999361 Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Wed, 5 Aug 2020 17:24:25 +0000
+Subject: [PATCH] patch
+
+---
+ tests/RedisTest.php | 52 ++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 37 insertions(+), 15 deletions(-)
+
+diff --git a/tests/RedisTest.php b/tests/RedisTest.php
+index c7a403f..cdc4d92 100644
+--- a/tests/RedisTest.php
++++ b/tests/RedisTest.php
+@@ -6222,6 +6222,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_savedToRedis()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+
+         $sessionId = $this->generateSessionId();
+@@ -6233,6 +6234,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockKeyCorrect()
+     {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 5, true);
+@@ -6243,6 +6245,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockingDisabledByDefault()
+     {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 5, true, 300, false);
+@@ -6260,7 +6263,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockReleasedOnClose()
+     {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 1, true);
+         usleep(1100000);
+@@ -6270,6 +6274,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lock_ttlMaxExecutionTime()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true, 2);
+@@ -6286,7 +6291,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lock_ttlLockExpire()
+     {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true, 300, true, null, -1, 2);
+         usleep(100000);
+@@ -6302,7 +6308,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockHoldCheckBeforeWrite_otherProcessHasLock()
+     {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 2, true, 300, true, null, -1, 1, 'firstProcess');
+         usleep(1500000); // 1.5 sec
+@@ -6325,7 +6332,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_correctLockRetryCount()
+     {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true);
+         usleep(100000);
+@@ -6341,6 +6349,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_defaultLockRetryCount()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 10, true);
+@@ -6357,6 +6366,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_noUnlockOfOtherProcess()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 3, true, 1); // Process 1
+@@ -6377,6 +6387,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_lockWaitTime()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 1, true, 300);
+@@ -6434,7 +6445,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_noLock_noDestroy() {
+-        $this->setSessionHandler();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+
+@@ -6445,7 +6457,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_noLock_withDestroy() {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+
+@@ -6456,7 +6469,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_withLock_noDestroy() {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+
+@@ -6467,7 +6481,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_withLock_withDestroy() {
+-        $this->setSessionHandler();
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    $this->setSessionHandler();
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+
+@@ -6478,7 +6493,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_noLock_noDestroy_withProxy() {
+-        if (!interface_exists('SessionHandlerInterface')) {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	    if (!interface_exists('SessionHandlerInterface')) {
+             $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+         }
+
+@@ -6493,7 +6509,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_noLock_withDestroy_withProxy() {
+-        if (!interface_exists('SessionHandlerInterface')) {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	if (!interface_exists('SessionHandlerInterface')) {
+             $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+         }
+
+@@ -6508,7 +6525,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_withLock_noDestroy_withProxy() {
+-        if (!interface_exists('SessionHandlerInterface')) {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	if (!interface_exists('SessionHandlerInterface')) {
+             $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+         }
+
+@@ -6523,7 +6541,8 @@ class Redis_Test extends TestSuite
+     }
+
+     public  function testSession_regenerateSessionId_withLock_withDestroy_withProxy() {
+-        if (!interface_exists('SessionHandlerInterface')) {
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	if (!interface_exists('SessionHandlerInterface')) {
+             $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+         }
+
+@@ -6539,7 +6558,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_ttl_equalsToSessionLifetime()
+     {
+-        $sessionId = $this->generateSessionId();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 0, 'test', 600);
+         $ttl = $this->redis->ttl($this->sessionPrefix . $sessionId);
+
+@@ -6548,6 +6568,7 @@ class Redis_Test extends TestSuite
+
+     public function testSession_ttl_resetOnWrite()
+     {
++	    return $this->markTestSkipped('disabling some session tests as we miss proper setup');
+         $sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 0, 'test', 600);
+         $this->redis->expire($this->sessionPrefix . $sessionId, 9999);
+@@ -6559,7 +6580,8 @@ class Redis_Test extends TestSuite
+
+     public function testSession_ttl_resetOnRead()
+     {
+-        $sessionId = $this->generateSessionId();
++	return $this->markTestSkipped('disabling some session tests as we miss proper setup');
++	$sessionId = $this->generateSessionId();
+         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 0, 'test', 600);
+         $this->redis->expire($this->sessionPrefix . $sessionId, 9999);
+         $this->getSessionData($sessionId, 600);
+@@ -6703,7 +6725,7 @@ class Redis_Test extends TestSuite
+                             $str_extension = dirname(__DIR__) . '/modules/redis';
+                         }
+
+-                        $cmd .= " --define extension=$str_extension.so";
++                        $cmd .= " --define extension=redis.so";
+                     }
+                 }
+             }
+--
+2.20.1

--- a/dockerfiles/frameworks/contrib/phpredis/5.3.1/run.sh
+++ b/dockerfiles/frameworks/contrib/phpredis/5.3.1/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+switch_php 7.3
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class Redis
+DD_TRACE_CLI_ENABLED=true php ./tests/TestRedis.php --host ${REDIS_HOST} --class RedisArray

--- a/dockerfiles/frameworks/contrib/switch_php.sh
+++ b/dockerfiles/frameworks/contrib/switch_php.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+PHP_VERSION=${1:-7.3}
+
+update-alternatives --set php /usr/bin/php${PHP_VERSION}
+update-alternatives --set php /usr/bin/php${PHP_VERSION}
+update-alternatives --set phar /usr/bin/phar${PHP_VERSION}
+update-alternatives --set phar.phar /usr/bin/phar.phar${PHP_VERSION}
+update-alternatives --set phpize /usr/bin/phpize${PHP_VERSION}
+update-alternatives --set php-config /usr/bin/php-config${PHP_VERSION}
+
+if [[ -x /opt/datadog-php/bin/post-install.sh ]]; then
+    /opt/datadog-php/bin/post-install.sh
+fi

--- a/dockerfiles/frameworks/contrib/symfony/run.sh
+++ b/dockerfiles/frameworks/contrib/symfony/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+php /home/symfony/phpunit --exclude-group tty,benchmark,intl-data,legacy -v | tee output.txt
+grep "OK, but incomplete, skipped, or risky tests!" output.txt

--- a/dockerfiles/frameworks/contrib/symfony/v4.3.4.patch
+++ b/dockerfiles/frameworks/contrib/symfony/v4.3.4.patch
@@ -1,0 +1,228 @@
+From 37f7307cd0103c509e8b4c721c312fcb62cc2b40 Mon Sep 17 00:00:00 2001
+From: Your Name <you@example.com>
+Date: Wed, 28 Aug 2019 13:17:10 +0000
+Subject: [PATCH] patch
+
+---
+ .../Controller/TemplateControllerTest.php     |  1 +
+ .../HttpClient/Tests/CurlHttpClientTest.php   |  3 ++-
+ .../HttpFoundation/Tests/ResponseTest.php     |  4 +++-
+ .../Transport/RedisExt/ConnectionTest.php     | 24 +++++++++----------
+ .../RedisExt/RedisTransportFactoryTest.php    |  6 ++---
+ .../Tests/Caster/RedisCasterTest.php          |  4 ++--
+ .../HttpClient/Test/HttpClientTestCase.php    |  4 +++-
+ 7 files changed, 26 insertions(+), 20 deletions(-)
+
+diff --git a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+index 31847b2..0dea189 100644
+--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
++++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+@@ -33,6 +33,7 @@ class TemplateControllerTest extends TestCase
+
+     public function testTemplating()
+     {
++	return $this->markTestIncomplete("wrong_install");
+         $templating = $this->getMockBuilder(EngineInterface::class)->getMock();
+         $templating->expects($this->exactly(2))->method('render')->willReturn('bar');
+
+diff --git a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+index 2c27bb7..e1ecf19 100644
+--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
++++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+@@ -45,8 +45,9 @@ class CurlHttpClientTest extends HttpClientTestCase
+             {
+                 $this->logs[] = $message;
+             }
+-        };
++	};
+
++	return $this->markTestIncomplete("wrong_install");
+         $client = new CurlHttpClient();
+         $client->setLogger($logger);
+
+diff --git a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+index b20bb0b..d8d9270 100644
+--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
++++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+@@ -389,7 +389,9 @@ class ResponseTest extends ResponseTestCase
+         $this->assertSame(0, $response->getTtl(), '->getTtl() correctly handles zero');
+
+         $response = new Response();
+-        $response->headers->set('Cache-Control', 'max-age=60');
++	$response->headers->set('Cache-Control', 'max-age=60');
++	return $this->markTestIncomplete("wrong_install");
++
+         $this->assertEquals(60, $response->getTtl(), '->getTtl() uses Cache-Control max-age when present');
+     }
+
+diff --git a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+index 066b4c1..ce70c37 100644
+--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
++++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+@@ -32,10 +32,10 @@ class ConnectionTest extends TestCase
+     {
+         $this->assertEquals(
+             new Connection(['stream' => 'queue'], [
+-                'host' => 'localhost',
++                'host' => getenv('REDIS_HOST'),
+                 'port' => 6379,
+             ]),
+-            Connection::fromDsn('redis://localhost/queue')
++            Connection::fromDsn('redis://'.getenv('REDIS_HOST').'/queue')
+         );
+     }
+
+@@ -43,12 +43,12 @@ class ConnectionTest extends TestCase
+     {
+         $this->assertEquals(
+             new Connection(['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false], [
+-                'host' => 'localhost',
++                'host' => getenv('REDIS_HOST'),
+                 'port' => 6379,
+             ], [
+                 'serializer' => 2,
+             ]),
+-            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['serializer' => 2, 'auto_setup' => false])
++            Connection::fromDsn('redis://' . getenv('REDIS_HOST') . '/queue/group1/consumer1', ['serializer' => 2, 'auto_setup' => false])
+         );
+     }
+
+@@ -56,12 +56,12 @@ class ConnectionTest extends TestCase
+     {
+         $this->assertEquals(
+             new Connection(['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1'], [
+-                'host' => 'localhost',
++                'host' => getenv('REDIS_HOST'),
+                 'port' => 6379,
+             ], [
+                 'serializer' => 2,
+             ]),
+-            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2')
++            Connection::fromDsn('redis://' . getenv('REDIS_HOST') . '/queue/group1/consumer1?serializer=2')
+         );
+     }
+
+@@ -73,7 +73,7 @@ class ConnectionTest extends TestCase
+             ->with('symfony', 'consumer', ['queue' => 0], 1, null)
+             ->willReturn(['queue' => [['message' => json_encode(['body' => 'Test', 'headers' => []])]]]);
+
+-        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
++        $connection = Connection::fromDsn('redis://'.getenv("REDIS_HOST").'/queue', [], $redis);
+         $this->assertNotNull($connection->get());
+         $this->assertNotNull($connection->get());
+         $this->assertNotNull($connection->get());
+@@ -86,7 +86,7 @@ class ConnectionTest extends TestCase
+         $redis->expects($this->exactly(1))->method('auth')
+             ->with('password');
+
+-        Connection::fromDsn('redis://password@localhost/queue', [], $redis);
++        Connection::fromDsn('redis://password@'.getenv('REDIS_HOST').'/queue', [], $redis);
+     }
+
+     public function testFirstGetPendingMessagesThenNewMessages()
+@@ -126,7 +126,7 @@ class ConnectionTest extends TestCase
+     public function testGetAfterReject()
+     {
+         $redis = new \Redis();
+-        $connection = Connection::fromDsn('redis://localhost/messenger-rejectthenget', [], $redis);
++        $connection = Connection::fromDsn('redis://'.getenv('REDIS_HOST').'/messenger-rejectthenget', [], $redis);
+
+         $connection->add('1', []);
+         $connection->add('2', []);
+@@ -134,7 +134,7 @@ class ConnectionTest extends TestCase
+         $failing = $connection->get();
+         $connection->reject($failing['id']);
+
+-        $connection = Connection::fromDsn('redis://localhost/messenger-rejectthenget');
++        $connection = Connection::fromDsn('redis://'.getenv('REDIS_HOST').'/messenger-rejectthenget');
+         $this->assertNotNull($connection->get());
+
+         $redis->del('messenger-rejectthenget');
+@@ -144,7 +144,7 @@ class ConnectionTest extends TestCase
+     {
+         $redis = new \Redis();
+
+-        $connection = Connection::fromDsn('redis://localhost/messenger-getnonblocking', [], $redis);
++        $connection = Connection::fromDsn('redis://'.getenv('REDIS_HOST').'/messenger-getnonblocking', [], $redis);
+
+         $this->assertNull($connection->get()); // no message, should return null immediately
+         $connection->add('1', []);
+@@ -163,7 +163,7 @@ class ConnectionTest extends TestCase
+         $redis->method('getLastError')->willReturnOnConsecutiveCalls('xadd error', 'xack error');
+         $redis->expects($this->exactly(2))->method('clearLastError');
+
+-        $connection = Connection::fromDsn('redis://localhost/messenger-clearlasterror', ['auto_setup' => false], $redis);
++        $connection = Connection::fromDsn('redis://'.getenv('REDIS_HOST').'/messenger-clearlasterror', ['auto_setup' => false], $redis);
+
+         try {
+             $connection->add('message', []);
+diff --git a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+index 58b7153..c12ab4b 100644
+--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
++++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+@@ -26,7 +26,7 @@ class RedisTransportFactoryTest extends TestCase
+     {
+         $factory = new RedisTransportFactory();
+
+-        $this->assertTrue($factory->supports('redis://localhost', []));
++        $this->assertTrue($factory->supports('redis://' . getenv('REDIS_HOST'), []));
+         $this->assertFalse($factory->supports('sqs://localhost', []));
+         $this->assertFalse($factory->supports('invalid-dsn', []));
+     }
+@@ -35,8 +35,8 @@ class RedisTransportFactoryTest extends TestCase
+     {
+         $factory = new RedisTransportFactory();
+         $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+-        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://localhost', ['foo' => 'bar']), $serializer);
++        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://' . getenv('REDIS_HOST'), ['foo' => 'bar']), $serializer);
+
+-        $this->assertEquals($expectedTransport, $factory->createTransport('redis://localhost', ['foo' => 'bar'], $serializer));
++        $this->assertEquals($expectedTransport, $factory->createTransport('redis://' . getenv('REDIS_HOST'), ['foo' => 'bar'], $serializer));
+     }
+ }
+diff --git a/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php b/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
+index 3edbed6..034839c 100644
+--- a/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
++++ b/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
+@@ -38,7 +38,7 @@ EODUMP;
+     public function testConnected()
+     {
+         $redis = new \Redis();
+-        if (!@$redis->connect('127.0.0.1')) {
++        if (!@$redis->connect('redis')) {
+             $e = error_get_last();
+             self::markTestSkipped($e['message']);
+         }
+@@ -46,7 +46,7 @@ EODUMP;
+         $xCast = <<<'EODUMP'
+ Redis {%A
+   isConnected: true
+-  host: "127.0.0.1"
++  host: "redis"
+   port: 6379
+   auth: null
+   mode: ATOMIC
+diff --git a/vendor/symfony/contracts/HttpClient/Test/HttpClientTestCase.php b/vendor/symfony/contracts/HttpClient/Test/HttpClientTestCase.php
+index b5364ec..2fbac02 100644
+--- a/vendor/symfony/contracts/HttpClient/Test/HttpClientTestCase.php
++++ b/vendor/symfony/contracts/HttpClient/Test/HttpClientTestCase.php
+@@ -585,6 +585,7 @@ abstract class HttpClientTestCase extends TestCase
+
+     public function testNotATimeout()
+     {
++	return $this->markTestIncomplete("wrong_install");
+         $client = $this->getHttpClient(__FUNCTION__);
+         $response = $client->request('GET', 'http://localhost:8057/timeout-header', [
+             'timeout' => 0.5,
+@@ -790,7 +791,8 @@ abstract class HttpClientTestCase extends TestCase
+
+     public function testMaxDuration()
+     {
+-        $client = $this->getHttpClient(__FUNCTION__);
++        return $this->markTestIncomplete("wrong_install");
++	$client = $this->getHttpClient(__FUNCTION__);
+         $response = $client->request('GET', 'http://localhost:8057/max-duration', [
+             'max_duration' => 0.1,
+         ]);
+--
+2.20.1

--- a/dockerfiles/frameworks/contrib/wordpress/4.8.10.patch
+++ b/dockerfiles/frameworks/contrib/wordpress/4.8.10.patch
@@ -1,0 +1,88 @@
+From 2aaf78135f6d0570abeb24bdbfa6e18f0a307930 Mon Sep 17 00:00:00 2001
+From: Patch Maker <example@example.com>
+Date: Wed, 11 Sep 2019 20:47:07 +0000
+Subject: [PATCH] Patch
+
+---
+ tests/phpunit/tests/basic.php                | 2 +-
+ tests/phpunit/tests/image/editor_imagick.php | 2 ++
+ tests/phpunit/tests/import/import.php        | 2 +-
+ tests/phpunit/tests/import/parser.php        | 2 +-
+ tests/phpunit/tests/import/postmeta.php      | 2 +-
+ 5 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/tests/phpunit/tests/basic.php b/tests/phpunit/tests/basic.php
+index 0d145f6..4c04551 100644
+--- a/tests/phpunit/tests/basic.php
++++ b/tests/phpunit/tests/basic.php
+@@ -13,7 +13,7 @@ class Tests_Basic extends WP_UnitTestCase {
+
+ 		$license = file_get_contents( ABSPATH . 'license.txt' );
+ 		preg_match( '#Copyright 2011-(\d+) by the contributors#', $license, $matches );
+-		$this_year = date( 'Y' );
++		$this_year = '2018';
+ 		$this->assertEquals( $this_year, trim( $matches[1] ), "license.txt's year needs to be updated to $this_year." );
+ 	}
+
+diff --git a/tests/phpunit/tests/image/editor_imagick.php b/tests/phpunit/tests/image/editor_imagick.php
+index e113b77..770fb97 100644
+--- a/tests/phpunit/tests/image/editor_imagick.php
++++ b/tests/phpunit/tests/image/editor_imagick.php
+@@ -420,6 +420,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
+ 	 * Test rotating an image 180 deg
+ 	 */
+ 	public function test_rotate() {
++		$this->markTestSkipped('Test fails out of the box');
+ 		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
+
+ 		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
+@@ -439,6 +440,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
+ 	 * Test flipping an image
+ 	 */
+ 	public function test_flip() {
++		$this->markTestSkipped('Test fails out of the box');
+ 		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
+
+ 		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
+diff --git a/tests/phpunit/tests/import/import.php b/tests/phpunit/tests/import/import.php
+index 9303444..fa0bcbb 100644
+--- a/tests/phpunit/tests/import/import.php
++++ b/tests/phpunit/tests/import/import.php
+@@ -18,7 +18,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
+ 		add_filter( 'import_allow_create_users', '__return_true' );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+diff --git a/tests/phpunit/tests/import/parser.php b/tests/phpunit/tests/import/parser.php
+index 890fd0a..3e2ee20 100644
+--- a/tests/phpunit/tests/import/parser.php
++++ b/tests/phpunit/tests/import/parser.php
+@@ -16,7 +16,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
+ 			define( 'WP_LOAD_IMPORTERS', true );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+diff --git a/tests/phpunit/tests/import/postmeta.php b/tests/phpunit/tests/import/postmeta.php
+index bf468a1..0fd8dae 100644
+--- a/tests/phpunit/tests/import/postmeta.php
++++ b/tests/phpunit/tests/import/postmeta.php
+@@ -16,7 +16,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
+ 			define( 'WP_LOAD_IMPORTERS', true );
+
+ 		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
+-			$this->fail( 'WordPress Importer plugin is not installed.' );
++			$this->markTestSkipped( 'WordPress Importer plugin is not installed.' );
+ 		}
+
+ 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+--
+2.20.1
+

--- a/dockerfiles/frameworks/contrib/wordpress/run.sh
+++ b/dockerfiles/frameworks/contrib/wordpress/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+
+for cnt in {1..100}; do
+    mysql -h mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_functional_testing;' && break || true
+    sleep 1
+done
+
+vendor/bin/phpunit

--- a/dockerfiles/frameworks/contrib/wordpress/wp-tests-config.php
+++ b/dockerfiles/frameworks/contrib/wordpress/wp-tests-config.php
@@ -1,0 +1,64 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress install defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', 'wordpress_functional_testing' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', '' );
+define( 'DB_HOST', 'mysql' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define('AUTH_KEY',         'B?xL|x=s6|8/Yi3ZW(]MVoxO-O:8taK91C$wfDpZ$`(Zo2ak*q J^+ir9s.|qwu3');
+define('SECURE_AUTH_KEY',  'SJ?)H|@e9Ezad3+LbS:j^7^lIN7-$.40-s,bM]a4{;P@cD+J8;X]jWbUaVA1<VG ');
+define('LOGGED_IN_KEY',    'MJ4N7Woe^gy5{ 9?WR4S6H8Z>nns?6tMwCt#,:xeQ g,$bT9d<4VN/(lhXR#z6QL');
+define('NONCE_KEY',        '.V+R ZJ$6-RG5|wqlv)HOTI_Rdj<aDUz(q])*N{#7VBk/U&`o|,_q;^$mN0o!m-j');
+define('AUTH_SALT',        'V>o&_Y+dI2ayQ!P`(<0iL IS@Aw%bqkwhQ!wBXc;_`KYR_Oxu@x!3wwr6U>BtQ-?');
+define('SECURE_AUTH_SALT', 'd6::Ym$|XSy?$-X~HT7K2}Q 4%?U Xe+gwY2V7FO;kNvnTG5//YZW4:*kfVA5eWw');
+define('LOGGED_IN_SALT',   '-ONc3g-<Pm@M-&6;R2JIDX=/~`1 GXaDewKRlAmr2.->k0=hV1!xr8l=j![XDl28');
+define('NONCE_SALT',       'vi/{40CMK^mNYWMYv<>+Gi)>g.!S=!h@^^)]*.|Gf>5=JN7(lI1~cB-@>88,mhB1');
+
+$table_prefix  = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/dockerfiles/frameworks/flow.yml
+++ b/dockerfiles/frameworks/flow.yml
@@ -4,6 +4,9 @@ services:
   flow:
     depends_on: ['mysql', 'nginx_file_server']
     image: 'datadog/dd-trace-ci:php-framework-flow'
+    build:
+      context: contrib
+      target: flow
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/laravel.yml
+++ b/dockerfiles/frameworks/laravel.yml
@@ -7,6 +7,9 @@ services:
       - "REDIS_HOST=redis"
       - "MEMCACHED_HOST=memcached"
     image: 'datadog/dd-trace-ci:php-framework-laravel'
+    build:
+      context: contrib
+      target: laravel
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/phpredis3.yml
+++ b/dockerfiles/frameworks/phpredis3.yml
@@ -9,6 +9,11 @@ services:
     environment:
       - REDIS_HOST=redis
     image: datadog/dd-trace-ci:php-framework-phpredis-3
+    build:
+      context: contrib
+      target: phpredis
+      args:
+        - PHPREDIS_VERSION_TAG=3.1.6
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/phpredis4.yml
+++ b/dockerfiles/frameworks/phpredis4.yml
@@ -9,6 +9,11 @@ services:
     environment:
       - REDIS_HOST=redis
     image: datadog/dd-trace-ci:php-framework-phpredis-4
+    build:
+      context: contrib
+      target: phpredis
+      args:
+        - PHPREDIS_VERSION_TAG=4.3.0
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/phpredis5.yml
+++ b/dockerfiles/frameworks/phpredis5.yml
@@ -1,7 +1,6 @@
 version: "3.6"
 
 services:
-
   phpredis5:
     depends_on:
       - nginx_file_server
@@ -9,6 +8,11 @@ services:
     environment:
       - REDIS_HOST=redis
     image: datadog/dd-trace-ci:php-framework-phpredis-5
+    build:
+      context: contrib
+      target: phpredis
+      args:
+        - PHPREDIS_VERSION_TAG=5.3.1
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/symfony.yml
+++ b/dockerfiles/frameworks/symfony.yml
@@ -8,6 +8,9 @@ services:
       - "MEMCACHED_HOST=memcached"
       - "REDIS_CLUSTER_HOSTS=redis_cluster:7000 redis_cluster:7001 redis_cluster:7002 redis_cluster:7003 redis_cluster:7004 redis_cluster:7005"
     image: 'datadog/dd-trace-ci:php-framework-symfony'
+    build:
+      context: contrib
+      target: symfony
     ulimits:
       core: 99999999999
     cap_add:

--- a/dockerfiles/frameworks/wordpress.yml
+++ b/dockerfiles/frameworks/wordpress.yml
@@ -4,6 +4,9 @@ services:
   wordpress:
     depends_on: ['mysql', 'nginx_file_server']
     image: 'datadog/dd-trace-ci:php-framework-wordpress'
+    build:
+      context: contrib
+      target: wordpress
     ulimits:
       core: 99999999999
     cap_add:


### PR DESCRIPTION
Note to the reviewer:
- this commit https://github.com/DataDog/dd-trace-php/pull/1183/commits/dc729ac39a174455a5546201fa0713a6aeba8192 brings the code over as it is from https://github.com/DataDog/dd-trace-ci/pull/32
- this commit https://github.com/DataDog/dd-trace-php/pull/1183/commits/f0106a7e336c1b3fa71d33e242575ff883fd3518 contains the actual changes

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
