### PR TITLE
handle laravel 7+ generated:: prefix for unnamed routes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,13 +119,6 @@ aliases:
       name: Disable Xdebug for built-in web tests
       command: test -e /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && sudo rm -f $_ || true
 
-  - &STEP_INSTALL_DOCKERIZE
-    run:
-      name: Installing dockerize
-      command: |
-        curl -L --output dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
-        sudo tar -xf dockerize.tar.gz -C /usr/local/bin/ --overwrite
-
   - &STEP_WAIT_AGENT
     run:
       name: Waiting for Dockerized agent
@@ -558,7 +551,6 @@ jobs:
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
-      - <<: *STEP_INSTALL_DOCKERIZE
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
@@ -618,7 +610,6 @@ jobs:
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_DISABLE_XDEBUG
-      - <<: *STEP_INSTALL_DOCKERIZE
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ aliases:
       name: Installing dockerize
       command: |
         curl -L --output dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
-        tar -xf dockerize.tar.gz -C /usr/local/bin/ --overwrite
+        sudo tar -xf dockerize.tar.gz -C /usr/local/bin/ --overwrite
 
   - &STEP_WAIT_AGENT
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ aliases:
       name: Installing dockerize
       command: |
         curl -L --output dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
-        tar -xf dockerize.tar.gz -C /usr/local/bin/
+        tar -xf dockerize.tar.gz -C /usr/local/bin/ --overwrite
 
   - &STEP_WAIT_AGENT
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,13 @@ aliases:
       name: Disable Xdebug for built-in web tests
       command: test -e /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && sudo rm -f $_ || true
 
+  - &STEP_INSTALL_DOCKERIZE
+    run:
+      name: Installing dockerize
+      command: |
+        curl -L --output dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
+        tar -xf dockerize.tar.gz -C /usr/local/bin/
+
   - &STEP_WAIT_AGENT
     run:
       name: Waiting for Dockerized agent
@@ -551,6 +558,7 @@ jobs:
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
+      - <<: *STEP_INSTALL_DOCKERIZE
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
@@ -610,6 +618,7 @@ jobs:
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_DISABLE_XDEBUG
+      - <<: *STEP_INSTALL_DOCKERIZE
       - <<: *STEP_WAIT_AGENT
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER

--- a/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/RouteCachingController.php
+++ b/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/RouteCachingController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class RouteCachingController extends Controller
+{
+    public function unnamed()
+    {
+        return "unnamed";
+    }
+}

--- a/tests/Frameworks/Laravel/Version_8_x/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_8_x/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\CommonSpecsController;
 use App\Http\Controllers\EloquentTestController;
+use App\Http\Controllers\RouteCachingController;
 
 /*
 |--------------------------------------------------------------------------
@@ -24,3 +25,6 @@ Route::get('eloquent/update', [EloquentTestController::class, 'update']);
 Route::get('eloquent/delete', [EloquentTestController::class, 'delete']);
 Route::get('eloquent/destroy', [EloquentTestController::class, 'destroy']);
 Route::get('eloquent/refresh', [EloquentTestController::class, 'refresh']);
+
+// This route has to remain unnamed so we test both route cached and not cached.
+Route::get('/unnamed-route', [RouteCachingController::class, 'unnamed']);

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -68,12 +68,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
                     )->withExactTags([
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
-                    ])->withExistingTagsNames([
-                        'laravel.route.name',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
@@ -106,7 +105,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@error unnamed_route'
                     )->withExactTags([
-                        'laravel.route.name' => '',
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -68,12 +68,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
                     )->withExactTags([
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
-                    ])->withExistingTagsNames([
-                        'laravel.route.name',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
@@ -106,7 +105,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@error unnamed_route'
                     )->withExactTags([
-                        'laravel.route.name' => '',
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',

--- a/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
@@ -68,12 +68,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
                     )->withExactTags([
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view',
                         'http.status_code' => '200',
-                    ])->withExistingTagsNames([
-                        'laravel.route.name',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
@@ -106,7 +105,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'web',
                         'App\Http\Controllers\CommonSpecsController@error unnamed_route'
                     )->withExactTags([
-                        'laravel.route.name' => '',
+                        'laravel.route.name' => 'unnamed_route',
                         'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Laravel\V8_x;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+class RouteCachingTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Laravel/Version_8_x/public/index.php';
+    }
+
+    protected function ddTearDown()
+    {
+        parent::ddTearDown();
+        $this->routeClear();
+    }
+
+    public function testNotCached()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Testing route caching: uncached', '/unnamed-route'));
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'laravel.request',
+                    'Laravel',
+                    'web',
+                    'App\Http\Controllers\RouteCachingController@unnamed unnamed_route'
+                )
+                    ->withExactTags([
+                        'laravel.route.name' => 'unnamed_route',
+                        'laravel.route.action' => 'App\Http\Controllers\RouteCachingController@unnamed',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/unnamed-route',
+                        'http.status_code' => '200',
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('laravel.action'),
+                        SpanAssertion::exists('laravel.provider.load'),
+                    ]),
+            ]
+        );
+    }
+
+    public function testCached()
+    {
+        $this->routeCache();
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('Testing route caching: uncached', '/unnamed-route'));
+        });
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build(
+                    'laravel.request',
+                    'Laravel',
+                    'web',
+                    'App\Http\Controllers\RouteCachingController@unnamed unnamed_route'
+                )
+                    ->withExactTags([
+                        'laravel.route.name' => 'unnamed_route',
+                        'laravel.route.action' => 'App\Http\Controllers\RouteCachingController@unnamed',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/unnamed-route',
+                        'http.status_code' => '200',
+                    ])
+                    ->withChildren([
+                        SpanAssertion::exists('laravel.action'),
+                        SpanAssertion::exists('laravel.provider.load'),
+                    ]),
+            ]
+        );
+    }
+
+    private function routeCache()
+    {
+        $appRoot = \dirname(\dirname(self::getAppIndexScript()));
+        `cd $appRoot && php artisan route:cache`;
+    }
+
+    private function routeClear()
+    {
+        $appRoot = \dirname(\dirname(self::getAppIndexScript()));
+        `cd $appRoot && php artisan route:clear`;
+    }
+}


### PR DESCRIPTION
### Description

Starting from [7.x](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/AbstractRouteCollection.php#L227), unnamed routes in Laravel are given a randomly generated name. This PR normalized the randomly generated name to `unnamed_route` as we do for uncached routes.

Note: Symfony, on which Laravel is heavily based, does not seem to have a similar mechanism, based on their [official docs](https://symfony.com/doc/current/routing.html) and on the output of `ph bin/console list` command.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
