### PR TITLE
Release 0.57.0

### DIFF
--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.57.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -37,14 +37,14 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-    Added
+    ### Added
     - Add curl_multi scenarios to randomized tests #1171 #1173
     - Add component system, string_view and sapi components #1172
     - Add tests for Symfony 5.2 #1177 #1178
     - Support PsrHttpServerMiddleware for Slim 4 #1170
     - Container tagging for AWS Fargate 1.4+ #1190
 
-    Changed
+    ### Changed
     - Remove non php8 code from ext/php8 folder #1165
     - Enable Symfony on PHP 8.0 #1176 #1178
     - Move container ID detection to the extension level #1143
@@ -55,7 +55,7 @@
     - Import framework tests suite from dd-trace-ci to dd-trace-php (#1183)
     - Do not keep alive connections while executing randomized testing (#1163)
 
-    Fixed
+    ### Fixed
     - Fix "undefined symbol: curl_multi_ce" on PHP 8 #1181 (thanks for the report @metaxy)
     - Compatibility with opentracing/opentracing:1.0.1 #1188 (thanks for the contribution @bbaga)
     </notes>

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,29 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    Added
+    - Add curl_multi scenarios to randomized tests #1171 #1173
+    - Add component system, string_view and sapi components #1172
+    - Add tests for Symfony 5.2 #1177 #1178
+    - Support PsrHttpServerMiddleware for Slim 4 #1170
+    - Container tagging for AWS Fargate 1.4+ #1190
+
+    Changed
+    - Remove non php8 code from ext/php8 folder #1165
+    - Enable Symfony on PHP 8.0 #1176 #1178
+    - Move container ID detection to the extension level #1143
+    - Refactor the PHP 8 exception serialization #1179
+    - Accept multiple requests dumped from request-replayer (testing) #1193
+    - Exclude dockerfiles directory from the composer package #1192  (thanks for the contribution @djcrock)
+    - Disable php language tests `ext/openssl/tests/bug54992.phpt` (#1197)
+    - Import framework tests suite from dd-trace-ci to dd-trace-php (#1183)
+    - Do not keep alive connections while executing randomized testing (#1163)
+
+    Fixed
+    - Fix "undefined symbol: curl_multi_ce" on PHP 8 #1181 (thanks for the report @metaxy)
+    - Compatibility with opentracing/opentracing:1.0.1 #1188 (thanks for the contribution @bbaga)
+    </notes>
     <contents>
         <dir name="/">
             <!-- components -->

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.57.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Description

Version bump 0.57.0

Note for the reviewer: errors on php7.5 (pcntl) and the components failures are expected and fixed on master. They do not impact the quality of the release.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
