### PR TITLE
remove _tmp suffix from development buster images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,11 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/development/Dockerfile_54
-  '5.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.4_buster_tmp' }
+  '5.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.4_buster' }
   '5.4-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.4-debug' }
   '5.5': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5' }
   '5.5-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.5-debug' }
-  '5.5-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.5_buster_tmp' }
+  '5.5-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.5_buster' }
   '5.6':
     <<: *base_php_service
     image: datadog/dd-trace-ci:php-dev-5.6
@@ -63,7 +63,7 @@ services:
       context: .
       dockerfile: dockerfiles/development/Dockerfile_56
   '5.6-original': { <<: *base_56_service, image: 'circleci/php:5.6-zts' }
-  '5.6-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.6_buster_tmp' }
+  '5.6-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.6_buster' }
   '5.6-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-debug' }
   '5.6-zts': { <<: *base_56_service, image: 'datadog/docker-library:ddtrace_alpine_php-5.6-zts' }
   '7.0':
@@ -77,7 +77,7 @@ services:
         PHP_MAJOR_MINOR: '7.0'
         MCRYPT_PACKAGE: mcrypt
   '7.0-centos6': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.0_centos-6' }
-  '7.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.0_buster_tmp' }
+  '7.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.0_buster' }
   '7.0-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-debug' }
   '7.0-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.0-zts' }
   '7.1':
@@ -90,12 +90,12 @@ services:
       args:
         PHP_MAJOR_MINOR: '7.1'
         MCRYPT_PACKAGE: mcrypt-1.0.0
-  '7.1-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.1_buster_tmp' }
+  '7.1-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.1_buster' }
   '7.1-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-debug' }
   '7.1-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.1-zts' }
   '7.1-centos6': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.1_centos-6' }
   '7.1-centos-compiled': { <<: *base_php_service, build: 'dockerfiles/verify_packages/centos7-compiled' }
-  '7.2-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.2_buster_tmp' }
+  '7.2-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.2_buster' }
   '7.2-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-debug' }
   '7.2-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.2-zts' }
   '7.3':
@@ -109,14 +109,14 @@ services:
         PHP_MAJOR_MINOR: '7.3'
         MCRYPT_PACKAGE: mcrypt-1.0.3
   '7.3-centos6': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.3_centos-6' }
-  '7.3-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.3_buster_tmp' }
+  '7.3-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.3_buster' }
   '7.3-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-debug' }
   '7.3-zts-debug': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts-debug' }
   '7.3-zts': { <<: *base_php_service, image: 'datadog/docker-library:ddtrace_alpine_php-7.3-zts' }
-  '7.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4_buster_tmp' }
+  '7.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4_buster' }
   '7.4-debug': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4-debug-alpine-3.11' }
   '7.4-debug-asan': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4-debug-asan-buster' }
-  '8.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_buster_tmp' }
+  '8.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_buster' }
   '8.0-shared-ext': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0-shared-ext' }
   '8.0-centos6': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_centos-6' }
   '8.0-alpine': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_alpine' }


### PR DESCRIPTION
### Description

While developing https://github.com/DataDog/dd-trace-php/pull/1210 we had renamed the buster images to `_tmp` in order to avoid breaking master.

Now that the PR is on master, we can go back to _tmp-less as usual.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
