### PR TITLE
Detect ZAI ZMM leaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1098,6 +1098,7 @@ jobs:
                       ~/datadog/zend_abstract_interface
                     make -j all
                     make test
+                    grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
                   done
 
       # Builds that do not support ASan
@@ -1128,6 +1129,7 @@ jobs:
                       ~/datadog/zend_abstract_interface
                     make -j all
                     make test
+                    grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
                   done
 
       - run:
@@ -1145,6 +1147,7 @@ jobs:
               ~/datadog/zend_abstract_interface
             make -j all
             make test
+            grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
 
       - run:
           command: |

--- a/zend_abstract_interface/methods/tests/php5/methods.cc
+++ b/zend_abstract_interface/methods/tests/php5/methods.cc
@@ -737,6 +737,8 @@ TEST_CASE("call static method: non-static method (userland)", "[zai_methods]") {
     REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
 
+    zval_ptr_dtor(&retval);
+
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
 }

--- a/zend_abstract_interface/sandbox/tests/sandbox.cc
+++ b/zend_abstract_interface/sandbox/tests/sandbox.cc
@@ -395,6 +395,7 @@ TEST_CASE("exception state: existing unhandled exception", "[zai_sandbox]") {
     zai_sandbox_exception_state_restore(&es);
 
     REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+    zai_sapi_unhandled_exception_ignore();
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -509,6 +510,7 @@ TEST_CASE("exception state: zend_throw_exception_hook called once", "[zai_sandbo
      * when restoring the original exception.
      */
     REQUIRE(zai_throw_exception_hook_calls_count == 2);
+    zai_sapi_unhandled_exception_ignore();
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -671,6 +673,7 @@ TEST_CASE("sandbox exception: existing unhandled exception", "[zai_sandbox]") {
     zai_sandbox_close(&sandbox);
 
     REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+    zai_sapi_unhandled_exception_ignore();
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -778,6 +781,7 @@ TEST_CASE("sandbox: existing exception & existing error", "[zai_sandbox]") {
 
     REQUIRE(zai_sapi_last_error_eq(E_WARNING, "Original non-fatal error"));
     REQUIRE(zai_sapi_unhandled_exception_eq(orig_exception_ce, "Original exception"));
+    zai_sapi_unhandled_exception_ignore();
 
     zai_sapi_fake_frame_pop(&fake_frame);
 

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -270,3 +270,5 @@ bool zai_sapi_unhandled_exception_eq(zend_class_entry *ce, const char *message) 
 }
 
 bool zai_sapi_unhandled_exception_exists(void) { return EG(exception) != NULL; }
+
+void zai_sapi_unhandled_exception_ignore(void) { zend_clear_exception(); }

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -237,3 +237,5 @@ bool zai_sapi_unhandled_exception_eq(zend_class_entry *ce, const char *message) 
 }
 
 bool zai_sapi_unhandled_exception_exists(void) { return EG(exception) != NULL; }
+
+void zai_sapi_unhandled_exception_ignore(void) { zend_clear_exception(); }

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -110,7 +110,10 @@ bool zai_sapi_last_error_is_empty();
 /* Throws an exception using the default exception class entry and sets the
  * 'Exception::$message' string to 'message'. Returns the class entry used for
  * the thrown exception. An execution context (an active PHP frame stack) must
- * exist or this will raise a fatal error and call zend_bailout.
+ * exist or this will raise a fatal error and call zend_bailout. If the
+ * exception is not handled by the PHP runtime, caller must free the exception
+ * with zai_sapi_unhandled_exception_ignore() before RSHUTDOWN to prevent a ZMM
+ * leak.
  */
 zend_class_entry *zai_sapi_throw_exception(const char *message);
 
@@ -121,6 +124,9 @@ bool zai_sapi_unhandled_exception_eq(zend_class_entry *ce, const char *message);
 
 /* Returns true if there is an unhandled exception. */
 bool zai_sapi_unhandled_exception_exists(void);
+
+/* Frees an unhandled exception from the executor globals. */
+void zai_sapi_unhandled_exception_ignore(void);
 
 /* Handling zend_bailout
  *


### PR DESCRIPTION
### Description

This PR adds a way to detect Zend Memory Manager leak messages in the ZAI tests by grepping the test log in CI for:

```
=== Total n memory leaks detected ===
```

There were a few ZMM leaks that were isolated to the tests (the leaks were not in the tracer or any production code paths) and those are fixed in d8b4c3e.

Ideally the leak detection would be implemented as part of the ZAI SAPI test runner, but every way I tired to implement it, I hit a blocker.

- ZMM bypasses the SAPI error logger and [writes the leak message directly to stderr](https://github.com/php/php-src/blob/PHP-8.0.4/main/main.c#L1588) which I haven't been able to capture from ZAI SAPI during RSHUTDOWN.
- There is no way to inject a [custom hook](https://github.com/php/php-src/blob/PHP-8.0.4/main/main.c#L2034) to capture the ZMM memory leak messages.
- I cannot get Catch2 to capture stdout or stderr from ZAI SAPI using a [custom event listener](https://github.com/catchorg/Catch2/blob/devel/docs/event-listeners.md);  `ZmmLeakListener`. The event listener works, but `testCaseStats.stdOut` and `testCaseStats.stdErr` are always empty from `testCaseEnded`.
- Changing the Catch2 reporter to one that captures output, [like `junit`](https://github.com/catchorg/Catch2/blob/2c269eb/src/catch2/reporters/catch_reporter_junit.cpp#L63), the custom `ZmmLeakListener` still cannot access ZAI SAPI stdout and stderr.
- Changing ZAI SAPI write operations from `write` to `fwrite` does not seem to make any difference.
- It seems as if the reporter doesn't even have access to the output streams; for `junit`, `<system-out/>` and `<system-err/>` are always empty.
- There doesn't appear to be a way to run a post-test script using cmake.

That leaves me with "manually" grepping the test log for the ZMM leak message in CI. I'm probably missing something obvious with the Catch2 setup, so if anyone else can figure out a better solution to this, I'd love to know your thoughts.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
