### PR TITLE
Fix meta header name for language version in BGS agent request

### DIFF
--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -624,8 +624,8 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
     dd_append_header(&list, "Datadog-Meta-Lang", "php");
-    dd_append_header(&list, "Datadog-Meta-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name);
+    dd_append_header(&list, "Datadog-Meta-Lang-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Tracer-Version", PHP_DDTRACE_VERSION);
 
     char *id = ddshared_container_id();

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -624,8 +624,8 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
     dd_append_header(&list, "Datadog-Meta-Lang", "php");
-    dd_append_header(&list, "Datadog-Meta-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name);
+    dd_append_header(&list, "Datadog-Meta-Lang-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Tracer-Version", PHP_DDTRACE_VERSION);
 
     char *id = ddshared_container_id();

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -624,8 +624,8 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
     dd_append_header(&list, "Datadog-Meta-Lang", "php");
-    dd_append_header(&list, "Datadog-Meta-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name);
+    dd_append_header(&list, "Datadog-Meta-Lang-Version", PHP_VERSION);
     dd_append_header(&list, "Datadog-Meta-Tracer-Version", PHP_DDTRACE_VERSION);
 
     char *id = ddshared_container_id();

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -378,8 +378,8 @@ trait TracerTestTrait
                 // Temporary workaround until we get a proper test runner
                 \usleep(
                     'fpm-fcgi' === \getenv('DD_TRACE_TEST_SAPI')
-                    ? 500 * 1000// 500 ms for PHP-FPM
-                    : 50 * 1000// 50 ms for other SAPIs
+                        ? 500 * 1000 // 500 ms for PHP-FPM
+                        : 50 * 1000 // 50 ms for other SAPIs
                 );
                 continue;
             } else {

--- a/tests/ext/background-sender/agent_headers.phpt
+++ b/tests/ext/background-sender/agent_headers.phpt
@@ -25,8 +25,8 @@ $headers = $rr->replayHeaders([
     'Content-Type',
     'Datadog-Meta-Lang',
     'Datadog-Meta-Lang-Interpreter',
+    'Datadog-Meta-Lang-Version',
     'Datadog-Meta-Tracer-Version',
-    'Datadog-Meta-Version',
     'X-Datadog-Trace-Count',
 ]);
 foreach ($headers as $name => $value) {
@@ -42,8 +42,8 @@ bool(true)
 Content-Type: application/msgpack
 Datadog-Meta-Lang: php
 Datadog-Meta-Lang-Interpreter: cli
+Datadog-Meta-Lang-Version: %d.%d.%d
 Datadog-Meta-Tracer-Version: %s
-Datadog-Meta-Version: %s
 X-Datadog-Trace-Count: 1
 
 Done.


### PR DESCRIPTION
### Description

Starting from `0.57.0` we were sending the language version using the header `Datadog-Meta-Version` instead of the correct name `Datadog-Meta-Lang-Version`. This results in wrong reports about language usage and in missing filters in urser's metrics panel, with missing possibility to filter.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
