### PR TITLE
Deferred loading with ZAI function-call seam (PHP 8)

### DIFF
--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -381,7 +381,6 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     }
 
     ddtrace_internal_handlers_rinit();
-    ddtrace_engine_hooks_rinit();
     ddtrace_bgs_log_rinit(PG(error_log));
     ddtrace_dispatch_init();
     DDTRACE_G(disable_in_current_request) = 0;
@@ -415,7 +414,6 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     zval_dtor(&DDTRACE_G(additional_trace_meta));
     ZVAL_NULL(&DDTRACE_G(additional_trace_meta));
 
-    ddtrace_engine_hooks_rshutdown();
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown();
 

--- a/ext/php8/engine_hooks.h
+++ b/ext/php8/engine_hooks.h
@@ -18,8 +18,6 @@ extern int ddtrace_op_array_extension;
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
-void ddtrace_engine_hooks_rinit(void);
-void ddtrace_engine_hooks_rshutdown(void);
 void ddtrace_engine_hooks_mshutdown(void);
 
 void ddtrace_compile_time_reset(void);


### PR DESCRIPTION
### Description

This uses the ZAI function-call seam added in #1234 to call the userland deferred loader function `DDTrace\Integrations\load_deferred_integration`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~~Tests added for this feature/bug.~~ Uses the exiting deferred-loader tests.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
