### PR TITLE
Autocomplete Makefile target names in buster dev images

### DIFF
--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 # Pretty prompt
     echo "PS1='\[\033[01;32m\]\u\[\033[00m\]\[\033[00;35m\](buster)\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" | \
         tee -a /home/circleci/.bashrc; \
+# Autocomplete of Makefile targets (see: https://stackoverflow.com/a/38415982)
+    echo "complete -W \"\\\`grep -oE '^[a-zA-Z0-9_.-]+:([^=]|$)' ?akefile | sed 's/[^a-zA-Z0-9_.-]*$//'\\\`\" make" | \
+        tee -a /home/circleci/.bashrc; \
 # Handy aliases
     echo "alias ll='ls -al'" | \
         tee -a /home/circleci/.bash_aliases; \


### PR DESCRIPTION
### Description

This adds `make [Tab]` autocomplete functionality to our dev images. Actually builds and push of images will progressively come next.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
