### PR TITLE
Accept multiple requests dumped from request-replayer

### DIFF
--- a/tests/Common/AgentReplayerTrait.php
+++ b/tests/Common/AgentReplayerTrait.php
@@ -24,6 +24,20 @@ trait AgentReplayerTrait
      */
     public function getLastAgentRequest()
     {
+        $allRequests = $this->getAllAgentRequests();
+        if (count($allRequests) === 0) {
+            return [];
+        }
+        return $allRequests[count($allRequests) - 1];
+    }
+
+    /**
+     * Returns the all the requests currently stored in the replayer request session.
+     *
+     * @return array
+     */
+    public function getAllAgentRequests()
+    {
         return json_decode(file_get_contents($this->getAgentReplayerEndpoint() . '/replay'), true);
     }
 }

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -23,7 +23,7 @@ final class LongRunningScriptTest extends CLITestCase
             'DD_TRACE_BGS_TIMEOUT' => 3000,
         ]);
 
-        $this->assertSame('3', $agentRequest['headers']['X-Datadog-Trace-Count']);
-        $this->assertCount(3, json_decode($agentRequest['body'], true));
+        $this->assertSame('3', $agentRequest[0]['headers']['X-Datadog-Trace-Count']);
+        $this->assertCount(3, json_decode($agentRequest[0]['body'], true));
     }
 }

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -23,7 +23,7 @@ final class LongRunningScriptTest extends CLITestCase
             'DD_TRACE_BGS_TIMEOUT' => 3000,
         ]);
 
-        $this->assertSame('3', $agentRequest[0]['headers']['X-Datadog-Trace-Count']);
-        $this->assertCount(3, json_decode($agentRequest[0]['body'], true));
+        $this->assertSame('3', $agentRequest['headers']['X-Datadog-Trace-Count']);
+        $this->assertCount(3, json_decode($agentRequest['body'], true));
     }
 }

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -144,7 +144,7 @@ final class HttpTest extends BaseTestCase
 
         $httpTransport->send($tracer);
 
-        $traceRequest = $this->getLastAgentRequest()[0];
+        $traceRequest = $this->getLastAgentRequest();
 
         $this->assertEquals('php', $traceRequest['headers']['Datadog-Meta-Lang']);
         $this->assertEquals(\PHP_VERSION, $traceRequest['headers']['Datadog-Meta-Lang-Version']);
@@ -166,7 +166,7 @@ final class HttpTest extends BaseTestCase
         $span->finish();
 
         $httpTransport->send($tracer);
-        $traceRequest = $this->getLastAgentRequest()[0];
+        $traceRequest = $this->getLastAgentRequest();
 
         $this->assertArrayHasKey('Content-Length', $traceRequest['headers']);
     }
@@ -244,7 +244,7 @@ final class HttpTest extends BaseTestCase
         $httpTransport->setHeader('X-my-custom-header', 'my-custom-value');
         $httpTransport->send($tracer);
 
-        $traceRequest = $this->getLastAgentRequest()[0];
+        $traceRequest = $this->getLastAgentRequest();
 
         $this->assertEquals('my-custom-value', $traceRequest['headers']['X-my-custom-header']);
     }

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -3,11 +3,11 @@
 namespace DDTrace\Tests\Integration\Transport;
 
 use DDTrace\Encoders\Json;
+use DDTrace\GlobalTracer;
 use DDTrace\Tests\Common\AgentReplayerTrait;
 use DDTrace\Tests\Common\BaseTestCase;
 use DDTrace\Tracer;
 use DDTrace\Transport\Http;
-use DDTrace\GlobalTracer;
 
 final class HttpTest extends BaseTestCase
 {
@@ -24,7 +24,7 @@ final class HttpTest extends BaseTestCase
 
     public function agentUrl()
     {
-        return 'http://' . ($_SERVER["DDAGENT_HOSTNAME"] ? $_SERVER["DDAGENT_HOSTNAME"] :  "localhost") . ':8126';
+        return 'http://' . ($_SERVER["DDAGENT_HOSTNAME"] ? $_SERVER["DDAGENT_HOSTNAME"] : "localhost") . ':8126';
     }
 
     public function agentTracesUrl()
@@ -37,7 +37,7 @@ final class HttpTest extends BaseTestCase
         $logger = $this->withDebugLogger();
 
         $httpTransport = new Http(new Json(), [
-            'endpoint' => 'http://0.0.0.0:8127/v0.3/traces'
+            'endpoint' => 'http://0.0.0.0:8127/v0.3/traces',
         ]);
         $tracer = new Tracer($httpTransport);
         GlobalTracer::set($tracer);
@@ -45,7 +45,7 @@ final class HttpTest extends BaseTestCase
         $span = $tracer->startSpan('test', [
             'tags' => [
                 'key1' => 'value1',
-            ]
+            ],
         ]);
 
         $span->finish();
@@ -65,10 +65,10 @@ final class HttpTest extends BaseTestCase
         $logger = $this->withDebugLogger();
 
         $badHttpTransport = new Http(new Json(), [
-            'endpoint' => 'http://0.0.0.0:8127/v0.3/traces'
+            'endpoint' => 'http://0.0.0.0:8127/v0.3/traces',
         ]);
         $goodHttpTransport = new Http(new Json(), [
-            'endpoint' => $this->agentTracesUrl()
+            'endpoint' => $this->agentTracesUrl(),
         ]);
 
         $tracer = new Tracer(null);
@@ -104,7 +104,7 @@ final class HttpTest extends BaseTestCase
         $logger = $this->withDebugLogger();
 
         $httpTransport = new Http(new Json(), [
-            'endpoint' => $this->agentTracesUrl()
+            'endpoint' => $this->agentTracesUrl(),
         ]);
         $tracer = new Tracer($httpTransport);
         GlobalTracer::set($tracer);
@@ -112,14 +112,14 @@ final class HttpTest extends BaseTestCase
         $span = $tracer->startSpan('test', [
             'tags' => [
                 'key1' => 'value1',
-            ]
+            ],
         ]);
 
         $childSpan = $tracer->startSpan('child_test', [
             'child_of' => $span,
             'tags' => [
                 'key2' => 'value2',
-            ]
+            ],
         ]);
 
         $childSpan->finish();
@@ -144,7 +144,7 @@ final class HttpTest extends BaseTestCase
 
         $httpTransport->send($tracer);
 
-        $traceRequest = $this->getLastAgentRequest();
+        $traceRequest = $this->getLastAgentRequest()[0];
 
         $this->assertEquals('php', $traceRequest['headers']['Datadog-Meta-Lang']);
         $this->assertEquals(\PHP_VERSION, $traceRequest['headers']['Datadog-Meta-Lang-Version']);
@@ -166,7 +166,7 @@ final class HttpTest extends BaseTestCase
         $span->finish();
 
         $httpTransport->send($tracer);
-        $traceRequest = $this->getLastAgentRequest();
+        $traceRequest = $this->getLastAgentRequest()[0];
 
         $this->assertArrayHasKey('Content-Length', $traceRequest['headers']);
     }
@@ -215,8 +215,8 @@ final class HttpTest extends BaseTestCase
 
         $records = $logger->all();
         $curlOperationTimedout = \version_compare(\PHP_VERSION, '5.5', '<')
-            ? \CURLE_OPERATION_TIMEOUTED
-            : \CURLE_OPERATION_TIMEDOUT;
+        ? \CURLE_OPERATION_TIMEOUTED
+        : \CURLE_OPERATION_TIMEDOUT;
         $prefix = "Reporting of spans failed: {$curlOperationTimedout} / ";
         $suffix = "(TIMEOUT_MS={$timeout}, CONNECTTIMEOUT_MS={$curlTimeout})";
 
@@ -244,7 +244,7 @@ final class HttpTest extends BaseTestCase
         $httpTransport->setHeader('X-my-custom-header', 'my-custom-value');
         $httpTransport->send($tracer);
 
-        $traceRequest = $this->getLastAgentRequest();
+        $traceRequest = $this->getLastAgentRequest()[0];
 
         $this->assertEquals('my-custom-value', $traceRequest['headers']['X-my-custom-header']);
     }

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -32,7 +32,10 @@ class RequestReplayer
 
     public function replayRequest()
     {
-        return json_decode(file_get_contents($this->endpoint . '/replay'), true);
+        // Request replayer now returns as many requests as were sent during a session.
+        // For the scope of the tests, we are returning the very first one.
+        $allRequests = json_decode(file_get_contents($this->endpoint . '/replay'), true);
+        return count($allRequests) == 0 ? [] : $allRequests[0];
     }
 
     public function replayHeaders($showOnly = [])


### PR DESCRIPTION
### Description

While we are still able to handle only one request in the response from the request replayer, the response is not in the format `[{req_1}, {req_2}]` instead of `{req}`, so that we can assert that only one request was done.

This was required in the context of `pcntl` testing.

Note: this expects https://github.com/DataDog/dd-trace-ci/pull/33 to be merged, as well. Image is already live.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug. (implicit, all integrations tests would fail)

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
