### PR TITLE
ZAI SAPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!dockerfiles/**/*' '!tests/ext/sandbox/**' '!tests/ext/sandbox-prehook/*' '!tests/ext/background-sender/**/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!ext/vendor/**/*' '!ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.*.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!LICENSE.*' '!tooling/*' '!tests/randomized/**' '!components/*/tests/stubs/**' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!dockerfiles/**/*' '!tests/ext/sandbox/**' '!tests/ext/sandbox-prehook/*' '!tests/ext/background-sender/**/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!ext/vendor/**/*' '!ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.*.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!LICENSE.*' '!tooling/*' '!tests/randomized/**' '!components/*/tests/stubs/**' '!**/CMakeLists.txt' || touch .failure
       - run:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure
@@ -1013,6 +1013,92 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  Zai:
+    working_directory: ~/datadog
+    parameters:
+      os:
+        type: string
+      php_version:
+        type: string
+      cmake_version:
+        type: string
+      catch2_version:
+        type: string
+    docker:
+      - image: datadog/dd-trace-ci:php-<< parameters.php_version >>_<< parameters.os >>
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Install cmake << parameters.cmake_version >>
+          command: |
+            if [ -d "/opt/cmake/<< parameters.cmake_version >>" ]
+            then
+              echo 'cmake << parameters.cmake_version >> already installed'
+              exit 0
+            fi
+            cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+            sudo mkdir -p /opt/cmake/<< parameters.cmake_version >>
+            cd /opt/cmake/<< parameters.cmake_version >> && sudo tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
+      - run:
+          name: Install Catch2
+          command: |
+            if [ -d "/opt/catch2" ]
+            then
+              echo 'catch2 already installed'
+              exit 0
+            fi
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            cd /tmp
+            curl -OL https://github.com/catchorg/Catch2/archive/v<< parameters.catch2_version >>.tar.gz
+            mkdir catch2
+            cd catch2
+            tar -xf ../v<< parameters.catch2_version >>.tar.gz --strip 1
+            cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2
+            cmake --build build/ --target install
+
+      - run:
+          name: Build and test Zend Abstract Interface (ASan)
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/zai_asan
+            cd /tmp/build/zai_asan
+            if [ "<< parameters.php_version >>" = "7.4" || "<< parameters.php_version >>" = "8.0" ]
+            then
+              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+            fi
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              ${toolchain} \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_ZAI_TESTING=ON \
+              -DPHP_CONFIG=$(which php-config) \
+              ~/datadog/zend_abstract_interface
+            make -j all
+            make test
+
+      - run:
+          name: Build and test Zend Abstract Interface (UBSan)
+          command: |
+            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            mkdir -p /tmp/build/zai_ubsan
+            cd /tmp/build/zai_ubsan
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              -DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/ubsan.cmake \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_ZAI_TESTING=ON \
+              -DPHP_CONFIG=$(which php-config) \
+              ~/datadog/zend_abstract_interface
+            make -j all
+            make test
+
+      - run:
+          command: |
+            mkdir -p /tmp/artifacts
+            cp /tmp/build/zai_asan/Testing/Temporary/LastTest.log /tmp/artifacts/LastTestASan.log
+            cp /tmp/build/zai_ubsan/Testing/Temporary/LastTest.log /tmp/artifacts/LastTestUBSan.log
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/artifacts
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -1180,6 +1266,32 @@ workflows:
                 - "3.19.6"
               catch2_version:
                 - "2.13.4"
+
+  zend_abstract_interface:
+    jobs:
+      - "Prepare Code"
+      - Zai:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              os:
+                # TODO Add CentOS & Alpine
+                - "buster"
+              php_version:
+                - "5.4"
+                - "5.5"
+                - "5.6"
+                - "7.0"
+                - "7.1"
+                - "7.2"
+                - "7.3"
+                - "7.4"
+                - "8.0"
+              cmake_version:
+                - "3.18.3"
+                - "3.20.1"
+              catch2_version:
+                - "2.13.5"
 
   build_packages:
     jobs:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
-C_FILES := $(shell find components ext src/dogstatsd -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
+C_FILES := $(shell find components ext src/dogstatsd zend_abstract_interface -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_STUB_FILES := $(shell find tests/ext -type d -name 'stubs' -exec find '{}' -type f \; | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 INIT_HOOK_TEST_FILES := $(shell find tests/C2PHP -name '*.phpt' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )

--- a/config.m4
+++ b/config.m4
@@ -82,6 +82,12 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php5/span.c \
       ext/php5/startup_logging.c \
     "
+
+    ZAI_SOURCES="\
+      zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_io.c \
+    "
   elif test $PHP_VERSION_ID -lt 70000; then
     dnl PHP 5.5 + PHP 5.6
     dnl ddtrace.c comes first, then everything else alphabetically
@@ -115,6 +121,12 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php5/signals.c \
       ext/php5/span.c \
       ext/php5/startup_logging.c \
+    "
+
+    ZAI_SOURCES="\
+      zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_io.c \
     "
   elif test $PHP_VERSION_ID -lt 80000; then
     dnl PHP 7.x
@@ -154,6 +166,12 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php7/span.c \
       ext/php7/startup_logging.c \
     "
+
+    ZAI_SOURCES="\
+      zend_abstract_interface/zai_sapi/php7/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_io.c \
+    "
   elif test $PHP_VERSION_ID -lt 90000; then
     dnl PHP 8.x
     dnl ddtrace.c comes first, then everything else alphabetically
@@ -192,9 +210,15 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php8/span.c \
       ext/php8/startup_logging.c \
     "
+
+    ZAI_SOURCES="\
+      zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_io.c \
+    "
   fi
 
-  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_COMPONENT_SOURCES $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
+  PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_COMPONENT_SOURCES $ZAI_SOURCES $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)
   PHP_ADD_BUILD_DIR($ext_builddir/ext, 1)
 
   PHP_CHECK_LIBRARY(rt, shm_open,
@@ -215,6 +239,13 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/components/container_id])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/sapi])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/string_view])
+
+  PHP_ADD_INCLUDE([$ext_srcdir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php5])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php7])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php8])
 
   PHP_ADD_INCLUDE([$ext_srcdir/ext/vendor])
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/vendor])

--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,16 @@
             <file name="components/string_view/string_view.c" role="src" />
             <file name="components/string_view/string_view.h" role="src" />
 
+            <!-- Zend Abstract Interface -->
+            <file name="zend_abstract_interface/zai_sapi/php5/zai_sapi.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/php8/zai_sapi.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi.h" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_ini.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_ini.h" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_io.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_io.h" role="src" />
+
             <!-- Shared -->
             <file name="ext/DatadogArena/arena.c" role="src" />
             <file name="ext/DatadogArena/datadog/arena.h" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Need CMake 3.18 for using 'REQUIRED' with find_library().
+cmake_minimum_required(VERSION 3.18)
+
+project(zend-abstract-interface VERSION 0.1.0 LANGUAGES C)
+
+option(BUILD_ZAI_TESTING "Enable tests" OFF)
+if (${BUILD_ZAI_TESTING})
+  # Tests uses the C++ testing framework Catch2
+  enable_language(CXX)
+
+  # The Catch2::Catch2 target has been available since 2.1.2
+  # We are unsure of the true minimum, but have tested 2.4
+  find_package(Catch2 2.4 REQUIRED)
+
+  #[[ This file takes a while to build, so we do it once here and every test
+      executable can link to it to save time.
+  ]]
+  add_library(catch2_main catch2_main.cc)
+  target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
+  target_compile_features(catch2_main PUBLIC cxx_std_11)
+
+  include(Catch)
+  enable_testing()
+endif()
+
+include(GNUInstallDirs)
+
+add_library(zai_zend_abstract_interface INTERFACE)
+
+# Get the PHP prefix path from php-config
+execute_process(COMMAND ${PHP_CONFIG} --prefix
+                OUTPUT_VARIABLE PHP_PREFIX_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE ret)
+
+if(NOT ret EQUAL "0")
+  message(FATAL_ERROR
+    "Failed to execute 'php-config'. Check that PHP_CONFIG is set to the 'php-config' executable.")
+endif()
+
+find_library(PHP_LIB
+             # Before PHP 8 the lib was named, 'libphp<version>.so'
+             NAMES php php7 php5 
+             PATHS "${PHP_PREFIX_PATH}/lib"
+             NO_DEFAULT_PATH
+             # 'REQUIRED' added in cmake v3.18
+             REQUIRED)
+
+include_directories("${PHP_PREFIX_PATH}/include/php/"
+                    "${PHP_PREFIX_PATH}/include/php/TSRM"
+                    "${PHP_PREFIX_PATH}/include/php/Zend"
+                    "${PHP_PREFIX_PATH}/include/php/ext"
+                    "${PHP_PREFIX_PATH}/include/php/main")
+
+#[[ Get the PHP version number from php-config. This is used to compile the
+    version-specific source files.
+]]
+execute_process(COMMAND ${PHP_CONFIG} --vernum
+                OUTPUT_VARIABLE PHP_VERSION_ID
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE ret)
+
+if(NOT ret EQUAL "0")
+  message(FATAL_ERROR
+          "Failed to get the PHP version number from 'php-config'.")
+endif()
+
+if(PHP_VERSION_ID LESS "70000")
+  set(PHP_VERSION_DIRECTORY "php5")
+elseif(PHP_VERSION_ID LESS "80000")
+  set(PHP_VERSION_DIRECTORY "php7")
+elseif(PHP_VERSION_ID LESS "90000")
+  set(PHP_VERSION_DIRECTORY "php8")
+else()
+  message(FATAL_ERROR "Unsupported PHP version '${PHP_VERSION_ID}'.")
+endif()
+
+add_subdirectory(zai_sapi)
+
+install(EXPORT ZendAbstractInterfaceTargets
+        FILE ZendAbstractInterfaceTargets.cmake
+        NAMESPACE Zai::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)

--- a/zend_abstract_interface/catch2_main.cc
+++ b/zend_abstract_interface/catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/zend_abstract_interface/zai_sapi/CMakeLists.txt
+++ b/zend_abstract_interface/zai_sapi/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_library(zai_sapi "zai_sapi_ini.c" "zai_sapi_io.c"
+                     "${PHP_VERSION_DIRECTORY}/zai_sapi.c")
+
+target_include_directories(zai_sapi
+                           PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_sapi PUBLIC c_std_99)
+
+target_link_libraries(zai_sapi PUBLIC "${PHP_LIB}")
+
+set_target_properties(zai_sapi PROPERTIES
+  EXPORT_NAME Sapi
+  VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Sapi ALIAS zai_sapi)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi_ini.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi_io.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zai_sapi/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_sapi)
+
+install(TARGETS zai_sapi EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -7,13 +7,10 @@
 #include "../zai_sapi_ini.h"
 #include "../zai_sapi_io.h"
 
-#define DEFAULT_INI          \
-    "html_errors=0\n"        \
-    "implicit_flush=1\n"     \
-    "output_buffering=0\n"   \
-    "max_execution_time=0\n" \
-    "max_input_time=-1\n"    \
-    "memory_limit=-1\n"      \
+#define DEFAULT_INI        \
+    "html_errors=0\n"      \
+    "implicit_flush=1\n"   \
+    "output_buffering=0\n" \
     "\0"
 
 #define UNUSED(x) (void)(x)

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -1,0 +1,220 @@
+#include "../zai_sapi.h"
+
+#include <main/SAPI.h>
+#include <main/php_main.h>
+#include <main/php_variables.h>
+
+#include "../zai_sapi_ini.h"
+#include "../zai_sapi_io.h"
+
+#define DEFAULT_INI          \
+    "html_errors=0\n"        \
+    "implicit_flush=1\n"     \
+    "output_buffering=0\n"   \
+    "max_execution_time=0\n" \
+    "max_input_time=-1\n"    \
+    "memory_limit=-1\n"      \
+    "\0"
+
+#define UNUSED(x) (void)(x)
+
+static size_t ini_entries_len = 0;
+
+static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
+
+static int zs_deactivate(TSRMLS_D) {
+#ifdef ZTS
+    UNUSED(TSRMLS_C);
+#endif
+    return SUCCESS;
+}
+
+static void zs_send_header(sapi_header_struct *sapi_header, void *server_context TSRMLS_DC) {
+    UNUSED(sapi_header);
+    UNUSED(server_context);
+#ifdef ZTS
+    UNUSED(TSRMLS_C);
+#endif
+}
+
+static char *zs_read_cookies(TSRMLS_D) {
+#ifdef ZTS
+    UNUSED(TSRMLS_C);
+#endif
+    return NULL;
+}
+
+static void zs_register_variables(zval *track_vars_array TSRMLS_DC) {
+    php_import_environment_variables(track_vars_array TSRMLS_CC);
+}
+
+static int zs_io_write_stdout(const char *str, unsigned int str_length TSRMLS_DC) {
+#ifdef ZTS
+    UNUSED(TSRMLS_C);
+#endif
+    size_t len = zai_sapi_io_write_stdout(str, (size_t)str_length);
+    if (len == 0) php_handle_aborted_connection();
+    return (int)len;
+}
+
+static void zs_io_log_message(char *message TSRMLS_DC) {
+#ifdef ZTS
+    UNUSED(TSRMLS_C);
+#endif
+    char buf[ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE];
+    size_t len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+    /* We ignore the return because PHP does not care if this fails. */
+    (void)zai_sapi_io_write_stderr(buf, len);
+}
+
+static sapi_module_struct zai_module = {
+    "zai",                     /* name */
+    "Zend Abstract Interface", /* pretty name */
+
+    zs_startup,                  /* startup */
+    php_module_shutdown_wrapper, /* shutdown */
+
+    NULL,          /* activate */
+    zs_deactivate, /* deactivate */
+
+    zs_io_write_stdout, /* unbuffered write */
+    zai_sapi_io_flush,  /* flush */
+
+    NULL, /* get uid */
+    NULL, /* getenv */
+
+    php_error, /* error handler */
+
+    NULL,           /* header handler */
+    NULL,           /* send headers handler */
+    zs_send_header, /* send header handler */
+
+    NULL,            /* read POST data */
+    zs_read_cookies, /* read Cookies */
+
+    zs_register_variables, /* register server variables */
+    zs_io_log_message,     /* Log message */
+    NULL,                  /* Get request time */
+    NULL,                  /* Child terminate */
+
+    NULL, /* php_ini_path_override   */
+    NULL, /* block_interruptions     */
+    NULL, /* unblock_interruptions   */
+    NULL, /* default_post_reader     */
+    NULL, /* treat_data              */
+    NULL, /* executable_location     */
+    0,    /* php_ini_ignore          */
+    0,    /* php_ini_ignore_cwd      */
+    NULL, /* get_fd                  */
+    NULL, /* force_http_10           */
+    NULL, /* get_target_uid          */
+    NULL, /* get_target_gid          */
+    NULL, /* input_filter            */
+    NULL, /* ini_defaults            */
+    0,    /* phpinfo_as_text;        */
+    NULL, /* ini_entries;            */
+    NULL, /* additional_functions    */
+    NULL  /* input_filter_init       */
+};
+
+bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
+    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    if (len <= ini_entries_len) {
+        /* Play it safe and free if writing failed. */
+        zai_sapi_ini_entries_free(&zai_module.ini_entries);
+        return false;
+    }
+    ini_entries_len = len;
+    return true;
+}
+
+#ifdef ZTS
+static void zs_tsrm_startup(void) {
+    tsrm_startup(1, 1, 0, NULL);
+    (void)ts_resource(0);
+}
+#endif
+
+bool zai_sapi_sinit(void) {
+#ifdef ZTS
+    zs_tsrm_startup();
+    TSRMLS_FETCH();
+#endif
+
+    /* Initialize the SAPI globals (memset to '0'), and set up reentrancy. */
+    sapi_startup(&zai_module);
+
+    /* Do not chdir to the script's directory (equivalent to running the CLI
+     * SAPI with '-C').
+     */
+    SG(options) |= SAPI_OPTION_NO_CHDIR;
+
+    /* Allocate the initial SAPI INI settings. Append new INI settings to this
+     * with zai_sapi_append_system_ini_entry() before MINIT is run.
+     */
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+
+    /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
+     * This will prevent inadvertently loading any extensions that we did not
+     * intend to. It also gives us a consistent clean slate of INI settings.
+     */
+    zai_module.php_ini_ignore = 1;
+
+    /* Show phpinfo()/module info as plain text. */
+    zai_module.phpinfo_as_text = 1;
+
+    /* TODO: When we want to expose a function to userland for testing purposes
+     * (e.g. DDTrace\Testing\trigger_error()), we can add them as custom SAPI
+     * functions here. These functions will only exist in the ZAI SAPI for
+     * testing at the C unit test level and will not be shipped as a public
+     * userland API in the PHP tracer.
+     */
+    zai_module.additional_functions = NULL;
+
+    return true;
+}
+
+void zai_sapi_sshutdown(void) {
+    sapi_shutdown();
+#ifdef ZTS
+    tsrm_shutdown();
+#endif
+    zai_sapi_ini_entries_free(&zai_module.ini_entries);
+}
+
+bool zai_sapi_minit(void) {
+    if (zai_module.startup(&zai_module) == FAILURE) {
+        zai_sapi_sshutdown();
+        return false;
+    }
+    return true;
+}
+
+void zai_sapi_mshutdown(void) {
+    TSRMLS_FETCH();
+    php_module_shutdown(TSRMLS_C);
+}
+
+bool zai_sapi_rinit(void) {
+    TSRMLS_FETCH();
+    if (php_request_startup(TSRMLS_C) == FAILURE) {
+        return false;
+    }
+
+    SG(headers_sent) = 1;
+    SG(request_info).no_headers = 1;
+
+    php_register_variable("PHP_SELF", "-", NULL TSRMLS_CC);
+
+    return true;
+}
+
+void zai_sapi_rshutdown(void) { php_request_shutdown((void *)0); }
+
+bool zai_sapi_spinup(void) { return zai_sapi_sinit() && zai_sapi_minit() && zai_sapi_rinit(); }
+
+void zai_sapi_spindown(void) {
+    zai_sapi_rshutdown();
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -18,7 +18,7 @@
 
 #define UNUSED(x) (void)(x)
 
-static size_t ini_entries_len = 0;
+static ssize_t ini_entries_len = -1;
 
 static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
 
@@ -118,7 +118,7 @@ static sapi_module_struct zai_module = {
 };
 
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
-    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    ssize_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, (size_t)ini_entries_len, key, value);
     if (len <= ini_entries_len) {
         /* Play it safe and free if writing failed. */
         zai_sapi_ini_entries_free(&zai_module.ini_entries);
@@ -152,7 +152,7 @@ bool zai_sapi_sinit(void) {
     /* Allocate the initial SAPI INI settings. Append new INI settings to this
      * with zai_sapi_append_system_ini_entry() before MINIT is run.
      */
-    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == -1) return false;
 
     /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
      * This will prevent inadvertently loading any extensions that we did not

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -18,7 +18,7 @@
 
 #define UNUSED(x) (void)(x)
 
-static size_t ini_entries_len = 0;
+static ssize_t ini_entries_len = -1;
 
 static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
 
@@ -109,7 +109,7 @@ static sapi_module_struct zai_module = {
 };
 
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
-    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    ssize_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, (size_t)ini_entries_len, key, value);
     if (len <= ini_entries_len) {
         /* Play it safe and free if writing failed. */
         zai_sapi_ini_entries_free(&zai_module.ini_entries);
@@ -158,7 +158,7 @@ bool zai_sapi_sinit(void) {
     /* Allocate the initial SAPI INI settings. Append new INI settings to this
      * with zai_sapi_append_system_ini_entry() before MINIT is run.
      */
-    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == -1) return false;
 
     /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
      * This will prevent inadvertently loading any extensions that we did not

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -7,13 +7,10 @@
 #include "../zai_sapi_ini.h"
 #include "../zai_sapi_io.h"
 
-#define DEFAULT_INI          \
-    "html_errors=0\n"        \
-    "implicit_flush=1\n"     \
-    "output_buffering=0\n"   \
-    "max_execution_time=0\n" \
-    "max_input_time=-1\n"    \
-    "memory_limit=-1\n"      \
+#define DEFAULT_INI        \
+    "html_errors=0\n"      \
+    "implicit_flush=1\n"   \
+    "output_buffering=0\n" \
     "\0"
 
 #define UNUSED(x) (void)(x)

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -1,0 +1,222 @@
+#include "../zai_sapi.h"
+
+#include <main/SAPI.h>
+#include <main/php_main.h>
+#include <main/php_variables.h>
+
+#include "../zai_sapi_ini.h"
+#include "../zai_sapi_io.h"
+
+#define DEFAULT_INI          \
+    "html_errors=0\n"        \
+    "implicit_flush=1\n"     \
+    "output_buffering=0\n"   \
+    "max_execution_time=0\n" \
+    "max_input_time=-1\n"    \
+    "memory_limit=-1\n"      \
+    "\0"
+
+#define UNUSED(x) (void)(x)
+
+static size_t ini_entries_len = 0;
+
+static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
+
+static int zs_deactivate(void) { return SUCCESS; }
+
+static void zs_send_header(sapi_header_struct *sapi_header, void *server_context) {
+    UNUSED(sapi_header);
+    UNUSED(server_context);
+}
+
+static char *zs_read_cookies(void) { return NULL; }
+
+static void zs_register_variables(zval *track_vars_array) { php_import_environment_variables(track_vars_array); }
+
+static size_t zs_io_write_stdout(const char *str, size_t str_length) {
+    size_t len = zai_sapi_io_write_stdout(str, str_length);
+    if (len == 0) php_handle_aborted_connection();
+    return len;
+}
+
+#if PHP_VERSION_ID >= 70100
+static void zs_io_log_message(char *message, int syslog_type_int) {
+    UNUSED(syslog_type_int);
+    char buf[ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE];
+    size_t len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+    /* We ignore the return because PHP does not care if this fails. */
+    (void)zai_sapi_io_write_stderr(buf, len);
+}
+#else
+static void zs_io_log_message(char *message) {
+    char buf[ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE];
+    size_t len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+    /* We ignore the return because PHP does not care if this fails. */
+    (void)zai_sapi_io_write_stderr(buf, len);
+}
+#endif
+
+static sapi_module_struct zai_module = {
+    "zai",                     /* name */
+    "Zend Abstract Interface", /* pretty name */
+
+    zs_startup,                  /* startup */
+    php_module_shutdown_wrapper, /* shutdown */
+
+    NULL,          /* activate */
+    zs_deactivate, /* deactivate */
+
+    zs_io_write_stdout, /* unbuffered write */
+    zai_sapi_io_flush,  /* flush */
+
+    NULL, /* get uid */
+    NULL, /* getenv */
+
+    php_error, /* error handler */
+
+    NULL,           /* header handler */
+    NULL,           /* send headers handler */
+    zs_send_header, /* send header handler */
+
+    NULL,            /* read POST data */
+    zs_read_cookies, /* read Cookies */
+
+    zs_register_variables, /* register server variables */
+    zs_io_log_message,     /* Log message */
+    NULL,                  /* Get request time */
+    NULL,                  /* Child terminate */
+
+    NULL, /* php_ini_path_override   */
+#if PHP_VERSION_ID < 70100
+    NULL, /* block_interruptions     */
+    NULL, /* unblock_interruptions   */
+#endif
+    NULL, /* default_post_reader     */
+    NULL, /* treat_data              */
+    NULL, /* executable_location     */
+    0,    /* php_ini_ignore          */
+    0,    /* php_ini_ignore_cwd      */
+    NULL, /* get_fd                  */
+    NULL, /* force_http_10           */
+    NULL, /* get_target_uid          */
+    NULL, /* get_target_gid          */
+    NULL, /* input_filter            */
+    NULL, /* ini_defaults            */
+    0,    /* phpinfo_as_text;        */
+    NULL, /* ini_entries;            */
+    NULL, /* additional_functions    */
+    NULL  /* input_filter_init       */
+};
+
+bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
+    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    if (len <= ini_entries_len) {
+        /* Play it safe and free if writing failed. */
+        zai_sapi_ini_entries_free(&zai_module.ini_entries);
+        return false;
+    }
+    ini_entries_len = len;
+    return true;
+}
+
+#ifdef ZTS
+static void zs_tsrm_startup(void) {
+#if PHP_VERSION_ID >= 70400
+    php_tsrm_startup();
+#else
+    tsrm_startup(1, 1, 0, NULL);
+    (void)ts_resource(0);
+#endif
+    ZEND_TSRMLS_CACHE_UPDATE();
+}
+#endif
+
+bool zai_sapi_sinit(void) {
+#ifdef ZTS
+    zs_tsrm_startup();
+#endif
+
+#if (PHP_VERSION_ID >= 70125 && PHP_VERSION_ID < 70200) || (PHP_VERSION_ID >= 70214 && PHP_VERSION_ID < 70300) || \
+    (PHP_VERSION_ID >= 70301)
+    /* Due to php-src bug #71041, 'zend_signal_startup' was not exported to
+     * shared libs with 'ZEND_API' until PHP 7.1.25, 7.2.14, and 7.3.1+.
+     *
+     * https://bugs.php.net/bug.php?id=71041
+     * https://github.com/php/php-src/commit/11ddf76
+     */
+    zend_signal_startup();
+#endif
+
+    /* Initialize the SAPI globals (memset to '0'), and set up reentrancy. */
+    sapi_startup(&zai_module);
+
+    /* Do not chdir to the script's directory (equivalent to running the CLI
+     * SAPI with '-C').
+     */
+    SG(options) |= SAPI_OPTION_NO_CHDIR;
+
+    /* Allocate the initial SAPI INI settings. Append new INI settings to this
+     * with zai_sapi_append_system_ini_entry() before MINIT is run.
+     */
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+
+    /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
+     * This will prevent inadvertently loading any extensions that we did not
+     * intend to. It also gives us a consistent clean slate of INI settings.
+     */
+    zai_module.php_ini_ignore = 1;
+
+    /* Show phpinfo()/module info as plain text. */
+    zai_module.phpinfo_as_text = 1;
+
+    /* TODO: When we want to expose a function to userland for testing purposes
+     * (e.g. DDTrace\Testing\trigger_error()), we can add them as custom SAPI
+     * functions here. These functions will only exist in the ZAI SAPI for
+     * testing at the C unit test level and will not be shipped as a public
+     * userland API in the PHP tracer.
+     */
+    zai_module.additional_functions = NULL;
+
+    return true;
+}
+
+void zai_sapi_sshutdown(void) {
+    sapi_shutdown();
+#ifdef ZTS
+    tsrm_shutdown();
+#endif
+    zai_sapi_ini_entries_free(&zai_module.ini_entries);
+}
+
+bool zai_sapi_minit(void) {
+    if (zai_module.startup(&zai_module) == FAILURE) {
+        zai_sapi_sshutdown();
+        return false;
+    }
+    return true;
+}
+
+void zai_sapi_mshutdown(void) { php_module_shutdown(); }
+
+bool zai_sapi_rinit(void) {
+    if (php_request_startup() == FAILURE) {
+        return false;
+    }
+
+    SG(headers_sent) = 1;
+    SG(request_info).no_headers = 1;
+
+    php_register_variable("PHP_SELF", "-", NULL);
+
+    return true;
+}
+
+void zai_sapi_rshutdown(void) { php_request_shutdown((void *)0); }
+
+bool zai_sapi_spinup(void) { return zai_sapi_sinit() && zai_sapi_minit() && zai_sapi_rinit(); }
+
+void zai_sapi_spindown(void) {
+    zai_sapi_rshutdown();
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -18,7 +18,7 @@
 
 #define UNUSED(x) (void)(x)
 
-static size_t ini_entries_len = 0;
+static ssize_t ini_entries_len = -1;
 
 static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
 
@@ -96,7 +96,7 @@ static sapi_module_struct zai_module = {
 };
 
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
-    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    ssize_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, (size_t)ini_entries_len, key, value);
     if (len <= ini_entries_len) {
         /* Play it safe and free if writing failed. */
         zai_sapi_ini_entries_free(&zai_module.ini_entries);
@@ -131,7 +131,7 @@ bool zai_sapi_sinit(void) {
     /* Allocate the initial SAPI INI settings. Append new INI settings to this
      * with zai_sapi_append_system_ini_entry() before MINIT is run.
      */
-    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == -1) return false;
 
     /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
      * This will prevent inadvertently loading any extensions that we did not

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -7,13 +7,10 @@
 #include "../zai_sapi_ini.h"
 #include "../zai_sapi_io.h"
 
-#define DEFAULT_INI          \
-    "html_errors=0\n"        \
-    "implicit_flush=1\n"     \
-    "output_buffering=0\n"   \
-    "max_execution_time=0\n" \
-    "max_input_time=-1\n"    \
-    "memory_limit=-1\n"      \
+#define DEFAULT_INI        \
+    "html_errors=0\n"      \
+    "implicit_flush=1\n"   \
+    "output_buffering=0\n" \
     "\0"
 
 #define UNUSED(x) (void)(x)

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -1,0 +1,195 @@
+#include "../zai_sapi.h"
+
+#include <main/SAPI.h>
+#include <main/php_main.h>
+#include <main/php_variables.h>
+
+#include "../zai_sapi_ini.h"
+#include "../zai_sapi_io.h"
+
+#define DEFAULT_INI          \
+    "html_errors=0\n"        \
+    "implicit_flush=1\n"     \
+    "output_buffering=0\n"   \
+    "max_execution_time=0\n" \
+    "max_input_time=-1\n"    \
+    "memory_limit=-1\n"      \
+    "\0"
+
+#define UNUSED(x) (void)(x)
+
+static size_t ini_entries_len = 0;
+
+static int zs_startup(sapi_module_struct *sapi_module) { return php_module_startup(sapi_module, NULL, 0); }
+
+static int zs_deactivate(void) { return SUCCESS; }
+
+static void zs_send_header(sapi_header_struct *sapi_header, void *server_context) {
+    UNUSED(sapi_header);
+    UNUSED(server_context);
+}
+
+static char *zs_read_cookies(void) { return NULL; }
+
+static void zs_register_variables(zval *track_vars_array) { php_import_environment_variables(track_vars_array); }
+
+static size_t zs_io_write_stdout(const char *str, size_t str_length) {
+    size_t len = zai_sapi_io_write_stdout(str, str_length);
+    if (len == 0) php_handle_aborted_connection();
+    return len;
+}
+
+static void zs_io_log_message(const char *message, int syslog_type_int) {
+    UNUSED(syslog_type_int);
+    char buf[ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE];
+    size_t len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+    /* We ignore the return because PHP does not care if this fails. */
+    (void)zai_sapi_io_write_stderr(buf, len);
+}
+
+static sapi_module_struct zai_module = {
+    "zai",                     /* name */
+    "Zend Abstract Interface", /* pretty name */
+
+    zs_startup,                  /* startup */
+    php_module_shutdown_wrapper, /* shutdown */
+
+    NULL,          /* activate */
+    zs_deactivate, /* deactivate */
+
+    zs_io_write_stdout, /* unbuffered write */
+    zai_sapi_io_flush,  /* flush */
+
+    NULL, /* get uid */
+    NULL, /* getenv */
+
+    php_error, /* error handler */
+
+    NULL,           /* header handler */
+    NULL,           /* send headers handler */
+    zs_send_header, /* send header handler */
+
+    NULL,            /* read POST data */
+    zs_read_cookies, /* read Cookies */
+
+    zs_register_variables, /* register server variables */
+    zs_io_log_message,     /* Log message */
+    NULL,                  /* Get request time */
+    NULL,                  /* Child terminate */
+
+    NULL, /* php_ini_path_override   */
+    NULL, /* default_post_reader     */
+    NULL, /* treat_data              */
+    NULL, /* executable_location     */
+    0,    /* php_ini_ignore          */
+    0,    /* php_ini_ignore_cwd      */
+    NULL, /* get_fd                  */
+    NULL, /* force_http_10           */
+    NULL, /* get_target_uid          */
+    NULL, /* get_target_gid          */
+    NULL, /* input_filter            */
+    NULL, /* ini_defaults            */
+    0,    /* phpinfo_as_text;        */
+    NULL, /* ini_entries;            */
+    NULL, /* additional_functions    */
+    NULL  /* input_filter_init       */
+};
+
+bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
+    size_t len = zai_sapi_ini_entries_realloc_append(&zai_module.ini_entries, ini_entries_len, key, value);
+    if (len <= ini_entries_len) {
+        /* Play it safe and free if writing failed. */
+        zai_sapi_ini_entries_free(&zai_module.ini_entries);
+        return false;
+    }
+    ini_entries_len = len;
+    return true;
+}
+
+#ifdef ZTS
+static void zs_tsrm_startup(void) {
+    php_tsrm_startup();
+    ZEND_TSRMLS_CACHE_UPDATE();
+}
+#endif
+
+bool zai_sapi_sinit(void) {
+#ifdef ZTS
+    zs_tsrm_startup();
+#endif
+
+    zend_signal_startup();
+
+    /* Initialize the SAPI globals (memset to '0'), and set up reentrancy. */
+    sapi_startup(&zai_module);
+
+    /* Do not chdir to the script's directory (equivalent to running the CLI
+     * SAPI with '-C').
+     */
+    SG(options) |= SAPI_OPTION_NO_CHDIR;
+
+    /* Allocate the initial SAPI INI settings. Append new INI settings to this
+     * with zai_sapi_append_system_ini_entry() before MINIT is run.
+     */
+    if ((ini_entries_len = zai_sapi_ini_entries_alloc(DEFAULT_INI, &zai_module.ini_entries)) == 0) return false;
+
+    /* Don't load any INI files (equivalent to running the CLI SAPI with '-n').
+     * This will prevent inadvertently loading any extensions that we did not
+     * intend to. It also gives us a consistent clean slate of INI settings.
+     */
+    zai_module.php_ini_ignore = 1;
+
+    /* Show phpinfo()/module info as plain text. */
+    zai_module.phpinfo_as_text = 1;
+
+    /* TODO: When we want to expose a function to userland for testing purposes
+     * (e.g. DDTrace\Testing\trigger_error()), we can add them as custom SAPI
+     * functions here. These functions will only exist in the ZAI SAPI for
+     * testing at the C unit test level and will not be shipped as a public
+     * userland API in the PHP tracer.
+     */
+    zai_module.additional_functions = NULL;
+
+    return true;
+}
+
+void zai_sapi_sshutdown(void) {
+    sapi_shutdown();
+#ifdef ZTS
+    tsrm_shutdown();
+#endif
+    zai_sapi_ini_entries_free(&zai_module.ini_entries);
+}
+
+bool zai_sapi_minit(void) {
+    if (zai_module.startup(&zai_module) == FAILURE) {
+        zai_sapi_sshutdown();
+        return false;
+    }
+    return true;
+}
+
+void zai_sapi_mshutdown(void) { php_module_shutdown(); }
+
+bool zai_sapi_rinit(void) {
+    if (php_request_startup() == FAILURE) {
+        return false;
+    }
+
+    SG(headers_sent) = 1;
+    SG(request_info).no_headers = 1;
+
+    php_register_variable("PHP_SELF", "-", NULL);
+
+    return true;
+}
+
+void zai_sapi_rshutdown(void) { php_request_shutdown((void *)0); }
+
+bool zai_sapi_spinup(void) { return zai_sapi_sinit() && zai_sapi_minit() && zai_sapi_rinit(); }
+
+void zai_sapi_spindown(void) {
+    zai_sapi_rshutdown();
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}

--- a/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
+++ b/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(zai_sapi_tests zai_sapi_ini.cc zai_sapi_io.cc)
+
+target_link_libraries(zai_sapi_tests PUBLIC catch2_main Zai::Sapi)
+
+catch_discover_tests(zai_sapi_tests)

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi_ini.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi_ini.cc
@@ -1,0 +1,152 @@
+extern "C" {
+#include "zai_sapi/zai_sapi_ini.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+/************************ zai_sapi_ini_entries_alloc ************************/
+
+TEST_CASE("alloc INI entries", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    REQUIRE(entries != NULL);
+    REQUIRE(len == 8);
+    REQUIRE(strcmp("foo=bar\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("alloc INI does not overwrite existing ptr", "[zai_sapi_ini]") {
+    char *entries = (char *)(void *)1;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    REQUIRE(entries == (char *)(void *)1);
+    REQUIRE(len == 0);
+}
+
+TEST_CASE("alloc NULL INI src entries", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc(NULL, &entries);
+
+    REQUIRE(entries == NULL);
+    REQUIRE(len == 0);
+}
+
+TEST_CASE("alloc NULL INI dest", "[zai_sapi_ini]") {
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", NULL);
+
+    REQUIRE(len == 0);
+}
+
+/************************* zai_sapi_ini_entries_free *************************/
+
+TEST_CASE("freeing entries sets NULL pointer", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar", &entries);
+
+    REQUIRE(entries != NULL);
+
+    zai_sapi_ini_entries_free(&entries);
+
+    REQUIRE(entries == NULL);
+}
+
+TEST_CASE("free NULL pointer", "[zai_sapi_ini]") {
+    char *entries = NULL;
+
+    zai_sapi_ini_entries_free(&entries);
+    zai_sapi_ini_entries_free(NULL);
+
+    REQUIRE(entries == NULL);
+}
+
+/******************** zai_sapi_ini_entries_realloc_append ********************/
+
+TEST_CASE("append INI entry", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "abc", "123");
+
+    REQUIRE(entries != NULL);
+    REQUIRE(len == 16);
+    REQUIRE(strcmp("foo=bar\nabc=123\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("append several INI entries", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\nabc=123\n", &entries);
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "abc", "123");
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "extension", "ddtrace.so");
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "ddtrace.request_init_hook", "/path/to/init_hook.php");
+
+    REQUIRE(entries != NULL);
+    REQUIRE(len == 94);
+    REQUIRE(strcmp("foo=bar\nabc=123\nabc=123\nextension=ddtrace.so\nddtrace.request_init_hook=/path/to/init_hook.php\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("append entries pointing to NULL", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = 42;
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "abc", "123");
+
+    REQUIRE(entries == NULL);
+    REQUIRE(len == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("append NULL entries", "[zai_sapi_ini]") {
+    size_t len = 42;
+
+    len = zai_sapi_ini_entries_realloc_append(NULL, len, "abc", "123");
+
+    REQUIRE(len == 0);
+}
+
+TEST_CASE("append zero-len entries", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, 0, "abc", "123");
+
+    REQUIRE(len == 0);
+    REQUIRE(entries != NULL);
+    REQUIRE(strcmp("foo=bar\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("append NULL key", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, NULL, "123");
+
+    REQUIRE(entries != NULL);
+    REQUIRE(len == 0);
+    REQUIRE(strcmp("foo=bar\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}
+
+TEST_CASE("append NULL value", "[zai_sapi_ini]") {
+    char *entries = NULL;
+    size_t len = zai_sapi_ini_entries_alloc("foo=bar\n", &entries);
+
+    len = zai_sapi_ini_entries_realloc_append(&entries, len, "abc", NULL);
+
+    REQUIRE(entries != NULL);
+    REQUIRE(len == 0);
+    REQUIRE(strcmp("foo=bar\n", entries) == 0);
+
+    zai_sapi_ini_entries_free(&entries);
+}

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi_io.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi_io.cc
@@ -1,0 +1,147 @@
+extern "C" {
+#include "zai_sapi/zai_sapi_io.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+/************************* zai_sapi_io_write_stdout *************************/
+
+TEST_CASE("basic write to stdout", "[zai_sapi_io]") {
+    char out[] = "Hello world\n";
+    size_t len = (sizeof out - 1);
+
+    size_t wrote_len = zai_sapi_io_write_stdout(out, len);
+
+    REQUIRE(wrote_len == len);
+    // TODO Capture stdout into a buffer?
+    //REQUIRE(strcmp("Hello world\n", buf) == 0);
+}
+
+TEST_CASE("write empty string stdout", "[zai_sapi_io]") {
+    char out[] = "";
+    size_t len = (sizeof out - 1);
+
+    size_t wrote_len = zai_sapi_io_write_stdout(out, len);
+
+    REQUIRE(wrote_len == 0);
+}
+
+TEST_CASE("write NULL to stdout", "[zai_sapi_io]") {
+    size_t wrote_len = zai_sapi_io_write_stdout(NULL, 42);
+    REQUIRE(wrote_len == 0);
+}
+
+TEST_CASE("write 0 len to stdout", "[zai_sapi_io]") {
+    char out[] = "Hello world\n";
+    size_t len = 0;
+
+    size_t wrote_len = zai_sapi_io_write_stdout(out, len);
+
+    REQUIRE(wrote_len == 0);
+}
+
+/************************* zai_sapi_io_write_stderr *************************/
+
+TEST_CASE("basic write to stderr", "[zai_sapi_io]") {
+    char err[] = "Hello error\n";
+    size_t len = (sizeof err - 1);
+
+    size_t wrote_len = zai_sapi_io_write_stderr(err, len);
+
+    REQUIRE(wrote_len == len);
+    // TODO Capture stderr into a buffer?
+    //REQUIRE(strcmp("Hello error\n", buf) == 0);
+}
+
+TEST_CASE("write empty string to stderr", "[zai_sapi_io]") {
+    char err[] = "";
+    size_t len = (sizeof err - 1);
+
+    size_t wrote_len = zai_sapi_io_write_stderr(err, len);
+
+    REQUIRE(wrote_len == len);
+}
+
+TEST_CASE("write NULL to stderr", "[zai_sapi_io]") {
+    size_t wrote_len = zai_sapi_io_write_stderr(NULL, 42);
+    REQUIRE(wrote_len == 0);
+}
+
+TEST_CASE("write 0 len to stderr", "[zai_sapi_io]") {
+    char err[] = "Hello error\n";
+    size_t len = 0;
+
+    size_t wrote_len = zai_sapi_io_write_stderr(err, len);
+
+    REQUIRE(wrote_len == 0);
+}
+
+/*********************** zai_sapi_io_format_error_log ***********************/
+
+TEST_CASE("error_log formatted message", "[zai_sapi_io]") {
+    char buf[ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE];
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+
+    REQUIRE(wrote_len == 15);
+    REQUIRE(strcmp("Error: E_ERROR\n", buf) == 0);
+}
+
+TEST_CASE("error_log format with exact buffer size", "[zai_sapi_io]") {
+    char buf[14 /* message len */ + 1 /* new line */ + 1 /* null terminator */];
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+
+    REQUIRE(wrote_len == 15);
+    REQUIRE(strcmp("Error: E_ERROR\n", buf) == 0);
+}
+
+TEST_CASE("error_log format with one truncated character", "[zai_sapi_io]") {
+    char buf[14 /* message len */ + 1 /* null terminator */ /* no room for new line */];
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+
+    REQUIRE(wrote_len == 14);
+    REQUIRE(strcmp("Error: E_ERROR", buf) == 0);
+}
+
+TEST_CASE("error_log format truncated", "[zai_sapi_io]") {
+    char buf[6];
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, buf, sizeof buf);
+
+    REQUIRE(wrote_len == 5);
+    REQUIRE(strcmp("Error", buf) == 0);
+}
+
+TEST_CASE("error_log with NULL message", "[zai_sapi_io]") {
+    char buf[256] = {0};
+
+    size_t wrote_len = zai_sapi_io_format_error_log(NULL, buf, sizeof buf);
+
+    REQUIRE(wrote_len == 0);
+    REQUIRE(*buf == '\0');
+}
+
+TEST_CASE("error_log with NULL buffer", "[zai_sapi_io]") {
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, NULL, 42);
+
+    REQUIRE(wrote_len == 0);
+}
+
+TEST_CASE("error_log with zero buffer size", "[zai_sapi_io]") {
+    char buf[256] = {0};
+    char message[] = "Error: E_ERROR";
+
+    size_t wrote_len = zai_sapi_io_format_error_log(message, buf, 0);
+
+    REQUIRE(wrote_len == 0);
+    REQUIRE(*buf == '\0');
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -6,7 +6,7 @@
  * ZAI SAPI is designed to test software components that are tightly coupled to
  * the Zend Engine.
  *
- * ZAI SAPI is a fork the the embed SAPI:
+ * ZAI SAPI is a fork of the embed SAPI:
  * https://github.com/php/php-src/tree/master/sapi/embed
  */
 #ifndef ZAI_SAPI_H

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -1,0 +1,73 @@
+/*                   ____   __   __    ____   __   ____  __
+ *                  (__  ) / _\ (  )  / ___) / _\ (  _ \(  )
+ *                   / _/ /    \ )(   \___ \/    \ ) __/ )(
+ *                  (____)\_/\_/(__)  (____/\_/\_/(__)  (__)
+ *
+ * ZAI SAPI is designed to test software components that are tightly coupled to
+ * the Zend Engine.
+ *
+ * ZAI SAPI is a fork the the embed SAPI:
+ * https://github.com/php/php-src/tree/master/sapi/embed
+ */
+#ifndef ZAI_SAPI_H
+#define ZAI_SAPI_H
+
+#include <main/php.h>
+#include <stdbool.h>
+
+#if PHP_VERSION_ID >= 70000 && defined(ZTS)
+ZEND_TSRMLS_CACHE_EXTERN()
+#endif
+
+/* Initializes the SAPI, modules, and request. */
+bool zai_sapi_spinup(void);
+/* Shuts down the request, modules, and SAPI. */
+void zai_sapi_spindown(void);
+
+/* SINIT: SAPI initialization
+ *
+ * Characterized by sapi_startup().
+ *   - Initialize SAPI globals
+ *   - Allocate SAPI INI settings
+ *   - Set startup behavior
+ *   - Start up ZTS & signals
+ */
+bool zai_sapi_sinit(void);
+void zai_sapi_sshutdown(void);
+
+/* MINIT: Module initialization
+ *
+ * Basically a wrapper for php_module_startup().
+ */
+bool zai_sapi_minit(void);
+void zai_sapi_mshutdown(void);
+
+/* RINIT: Request initialization.
+ *
+ * Characterized by php_request_startup().
+ *   - Set late-stage configuration
+ *   - Send headers
+ */
+bool zai_sapi_rinit(void);
+void zai_sapi_rshutdown(void);
+
+/* Appends an INI entry to the existing 'ini_entries'.
+ *
+ *   zai_sapi_append_system_ini_entry("extension", "ddtrace.so");
+ *
+ * Must be called:
+ *   - After SAPI initialization zai_sapi_sinit()
+ *   - Before module initialization zai_sapi_minit()
+ *
+ * We cannot use PHP's zend_alter_ini_entry_*() API to modify INI entries
+ * before MINIT because the configuration hash table does not exist before
+ * MINIT. The SAPI 'ini_entries' (member of the 'sapi_module_struct') and any
+ * INI settings from '.ini' files are parsed and added to the configuration
+ * hash table in php_init_config() during MINIT. If we need to add an INI
+ * setting that is accessed very early in the startup process (i.e.
+ * 'disable_functions' which is read as part of MINIT), then we must reallocate
+ * our C string of SAPI 'ini_entries' and append to it before MINIT occurs.
+ */
+bool zai_sapi_append_system_ini_entry(const char *key, const char *value);
+
+#endif  // ZAI_SAPI_H

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
@@ -4,17 +4,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-size_t zai_sapi_ini_entries_alloc(const char *src, char **dest) {
-    if (!src || !dest) return 0;
+ssize_t zai_sapi_ini_entries_alloc(const char *src, char **dest) {
+    if (!src || !dest) return -1;
 
     /* Prevent a potential dangling pointer in case the caller accidentally
      * sent in an allocated dest.
      */
-    if (*dest != NULL) return 0;
+    if (*dest != NULL) return -1;
 
     size_t len = strlen(src);
 
-    if ((*dest = (char *)malloc(len + 1)) == NULL) return 0;
+    if ((*dest = (char *)malloc(len + 1)) == NULL) return -1;
     memcpy(*dest, src, (len + 1));
 
     return len;
@@ -27,17 +27,20 @@ void zai_sapi_ini_entries_free(char **entries) {
     }
 }
 
-size_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value) {
-    if (!entries || !*entries || !key || !value || entries_len <= 0) return 0;
+ssize_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value) {
+    if (!entries || !*entries || !key || !value) return -1;
+
+    /* An empty 'value' is fine, but a 'key' must be non-empty. */
+    if (*key == '\0') return -1;
 
     size_t append_len = strlen(key) + strlen(value) + (sizeof("=\n") - 1);
 
     char *newents;
-    if ((newents = (char *)realloc(*entries, (entries_len + append_len + 1))) == NULL) return 0;
+    if ((newents = (char *)realloc(*entries, (entries_len + append_len + 1))) == NULL) return -1;
     *entries = newents;
 
     char *ptr = (*entries + entries_len);
     size_t written_len = (size_t)snprintf(ptr, (append_len + 1), "%s=%s\n", key, value);
 
-    return (written_len != append_len) ? 0 : (entries_len + append_len);
+    return (written_len != append_len) ? -1 : (ssize_t)(entries_len + append_len);
 }

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
@@ -1,0 +1,43 @@
+#include "zai_sapi_ini.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+size_t zai_sapi_ini_entries_alloc(const char *src, char **dest) {
+    if (!src || !dest) return 0;
+
+    /* Prevent a potential dangling pointer in case the caller accidentally
+     * sent in an allocated dest.
+     */
+    if (*dest != NULL) return 0;
+
+    size_t len = strlen(src);
+
+    if ((*dest = (char *)malloc(len + 1)) == NULL) return 0;
+    memcpy(*dest, src, (len + 1));
+
+    return len;
+}
+
+void zai_sapi_ini_entries_free(char **entries) {
+    if (entries != NULL && *entries != NULL) {
+        free(*entries);
+        *entries = NULL;
+    }
+}
+
+size_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value) {
+    if (!entries || !*entries || !key || !value || entries_len <= 0) return 0;
+
+    size_t append_len = strlen(key) + strlen(value) + (sizeof("=\n") - 1);
+
+    char *newents;
+    if ((newents = (char *)realloc(*entries, (entries_len + append_len + 1))) == NULL) return 0;
+    *entries = newents;
+
+    char *ptr = (*entries + entries_len);
+    size_t written_len = (size_t)snprintf(ptr, (append_len + 1), "%s=%s\n", key, value);
+
+    return (written_len != append_len) ? 0 : (entries_len + append_len);
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
@@ -1,0 +1,28 @@
+#ifndef ZAI_SAPI_INI_H
+#define ZAI_SAPI_INI_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Allocates memory for 'dest' and copies the entires from 'src' into it.
+ * 'dest' must point to NULL or no allocation will occur. Caller must free with
+ * zai_sapi_ini_entries_free().
+ */
+size_t zai_sapi_ini_entries_alloc(const char *src, char **dest);
+
+/* Frees the INI entires and sets the pointer to NULL to prevent a use after
+ * free.
+ */
+void zai_sapi_ini_entries_free(char **entries);
+
+/* Reallocates the INI entries and append a new entry. Returns the new length
+ * of the entires (not counting the null terminator) after appending the new
+ * entry. The pointer to 'entries' might change after reallocation.
+ *
+ * A length of '0' will be returned if:
+ *   - Reallocation fails (the 'entries' pointer will be unchanged)
+ *   - There was an error copying the new entry into memory
+ */
+size_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value);
+
+#endif  // ZAI_SAPI_INI_H

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
@@ -4,19 +4,19 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-/* Allocates memory for 'dest' and copies the entires from 'src' into it.
+/* Allocates memory for 'dest' and copies the entries from 'src' into it.
  * 'dest' must point to NULL or no allocation will occur. Caller must free with
  * zai_sapi_ini_entries_free().
  */
 size_t zai_sapi_ini_entries_alloc(const char *src, char **dest);
 
-/* Frees the INI entires and sets the pointer to NULL to prevent a use after
+/* Frees the INI entries and sets the pointer to NULL to prevent a use after
  * free.
  */
 void zai_sapi_ini_entries_free(char **entries);
 
 /* Reallocates the INI entries and append a new entry. Returns the new length
- * of the entires (not counting the null terminator) after appending the new
+ * of the entries (not counting the null terminator) after appending the new
  * entry. The pointer to 'entries' might change after reallocation.
  *
  * A length of '0' will be returned if:

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
@@ -3,12 +3,13 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 /* Allocates memory for 'dest' and copies the entries from 'src' into it.
  * 'dest' must point to NULL or no allocation will occur. Caller must free with
- * zai_sapi_ini_entries_free().
+ * zai_sapi_ini_entries_free(). Returns '-1' on failure.
  */
-size_t zai_sapi_ini_entries_alloc(const char *src, char **dest);
+ssize_t zai_sapi_ini_entries_alloc(const char *src, char **dest);
 
 /* Frees the INI entries and sets the pointer to NULL to prevent a use after
  * free.
@@ -19,10 +20,11 @@ void zai_sapi_ini_entries_free(char **entries);
  * of the entries (not counting the null terminator) after appending the new
  * entry. The pointer to 'entries' might change after reallocation.
  *
- * A length of '0' will be returned if:
+ * A length of '-1' will be returned if:
  *   - Reallocation fails (the 'entries' pointer will be unchanged)
  *   - There was an error copying the new entry into memory
+ *   - 'key' is an empty string
  */
-size_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value);
+ssize_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value);
 
 #endif  // ZAI_SAPI_INI_H

--- a/zend_abstract_interface/zai_sapi/zai_sapi_io.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_io.c
@@ -1,0 +1,21 @@
+#include "zai_sapi_io.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static size_t zs_unbuffered_write(int fd, const char *str, size_t len) {
+    if (!fd || !str || len <= 0) return 0;
+    ssize_t wrote_len = write(fd, str, len);
+    return (wrote_len > 0) ? (size_t)wrote_len : 0;
+}
+
+size_t zai_sapi_io_write_stdout(const char *str, size_t len) { return zs_unbuffered_write(STDOUT_FILENO, str, len); }
+
+size_t zai_sapi_io_write_stderr(const char *str, size_t len) { return zs_unbuffered_write(STDERR_FILENO, str, len); }
+
+size_t zai_sapi_io_format_error_log(const char *message, char *buf, size_t buf_size) {
+    if (!message || !buf || buf_size <= 0) return 0;
+    size_t len = snprintf(buf, buf_size, "%s\n", message);
+    return len < buf_size ? len : (buf_size - 1);
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi_io.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_io.h
@@ -1,0 +1,46 @@
+#ifndef ZAI_SAPI_IO_H
+#define ZAI_SAPI_IO_H
+
+#include <stddef.h>
+
+/* Writes to stdout (unbuffered).
+ *
+ * Output buffering is handled by PHP. Once PHP is ready to flush it sends the
+ * output to the SAPI's unbuffered write operation. We do not buffer when
+ * writing to stdout as to not conflict with the PHP output buffer.
+ */
+size_t zai_sapi_io_write_stdout(const char *str, size_t len);
+
+/* Writes to stderr (unbuffered).
+ *
+ * As PHP does not buffer stderr, it is not required to have an unbuffered
+ * write operation for stderr at the SAPI level. But we still perform
+ * unbuffered write operations to stderr for consistency with stdout.
+ */
+size_t zai_sapi_io_write_stderr(const char *str, size_t len);
+
+/* Flushes stdout (NOOP).
+ *
+ * ZAI SAPI only supports unbuffered write operations.
+ */
+static inline void zai_sapi_io_flush(void *server_context) { (void)server_context; }
+
+/* The max stack-allocated buffer size to store the formatted error message in
+ * the SAPI error logger.
+ *
+ * This is the same buffer size that the PHP-FPM SAPI uses.
+ * https://github.com/php/php-src/blob/0bc6a66/sapi/fpm/fpm/zlog.c#L20
+ */
+#define ZAI_SAPI_IO_ERROR_LOG_MAX_BUF_SIZE 2048
+
+/* Formats the error message for the SAPI error logger and copy the formatted
+ * message into the buffer. Returns the length of the string written into the
+ * buffer excluding the null terminator.
+ *
+ * E_ERROR and friends go to the SAPI error logger if the 'error_log' INI
+ * setting is not set.
+ * https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-log
+ */
+size_t zai_sapi_io_format_error_log(const char *message, char *buf, size_t buf_size);
+
+#endif  // ZAI_SAPI_IO_H


### PR DESCRIPTION
### Description

Zend Abstract Interface (ZAI) SAPI is a new test runner for testing software components that are tightly coupled to the Zend Engine. It is a fork of the [embed SAPI](https://github.com/php/php-src/tree/master/sapi/embed).

This first edition of ZAPI SAPI comes with:

- PHP 5.4 through PHP 8.0 support.
- C-level unit tests in CI with ASan + UBSan.
- Independent control over Zend Engine startup & shutdown cycles (SINIT, MINIT, and RINIT).
- Overwritable INI settings before MINIT.

We will use ZAI SAPI to test the Zend Abstract Interface seams (WIP #1186) and parts of the tracer we have been unable to test with traditional PhpUnit and phpt tests.

Some future wishlist features include:

- [ ] Custom SAPI-level functions (e.g. `DDTrace\Testing\trigger_error()`)
- [ ] Overridable unbuffered output hook
- [ ] Fuzzer integration
- [ ] Imposter: pose as another SAPI (can be handy when testing parts of OPcache and other extensions that have code paths that are [gated by the SAPI name](https://github.com/php/php-src/blob/e0e19fd955b1fdf9f4b202343b1c9e61f1f18b35/ext/opcache/ZendAccelerator.c#L2823-L2853))

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
