### PR TITLE
Release 0.58.0

### DIFF
--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.58.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,17 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ### Added
+    - ZAI SAPI #1204
+    - [ZAI SAPI] Add test helpers #1208
+    - Add a Kubernetes example to container tagging tests #1206
+    - Add Buster containers for PHP 5.4 through 7.4 #1201
+    ### Changed
+    - Remove PHP version prefix from buster development containers #1203
+    ### Fixed
+    - handle laravel 7+ generated:: prefix for unnamed routes #1198
+    </notes>
     <contents>
         <dir name="/">
             <!-- components -->

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.58.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Description

Release 0.58.0

**Note to the reviewer**
- Randomized test failure is not related to a code flaw, is an operation issue.
- Failures on 8 are known and are only a CI issue, not a code issue. will be fixed once  https://github.com/DataDog/dd-trace-php/pull/1210 gets merged.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
