### PR TITLE
Disable php language tests `ext/openssl/tests/bug54992.phpt`

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -71,6 +71,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/bug68819_002.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests/005.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/json/tests/pass003.phpt

--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -76,6 +76,7 @@ ext/json/tests/pass001.phpt
 ext/json/tests/pass003.phpt
 ext/mbstring/tests/zend_multibyte-08.phpt
 ext/openssl/tests/003.phpt
+ext/openssl/tests/bug54992.phpt
 ext/pdo/tests/pdo_013.phpt
 ext/pdo/tests/pdo_014.phpt
 ext/pdo/tests/pdo_023.phpt

--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -79,6 +79,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/bug68819_002.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests/005.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/json/tests/pass003.phpt

--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -84,6 +84,7 @@ ext/json/tests/pass001.phpt
 ext/json/tests/pass003.phpt
 ext/json/tests/unsupported_type_error.phpt
 ext/openssl/tests/003.phpt
+ext/openssl/tests/bug54992.phpt
 ext/pdo/tests/pdo_014.phpt
 ext/pdo_sqlite/tests/bug50728.phpt
 ext/pdo_sqlite/tests/pdo_013.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -1,0 +1,17 @@
+# Overview
+
+This file explains why we decided to disable specific PHP language tests. Investigations for tests disabled before this file was created are not present.
+
+## `ext/openssl/tests/bug54992.phpt`
+
+Disabled on versions: `5.4`, `5.5`.
+
+Links to sample broken executions: [5.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5511/workflows/3d3921f6-bcfc-4975-9a8f-3b8db6005462/jobs/375326), [5.5](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5511/workflows/3d3921f6-bcfc-4975-9a8f-3b8db6005462/jobs/375320).
+
+_Investigation_
+
+This test started to fail after we [enabled the pcntl extension](https://github.com/DataDog/dd-trace-ci/pull/34/files) in our buster containers.
+
+It was [skipped before](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L6) because function `pcntl_fork` was not available.
+
+Building again the container without `pcntl` enabled AND not even building the tracer, the test still fails. Possibly the reason is that we need an ssh server listening internally on [port 64321](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L13). Configuring the openssh server to run even this last test is neyond the scope of our language tests.

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -15,3 +15,17 @@ This test started to fail after we [enabled the pcntl extension](https://github.
 It was [skipped before](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L6) because function `pcntl_fork` was not available.
 
 Building again the container without `pcntl` enabled AND not even building the tracer, the test still fails. Possibly the reason is that we need an ssh server listening internally on [port 64321](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L13). Configuring the openssh server to run even this last test is neyond the scope of our language tests.
+
+## `ext/ftp/tests/005.phpt`
+
+Disabled on versions: `5.4`, `5.5`.
+
+Links to sample broken executions: [5.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5515/workflows/b1b283f3-70ab-4fc8-b142-909f4668515b/jobs/376256), [5.5](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5515/workflows/b1b283f3-70ab-4fc8-b142-909f4668515b/jobs/376255).
+
+_Investigation_
+
+This test started to fail after we [enabled the pcntl extension](https://github.com/DataDog/dd-trace-ci/pull/34/files) in our buster containers.
+
+It was [skipped before](https://github.com/php/php-src/blob/29ac2c59a49e0ca9d6a5399a49f4fd1afb058fa3/ext/ftp/tests/skipif.inc#L3) because function `pcntl_fork` was not available.
+
+The reason happens only in CI, not locally and it happens regardless of tracer being installed or not. It seems related to how routing is done in CI with the local network is shared (e.g. agent running in different container reachable via `127.0.0.1`). The conflict is due to the fact that the ftp servers launched by different suites have comnflicting ports.


### PR DESCRIPTION
### Description

#### `ext/openssl/tests/bug54992.phpt`

Disabled on versions: `5.4`, `5.5`.

Links to sample broken executions: [5.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5511/workflows/3d3921f6-bcfc-4975-9a8f-3b8db6005462/jobs/375326), [5.5](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5511/workflows/3d3921f6-bcfc-4975-9a8f-3b8db6005462/jobs/375320).

_Investigation_

This test started to fail after we [enabled the pcntl extension](https://github.com/DataDog/dd-trace-ci/pull/34/files) in our buster containers.

It was [skipped before](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L6) because function `pcntl_fork` was not available.

Building again the container without `pcntl` enabled AND not even building the tracer, the test still fails. Possibly the reason is that we need an ssh server listening internally on [port 64321](https://github.com/php/php-src/blob/bcd100d812b525c982cf75d6c6dabe839f61634a/ext/openssl/tests/bug54992.phpt#L13). Configuring the openssh server to run even this last test is neyond the scope of our language tests.

#### `ext/ftp/tests/005.phpt`

Disabled on versions: `5.4`, `5.5`.

Links to sample broken executions: [5.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5515/workflows/b1b283f3-70ab-4fc8-b142-909f4668515b/jobs/376256), [5.5](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5515/workflows/b1b283f3-70ab-4fc8-b142-909f4668515b/jobs/376255).

_Investigation_

This test started to fail after we [enabled the pcntl extension](https://github.com/DataDog/dd-trace-ci/pull/34/files) in our buster containers.

It was [skipped before](https://github.com/php/php-src/blob/29ac2c59a49e0ca9d6a5399a49f4fd1afb058fa3/ext/ftp/tests/skipif.inc#L3) because function `pcntl_fork` was not available.

The reason happens only in CI, not locally and it happens regardless of tracer being installed or not. It seems related to how routing is done in CI with the local network is shared (e.g. agent running in different container reachable via `127.0.0.1`). The conflict is due to the fact that the ftp servers launched by different suites have comnflicting ports.

**NOTE TO THE REVIEWER**: the failing php 7.4 tests are the ones that will be fixed as part of the pcntl work.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
