### PR TITLE
Change config.m4 to allow in-tree build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -14,8 +14,9 @@ if test "$PHP_DDTRACE" != "no"; then
     AC_MSG_RESULT([yes])
   ])
 
-  m4_include([m4/polyfill.m4])
-  m4_include([m4/ax_execinfo.m4])
+  define(DDTRACE_BASEDIR, esyscmd(printf %s "$(dirname "__file__")"))
+  m4_include(DDTRACE_BASEDIR/m4/polyfill.m4)
+  m4_include(DDTRACE_BASEDIR/m4/ax_execinfo.m4)
 
   AX_EXECINFO
 
@@ -46,7 +47,9 @@ if test "$PHP_DDTRACE" != "no"; then
     components/string_view/string_view.c \
   "
 
-  PHP_VERSION_ID=$($PHP_CONFIG --vernum)
+  if test -z ${PHP_VERSION_ID+x}; then
+    PHP_VERSION_ID=$("$PHP_CONFIG" --vernum)
+  fi
 
   if test $PHP_VERSION_ID -lt 50500; then
     dnl PHP 5.4

--- a/ext/php5/signals.c
+++ b/ext/php5/signals.c
@@ -1,6 +1,9 @@
 #include "signals.h"
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
 #include "php_config.h"
 
 #if HAVE_SIGACTION

--- a/ext/php7/signals.c
+++ b/ext/php7/signals.c
@@ -1,6 +1,9 @@
 #include "signals.h"
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
 #include "php_config.h"
 
 #if HAVE_SIGACTION

--- a/ext/php8/signals.c
+++ b/ext/php8/signals.c
@@ -1,6 +1,9 @@
 #include "signals.h"
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
 #include "php_config.h"
 
 #if HAVE_SIGACTION

--- a/php_ddtrace.h
+++ b/php_ddtrace.h
@@ -1,0 +1,9 @@
+#if PHP_VERSION_ID < 70000
+#include "ext/php5/ddtrace.h"
+#elif PHP_VERSION_ID < 80000
+#include "ext/php7/ddtrace.h"
+#else
+#include "ext/php8/ddtrace.h"
+#endif
+
+#define phpext_ddtrace_ptr &ddtrace_module_entry


### PR DESCRIPTION
### Description

Putting dd-trace-php directly under php-src/ext should now work.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
