### PR TITLE
Self update composer in the image we use to prepare the code in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ aliases:
   - &STEP_COMPOSER_SELF_UPDATE
     run:
       name: Upgrading composer
-      command: composer self-update --no-interaction
+      command: sudo composer self-update --no-interaction
 
   - &STEP_COMPOSER_UPDATE
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,11 @@ aliases:
           echo "TLS is enabled"
         fi
 
+  - &STEP_COMPOSER_SELF_UPDATE
+    run:
+      name: Upgrading composer
+      command: composer self-update --no-interaction
+
   - &STEP_COMPOSER_UPDATE
     run:
       name: Installing dependencies with composer
@@ -1171,6 +1176,7 @@ jobs:
           paths:
             - ".git"
       - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_GENERATE
       - run:


### PR DESCRIPTION
### Description

Due to:
- https://blog.packagist.com/composer-command-injection-vulnerability/
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29472

Note, we wait for composer images to be released on docker hub before rebuilding the development images.
We do not use composer in other images used to build the final artifact.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
