### PR TITLE
[ZAI SAPI] Zai\trigger_error() SAPI function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!dockerfiles/**/*' '!tests/ext/sandbox/**' '!tests/ext/sandbox-prehook/*' '!tests/ext/background-sender/**/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!ext/vendor/**/*' '!ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.*.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!LICENSE.*' '!tooling/*' '!tests/randomized/**' '!components/*/tests/stubs/**' '!**/CMakeLists.txt' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!dockerfiles/**/*' '!tests/ext/sandbox/**' '!tests/ext/sandbox-prehook/*' '!tests/ext/background-sender/**/*' '!config.*' '!m4/*' '!tmp/**/*' '!vendor/**/*' '!ext/vendor/**/*' '!ext/.libs/*' '!src/dogstatsd/**' '!LICENSE' '!phpstan.*.neon' '!tests/overhead/**' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!LICENSE.*' '!tooling/*' '!tests/randomized/**' '!**/tests/stubs/**' '!**/CMakeLists.txt' || touch .failure
       - run:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -50,5 +50,6 @@
     <exclude-pattern>tests/overhead/*</exclude-pattern>
     <exclude-pattern>tests/Frameworks/*/Version_*/*</exclude-pattern>
     <exclude-pattern>tests/AutoInstrumentation</exclude-pattern>
+    <exclude-pattern>*/tests/stubs/*</exclude-pattern>
     <exclude-pattern>tmp</exclude-pattern>
 </ruleset>

--- a/config.m4
+++ b/config.m4
@@ -85,6 +85,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
       zend_abstract_interface/zai_sapi/zai_sapi_io.c \
     "
@@ -125,6 +126,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
       zend_abstract_interface/zai_sapi/zai_sapi_io.c \
     "
@@ -169,6 +171,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/zai_sapi/php7/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
       zend_abstract_interface/zai_sapi/zai_sapi_io.c \
     "
@@ -213,6 +216,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
+      zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
       zend_abstract_interface/zai_sapi/zai_sapi_io.c \
     "

--- a/package.xml
+++ b/package.xml
@@ -52,6 +52,8 @@
             <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php8/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi.h" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_functions.c" role="src" />
+            <file name="zend_abstract_interface/zai_sapi/zai_sapi_functions.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_ini.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_ini.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_io.c" role="src" />

--- a/zend_abstract_interface/zai_sapi/CMakeLists.txt
+++ b/zend_abstract_interface/zai_sapi/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(zai_sapi "zai_sapi_ini.c" "zai_sapi_io.c"
+add_library(zai_sapi zai_sapi_functions.c zai_sapi_ini.c zai_sapi_io.c
                      "${PHP_VERSION_DIRECTORY}/zai_sapi.c")
 
 target_include_directories(zai_sapi
@@ -21,6 +21,7 @@ endif()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi_functions.h
               ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi_ini.h
               ${CMAKE_CURRENT_SOURCE_DIR}/zai_sapi_io.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zai_sapi/)

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -4,6 +4,7 @@
 #include <main/php_main.h>
 #include <main/php_variables.h>
 
+#include "../zai_sapi_functions.h"
 #include "../zai_sapi_ini.h"
 #include "../zai_sapi_io.h"
 
@@ -110,8 +111,10 @@ static sapi_module_struct zai_module = {
     NULL, /* ini_defaults            */
     0,    /* phpinfo_as_text;        */
     NULL, /* ini_entries;            */
-    NULL, /* additional_functions    */
-    NULL  /* input_filter_init       */
+
+    zai_sapi_functions, /* additional_functions */
+
+    NULL /* input_filter_init */
 };
 
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
@@ -159,14 +162,6 @@ bool zai_sapi_sinit(void) {
 
     /* Show phpinfo()/module info as plain text. */
     zai_module.phpinfo_as_text = 1;
-
-    /* TODO: When we want to expose a function to userland for testing purposes
-     * (e.g. DDTrace\Testing\trigger_error()), we can add them as custom SAPI
-     * functions here. These functions will only exist in the ZAI SAPI for
-     * testing at the C unit test level and will not be shipped as a public
-     * userland API in the PHP tracer.
-     */
-    zai_module.additional_functions = NULL;
 
     return true;
 }
@@ -225,4 +220,16 @@ bool zai_sapi_execute_script(const char *file) {
     handle.filename = file;
 
     return zend_execute_scripts(ZEND_REQUIRE TSRMLS_CC, NULL, 1, &handle) == SUCCESS;
+}
+
+bool zai_sapi_last_error_message_eq(const char *msg) {
+    TSRMLS_FETCH();
+    if (msg == NULL) return PG(last_error_message) == NULL;
+    if (PG(last_error_message) == NULL) return false;
+    return strcmp(msg, PG(last_error_message)) == 0;
+}
+
+bool zai_sapi_last_error_type_eq(int error_type) {
+    TSRMLS_FETCH();
+    return PG(last_error_type) == error_type;
 }

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -4,6 +4,7 @@
 #include <main/php_main.h>
 #include <main/php_variables.h>
 
+#include "../zai_sapi_functions.h"
 #include "../zai_sapi_ini.h"
 #include "../zai_sapi_io.h"
 
@@ -101,8 +102,10 @@ static sapi_module_struct zai_module = {
     NULL, /* ini_defaults            */
     0,    /* phpinfo_as_text;        */
     NULL, /* ini_entries;            */
-    NULL, /* additional_functions    */
-    NULL  /* input_filter_init       */
+
+    zai_sapi_functions, /* additional_functions */
+
+    NULL /* input_filter_init */
 };
 
 bool zai_sapi_append_system_ini_entry(const char *key, const char *value) {
@@ -166,14 +169,6 @@ bool zai_sapi_sinit(void) {
     /* Show phpinfo()/module info as plain text. */
     zai_module.phpinfo_as_text = 1;
 
-    /* TODO: When we want to expose a function to userland for testing purposes
-     * (e.g. DDTrace\Testing\trigger_error()), we can add them as custom SAPI
-     * functions here. These functions will only exist in the ZAI SAPI for
-     * testing at the C unit test level and will not be shipped as a public
-     * userland API in the PHP tracer.
-     */
-    zai_module.additional_functions = NULL;
-
     return true;
 }
 
@@ -227,3 +222,11 @@ bool zai_sapi_execute_script(const char *file) {
 
     return zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &handle) == SUCCESS;
 }
+
+bool zai_sapi_last_error_message_eq(const char *msg) {
+    if (msg == NULL) return PG(last_error_message) == NULL;
+    if (PG(last_error_message) == NULL) return false;
+    return strcmp(msg, PG(last_error_message)) == 0;
+}
+
+bool zai_sapi_last_error_type_eq(int error_type) { return PG(last_error_type) == error_type; }

--- a/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
+++ b/zend_abstract_interface/zai_sapi/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_executable(zai_sapi_tests zai_sapi.cc zai_sapi_ini.cc zai_sapi_io.cc)
+add_executable(zai_sapi_tests zai_sapi.cc zai_sapi_functions.cc zai_sapi_ini.cc
+                              zai_sapi_io.cc)
 
 target_link_libraries(zai_sapi_tests PUBLIC catch2_main Zai::Sapi)
 

--- a/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_CORE_ERROR.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_CORE_ERROR.php
@@ -1,0 +1,10 @@
+<?php
+
+function doError()
+{
+    var_dump(Zai\trigger_error('My E_CORE_ERROR', E_CORE_ERROR));
+}
+
+doError();
+
+echo 'Done.' . PHP_EOL;

--- a/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_ERROR.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_ERROR.php
@@ -1,0 +1,10 @@
+<?php
+
+function doError()
+{
+    var_dump(Zai\trigger_error('My E_ERROR', E_ERROR));
+}
+
+doError();
+
+echo 'Done.' . PHP_EOL;

--- a/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_NOTICE.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_NOTICE.php
@@ -1,0 +1,10 @@
+<?php
+
+function doError()
+{
+    var_dump(Zai\trigger_error('My E_NOTICE', E_NOTICE));
+}
+
+doError();
+
+echo 'Done.' . PHP_EOL;

--- a/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_WARNING.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_E_WARNING.php
@@ -1,0 +1,10 @@
+<?php
+
+function doError()
+{
+    var_dump(Zai\trigger_error('My E_WARNING', E_WARNING));
+}
+
+doError();
+
+echo 'Done.' . PHP_EOL;

--- a/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_invalid.php
+++ b/zend_abstract_interface/zai_sapi/tests/stubs/trigger_error_invalid.php
@@ -1,0 +1,10 @@
+<?php
+
+function doError()
+{
+    var_dump(Zai\trigger_error('My INVALID_ERROR', 9999999999));
+}
+
+doError();
+
+echo 'Done.' . PHP_EOL;

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi_functions.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi_functions.cc
@@ -1,0 +1,72 @@
+extern "C" {
+#include "zai_sapi/zai_sapi.h"
+}
+
+#include <catch2/catch.hpp>
+
+/**************************** Zai\trigger_error() ****************************/
+
+TEST_CASE("trigger_error: E_CORE_ERROR", "[zai_sapi_functions]") {
+    REQUIRE(zai_sapi_spinup());
+
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_CORE_ERROR.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_type_eq(E_CORE_ERROR));
+    REQUIRE(zai_sapi_last_error_message_eq("My E_CORE_ERROR"));
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("trigger_error: E_ERROR", "[zai_sapi_functions]") {
+    REQUIRE(zai_sapi_spinup());
+
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_ERROR.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_type_eq(E_ERROR));
+    REQUIRE(zai_sapi_last_error_message_eq("My E_ERROR"));
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("trigger_error: E_NOTICE", "[zai_sapi_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_E_NOTICE.php"));
+
+    REQUIRE(zai_sapi_last_error_type_eq(E_NOTICE));
+    REQUIRE(zai_sapi_last_error_message_eq("My E_NOTICE"));
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("trigger_error: E_WARNING", "[zai_sapi_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_E_WARNING.php"));
+
+    REQUIRE(zai_sapi_last_error_type_eq(E_WARNING));
+    REQUIRE(zai_sapi_last_error_message_eq("My E_WARNING"));
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("trigger_error: invalid error type returns NULL", "[zai_sapi_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_invalid.php"));
+
+    REQUIRE(zai_sapi_last_error_type_eq(0));
+    REQUIRE(zai_sapi_last_error_message_eq(NULL));
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -78,6 +78,14 @@ bool zai_sapi_append_system_ini_entry(const char *key, const char *value);
  */
 bool zai_sapi_execute_script(const char *file);
 
+/* Returns true if 'msg' exactly matches the last error message from PHP
+ * globals.
+ */
+bool zai_sapi_last_error_message_eq(const char *msg);
+
+/* Returns true if 'error_type' equals the last error type from PHP globals. */
+bool zai_sapi_last_error_type_eq(int error_type);
+
 /* Handling zend_bailout
  *
  * A test will provide a false-positive when a component calls zend_bailout.

--- a/zend_abstract_interface/zai_sapi/zai_sapi_functions.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_functions.c
@@ -1,0 +1,67 @@
+#include "zai_sapi_functions.h"
+
+#if PHP_VERSION_ID < 70000
+#define UNUSED_PHP_FN_VARS()   \
+    (void)(ht);                \
+    (void)(return_value_ptr);  \
+    (void)(return_value_used); \
+    (void)(this_ptr)
+#else
+#define UNUSED_PHP_FN_VARS()
+#endif
+
+/* Triggers an arbitrary error from userland.
+ *
+ * Zai\trigger_error(string message, int error_level): void
+ */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_trigger_error, 0, 0, 2)
+ZEND_ARG_INFO(0, level)
+ZEND_ARG_INFO(0, message)
+ZEND_END_ARG_INFO()
+
+static PHP_FUNCTION(trigger_error) {
+    UNUSED_PHP_FN_VARS();
+#if PHP_VERSION_ID < 70000
+    char *msg;
+    int msg_len = 0;
+    long error_type = 0;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &msg, &msg_len, &error_type) != SUCCESS) RETURN_NULL();
+#else
+    zend_string *message;
+    zend_long error_type = 0;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sl", &message, &error_type) != SUCCESS) RETURN_NULL();
+
+    const char *msg = ZSTR_VAL(message);
+#endif
+
+    int level = (int)error_type;
+    switch (level) {
+        case E_ERROR:
+        case E_WARNING:
+        case E_PARSE:
+        case E_NOTICE:
+        case E_CORE_ERROR:
+        case E_CORE_WARNING:
+        case E_COMPILE_ERROR:
+        case E_USER_ERROR:
+        case E_USER_WARNING:
+        case E_USER_NOTICE:
+        case E_STRICT:
+        case E_RECOVERABLE_ERROR:
+        case E_DEPRECATED:
+        case E_USER_DEPRECATED:
+            zend_error(level, "%s", msg);
+            break;
+
+        default:
+            RETURN_NULL();
+            break;
+    }
+}
+
+// clang-format off
+const zend_function_entry zai_sapi_functions[] = {
+    ZEND_NS_FE("Zai", trigger_error, arginfo_trigger_error)
+    PHP_FE_END
+};
+// clang-format on

--- a/zend_abstract_interface/zai_sapi/zai_sapi_functions.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_functions.h
@@ -1,0 +1,11 @@
+#ifndef ZAI_SAPI_FUNCTIONS_H
+#define ZAI_SAPI_FUNCTIONS_H
+
+#include <main/php.h>
+
+/* These functions only exist in the ZAI SAPI for testing at the C unit test
+ * level and are not shipped as a public userland API in the PHP tracer.
+ */
+extern const zend_function_entry zai_sapi_functions[];
+
+#endif  // ZAI_SAPI_FUNCTIONS_H


### PR DESCRIPTION
### Description

This copies `DDTrace\Testing\trigger_error()` into the ZAI SAPI as `Zai\trigger_error()`. This will be necessary to test an upcoming PR that adds ZAI sandboxing.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
