### PR TITLE
Fix ingestion control reporting

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -93,6 +93,9 @@ function _ddtrace_config_json($value, $default)
         return $default;
     }
 
+    // If the char `'` used to escape the json object reaches this variable, it has to be removed.
+    $value = trim($value, "'");
+
     $parsed = \json_decode($value, true);
     if (null === $parsed) {
         return $default;

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -364,6 +364,16 @@ EOD;
                     ],
                 ],
             ],
+            'DD_TRACE_SAMPLING_RULES escaped' => [
+                '\'[{"name": "^a.*b$", "sample_rate": 0.3}]\'',
+                [
+                    [
+                        'service' => '.*',
+                        'name' => '^a.*b$',
+                        'sample_rate' => 0.3,
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/Unit/Sampling/ConfigurableSamplerTest.php
+++ b/tests/Unit/Sampling/ConfigurableSamplerTest.php
@@ -132,7 +132,7 @@ final class ConfigurableSamplerTest extends BaseTestCase
         ];
     }
 
-    public function testMetricIsAddedToCommunicateSampleRateUsed()
+    public function testMetricIsAddedToCommunicateSampleRateUsedWhenSamplingRules()
     {
         putenv('DD_TRACE_SAMPLING_RULES=[{"sample_rate":0.7}]');
         $sampler = new ConfigurableSampler();
@@ -142,5 +142,28 @@ final class ConfigurableSamplerTest extends BaseTestCase
         $sampler->getPrioritySampling($span);
 
         $this->assertSame(0.7, $span->getMetrics()['_dd.rule_psr']);
+    }
+
+    public function testMetricIsAddedToCommunicateSampleRateUsedWhenSampleRate()
+    {
+        putenv('DD_TRACE_SAMPLE_RATE=0.3');
+        $sampler = new ConfigurableSampler();
+
+        $context = new SpanContext('', dd_trace_generate_id());
+        $span = new Span('my_name', $context, 'my_service', '');
+        $sampler->getPrioritySampling($span);
+
+        $this->assertSame(0.3, $span->getMetrics()['_dd.rule_psr']);
+    }
+
+    public function testMetricIsAddedToCommunicateSampleRateNothingSet()
+    {
+        $sampler = new ConfigurableSampler();
+
+        $context = new SpanContext('', dd_trace_generate_id());
+        $span = new Span('my_name', $context, 'my_service', '');
+        $sampler->getPrioritySampling($span);
+
+        $this->assertSame(1.0, $span->getMetrics()['_dd.rule_psr']);
     }
 }

--- a/tests/Unit/Sampling/ConfigurableSamplerTest.php
+++ b/tests/Unit/Sampling/ConfigurableSamplerTest.php
@@ -144,6 +144,20 @@ final class ConfigurableSamplerTest extends BaseTestCase
         $this->assertSame(0.7, $span->getMetrics()['_dd.rule_psr']);
     }
 
+    public function testMetricIsAddedToCommunicateSampleRateUsedWhenSamplingRulesIsEscaped()
+    {
+        // while we suggest to escape the json object, in some cases the `'` are passed to the string and we have to
+        // verify that parsing still works.
+        putenv('DD_TRACE_SAMPLING_RULES=\'[{"sample_rate":0.7}]\'');
+        $sampler = new ConfigurableSampler();
+
+        $context = new SpanContext('', dd_trace_generate_id());
+        $span = new Span('my_name', $context, 'my_service', '');
+        $sampler->getPrioritySampling($span);
+
+        $this->assertSame(0.7, $span->getMetrics()['_dd.rule_psr']);
+    }
+
     public function testMetricIsAddedToCommunicateSampleRateUsedWhenSampleRate()
     {
         putenv('DD_TRACE_SAMPLE_RATE=0.3');


### PR DESCRIPTION
### Description

`_dd.rule_psr` has always to be set. Previously we were only setting it for sampling rules. It is necessary to have the correct values in the ingestion control pages.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
