### PR TITLE
Create property ZAI seam for PHP 8

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -228,6 +228,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/functions/php8/functions.c \
+      zend_abstract_interface/properties/php7-8/properties.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \
       zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_functions.c \
@@ -264,6 +265,8 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods/php5])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/properties])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/properties/php7-8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])

--- a/package.xml
+++ b/package.xml
@@ -56,6 +56,9 @@
             <file name="zend_abstract_interface/sandbox/php7/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/php8/sandbox.c" role="src" />
             <file name="zend_abstract_interface/sandbox/sandbox.h" role="src" />
+            <file name="zend_abstract_interface/properties/php7-8/properties.c" role="src" />
+            <file name="zend_abstract_interface/properties/php7-8/properties.h" role="src" />
+            <file name="zend_abstract_interface/properties/properties.h" role="src" />
             <file name="zend_abstract_interface/zai_assert/zai_assert.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php5/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -88,6 +88,10 @@ if(PHP_VERSION_DIRECTORY STREQUAL "php5")
 endif()
 add_subdirectory(sandbox)
 add_subdirectory(zai_assert)
+if(PHP_VERSION_DIRECTORY STREQUAL "php8")
+  # should support php7 as well, but depends on functions ZAI to test, disabling for now
+  add_subdirectory(properties)
+endif()
 
 install(EXPORT ZendAbstractInterfaceTargets
         FILE ZendAbstractInterfaceTargets.cmake

--- a/zend_abstract_interface/properties/CMakeLists.txt
+++ b/zend_abstract_interface/properties/CMakeLists.txt
@@ -1,0 +1,33 @@
+if(PHP_VERSION_DIRECTORY STREQUAL "php7" OR PHP_VERSION_DIRECTORY STREQUAL "php8")
+    set(PHP_PROPERTIES_VERSION_DIRECTORY "php7-8")
+else()
+    set(PHP_PROPERTIES_VERSION_DIRECTORY PHP_VERSION_DIRECTORY)
+endif()
+
+add_library(zai_properties "${PHP_PROPERTIES_VERSION_DIRECTORY}/properties.c")
+
+target_include_directories(zai_properties PUBLIC
+                                          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                          $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_properties PUBLIC c_std_99)
+
+target_link_libraries(zai_properties PUBLIC "${PHP_LIB}")
+
+set_target_properties(zai_properties PROPERTIES
+                                     EXPORT_NAME properties
+                                     VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Properties ALIAS zai_properties)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/properties.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/properties/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_properties)
+
+install(TARGETS zai_properties EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/properties/php7-8/properties.c
+++ b/zend_abstract_interface/properties/php7-8/properties.c
@@ -1,0 +1,51 @@
+#include "properties.h"
+
+zval *zai_read_property_direct(zend_class_entry *ce, zend_object *object, zend_string *name) {
+    if (!ce) {
+        return &EG(error_zval);
+    }
+    if (!object) {
+        return &EG(error_zval);
+    }
+    if (!name) {
+        return &EG(error_zval);
+    }
+    if (!instanceof_function(object->ce, ce)) {
+        return &EG(error_zval);
+    }
+
+    zend_class_entry *prev_fake_scope = EG(fake_scope);
+    EG(fake_scope) = ce;
+    zend_property_info *prop_info = zend_get_property_info(object->ce, name, 1);
+    EG(fake_scope) = prev_fake_scope;
+
+    if (UNEXPECTED(prop_info == NULL)) {
+        if (object->properties == NULL) {
+            return &EG(uninitialized_zval);
+        }
+        zval *zv = zend_hash_find(object->properties, name);
+        if (zv == NULL) {
+            return &EG(uninitialized_zval);
+        }
+        return zv;
+    }
+
+    if (UNEXPECTED(prop_info == ZEND_WRONG_PROPERTY_INFO)) {
+        return &EG(error_zval);
+    }
+
+    return OBJ_PROP(object, prop_info->offset);
+}
+
+#undef zai_read_property_direct_literal
+zval *zai_read_property_direct_literal(zend_class_entry *ce, zend_object *obj, const char *name, int name_len) {
+    zend_string *name_str;
+    ALLOCA_FLAG(use_heap);
+    ZSTR_ALLOCA_INIT(name_str, name, name_len, use_heap);
+
+    zval *val = zai_read_property_direct(ce, obj, name_str);
+
+    ZSTR_ALLOCA_FREE(name_str, use_heap);
+
+    return val;
+}

--- a/zend_abstract_interface/properties/php7-8/properties.c
+++ b/zend_abstract_interface/properties/php7-8/properties.c
@@ -37,8 +37,7 @@ zval *zai_read_property_direct(zend_class_entry *ce, zend_object *object, zend_s
     return OBJ_PROP(object, prop_info->offset);
 }
 
-#undef zai_read_property_direct_literal
-zval *zai_read_property_direct_literal(zend_class_entry *ce, zend_object *obj, const char *name, int name_len) {
+zval *zai_read_property_direct_cstr(zend_class_entry *ce, zend_object *obj, const char *name, int name_len) {
     zend_string *name_str;
     ALLOCA_FLAG(use_heap);
     ZSTR_ALLOCA_INIT(name_str, name, name_len, use_heap);

--- a/zend_abstract_interface/properties/php7-8/properties.h
+++ b/zend_abstract_interface/properties/php7-8/properties.h
@@ -6,7 +6,7 @@
 // Note that the function will completely bypass read_property. ce (scope) must be object ce or parent of object ce.
 zval *zai_read_property_direct(zend_class_entry *ce, zend_object *object, zend_string *name);
 
-zval *zai_read_property_direct_literal(zend_class_entry *ce, zend_object *obj, const char *name, int name_len);
-#define zai_read_property_direct_literal(obj, ce, name) zai_read_property_direct_literal(obj, ce, ZEND_STRL(name))
+zval *zai_read_property_direct_cstr(zend_class_entry *ce, zend_object *obj, const char *name, int name_len);
+#define zai_read_property_direct_literal(obj, ce, name) zai_read_property_direct_cstr(obj, ce, ZEND_STRL(name))
 
 #endif  // ZAI_PROPERTIES_H

--- a/zend_abstract_interface/properties/php7-8/properties.h
+++ b/zend_abstract_interface/properties/php7-8/properties.h
@@ -1,0 +1,12 @@
+#ifndef ZAI_PROPERTIES_H
+#define ZAI_PROPERTIES_H
+
+#include "Zend/zend_API.h"
+
+// Note that the function will completely bypass read_property. ce (scope) must be object ce or parent of object ce.
+zval *zai_read_property_direct(zend_class_entry *ce, zend_object *object, zend_string *name);
+
+zval *zai_read_property_direct_literal(zend_class_entry *ce, zend_object *obj, const char *name, int name_len);
+#define zai_read_property_direct_literal(obj, ce, name) zai_read_property_direct_literal(obj, ce, ZEND_STRL(name))
+
+#endif  // ZAI_PROPERTIES_H

--- a/zend_abstract_interface/properties/properties.h
+++ b/zend_abstract_interface/properties/properties.h
@@ -1,0 +1,5 @@
+#if PHP_VERSION_ID < 70000
+#include "php5/properties.h"
+#else
+#include "php7-8/properties.h"
+#endif

--- a/zend_abstract_interface/properties/tests/CMakeLists.txt
+++ b/zend_abstract_interface/properties/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(properties "${PHP_PROPERTIES_VERSION_DIRECTORY}/properties.cc")
+
+target_link_libraries(properties PUBLIC catch2_main Zai::Sapi Zai::Properties Zai::Functions)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(properties)

--- a/zend_abstract_interface/properties/tests/php7-8/properties.cc
+++ b/zend_abstract_interface/properties/tests/php7-8/properties.cc
@@ -1,0 +1,126 @@
+extern "C" {
+#include "zai_sapi/zai_sapi.h"
+#include "properties/properties.h"
+#include "functions/functions.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+#define TEST(name, code) TEST_CASE(name, "[zai properties]") { \
+        REQUIRE(zai_sapi_spinup()); \
+        ZAI_SAPI_TSRMLS_FETCH(); \
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() \
+        REQUIRE(zai_sapi_execute_script("./stubs/classes.php")); \
+        { code } \
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE() \
+        zai_sapi_spindown(); \
+    }
+
+TEST("access private property", {
+    zval super;
+    zai_call_function_literal("zai\\properties\\test\\super", &super);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(super), Z_OBJ(super), "private");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "private"));
+
+    zval_ptr_dtor(&super);
+})
+
+TEST("access protected property", {
+    zval super;
+    zai_call_function_literal("zai\\properties\\test\\super", &super);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(super), Z_OBJ(super), "protected");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "protected"));
+
+    zval_ptr_dtor(&super);
+})
+
+TEST("access public property", {
+    zval super;
+    zai_call_function_literal("zai\\properties\\test\\super", &super);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(super), Z_OBJ(super), "public");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "public"));
+
+    zval_ptr_dtor(&super);
+})
+
+TEST("access overridden private property on child", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child), Z_OBJ(child), "private");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "private from child"));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access overridden private property on parent", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child)->parent, Z_OBJ(child), "private");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "private"));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access private property on parent", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child)->parent, Z_OBJ(child), "superPrivate");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "superPrivate"));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access public property of parent", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child), Z_OBJ(child), "public");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "public"));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access dynamic property", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child), Z_OBJ(child), "dynamicPrivate");
+    REQUIRE(Z_TYPE_P(val) == IS_STRING);
+    REQUIRE(zend_string_equals_literal(Z_STR_P(val), "dynamicPrivate from child"));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access inexistent property is null", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child), Z_OBJ(child), "undefined");
+    REQUIRE(val == &EG(uninitialized_zval));
+
+    zval_ptr_dtor(&child);
+})
+
+TEST("access property with invalid name is error", {
+    zval child;
+    zai_call_function_literal("zai\\properties\\test\\child", &child);
+
+    zval *val = zai_read_property_direct_literal(Z_OBJCE(child), Z_OBJ(child), "\0with zero byte");
+    REQUIRE(val == &EG(error_zval));
+
+    zval_ptr_dtor(&child);
+})

--- a/zend_abstract_interface/properties/tests/stubs/classes.php
+++ b/zend_abstract_interface/properties/tests/stubs/classes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace zai\properties\test;
+
+class Super {
+    private $superPrivate = "superPrivate";
+    private $private = "private";
+    private $dynamicPrivate = "dynamicPrivate";
+    protected $superProtected = "superProtected";
+    protected $protected = "protected";
+    public $public = "public";
+}
+
+class Child extends Super {
+    private $private = "private from child";
+    public $protected = "protected from child";
+}
+
+// easy access functions
+function super() {
+    return new Super;
+}
+
+function child() {
+    $dyn = new Child;
+    $dyn->dynamicPrivate = "dynamicPrivate from child";
+    return $dyn;
+}


### PR DESCRIPTION
### Description

A simple function allowing direct access into userland (and internal classes without very special property storage) properties, bypassing __get() and similar.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
