### PR TITLE
Begin documenting architecture

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,21 +2,12 @@ root = true
 
 [*]
 charset = utf-8
-indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
 
 [*.{c,h}]
 indent_size = none
-
-[*.md]
-trim_trailing_whitespace = false
-indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
@@ -28,6 +19,7 @@ indent_size = 2
 block_comment_start = /*
 block_comment = *
 block_comment_end = */
+indent_size = 4
 
 [*Makefile]
 indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ First you need to update composer's dependecies in `./tests` folder:
     $ make composer_tests_update
 
 > :memo: **Note:** To disable reliance on the generated files during development and testing, set the following environment variable:
-> 
+>
 > `export DD_AUTOLOAD_NO_COMPILE=true`
 
 Then you can run tests:

--- a/UPGRADE-0.10.md
+++ b/UPGRADE-0.10.md
@@ -80,7 +80,7 @@ All of the OpenTracing interfaces and classes were moved under the `DDTrace` nam
 
 ## Removing the OpenTracing dependency
 
-Once all references to the OpenTracing API have been updated, you can remove `opentracing/opentracing` with Composer. 
+Once all references to the OpenTracing API have been updated, you can remove `opentracing/opentracing` with Composer.
 
 ```bash
 $ composer remove opentracing/opentracing

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,86 @@
+# Architecture
+
+The structure of the project has changed quite a bit over time due to changes
+in project scope, PHP versions supported, etc. This is a living document to
+describe the project's current architecture and the direction it's headed.
+
+ 1. [Components](#components)
+ 2. [PHP version specific code](#php-version-specific-code)
+ 3. [Background sender](#background-sender)
+
+## Components
+
+Components should be the main building blocks of PHP-agnostic code. They have a
+single header and source file that matches the component name. They have a tests
+folder for doing unit tests which integrate with CMake. Here is the layout for
+an example component, the `string_view`:
+
+    components/string_view/
+    ├── CMakeLists.txt
+    ├── string_view.c
+    ├── string_view.h
+    └── tests
+        ├── CMakeLists.txt
+        └── string_view.cc
+
+Components are detailed in their own
+[components/README.md](./components/README.md).
+
+## PHP version specific code
+
+We used to maintain code that was intended to work across all supported PHP
+versions in a single file per "unit". This became problematic for a few reasons:
+
+ 1. It was hard to make an improvement or change for a given unit in one version
+    without accidentally breaking another version.
+ 2. Not all features worked the same way at a technical level across the
+    different PHP versions, and maintaining this in a single file was a pain.
+ 3. The `TSRMLS_CC` stuff was always annoying, and with PHP 8.0 these macros
+    were removed altogether.
+
+So, we split them into their own directories:
+
+    ext
+    ├── php5
+    ├── php7
+    └── php8
+
+At the time of this writing, quite a bit of code is still duplicated across
+these folders. The intent is for the pieces that are PHP version agnostic to
+eventually become components.
+
+## Background sender
+
+The background sender is used to upload traces to the agent in a way that
+doesn't block the PHP threads from continuing. This code is mostly PHP version
+agnostic and should be split into a component.
+
+The background sender's sources are in `ext/php$n/`, mostly in `comms_php.{c,h}`
+and `coms.{c,h}`. The background sender's design altered part-way through, and
+was not properly refactored. Roughly, it works like this:
+
+  - A trace is encoded into msgpack, and then copied into a buffer that is owned
+    by the background sender.
+  - Only a single trace may be encoded at a time, but you can work around this
+    by encoding each trace individually. If you send multiple traces in the same
+    encoding, the background sender will reject it and the trace will fall back
+    to an uploader written in PHP.
+  - Each buffer may contain multiple traces, so it has accounting for this.
+  - Originally a chunk of the trace could be uploaded, instead of the whole
+    thing. This was later removed, but the design of working with spans instead
+    of traces remains.
+  - The background sender uploads the trace via libcurl to the agent every N
+    requests or X milliseconds. These are both controlled via configuration.
+
+This design is close to having a fixed-size, thread-safe queue of
+msgpack-encoded traces. The next time this code is touched, it probably ought to
+be cleaned up to more closely match that design, or better yet use a shared
+library for doing it (does not exist at this time, but has been discussed).
+
+### Background sender configuration
+
+Functions like `getenv` are not thread-safe, and the background sender uses a
+thread. To work around this, the configuration is memoized. The directory
+`ext/php$n/` has files `configuration.{c,h}`, `configuration_php_iface.{c,h}`,
+and `configuration_render.h`. If you are not familiar with the term "x macros",
+you need to get acquainted with them before you can understand how it works.

--- a/components/README.md
+++ b/components/README.md
@@ -74,7 +74,7 @@ Macros should have a prefix of `DATADOG_PHP_`.
 
 Components must avoid creating and using global state. If you think you need
 global state, such as thread-local globals for a PHP extension, then what you
-need to do is make a component that does not use globals state which is then
+need to do is make a component that does not use global state which is then
 wrapped by something that is specifically designed for handling the global
 state. The details haven't been fleshed out yet, but these will probably be
 called "plugins", so you would have a `component_plugin` that uses a

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,82 @@
+# Components
+
+Components should be the main building blocks of PHP-agnostic code. They have a
+single header and source file that matches the component name. They have a tests
+folder for doing unit tests which integrate with CMake. Here is the layout for
+an example component, the `string_view`:
+
+    components/string_view/
+    ├── CMakeLists.txt
+    ├── string_view.c
+    ├── string_view.h
+    └── tests
+        ├── CMakeLists.txt
+        └── string_view.cc
+
+Components may depend on other components or on libraries, but must not depend
+on anything from the php-src codebase.
+
+## Components must not depend on PHP
+
+Components must not use any headers or other things from the PHP code base.
+Components can be used across all PHP versions because they are divorced from
+the PHP implementation details.
+
+Additionally, it makes them much easier to test when they are not coupled to PHP
+at all. Testing internal units was a notable weakness of the codebase before
+moving to components, and sometimes internal features would expose PHP functions
+that existed only to test internal features. This is an anti-pattern that is
+avoided by using components.
+
+## Components should be tested
+
+Components must have a tests subdirectory which gets added to the CMake project
+when the `BUILD_COMPONENTS_TESTING` option is set to true/on. The tests need to
+integrate with CMake so that when the main `test` target is run that the
+component's tests are run as well.
+
+Currently, all existing tests use the C++ Catch2 testing framework. This is not
+a requirement, but it helps to be consistent.
+
+The tests directory can contain more than one test file if desired, but often
+there will be just a single test file.
+
+## Components may use libraries
+
+Components can wrap third-party libraries from outside of this project, such as
+wrapping a hashing library, or a logging library. When doing this, try not to
+let the underlying library leak through the component; otherwise we would just
+use the library directly without reaching for a component.
+
+There should still be tests for components based on libraries.
+
+## Building and using components
+
+Components must have a CMakeLists.txt for building with CMake. As mentioned
+previously, this is used to test components. I expect we will integrate the
+artifacts from CMake builds into the main extension, but we have not done this
+yet. This means you still need to add the source file to
+`DD_TRACE_COMPONENT_SOURCES` in [config.m4](../config.m4). You do not need to
+add anything to the include path, as `components/` is already a part of the
+include directories.
+
+Component headers should be included by using double-quotes, and referring to
+the component name and then the component header. For example:
+
+```c
+#include "string_view/string_view.h"
+```
+
+All symbols that are in the header should have a prefix of `datadog_php_`.
+Macros should have a prefix of `DATADOG_PHP_`.
+
+## Components do not use globals
+
+Components must avoid creating and using global state. If you think you need
+global state, such as thread-local globals for a PHP extension, then what you
+need to do is make a component that does not use globals state which is then
+wrapped by something that is specifically designed for handling the global
+state. The details haven't been fleshed out yet, but these will probably be
+called "plugins", so you would have a `component_plugin` that uses a
+`component` internally (or even publicly, we don't need to hide that).
+

--- a/tests/PostInstallHook/README.md
+++ b/tests/PostInstallHook/README.md
@@ -24,7 +24,7 @@ $ cd ~/datadog \
 2. Add the new port number `80<PHP VERSION>` to **docker-compose.yml**.
 3. Head over to [the Docker set up for `datadog/dd-trace-ci:php-nginx-apache2`](https://github.com/DataDog/dd-trace-ci/tree/master/php/nginx-apache2).
 4. Add the new version to the `apt-get install` line in the **Dockerfile**. _Note: there should only be one version that installs mod_php (`libapache2-mod-php<version>`). If you update it, make sure to also update **apache-ports.conf**._
-5. Add a new `server` context for the new version in **nginx-default-site**. 
+5. Add a new `server` context for the new version in **nginx-default-site**.
 6. Finally, add the new process config to **supervisord.conf**.
 
 > **Note:** `mod_php` only supports one PHP version at a time. If the Apache PHP version is updated, make sure to update the `apachePhpVersion` variable in the **run-tests.sh** script and edit the port in the **docker-compose.yml** file.


### PR DESCRIPTION
### Description

This is an incomplete documentation of components, ext/php$n, and
the background sender. This information should be valuable to
newcomers.

I opted to write this as markdown in this repository instead of
a Google Document so that it is close to the thing it documents
and is open to everyone, not just Datadog employees.

This also changes the `.editorconfig` to care less about
formatting in Markdown files, though it now enforces that
trailing whitespace is removed.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ This is markdown only.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
