### PR TITLE
Tidy the components/

### DIFF
--- a/components/container_id/container_id.c
+++ b/components/container_id/container_id.c
@@ -38,9 +38,6 @@
  */
 #define TASK_REGEX "[0-9a-f]\\{32\\}-[0-9]\\{1,20\\}"  // Original ERE: "[0-9a-f]{32}-[0-9]+"
 
-#define MIN_ID_LEN DATADOG_PHP_CONTAINER_ID_MIN_LEN
-#define MAX_ID_LEN DATADOG_PHP_CONTAINER_ID_MAX_LEN
-
 typedef datadog_php_container_id_parser dd_parser;
 
 static bool dd_parser_is_valid_line(dd_parser *parser, const char *line) {

--- a/components/container_id/container_id.h
+++ b/components/container_id/container_id.h
@@ -4,15 +4,10 @@
 #include <regex.h>
 #include <stdbool.h>
 
-/* The shortest possible ID would be a Fargate 1.4+ ID that matches:
+/* Fargate 1.4+ IDs match:
  *    [0-9a-f]{32}-\d+
  * Assuming it is possible for '\d+' to be a single digit, the shortest
  * expected ID would be 32 + 1 + 1 = 34.
- */
-#define DATADOG_PHP_CONTAINER_ID_MIN_LEN 34
-
-/* Fargate 1.4+ IDs match:
- *    [0-9a-f]{32}-\d+
  * Assuming '\d+' is an unsigned 64-bit integer, the maximum possible value is
  * 18446744073709551615 which is 20 characters long. Thus the longest possible
  * Fargate 1.4+ ID would be 32 + 1 + 20 = 53 characters long.

--- a/components/container_id/tests/container_id_from_file.cc
+++ b/components/container_id/tests/container_id_from_file.cc
@@ -2,9 +2,8 @@ extern "C" {
 #include "container_id/container_id.h"
 }
 
-#include <cstring>
-
 #include <catch2/catch.hpp>
+#include <cstring>
 
 TEST_CASE("parse a Docker container ID", "[container_id]") {
     char id[DATADOG_PHP_CONTAINER_ID_MAX_LEN + 1];
@@ -74,12 +73,12 @@ TEST_CASE("error edge cases when parsing container ID", "[container_id]") {
 
 TEST_CASE("a NULL cgroup file makes an empty string", "[container_id]") {
     char id[DATADOG_PHP_CONTAINER_ID_MAX_LEN + 1];
-    REQUIRE(false == datadog_php_container_id_from_file(id, NULL));
+    REQUIRE(false == datadog_php_container_id_from_file(id, nullptr));
     REQUIRE(id[0] == '\0');
 }
 
 TEST_CASE("a NULL buf does not crash", "[container_id]") {
-    REQUIRE(false == datadog_php_container_id_from_file(NULL, "./stubs/cgroup.docker"));
+    REQUIRE(false == datadog_php_container_id_from_file(nullptr, "./stubs/cgroup.docker"));
     REQUIRE(true);
 }
 

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -1,7 +1,5 @@
 #include "sapi/sapi.h"
 
-#include <string.h>
-
 typedef datadog_php_sapi sapi_t;
 typedef datadog_php_string_view string_view_t;
 

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -4,12 +4,12 @@ extern "C" {
 
 #include <catch2/catch.hpp>
 
-TEST_CASE("recongize real sapis", "[sapi]") {
+TEST_CASE("recognize real sapis", "[sapi]") {
     // these strings were taken from the PHP 8.0's sapi/ folder
     struct {
         const char *name;
         datadog_php_sapi sapi;
-    } cases[] = {
+    } servers[] = {
         {"apache2handler", DATADOG_PHP_SAPI_APACHE2HANDLER},
         {"cgi-fcgi", DATADOG_PHP_SAPI_CGI_FCGI},
         {"cli", DATADOG_PHP_SAPI_CLI},
@@ -20,24 +20,23 @@ TEST_CASE("recongize real sapis", "[sapi]") {
         {"phpdbg", DATADOG_PHP_SAPI_PHPDBG},
     };
 
-    unsigned n_sapis = sizeof cases / sizeof *cases;
-    for (unsigned i = 0; i != n_sapis; ++i) {
-        datadog_php_string_view view = datadog_php_string_view_from_cstr(cases[i].name);
+    for (auto server : servers) {
+        datadog_php_string_view view = datadog_php_string_view_from_cstr(server.name);
         datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
 
-        REQUIRE(sapi == cases[i].sapi);
+        REQUIRE(sapi == server.sapi);
     }
 }
 
 TEST_CASE("unknown sapis", "[sapi]") {
     /* These used to be SAPIs, but have since been removed. I think that makes
-     * them good testing canidates for unknown SAPIs.
+     * them good testing candidates for unknown SAPIs.
      */
-    const char *cases[] = {
+    const char *servers[] = {
         "aolserver",
         "caudium",
 
-        // The fact "Continuity" is upper-cased gave me a giggle
+        // "Continuity" being upper-cased gave me a giggle, as all others aren't
         "Continuity",
 
         "isapi",
@@ -47,9 +46,8 @@ TEST_CASE("unknown sapis", "[sapi]") {
         "webjames",
     };
 
-    unsigned n_sapis = sizeof cases / sizeof *cases;
-    for (unsigned i = 0; i != n_sapis; ++i) {
-        datadog_php_string_view view = datadog_php_string_view_from_cstr(cases[i]);
+    for (auto server : servers) {
+        datadog_php_string_view view = datadog_php_string_view_from_cstr(server);
         datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
 
         REQUIRE(sapi == DATADOG_PHP_SAPI_UNKNOWN);


### PR DESCRIPTION
### Description

Remove unused macros.
Remove unused include.
Fix mis-spellings.
Use nullptr over NULL in C++ files.

Use C++ ranged-based for loops instead of calculating the size of
the array by hand (in C++ files only, ofc). Rename cases to servers
so that the singular form is a valid variable name (cannot have a
variable named 'case', since it's part of the langauge).

With these changes, the components/ directory is free from warnings
from clang-tidy, at least with the options enabled by default in
CLion.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ This cleanup does not require new tests.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document.
