### PR TITLE
speed up randomized testing using a post #1192  version

### DIFF
--- a/tests/randomized/app/composer-5.4.json
+++ b/tests/randomized/app/composer-5.4.json
@@ -6,6 +6,6 @@
     },
     "require": {
         "guzzlehttp/guzzle": "5.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-5.5.json
+++ b/tests/randomized/app/composer-5.5.json
@@ -6,6 +6,6 @@
     },
     "require": {
         "guzzlehttp/guzzle": "5.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-5.6.json
+++ b/tests/randomized/app/composer-5.6.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "5.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-7.0.json
+++ b/tests/randomized/app/composer-7.0.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "6.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-7.1.json
+++ b/tests/randomized/app/composer-7.1.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "6.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-7.2.json
+++ b/tests/randomized/app/composer-7.2.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "6.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-7.3.json
+++ b/tests/randomized/app/composer-7.3.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "6.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-7.4.json
+++ b/tests/randomized/app/composer-7.4.json
@@ -7,6 +7,6 @@
     "require": {
         "elasticsearch/elasticsearch": "6.*",
         "guzzlehttp/guzzle": "6.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }

--- a/tests/randomized/app/composer-8.0.json
+++ b/tests/randomized/app/composer-8.0.json
@@ -6,6 +6,6 @@
     },
     "require": {
         "guzzlehttp/guzzle": "7.*",
-        "datadog/dd-trace": "^0.49.0"
+        "datadog/dd-trace": "0.59.0"
     }
 }


### PR DESCRIPTION
### Description

After 0.57.0 our composer package is way smaller thanks to #1192. We want to use a post-0.57.0 version to make the update operation quicker.

Moreover we pin the exact version in composer to improve reproducibility of regressions, since the composer file is copied and pasted.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
