### PR TITLE
[ZAI SAPI] Add test helpers

### DIFF
--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -215,3 +215,14 @@ void zai_sapi_spindown(void) {
     zai_sapi_mshutdown();
     zai_sapi_sshutdown();
 }
+
+bool zai_sapi_execute_script(const char *file) {
+    TSRMLS_FETCH();
+    zend_file_handle handle;
+
+    memset((void *)&handle, 0, sizeof(zend_file_handle));
+    handle.type = ZEND_HANDLE_FILENAME;
+    handle.filename = file;
+
+    return zend_execute_scripts(ZEND_REQUIRE TSRMLS_CC, NULL, 1, &handle) == SUCCESS;
+}

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -217,3 +217,13 @@ void zai_sapi_spindown(void) {
     zai_sapi_mshutdown();
     zai_sapi_sshutdown();
 }
+
+bool zai_sapi_execute_script(const char *file) {
+    zend_file_handle handle;
+
+    memset((void *)&handle, 0, sizeof(zend_file_handle));
+    handle.type = ZEND_HANDLE_FILENAME;
+    handle.filename = file;
+
+    return zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &handle) == SUCCESS;
+}

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -190,3 +190,9 @@ void zai_sapi_spindown(void) {
     zai_sapi_mshutdown();
     zai_sapi_sshutdown();
 }
+
+bool zai_sapi_execute_script(const char *file) {
+    zend_file_handle handle;
+    zend_stream_init_filename(&handle, file);
+    return zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &handle) == SUCCESS;
+}

--- a/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
+++ b/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
-add_executable(zai_sapi_tests zai_sapi_ini.cc zai_sapi_io.cc)
+add_executable(zai_sapi_tests zai_sapi.cc zai_sapi_ini.cc zai_sapi_io.cc)
 
 target_link_libraries(zai_sapi_tests PUBLIC catch2_main Zai::Sapi)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 catch_discover_tests(zai_sapi_tests)

--- a/zend_abstract_interface/zai_sapi/tests/stubs/basic.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/basic.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Zai\Sapi;
+
+class Test
+{
+    public function returnsTrue()
+    {
+        return true;
+    }
+}

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi.cc
@@ -1,0 +1,87 @@
+extern "C" {
+#include "zai_sapi/zai_sapi.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("eval: SAPI, modules, and request init/shutdown", "[zai_sapi]") {
+    REQUIRE(zai_sapi_sinit());
+    REQUIRE(zai_sapi_minit());
+    REQUIRE(zai_sapi_rinit());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(ZAI_SAPI_EVAL_STR("echo 'Hello world' . PHP_EOL;") == SUCCESS);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_rshutdown();
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+
+TEST_CASE("eval: spinup/spindown", "[zai_sapi]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(ZAI_SAPI_EVAL_STR("echo 'Hello world' . PHP_EOL;") == SUCCESS);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("compile file success", "[zai_sapi]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("compile file failure (file not found)", "[zai_sapi]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+
+    // No need to wrap with REQUIRE() since it will zend_bailout (long jump)
+    zai_sapi_execute_script("./this_does_not_exist.php");
+
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("hard-coded SAPI INI entries added to config hash table", "[zai_sapi]") {
+    REQUIRE(zai_sapi_sinit());
+    REQUIRE(zai_sapi_minit());
+
+    // Hard-coded SAPI INI entries from 'zai_sapi.c'
+    REQUIRE(strcmp(ZAI_SAPI_INI_STR("html_errors"), "0") == 0);
+    REQUIRE(strcmp(ZAI_SAPI_INI_STR("implicit_flush"), "1") == 0);
+    REQUIRE(strcmp(ZAI_SAPI_INI_STR("output_buffering"), "0") == 0);
+
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+
+TEST_CASE("overwrite hard-coded SAPI INI", "[zai_sapi]") {
+    REQUIRE(zai_sapi_sinit());
+    // Hard-coded SAPI INI entry: "html_errors=0"
+    REQUIRE(zai_sapi_append_system_ini_entry("html_errors", "1"));
+    REQUIRE(zai_sapi_minit());
+
+    REQUIRE(strcmp(ZAI_SAPI_INI_STR("html_errors"), "1") == 0);
+
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+
+TEST_CASE("access modified INI", "[zai_sapi]") {
+    REQUIRE(zai_sapi_sinit());
+    REQUIRE(zai_sapi_append_system_ini_entry("error_prepend_string", "Foo prepend"));
+    REQUIRE(zai_sapi_minit());
+
+    REQUIRE(strcmp(ZAI_SAPI_INI_STR("error_prepend_string"), "Foo prepend") == 0);
+
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -12,6 +12,7 @@
 #ifndef ZAI_SAPI_H
 #define ZAI_SAPI_H
 
+#include <assert.h>
 #include <main/php.h>
 #include <stdbool.h>
 
@@ -69,5 +70,92 @@ void zai_sapi_rshutdown(void);
  * our C string of SAPI 'ini_entries' and append to it before MINIT occurs.
  */
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value);
+
+/* Executes a PHP script located at 'file'. Relative file paths are relative to
+ * the path of the executable. A zend_bailout could occur here and this
+ * function does not catch it. Returns false if the script exists but failed to
+ * compile.
+ */
+bool zai_sapi_execute_script(const char *file);
+
+/* Handling zend_bailout
+ *
+ * A test will provide a false-positive when a component calls zend_bailout.
+ * This is because a zend_bailout will cause an unclean shutdown for
+ * RSHUTDOWN, but the process will exit normally. For this reason it is
+ * always important to explicitly test for expected or unexpected
+ * zend_bailouts.
+ *
+ * When a zend_bailout is unexpected, wrap the component with:
+ *
+ *   ZAI_SAPI_ABORT_ON_BAILOUT_{OPEN|CLOSE}()
+ *
+ * When a zend_bailout is expected, wrap the component with:
+ *
+ *   ZAI_SAPI_BAILOUT_EXPECTED_{OPEN|CLOSE}()
+ */
+#define ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() zend_first_try {
+#define ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()                      \
+    }                                                          \
+    zend_catch { assert(false && "Unexpected zend_bailout"); } \
+    zend_end_try();
+
+#define ZAI_SAPI_BAILOUT_EXPECTED_OPEN() zend_first_try {
+#define ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()       \
+    assert(false && "Expected a zend_bailout"); \
+    }                                           \
+    zend_end_try();
+
+/* Obscured in the compiler directives below are the following function-call
+ * wrappers:
+ *
+ * ---
+ *
+ * zend_result ZAI_SAPI_EVAL_STR(const char *str)
+ *
+ * Evaluates PHP code from a C string and ignores the userland return value.
+ * Wrapper for 'zend_eval_stringl'.
+ *
+ * @param str The PHP code to be evaluated without the opening PHP tag '<php'
+ *
+ * @return (SUCCESS|FAILURE)
+ *
+ * ---
+ *
+ * char *ZAI_SAPI_INI_STR(const char *name)
+ *
+ * Accesses an INI value by name. Wrapper for 'zend_ini_string_ex'.
+ *
+ * @param name The name of the INI setting
+ *
+ * @return A C string containing the INI value (if the INI setting has been
+ *         modified the modified value will be returned) or NULL if the entry
+ *         could not be found in the EG(ini_directives) hash table
+ */
+
+#if PHP_VERSION_ID >= 80000
+/********************************** <PHP 8> **********************************/
+#define ZAI_SAPI_EVAL_STR(str) zend_eval_stringl(str, sizeof(str) - 1, NULL, "ZAI SAPI")
+#define ZAI_SAPI_INI_STR(name) zend_ini_string_ex((name), strlen(name), 0, NULL)
+/********************************** </PHP 8> *********************************/
+#elif PHP_VERSION_ID >= 70000
+/********************************** <PHP 7> **********************************/
+#define ZAI_SAPI_EVAL_STR(str) zend_eval_stringl((char *)str, sizeof(str) - 1, NULL, (char *)"ZAI SAPI")
+#define ZAI_SAPI_INI_STR(name) zend_ini_string_ex((char *)(name), strlen(name), 0, NULL)
+/********************************** </PHP 7> *********************************/
+#else
+/********************************** <PHP 5> **********************************/
+#undef ZAI_SAPI_ABORT_ON_BAILOUT_OPEN
+#define ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() \
+    TSRMLS_FETCH();                      \
+    zend_first_try {
+#undef ZAI_SAPI_BAILOUT_EXPECTED_OPEN
+#define ZAI_SAPI_BAILOUT_EXPECTED_OPEN() \
+    TSRMLS_FETCH();                      \
+    zend_first_try {
+#define ZAI_SAPI_EVAL_STR(str) zend_eval_stringl((char *)str, sizeof(str) - 1, NULL, (char *)"ZAI SAPI" TSRMLS_CC)
+#define ZAI_SAPI_INI_STR(name) zend_ini_string_ex((char *)(name), sizeof(name) /* - 1 */, 0, NULL)
+/********************************** </PHP 5> *********************************/
+#endif
 
 #endif  // ZAI_SAPI_H


### PR DESCRIPTION
### Description

- Add some version agnostic APIs for performing common tasks in the Zend Engine for use in C-level tests (PHP 5, PHP 7, and PHP 8).
- Add some basic hello-world SAPI test functionality as [requested](https://github.com/DataDog/dd-trace-php/pull/1204#pullrequestreview-637065530) in #1204.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
