### PR TITLE
Exclude dockerfiles directory from the composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 tests               export-ignore
+dockerfiles         export-ignore
 .editorconfig       export-ignore
 .gitattributes      export-ignore
 .gitignore          export-ignore


### PR DESCRIPTION
### Description

When installing `datadog/dd-trace` via composer, the large `dockerfiles/` directory is pulled down as well.
This directory is over 40 MB uncompressed, and makes up the majority of the package contents.
Similar to #61, this change excludes that directory from the resulting archive to slim down installs.

If some of the contents of `dockerfiles/` are needed in the release, most of the benefit of this PR could be achieved by excluding just `dockerfiles/testing-environment/`.

Comparison of the resulting archives:
![image](https://user-images.githubusercontent.com/624286/113416924-4e1c8e00-9390-11eb-9a81-c33072766ac9.png)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
