### PR TITLE
Add a Kubernetes example to container tagging tests

### DIFF
--- a/components/container_id/tests/container_id_parser.cc
+++ b/components/container_id/tests/container_id_parser.cc
@@ -204,3 +204,18 @@ TEST_CASE("parser: fail to parse a task ID", "[container_id_parser]") {
 
     REQUIRE(datadog_php_container_id_parser_dtor(&parser));
 }
+
+/* This specific k8s example was reported as not being parsed correctly on the
+ * Python tracer.
+ * https://github.com/DataDog/dd-trace-py/issues/2314
+ */
+TEST_CASE("parser: successfully parse a Kubernetes container ID", "[container_id_parser]") {
+    dd_parser parser;
+    char buf[MAX_ID_LEN + 1] = {0};
+    const char line[] = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope";
+
+    REQUIRE(datadog_php_container_id_parser_ctor(&parser));
+    REQUIRE(parser.extract_container_id(&parser, buf, line));
+    REQUIRE(strcmp("7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199", buf) == 0);
+    REQUIRE(datadog_php_container_id_parser_dtor(&parser));
+}


### PR DESCRIPTION
### Description

This specific line from a Kubernetes cgroup file was reported as not being parsed correctly on the Python tracer (DataDog/dd-trace-py#2314). 

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
