### PR TITLE
Always resolve curl class entry symbols at runtime (PHP 8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,6 +634,49 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  min_install_tests:
+    parameters:
+      php_version:
+        type: string
+    working_directory: ~/datadog
+    environment:
+      DDAGENT_HOSTNAME: 127.0.0.1
+      DD_AGENT_HOST: 127.0.0.1
+      HTTPBIN_HOSTNAME: httpbin_integration
+      DATADOG_HAVE_DEV_ENV: 1
+    executor:
+      name: with_httpbin_and_request_replayer
+      docker_image: datadog/dd-trace-ci:php-<< parameters.php_version >>-shared-ext
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_PREPARE_TEST_RESULTS_DIR
+      - <<: *STEP_EXPORT_CI_ENV
+      - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - run:
+          name: Install .deb from artifacts
+          command: |
+            sudo dpkg -i ./build/packages/*.deb
+            php --ri=ddtrace
+      - run:
+          name: Run phpt tests against shippable package
+          command: |
+            switch-php debug
+            export DDTRACE_PKG_SO="/opt/datadog-php/extensions/ddtrace-$(php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $NF }')-debug.so"
+            make run_tests TESTS="-d 'extension=$DDTRACE_PKG_SO'"
+      - run:
+          name: Run phpt tests against build from source
+          command: |
+            make test_c
+      - <<: *STEP_STORE_TEST_RESULTS
+      - run:
+          command: |
+            mkdir -p /tmp/artifacts/core_dumps
+            find tmp -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
+            cp -a tmp/build_extension/tests/ext /tmp/artifacts/tests
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/artifacts
+
   framework_tests:
     working_directory: ~/datadog
     parameters:
@@ -1602,6 +1645,14 @@ workflows:
           sapi: fpm-fcgi
           integration_testsuite: "test_web_custom"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
+
+      - min_install_tests:
+          requires: [ 'package extension' ]
+          name: "PHP min install tests"
+          matrix:
+            parameters:
+              php_version:
+                - '8.0'
 
   build:
     jobs:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
+RUN_TESTS_CMD := REPORT_EXIT_STATUS=1 TEST_PHP_SRCDIR=$(BUILD_DIR) USE_TRACKED_ALLOC=1 php -n -d 'memory_limit=-1' $(BUILD_DIR)/run-tests.php -n -p $(shell which php) -q
+
 C_FILES := $(shell find components ext src/dogstatsd zend_abstract_interface -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_STUB_FILES := $(shell find tests/ext -type d -name 'stubs' -exec find '{}' -type f \; | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
@@ -71,21 +73,16 @@ install_ini: $(INI_FILE)
 
 install_all: install install_ini
 
+run_tests: $(TEST_FILES) $(TEST_STUB_FILES) $(BUILD_DIR)/configure
+	$(RUN_TESTS_CMD) $(TESTS)
+
 test_c: export DD_TRACE_CLI_ENABLED=1
 test_c: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
-	set -xe; \
-	export REPORT_EXIT_STATUS=1; \
-	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
-	export USE_TRACKED_ALLOC=1; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all $(TESTS)
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(TESTS)
 
 test_c_mem: export DD_TRACE_CLI_ENABLED=1
 test_c_mem: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
-	set -xe; \
-	export REPORT_EXIT_STATUS=1; \
-	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
-	export USE_TRACKED_ALLOC=1; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all -m $(TESTS)
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -m $(TESTS)
 
 test_c2php: $(SO_FILE) $(INIT_HOOK_TEST_FILES)
 	( \
@@ -101,38 +98,30 @@ test_with_init_hook_asan: $(SO_FILE) $(INIT_HOOK_TEST_FILES)
 	( \
 	set -xe; \
 	export DD_TRACE_CLI_ENABLED=1; \
-	export REPORT_EXIT_STATUS=1; \
-	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/asan-extension-init-hook-test.xml; \
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g -fsanitize=address" LDFLAGS="-fsanitize=address" clean all; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -d ddtrace.request_init_hook=$$(pwd)/bridge/dd_wrap_autoloader.php -q --show-all --asan $(INIT_HOOK_TEST_FILES); \
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -d ddtrace.request_init_hook=$$(pwd)/bridge/dd_wrap_autoloader.php --asan $(INIT_HOOK_TEST_FILES); \
 	)
 
 test_c_asan: export DD_TRACE_CLI_ENABLED=1
 test_c_asan: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	( \
 	set -xe; \
-	export REPORT_EXIT_STATUS=1; \
-	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
-	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/asan-extension-test.xml; \
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g -fsanitize=address" LDFLAGS="-fsanitize=address" clean all; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all --asan $(TESTS); \
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) --asan $(TESTS); \
 	)
 
 test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	( \
 	set -xe; \
-	export REPORT_EXIT_STATUS=1; \
-	export TEST_PHP_SRCDIR=$(BUILD_DIR); \
-	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/normal-extension-test.xml; \
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all $(TESTS); \
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(TESTS); \
 	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/valgrind-extension-test.xml; \
 	export TEST_PHP_OUTPUT=$(JUNIT_RESULTS_DIR)/valgrind-run-tests.out; \
-	php -n -d 'memory_limit=-1' $$TEST_PHP_SRCDIR/run-tests.php -n -p $$(which php) -d extension=$(SO_FILE) -q --show-all -m -s $$TEST_PHP_OUTPUT $(TESTS) && ! grep -e 'LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -m -s $$TEST_PHP_OUTPUT $(TESTS) && ! grep -e 'LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
 	)
 
 dist_clean:

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -1,12 +1,8 @@
 #include <php.h>
 #include <stdbool.h>
 
-#if defined(HAVE_CURL) && !defined(COMPILE_DL_CURL)
-#include <ext/curl/php_curl.h>
-#else
 __attribute__((weak)) zend_class_entry *curl_ce = NULL;
 __attribute__((weak)) zend_class_entry *curl_multi_ce = NULL;
-#endif
 
 #include "configuration.h"
 #include "engine_api.h"
@@ -391,7 +387,6 @@ void ddtrace_curl_handlers_startup(void) {
         return;
     }
 
-#if !(defined(HAVE_CURL) && !defined(COMPILE_DL_CURL))
     /* If curl is loaded as a shared library we need to fetch the addresses of
      * the class entry symbols and account or any name mangling.
      */
@@ -420,7 +415,6 @@ void ddtrace_curl_handlers_startup(void) {
             return;
         }
     }
-#endif
 
     zend_string *const_name = zend_string_init(ZEND_STRL("CURLOPT_HTTPHEADER"), 1);
     zval *const_value = zend_get_constant_ex(const_name, NULL, ZEND_FETCH_CLASS_SILENT);

--- a/tests/ext/from_php_7_3_bug61728.phpt
+++ b/tests/ext/from_php_7_3_bug61728.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #61728 (PHP crash when calling ob_start in request_shutdown phase)
+--SKIPIF--
+<?php if (!extension_loaded('session')) die('skip: session extension required'); ?>
 --FILE--
 <?php
 function output_html($ext) {

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -3,6 +3,8 @@ Long running autoflush
 --SKIPIF--
 <?php
 include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
 if (PHP_VERSION_ID < 70000) die('skip: Auto flushing not supported on PHP 5');
 ?>
 --ENV--

--- a/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Long running manual flush
 --SKIPIF--
-<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
 --ENV--
 DD_TRACE_CLI_ENABLED=true
 DD_TRACE_GENERATE_ROOT_SPAN=false

--- a/tests/ext/pcntl/pcntl_fork_short_running_multiple.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_multiple.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Short running multiple forks
 --SKIPIF--
-<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
 --FILE--
 <?php
 

--- a/tests/ext/pcntl/pcntl_fork_short_running_nested.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_nested.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Short running nested forks
 --SKIPIF--
-<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
 --FILE--
 <?php
 

--- a/tests/ext/pcntl/pcntl_fork_short_running_single.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_single.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Short running single fork
 --SKIPIF--
-<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
 --FILE--
 <?php
 

--- a/tests/ext/segfault_backtrace_disabled.phpt
+++ b/tests/ext/segfault_backtrace_disabled.phpt
@@ -2,6 +2,7 @@
 Don't dump backtrace when segmentation fault signal is raised and config is default
 --SKIPIF--
 <?php
+if (!extension_loaded('posix')) die('skip: posix extension required');
 if (getenv('SKIP_ASAN') || getenv('USE_ZEND_ALLOC') === '0') die("skip: intentionally causes segfaults");
 if (file_exists("/etc/os-release") && preg_match("/alpine/i", file_get_contents("/etc/os-release"))) die("skip Unsupported LIBC");
 ?>

--- a/tests/ext/segfault_backtrace_enabled.phpt
+++ b/tests/ext/segfault_backtrace_enabled.phpt
@@ -2,6 +2,7 @@
 Dump backtrace when segmentation fault signal is raised and config enables it
 --SKIPIF--
 <?php
+if (!extension_loaded('posix')) die('skip: posix extension required');
 if (getenv('SKIP_ASAN') || getenv('USE_ZEND_ALLOC') === '0') die("skip: intentionally causes segfaults");
 if (file_exists("/etc/os-release") && preg_match("/alpine/i", file_get_contents("/etc/os-release"))) die("skip Unsupported LIBC");
 ?>


### PR DESCRIPTION
### Description

This is a followup PR to #1181 which addressed #1157 when the tracer was installed from source. However, the prebuilt packages are built on a machine that has ext/curl enabled as part of the PHP build. This results in the `undefined symbol: curl_multi_ce` error when the PHP tracer is installed from a prebuilt package and ext/curl is loaded as a shared library.

This PR removes the dependency on the `ext/curl/php_curl.h` header entirely and always resolves the curl symbols at runtime.

To test this (on Debian), the phpt tests are run in CI after installing the tracer from a `.deb` package and then tested again after compiling from source. It is tested on a minimum build of PHP (`--disable-all`) to ensure maximum missing symbols from extensions.

Thank you to @metaxy for the followup report!

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
