### PR TITLE
ZAI function-call seam (PHP 8)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -224,6 +224,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/functions/php8/functions.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \
       zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
@@ -256,6 +257,8 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir/zend_abstract_interface])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])

--- a/config.m4
+++ b/config.m4
@@ -265,6 +265,7 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php8])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_assert])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php7])

--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,8 @@
             <file name="components/string_view/string_view.h" role="src" />
 
             <!-- Zend Abstract Interface -->
+            <file name="zend_abstract_interface/functions/functions.h" role="src" />
+            <file name="zend_abstract_interface/functions/php8/functions.c" role="src" />
             <file name="zend_abstract_interface/methods/methods.h" role="src" />
             <file name="zend_abstract_interface/methods/php5/methods.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php5/sandbox.c" role="src" />

--- a/package.xml
+++ b/package.xml
@@ -56,6 +56,7 @@
             <file name="zend_abstract_interface/sandbox/php7/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php8/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/sandbox.h" role="src" />
+            <file name="zend_abstract_interface/zai_assert/zai_assert.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php5/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php8/zai_sapi.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -87,6 +87,7 @@ if(PHP_VERSION_DIRECTORY STREQUAL "php5")
   add_subdirectory(methods)
 endif()
 add_subdirectory(sandbox)
+add_subdirectory(zai_assert)
 
 install(EXPORT ZendAbstractInterfaceTargets
         FILE ZendAbstractInterfaceTargets.cmake

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -78,8 +78,12 @@ endif()
 add_subdirectory(zai_sapi)
 
 # All tests depend on zai_sapi
-if(PHP_VERSION_ID LESS_EQUAL "70000")
-  # TODO Support PHP 7
+if(PHP_VERSION_DIRECTORY STREQUAL "php8")
+  # TODO Support PHP 5 & PHP 7
+  add_subdirectory(functions)
+endif()
+if(PHP_VERSION_DIRECTORY STREQUAL "php5")
+  # TODO Support PHP 7 & PHP 8
   add_subdirectory(methods)
 endif()
 add_subdirectory(sandbox)

--- a/zend_abstract_interface/functions/CMakeLists.txt
+++ b/zend_abstract_interface/functions/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_library(zai_functions "${PHP_VERSION_DIRECTORY}/functions.c")
+
+target_include_directories(zai_functions PUBLIC
+                                         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                         $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_functions PUBLIC c_std_99)
+
+target_link_libraries(zai_functions PUBLIC "${PHP_LIB}" Zai::Sandbox)
+
+set_target_properties(zai_functions PROPERTIES
+                                    EXPORT_NAME Functions
+                                    VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Functions ALIAS zai_functions)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+# TODO: How to make this zai/functions.h?
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/functions.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/functions/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_functions)
+
+install(TARGETS zai_functions EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/functions/functions.h
+++ b/zend_abstract_interface/functions/functions.h
@@ -1,0 +1,32 @@
+#ifndef ZAI_FUNCTIONS_H
+#define ZAI_FUNCTIONS_H
+
+#include <main/php.h>
+#include <stdbool.h>
+
+/* Work in progress
+ *
+ * The long-term goal is to provide ZAI data-structure shims so that the
+ * following APIs are the same across all PHP versions. For now we will provide
+ * ZAI seams using native Zend Engine data structures.
+ */
+
+/* Calls a function with 'argc' number of zval arguments. Caller owns the
+ * arguments and the 'retval'. Caller is responsible for freeing any refcounted
+ * arguments. Caller must provide a pointer to a stack-allocated zval for the
+ * return value, 'retval'. In error cases, 'retval' will be set to IS_UNDEF.
+ * Caller must dtor the 'retval' after the call:
+ *
+ *   zval_ptr_dtor(&retval);
+ *
+ * Functions cannot be called outside of a request context so this MUST be
+ * called from within a request context (after RINIT and before RSHUTDOWN).
+ */
+bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...);
+
+/* Calls a function the same way as zai_call_function() but without passing any
+ * arguments to the function.
+ */
+bool zai_call_function_without_args(const char *name, size_t name_len, zval *retval);
+
+#endif  // ZAI_FUNCTIONS_H

--- a/zend_abstract_interface/functions/functions.h
+++ b/zend_abstract_interface/functions/functions.h
@@ -26,17 +26,16 @@ bool zai_call_function_ex(const char *name, size_t name_len, zval *retval, int a
 
 /* A wrapper for zai_call_function_ex() that automatically populates 'argc'. */
 #define zai_call_function(name, name_len, retval, ...) \
-    zai_call_function_ex(name, name_len, retval, ZAI_CALL_FUNCTION_VA_ARG_COUNT(__VA_ARGS__), ## __VA_ARGS__)
+    zai_call_function_ex(name, name_len, retval, ZAI_CALL_FUNCTION_VA_ARG_COUNT(__VA_ARGS__), ##__VA_ARGS__)
 
 /* A convenience wrapper to call zai_call_function() using a string literal.
  * This API only works when the function name is a string literal. If the
  * function name exists as a 'const char *', use zai_call_function() or
  * zai_call_function_ex() directly. */
-#define zai_call_function_literal(name, retval, ...) \
-    zai_call_function(name, sizeof(name) - 1, retval, ## __VA_ARGS__)
+#define zai_call_function_literal(name, retval, ...) zai_call_function(name, sizeof(name) - 1, retval, ##__VA_ARGS__)
 
 #define ZAI_CALL_FUNCTION_VA_ARG_COUNT(...) \
-    ZAI_CALL_FUNCTION_VA_ARG_MAX(ignore, ## __VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+    ZAI_CALL_FUNCTION_VA_ARG_MAX(ignore, ##__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 #define ZAI_CALL_FUNCTION_VA_ARG_MAX(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ...) arg10
 
 #endif  // ZAI_FUNCTIONS_H

--- a/zend_abstract_interface/functions/functions.h
+++ b/zend_abstract_interface/functions/functions.h
@@ -22,11 +22,12 @@
  * Functions cannot be called outside of a request context so this MUST be
  * called from within a request context (after RINIT and before RSHUTDOWN).
  */
-bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...);
+bool zai_call_function_ex(const char *name, size_t name_len, zval *retval, int argc, ...);
 
-/* Calls a function the same way as zai_call_function() but without passing any
- * arguments to the function.
- */
-bool zai_call_function_without_args(const char *name, size_t name_len, zval *retval);
+#define zai_call_function(name, name_len, ...) \
+    zai_call_function_ex(name, name_len, ZAI_CALL_FUNCTION_VA_ARG_COUNT(__VA_ARGS__), ## __VA_ARGS__)
+#define ZAI_CALL_FUNCTION_VA_ARG_COUNT(...) \
+    ZAI_CALL_FUNCTION_VA_ARG_MAX(ignore, ## __VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define ZAI_CALL_FUNCTION_VA_ARG_MAX(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ...) arg10
 
 #endif  // ZAI_FUNCTIONS_H

--- a/zend_abstract_interface/functions/functions.h
+++ b/zend_abstract_interface/functions/functions.h
@@ -24,8 +24,17 @@
  */
 bool zai_call_function_ex(const char *name, size_t name_len, zval *retval, int argc, ...);
 
-#define zai_call_function(name, name_len, ...) \
-    zai_call_function_ex(name, name_len, ZAI_CALL_FUNCTION_VA_ARG_COUNT(__VA_ARGS__), ## __VA_ARGS__)
+/* A wrapper for zai_call_function_ex() that automatically populates 'argc'. */
+#define zai_call_function(name, name_len, retval, ...) \
+    zai_call_function_ex(name, name_len, retval, ZAI_CALL_FUNCTION_VA_ARG_COUNT(__VA_ARGS__), ## __VA_ARGS__)
+
+/* A convenience wrapper to call zai_call_function() using a string literal.
+ * This API only works when the function name is a string literal. If the
+ * function name exists as a 'const char *', use zai_call_function() or
+ * zai_call_function_ex() directly. */
+#define zai_call_function_literal(name, retval, ...) \
+    zai_call_function(name, sizeof(name) - 1, retval, ## __VA_ARGS__)
+
 #define ZAI_CALL_FUNCTION_VA_ARG_COUNT(...) \
     ZAI_CALL_FUNCTION_VA_ARG_MAX(ignore, ## __VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 #define ZAI_CALL_FUNCTION_VA_ARG_MAX(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ...) arg10

--- a/zend_abstract_interface/functions/php8/functions.c
+++ b/zend_abstract_interface/functions/php8/functions.c
@@ -1,18 +1,7 @@
 #include "../functions.h"
 
-#include <assert.h>
 #include <sandbox/sandbox.h>
-
-#ifndef NDEBUG
-static bool z_is_lower(const char *str) {
-    char *p = (char *)str;
-    while (*p) {
-        if (isalpha(*p) && !islower(*p)) return false;
-        p++;
-    }
-    return true;
-}
-#endif
+#include <zai_assert/zai_assert.h>
 
 bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...) {
     if (!retval) return false;
@@ -34,7 +23,7 @@ bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc
      */
     if (!PG(modules_activated)) return false;
 
-    assert(z_is_lower(name) && "Function names must be lowercase.");
+    zai_assert_is_lower(name, "Function names must be lowercase.");
     assert(*name != '\\' && "Function names must not have a root scope prefix '\\'.");
 
     zend_function *func = NULL;

--- a/zend_abstract_interface/functions/php8/functions.c
+++ b/zend_abstract_interface/functions/php8/functions.c
@@ -5,7 +5,7 @@
 
 #define MAX_ARGS 3
 
-bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...) {
+bool zai_call_function_ex(const char *name, size_t name_len, zval *retval, int argc, ...) {
     if (!retval) return false;
 
     /* For consistency with zend_call_function(), this wrapper also initializes
@@ -136,8 +136,4 @@ bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc
     bool ret = (call_fn_result == SUCCESS && !EG(exception));
     zai_sandbox_close(&sandbox);
     return ret;
-}
-
-bool zai_call_function_without_args(const char *name, size_t name_len, zval *retval) {
-    return zai_call_function(name, name_len, retval, 0);
 }

--- a/zend_abstract_interface/functions/php8/functions.c
+++ b/zend_abstract_interface/functions/php8/functions.c
@@ -104,20 +104,12 @@ bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc
         fci.param_count = (uint32_t)argc;
         fci.params = params;
 
-        zend_try {
-            call_fn_result = zend_call_function(&fci, &fcc);
-        }
-        zend_catch {
-            should_bail = true;
-        }
+        zend_try { call_fn_result = zend_call_function(&fci, &fcc); }
+        zend_catch { should_bail = true; }
         zend_end_try();
     } else {
-        zend_try {
-            call_fn_result = zend_call_function(&fci, &fcc);
-        }
-        zend_catch {
-            should_bail = true;
-        }
+        zend_try { call_fn_result = zend_call_function(&fci, &fcc); }
+        zend_catch { should_bail = true; }
         zend_end_try();
     }
 

--- a/zend_abstract_interface/functions/php8/functions.c
+++ b/zend_abstract_interface/functions/php8/functions.c
@@ -1,0 +1,139 @@
+#include "../functions.h"
+
+#include <assert.h>
+#include <sandbox/sandbox.h>
+
+#ifndef NDEBUG
+static bool z_is_lower(const char *str) {
+    char *p = (char *)str;
+    while (*p) {
+        if (isalpha(*p) && !islower(*p)) return false;
+        p++;
+    }
+    return true;
+}
+#endif
+
+bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...) {
+    if (!retval) return false;
+
+    /* For consistency with zend_call_function(), this wrapper also initializes
+     * the retval to IS_UNDEF so that the caller can expect an undefined retval
+     * in the error cases. Past wrappers of zend_call_function() did not mimic
+     * this behavior and that lead to a SIGSEGV.
+     *
+     * https://github.com/php/php-src/blob/PHP-8.0.3/Zend/zend_execute_API.c#L673
+     */
+    ZVAL_UNDEF(retval);
+
+    if (!name || !name_len) return false;
+
+    /* Functions cannot be called outside of a request context.
+     * PG(modules_activated) indicates that all of the module RINITs have been
+     * called and we are in a request context.
+     */
+    if (!PG(modules_activated)) return false;
+
+    assert(z_is_lower(name) && "Function names must be lowercase.");
+    assert(*name != '\\' && "Function names must not have a root scope prefix '\\'.");
+
+    zend_function *func = NULL;
+    zend_string *zsname = NULL;
+    ALLOCA_FLAG(use_heap)
+
+    /* We look up the function handler directly from zend_fetch_function()
+     * instead of calling zend_is_callable_ex() because:
+     *
+     *   - We always call functions by their string name and not one of the
+     *     many 'callable' types, so the code path can be simplified.
+     *   - We assume the caller always provides the lowercased function name so
+     *     we can avoid zend_str_tolower_copy().
+     *   - We assume the caller will not prefix the function name with a
+     *     root-scope prefix, '\'.
+     *
+     * In addition, we look up the function handler from zend_fetch_function()
+     * instead of directly from the EG(function_table) to ensure that the
+     * runtime cache for userland functions will be initialized.
+     */
+    ZSTR_ALLOCA_ALLOC(zsname, name_len, use_heap);
+    memcpy(ZSTR_VAL(zsname), name, (name_len + 1));
+    func = zend_fetch_function(zsname);
+    ZSTR_ALLOCA_FREE(zsname, use_heap);
+
+    /* "function %s() does not exist" */
+    if (!func) return false;
+
+    zend_fcall_info_cache fcc = {0};
+    fcc.function_handler = func;
+
+    zend_fcall_info fci = {0};
+    fci.size = sizeof(zend_fcall_info);
+    fci.retval = retval;
+
+    /* We add the zval args directly from the variable arguments API instead of
+     * using zend_fcall_info_argv() which allows us to NULL-check each arg. It
+     * also allows us to avoid an unnecessary call to
+     * zend_fcall_info_args_clear() since the 'param{s|_count}' members in
+     * 'zend_fcall_info' will always be zeroed out in our case.
+     *
+     * Based on zend_fcall_info_argv():
+     * https://github.com/php/php-src/blob/PHP-8.0.4/Zend/zend_API.c?#L3608-L3622
+     */
+    if (argc > 0) {
+        va_list argv;
+        va_start(argv, argc);
+
+        zval *arg;
+        fci.param_count = (uint32_t)argc;
+        fci.params = (zval *)ecalloc(1, (fci.param_count * sizeof(zval)));
+
+        for (uint32_t i = 0; i < (uint32_t)argc; ++i) {
+            arg = va_arg(argv, zval *);
+            if (!arg) {
+                /* Only dtor the zvals that were successfully copied */
+                fci.param_count = i;
+                zend_fcall_info_args_clear(&fci, /* free_mem */ true);
+                return false;
+            }
+            ZVAL_COPY(&fci.params[i], arg);
+        }
+
+        va_end(argv);
+    }
+
+    bool ret = false;
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    zend_try {
+        zend_result result = zend_call_function(&fci, &fcc);
+        /* An unhandled exception will not result in a zend_bailout if there is
+         * an active execution context. This is a failed call if an exception
+         * was thrown. The sandbox will clean up our mess when it closes.
+         */
+        ret = (result == SUCCESS && !EG(exception));
+    }
+    zend_catch {
+        /* An unclean shutdown from a zend_bailout can occur deep within a
+         * userland call stack which will long jump over dtors and frees. If we
+         * caught an arbitrary zend_bailout here and went on pretending like
+         * nothing happened, this would lead to a lot of ZMM leaks and likely a
+         * number of real memory leaks so the safest thing to do is clean up as
+         * best we can and then bubble up the zend_bailout.
+         */
+        zai_sandbox_close(&sandbox);
+        zend_fcall_info_args_clear(&fci, /* free_mem */ (argc != 0));
+        zend_bailout();
+    }
+    zend_end_try();
+
+    zai_sandbox_close(&sandbox);
+    zend_fcall_info_args_clear(&fci, /* free_mem */ (argc != 0));
+
+    return ret;
+}
+
+bool zai_call_function_without_args(const char *name, size_t name_len, zval *retval) {
+    return zai_call_function(name, name_len, retval, 0);
+}

--- a/zend_abstract_interface/functions/php8/functions.c
+++ b/zend_abstract_interface/functions/php8/functions.c
@@ -3,6 +3,8 @@
 #include <sandbox/sandbox.h>
 #include <zai_assert/zai_assert.h>
 
+#define MAX_ARGS 3
+
 bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc, ...) {
     if (!retval) return false;
 
@@ -15,7 +17,9 @@ bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc
      */
     ZVAL_UNDEF(retval);
 
-    if (!name || !name_len || argc < 0) return false;
+    assert(argc <= MAX_ARGS && "Increase MAX_ARGS to support more arguments.");
+
+    if (!name || !name_len || argc < 0 || argc > MAX_ARGS) return false;
 
     /* Functions cannot be called outside of a request context.
      * PG(modules_activated) indicates that all of the module RINITs have been
@@ -75,7 +79,7 @@ bool zai_call_function(const char *name, size_t name_len, zval *retval, int argc
      *   - We avoid unnecessary calls to zend_fcall_info_args_clear().
      */
     if (argc > 0) {
-        zval params[argc];
+        zval params[MAX_ARGS];
         va_list argv;
         va_start(argv, argc);
         for (uint32_t i = 0; i < (uint32_t)argc; ++i) {

--- a/zend_abstract_interface/functions/tests/CMakeLists.txt
+++ b/zend_abstract_interface/functions/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+#[[ TODO When we have a consistent API across all PHP versions with ZAI
+    data-structure shims, move these tests out of PHP-versioned directories.
+ ]]
+add_executable(functions "${PHP_VERSION_DIRECTORY}/functions.cc")
+
+target_link_libraries(functions PUBLIC catch2_main Zai::Sapi Zai::Functions)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(functions)

--- a/zend_abstract_interface/functions/tests/php8/functions.cc
+++ b/zend_abstract_interface/functions/tests/php8/functions.cc
@@ -1,0 +1,381 @@
+extern "C" {
+#include "functions/functions.h"
+#include "zai_sapi/zai_sapi.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+#define REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE()            \
+    REQUIRE(false == zai_sapi_unhandled_exception_exists()); \
+    REQUIRE(zai_sapi_last_error_is_empty())
+
+#ifndef NDEBUG
+#define SKIP_TEST_IN_DEBUG_MODE "[.]"
+#else
+#define SKIP_TEST_IN_DEBUG_MODE
+#endif
+
+#define MT_MIN 0
+#define MT_MAX 42
+
+/**************************** zai_call_function() ****************************/
+
+TEST_CASE("call function: int args (internal)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval min = {0};
+    zval max = {0};
+    ZVAL_LONG(&min, MT_MIN);
+    ZVAL_LONG(&max, MT_MAX);
+
+    zval retval = {0};
+    // mt_rand($min, $max)
+    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval, 2, &min, &max);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_LONG);
+    REQUIRE((Z_LVAL(retval) >= MT_MIN && Z_LVAL(retval) <= MT_MAX));
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: array arg (internal)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval arg = {0};
+    ZVAL_NEW_ARR(&arg);
+    zend_hash_init(Z_ARRVAL(arg), 8, NULL, NULL, /* persistent */ 0);
+
+    zval item0 = {0};
+    zval item1 = {0};
+    ZVAL_LONG(&item0, 2);
+    ZVAL_LONG(&item1, 40);
+    zend_hash_next_index_insert(Z_ARRVAL(arg), &item0);
+    zend_hash_next_index_insert(Z_ARRVAL(arg), &item1);
+
+    zval retval = {0};
+    // array_sum($arg)
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 1, &arg);
+    zval_ptr_dtor(&arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_LONG);
+    REQUIRE(Z_LVAL(retval) == 42);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: int arg (userland)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    zval arg = {0};
+    ZVAL_LONG(&arg, 42);
+
+    zval retval = {0};
+    // Zai\Functions\Test\return_arg($arg)
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_LONG);
+    REQUIRE(Z_LVAL(retval) == 42);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: bool arg (userland)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    zval arg = {0};
+    ZVAL_TRUE(&arg);
+
+    zval retval = {0};
+    // Zai\Functions\Test\return_arg($arg)
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_TRUE);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: string arg (userland)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    zval arg = {0};
+    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
+    ZVAL_STR(&arg, str);
+
+    zval retval = {0};
+    // Zai\Functions\Test\return_arg($arg)
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+    zval_ptr_dtor(&arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_STRING);
+    REQUIRE(strcmp("foo string", Z_STRVAL(retval)) == 0);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: NULL arg", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 1, NULL);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function: NULL args after refcounted arg", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval arg = {0};
+    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
+    ZVAL_STR(&arg, str);
+
+    zval retval = {0};
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 3, &arg, NULL, NULL);
+    zval_ptr_dtor(&arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+/********************* zai_call_function_without_args() **********************/
+
+TEST_CASE("call function no args: (internal)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    // mt_rand()
+    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_LONG);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: (userland)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    zval retval = {0};
+    // Zai\Functions\Test\returns_true()
+    bool result = zai_call_function_without_args(ZEND_STRL("zai\\functions\\test\\returns_true"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_TRUE);
+
+    zval_ptr_dtor(&retval);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: does not exist", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    // Foo\iDoNotExist()
+    bool result = zai_call_function_without_args(ZEND_STRL("foo\\idonotexist"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: root-scope prefix", "[zai_functions]" SKIP_TEST_IN_DEBUG_MODE) {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    bool result = zai_call_function_without_args(ZEND_STRL("\\mt_rand"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: wrong case", "[zai_functions]" SKIP_TEST_IN_DEBUG_MODE) {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    bool result = zai_call_function_without_args(ZEND_STRL("MT_RAND"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+/* The 'disable_functions' INI setting only disables internal functions.
+ * https://www.php.net/manual/en/ini.core.php#ini.disable-functions
+ */
+TEST_CASE("call function no args: disable_functions INI", "[zai_functions]") {
+    REQUIRE(zai_sapi_sinit());
+
+    REQUIRE(zai_sapi_append_system_ini_entry("disable_functions", "mt_rand"));
+
+    REQUIRE(zai_sapi_minit());
+    REQUIRE(zai_sapi_rinit());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    // mt_rand()
+    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: throws exception (userland)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/basic.php"));
+
+    /* Add a fake base/main frame to prevent the uncaught exception from
+     * bubbling all the way up and raising a fatal error (zend_bailout).
+     */
+    zend_execute_data fake_frame;
+    REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
+
+    zval retval = {0};
+    // Zai\Functions\Test\throws_exception()
+    bool result = zai_call_function_without_args(ZEND_STRL("zai\\functions\\test\\throws_exception"), &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    zai_sapi_fake_frame_pop(&fake_frame);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: NULL name", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    bool result = zai_call_function_without_args(NULL, 42, &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: zero-len name", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval retval = {0};
+    bool result = zai_call_function_without_args("mt_rand", 0, &retval);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: NULL retval", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), NULL);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}

--- a/zend_abstract_interface/functions/tests/php8/functions.cc
+++ b/zend_abstract_interface/functions/tests/php8/functions.cc
@@ -212,6 +212,27 @@ TEST_CASE("call function: -1 args", "[zai_functions]") {
     zai_sapi_spindown();
 }
 
+TEST_CASE("call function: more than MAX_ARGS", "[zai_functions]" SKIP_TEST_IN_DEBUG_MODE) {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval arg = {0};
+    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
+    ZVAL_STR(&arg, str);
+
+    zval retval = {0};
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 4, &arg, &arg, &arg, &arg);
+    zval_ptr_dtor(&arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
 /********************* zai_call_function_without_args() **********************/
 
 TEST_CASE("call function no args: (internal)", "[zai_functions]") {

--- a/zend_abstract_interface/functions/tests/php8/functions.cc
+++ b/zend_abstract_interface/functions/tests/php8/functions.cc
@@ -33,7 +33,7 @@ TEST_CASE("call function: int args (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand($min, $max)
-    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval, 2, &min, &max);
+    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval, &min, &max);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -64,7 +64,7 @@ TEST_CASE("call function: array arg (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // array_sum($arg)
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 1, &arg);
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -90,7 +90,7 @@ TEST_CASE("call function: int arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -115,7 +115,7 @@ TEST_CASE("call function: bool arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -140,7 +140,7 @@ TEST_CASE("call function: string arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, 1, &arg);
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -160,7 +160,7 @@ TEST_CASE("call function: NULL arg", "[zai_functions]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 1, NULL);
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, NULL);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -180,7 +180,7 @@ TEST_CASE("call function: NULL args after refcounted arg", "[zai_functions]") {
     ZVAL_STR(&arg, str);
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 3, &arg, NULL, NULL);
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg, NULL, NULL);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -201,7 +201,7 @@ TEST_CASE("call function: -1 args", "[zai_functions]") {
     ZVAL_STR(&arg, str);
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, -1, &arg);
+    bool result = zai_call_function_ex(ZEND_STRL("array_sum"), &retval, -1, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -222,7 +222,7 @@ TEST_CASE("call function: more than MAX_ARGS", "[zai_functions]" SKIP_TEST_IN_DE
     ZVAL_STR(&arg, str);
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, 4, &arg, &arg, &arg, &arg);
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg, &arg, &arg, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -233,7 +233,7 @@ TEST_CASE("call function: more than MAX_ARGS", "[zai_functions]" SKIP_TEST_IN_DE
     zai_sapi_spindown();
 }
 
-/********************* zai_call_function_without_args() **********************/
+/********************* zai_call_function() (without args) *********************/
 
 TEST_CASE("call function no args: (internal)", "[zai_functions]") {
     REQUIRE(zai_sapi_spinup());
@@ -242,7 +242,7 @@ TEST_CASE("call function no args: (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand()
-    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), &retval);
+    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -263,7 +263,7 @@ TEST_CASE("call function no args: (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\returns_true()
-    bool result = zai_call_function_without_args(ZEND_STRL("zai\\functions\\test\\returns_true"), &retval);
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\returns_true"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -282,7 +282,7 @@ TEST_CASE("call function no args: does not exist", "[zai_functions]") {
 
     zval retval = {0};
     // Foo\iDoNotExist()
-    bool result = zai_call_function_without_args(ZEND_STRL("foo\\idonotexist"), &retval);
+    bool result = zai_call_function(ZEND_STRL("foo\\idonotexist"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -298,7 +298,7 @@ TEST_CASE("call function no args: root-scope prefix", "[zai_functions]" SKIP_TES
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function_without_args(ZEND_STRL("\\mt_rand"), &retval);
+    bool result = zai_call_function(ZEND_STRL("\\mt_rand"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -314,7 +314,7 @@ TEST_CASE("call function no args: wrong case", "[zai_functions]" SKIP_TEST_IN_DE
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function_without_args(ZEND_STRL("MT_RAND"), &retval);
+    bool result = zai_call_function(ZEND_STRL("MT_RAND"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -339,7 +339,7 @@ TEST_CASE("call function no args: disable_functions INI", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand()
-    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), &retval);
+    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -364,7 +364,7 @@ TEST_CASE("call function no args: throws exception (userland)", "[zai_functions]
 
     zval retval = {0};
     // Zai\Functions\Test\throws_exception()
-    bool result = zai_call_function_without_args(ZEND_STRL("zai\\functions\\test\\throws_exception"), &retval);
+    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\throws_exception"), &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -382,7 +382,7 @@ TEST_CASE("call function no args: NULL name", "[zai_functions]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function_without_args(NULL, 42, &retval);
+    bool result = zai_call_function(NULL, 42, &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -398,7 +398,7 @@ TEST_CASE("call function no args: zero-len name", "[zai_functions]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function_without_args("mt_rand", 0, &retval);
+    bool result = zai_call_function("mt_rand", 0, &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -413,7 +413,7 @@ TEST_CASE("call function no args: NULL retval", "[zai_functions]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    bool result = zai_call_function_without_args(ZEND_STRL("mt_rand"), NULL);
+    bool result = zai_call_function(ZEND_STRL("mt_rand"), NULL);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);

--- a/zend_abstract_interface/functions/tests/php8/functions.cc
+++ b/zend_abstract_interface/functions/tests/php8/functions.cc
@@ -191,6 +191,27 @@ TEST_CASE("call function: NULL args after refcounted arg", "[zai_functions]") {
     zai_sapi_spindown();
 }
 
+TEST_CASE("call function: -1 args", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval arg = {0};
+    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
+    ZVAL_STR(&arg, str);
+
+    zval retval = {0};
+    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, -1, &arg);
+    zval_ptr_dtor(&arg);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
 /********************* zai_call_function_without_args() **********************/
 
 TEST_CASE("call function no args: (internal)", "[zai_functions]") {

--- a/zend_abstract_interface/functions/tests/php8/functions.cc
+++ b/zend_abstract_interface/functions/tests/php8/functions.cc
@@ -19,7 +19,7 @@ extern "C" {
 #define MT_MIN 0
 #define MT_MAX 42
 
-/**************************** zai_call_function() ****************************/
+/************************* zai_call_function_literal() ************************/
 
 TEST_CASE("call function: int args (internal)", "[zai_functions]") {
     REQUIRE(zai_sapi_spinup());
@@ -33,7 +33,7 @@ TEST_CASE("call function: int args (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand($min, $max)
-    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval, &min, &max);
+    bool result = zai_call_function_literal("mt_rand", &retval, &min, &max);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -64,7 +64,7 @@ TEST_CASE("call function: array arg (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // array_sum($arg)
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg);
+    bool result = zai_call_function_literal("array_sum", &retval, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -90,7 +90,7 @@ TEST_CASE("call function: int arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
+    bool result = zai_call_function_literal("zai\\functions\\test\\return_arg", &retval, &arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -115,7 +115,7 @@ TEST_CASE("call function: bool arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
+    bool result = zai_call_function_literal("zai\\functions\\test\\return_arg", &retval, &arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -140,7 +140,7 @@ TEST_CASE("call function: string arg (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\return_arg($arg)
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\return_arg"), &retval, &arg);
+    bool result = zai_call_function_literal("zai\\functions\\test\\return_arg", &retval, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -160,7 +160,7 @@ TEST_CASE("call function: NULL arg", "[zai_functions]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, NULL);
+    bool result = zai_call_function_literal("array_sum", &retval, NULL);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -180,28 +180,7 @@ TEST_CASE("call function: NULL args after refcounted arg", "[zai_functions]") {
     ZVAL_STR(&arg, str);
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg, NULL, NULL);
-    zval_ptr_dtor(&arg);
-
-    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
-    REQUIRE(result == false);
-    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
-
-    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
-    zai_sapi_spindown();
-}
-
-TEST_CASE("call function: -1 args", "[zai_functions]") {
-    REQUIRE(zai_sapi_spinup());
-    ZAI_SAPI_TSRMLS_FETCH();
-    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
-
-    zval arg = {0};
-    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
-    ZVAL_STR(&arg, str);
-
-    zval retval = {0};
-    bool result = zai_call_function_ex(ZEND_STRL("array_sum"), &retval, -1, &arg);
+    bool result = zai_call_function_literal("array_sum", &retval, &arg, NULL, NULL);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -222,7 +201,7 @@ TEST_CASE("call function: more than MAX_ARGS", "[zai_functions]" SKIP_TEST_IN_DE
     ZVAL_STR(&arg, str);
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("array_sum"), &retval, &arg, &arg, &arg, &arg);
+    bool result = zai_call_function_literal("array_sum", &retval, &arg, &arg, &arg, &arg);
     zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -233,7 +212,7 @@ TEST_CASE("call function: more than MAX_ARGS", "[zai_functions]" SKIP_TEST_IN_DE
     zai_sapi_spindown();
 }
 
-/********************* zai_call_function() (without args) *********************/
+/***************** zai_call_function_literal() (without args) *****************/
 
 TEST_CASE("call function no args: (internal)", "[zai_functions]") {
     REQUIRE(zai_sapi_spinup());
@@ -242,7 +221,7 @@ TEST_CASE("call function no args: (internal)", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand()
-    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval);
+    bool result = zai_call_function_literal("mt_rand", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -263,7 +242,7 @@ TEST_CASE("call function no args: (userland)", "[zai_functions]") {
 
     zval retval = {0};
     // Zai\Functions\Test\returns_true()
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\returns_true"), &retval);
+    bool result = zai_call_function_literal("zai\\functions\\test\\returns_true", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -282,7 +261,7 @@ TEST_CASE("call function no args: does not exist", "[zai_functions]") {
 
     zval retval = {0};
     // Foo\iDoNotExist()
-    bool result = zai_call_function(ZEND_STRL("foo\\idonotexist"), &retval);
+    bool result = zai_call_function_literal("foo\\idonotexist", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -298,7 +277,7 @@ TEST_CASE("call function no args: root-scope prefix", "[zai_functions]" SKIP_TES
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("\\mt_rand"), &retval);
+    bool result = zai_call_function_literal("\\mt_rand", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -314,7 +293,7 @@ TEST_CASE("call function no args: wrong case", "[zai_functions]" SKIP_TEST_IN_DE
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval retval = {0};
-    bool result = zai_call_function(ZEND_STRL("MT_RAND"), &retval);
+    bool result = zai_call_function_literal("MT_RAND", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -339,7 +318,7 @@ TEST_CASE("call function no args: disable_functions INI", "[zai_functions]") {
 
     zval retval = {0};
     // mt_rand()
-    bool result = zai_call_function(ZEND_STRL("mt_rand"), &retval);
+    bool result = zai_call_function_literal("mt_rand", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
@@ -364,13 +343,58 @@ TEST_CASE("call function no args: throws exception (userland)", "[zai_functions]
 
     zval retval = {0};
     // Zai\Functions\Test\throws_exception()
-    bool result = zai_call_function(ZEND_STRL("zai\\functions\\test\\throws_exception"), &retval);
+    bool result = zai_call_function_literal("zai\\functions\\test\\throws_exception", &retval);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
     REQUIRE(Z_TYPE(retval) == IS_UNDEF);
 
     zai_sapi_fake_frame_pop(&fake_frame);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call function no args: NULL retval", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    bool result = zai_call_function_literal("mt_rand", NULL);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+/**************************** zai_call_function() *****************************/
+
+TEST_CASE("call function: int args (non-literal function name)", "[zai_functions]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zval min = {0};
+    zval max = {0};
+    ZVAL_LONG(&min, MT_MIN);
+    ZVAL_LONG(&max, MT_MAX);
+
+    zend_string *fn = zend_string_init(ZEND_STRL("mt_rand"), /* persistent */ 0);
+
+    zval retval = {0};
+    // mt_rand($min, $max)
+    bool result = zai_call_function(ZSTR_VAL(fn), ZSTR_LEN(fn), &retval, &min, &max);
+
+    zend_string_release(fn);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE(retval) == IS_LONG);
+    REQUIRE((Z_LVAL(retval) >= MT_MIN && Z_LVAL(retval) <= MT_MAX));
+
+    zval_ptr_dtor(&retval);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -408,15 +432,24 @@ TEST_CASE("call function no args: zero-len name", "[zai_functions]") {
     zai_sapi_spindown();
 }
 
-TEST_CASE("call function no args: NULL retval", "[zai_functions]") {
+/*************************** zai_call_function_ex() ****************************/
+
+TEST_CASE("call function: -1 args", "[zai_functions]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    bool result = zai_call_function(ZEND_STRL("mt_rand"), NULL);
+    zval arg = {0};
+    zend_string *str = zend_string_init(ZEND_STRL("foo string"), /* persistent */ 0);
+    ZVAL_STR(&arg, str);
+
+    zval retval = {0};
+    bool result = zai_call_function_ex(ZEND_STRL("array_sum"), &retval, -1, &arg);
+    zval_ptr_dtor(&arg);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
+    REQUIRE(Z_TYPE(retval) == IS_UNDEF);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();

--- a/zend_abstract_interface/functions/tests/stubs/basic.php
+++ b/zend_abstract_interface/functions/tests/stubs/basic.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zai\Functions\Test;
+
+function return_arg($arg)
+{
+    return $arg;
+}
+
+function returns_true()
+{
+    return true;
+}
+
+function throws_exception()
+{
+    throw new \Exception('Oops!');
+}

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -1,25 +1,14 @@
 #include "../methods.h"
 
 #include <Zend/zend_interfaces.h>
-#include <assert.h>
 #include <sandbox/sandbox.h>
-
-#ifndef NDEBUG
-static bool z_is_lower(const char *str) {
-    char *p = (char *)str;
-    while (*p) {
-        if (isalpha(*p) && !islower(*p)) return false;
-        p++;
-    }
-    return true;
-}
-#endif
+#include <zai_assert/zai_assert.h>
 
 zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC) {
     if (!cname || !cname_len) return NULL;
     zend_class_entry **ce;
 
-    assert(z_is_lower(cname) && "Class names must be lowercase.");
+    zai_assert_is_lower(cname, "Class names must be lowercase.");
     assert(*cname != '\\' && "Class names must not have a root scope prefix '\\'.");
 
     /* Since we do not want to invoke the autoloader and we assume the caller
@@ -53,7 +42,7 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
     /* This one gets me all the time. Trying to save myself 5 minutes for the
      * next time it inevitably happens.
      */
-    assert(z_is_lower(method) && "Don't forget to send those method names in all lowercase. ;)");
+    zai_assert_is_lower(method, "Don't forget to send those method names in all lowercase. ;)");
 
     /* There is an important ZEND_ACC_ALLOW_STATIC check that occurs within the
      * VM that is circumvented when calling a method outside of a VM context

--- a/zend_abstract_interface/sandbox/php8/sandbox.c
+++ b/zend_abstract_interface/sandbox/php8/sandbox.c
@@ -4,7 +4,30 @@ extern inline void zai_sandbox_open(zai_sandbox *sandbox);
 extern inline void zai_sandbox_close(zai_sandbox *sandbox);
 
 extern inline void zai_sandbox_error_state_backup(zai_error_state *es);
-extern inline void zai_sandbox_error_state_restore(zai_error_state *es);
+
+/* In PHP 8, we cannot extern inline zai_sandbox_error_state_restore() because
+ * zend_string_release() is static which generates the following compiler
+ * warning:
+ *
+ *   "warning: 'zend_string_release' is static but used in inline function
+ *    'zai_sandbox_error_state_restore' which is not static"
+ */
+void zai_sandbox_error_state_restore(zai_error_state *es) {
+    if (PG(last_error_message)) {
+        if (PG(last_error_message) != es->message) {
+            zend_string_release(PG(last_error_message));
+        }
+        if (PG(last_error_file) != es->file) {
+            free(PG(last_error_file));
+        }
+    }
+    zend_restore_error_handling(&es->error_handling);
+    PG(last_error_type) = es->type;
+    PG(last_error_message) = es->message;
+    PG(last_error_file) = es->file;
+    PG(last_error_lineno) = es->lineno;
+    EG(error_reporting) = es->error_reporting;
+}
 
 extern inline void zai_sandbox_exception_state_backup(zai_exception_state *es);
 extern inline void zai_sandbox_exception_state_restore(zai_exception_state *es);

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -109,22 +109,7 @@ inline void zai_sandbox_error_state_backup(zai_error_state *es) {
     zend_replace_error_handling(EH_THROW, NULL, &es->error_handling);
 }
 
-inline void zai_sandbox_error_state_restore(zai_error_state *es) {
-    if (PG(last_error_message)) {
-        if (PG(last_error_message) != es->message) {
-            zend_string_release(PG(last_error_message));
-        }
-        if (PG(last_error_file) != es->file) {
-            free(PG(last_error_file));
-        }
-    }
-    zend_restore_error_handling(&es->error_handling);
-    PG(last_error_type) = es->type;
-    PG(last_error_message) = es->message;
-    PG(last_error_file) = es->file;
-    PG(last_error_lineno) = es->lineno;
-    EG(error_reporting) = es->error_reporting;
-}
+void zai_sandbox_error_state_restore(zai_error_state *es);
 
 inline void zai_sandbox_exception_state_backup(zai_exception_state *es) {
     if (UNEXPECTED(EG(exception) != NULL)) {

--- a/zend_abstract_interface/zai_assert/CMakeLists.txt
+++ b/zend_abstract_interface/zai_assert/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(zai_assert INTERFACE)
+
+target_include_directories(zai_assert INTERFACE
+                                      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                      $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_assert INTERFACE c_std_99)
+
+target_link_libraries(zai_assert INTERFACE "${PHP_LIB}")
+
+set_target_properties(zai_assert PROPERTIES
+                                 EXPORT_NAME ZaiAssert
+                                 VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Assert ALIAS zai_assert)
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/zai_assert.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zai_assert/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_assert)
+
+install(TARGETS zai_assert EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/zai_assert/CMakeLists.txt
+++ b/zend_abstract_interface/zai_assert/CMakeLists.txt
@@ -8,10 +8,6 @@ target_compile_features(zai_assert INTERFACE c_std_99)
 
 target_link_libraries(zai_assert INTERFACE "${PHP_LIB}")
 
-set_target_properties(zai_assert PROPERTIES
-                                 EXPORT_NAME ZaiAssert
-                                 VERSION ${PROJECT_VERSION})
-
 add_library(Zai::Assert ALIAS zai_assert)
 
 # This copies the include files when `install` is ran

--- a/zend_abstract_interface/zai_assert/zai_assert.h
+++ b/zend_abstract_interface/zai_assert/zai_assert.h
@@ -1,0 +1,24 @@
+#ifndef ZAI_ASSERT_H
+#define ZAI_ASSERT_H
+
+#include <main/php.h>
+
+#ifndef NDEBUG
+#include <assert.h>
+#include <ctype.h>
+
+#define zai_assert_is_lower(str, message)      \
+    do {                                       \
+        char *p = (char *)str;                 \
+        while (*p) {                           \
+            if (isalpha(*p) && !islower(*p)) { \
+                assert(false && message);      \
+            }                                  \
+            p++;                               \
+        }                                      \
+    } while (0)
+#else
+#define zai_assert_is_lower(str, message)
+#endif
+
+#endif  // ZAI_ASSERT_H


### PR DESCRIPTION
### Description

This PR adds a Zend Abstract Interface (ZAI) seam for safely calling (sandboxed) PHP functions from C in PHP 8:

- `bool zai_call_function_literal(const char *name, zval *retval, ...);`
- `bool zai_call_function(const char *name, size_t name_len, zval *retval, ...);`
- `bool zai_call_function_ex(const char *name, size_t name_len, zval *retval, int argc, ...);`

This seam will initially be used to call the [userland deferred-loading function](https://github.com/DataDog/dd-trace-php/blob/5b8ea36/ext/php8/php8/engine_hooks.c#L127-L160) in PHP 8.

This PR also includes a new macro for asserting lowercase strings (`zai_assert/zai_assert.h`):

```c
zai_assert_is_lower(str, "String must be lowercase.");
```

As with `assert()`, `zai_assert_is_lower()` will only abort on debug builds of PHP.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
