### PR TITLE
Remove PHP version prefix from buster development containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1709,13 +1709,13 @@ workflows:
           name: "PHP 80 asan tests"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           unit_test_target: test_c_asan
-          switch_php_version: 8.0-debug-zts-asan
+          switch_php_version: debug-zts-asan
       - unit_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 80 asan tests C2PHP"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           unit_test_target: test_with_init_hook_asan
-          switch_php_version: 8.0-debug-zts-asan
+          switch_php_version: debug-zts-asan
       - opcache_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 80 opcache tests"
@@ -1878,7 +1878,7 @@ workflows:
           name: "PHP 80 Integration tests (PHPRedis 5)"
           integration_testsuite: "test_integrations_phpredis5"
           docker_image: "datadog/dd-trace-ci:php-8.0_alpine"
-          switch_php_version: '8.0'
+          switch_php_version: nts
       - integration_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 54 Web integration tests"

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -98,6 +98,15 @@ RUN set -eux; \
     tar -xf ../v${CATCH2_VERSION}.tar.gz --strip 1; \
     /opt/cmake/${CMAKE_VERSION}/bin/cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2; \
     /opt/cmake/${CMAKE_VERSION}/bin/cmake --build build/ --target install; \
+#Install lcov
+    LCOV_VERSION="1.15"; \
+    LCOV_SHA256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a"; \
+    cd /tmp && curl -OL https://github.com/linux-test-project/lcov/releases/download/v${LCOV_VERSION}/lcov-${LCOV_VERSION}.tar.gz; \
+    (echo "${LCOV_SHA256} lcov-${LCOV_VERSION}.tar.gz" | sha256sum -c -); \
+    mkdir lcov && cd lcov; \
+    tar -xf ../lcov-${LCOV_VERSION}.tar.gz --strip 1; \
+    make install; \
+    lcov --version;\
 # Docker
     DOCKERIZE_VERSION="0.6.1"; \
     DOCKERIZE_SHA256="1fa29cd41a5854fd5423e242f3ea9737a50a8c3bcf852c9e62b9eb02c6ccd370"; \

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
     tar -xf ../v${CATCH2_VERSION}.tar.gz --strip 1; \
     /opt/cmake/${CMAKE_VERSION}/bin/cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2; \
     /opt/cmake/${CMAKE_VERSION}/bin/cmake --build build/ --target install; \
-#Install lcov
+# Install lcov
     LCOV_VERSION="1.15"; \
     LCOV_SHA256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a"; \
     cd /tmp && curl -OL https://github.com/linux-test-project/lcov/releases/download/v${LCOV_VERSION}/lcov-${LCOV_VERSION}.tar.gz; \

--- a/dockerfiles/ci/buster/php-5.4/Dockerfile
+++ b/dockerfiles/ci/buster/php-5.4/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 # Curl path workaround (PHP 5 was before pkg-config was used)
@@ -75,7 +75,7 @@ RUN set -eux; \
         switch-php ${phpVer}; \
         iniDir=$(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}'); \
         \
-        yes 'no' | pecl install memcached-2.2.0; \
+        yes 'no' | pecl install memcached-2.2.0; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongo; echo "extension=mongo.so" >> ${iniDir}/mongo.ini; \
         # Xdebug is disabled by default
         pecl install xdebug-2.2.7; \
@@ -83,7 +83,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-5.4/welcome
+++ b/dockerfiles/ci/buster/php-5.4/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    5.4, 5.4-debug, 5.4-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-5.5/Dockerfile
+++ b/dockerfiles/ci/buster/php-5.5/Dockerfile
@@ -75,7 +75,7 @@ RUN set -eux; \
         switch-php ${phpVer}; \
         iniDir=$(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}'); \
         \
-        yes 'no' | pecl install memcached-2.2.0; \
+        yes 'no' | pecl install memcached-2.2.0; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongo; echo "extension=mongo.so" >> ${iniDir}/mongo.ini; \
         # Xdebug is disabled by default
         pecl install xdebug-2.5.5; \

--- a/dockerfiles/ci/buster/php-5.5/Dockerfile
+++ b/dockerfiles/ci/buster/php-5.5/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 # Curl path workaround (PHP 5 was before pkg-config was used)
@@ -83,7 +83,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-5.5/welcome
+++ b/dockerfiles/ci/buster/php-5.5/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    5.5, 5.5-debug, 5.5-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-5.6/Dockerfile
+++ b/dockerfiles/ci/buster/php-5.6/Dockerfile
@@ -75,7 +75,7 @@ RUN set -eux; \
         switch-php ${phpVer}; \
         iniDir=$(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}'); \
         \
-        yes 'no' | pecl install memcached-2.2.0; \
+        yes 'no' | pecl install memcached-2.2.0; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongo; echo "extension=mongo.so" >> ${iniDir}/mongo.ini; \
         # Xdebug is disabled by default
         pecl install xdebug-2.5.5; \

--- a/dockerfiles/ci/buster/php-5.6/Dockerfile
+++ b/dockerfiles/ci/buster/php-5.6/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 # Curl path workaround (PHP 5 was before pkg-config was used)
@@ -83,7 +83,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-5.6/welcome
+++ b/dockerfiles/ci/buster/php-5.6/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    5.6, 5.6-debug, 5.6-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -69,7 +69,7 @@ RUN set -eux; \
         \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
-        yes 'no' | pecl install memcached; \
+        yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-7.0/welcome
+++ b/dockerfiles/ci/buster/php-7.0/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    7.0, 7.0-debug, 7.0-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-7.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -69,7 +69,7 @@ RUN set -eux; \
         \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
-        yes 'no' | pecl install memcached; \
+        yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-7.1/welcome
+++ b/dockerfiles/ci/buster/php-7.1/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    7.1, 7.1-debug, 7.1-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-7.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -69,7 +69,7 @@ RUN set -eux; \
         \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
-        yes 'no' | pecl install memcached; \
+        yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-7.2/welcome
+++ b/dockerfiles/ci/buster/php-7.2/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    7.2, 7.2-debug, 7.2-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-7.3/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.3/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -69,7 +69,7 @@ RUN set -eux; \
         \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
-        yes 'no' | pecl install memcached; \
+        yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-7.3/welcome
+++ b/dockerfiles/ci/buster/php-7.3/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    7.3, 7.3-debug, 7.3-debug-zts
+    nts, debug, debug-zts
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-7.4/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.4/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts-asan
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/debug-zts-asan
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -71,7 +71,7 @@ RUN set -eux; \
         \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
-        yes 'no' | pecl install memcached; \
+        yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
         pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
@@ -82,7 +82,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-7.4/welcome
+++ b/dockerfiles/ci/buster/php-7.4/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    7.4, 7.4-debug, 7.4-debug-zts-asan
+    nts, debug, debug-zts-asan
 
 To switch PHP versions run:
     $ switch-php <version>

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts-asan
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/debug-zts-asan
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -82,7 +82,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
@@ -1,9 +1,9 @@
 FROM datadog/dd-trace-ci:buster AS base
 
 ARG phpVersion
-ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/${phpVersion}-debug-zts-asan
-ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/${phpVersion}-debug
-ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/${phpVersion}
+ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/debug-zts-asan
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
 ENV PHP_VERSION=${phpVersion}
 
 FROM base as build
@@ -91,7 +91,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # Set the default PHP version
-    switch-php ${PHP_VERSION}-debug;
+    switch-php debug;
 
 # Install Composer
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/dockerfiles/ci/buster/php-8.0/welcome
+++ b/dockerfiles/ci/buster/php-8.0/welcome
@@ -7,7 +7,7 @@
 ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚═════╝
 
 The following PHP versions are supported:
-    8.0, 8.0-debug, 8.0-debug-zts-asan
+    nts, debug, debug-zts-asan
 
 To switch PHP versions run:
     $ switch-php <version>


### PR DESCRIPTION
### Description

Since we dismissed the idea of having multiple versions of PHP in our development containers due  to images size, we remove all the version prefixes from the installation dirs.

This will reduce code duplication in CI, since now you can have one `swith_php_version: <variant>` that serves well across multiple versions in a matrix configuration.

Moreover, we re-enable `memcached` extension that was installed but not enabled on 7.4-.

Note to the reviewer: tests are failing because I did not push the new images. We have probably to wait until 0.57.0 before we can push the images and consequently merge this PR, but I'd love to receive an early feedback since to rebuild images takes ages.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
