### PR TITLE
Create exceptions ZAI seam for PHP 8 

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -227,6 +227,7 @@ if test "$PHP_DDTRACE" != "no"; then
     "
 
     ZAI_SOURCES="\
+      zend_abstract_interface/exceptions/php8/exceptions.c \
       zend_abstract_interface/functions/php8/functions.c \
       zend_abstract_interface/properties/php7-8/properties.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \
@@ -261,6 +262,8 @@ if test "$PHP_DDTRACE" != "no"; then
 
   PHP_ADD_INCLUDE([$ext_srcdir/zend_abstract_interface])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/exceptions])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/exceptions/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods])

--- a/ext/php8/engine_hooks.c
+++ b/ext/php8/engine_hooks.c
@@ -79,4 +79,3 @@ void ddtrace_restore_error_handling(ddtrace_error_handling *eh) {
 extern inline void ddtrace_sandbox_end(ddtrace_sandbox_backup *backup);
 extern inline ddtrace_sandbox_backup ddtrace_sandbox_begin(void);
 extern inline void ddtrace_maybe_clear_exception(void);
-extern inline zend_class_entry *ddtrace_get_exception_base(zval *object);

--- a/ext/php8/engine_hooks.h
+++ b/ext/php8/engine_hooks.h
@@ -92,12 +92,4 @@ void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t er
 void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception);
 void ddtrace_close_all_open_spans(void);
 
-inline zend_class_entry *ddtrace_get_exception_base(zval *object) {
-    return (Z_OBJCE_P(object) == zend_ce_exception || instanceof_function_slow(Z_OBJCE_P(object), zend_ce_exception))
-               ? zend_ce_exception
-               : zend_ce_error;
-}
-#define GET_PROPERTY(object, id) \
-    zend_read_property_ex(ddtrace_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &rv)
-
 #endif  // DD_ENGINE_HOOKS_H

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -6,10 +6,9 @@
 #include <Zend/zend_generators.h>
 #include <Zend/zend_interfaces.h>
 #include <Zend/zend_observer.h>
+#include <exceptions/exceptions.h>
 #include <functions/functions.h>
 #include <stdbool.h>
-
-#include <ext/spl/spl_exceptions.h>
 
 #include "ext/php8/compatibility.h"
 #include "ext/php8/ddtrace.h"
@@ -72,8 +71,7 @@ static ZEND_RESULT_CODE dd_sandbox_fci_call(zend_execute_data *call, zend_fcall_
         dd_try_fetch_executing_function_name(call, &scope, &colon, &name);
 
         if (PG(last_error_message) && backup.eh.message != PG(last_error_message)) {
-            char *error;
-            error = ZSTR_VAL(PG(last_error_message));
+            char *error = ZSTR_VAL(PG(last_error_message));
             ddtrace_log_errf("Error raised in ddtrace's closure for %s%s%s(): %s in %s on line %d", scope, colon, name,
                              error, PG(last_error_file), PG(last_error_lineno));
         }
@@ -81,16 +79,10 @@ static ZEND_RESULT_CODE dd_sandbox_fci_call(zend_execute_data *call, zend_fcall_
         if (UNEXPECTED(EG(exception))) {
             zend_object *ex = EG(exception);
 
-            const char *type = ex->ce->name->val;
-            zval rv, obj;
-            ZVAL_OBJ(&obj, ex);
-            zval *message = GET_PROPERTY(&obj, ZEND_STR_MESSAGE);
-            const char *msg =
-                Z_TYPE_P(message) == IS_STRING ? Z_STR_P(message)->val : "(internal error reading exception message)";
-            ddtrace_log_errf("%s thrown in ddtrace's closure for %s%s%s(): %s", type, scope, colon, name, msg);
-            if (message == &rv) {
-                zval_dtor(message);
-            }
+            const char *type = ZSTR_VAL(ex->ce->name);
+            zend_string *msg = zai_exception_message(ex);
+            ddtrace_log_errf("%s thrown in ddtrace's closure for %s%s%s(): %s", type, scope, colon, name,
+                             ZSTR_VAL(msg));
         }
     }
     ddtrace_sandbox_end(&backup);

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -2,14 +2,14 @@
 #include <Zend/zend_builtin_functions.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_interfaces.h>
-#include <Zend/zend_smart_str.h>
 #include <Zend/zend_types.h>
 #include <inttypes.h>
 #include <php.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <ext/spl/spl_exceptions.h>
+// comment to prevent clang from reordering these headers
+#include <exceptions/exceptions.h>
+#include <properties/properties.h>
 
 #include "arrays.h"
 #include "compat_string.h"
@@ -154,110 +154,24 @@ static void _add_assoc_zval_copy(zval *el, const char *name, zval *prop) {
     add_assoc_zval(el, (name), &value);
 }
 
-/* Modeled after Exception::getTraceAsString:
- * @see https://heap.space/xref/PHP-8.0/Zend/zend_exceptions.c#getTraceAsString
- */
-static zend_string *dd_serialize_exception_trace_without_args(HashTable *trace) {
-    zval *frame;
-    smart_str str = {0};
-    uint32_t num = 0;
-    ZEND_HASH_FOREACH_VAL(trace, frame) {
-        if (UNEXPECTED(Z_TYPE_P(frame) != IS_ARRAY)) {
-            smart_str_free(&str);
-            return NULL;
-        }
-
-        HashTable *ht = Z_ARRVAL_P(frame);
-        smart_str_appendc(&str, '#');
-        smart_str_append_long(&str, num++);
-        smart_str_appendc(&str, ' ');
-
-        zval *file = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FILE), 1);
-        if (file) {
-            if (Z_TYPE_P(file) != IS_STRING) {
-                /* This is not the function, but the file. However, this is what
-                 * PHP itself reports, so we'll match it for consistency.
-                 */
-                smart_str_appends(&str, "[unknown function]");
-            } else {
-                zend_long line = 0;
-                zval *tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_LINE), 1);
-                if (tmp && Z_TYPE_P(tmp) == IS_LONG) {
-                    line = Z_LVAL_P(tmp);
-                }
-                smart_str_append(&str, Z_STR_P(file));
-                smart_str_appendc(&str, '(');
-                smart_str_append_long(&str, line);
-                smart_str_appends(&str, "): ");
-            }
-        } else {
-            smart_str_appends(&str, "[internal function]: ");
-        }
-
-        {
-            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_CLASS));
-            if (tmp) {
-                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
-            }
-        }
-        {
-            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_TYPE));
-            if (tmp) {
-                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
-            }
-        }
-        {
-            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_FUNCTION));
-            if (tmp) {
-                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
-            }
-        }
-
-        /* We intentionally do not show any arguments, not even an ellipsis if
-         * there are arguments. This is because in PHP 7.4+ there is an INI
-         * setting called zend.exception_ignore_args that prevents them from
-         * being generated, so we can't even reliably know if there are args.
-         */
-        smart_str_appends(&str, "()\n");
-    }
-    ZEND_HASH_FOREACH_END();
-
-    smart_str_appendc(&str, '#');
-    smart_str_append_long(&str, num);
-    smart_str_appends(&str, " {main}");
-    smart_str_0(&str);
-
-    return str.s;
-}
-
 typedef zend_result (*add_tag_fn_t)(void *context, ddtrace_string key, ddtrace_string value);
 
 static zend_result dd_exception_to_error_msg(zend_object *exception, void *context, add_tag_fn_t add_tag) {
-    zval msg = ddtrace_zval_undef();
-    zend_result status = ddtrace_call_method(exception, exception->ce, NULL, ZEND_STRL("getmessage"), &msg, 0, NULL);
-
-    if (status == SUCCESS && Z_TYPE(msg) == IS_STRING) {
-        ddtrace_string key = DDTRACE_STRING_LITERAL("error.msg");
-        ddtrace_string value = {Z_STRVAL(msg), Z_STRLEN(msg)};
-        status = add_tag(context, key, value);
-    } else {
-        ddtrace_assert_log_debug("Failed calling exception's getMessage()");
-    }
-
-    zval_ptr_dtor(&msg);
-    return status;
+    ddtrace_string key = DDTRACE_STRING_LITERAL("error.msg");
+    zend_string *msg = zai_exception_message(exception);
+    ddtrace_string value = {ZSTR_VAL(msg), ZSTR_LEN(msg)};
+    return add_tag(context, key, value);
 }
 
 static zend_result dd_exception_to_error_type(zend_object *exception, void *context, add_tag_fn_t add_tag) {
     ddtrace_string value, key = DDTRACE_STRING_LITERAL("error.type");
 
     if (instanceof_function(exception->ce, ddtrace_ce_fatal_error)) {
-        zval code = ddtrace_zval_undef();
-        int status = ddtrace_call_method(exception, exception->ce, NULL, ZEND_STRL("getcode"), &code, 0, NULL);
+        zval *code = ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_CODE);
         const char *error_type_string = "{unknown error}";
 
-        if (status == SUCCESS && Z_TYPE_INFO(code) == IS_LONG) {
-            switch (Z_LVAL(code)) {
+        if (Z_TYPE_P(code) == IS_LONG) {
+            switch (Z_LVAL_P(code)) {
                 case E_ERROR:
                     error_type_string = "E_ERROR";
                     break;
@@ -279,9 +193,7 @@ static zend_result dd_exception_to_error_type(zend_object *exception, void *cont
             ddtrace_assert_log_debug("Exception was a DDTrace\\FatalError but failed to get an exception code");
         }
 
-        zval_ptr_dtor(&code);
         value = ddtrace_string_cstring_ctor((char *)error_type_string);
-
     } else {
         zend_string *type_name = exception->ce->name;
         value.ptr = ZSTR_VAL(type_name);
@@ -292,25 +204,11 @@ static zend_result dd_exception_to_error_type(zend_object *exception, void *cont
 }
 
 static zend_result dd_exception_to_error_stack(zend_object *exception, void *context, add_tag_fn_t add_tag) {
-    zend_class_entry *base_ce =
-        instanceof_function(exception->ce, zend_ce_exception) ? zend_ce_exception : zend_ce_error;
-
-    // todo: we apparently need to sandbox this, as getTraceAsString checks for an exception.
-    zval rv;
-    zval *trace = zend_read_property_ex(base_ce, exception, ZSTR_KNOWN(ZEND_STR_TRACE), 1, &rv);
-    if (EG(exception) || !trace || Z_TYPE_P(trace) != IS_ARRAY) {
-        ddtrace_assert_log_debug("Failed getting exception's trace");
-        return FAILURE;
-    }
-
-    zend_string *trace_string = dd_serialize_exception_trace_without_args(Z_ARR_P(trace));
-    zend_result result = FAILURE;
-    if (trace_string) {
-        ddtrace_string key = DDTRACE_STRING_LITERAL("error.stack");
-        ddtrace_string value = {ZSTR_VAL(trace_string), ZSTR_LEN(trace_string)};
-        result = add_tag(context, key, value);
-        zend_string_release(trace_string);
-    }
+    zend_string *trace_string = zai_get_trace_without_args_from_exception(exception);
+    ddtrace_string key = DDTRACE_STRING_LITERAL("error.stack");
+    ddtrace_string value = {ZSTR_VAL(trace_string), ZSTR_LEN(trace_string)};
+    zend_result result = add_tag(context, key, value);
+    zend_string_release(trace_string);
     return result;
 }
 
@@ -352,14 +250,11 @@ static zend_string *dd_error_type(int code) {
 }
 
 static zend_string *dd_fatal_error_stack(void) {
-    zval stack;
+    zval stack = {0};
     zend_fetch_debug_backtrace(&stack, 0, DEBUG_BACKTRACE_IGNORE_ARGS, 0);
     zend_string *error_stack = NULL;
     if (Z_TYPE(stack) == IS_ARRAY) {
-        zend_string *s = dd_serialize_exception_trace_without_args(Z_ARR(stack));
-        if (s) {
-            error_stack = s;
-        }
+        error_stack = zai_get_trace_without_args(Z_ARR(stack));
     }
     zval_ptr_dtor(&stack);
     return error_stack;

--- a/package.xml
+++ b/package.xml
@@ -59,6 +59,10 @@
             <file name="zend_abstract_interface/properties/php7-8/properties.c" role="src" />
             <file name="zend_abstract_interface/properties/php7-8/properties.h" role="src" />
             <file name="zend_abstract_interface/properties/properties.h" role="src" />
+            <file name="zend_abstract_interface/exceptions/exceptions.h" role="src" />
+            <file name="zend_abstract_interface/exceptions/exceptions_common.h" role="src" />
+            <file name="zend_abstract_interface/exceptions/php8/exceptions.c" role="src" />
+            <file name="zend_abstract_interface/exceptions/php8/exceptions.h" role="src" />
             <file name="zend_abstract_interface/zai_assert/zai_assert.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php5/zai_sapi.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/php7/zai_sapi.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -91,6 +91,7 @@ add_subdirectory(zai_assert)
 if(PHP_VERSION_DIRECTORY STREQUAL "php8")
   # should support php7 as well, but depends on functions ZAI to test, disabling for now
   add_subdirectory(properties)
+  add_subdirectory(exceptions)
 endif()
 
 install(EXPORT ZendAbstractInterfaceTargets

--- a/zend_abstract_interface/exceptions/CMakeLists.txt
+++ b/zend_abstract_interface/exceptions/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(zai_exceptions "${PHP_VERSION_DIRECTORY}/exceptions.c")
+
+target_include_directories(zai_exceptions PUBLIC
+                                          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                          $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_exceptions PUBLIC c_std_99)
+
+target_link_libraries(zai_exceptions PUBLIC "${PHP_LIB}" Zai::Properties)
+
+set_target_properties(zai_exceptions PROPERTIES
+                                     EXPORT_NAME exceptions
+                                     VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Exceptions ALIAS zai_exceptions)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/exceptions.h ${CMAKE_CURRENT_SOURCE_DIR}/exceptions_common.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exceptions/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_exceptions)
+
+install(TARGETS zai_exceptions EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/exceptions/exceptions.h
+++ b/zend_abstract_interface/exceptions/exceptions.h
@@ -1,0 +1,7 @@
+#if PHP_VERSION_ID < 70000
+#include "php5/exceptions.h"
+#elif PHP_VERSION_ID < 80000
+#include "php7/exceptions.h"
+#else
+#include "php8/exceptions.h"
+#endif

--- a/zend_abstract_interface/exceptions/exceptions_common.h
+++ b/zend_abstract_interface/exceptions/exceptions_common.h
@@ -1,0 +1,7 @@
+#include <main/php.h>
+
+#if PHP_VERSION_ID < 70100
+
+#define ZEND_STR_MESSAGE "message"
+
+#endif

--- a/zend_abstract_interface/exceptions/php8/exceptions.c
+++ b/zend_abstract_interface/exceptions/php8/exceptions.c
@@ -1,0 +1,111 @@
+#include "exceptions.h"
+
+#include <Zend/zend_smart_str.h>
+
+zend_string *zai_exception_message(zend_object *ex) {
+    if (!ex) {
+        // should never happen; TODO: fail in CI
+        return zend_string_init_interned(ZEND_STRL("(internal error retrieving exception for message)"), 1);
+    }
+
+    zval *message = ZAI_EXCEPTION_PROPERTY(ex, ZEND_STR_MESSAGE);
+    if (Z_TYPE_P(message) != IS_STRING) {
+        // interned, so we can forego freeing it ourselves
+        return zend_string_init_interned(ZEND_STRL("(internal error reading exception message)"), 1);
+    }
+    return Z_STR_P(message);
+}
+
+/* Modeled after Exception::getTraceAsString:
+ * @see https://heap.space/xref/PHP-8.0/Zend/zend_exceptions.c#getTraceAsString
+ */
+zend_string *zai_get_trace_without_args(zend_array *trace) {
+    if (!trace) {
+        // should never happen; TODO: fail in CI
+        return zend_string_init_interned(ZEND_STRL("[broken trace]"), 1);
+    }
+
+    zval *frame;
+    smart_str str = {0};
+    uint32_t num = 0;
+    ZEND_HASH_FOREACH_VAL(trace, frame) {
+        smart_str_appendc(&str, '#');
+        smart_str_append_long(&str, num++);
+        smart_str_appendc(&str, ' ');
+
+        if (UNEXPECTED(Z_TYPE_P(frame) != IS_ARRAY)) {
+            smart_str_appends(&str, "[invalid frame]\n");
+            continue;
+        }
+
+        zend_array *ht = Z_ARRVAL_P(frame);
+
+        zval *file = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FILE), 1);
+        if (file) {
+            if (Z_TYPE_P(file) != IS_STRING) {
+                // before PHP 8.0.7 this was unknown function, but unknown file is much better
+                smart_str_appends(&str, "[unknown file]");
+            } else {
+                zend_long line = 0;
+                zval *tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_LINE), 1);
+                if (tmp && Z_TYPE_P(tmp) == IS_LONG) {
+                    line = Z_LVAL_P(tmp);
+                }
+                smart_str_append(&str, Z_STR_P(file));
+                smart_str_appendc(&str, '(');
+                smart_str_append_long(&str, line);
+                smart_str_appends(&str, "): ");
+            }
+        } else {
+            smart_str_appends(&str, "[internal function]: ");
+        }
+
+        {
+            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_CLASS));
+            if (tmp) {
+                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
+            }
+        }
+        {
+            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_TYPE));
+            if (tmp) {
+                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
+            }
+        }
+        {
+            zval *tmp = zend_hash_find(ht, ZSTR_KNOWN(ZEND_STR_FUNCTION));
+            if (tmp) {
+                smart_str_appends(&str, Z_TYPE_P(tmp) == IS_STRING ? Z_STRVAL_P(tmp) : "[unknown]");
+            }
+        }
+
+        /* We intentionally do not show any arguments, not even an ellipsis if
+         * there are arguments. This is because in PHP 7.4+ there is an INI
+         * setting called zend.exception_ignore_args that prevents them from
+         * being generated, so we can't even reliably know if there are args.
+         */
+        smart_str_appends(&str, "()\n");
+    }
+    ZEND_HASH_FOREACH_END();
+
+    smart_str_appendc(&str, '#');
+    smart_str_append_long(&str, num);
+    smart_str_appends(&str, " {main}");
+    smart_str_0(&str);
+
+    return str.s;
+}
+
+zend_string *zai_get_trace_without_args_from_exception(zend_object *ex) {
+    if (!ex) {
+        return ZSTR_EMPTY_ALLOC();  // should never happen; TODO: fail in CI
+    }
+
+    zval *trace = ZAI_EXCEPTION_PROPERTY(ex, ZEND_STR_TRACE);
+    if (Z_TYPE_P(trace) != IS_ARRAY) {
+        // return an empty string here instead of NULL to avoid having to think about handling this
+        return ZSTR_EMPTY_ALLOC();  // should never happen in PHP 8 as the property is typed and always initialized
+    }
+
+    return zai_get_trace_without_args(Z_ARR_P(trace));
+}

--- a/zend_abstract_interface/exceptions/php8/exceptions.h
+++ b/zend_abstract_interface/exceptions/php8/exceptions.h
@@ -1,0 +1,23 @@
+#ifndef ZAI_EXCEPTIONS_H
+#define ZAI_EXCEPTIONS_H
+
+#include <main/php.h>
+// dummy comment here to prevent clang format fixer from reordering includes here
+#include <Zend/zend_exceptions.h>
+#include <properties/properties.h>
+
+#include "../exceptions_common.h"
+
+static inline zend_class_entry *zai_get_exception_base(zend_object *object) {
+    assert(instanceof_function(object->ce, zend_ce_throwable));
+    return instanceof_function(object->ce, zend_ce_exception) ? zend_ce_exception : zend_ce_error;
+}
+
+#define ZAI_EXCEPTION_PROPERTY(object, id) \
+    zai_read_property_direct(zai_get_exception_base(object), object, ZSTR_KNOWN(id))
+
+zend_string *zai_exception_message(zend_object *ex);  // fallback string if message invalid
+zend_string *zai_get_trace_without_args(zend_array *trace);
+zend_string *zai_get_trace_without_args_from_exception(zend_object *ex);
+
+#endif  // ZAI_EXCEPTIONS_H

--- a/zend_abstract_interface/exceptions/tests/CMakeLists.txt
+++ b/zend_abstract_interface/exceptions/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(exceptions "${PHP_VERSION_DIRECTORY}/exceptions.cc")
+
+target_link_libraries(exceptions PUBLIC catch2_main Zai::Sapi Zai::Functions Zai::Exceptions)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(exceptions)

--- a/zend_abstract_interface/exceptions/tests/php8/exceptions.cc
+++ b/zend_abstract_interface/exceptions/tests/php8/exceptions.cc
@@ -1,0 +1,159 @@
+extern "C" {
+#include "zai_sapi/zai_sapi.h"
+#include "exceptions/exceptions.h"
+#include "functions/functions.h"
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+#define TEST(name, code) TEST_CASE(name, "[zai exceptions]") { \
+        REQUIRE(zai_sapi_spinup()); \
+        ZAI_SAPI_TSRMLS_FETCH(); \
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() \
+        REQUIRE(zai_sapi_execute_script("./stubs/functions.php")); \
+        { code } \
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE() \
+        zai_sapi_spindown(); \
+    }
+
+TEST("reading message with non-string type returns a non-empty string", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\broken_exception", &ex);
+
+    zend_string *str = zai_exception_message(Z_OBJ(ex));
+    REQUIRE(ZSTR_LEN(str) > 0);
+
+    zval_ptr_dtor(&ex);
+})
+
+TEST("reading message from exception", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\legitimate_exception", &ex);
+
+    zend_string *str = zai_exception_message(Z_OBJ(ex));
+    REQUIRE(zend_string_equals_literal(str, "msg"));
+
+    zval_ptr_dtor(&ex);
+})
+
+TEST("reading message from exception subclass", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\child_exception", &ex);
+
+    zend_string *str = zai_exception_message(Z_OBJ(ex));
+    REQUIRE(zend_string_equals_literal(str, "msg"));
+
+    zval_ptr_dtor(&ex);
+})
+
+TEST("reading message from error", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\legitimate_error", &ex);
+
+    zend_string *str = zai_exception_message(Z_OBJ(ex));
+    REQUIRE(zend_string_equals_literal(str, "msg"));
+
+    zval_ptr_dtor(&ex);
+})
+
+TEST("reading message from error subclass", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\child_error", &ex);
+
+    zend_string *str = zai_exception_message(Z_OBJ(ex));
+    REQUIRE(zend_string_equals_literal(str, "msg"));
+
+    zval_ptr_dtor(&ex);
+})
+
+TEST("reading trace from exception", {
+    zval ex;
+    zai_call_function_literal("zai\\exceptions\\test\\legitimate_exception", &ex);
+
+    zend_string *str = zai_get_trace_without_args_from_exception(Z_OBJ(ex));
+    REQUIRE(zend_string_equals_literal(str, "#0 [internal function]: zai\\exceptions\\test\\legitimate_exception()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&ex);
+})
+
+TEST("serializing trace with invalid frame", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\trace_with_bad_frame", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 functions.php(7): ()\n"
+                                            "#1 [invalid frame]\n"
+                                            "#2 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})
+
+TEST("serializing valid trace", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\good_trace_with_all_values", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 functions.php(7): Foo--bar()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})
+
+TEST("serializing trace with invalid filename", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\trace_with_invalid_filename", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 [unknown file]()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})
+
+TEST("serializing trace without line number", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\trace_without_line_number", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 functions.php(0): ()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})
+
+TEST("serializing trace with invalid line number", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\trace_with_invalid_line_number", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 functions.php(0): ()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})
+
+TEST("serializing trace with invalid class, type and function", {
+    zval trace;
+    zai_call_function_literal("zai\\exceptions\\test\\trace_with_invalid_class_type_function", &trace);
+
+    zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
+    printf("%s", ZSTR_VAL(str));
+    REQUIRE(zend_string_equals_literal(str, "#0 functions.php(7): [unknown][unknown][unknown]()\n"
+                                            "#1 {main}"));
+
+    zend_string_release(str);
+    zval_ptr_dtor(&trace);
+})

--- a/zend_abstract_interface/exceptions/tests/stubs/functions.php
+++ b/zend_abstract_interface/exceptions/tests/stubs/functions.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace zai\exceptions\test;
+
+if (PHP_VERSION_ID > 70000) {
+    class ChildError extends \Error {}
+
+    function legitimate_error() {
+        return new \Error("msg");
+    }
+
+    function child_error() {
+        return new ChildError("msg");
+    }
+}
+
+class ChildException extends \Exception {}
+
+function legitimate_exception() {
+    return new \Exception("msg");
+}
+
+function child_exception() {
+    return new ChildException("msg");
+}
+
+function broken_exception() {
+    $e = new \Exception;
+    $ref = new \ReflectionClass($e);
+    if (PHP_VERSION_ID < 80000) {
+        // trace is a typed property in PHP 8 and will always be array
+        $p = $ref->getProperty("trace");
+        $p->setAccessible(true);
+        $p->setValue($e, "Not an array");
+    }
+    $p = $ref->getProperty("message");
+    $p->setAccessible(true);
+    $p->setValue($e, new \stdClass);
+    return $e;
+}
+
+function trace_with_bad_frame() {
+    return [
+        ["file" => "functions.php", "line" => 7],
+        "foo",
+    ];
+}
+
+function good_trace_with_all_values() {
+    return [
+        ["file" => "functions.php", "line" => 7, "class" => "Foo", "type" => "--", "function" => "bar"],
+    ];
+}
+
+function trace_with_invalid_filename() {
+    return [
+        ["file" => 123]
+    ];
+}
+
+function trace_without_line_number() {
+    return [
+        ["file" => "functions.php"]
+    ];
+}
+
+function trace_with_invalid_line_number() {
+    return [
+        ["file" => "functions.php", "line" => new \stdClass]
+    ];
+}
+
+function trace_with_invalid_class_type_function() {
+    return [
+        ["file" => "functions.php", "line" => 7, "class" => new \stdClass, "type" => [], "function" => null]
+    ];
+}


### PR DESCRIPTION
### Description

Using the properties seam within an exceptions seam, and use that in the php 8 source.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
