### PR TITLE
Remove embed sapi

### DIFF
--- a/dockerfiles/ci/alpine/php-8.0/configure.sh
+++ b/dockerfiles/ci/alpine/php-8.0/configure.sh
@@ -7,7 +7,6 @@ ${PHP_SRC_DIR}/configure \
     --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.4/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.4/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.5/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.5/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.6/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.6/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.0/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.0/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.1/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.1/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.2/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.2/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.3/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.3/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.4/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.4/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-8.0/configure.sh
+++ b/dockerfiles/ci/centos/6/php-8.0/configure.sh
@@ -6,7 +6,6 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
-    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \


### PR DESCRIPTION
### Description

As a followup to https://github.com/DataDog/dd-trace-ci/pull/34, this PR removes the `embed` sapi.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
