### PR TITLE
ZAI Sandbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,31 +1017,74 @@ jobs:
             cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2
             cmake --build build/ --target install
 
-      - run:
-          name: Build and test Zend Abstract Interface (ASan)
-          command: |
-            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
-            mkdir -p /tmp/build/zai_asan
-            cd /tmp/build/zai_asan
-            if [ "<< parameters.php_version >>" = "7.4" || "<< parameters.php_version >>" = "8.0" ]
-            then
-              toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
-            fi
-            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
-              ${toolchain} \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_ZAI_TESTING=ON \
-              -DPHP_CONFIG=$(which php-config) \
-              ~/datadog/zend_abstract_interface
-            make -j all
-            make test
+      # Builds that support ASan
+      - when:
+          condition:
+            or:
+              - equal: [ "7.4", << parameters.php_version >> ]
+              - equal: [ "8.0", << parameters.php_version >> ]
+          steps:
+            - run:
+                name: Build and test Zend Abstract Interface (nts, debug, debug-zts-asan)
+                command: |
+                  export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+                  for phpBuild in nts debug debug-zts-asan
+                  do
+                    switch-php ${phpBuild}
+                    mkdir -p /tmp/build/zai-${phpBuild}
+                    cd /tmp/build/zai-${phpBuild}
+                    toolchain=""
+                    if [ "${phpBuild}" = "debug-zts-asan" ]
+                    then
+                      toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+                    fi
+                    CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+                      ${toolchain} \
+                      -DCMAKE_BUILD_TYPE=Debug \
+                      -DBUILD_ZAI_TESTING=ON \
+                      -DPHP_CONFIG=$(which php-config) \
+                      ~/datadog/zend_abstract_interface
+                    make -j all
+                    make test
+                  done
+
+      # Builds that do not support ASan
+      - when:
+          condition:
+            or:
+              - equal: [ "5.4", << parameters.php_version >> ]
+              - equal: [ "5.5", << parameters.php_version >> ]
+              - equal: [ "5.6", << parameters.php_version >> ]
+              - equal: [ "7.0", << parameters.php_version >> ]
+              - equal: [ "7.1", << parameters.php_version >> ]
+              - equal: [ "7.2", << parameters.php_version >> ]
+              - equal: [ "7.3", << parameters.php_version >> ]
+          steps:
+            - run:
+                name: Build and test Zend Abstract Interface (nts, debug, debug-zts)
+                command: |
+                  export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+                  for phpBuild in nts debug debug-zts
+                  do
+                    switch-php ${phpBuild}
+                    mkdir -p /tmp/build/zai-${phpBuild}
+                    cd /tmp/build/zai-${phpBuild}
+                    CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+                      -DCMAKE_BUILD_TYPE=Debug \
+                      -DBUILD_ZAI_TESTING=ON \
+                      -DPHP_CONFIG=$(which php-config) \
+                      ~/datadog/zend_abstract_interface
+                    make -j all
+                    make test
+                  done
 
       - run:
-          name: Build and test Zend Abstract Interface (UBSan)
+          name: Build and test Zend Abstract Interface (debug + UBSan)
           command: |
+            switch-php debug
             export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
-            mkdir -p /tmp/build/zai_ubsan
-            cd /tmp/build/zai_ubsan
+            mkdir -p /tmp/build/zai-debug-ubsan
+            cd /tmp/build/zai-debug-ubsan
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               -DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/ubsan.cmake \
               -DCMAKE_BUILD_TYPE=Debug \
@@ -1054,8 +1097,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/artifacts
-            cp /tmp/build/zai_asan/Testing/Temporary/LastTest.log /tmp/artifacts/LastTestASan.log
-            cp /tmp/build/zai_ubsan/Testing/Temporary/LastTest.log /tmp/artifacts/LastTestUBSan.log
+            cp --parents /tmp/build/zai-*/Testing/Temporary/LastTest.log /tmp/artifacts/
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts

--- a/config.m4
+++ b/config.m4
@@ -84,6 +84,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/sandbox/php5/sandbox.c \
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
@@ -125,6 +126,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/sandbox/php5/sandbox.c \
       zend_abstract_interface/zai_sapi/php5/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
@@ -170,6 +172,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/sandbox/php7/sandbox.c \
       zend_abstract_interface/zai_sapi/php7/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
@@ -215,6 +218,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/sandbox/php8/sandbox.c \
       zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
       zend_abstract_interface/zai_sapi/zai_sapi_ini.c \
@@ -246,6 +250,10 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir/zend_abstract_interface])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php5])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php7])

--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,10 @@
             <file name="components/string_view/string_view.h" role="src" />
 
             <!-- Zend Abstract Interface -->
+            <file name="zend_abstract_interface/sandbox/php5/sandbox.c" role="src" />
+            <file name="zend_abstract_interface/sandbox/php7/sandbox.c" role="src" />
+            <file name="zend_abstract_interface/sandbox/php8/sandbox.c" role="src" />
+            <file name="zend_abstract_interface/sandbox/sandbox.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php5/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php8/zai_sapi.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -76,6 +76,7 @@ else()
 endif()
 
 add_subdirectory(zai_sapi)
+add_subdirectory(sandbox)
 
 install(EXPORT ZendAbstractInterfaceTargets
         FILE ZendAbstractInterfaceTargets.cmake

--- a/zend_abstract_interface/sandbox/CMakeLists.txt
+++ b/zend_abstract_interface/sandbox/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_library(zai_sandbox "${PHP_VERSION_DIRECTORY}/sandbox.c")
+
+target_include_directories(zai_sandbox PUBLIC
+                                       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                       $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_sandbox PUBLIC c_std_99)
+
+target_link_libraries(zai_sandbox PUBLIC "${PHP_LIB}")
+
+set_target_properties(zai_sandbox PROPERTIES
+                                  EXPORT_NAME Sandbox
+                                  VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Sandbox ALIAS zai_sandbox)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+# TODO: How to make this zai/sandbox.h?
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sandbox.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sandbox/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_sandbox)
+
+install(TARGETS zai_sandbox EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/sandbox/php5/sandbox.c
+++ b/zend_abstract_interface/sandbox/php5/sandbox.c
@@ -1,0 +1,10 @@
+#include "../sandbox.h"
+
+extern inline void zai_sandbox_open_ex(zai_sandbox *sandbox TSRMLS_DC);
+extern inline void zai_sandbox_close_ex(zai_sandbox *sandbox TSRMLS_DC);
+
+extern inline void zai_sandbox_error_state_backup_ex(zai_error_state *es TSRMLS_DC);
+extern inline void zai_sandbox_error_state_restore_ex(zai_error_state *es TSRMLS_DC);
+
+extern inline void zai_sandbox_exception_state_backup_ex(zai_exception_state *es TSRMLS_DC);
+extern inline void zai_sandbox_exception_state_restore_ex(zai_exception_state *es TSRMLS_DC);

--- a/zend_abstract_interface/sandbox/php7/sandbox.c
+++ b/zend_abstract_interface/sandbox/php7/sandbox.c
@@ -1,0 +1,10 @@
+#include "../sandbox.h"
+
+extern inline void zai_sandbox_open(zai_sandbox *sandbox);
+extern inline void zai_sandbox_close(zai_sandbox *sandbox);
+
+extern inline void zai_sandbox_error_state_backup(zai_error_state *es);
+extern inline void zai_sandbox_error_state_restore(zai_error_state *es);
+
+extern inline void zai_sandbox_exception_state_backup(zai_exception_state *es);
+extern inline void zai_sandbox_exception_state_restore(zai_exception_state *es);

--- a/zend_abstract_interface/sandbox/php8/sandbox.c
+++ b/zend_abstract_interface/sandbox/php8/sandbox.c
@@ -1,0 +1,10 @@
+#include "../sandbox.h"
+
+extern inline void zai_sandbox_open(zai_sandbox *sandbox);
+extern inline void zai_sandbox_close(zai_sandbox *sandbox);
+
+extern inline void zai_sandbox_error_state_backup(zai_error_state *es);
+extern inline void zai_sandbox_error_state_restore(zai_error_state *es);
+
+extern inline void zai_sandbox_exception_state_backup(zai_exception_state *es);
+extern inline void zai_sandbox_exception_state_restore(zai_exception_state *es);

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -82,6 +82,7 @@ typedef struct zai_error_state_s {
 typedef struct zai_exception_state_s {
     zend_object *exception;
     zend_object *prev_exception;
+    const zend_op *opline_before_exception;
 } zai_exception_state;
 
 typedef struct zai_sandbox_s {
@@ -126,13 +127,15 @@ inline void zai_sandbox_error_state_restore(zai_error_state *es) {
 }
 
 inline void zai_sandbox_exception_state_backup(zai_exception_state *es) {
-    es->exception = NULL;
-    es->prev_exception = NULL;
-    if (EG(exception)) {
+    if (UNEXPECTED(EG(exception) != NULL)) {
         es->exception = EG(exception);
         es->prev_exception = EG(prev_exception);
+        es->opline_before_exception = EG(opline_before_exception);
         EG(exception) = NULL;
         EG(prev_exception) = NULL;
+    } else {
+        es->exception = NULL;
+        es->prev_exception = NULL;
     }
 }
 
@@ -144,8 +147,7 @@ inline void zai_sandbox_exception_state_restore(zai_exception_state *es) {
     if (es->exception) {
         EG(exception) = es->exception;
         EG(prev_exception) = es->prev_exception;
-
-        zend_throw_exception_internal(NULL);
+        EG(opline_before_exception) = es->opline_before_exception;
     }
 }
 
@@ -175,6 +177,7 @@ typedef struct zai_error_state_s {
 typedef struct zai_exception_state_s {
     zend_object *exception;
     zend_object *prev_exception;
+    const zend_op *opline_before_exception;
 } zai_exception_state;
 
 typedef struct zai_sandbox_s {
@@ -219,13 +222,15 @@ inline void zai_sandbox_error_state_restore(zai_error_state *es) {
 }
 
 inline void zai_sandbox_exception_state_backup(zai_exception_state *es) {
-    es->exception = NULL;
-    es->prev_exception = NULL;
-    if (EG(exception)) {
+    if (UNEXPECTED(EG(exception) != NULL)) {
         es->exception = EG(exception);
         es->prev_exception = EG(prev_exception);
+        es->opline_before_exception = EG(opline_before_exception);
         EG(exception) = NULL;
         EG(prev_exception) = NULL;
+    } else {
+        es->exception = NULL;
+        es->prev_exception = NULL;
     }
 }
 
@@ -237,8 +242,7 @@ inline void zai_sandbox_exception_state_restore(zai_exception_state *es) {
     if (es->exception) {
         EG(exception) = es->exception;
         EG(prev_exception) = es->prev_exception;
-
-        zend_throw_exception_internal(NULL);
+        EG(opline_before_exception) = es->opline_before_exception;
     }
 }
 
@@ -311,14 +315,15 @@ inline void zai_sandbox_error_state_restore_ex(zai_error_state *es TSRMLS_DC) {
 }
 
 inline void zai_sandbox_exception_state_backup_ex(zai_exception_state *es TSRMLS_DC) {
-    es->exception = NULL;
-    es->prev_exception = NULL;
-    if (EG(exception)) {
+    if (UNEXPECTED(EG(exception) != NULL)) {
         es->opline_before_exception = EG(opline_before_exception);
         es->exception = EG(exception);
         es->prev_exception = EG(prev_exception);
         EG(exception) = NULL;
         EG(prev_exception) = NULL;
+    } else {
+        es->exception = NULL;
+        es->prev_exception = NULL;
     }
 }
 
@@ -341,7 +346,6 @@ inline void zai_sandbox_exception_state_restore_ex(zai_exception_state *es TSRML
     if (es->exception) {
         EG(exception) = es->exception;
         EG(prev_exception) = es->prev_exception;
-
         EG(opline_before_exception) = es->opline_before_exception;
 #if PHP_VERSION_ID >= 50500
         EG(current_execute_data)->opline = EG(exception_op);

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -1,0 +1,374 @@
+#ifndef ZAI_SANDBOX_H
+#define ZAI_SANDBOX_H
+
+#include <main/php.h>
+#include <stdbool.h>
+
+/* Work in progress
+ *
+ * The long-term goal is to provide version-agnostic ZAI error types that have
+ * sandboxing capabilities baked in. For now this is a direct migration of the
+ * existing ddtrace sandbox API.
+ */
+
+/******************************************************************************
+ ************** WARNING: The sandbox does NOT catch zend_bailout **************
+ ******************************************************************************
+ *** The sandbox API is only concerned with backing up and restoring error  ***
+ *** and exception state. Fatal errors are always accompanied by a          ***
+ *** zend_bailout but a zend_bailout may occur in unsuspecting code paths   ***
+ *** therefore usage of the sandbox API MUST be accompanied by a 'zend_try' ***
+ *** block to catch a possible zend_bailout.                                ***
+ ******************************************************************************
+ ******************************************************************************
+ */
+
+/* Obscured in the compiler directives below are the following APIs: */
+
+/* ######## Error & exception sandbox (Does NOT catch a zend_bailout) #########
+ *
+ * Convenience function that backs up the error and exception states using the
+ * 'zai_sandbox_*_backup' APIs below.
+ *
+ *     void zai_sandbox_open(zai_sandbox *sandbox);
+ *
+ * Convenience function that restores the error and exception states using the
+ * 'zai_sandbox_*_restore' APIs below.
+ *
+ *     void zai_sandbox_close(zai_sandbox *sandbox);
+ */
+
+/* ########### Error state sandbox (Does NOT catch a zend_bailout) ############
+ *
+ * Backs up the error handler and the active error if present. Disables
+ * 'EH_NORMAL' error handling so that user error handlers are not called.
+ * Provides a clean slate of error state.
+ *
+ *     void zai_sandbox_error_state_backup(zai_error_state *es);
+ *
+ * Restores the error handler back to 'EH_NORMAL'. Clears any errors
+ * encountered since the backup. If an error was present during backup, the
+ * error is restored.
+ *
+ *     void zai_sandbox_error_state_restore(zai_error_state *es);
+ */
+
+/* ######### Exception state sandbox (Does NOT catch a zend_bailout) ##########
+ *
+ * Backs up exception state if there is an unhandled exception present during
+ * backup. Provides a clean slate of exception state.
+ *
+ *     void zai_sandbox_exception_state_backup(zai_exception_state *es);
+ *
+ * Restores the exception state that was present during backup. Clears any
+ * unhandled exception state that may have occurred since the last backup.
+ *
+ *     void zai_sandbox_exception_state_restore(zai_exception_state *es);
+ */
+
+#if PHP_VERSION_ID >= 80000
+/********************************** <PHP 8> **********************************/
+#include <Zend/zend_exceptions.h>
+
+typedef struct zai_error_state_s {
+    int type;
+    int lineno;
+    zend_string *message;
+    char *file;
+    int error_reporting;
+    zend_error_handling error_handling;
+} zai_error_state;
+
+typedef struct zai_exception_state_s {
+    zend_object *exception;
+    zend_object *prev_exception;
+} zai_exception_state;
+
+typedef struct zai_sandbox_s {
+    zai_error_state error_state;
+    zai_exception_state exception_state;
+} zai_sandbox;
+
+inline void zai_sandbox_error_state_backup(zai_error_state *es) {
+    es->type = PG(last_error_type);
+    es->lineno = PG(last_error_lineno);
+    es->message = PG(last_error_message);
+    es->file = PG(last_error_file);
+
+    PG(last_error_type) = 0;
+    PG(last_error_lineno) = 0;
+    /* We need to null these so that if another error comes along they do not
+     * get double-freed.
+     */
+    PG(last_error_message) = NULL;
+    PG(last_error_file) = NULL;
+
+    es->error_reporting = EG(error_reporting);
+    EG(error_reporting) = 0;
+    zend_replace_error_handling(EH_THROW, NULL, &es->error_handling);
+}
+
+inline void zai_sandbox_error_state_restore(zai_error_state *es) {
+    if (PG(last_error_message)) {
+        if (PG(last_error_message) != es->message) {
+            zend_string_release(PG(last_error_message));
+        }
+        if (PG(last_error_file) != es->file) {
+            free(PG(last_error_file));
+        }
+    }
+    zend_restore_error_handling(&es->error_handling);
+    PG(last_error_type) = es->type;
+    PG(last_error_message) = es->message;
+    PG(last_error_file) = es->file;
+    PG(last_error_lineno) = es->lineno;
+    EG(error_reporting) = es->error_reporting;
+}
+
+inline void zai_sandbox_exception_state_backup(zai_exception_state *es) {
+    es->exception = NULL;
+    es->prev_exception = NULL;
+    if (EG(exception)) {
+        es->exception = EG(exception);
+        es->prev_exception = EG(prev_exception);
+        EG(exception) = NULL;
+        EG(prev_exception) = NULL;
+    }
+}
+
+inline void zai_sandbox_exception_state_restore(zai_exception_state *es) {
+    if (EG(exception)) {
+        zend_clear_exception();
+    }
+
+    if (es->exception) {
+        EG(exception) = es->exception;
+        EG(prev_exception) = es->prev_exception;
+
+        zend_throw_exception_internal(NULL);
+    }
+}
+
+inline void zai_sandbox_open(zai_sandbox *sandbox) {
+    zai_sandbox_exception_state_backup(&sandbox->exception_state);
+    zai_sandbox_error_state_backup(&sandbox->error_state);
+}
+
+inline void zai_sandbox_close(zai_sandbox *sandbox) {
+    zai_sandbox_error_state_restore(&sandbox->error_state);
+    zai_sandbox_exception_state_restore(&sandbox->exception_state);
+}
+/********************************** </PHP 8> *********************************/
+#elif PHP_VERSION_ID >= 70000
+/********************************** <PHP 7> **********************************/
+#include <Zend/zend_exceptions.h>
+
+typedef struct zai_error_state_s {
+    int type;
+    int lineno;
+    char *message;
+    char *file;
+    int error_reporting;
+    zend_error_handling error_handling;
+} zai_error_state;
+
+typedef struct zai_exception_state_s {
+    zend_object *exception;
+    zend_object *prev_exception;
+} zai_exception_state;
+
+typedef struct zai_sandbox_s {
+    zai_error_state error_state;
+    zai_exception_state exception_state;
+} zai_sandbox;
+
+inline void zai_sandbox_error_state_backup(zai_error_state *es) {
+    es->type = PG(last_error_type);
+    es->lineno = PG(last_error_lineno);
+    es->message = PG(last_error_message);
+    es->file = PG(last_error_file);
+
+    PG(last_error_type) = 0;
+    PG(last_error_lineno) = 0;
+    /* We need to null these so that if another error comes along they do not
+     * get double-freed.
+     */
+    PG(last_error_message) = NULL;
+    PG(last_error_file) = NULL;
+
+    es->error_reporting = EG(error_reporting);
+    EG(error_reporting) = 0;
+    zend_replace_error_handling(EH_THROW, NULL, &es->error_handling);
+}
+
+inline void zai_sandbox_error_state_restore(zai_error_state *es) {
+    if (PG(last_error_message)) {
+        if (PG(last_error_message) != es->message) {
+            free(PG(last_error_message));
+        }
+        if (PG(last_error_file) != es->file) {
+            free(PG(last_error_file));
+        }
+    }
+    zend_restore_error_handling(&es->error_handling);
+    PG(last_error_type) = es->type;
+    PG(last_error_message) = es->message;
+    PG(last_error_file) = es->file;
+    PG(last_error_lineno) = es->lineno;
+    EG(error_reporting) = es->error_reporting;
+}
+
+inline void zai_sandbox_exception_state_backup(zai_exception_state *es) {
+    es->exception = NULL;
+    es->prev_exception = NULL;
+    if (EG(exception)) {
+        es->exception = EG(exception);
+        es->prev_exception = EG(prev_exception);
+        EG(exception) = NULL;
+        EG(prev_exception) = NULL;
+    }
+}
+
+inline void zai_sandbox_exception_state_restore(zai_exception_state *es) {
+    if (EG(exception)) {
+        zend_clear_exception();
+    }
+
+    if (es->exception) {
+        EG(exception) = es->exception;
+        EG(prev_exception) = es->prev_exception;
+
+        zend_throw_exception_internal(NULL);
+    }
+}
+
+inline void zai_sandbox_open(zai_sandbox *sandbox) {
+    zai_sandbox_exception_state_backup(&sandbox->exception_state);
+    zai_sandbox_error_state_backup(&sandbox->error_state);
+}
+
+inline void zai_sandbox_close(zai_sandbox *sandbox) {
+    zai_sandbox_error_state_restore(&sandbox->error_state);
+    zai_sandbox_exception_state_restore(&sandbox->exception_state);
+}
+/********************************** </PHP 7> *********************************/
+#else
+/********************************** <PHP 5> **********************************/
+typedef struct zai_error_state_s {
+    int type;
+    int lineno;
+    char *message;
+    char *file;
+    int error_reporting;
+    zend_error_handling error_handling;
+} zai_error_state;
+
+typedef struct zai_exception_state_s {
+    zval *exception;
+    zval *prev_exception;
+    zend_op *opline_before_exception;
+} zai_exception_state;
+
+typedef struct zai_sandbox_s {
+    zai_error_state error_state;
+    zai_exception_state exception_state;
+} zai_sandbox;
+
+inline void zai_sandbox_error_state_backup_ex(zai_error_state *es TSRMLS_DC) {
+    es->type = PG(last_error_type);
+    es->lineno = PG(last_error_lineno);
+    es->message = PG(last_error_message);
+    es->file = PG(last_error_file);
+
+    PG(last_error_type) = 0;
+    PG(last_error_lineno) = 0;
+    /* We need to null these so that if another error comes along they do not
+     * get double-freed.
+     */
+    PG(last_error_message) = NULL;
+    PG(last_error_file) = NULL;
+
+    es->error_reporting = EG(error_reporting);
+    EG(error_reporting) = 0;
+    zend_replace_error_handling(EH_SUPPRESS, NULL, &es->error_handling TSRMLS_CC);
+}
+
+inline void zai_sandbox_error_state_restore_ex(zai_error_state *es TSRMLS_DC) {
+    if (PG(last_error_message)) {
+        if (PG(last_error_message) != es->message) {
+            free(PG(last_error_message));
+        }
+        if (PG(last_error_file) != es->file) {
+            free(PG(last_error_file));
+        }
+    }
+    zend_restore_error_handling(&es->error_handling TSRMLS_CC);
+    PG(last_error_type) = es->type;
+    PG(last_error_message) = es->message;
+    PG(last_error_file) = es->file;
+    PG(last_error_lineno) = es->lineno;
+    EG(error_reporting) = es->error_reporting;
+}
+
+inline void zai_sandbox_exception_state_backup_ex(zai_exception_state *es TSRMLS_DC) {
+    es->exception = NULL;
+    es->prev_exception = NULL;
+    if (EG(exception)) {
+        es->opline_before_exception = EG(opline_before_exception);
+        es->exception = EG(exception);
+        es->prev_exception = EG(prev_exception);
+        EG(exception) = NULL;
+        EG(prev_exception) = NULL;
+    }
+}
+
+inline void zai_sandbox_exception_state_restore_ex(zai_exception_state *es TSRMLS_DC) {
+    if (EG(exception)) {
+        /* We cannot use zend_clear_exception() here in PHP 5 since there is no
+         * NULL check on the opline.
+         */
+        zval_ptr_dtor(&EG(exception));
+        EG(exception) = NULL;
+        if (EG(prev_exception)) {
+            zval_ptr_dtor(&EG(prev_exception));
+            EG(prev_exception) = NULL;
+        }
+        if (EG(current_execute_data)) {
+            EG(current_execute_data)->opline = EG(opline_before_exception);
+        }
+    }
+
+    if (es->exception) {
+        EG(exception) = es->exception;
+        EG(prev_exception) = es->prev_exception;
+
+        EG(opline_before_exception) = es->opline_before_exception;
+#if PHP_VERSION_ID >= 50500
+        EG(current_execute_data)->opline = EG(exception_op);
+#endif
+    }
+}
+
+inline void zai_sandbox_open_ex(zai_sandbox *sandbox TSRMLS_DC) {
+    zai_sandbox_exception_state_backup_ex(&sandbox->exception_state TSRMLS_CC);
+    zai_sandbox_error_state_backup_ex(&sandbox->error_state TSRMLS_CC);
+}
+
+inline void zai_sandbox_close_ex(zai_sandbox *sandbox TSRMLS_DC) {
+    zai_sandbox_error_state_restore_ex(&sandbox->error_state TSRMLS_CC);
+    zai_sandbox_exception_state_restore_ex(&sandbox->exception_state TSRMLS_CC);
+}
+
+/* Mask away the TSRMLS_* macros with more macros */
+#define zai_sandbox_open(sandbox) zai_sandbox_open_ex(sandbox TSRMLS_CC)
+#define zai_sandbox_close(sandbox) zai_sandbox_close_ex(sandbox TSRMLS_CC)
+
+#define zai_sandbox_error_state_backup(es) zai_sandbox_error_state_backup_ex(es TSRMLS_CC)
+#define zai_sandbox_error_state_restore(es) zai_sandbox_error_state_restore_ex(es TSRMLS_CC)
+
+#define zai_sandbox_exception_state_backup(es) zai_sandbox_exception_state_backup_ex(es TSRMLS_CC)
+#define zai_sandbox_exception_state_restore(es) zai_sandbox_exception_state_restore_ex(es TSRMLS_CC)
+/********************************** </PHP 5> *********************************/
+#endif
+
+#endif  // ZAI_SANDBOX_H

--- a/zend_abstract_interface/sandbox/tests/CMakeLists.txt
+++ b/zend_abstract_interface/sandbox/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(sandbox sandbox.cc)
+
+target_link_libraries(sandbox PUBLIC catch2_main Zai::Sapi Zai::Sandbox)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(sandbox)

--- a/zend_abstract_interface/sandbox/tests/sandbox.cc
+++ b/zend_abstract_interface/sandbox/tests/sandbox.cc
@@ -464,7 +464,7 @@ static void zai_throw_exception_hook(zend_object *exception) {
     zai_throw_exception_hook_calls_count++;
 }
 #else
-static void zai_throw_exception_hook(zval *exception) {
+static void zai_throw_exception_hook(zval *exception TSRMLS_DC) {
     zai_throw_exception_hook_calls_count++;
 }
 #endif

--- a/zend_abstract_interface/sandbox/tests/sandbox.cc
+++ b/zend_abstract_interface/sandbox/tests/sandbox.cc
@@ -1,0 +1,726 @@
+extern "C" {
+#include "sandbox/sandbox.h"
+#include "zai_sapi/zai_sapi.h"
+}
+
+#include <catch2/catch.hpp>
+
+#define REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE()            \
+    REQUIRE(false == zai_sapi_unhandled_exception_exists()); \
+    REQUIRE(zai_sapi_last_error_is_empty());
+
+static int fatal_errors[] = {
+    E_COMPILE_ERROR,
+    E_CORE_ERROR,
+    E_ERROR,
+#if PHP_VERSION_ID >= 80000
+    /* Starting in PHP 8, E_PARSE and E_RECOVERABLE_ERROR were considered true
+     * fatal errors.
+     */
+    E_PARSE,
+    E_RECOVERABLE_ERROR,
+#endif
+    E_USER_ERROR,
+};
+
+static int non_fatal_errors[] = {
+    E_DEPRECATED,
+    E_NOTICE,
+    E_STRICT,
+    E_USER_DEPRECATED,
+    E_USER_NOTICE,
+};
+
+/* On PHP 7.0+ we set the error handler to EH_THROW but not all errors can
+ * convert to exceptions. These are the non-fatal errors that will throw.
+ */
+static int non_fatal_throwable_errors[] = {
+    E_COMPILE_WARNING,
+    E_CORE_WARNING,
+#if PHP_VERSION_ID <= 70000
+    /* Prior to PHP 8, E_RECOVERABLE_ERROR and E_PARSE were not treated as true
+     * fatal errors.
+     */
+    E_PARSE,
+    E_RECOVERABLE_ERROR,
+#endif
+    E_USER_WARNING,
+    E_WARNING,
+};
+
+/**************** zai_sandbox_error_state_{backup|restore}() *****************/
+
+TEST_CASE("error state: fatal errors", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    for (int error_type : fatal_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+        zend_error(error_type, "Foo fatal error");
+        ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: fatal errors restore to existing error", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_WARNING, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+
+    for (int error_type : fatal_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+        zend_error(error_type, "Foo fatal error");
+        ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: non-fatal errors", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    for (int error_type : non_fatal_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+        zend_error(error_type, "Foo non-fatal error");
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo non-fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: non-fatal errors restore to existing error", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_NOTICE, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Original non-fatal error"));
+
+    for (int error_type : non_fatal_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+        zend_error(error_type, "Foo non-fatal error");
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo non-fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Original non-fatal error"));
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: fatal-error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_error_state es;
+    zai_sandbox_error_state_backup(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_ERROR.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_ERROR, "My E_ERROR"));
+
+    zai_sandbox_error_state_restore(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: non-fatal error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    zai_error_state es;
+    zai_sandbox_error_state_backup(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_E_NOTICE.php"));
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "My E_NOTICE"));
+
+    zai_sandbox_error_state_restore(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_spindown();
+}
+
+#if PHP_VERSION_ID >= 70000
+/* Although these are non-fatal errors, on PHP 7.0+ we have to set the error
+ * handler to EH_THROW since EH_SUPPRESS was removed from core in PHP 7.3. This
+ * means zend_bailout is expected for these non-fatal errors on PHP 7+ because
+ * they are converted into exceptions.
+ */
+TEST_CASE("error state: throwable non-fatal errors (PHP 7+)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    for (int error_type : non_fatal_throwable_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+        zend_error(error_type, "Foo throwable non-fatal error");
+        ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(E_ERROR, "Uncaught Exception: Foo throwable non-fatal error in [no active file]:0\nStack trace:\n#0 {main}\n  thrown"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: throwable non-fatal errors restore to existing error (PHP 7+)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_WARNING, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+
+    for (int error_type : non_fatal_throwable_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+        zend_error(error_type, "Foo throwable non-fatal error");
+        ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(E_ERROR, "Uncaught Exception: Foo throwable non-fatal error in [no active file]:0\nStack trace:\n#0 {main}\n  thrown"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+    }
+
+    zai_sapi_spindown();
+}
+#else
+/* In PHP 5 we set the error handler to EH_SUPPRESS so throwable non-fatal
+ * errors are just treated as normal non-fatal errors.
+ */
+TEST_CASE("error state: throwable non-fatal errors (PHP 5)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    for (int error_type : non_fatal_throwable_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+        zend_error(error_type, "Foo throwable non-fatal error");
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo throwable non-fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    }
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("error state: throwable non-fatal errors restore to existing error (PHP 5)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_WARNING, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+
+    for (int error_type : non_fatal_throwable_errors) {
+        zai_error_state es;
+        zai_sandbox_error_state_backup(&es);
+
+        REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+        zend_error(error_type, "Foo throwable non-fatal error");
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+        REQUIRE(zai_sapi_last_error_eq(error_type, "Foo throwable non-fatal error"));
+
+        zai_sandbox_error_state_restore(&es);
+
+        REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+    }
+
+    zai_sapi_spindown();
+}
+#endif
+
+/************** zai_sandbox_exception_state_{backup|restore}() ***************/
+
+TEST_CASE("exception state: throw exception", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    /* Exceptions thrown with zend_throw_exception will generate a fatal error
+     * if there is no active PHP frame. That is why we have to insert a fake
+     * frame before throwing the exception.
+     */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zai_exception_state es;
+    zai_sandbox_exception_state_backup(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    ce = zai_sapi_throw_exception("Foo exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+
+    zai_sandbox_exception_state_restore(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("exception state: existing unhandled exception", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    /* Throwing exceptions require an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zend_class_entry *orig_exception_ce = zai_sapi_throw_exception("Original exception");
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_exception_state es;
+    zai_sandbox_exception_state_backup(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    ce = zai_sapi_throw_exception("Foo exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+
+    zai_sandbox_exception_state_restore(&es);
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}
+
+/* TODO Test 'EG(prev_exception)' handling. The previous exception in the
+ * executor globals is set via zend_exception_save and is used in the VM when
+ * throwing exceptions and also for autoloading. This is different than
+ * 'Exception::$previous' which contains the previously caught exception. In
+ * order to test the former, the ZAI SAPI needs support VM runtime hooks like
+ * custom opcode handlers.
+ */
+//TEST_CASE("exception state: prev_exception", "[zai_sandbox]") {}
+
+TEST_CASE("exception state: throw exception (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_exception_state es;
+    zai_sandbox_exception_state_backup(&es);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+#if PHP_VERSION_ID >= 80000
+    /* Starting in PHP 8, uncaught exceptions have a clean shutdown with the
+     * introduction of E_DONT_BAIL.
+     *
+     * https://github.com/php/php-src/blob/php-8.0.0/Zend/zend_exceptions.c#L976-L978
+     */
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zai_sapi_execute_script("./stubs/throw_exception.php");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+#else
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/throw_exception.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+#endif
+
+    /* TODO The exception thrown in userland is handled and freed before the
+     * zend_bailout so we cannot access the exception after the zend_bailout.
+     * To access the userland exception, the ZAI SAPI must support arbitrary
+     * code execution during runtime (e.g. a custom opcode handler) that will
+     * fire after the exception is thrown and before ZEND_HANDLE_EXCEPTION is
+     * called.
+     */
+    //REQUIRE(zai_sapi_unhandled_exception_eq(userland_ce, "My foo exception"));
+
+    zai_sandbox_exception_state_restore(&es);
+
+    REQUIRE(false == zai_sapi_unhandled_exception_exists());
+    /* An uncaught exception changes the error state.
+     *
+     * TODO Support scanf-style formatted errors.
+     */
+    //REQUIRE(zai_sapi_last_error_eq(E_ERROR, "Fatal error - Uncaught Exception: My foo exception in %s:%d"));
+
+    zai_sapi_spindown();
+}
+
+/************************ zai_sandbox_{open|close}() *************************/
+
+TEST_CASE("sandbox error: fatal error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_ERROR.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_ERROR, "My E_ERROR"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox error: fatal error with existing error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_NOTICE, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Original non-fatal error"));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_ERROR.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_ERROR, "My E_ERROR"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Original non-fatal error"));
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox error: non-fatal error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_NOTICE.php");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "My E_NOTICE"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox error: non-fatal error with existing error (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_WARNING, "Original non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zai_sapi_execute_script("./stubs/trigger_error_E_NOTICE.php");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "My E_NOTICE"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox exception: throw exception", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    /* Throwing exceptions require an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    ce = zai_sapi_throw_exception("Foo exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox exception: existing unhandled exception", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    /* Throwing exceptions require an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zend_class_entry *orig_exception_ce;
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    orig_exception_ce = zai_sapi_throw_exception("Original exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    ce = zai_sapi_throw_exception("Foo exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox exception: throw exception (userland)", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+#if PHP_VERSION_ID >= 80000
+    /* Uncaught exceptions have a clean shutdown in PHP 8. */
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zai_sapi_execute_script("./stubs/throw_exception.php");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+#else
+    ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
+    zai_sapi_execute_script("./stubs/throw_exception.php");
+    ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
+#endif
+
+    /* TODO See comment from "exception state: throw exception (userland)". */
+    //REQUIRE(zai_sapi_unhandled_exception_eq(userland_ce, "My foo exception"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox: exception & error", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    /* Throwing exceptions require an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    ce = zai_sapi_throw_exception("Foo exception");
+    zend_error(E_NOTICE, "Foo non-fatal error");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Foo non-fatal error"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}
+
+TEST_CASE("sandbox: existing exception & existing error", "[zai_sandbox]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+
+    /* Throwing exceptions require an active execution context. */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zend_class_entry *orig_exception_ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_WARNING, "Original non-fatal error");
+    orig_exception_ce = zai_sapi_throw_exception("Original exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+
+    zend_class_entry *ce;
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+    zend_error(E_NOTICE, "Foo non-fatal error");
+    ce = zai_sapi_throw_exception("Foo exception");
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "Foo non-fatal error"));
+    REQUIRE(zai_sapi_unhandled_exception_eq(ce, "Foo exception"));
+
+    zai_sandbox_close(&sandbox);
+
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
+    REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    zai_sapi_spindown();
+}

--- a/zend_abstract_interface/sandbox/tests/stubs/throw_exception.php
+++ b/zend_abstract_interface/sandbox/tests/stubs/throw_exception.php
@@ -1,0 +1,8 @@
+<?php
+
+function doException()
+{
+    throw new Exception('My foo exception');
+}
+
+doException();

--- a/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_ERROR.php
+++ b/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_ERROR.php
@@ -1,0 +1,8 @@
+<?php
+
+function doError()
+{
+    Zai\trigger_error('My E_ERROR', E_ERROR);
+}
+
+doError();

--- a/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_NOTICE.php
+++ b/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_NOTICE.php
@@ -1,0 +1,8 @@
+<?php
+
+function doError()
+{
+    Zai\trigger_error('My E_NOTICE', E_NOTICE);
+}
+
+doError();

--- a/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_WARNING.php
+++ b/zend_abstract_interface/sandbox/tests/stubs/trigger_error_E_WARNING.php
@@ -1,0 +1,8 @@
+<?php
+
+function doError()
+{
+    Zai\trigger_error('My E_WARNING', E_WARNING);
+}
+
+doError();

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -1,5 +1,6 @@
 #include "../zai_sapi.h"
 
+#include <Zend/zend_exceptions.h>
 #include <main/SAPI.h>
 #include <main/php_main.h>
 #include <main/php_variables.h>
@@ -192,10 +193,47 @@ bool zai_sapi_execute_script(const char *file) {
     return zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &handle) == SUCCESS;
 }
 
-bool zai_sapi_last_error_message_eq(const char *msg) {
-    if (msg == NULL) return PG(last_error_message) == NULL;
-    if (PG(last_error_message) == NULL) return false;
+bool zai_sapi_fake_frame_push(zend_execute_data *frame) {
+    zend_function *func = zend_hash_str_find_ptr(EG(function_table), ZEND_STRL("zai\\noop"));
+    if (func) {
+        memset(frame, 0, sizeof(zend_execute_data));
+
+        frame->func = func;
+        frame->prev_execute_data = EG(current_execute_data);
+
+        EG(current_execute_data) = frame;
+        return true;
+    }
+    return false;
+}
+
+void zai_sapi_fake_frame_pop(zend_execute_data *frame) { EG(current_execute_data) = frame->prev_execute_data; }
+
+bool zai_sapi_last_error_eq(int error_type, const char *msg) {
+    if (PG(last_error_type) != error_type || PG(last_error_message) == NULL) return false;
     return strcmp(msg, ZSTR_VAL(PG(last_error_message))) == 0;
 }
 
-bool zai_sapi_last_error_type_eq(int error_type) { return PG(last_error_type) == error_type; }
+bool zai_sapi_last_error_is_empty(void) {
+    return PG(last_error_type) == 0 && PG(last_error_lineno) == 0 && PG(last_error_message) == NULL &&
+           PG(last_error_file) == NULL;
+}
+
+zend_class_entry *zai_sapi_throw_exception(const char *message) {
+    zend_class_entry *ce = zend_exception_get_default();
+    zend_throw_exception(ce, message, 0);
+    return ce;
+}
+
+bool zai_sapi_unhandled_exception_eq(zend_class_entry *ce, const char *message) {
+    if (!zai_sapi_unhandled_exception_exists()) return false;
+    if (ce != EG(exception)->ce) return false;
+
+    zval rv;
+    zval *zmsg = zend_read_property_ex(ce, EG(exception), ZSTR_KNOWN(ZEND_STR_MESSAGE), 1, &rv);
+    if (!zmsg && Z_TYPE_P(zmsg) != IS_STRING) return false;
+
+    return strcmp(Z_STRVAL_P(zmsg), message) == 0;
+}
+
+bool zai_sapi_unhandled_exception_exists(void) { return EG(exception) != NULL; }

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi.cc
@@ -9,6 +9,7 @@ TEST_CASE("eval: SAPI, modules, and request init/shutdown", "[zai_sapi]") {
     REQUIRE(zai_sapi_sinit());
     REQUIRE(zai_sapi_minit());
     REQUIRE(zai_sapi_rinit());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(ZAI_SAPI_EVAL_STR("echo 'Hello world' . PHP_EOL;") == SUCCESS);
@@ -21,6 +22,7 @@ TEST_CASE("eval: SAPI, modules, and request init/shutdown", "[zai_sapi]") {
 
 TEST_CASE("eval: spinup/spindown", "[zai_sapi]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(ZAI_SAPI_EVAL_STR("echo 'Hello world' . PHP_EOL;") == SUCCESS);
@@ -31,6 +33,7 @@ TEST_CASE("eval: spinup/spindown", "[zai_sapi]") {
 
 TEST_CASE("compile file success", "[zai_sapi]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
@@ -41,6 +44,7 @@ TEST_CASE("compile file success", "[zai_sapi]") {
 
 TEST_CASE("compile file failure (file not found)", "[zai_sapi]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
 
     // No need to wrap with REQUIRE() since it will zend_bailout (long jump)

--- a/zend_abstract_interface/zai_sapi/tests/zai_sapi_functions.cc
+++ b/zend_abstract_interface/zai_sapi/tests/zai_sapi_functions.cc
@@ -8,38 +8,38 @@ extern "C" {
 
 TEST_CASE("trigger_error: E_CORE_ERROR", "[zai_sapi_functions]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
 
     ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
     zai_sapi_execute_script("./stubs/trigger_error_E_CORE_ERROR.php");
     ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
 
-    REQUIRE(zai_sapi_last_error_type_eq(E_CORE_ERROR));
-    REQUIRE(zai_sapi_last_error_message_eq("My E_CORE_ERROR"));
+    REQUIRE(zai_sapi_last_error_eq(E_CORE_ERROR, "My E_CORE_ERROR"));
 
     zai_sapi_spindown();
 }
 
 TEST_CASE("trigger_error: E_ERROR", "[zai_sapi_functions]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
 
     ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
     zai_sapi_execute_script("./stubs/trigger_error_E_ERROR.php");
     ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
 
-    REQUIRE(zai_sapi_last_error_type_eq(E_ERROR));
-    REQUIRE(zai_sapi_last_error_message_eq("My E_ERROR"));
+    REQUIRE(zai_sapi_last_error_eq(E_ERROR, "My E_ERROR"));
 
     zai_sapi_spindown();
 }
 
 TEST_CASE("trigger_error: E_NOTICE", "[zai_sapi_functions]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_E_NOTICE.php"));
 
-    REQUIRE(zai_sapi_last_error_type_eq(E_NOTICE));
-    REQUIRE(zai_sapi_last_error_message_eq("My E_NOTICE"));
+    REQUIRE(zai_sapi_last_error_eq(E_NOTICE, "My E_NOTICE"));
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -47,12 +47,12 @@ TEST_CASE("trigger_error: E_NOTICE", "[zai_sapi_functions]") {
 
 TEST_CASE("trigger_error: E_WARNING", "[zai_sapi_functions]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_E_WARNING.php"));
 
-    REQUIRE(zai_sapi_last_error_type_eq(E_WARNING));
-    REQUIRE(zai_sapi_last_error_message_eq("My E_WARNING"));
+    REQUIRE(zai_sapi_last_error_eq(E_WARNING, "My E_WARNING"));
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -60,12 +60,12 @@ TEST_CASE("trigger_error: E_WARNING", "[zai_sapi_functions]") {
 
 TEST_CASE("trigger_error: invalid error type returns NULL", "[zai_sapi_functions]") {
     REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/trigger_error_invalid.php"));
 
-    REQUIRE(zai_sapi_last_error_type_eq(0));
-    REQUIRE(zai_sapi_last_error_message_eq(NULL));
+    REQUIRE(zai_sapi_last_error_is_empty());
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();

--- a/zend_abstract_interface/zai_sapi/zai_sapi_functions.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_functions.c
@@ -10,13 +10,33 @@
 #define UNUSED_PHP_FN_VARS()
 #endif
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+/* NOOP function that can be used to make fake execute frames.
+ *
+ * Zai\noop(void): null
+ */
+static PHP_FUNCTION(noop) {
+    UNUSED_PHP_FN_VARS();
+#if PHP_VERSION_ID < 70000
+#ifdef ZTS
+    (void)(TSRMLS_C);
+#endif
+#else
+    (void)(execute_data);
+#endif
+    /* NOOP */
+    RETURN_NULL();
+}
+
 /* Triggers an arbitrary error from userland.
  *
  * Zai\trigger_error(string message, int error_level): void
  */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_trigger_error, 0, 0, 2)
-ZEND_ARG_INFO(0, level)
 ZEND_ARG_INFO(0, message)
+ZEND_ARG_INFO(0, level)
 ZEND_END_ARG_INFO()
 
 static PHP_FUNCTION(trigger_error) {
@@ -61,6 +81,7 @@ static PHP_FUNCTION(trigger_error) {
 
 // clang-format off
 const zend_function_entry zai_sapi_functions[] = {
+    ZEND_NS_FE("Zai", noop, arginfo_void)
     ZEND_NS_FE("Zai", trigger_error, arginfo_trigger_error)
     PHP_FE_END
 };


### PR DESCRIPTION
### Description

ZAI Sandbox prevents PHP code execution from throwing exceptions or raising errors if executed inside the sandbox. It ensures that if there is an existing error or unhandled exception when the sandbox is opened, the error and exception state will be unchanged after closing the sandbox.

This PR includes a number of other enhancements to the ZAI SAPI test runner including:

- Fake PHP frame injection (scoped to the `Zai\noop()` internal function)
- Last error introspection
- Exception throwing
- Unhandled exception introspection

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
