### PR TITLE
Zend Abstract Interface: Method call seam (PHP 5)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -85,6 +85,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/methods/php5/methods.c \
       zend_abstract_interface/sandbox/php5/sandbox.c \
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
@@ -128,6 +129,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/methods/php5/methods.c \
       zend_abstract_interface/sandbox/php5/sandbox.c \
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
@@ -254,6 +256,8 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir/zend_abstract_interface])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])

--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,8 @@
             <file name="components/string_view/string_view.h" role="src" />
 
             <!-- Zend Abstract Interface -->
+            <file name="zend_abstract_interface/methods/methods.h" role="src" />
+            <file name="zend_abstract_interface/methods/php5/methods.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php5/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php7/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php8/sandbox.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -76,6 +76,12 @@ else()
 endif()
 
 add_subdirectory(zai_sapi)
+
+# All tests depend on zai_sapi
+if(PHP_VERSION_ID LESS_EQUAL "70000")
+  # TODO Support PHP 7
+  add_subdirectory(methods)
+endif()
 add_subdirectory(sandbox)
 
 install(EXPORT ZendAbstractInterfaceTargets

--- a/zend_abstract_interface/methods/CMakeLists.txt
+++ b/zend_abstract_interface/methods/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_library(zai_methods "${PHP_VERSION_DIRECTORY}/methods.c")
+
+target_include_directories(zai_methods PUBLIC
+                                       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                       $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_methods PUBLIC c_std_99)
+
+target_link_libraries(zai_methods PUBLIC "${PHP_LIB}" Zai::Sandbox)
+
+set_target_properties(zai_methods PROPERTIES
+                                  EXPORT_NAME Methods
+                                  VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Methods ALIAS zai_methods)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+# TODO: How to make this zai/methods.h?
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/methods.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/methods/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_methods)
+
+install(TARGETS zai_methods EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -29,8 +29,7 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS
  *   }
  *
  * Methods cannot be called outside of a request context so this MUST be called
- * from within a request context (after RINIT and before RSHUTDOWN). A crash
- * will occur if this is called outside of a request context.
+ * from within a request context (after RINIT and before RSHUTDOWN).
  */
 bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC);
 

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -11,10 +11,12 @@
  * ZAI seams using native Zend Engine data structures.
  */
 
-/* Looks up a class entry directly from the EG(class_table). The lookup is
+/* Looks up a class entry directly from the CG(class_table). The lookup is
  * case-sensitive so the class name should be lowercase. The class name should
  * not contain a root-scope '\' prefix. Does not invoke the autoloader. Returns
- * NULL if the class entry could not be found.
+ * NULL if the class entry could not be found. Because the class lookup occurs
+ * from the compiler globals, this can be called safely outside of a request
+ * context.
  */
 zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC);
 
@@ -25,6 +27,10 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS
  *   if (retval) {
  *     zval_ptr_dtor(&retval);
  *   }
+ * 
+ * Methods cannot be called outside of a request context so this MUST be called
+ * from within a request context (after RINIT and before RSHUTDOWN). A crash
+ * will occur if this is called outside of a request context. 
  */
 bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC);
 

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -27,10 +27,10 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS
  *   if (retval) {
  *     zval_ptr_dtor(&retval);
  *   }
- * 
+ *
  * Methods cannot be called outside of a request context so this MUST be called
  * from within a request context (after RINIT and before RSHUTDOWN). A crash
- * will occur if this is called outside of a request context. 
+ * will occur if this is called outside of a request context.
  */
 bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC);
 

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -1,0 +1,42 @@
+#ifndef ZAI_METHODS_H
+#define ZAI_METHODS_H
+
+#include <main/php.h>
+#include <stdbool.h>
+
+/* Work in progress
+ *
+ * The long-term goal is to provide ZAI data-structure shims so that the
+ * following APIs are the same across all PHP versions. For now we will provide
+ * ZAI seams using native Zend Engine data structures.
+ */
+
+/* Looks up a class entry directly from the EG(class_table). The lookup is
+ * case-sensitive so the class name should be lowercase. The class name should
+ * not contain a root-scope '\' prefix. Does not invoke the autoloader. Returns
+ * NULL if the class entry could not be found.
+ */
+zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC);
+
+/* Calls a method on an instance of 'object' without passing any arguments.
+ * Caller must pass in a NULL pointer-pointer for the return value 'retval'.
+ * Caller must dtor a non-NULL 'retval' after the call:
+ *
+ *   if (retval) {
+ *     zval_ptr_dtor(&retval);
+ *   }
+ */
+bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC);
+
+/* Calls a static method on a class entry 'ce' without passing any arguments.
+ * Return value handling is the same as zai_call_method_without_args().
+ */
+bool zai_call_static_method_without_args_ex(zend_class_entry *ce, const char *method, size_t method_len,
+                                            zval **retval TSRMLS_DC);
+
+/* Mask away the TSRMLS_* macros with more macros */
+#define zai_class_lookup(...) zai_class_lookup_ex(__VA_ARGS__ TSRMLS_CC)
+#define zai_call_method_without_args(...) zai_call_method_without_args_ex(__VA_ARGS__ TSRMLS_CC)
+#define zai_call_static_method_without_args(...) zai_call_static_method_without_args_ex(__VA_ARGS__ TSRMLS_CC)
+
+#endif  // ZAI_METHODS_H

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -36,6 +36,12 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
                                           zval **retval TSRMLS_DC) {
     if (!ce || !method || !method_len || !retval) return false;
 
+    /* Methods cannot be called outside of a request context.
+     * PG(modules_activated) indicates that all of the module RINITs have been
+     * called and we are in a request context.
+     */
+    if (!PG(modules_activated)) return false;
+
     /* Prevent a potential dangling pointer in case the caller accidentally
      * sent in an allocated retval.
      */

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -24,9 +24,12 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS
 
     /* Since we do not want to invoke the autoloader and we assume the caller
      * will pass in the lowercased class name, we look up the class entry from
-     * the EG(class_table) directly versus calling zend_lookup_class_ex().
+     * the CG(class_table) directly versus calling zend_lookup_class_ex(). This
+     * also allows us to make class lookups outside of a request context which
+     * is not possible for zend_lookup_class_ex() since it relies on executor
+     * global EG(class_table) for the lookup.
      */
-    return (zend_hash_find(EG(class_table), cname, (cname_len + 1), (void **)&ce) == SUCCESS) ? *ce : NULL;
+    return (zend_hash_find(CG(class_table), cname, (cname_len + 1), (void **)&ce) == SUCCESS) ? *ce : NULL;
 }
 
 static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, const char *method, size_t method_len,

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -1,0 +1,109 @@
+#include "../methods.h"
+
+#include <Zend/zend_interfaces.h>
+#include <assert.h>
+#include <sandbox/sandbox.h>
+
+zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC) {
+    if (!cname || !cname_len) return NULL;
+    zend_class_entry **ce;
+    /* Since we do not want to invoke the autoloader and we assume the caller
+     * will pass in the lowercased class name, we look up the class entry from
+     * the EG(class_table) directly versus calling zend_lookup_class_ex().
+     */
+    return (zend_hash_find(EG(class_table), cname, (cname_len + 1), (void **)&ce) == SUCCESS) ? *ce : NULL;
+}
+
+#ifndef NDEBUG
+static bool z_is_lower(const char *str) {
+    char *p = (char *)str;
+    while (*p) {
+        if (isalpha(*p) && !islower(*p)) return false;
+        p++;
+    }
+    return true;
+}
+#endif
+
+static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, const char *method, size_t method_len,
+                                          zval **retval TSRMLS_DC) {
+    if (!ce || !method || !method_len || !retval) return false;
+
+    /* Prevent a potential dangling pointer in case the caller accidentally
+     * sent in an allocated retval.
+     */
+    if (*retval != NULL) return false;
+
+    /* If 'object' is NULL, the caller wants to call this method statically. */
+    zval **obj = object ? &object : NULL;
+
+    /* This one gets me all the time. Trying to save myself 5 minutes for the
+     * next time it inevitably happens.
+     */
+    assert(z_is_lower(method) && "Don't forget to send those method names in all lowercase. ;)");
+
+    /* There is an important ZEND_ACC_ALLOW_STATIC check that occurs within the
+     * VM that is circumvented when calling a method outside of a VM context
+     * via zend_call_method(). Bypassing this check can result in an
+     * application crash therefore we must look up the function handler and
+     * perform the check manually here.
+     *
+     * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_vm_def.h#L2639-L2642
+     */
+    zend_function *func = NULL;
+    if (zend_hash_find(&ce->function_table, method, (method_len + 1), (void **)&func) == FAILURE) return false;
+
+    /* Calling a non-static method statically can result in a SIGSEGV because
+     * the VM acts as a NULL check on the object before calling the function
+     * handler and we are bypassing that check with a direct call to
+     * zend_call_method(). We only want to allow this behavior on a non-static
+     * method if the function has been explicitly marked with
+     * ZEND_ACC_ALLOW_STATIC signifying that it is safe to do so.
+     */
+    if (!obj && func->common.scope && !(func->common.fn_flags & (ZEND_ACC_STATIC | ZEND_ACC_ALLOW_STATIC))) {
+        // "Non-static method %s::%s() cannot be called statically"
+        return false;
+    }
+
+    /* The ZEND_ACC_ABSTRACT check still occurs when calling zend_call_method()
+     * directly (but not until zend_call_function() is called). Since we
+     * already did the work of pulling out the function handler, we might as
+     * well fail early and avoid a potential zend_bailout while we can.
+     *
+     * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_execute_API.c#L838-L840
+     */
+    if (func->common.fn_flags & ZEND_ACC_ABSTRACT) {
+        // "Cannot call abstract method %s::%s()"
+        return false;
+    }
+
+    bool ret = false;
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    zend_try {
+        /* We cannot use zend_call_method_with_0_params() here since it is a
+         * macro that masks sizeof() and therefore does not calculate the
+         * method len correctly without using a string literal.
+         */
+        zend_call_method(obj, ce, &func, method, method_len, retval, 0, NULL, NULL TSRMLS_CC);
+        ret = true;
+    }
+    zend_end_try();
+
+    zai_sandbox_close(&sandbox);
+
+    return ret;
+}
+
+bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC) {
+    if (!object || Z_TYPE_P(object) != IS_OBJECT) return false;
+    return z_call_method_without_args_ex(object, Z_OBJCE_P(object), method, method_len, retval TSRMLS_CC);
+}
+
+bool zai_call_static_method_without_args_ex(zend_class_entry *ce, const char *method, size_t method_len,
+                                            zval **retval TSRMLS_DC) {
+    if (!ce) return false;
+    return z_call_method_without_args_ex(NULL, ce, method, method_len, retval TSRMLS_CC);
+}

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -88,7 +88,11 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
          * method len correctly without using a string literal.
          */
         zend_call_method(obj, ce, &func, method, method_len, retval, 0, NULL, NULL TSRMLS_CC);
-        ret = true;
+        /* An unhandled exception will not result in a zend_bailout if there is
+         * an active execution context. This is a failed call if an exception
+         * was thrown. The sandbox will clean up our mess when it closes.
+         */
+        ret = !EG(exception);
     }
     zend_end_try();
 

--- a/zend_abstract_interface/methods/tests/CMakeLists.txt
+++ b/zend_abstract_interface/methods/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+#[[ TODO When we have a consistent API across all PHP versions with ZAI
+    data-structure shims, move these tests out of PHP-versioned directories.
+ ]]
+add_executable(methods "${PHP_VERSION_DIRECTORY}/methods.cc")
+
+target_link_libraries(methods PUBLIC catch2_main Zai::Sapi Zai::Methods)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(methods)

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -13,6 +13,12 @@ extern "C" {
     REQUIRE(false == zai_sapi_unhandled_exception_exists()); \
     REQUIRE(zai_sapi_last_error_is_empty())
 
+#ifndef NDEBUG
+#define SKIP_TEST_IN_DEBUG_MODE "[.]"
+#else
+#define SKIP_TEST_IN_DEBUG_MODE
+#endif
+
 /***************************** zai_class_lookup() ****************************/
 
 TEST_CASE("class lookup: (internal)", "[zai_methods]") {
@@ -43,7 +49,7 @@ TEST_CASE("class lookup: (userland)", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
-TEST_CASE("class lookup: root-scope prefix", "[zai_methods]") {
+TEST_CASE("class lookup: root-scope prefix", "[zai_methods]" SKIP_TEST_IN_DEBUG_MODE) {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
@@ -56,7 +62,7 @@ TEST_CASE("class lookup: root-scope prefix", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
-TEST_CASE("class lookup: wrong case", "[zai_methods]") {
+TEST_CASE("class lookup: wrong case", "[zai_methods]" SKIP_TEST_IN_DEBUG_MODE) {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -247,6 +247,35 @@ TEST_CASE("call method: throws exception (userland)", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
+TEST_CASE("call method: throws exception with active frame (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    REQUIRE(ce != NULL);
+
+    /* Simulate an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\ExceptionTest::throwsException()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexception"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
 TEST_CASE("call method: non-object", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
@@ -539,6 +568,35 @@ TEST_CASE("call static method: throws exception (userland)", "[zai_methods]") {
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
     REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: throws exception with active frame (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    REQUIRE(ce != NULL);
+
+    /* Simulate an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\ExceptionTest::throwsExceptionFromStatic()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexceptionfromstatic"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    zai_sapi_fake_frame_pop(&fake_frame);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -105,6 +105,19 @@ TEST_CASE("class lookup: disable_classes INI", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
+TEST_CASE("class lookup: outside of request context", "[zai_methods]") {
+    REQUIRE((zai_sapi_sinit() && zai_sapi_minit()));
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+    REQUIRE(ce == spl_ce_SplDoublyLinkedList);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+
 TEST_CASE("class lookup: NULL class name", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
@@ -180,6 +193,34 @@ TEST_CASE("call method: (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
 }
+
+/* This test will crash because methods must be called within a request context
+TEST_CASE("call method: outside of request context", "[zai_methods]") {
+    REQUIRE((zai_sapi_sinit() && zai_sapi_minit()));
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+    REQUIRE(ce == spl_ce_SplDoublyLinkedList);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // SplDoublyLinkedList::count()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+*/
 
 TEST_CASE("call method: does not exist on object (internal)", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -1,0 +1,610 @@
+extern "C" {
+#include "methods/methods.h"
+#include "zai_sapi/zai_sapi.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+#include <ext/spl/spl_dllist.h> // For 'SplDoublyLinkedList' class entry
+
+#define ZAI_STRL(str) (str), (sizeof(str) - 1)
+
+#define REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE()            \
+    REQUIRE(false == zai_sapi_unhandled_exception_exists()); \
+    REQUIRE(zai_sapi_last_error_is_empty())
+
+/***************************** zai_class_lookup() ****************************/
+
+TEST_CASE("class lookup: (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+
+    REQUIRE(ce == spl_ce_SplDoublyLinkedList);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("class lookup: (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+
+    REQUIRE(ce != NULL);
+    REQUIRE(strcmp("Zai\\Methods\\Test", ce->name) == 0);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("class lookup: root-scope prefix", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("\\spldoublylinkedlist"));
+
+    REQUIRE(ce == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("class lookup: wrong case", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("SplDoublyLinkedList"));
+
+    REQUIRE(ce == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("class lookup: NULL class name", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(NULL, 42);
+
+    REQUIRE(ce == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("class lookup: 0 class len", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup("spldoublylinkedlist", 0);
+
+    REQUIRE(ce == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+/*********************** zai_call_method_without_args() **********************/
+
+static zval *zai_instantiate_object_from_ce(zend_class_entry *ce) {
+    TSRMLS_FETCH();
+    zval *obj = NULL;
+    ALLOC_ZVAL(obj);
+    /* This can call zend_bailout. */
+    object_init_ex(obj, ce);
+    Z_SET_REFCOUNT_P(obj, 1);
+    Z_SET_ISREF_P(obj);
+    return obj;
+}
+
+TEST_CASE("call method: (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
+    zval *retval = NULL;
+    // SplDoublyLinkedList::count()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\Test::returnsTrue()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("returnstrue"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: does not exist on object (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
+    zval *retval = NULL;
+    // SplDoublyLinkedList::iDoNotExist()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("idonotexist"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: does not exist on object (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\Test::iDoNotExist()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("idonotexist"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: accesses $this (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\Test::usesThis()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("usesthis"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: non-object", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *nonobj = NULL;
+    MAKE_STD_ZVAL(nonobj);
+    ZVAL_STRING(nonobj, "spldoublylinkedlist", 1);
+
+    zval *retval = NULL;
+    // SplDoublyLinkedList::count()
+    bool result = zai_call_method_without_args(nonobj, ZAI_STRL("count"), &retval);
+    zval_ptr_dtor(&nonobj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: NULL object", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *retval = NULL;
+    // {NULL}::count()
+    bool result = zai_call_method_without_args(NULL, ZAI_STRL("count"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: NULL method name", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
+    zval *retval = NULL;
+    // SplDoublyLinkedList::{NULL}()
+    bool result = zai_call_method_without_args(obj, NULL, 42, &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: 0 len method name", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
+    zval *retval = NULL;
+    // SplDoublyLinkedList::()
+    bool result = zai_call_method_without_args(obj, "count", 0, &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: non-NULL retval", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
+    zval *retval = (zval *)(void *)1;
+    // SplDoublyLinkedList::count()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == (zval *)(void *)1);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: static method (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    REQUIRE((ce != NULL && "ext/date required"));
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // DateTime::getLastErrors()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("getlasterrors"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE((Z_TYPE_P(retval) == IS_BOOL || Z_TYPE_P(retval) == IS_ARRAY));
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: static method (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\Test::returns42()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("returns42"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
+    REQUIRE(Z_LVAL_P(retval) == 42);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+/******************* zai_call_static_method_without_args() *******************/
+
+TEST_CASE("call static method: (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    REQUIRE((ce != NULL && "ext/date required"));
+
+    zval *retval = NULL;
+    // DateTime::getLastErrors()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("getlasterrors"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE((Z_TYPE_P(retval) == IS_BOOL || Z_TYPE_P(retval) == IS_ARRAY));
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *retval = NULL;
+    // Zai\Methods\Test::returns42()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("returns42"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
+    REQUIRE(Z_LVAL_P(retval) == 42);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: call method on retval (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *retval_self = NULL;
+    // Zai\Methods\Test::newSelf()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("newself"), &retval_self);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval_self != NULL);
+    REQUIRE(Z_TYPE_P(retval_self) == IS_OBJECT);
+    REQUIRE(Z_OBJCE_P(retval_self) == ce);
+
+    zval *retval_true = NULL;
+    // Zai\Methods\Test::usesThis()
+    bool result2 = zai_call_method_without_args(retval_self, ZAI_STRL("usesthis"), &retval_true);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result2 == true);
+    REQUIRE(retval_true != NULL);
+    REQUIRE(Z_TYPE_P(retval_true) == IS_BOOL);
+
+    zval_ptr_dtor(&retval_true);
+    zval_ptr_dtor(&retval_self);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: does not exist on class (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    REQUIRE((ce != NULL && "ext/date required"));
+
+    zval *retval = NULL;
+    // DateTime::iDoNotExist()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("idonotexist"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: does not exist on class (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *retval = NULL;
+    // Zai\Methods\Test::iDoNotExist()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("idonotexist"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: NULL ce", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *retval = NULL;
+    bool result = zai_call_static_method_without_args(NULL, ZAI_STRL("count"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: non-static method (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval *retval = NULL;
+    /* This call will fail because SplDoublyLinkedList::count() is not marked
+     * with ZEND_ACC_ALLOW_STATIC.
+     *
+     * https://github.com/php/php-src/blob/PHP-5.4/ext/spl/spl_dllist.c#L1324
+     */
+    bool result = zai_call_static_method_without_args(spl_ce_SplDoublyLinkedList, ZAI_STRL("count"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: non-static method (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *retval = NULL;
+    /* Calling the non-static method Zai\Methods\Test::returnsTrue() statically
+     * is allowed here because the compiler marks non-static userland methods
+     * with ZEND_ACC_ALLOW_STATIC.
+     *
+     * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_compile.c#L1679
+     */
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("returnstrue"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(retval != NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: non-static method that accesses $this (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    REQUIRE(ce != NULL);
+
+    zval *retval = NULL;
+    /* Although the compiler marks this non-static userland method
+     * Zai\Methods\Test::usesThis() with ZEND_ACC_ALLOW_STATIC, the call will
+     * fail when '$this' is accessed from a static context.
+     *
+     * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_execute.c#L460-L506
+     */
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("usesthis"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: abstract method (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/AbstractTest.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\abstracttest"));
+    REQUIRE(ce != NULL);
+
+    zval *retval = NULL;
+    // Zai\Methods\AbstractTest::abstractMethod()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("abstractmethod"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -194,34 +194,6 @@ TEST_CASE("call method: (userland)", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
-/* This test will crash because methods must be called within a request context
-TEST_CASE("call method: outside of request context", "[zai_methods]") {
-    REQUIRE((zai_sapi_sinit() && zai_sapi_minit()));
-    ZAI_SAPI_TSRMLS_FETCH();
-    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
-
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
-    REQUIRE(ce == spl_ce_SplDoublyLinkedList);
-
-    zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
-    // SplDoublyLinkedList::count()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
-    zval_ptr_dtor(&obj);
-
-    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
-    REQUIRE(result == true);
-    REQUIRE(retval != NULL);
-    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
-
-    zval_ptr_dtor(&retval);
-
-    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
-    zai_sapi_mshutdown();
-    zai_sapi_sshutdown();
-}
-*/
-
 TEST_CASE("call method: does not exist on object (internal)", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
@@ -581,6 +553,27 @@ TEST_CASE("call static method: call method on retval (userland)", "[zai_methods]
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: outside of request context", "[zai_methods]") {
+    REQUIRE((zai_sapi_sinit() && zai_sapi_minit()));
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    REQUIRE((ce != NULL && "ext/date required"));
+
+    zval *retval = NULL;
+    // DateTime::getLastErrors()
+    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("getlasterrors"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
 }
 
 TEST_CASE("call static method: does not exist on class (internal)", "[zai_methods]") {

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -224,6 +224,29 @@ TEST_CASE("call method: accesses $this (userland)", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
+TEST_CASE("call method: throws exception (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\ExceptionTest::throwsException()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexception"), &retval);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
 TEST_CASE("call method: non-object", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
@@ -489,6 +512,29 @@ TEST_CASE("call static method: does not exist on class (userland)", "[zai_method
     zval *retval = NULL;
     // Zai\Methods\Test::iDoNotExist()
     bool result = zai_call_static_method_without_args(ce, ZAI_STRL("idonotexist"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(retval == NULL);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call static method: throws exception (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
+    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval *retval = NULL;
+    // Zai\Methods\ExceptionTest::throwsExceptionFromStatic()
+    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexceptionfromstatic"), &retval);
+    zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);

--- a/zend_abstract_interface/methods/tests/stubs/AbstractTest.php
+++ b/zend_abstract_interface/methods/tests/stubs/AbstractTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Zai\Methods;
+
+abstract class AbstractTest
+{
+    abstract public function abstractMethod();
+}

--- a/zend_abstract_interface/methods/tests/stubs/ExceptionTest.php
+++ b/zend_abstract_interface/methods/tests/stubs/ExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Zai\Methods;
+
+class ExceptionTest
+{
+    private $message = 'Oops!';
+    private static $staticMessage = 'Oops!';
+
+    public function throwsException()
+    {
+        throw new \Exception($this->message);
+    }
+
+    public static function throwsExceptionFromStatic()
+    {
+        throw new \Exception(static::$staticMessage);
+    }
+}

--- a/zend_abstract_interface/methods/tests/stubs/Test.php
+++ b/zend_abstract_interface/methods/tests/stubs/Test.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zai\Methods;
+
+class Test
+{
+    private $trueValue = true;
+
+    public function returnsTrue()
+    {
+        return true;
+    }
+
+    public function usesThis()
+    {
+        return $this->trueValue;
+    }
+
+    public static function returns42()
+    {
+        return 42;
+    }
+
+    public static function newSelf()
+    {
+        return new static;
+    }
+}


### PR DESCRIPTION
### Description

The Zend Abstract Interface (ZAI) is an API for calling into PHP from C. The seams are decoupled from the main PHP tracer and tested using the ZAI SAPI.

This PR includes the first ZAI seam on PHP 5 for safely calling methods (sandboxed):

- `zai_class_lookup()`
- `zai_call_method_without_args()`
- `zai_call_static_method_without_args()`

This seam will be used to finish the implementation of autoflushing in #1189.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
