### PR TITLE
Moving spans from userland to extension

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -20,6 +20,7 @@
     </rule>
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>
+        <exclude-pattern>*/Span.php</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>bridge/dd_init.php</exclude-pattern>

--- a/ext/php8/auto_flush.c
+++ b/ext/php8/auto_flush.c
@@ -1,65 +1,50 @@
 #include "auto_flush.h"
 
-#include <php.h>
-
-#include "configuration.h"
-#include "engine_api.h"
-#include "engine_hooks.h"  // for ddtrace_backup_error_handling
+#include "comms_php.h"
+#include "ddtrace_string.h"
+#include "logging.h"
+#include "serializer.h"
+#include "span.h"
 
 ZEND_RESULT_CODE ddtrace_flush_tracer() {
-    zval tracer, retval;
-    zend_class_entry *GlobalTracer_ce = ddtrace_lookup_ce(ZEND_STRL("DDTrace\\GlobalTracer"));
     bool success = true;
 
-    zend_object *exception = NULL, *prev_exception = NULL;
-    if (EG(exception)) {
-        exception = EG(exception);
-        EG(exception) = NULL;
-        prev_exception = EG(prev_exception);
-        EG(prev_exception) = NULL;
-        zend_clear_exception();
+    zval trace, traces;
+    ddtrace_serialize_closed_spans(&trace);
+
+    if (zend_hash_num_elements(Z_ARR(trace)) == 0) {
+        zend_array_destroy(Z_ARR(trace));
+        ddtrace_log_debug("No finished traces to be sent to the agent");
+        return SUCCESS;
     }
 
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
+    // background sender only wants a singular trace
+    array_init(&traces);
+    zend_hash_index_add(Z_ARR(traces), 0, &trace);
 
-    zend_bool orig_disable_in_current_request = DDTRACE_G(disable_in_current_request);
-    DDTRACE_G(disable_in_current_request) = 1;
-
-    // $tracer = \DDTrace\GlobalTracer::get();
-    if (!GlobalTracer_ce ||
-        ddtrace_call_method(NULL, GlobalTracer_ce, NULL, ZEND_STRL("get"), &tracer, 0, NULL) == FAILURE) {
-        DDTRACE_G(disable_in_current_request) = orig_disable_in_current_request;
-
-        ddtrace_restore_error_handling(&eh);
-        ddtrace_maybe_clear_exception();
-        if (exception) {
-            EG(exception) = exception;
-            EG(prev_exception) = prev_exception;
-            zend_throw_exception_internal(NULL);
+    char *payload;
+    size_t size;
+    if (ddtrace_serialize_simple_array_into_c_string(&traces, &payload, &size)) {
+        // The 10MB payload cap is inclusive, thus we use >, not >=
+        // https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/limited_reader.go#L37
+        if (size > AGENT_REQUEST_BODY_LIMIT) {
+            ddtrace_log_errf("Agent request payload of %zu bytes exceeds 10MB limit; dropping request", size);
+            success = false;
+        } else {
+            success = ddtrace_send_traces_via_thread(1, payload, size);
+            if (success) {
+                ddtrace_log_debugf("Successfully triggered auto-flush with trace of size %d",
+                                   zend_hash_num_elements(Z_ARR(trace)));
+            }
+            dd_prepare_for_new_trace();
         }
-        return FAILURE;
+
+        free(payload);
+    } else {
+        success = false;
     }
 
-    if (Z_TYPE(tracer) == IS_OBJECT) {
-        zend_object *obj = Z_OBJ(tracer);
-        zend_class_entry *ce = obj->ce;
-        success = ddtrace_call_method(obj, ce, NULL, ZEND_STRL("flush"), &retval, 0, NULL) == SUCCESS &&
-                  ddtrace_call_method(obj, ce, NULL, ZEND_STRL("reset"), &retval, 0, NULL) == SUCCESS;
-    }
-
-    DDTRACE_G(disable_in_current_request) = orig_disable_in_current_request;
-
-    ddtrace_restore_error_handling(&eh);
-    ddtrace_maybe_clear_exception();
-    if (exception) {
-        EG(exception) = exception;
-        EG(prev_exception) = prev_exception;
-        zend_throw_exception_internal(NULL);
-    }
-
-    zval_dtor(&tracer);
-    zval_dtor(&retval);
+    zval_ptr_dtor(&traces);
 
     return success ? SUCCESS : FAILURE;
 }

--- a/ext/php8/comms_php.h
+++ b/ext/php8/comms_php.h
@@ -7,6 +7,8 @@
 
 #include "compatibility.h"
 
+static const size_t AGENT_REQUEST_BODY_LIMIT = 10485760;
+
 bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t payload_len);
 
 #endif  // DDTRACE_COMMS_PHP_H

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -88,6 +88,7 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_distributed_tracing, "DD_DISTRIBUTED_TRACING", true)                                                 \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     CHAR(get_dd_env, "DD_ENV", "")                                                                                   \
+    BOOL(get_dd_autofinish_spans, "DD_AUTOFINISH_SPANS", false)                                                      \
     CHAR(get_dd_integrations_disabled, "DD_INTEGRATIONS_DISABLED", "")                                               \
     BOOL(get_dd_priority_sampling, "DD_PRIORITY_SAMPLING", true)                                                     \
     CHAR(get_dd_service, "DD_SERVICE", "")                                                                           \
@@ -120,10 +121,6 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_trace_generate_root_span, "DD_TRACE_GENERATE_ROOT_SPAN", true)                                       \
     BOOL(get_dd_trace_sandbox_enabled, "DD_TRACE_SANDBOX_ENABLED", true)                                             \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", true,                          \
-         "use background thread to send traces to the agent")                                                        \
-    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", true,                                                     \
-         "use background sender (BGS) to send traces to the agent")                                                  \
     INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
     INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \
     INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -14,15 +14,18 @@ extern zend_class_entry *ddtrace_ce_fatal_error;
 
 typedef struct ddtrace_span_ids_t ddtrace_span_ids_t;
 typedef struct ddtrace_span_fci ddtrace_span_fci;
+typedef struct ddtrace_span_t ddtrace_span_t;
 
-zval *ddtrace_spandata_property_name(zval *spandata);
-zval *ddtrace_spandata_property_resource(zval *spandata);
-zval *ddtrace_spandata_property_service(zval *spandata);
-zval *ddtrace_spandata_property_type(zval *spandata);
-zval *ddtrace_spandata_property_meta(zval *spandata);
-zval *ddtrace_spandata_property_metrics(zval *spandata);
+zval *ddtrace_spandata_property_name(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_resource(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_service(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_type(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 
 BOOL_T ddtrace_tracer_is_limited(void);
+// prepare the tracer state to start handling a new trace
+void dd_prepare_for_new_trace(void);
 
 // clang-format off
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
@@ -38,6 +41,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     HashTable *class_lookup;
     HashTable *function_lookup;
     zval additional_trace_meta; // IS_ARRAY
+    zend_array *additional_global_tags;
     zend_bool log_backtrace;
     zend_bool backtrace_handler_already_run;
     dogstatsd_client dogstatsd_client;

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -290,7 +290,7 @@ static zend_result dd_add_meta_array(void *context, ddtrace_string key, ddtrace_
 
 static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
     ddtrace_span_t *span = &span_fci->span;
-    zval meta_zv, *meta = ddtrace_spandata_property_meta(span->span_data);
+    zval meta_zv, *meta = ddtrace_spandata_property_meta(span);
 
     array_init(&meta_zv);
     if (meta && Z_TYPE_P(meta) == IS_ARRAY) {
@@ -320,6 +320,40 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
         snprintf(pid, sizeof(pid), "%ld", (long)span->pid);
         add_assoc_string(meta, "system.pid", pid);
     }
+
+    char *version = get_dd_version();
+    if (*version) {  // non-empty
+        add_assoc_string(meta, "version", version);
+    }
+    free(version);
+
+    char *env = get_dd_env();
+    if (*env) {  // non-empty
+        add_assoc_string(meta, "env", env);
+    }
+    free(env);
+
+    zend_array *global_tags = get_dd_tags();
+    if (zend_hash_num_elements(global_tags) == 0) {
+        zend_hash_release(global_tags);
+        global_tags = get_dd_trace_global_tags();
+    }
+    zend_string *global_key;
+    zval *global_val;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(global_tags, global_key, global_val) {
+        Z_TRY_ADDREF_P(global_val);  // they're actually persistent strings, but doing the check does no harm here
+        zend_hash_add(Z_ARR_P(meta), global_key, global_val);
+    }
+    ZEND_HASH_FOREACH_END();
+    zend_hash_release(global_tags);
+
+    zend_string *tag_key;
+    zval *tag_value;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(DDTRACE_G(additional_global_tags), tag_key, tag_value) {
+        Z_TRY_ADDREF_P(tag_value);
+        zend_hash_add(Z_ARR_P(meta), tag_key, tag_value);
+    }
+    ZEND_HASH_FOREACH_END();
 
     if (zend_array_count(Z_ARRVAL_P(meta))) {
         add_assoc_zval(el, "meta", meta);
@@ -359,40 +393,46 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
     add_assoc_long(el, "duration", span->duration);
 
     // SpanData::$name defaults to fully qualified called name (set at span close)
-    zval *prop_name = ddtrace_spandata_property_name(span->span_data);
+    zval *prop_name = ddtrace_spandata_property_name(span);
     zval prop_name_as_string;
-    if (Z_TYPE_P(prop_name) != IS_NULL) {
+    if (Z_TYPE_P(prop_name) > IS_NULL) {
         ddtrace_convert_to_string(&prop_name_as_string, prop_name);
-        _add_assoc_zval_copy(el, "name", &prop_name_as_string);
+        zend_array *service_mappings = get_dd_service_mapping();
+        zval *new_name = zend_hash_find(service_mappings, Z_STR(prop_name_as_string));
+        if (new_name) {
+            zend_string_release(Z_STR(prop_name_as_string));
+            ZVAL_COPY(&prop_name_as_string, new_name);
+        }
+        zend_hash_release(service_mappings);
+        prop_name = zend_hash_str_update(Z_ARR_P(el), ZEND_STRL("name"), &prop_name_as_string);
     }
 
     // SpanData::$resource defaults to SpanData::$name
-    zval *prop_resource = ddtrace_spandata_property_resource(span->span_data);
-    if (Z_TYPE_P(prop_resource) != IS_NULL) {
+    zval *prop_resource = ddtrace_spandata_property_resource(span);
+    if (Z_TYPE_P(prop_resource) > IS_FALSE && (Z_TYPE_P(prop_resource) != IS_STRING || Z_STRLEN_P(prop_resource) > 0)) {
         _dd_add_assoc_zval_as_string(el, "resource", prop_resource);
-    } else {
-        _add_assoc_zval_copy(el, "resource", &prop_name_as_string);
-    }
-
-    if (Z_TYPE_P(prop_name) != IS_NULL) {
-        zval_dtor(&prop_name_as_string);
+    } else if (Z_TYPE_P(prop_name) != IS_NULL) {
+        _add_assoc_zval_copy(el, "resource", prop_name);
     }
 
     // TODO: SpanData::$service defaults to parent SpanData::$service or DD_SERVICE if root span
-    zval *prop_service = ddtrace_spandata_property_service(span->span_data);
-    if (Z_TYPE_P(prop_service) != IS_NULL) {
-        _dd_add_assoc_zval_as_string(el, "service", prop_service);
+    zval *prop_service = ddtrace_spandata_property_service(span);
+    if (Z_TYPE_P(prop_service) > IS_NULL) {
+        zval service_zv;
+        ddtrace_convert_to_string(&service_zv, prop_service);
+
+        add_assoc_zval(el, "service", &service_zv);
     }
 
     // SpanData::$type is optional and defaults to 'custom' at the Agent level
-    zval *prop_type = ddtrace_spandata_property_type(span->span_data);
-    if (Z_TYPE_P(prop_type) != IS_NULL) {
+    zval *prop_type = ddtrace_spandata_property_type(span);
+    if (Z_TYPE_P(prop_type) > IS_NULL) {
         _dd_add_assoc_zval_as_string(el, "type", prop_type);
     }
 
     _serialize_meta(el, span_fci);
 
-    zval *metrics = ddtrace_spandata_property_metrics(span->span_data);
+    zval *metrics = ddtrace_spandata_property_metrics(span);
     if (Z_TYPE_P(metrics) == IS_ARRAY) {
         _add_assoc_zval_copy(el, "metrics", metrics);
     }
@@ -439,15 +479,11 @@ void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t er
             dd_fatal_error_to_meta(&DDTRACE_G(additional_trace_meta), error);
             ddtrace_span_fci *span;
             for (span = DDTRACE_G(open_spans_top); span; span = span->next) {
-                if (span->exception || !span->span.span_data) {
+                if (span->exception) {
                     continue;
                 }
 
-                zval *meta = ddtrace_spandata_property_meta(span->span.span_data);
-                if (!meta) {
-                    continue;
-                }
-
+                zval *meta = ddtrace_spandata_property_meta(&span->span);
                 if (Z_TYPE_P(meta) != IS_ARRAY) {
                     zval_ptr_dtor(meta);
                     array_init_size(meta, ddtrace_num_error_tags);

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -14,25 +14,23 @@ static const int ddtrace_num_error_tags = 3;
 struct ddtrace_dispatch_t;
 
 struct ddtrace_span_t {
-    zval *span_data;
+    zend_object std;
+    zval properties_table_placeholder[5];
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;
     uint64_t start;
-    union {
-        uint64_t duration_start;
-        uint64_t duration;
-    };
+    uint64_t duration_start;
+    uint64_t duration;
     pid_t pid;
 };
-typedef struct ddtrace_span_t ddtrace_span_t;
 
 struct ddtrace_span_fci {
+    ddtrace_span_t span;
     zend_execute_data *execute_data;
     struct ddtrace_dispatch_t *dispatch;
     ddtrace_exception_t *exception;
     struct ddtrace_span_fci *next;
-    ddtrace_span_t span;
 };
 typedef struct ddtrace_span_fci ddtrace_span_fci;
 
@@ -41,8 +39,12 @@ void ddtrace_free_span_stacks(void);
 
 void ddtrace_push_span(ddtrace_span_fci *span_fci);
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
+ddtrace_span_fci *ddtrace_init_span();
+void ddtrace_push_root_span();
 void dd_trace_stop_span_time(ddtrace_span_t *span);
-void ddtrace_close_span(void);
+void ddtrace_close_userland_spans_until(ddtrace_span_fci *until);
+void ddtrace_close_span(ddtrace_span_fci *span_fci);
+void ddtrace_close_all_open_spans(void);
 void ddtrace_drop_top_open_span(void);
 void ddtrace_serialize_closed_spans(zval *serialized);
 

--- a/src/DDTrace/Encoders/SpanEncoder.php
+++ b/src/DDTrace/Encoders/SpanEncoder.php
@@ -60,10 +60,6 @@ final class SpanEncoder
             $metrics[$metricName] = $metricValue;
         }
         if ($span->context->isHostRoot()) {
-            $prioritySampling = GlobalTracer::get()->getPrioritySampling();
-            if ($prioritySampling !== PrioritySampling::UNKNOWN) {
-                $metrics['_sampling_priority_v1'] = $prioritySampling;
-            }
             if (\dd_trace_env_config('DD_TRACE_MEASURE_COMPILE_TIME')) {
                 // Metric expects milliseconds
                 $metrics['php.compilation.total_time_ms'] = (float) dd_trace_compile_time_microseconds() / 1000;

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -11,413 +11,810 @@ use Exception;
 use InvalidArgumentException;
 use Throwable;
 
-final class Span extends DataSpan
-{
-    private static $metricNames = [ Tag::ANALYTICS_KEY => true ];
-    // associative array for quickly checking if tag has special meaning, should include metric_names
-    private static $specialTags = [
-        Tag::ANALYTICS_KEY => true,
-        Tag::ERROR => true,
-        Tag::ERROR_MSG => true,
-        Tag::SERVICE_NAME => true,
-        Tag::RESOURCE_NAME => true,
-        Tag::SPAN_TYPE => true,
-        Tag::HTTP_URL => true,
-        Tag::HTTP_STATUS_CODE => true,
-        Tag::MANUAL_KEEP => true,
-        Tag::MANUAL_DROP => true,
-        Tag::SERVICE_VERSION => true,
-    ];
-
-    /**
-     * Span constructor.
-     * @param string $operationName
-     * @param SpanContext $context
-     * @param string $service
-     * @param string $resource
-     * @param int|null $startTime
-     */
-    public function __construct(
-        $operationName,
-        SpanContext $context,
-        $service,
-        $resource,
-        $startTime = null
-    ) {
-        $this->context = $context;
-        $this->operationName = (string)$operationName;
-        $this->service = (string)$service;
-        $this->resource = null === $resource ? null : (string)$resource;
-        $this->startTime = $startTime ?: Time::now();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTraceId()
+if (PHP_VERSION_ID < 80000) {
+    final class Span extends DataSpan
     {
-        return $this->context->traceId;
-    }
+        private static $metricNames = [Tag::ANALYTICS_KEY => true];
+        // associative array for quickly checking if tag has special meaning, should include metric_names
+        private static $specialTags = [
+            Tag::ANALYTICS_KEY => true,
+            Tag::ERROR => true,
+            Tag::ERROR_MSG => true,
+            Tag::SERVICE_NAME => true,
+            Tag::RESOURCE_NAME => true,
+            Tag::SPAN_TYPE => true,
+            Tag::HTTP_URL => true,
+            Tag::HTTP_STATUS_CODE => true,
+            Tag::MANUAL_KEEP => true,
+            Tag::MANUAL_DROP => true,
+            Tag::SERVICE_VERSION => true,
+        ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSpanId()
-    {
-        return $this->context->spanId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParentId()
-    {
-        return $this->context->parentId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function overwriteOperationName($operationName)
-    {
-        $this->operationName = $operationName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResource()
-    {
-        return $this->resource;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getService()
-    {
-        return $this->service;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStartTime()
-    {
-        return $this->startTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDuration()
-    {
-        return $this->duration;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setTag($key, $value, $setIfFinished = false)
-    {
-        if ($this->duration !== null && !$setIfFinished) { // if finished
-            return;
-        }
-        if ($key !== (string)$key) {
-            throw InvalidSpanArgument::forTagKey($key);
-        }
-        // Since sub classes can change the return value of a known method,
-        // we quietly ignore values that could cause errors when converting to string
-        if (is_object($value) && $key !== Tag::ERROR) {
-            return;
+        /**
+         * Span constructor.
+         * @param string $operationName
+         * @param SpanContext $context
+         * @param string $service
+         * @param string $resource
+         * @param int|null $startTime
+         */
+        public function __construct(
+            $operationName,
+            SpanContext $context,
+            $service,
+            $resource,
+            $startTime = null
+        ) {
+            $this->context = $context;
+            $this->operationName = (string)$operationName;
+            $this->service = (string)$service;
+            $this->resource = null === $resource ? null : (string)$resource;
+            $this->startTime = $startTime ?: Time::now();
         }
 
-        if (array_key_exists($key, self::$specialTags)) {
-            if ($key === Tag::ERROR) {
-                $this->setError($value);
+        /**
+         * {@inheritdoc}
+         */
+        public function getTraceId()
+        {
+            return $this->context->traceId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getSpanId()
+        {
+            return $this->context->spanId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getParentId()
+        {
+            return $this->context->parentId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function overwriteOperationName($operationName)
+        {
+            $this->operationName = $operationName;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getResource()
+        {
+            return $this->resource;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getService()
+        {
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getStartTime()
+        {
+            return $this->startTime;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDuration()
+        {
+            return $this->duration;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setTag($key, $value, $setIfFinished = false)
+        {
+            if ($this->duration !== null && !$setIfFinished) { // if finished
+                return;
+            }
+            if ($key !== (string)$key) {
+                throw InvalidSpanArgument::forTagKey($key);
+            }
+            // Since sub classes can change the return value of a known method,
+            // we quietly ignore values that could cause errors when converting to string
+            if (is_object($value) && $key !== Tag::ERROR) {
                 return;
             }
 
-            if ($key === Tag::ERROR_MSG) {
-                $this->tags[$key] = (string)$value;
-                $this->setError(true);
-                return;
-            }
+            if (array_key_exists($key, self::$specialTags)) {
+                if ($key === Tag::ERROR) {
+                    $this->setError($value);
+                    return;
+                }
 
-            if ($key === Tag::SERVICE_NAME) {
-                $this->service = $value;
-                return;
-            }
+                if ($key === Tag::ERROR_MSG) {
+                    $this->tags[$key] = (string)$value;
+                    $this->setError(true);
+                    return;
+                }
 
-            if ($key === Tag::MANUAL_KEEP) {
-                GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
-                return;
-            }
+                if ($key === Tag::SERVICE_NAME) {
+                    $this->service = $value;
+                    return;
+                }
 
-            if ($key === Tag::MANUAL_DROP) {
-                GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
-                return;
-            }
+                if ($key === Tag::MANUAL_KEEP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
+                    return;
+                }
 
-            if ($key === Tag::RESOURCE_NAME) {
-                $this->resource = (string)$value;
-                return;
-            }
+                if ($key === Tag::MANUAL_DROP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
+                    return;
+                }
 
-            if ($key === Tag::SPAN_TYPE) {
-                $this->type = $value;
-                return;
-            }
+                if ($key === Tag::RESOURCE_NAME) {
+                    $this->resource = (string)$value;
+                    return;
+                }
 
-            if ($key === Tag::HTTP_URL) {
-                $value = Urls::sanitize((string)$value);
-            }
+                if ($key === Tag::SPAN_TYPE) {
+                    $this->type = $value;
+                    return;
+                }
 
-            if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
-                $this->hasError = true;
-                if (!isset($this->tags[Tag::ERROR_TYPE])) {
-                    $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+                if ($key === Tag::HTTP_URL) {
+                    $value = Urls::sanitize((string)$value);
+                }
+
+                if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
+                    $this->hasError = true;
+                    if (!isset($this->tags[Tag::ERROR_TYPE])) {
+                        $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+                    }
+                }
+
+                if ($key === Tag::SERVICE_VERSION) {
+                    // Also set `version` tag (we want both)
+                    $this->setTag(Tag::VERSION, $value);
+                }
+
+                if (array_key_exists($key, self::$metricNames)) {
+                    $this->setMetric($key, $value);
+                    return;
                 }
             }
 
-            if ($key === Tag::SERVICE_VERSION) {
-                // Also set `version` tag (we want both)
-                $this->setTag(Tag::VERSION, $value);
+            $this->tags[$key] = (string)$value;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTag($key)
+        {
+            if (array_key_exists($key, $this->tags)) {
+                return $this->tags[$key];
             }
 
-            if (array_key_exists($key, self::$metricNames)) {
-                $this->setMetric($key, $value);
+            return null;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllTags()
+        {
+            return $this->tags;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function hasTag($name)
+        {
+            return array_key_exists($name, $this->getAllTags());
+        }
+
+        /**
+         * @param string $key
+         * @param mixed $value
+         */
+        public function setMetric($key, $value)
+        {
+            if ($key === Tag::ANALYTICS_KEY) {
+                TraceAnalyticsProcessor::normalizeAnalyticsValue($this->metrics, $value);
                 return;
             }
+
+            $this->metrics[$key] = $value;
         }
 
-        $this->tags[$key] = (string)$value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTag($key)
-    {
-        if (array_key_exists($key, $this->tags)) {
-            return $this->tags[$key];
+        /**
+         * @return array
+         */
+        public function getMetrics()
+        {
+            return $this->metrics;
         }
 
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAllTags()
-    {
-        return $this->tags;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTag($name)
-    {
-        return array_key_exists($name, $this->getAllTags());
-    }
-
-    /**
-     * @param string $key
-     * @param mixed $value
-     */
-    public function setMetric($key, $value)
-    {
-        if ($key === Tag::ANALYTICS_KEY) {
-            TraceAnalyticsProcessor::normalizeAnalyticsValue($this->metrics, $value);
-            return;
+        /**
+         * {@inheritdoc}
+         */
+        public function setResource($resource)
+        {
+            $this->resource = (string)$resource;
         }
 
-        $this->metrics[$key] = $value;
-    }
+        /**
+         * Stores a Throwable object within the span tags. The error status is
+         * updated and the error.Error() string is included with a default tag key.
+         * If the Span has been finished, it will not be modified by this method.
+         *
+         * @param Throwable|Exception|bool|string|null $error
+         * @throws InvalidArgumentException
+         */
+        public function setError($error)
+        {
+            if (($error instanceof Exception) || ($error instanceof Throwable)) {
+                $this->hasError = true;
+                $this->tags[Tag::ERROR_MSG] = $error->getMessage();
+                $this->tags[Tag::ERROR_TYPE] = get_class($error);
+                $this->tags[Tag::ERROR_STACK] = $error->getTraceAsString();
+                return;
+            }
 
-    /**
-     * @return array
-     */
-    public function getMetrics()
-    {
-        return $this->metrics;
-    }
+            if (is_bool($error)) {
+                $this->hasError = $error;
+                return;
+            }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setResource($resource)
-    {
-        $this->resource = (string)$resource;
-    }
+            if (is_null($error)) {
+                $this->hasError = false;
+            }
 
-    /**
-     * Stores a Throwable object within the span tags. The error status is
-     * updated and the error.Error() string is included with a default tag key.
-     * If the Span has been finished, it will not be modified by this method.
-     *
-     * @param Throwable|Exception|bool|string|null $error
-     * @throws InvalidArgumentException
-     */
-    public function setError($error)
-    {
-        if (($error instanceof Exception) || ($error instanceof Throwable)) {
+            throw InvalidSpanArgument::forError($error);
+        }
+
+        /**
+         * @param string $message
+         * @param string $type
+         */
+        public function setRawError($message, $type)
+        {
             $this->hasError = true;
-            $this->tags[Tag::ERROR_MSG] = $error->getMessage();
-            $this->tags[Tag::ERROR_TYPE] = get_class($error);
-            $this->tags[Tag::ERROR_STACK] = $error->getTraceAsString();
-            return;
+            $this->tags[Tag::ERROR_MSG] = $message;
+            $this->tags[Tag::ERROR_TYPE] = $type;
         }
 
-        if (is_bool($error)) {
-            $this->hasError = $error;
-            return;
+        public function hasError()
+        {
+            return $this->hasError;
         }
 
-        if (is_null($error)) {
-            $this->hasError = false;
+        /**
+         * {@inheritdoc}
+         */
+        public function finish($finishTime = null)
+        {
+            if ($this->duration !== null) { // if finished
+                return;
+            }
+
+            $this->duration = ($finishTime ?: Time::now()) - $this->startTime;
+            // Sync with span ID stack at the C level
+            dd_trace_pop_span_id();
         }
 
-        throw InvalidSpanArgument::forError($error);
-    }
-
-    /**
-     * @param string $message
-     * @param string $type
-     */
-    public function setRawError($message, $type)
-    {
-        $this->hasError = true;
-        $this->tags[Tag::ERROR_MSG] = $message;
-        $this->tags[Tag::ERROR_TYPE] = $type;
-    }
-
-    public function hasError()
-    {
-        return $this->hasError;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function finish($finishTime = null)
-    {
-        if ($this->duration !== null) { // if finished
-            return;
+        /**
+         * @param Throwable|Exception $error
+         * @return void
+         */
+        public function finishWithError($error)
+        {
+            $this->setError($error);
+            $this->finish();
         }
 
-        $this->duration = ($finishTime ?: Time::now()) - $this->startTime;
-        // Sync with span ID stack at the C level
-        dd_trace_pop_span_id();
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function isFinished()
+        {
+            return $this->duration !== null;
+        }
 
-    /**
-     * @param Throwable|Exception $error
-     * @return void
-     */
-    public function finishWithError($error)
-    {
-        $this->setError($error);
-        $this->finish();
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getOperationName()
+        {
+            return $this->operationName;
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isFinished()
-    {
-        return $this->duration !== null;
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getContext()
+        {
+            return $this->context;
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOperationName()
-    {
-        return $this->operationName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getContext()
-    {
-        return $this->context;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function log(array $fields = [], $timestamp = null)
-    {
-        foreach ($fields as $key => $value) {
-            if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
-                $this->setError(true);
-            } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
-                $this->setError($value);
-            } elseif ($key === Tag::LOG_MESSAGE) {
-                // We recently changed our span behavior: when we set an error message, we now mark the span as 'error'.
-                // In order to be backward compatible with this publicly exposed method we manually set the message,
-                // and not the errror, internally.
-                // This should be considered a broken behavior because it would not allow for users to log multiple
-                // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
-                // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
-                // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
-                $this->tags[Tag::ERROR_MSG] = (string)$value;
-            } elseif ($key === Tag::LOG_STACK) {
-                $this->setTag(Tag::ERROR_STACK, $value);
+        /**
+         * {@inheritdoc}
+         */
+        public function log(array $fields = [], $timestamp = null)
+        {
+            foreach ($fields as $key => $value) {
+                if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
+                    $this->setError(true);
+                } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
+                    $this->setError($value);
+                } elseif ($key === Tag::LOG_MESSAGE) {
+                    // We recently changed our span behavior:
+                    // when we set an error message, we now mark the span as 'error'.
+                    // In order to be backward compatible with this publicly exposed method we manually set the message,
+                    // and not the errror, internally.
+                    // This should be considered a broken behavior because it would not allow for users to log multiple
+                    // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
+                    // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
+                    // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
+                    $this->tags[Tag::ERROR_MSG] = (string)$value;
+                } elseif ($key === Tag::LOG_STACK) {
+                    $this->setTag(Tag::ERROR_STACK, $value);
+                }
             }
         }
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addBaggageItem($key, $value)
-    {
-        $this->context = $this->context->withBaggageItem($key, $value);
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function addBaggageItem($key, $value)
+        {
+            $this->context = $this->context->withBaggageItem($key, $value);
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaggageItem($key)
-    {
-        return $this->context->getBaggageItem($key);
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getBaggageItem($key)
+        {
+            return $this->context->getBaggageItem($key);
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAllBaggageItems()
-    {
-        return $this->context->baggageItems;
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllBaggageItems()
+        {
+            return $this->context->baggageItems;
+        }
 
-    /**
-     * @param bool $value
-     * @return self
-     */
-    public function setTraceAnalyticsCandidate($value = true)
-    {
-        $this->isTraceAnalyticsCandidate = $value;
-        return $this;
-    }
 
-    /**
-     * @return bool
-     */
-    public function isTraceAnalyticsCandidate()
+        /**
+         * @param bool $value
+         * @return self
+         * @deprecated
+         */
+        public function setTraceAnalyticsCandidate($value = true)
+        {
+            return $this;
+        }
+
+        /**
+         * @return bool
+         * @deprecated
+         */
+        public function isTraceAnalyticsCandidate()
+        {
+            return false;
+        }
+    }
+} else {
+    final class Span extends DataSpan
     {
-        return $this->isTraceAnalyticsCandidate;
+        private static $metricNames = [ Tag::ANALYTICS_KEY => true ];
+        // associative array for quickly checking if tag has special meaning, should include metric_names
+        private static $specialTags = [
+            Tag::ANALYTICS_KEY => true,
+            Tag::ERROR => true,
+            Tag::ERROR_MSG => true,
+            Tag::SERVICE_NAME => true,
+            Tag::RESOURCE_NAME => true,
+            Tag::SPAN_TYPE => true,
+            Tag::HTTP_URL => true,
+            Tag::HTTP_STATUS_CODE => true,
+            Tag::MANUAL_KEEP => true,
+            Tag::MANUAL_DROP => true,
+            Tag::SERVICE_VERSION => true,
+        ];
+
+        /**
+         * Span constructor.
+         * @param string $operationName
+         * @param SpanContext $context
+         * @param string $service
+         * @param string $resource
+         * @param int|null $startTime
+         */
+        public function __construct(SpanData $internalSpan, SpanContext $context)
+        {
+            $this->internalSpan = $internalSpan;
+            $this->context = $context;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTraceId()
+        {
+            return $this->context->traceId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getSpanId()
+        {
+            return $this->context->spanId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getParentId()
+        {
+            return $this->context->parentId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function overwriteOperationName($operationName)
+        {
+            $this->internalSpan->name = $operationName;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getResource()
+        {
+            return $this->internalSpan->resource;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getService()
+        {
+            return $this->internalSpan->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getType()
+        {
+            return $this->internalSpan->type;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getStartTime()
+        {
+            // internally we have nanoseconds, but we'll expose microseconds here
+            return (int) ($this->internalSpan->getStartTime() / 1000);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDuration()
+        {
+            // internally we have nanoseconds, but we'll expose microseconds here
+            return (int) ($this->internalSpan->getDuration() / 1000);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setTag($key, $value, $setIfFinished = false)
+        {
+            // Note: Currently only supporting root span, which is never finished
+
+            if ($key !== (string)$key) {
+                throw InvalidSpanArgument::forTagKey($key);
+            }
+            // Since sub classes can change the return value of a known method,
+            // we quietly ignore values that could cause errors when converting to string
+            if (is_object($value) && $key !== Tag::ERROR) {
+                return;
+            }
+
+            if (array_key_exists($key, self::$specialTags)) {
+                if ($key === Tag::ERROR) {
+                    $this->setError($value);
+                    return;
+                }
+
+                if ($key === Tag::ERROR_MSG) {
+                    $this->internalSpan->meta[$key] = (string)$value;
+                    $this->setError(true);
+                    return;
+                }
+
+                if ($key === Tag::SERVICE_NAME) {
+                    $this->internalSpan->service = $value;
+                    return;
+                }
+
+                if ($key === Tag::MANUAL_KEEP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
+                    return;
+                }
+
+                if ($key === Tag::MANUAL_DROP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
+                    return;
+                }
+
+                if ($key === Tag::RESOURCE_NAME) {
+                    $this->internalSpan->resource = (string)$value;
+                    return;
+                }
+
+                if ($key === Tag::SPAN_TYPE) {
+                    $this->internalSpan->type = $value;
+                    return;
+                }
+
+                if ($key === Tag::HTTP_URL) {
+                    $value = Urls::sanitize((string)$value);
+                }
+
+                if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
+                    $this->hasError = true;
+                    if (!isset($this->internalSpan->meta[Tag::ERROR_TYPE])) {
+                        $this->internalSpan->meta[Tag::ERROR_TYPE] = 'Internal Server Error';
+                    }
+                }
+
+                if ($key === Tag::SERVICE_VERSION) {
+                    // Also set `version` tag (we want both)
+                    $this->setTag(Tag::VERSION, $value);
+                }
+
+                if (array_key_exists($key, self::$metricNames)) {
+                    $this->setMetric($key, $value);
+                    return;
+                }
+            }
+
+            $this->internalSpan->meta[$key] = (string)$value;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTag($key)
+        {
+            if (array_key_exists($key, $this->internalSpan->meta)) {
+                return $this->internalSpan->meta[$key];
+            }
+
+            return null;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllTags()
+        {
+            return $this->internalSpan->meta;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function hasTag($name)
+        {
+            return array_key_exists($name, $this->getAllTags());
+        }
+
+        /**
+         * @param string $key
+         * @param mixed $value
+         */
+        public function setMetric($key, $value)
+        {
+            if ($key === Tag::ANALYTICS_KEY) {
+                TraceAnalyticsProcessor::normalizeAnalyticsValue($this->internalSpan->metrics, $value);
+                return;
+            }
+
+            $this->internalSpan->metrics[$key] = $value;
+        }
+
+        /**
+         * @return array
+         */
+        public function getMetrics()
+        {
+            return $this->internalSpan->metrics;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setResource($resource)
+        {
+            $this->internalSpan->resource = (string)$resource;
+        }
+
+        /**
+         * Stores a Throwable object within the span tags. The error status is
+         * updated and the error.Error() string is included with a default tag key.
+         * If the Span has been finished, it will not be modified by this method.
+         *
+         * @param Throwable|Exception|bool|string|null $error
+         * @throws InvalidArgumentException
+         */
+        public function setError($error)
+        {
+            if (($error instanceof Exception) || ($error instanceof Throwable)) {
+                $this->hasError = true;
+                $this->internalSpan->meta[Tag::ERROR_MSG] = $error->getMessage();
+                $this->internalSpan->meta[Tag::ERROR_TYPE] = get_class($error);
+                $this->internalSpan->meta[Tag::ERROR_STACK] = $error->getTraceAsString();
+                return;
+            }
+
+            if (is_bool($error)) {
+                $this->hasError = $error;
+                return;
+            }
+
+            if (is_null($error)) {
+                $this->hasError = false;
+            }
+
+            throw InvalidSpanArgument::forError($error);
+        }
+
+        /**
+         * @param string $message
+         * @param string $type
+         */
+        public function setRawError($message, $type)
+        {
+            $this->hasError = true;
+            $this->internalSpan->meta[Tag::ERROR_MSG] = $message;
+            $this->internalSpan->meta[Tag::ERROR_TYPE] = $type;
+        }
+
+        public function hasError()
+        {
+            return $this->hasError;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function finish($finishTime = null)
+        {
+            if (!$this->isFinished()) {
+                close_span($finishTime);
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function isFinished()
+        {
+            return $this->internalSpan->getDuration() !== 0;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getOperationName()
+        {
+            return $this->internalSpan->name;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getContext()
+        {
+            return $this->context;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function log(array $fields = [], $timestamp = null)
+        {
+            foreach ($fields as $key => $value) {
+                if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
+                    $this->setError(true);
+                } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
+                    $this->setError($value);
+                } elseif ($key === Tag::LOG_MESSAGE) {
+                    // We recently changed our span behavior:
+                    // when we set an error message, we now mark the span as 'error'.
+                    // In order to be backward compatible with this publicly exposed method we manually set the message,
+                    // and not the errror, internally.
+                    // This should be considered a broken behavior because it would not allow for users to log multiple
+                    // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
+                    // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
+                    // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
+                    $this->internalSpan->meta[Tag::ERROR_MSG] = (string)$value;
+                } elseif ($key === Tag::LOG_STACK) {
+                    $this->setTag(Tag::ERROR_STACK, $value);
+                }
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function addBaggageItem($key, $value)
+        {
+            $this->context = $this->context->withBaggageItem($key, $value);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getBaggageItem($key)
+        {
+            return $this->context->getBaggageItem($key);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllBaggageItems()
+        {
+            return $this->context->baggageItems;
+        }
+
+        /**
+         * @deprecated
+         * @param bool $value
+         * @return self
+         */
+        public function setTraceAnalyticsCandidate($value = true)
+        {
+            return $this;
+        }
+
+        /**
+         * @deprecated
+         * @return bool
+         */
+        public function isTraceAnalyticsCandidate()
+        {
+            return false;
+        }
     }
 }

--- a/src/api/Data/Span.php
+++ b/src/api/Data/Span.php
@@ -6,80 +6,124 @@ use DDTrace\Time;
 use DDTrace\Data\SpanContext as SpanContextData;
 use DDTrace\Contracts\Span as SpanInterface;
 
-abstract class Span implements SpanInterface
-{
-    /**
-     * Operation Name is the name of the operation being measured. Some examples
-     * might be "http.handler", "fileserver.upload" or "video.decompress".
-     * Name should be set on every span.
-     *
-     * @var string
-     */
-    public $operationName;
+if (PHP_VERSION_ID < 80000) {
+    abstract class Span implements SpanInterface
+    {
+        /**
+         * Operation Name is the name of the operation being measured. Some examples
+         * might be "http.handler", "fileserver.upload" or "video.decompress".
+         * Name should be set on every span.
+         *
+         * @var string
+         */
+        public $operationName;
 
-    /**
-     * @var SpanContextData
-     */
-    public $context;
+        /**
+         * @var SpanContextData
+         */
+        public $context;
 
-    /**
-     * Resource is a query to a service. A web application might use
-     * resources like "/user/{user_id}". A sql database might use resources
-     * like "select * from user where id = ?".
-     *
-     * You can track thousands of resources (not millions or billions) so
-     * prefer normalized resources like "/user/{id}" to "/user/123".
-     *
-     * Note that resource name will be inherited from parent if its not set.
-     *
-     * @var string
-     */
-    public $resource;
+        /**
+         * Resource is a query to a service. A web application might use
+         * resources like "/user/{user_id}". A sql database might use resources
+         * like "select * from user where id = ?".
+         *
+         * You can track thousands of resources (not millions or billions) so
+         * prefer normalized resources like "/user/{id}" to "/user/123".
+         *
+         * Note that resource name will be inherited from parent if its not set.
+         *
+         * @var string
+         */
+        public $resource;
 
-    /**
-     * Service is the name of the process doing a particular job. Some
-     * examples might be "user-database" or "datadog-web-app".
-     *
-     * Note that service name will be inherited from parent if its not set.
-     *
-     * @var string
-     */
-    public $service;
+        /**
+         * Service is the name of the process doing a particular job. Some
+         * examples might be "user-database" or "datadog-web-app".
+         *
+         * Note that service name will be inherited from parent if its not set.
+         *
+         * @var string
+         */
+        public $service;
 
-    /**
-     * Protocol associated with the span
-     *
-     * @var string|null
-     */
-    public $type;
+        /**
+         * Protocol associated with the span
+         *
+         * @var string|null
+         */
+        public $type;
 
-    /**
-     * @var int
-     */
-    public $startTime;
+        /**
+         * @var int
+         */
+        public $startTime;
 
-    /**
-     * @var int|null
-     */
-    public $duration;
+        /**
+         * @var int|null
+         */
+        public $duration;
 
-    /**
-     * @var array
-     */
-    public $tags = [];
+        /**
+         * @var array
+         */
+        public $tags = [];
 
-    /**
-     * @var bool
-     */
-    public $hasError = false;
+        /**
+         * @var bool
+         */
+        public $hasError = false;
 
-    /**
-     * @var array
-     */
-    public $metrics = [];
+        /**
+         * @var array
+         */
+        public $metrics = [];
 
-    /**
-     * @var bool Whether or not this trace can be even considered for trace analytics automatic configuration.
-     */
-    public $isTraceAnalyticsCandidate = false;
+        /**
+         * @var bool Whether or not this trace can be even considered for trace analytics automatic configuration.
+         */
+        public $isTraceAnalyticsCandidate = false;
+    }
+} else {
+    abstract class Span implements SpanInterface
+    {
+        /**
+         * @var SpanContextData
+         */
+        public $context;
+
+        /**
+         * @var bool
+         */
+        public $hasError = false;
+
+        /**
+         * @var \DDTrace\SpanData
+         */
+        protected $internalSpan;
+
+        public function &__get($name)
+        {
+            if ($name == "operationName") {
+                $name = "name";
+            } elseif ($name == "tags") {
+                $name = "meta";
+            } elseif ($name == "duration") {
+                return $this->internalSpan->getDuration();
+            } elseif ($name == "startTime") {
+                return $this->internalSpan->getStartTime();
+            }
+            return $this->internalSpan->$name;
+        }
+
+        public function __set($name, $value)
+        {
+            if ($name == "operationName") {
+                $name = "name";
+            } elseif ($name == "tags") {
+                $name = "meta";
+            }
+            return $this->internalSpan->$name = $value;
+        }
+    }
 }

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -266,16 +266,6 @@ final class SpanTest extends BaseTestCase
         $this->assertSame(1.0, $span->getMetrics()['exists']);
     }
 
-    public function testIsTraceAnalyticsConfigCandidate()
-    {
-        $span = $this->createSpan();
-        $this->assertFalse($span->isTraceAnalyticsCandidate());
-        $span->setTraceAnalyticsCandidate();
-        $this->assertTrue($span->isTraceAnalyticsCandidate());
-        $span->setTraceAnalyticsCandidate(false);
-        $this->assertFalse($span->isTraceAnalyticsCandidate());
-    }
-
     public function testTraceAnalyticsConfigEnabledByTag()
     {
         $span = $this->createSpan();

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -246,10 +246,6 @@ final class TracerTest extends BaseTestCase
 
         $tracer = new Tracer(new NoopTransport());
         $scope = $tracer->startRootSpan(self::OPERATION_NAME);
-        $this->assertNull($tracer->getRootScope()->getSpan()->getTag(Tag::HOSTNAME));
-
-        $tracer->flush();
-
         $this->assertEquals(gethostname(), $tracer->getRootScope()->getSpan()->getTag(Tag::HOSTNAME));
     }
 

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -1,0 +1,32 @@
+--TEST--
+DDTrace\active_span basic functionality
+--INI--
+--FILE--
+<?php
+
+DDTrace\trace_function('greet',
+    function ($span) {
+        echo "greet tracer.\n";
+        $span->name = "foo";
+        var_dump($span == DDTrace\active_span());
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+var_dump(DDTrace\active_span());
+var_dump(DDTrace\active_span() == DDTrace\active_span());
+
+?>
+--EXPECT--
+Hello, Datadog.
+greet tracer.
+bool(true)
+object(DDTrace\SpanData)#1 (0) {
+}
+bool(true)

--- a/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
+++ b/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
@@ -1,0 +1,86 @@
+--TEST--
+DDTrace\add_global_tag() on all sorts of spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+
+$span = DDTrace\start_span();
+$span->name = "polar " . ($_ = "bear");
+
+function test($a) {
+    return 'METHOD ' . $a;
+}
+
+DDTrace\trace_function("test", function($s, $a, $retval) {
+    echo 'HOOK ' . $retval . PHP_EOL;
+});
+
+test("arg");
+
+DDTrace\add_global_tag("alone", ($_ = "n") . "o");
+DDTrace\add_global_tag("cubs", ($_ = "n") . "o");
+DDTrace\add_global_tag("cubs", ($_ = "y") . "es"); // overwrites older entries
+
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+HOOK METHOD arg
+array(2) {
+  [0]=>
+  array(9) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(10) "polar bear"
+    ["resource"]=>
+    string(10) "polar bear"
+    ["meta"]=>
+    array(2) {
+      ["alone"]=>
+      string(2) "no"
+      ["cubs"]=>
+      string(3) "yes"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(2) {
+      ["alone"]=>
+      string(2) "no"
+      ["cubs"]=>
+      string(3) "yes"
+    }
+  }
+}

--- a/tests/ext/background-sender/agent_headers.phpt
+++ b/tests/ext/background-sender/agent_headers.phpt
@@ -35,6 +35,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -47,3 +52,4 @@ Datadog-Meta-Tracer-Version: %s
 X-Datadog-Trace-Count: 1
 
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/background-sender/agent_headers_container_id.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id.phpt
@@ -33,6 +33,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -41,3 +46,4 @@ Datadog-Container-Id: 9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416
 Datadog-Meta-Lang: php
 
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/background-sender/agent_headers_container_id_empty.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_empty.phpt
@@ -33,6 +33,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -40,3 +45,4 @@ bool(true)
 Datadog-Meta-Lang: php
 
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
@@ -32,6 +32,11 @@ echo 'Datadog-Meta-Lang: ' . $headers['Datadog-Meta-Lang'] . PHP_EOL;
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -40,3 +45,4 @@ Datadog-Container-Id: 34dc0b5e626f2c5c4c5170e34b10e765-1234567890
 Datadog-Meta-Lang: php
 
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/background-sender/agent_headers_ignore_userland.phpt
+++ b/tests/ext/background-sender/agent_headers_ignore_userland.phpt
@@ -32,6 +32,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -39,3 +44,4 @@ bool(true)
 Datadog-Meta-Lang: php
 
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,70 @@
+--TEST--
+dd_trace() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_WARN_LEGACY_DD_TRACE=0
+--FILE--
+<?php
+# Functions
+var_dump(dd_trace('foo', 'bar'));
+var_dump(dd_trace('foo', ['bar']));
+var_dump(dd_trace('foo', [
+    'bar' => 'baz',
+]));
+var_dump(dd_trace('foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(dd_trace('foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace('foo', [
+    'prehook' => new stdClass(),
+]));
+var_dump(dd_trace('foo', [
+    'posthook' => function () {},
+]));
+var_dump(dd_trace('foo', []));
+
+# Methods
+echo PHP_EOL;
+var_dump(dd_trace('foo', 'foo', 'bar'));
+var_dump(dd_trace('foo', 'foo', ['bar']));
+var_dump(dd_trace('foo', 'foo', [
+    'bar' => 'baz',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'prehook' => new stdClass(),
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'posthook' => function () {},
+]));
+var_dump(dd_trace('foo', 'foo', []));
+?>
+--EXPECT--
+Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+
+Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)

--- a/tests/ext/dd_trace_api_error.phpt
+++ b/tests/ext/dd_trace_api_error.phpt
@@ -45,6 +45,11 @@ var_dump(dd_trace('foo', 'foo', [
     'posthook' => function () {},
 ]));
 var_dump(dd_trace('foo', 'foo', []));
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
@@ -66,3 +71,4 @@ bool(false)
 bool(false)
 bool(false)
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/dd_trace_push_span_id_from_userland.phpt
+++ b/tests/ext/dd_trace_push_span_id_from_userland.phpt
@@ -2,6 +2,7 @@
 Push a span ID onto the stack from userland
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 echo dd_trace_push_span_id('42') . PHP_EOL;

--- a/tests/ext/dd_trace_serialize_msgpack_error-legacy.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error-legacy.phpt
@@ -1,0 +1,43 @@
+--TEST--
+dd_trace_serialize_msgpack() error conditions
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+array_map(function ($data) {
+    var_dump($data, dd_trace_serialize_msgpack($data));
+    echo "\n";
+}, [
+    true,
+    'foo',
+    [new stdClass()],
+    ['bar', stream_context_create()],
+]);
+?>
+--EXPECTF--
+Expected argument to dd_trace_serialize_msgpack() to be an array
+bool(true)
+bool(false)
+
+Expected argument to dd_trace_serialize_msgpack() to be an array
+string(3) "foo"
+bool(false)
+
+Serialize values must be of type array, string, int, float, bool or null
+array(1) {
+  [0]=>
+  object(stdClass)#%d (0) {
+  }
+}
+bool(false)
+
+Serialize values must be of type array, string, int, float, bool or null
+array(2) {
+  [0]=>
+  string(3) "bar"
+  [1]=>
+  resource(%d) of type (stream-context)
+}
+bool(false)

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_serialize_msgpack() error conditions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -39,3 +41,5 @@ array(2) {
   resource(%d) of type (stream-context)
 }
 bool(false)
+
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -33,9 +33,15 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($headers['x-datadog-parent-id'] === (string) $spans[0]['span_id']);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -57,6 +57,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 5", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -80,3 +85,4 @@ x-datadog-parent-id: %d
 x-foo: after-the-copy
 
 Done.
+Successfully triggered auto-flush with trace of size 5

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -45,6 +45,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -60,3 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -45,6 +45,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -60,3 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
@@ -33,7 +33,13 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump(isset($headers['x-datadog-parent-id']));
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 bool(false)
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -59,6 +59,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -66,3 +71,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -60,6 +60,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -67,3 +72,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -73,6 +73,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -85,3 +90,4 @@ x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 x-foo: not copied
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
@@ -72,6 +72,11 @@ echo 'Disabled.' . PHP_EOL;
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -84,3 +89,4 @@ Disabled.
 x-foo: foo
 x-foo: foo
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -71,6 +71,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-ch-1-bar: bar
@@ -82,3 +87,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -75,6 +75,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-ch-1-bar: bar
@@ -86,3 +91,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
@@ -34,7 +34,13 @@ dt_dump_headers_from_httpbin($headers, [
 ]);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 x-my-custom-header: foo
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Long running autoflush
+--SKIPIF--
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=false
+DD_TRACE_AUTO_FLUSH_ENABLED=true
+--FILE--
+<?php
+
+require 'functions.inc';
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+const ITERATIONS = 2;
+
+\DDTrace\trace_function('long_running_entry_point', function ($span) {
+    $span->type = 'custom';
+    $span->service = 'pcntl-testing-service';
+});
+
+for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
+    long_running_entry_point();
+    sleep(1);
+    $output = ob_get_contents();
+    ob_end_clean();
+    $lines = explode(PHP_EOL, $output);
+    if ((in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) || in_array("Successfully triggered auto-flush with trace of size 1", $lines)) {
+        echo "OK" . PHP_EOL;
+    }
+}
+
+function long_running_entry_point()
+{
+    call_httpbin();
+
+    $forkPid = pcntl_fork();
+
+    ob_start();
+
+    if ($forkPid > 0) {
+        // Main
+        call_httpbin();
+    } else if ($forkPid === 0) {
+        // Child
+        call_httpbin();
+    } else {
+        error_log('Error');
+        exit(-1);
+    }
+    call_httpbin();
+}
+
+?>
+--EXPECTF--
+OK
+OK
+OK
+OK

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -6,15 +6,15 @@ include __DIR__ . '/../includes/skipif_no_dev_env.inc';
 if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
 if (!extension_loaded('curl')) die('skip: curl extension required');
 ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=false
 DD_TRACE_AUTO_FLUSH_ENABLED=true
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 
 require 'functions.inc';
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 const ITERATIONS = 2;
 
@@ -25,13 +25,7 @@ const ITERATIONS = 2;
 
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     long_running_entry_point();
-    sleep(1);
-    $output = ob_get_contents();
-    ob_end_clean();
-    $lines = explode(PHP_EOL, $output);
-    if (in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) {
-        echo "OK" . PHP_EOL;
-    }
+    usleep(200000);
 }
 
 function long_running_entry_point()
@@ -47,6 +41,7 @@ function long_running_entry_point()
         call_httpbin();
     } else if ($forkPid === 0) {
         // Child
+        usleep(100000);
         call_httpbin();
     } else {
         error_log('Error');
@@ -57,7 +52,13 @@ function long_running_entry_point()
 
 ?>
 --EXPECTF--
-OK
-OK
-OK
-OK
+Successfully triggered auto-flush with trace of size 1
+Traces are dropped by PID %d because global 'drop_all_spans' is set.
+Successfully triggered auto-flush with trace of size 1
+Successfully triggered auto-flush with trace of size 1
+Traces are dropped by PID %d because global 'drop_all_spans' is set.
+Successfully triggered auto-flush with trace of size 1
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -13,11 +13,6 @@ echo dd_trace_env_config("DD_TRACE_AGENT_DEBUG_VERBOSE_CURL") ? 'TRUE' : 'FALSE'
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_DEBUG_CURL_OUTPUT") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=";
-echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
-echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_MEMORY_LIMIT");
 echo PHP_EOL;
 echo dd_trace_env_config("DD_NON_EXISTING_ENTRY") === NULL ? 'NULL' : 'NOT_NULL' ;
@@ -32,9 +27,6 @@ echo dd_trace_env_config("trace.agent.debug.verbose.curl") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("trace.debug.curl.output") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "trace.beta.send.traces.via.thread=";
-echo dd_trace_env_config("trace.beta.send.traces.via.thread") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
 echo dd_trace_env_config("trace.memory.limit");
 echo PHP_EOL;
 echo dd_trace_env_config("non.existing.entry") === NULL ? 'NULL' : 'NOT_NULL' ;
@@ -44,14 +36,11 @@ some_known_host
 8126
 FALSE
 FALSE
-DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=TRUE
-DD_TRACE_BGS_ENABLED=TRUE
 9999
 NULL
 some_known_host
 8126
 FALSE
 FALSE
-trace.beta.send.traces.via.thread=TRUE
 9999
 NULL

--- a/tests/ext/request-init-hook/dd_init_open_basedir-legacy.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Calling dd_init.php is confined to open_basedir settings
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+open_basedir={PWD}
+ddtrace.request_init_hook={PWD}/dd_init_open_basedir.inc
+--FILE--
+<?php
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+Calling dd_init.php from parent directory "%s/includes"
+Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
+Error opening request init hook: %s/dd_init.php
+Done.

--- a/tests/ext/request-init-hook/dd_init_open_basedir.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Calling dd_init.php is confined to open_basedir settings
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -14,3 +16,4 @@ Calling dd_init.php from parent directory "%s/includes"
 Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
 Error opening request init hook: %s/dd_init.php
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected-legacy.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected-legacy.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Errors in request init hook do not affect error_get_last()
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+ddtrace.request_init_hook={PWD}/raises_e_notice.php
+--FILE--
+<?php
+var_dump(error_get_last());
+?>
+--EXPECTF--
+%s in request init hook: Undefined variable%sthis_does_not_%s
+NULL

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Errors in request init hook do not affect error_get_last()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -12,3 +14,4 @@ var_dump(error_get_last());
 --EXPECTF--
 %s in request init hook: Undefined variable%sthis_does_not_%s
 NULL
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir-legacy.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Request init hook is confined to open_basedir
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+open_basedir=tests/ext/request-init-hook
+ddtrace.request_init_hook={PWD}/../includes/sanity_check.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Request init hook is confined to open_basedir
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -13,3 +15,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found-legacy.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Do not fail when PHP code couldn't be loaded
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/this_file_doesnt_exist.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Do not fail when PHP code couldn't be loaded
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -12,3 +14,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions-legacy.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Request init hook ignores exceptions
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/throws_exception.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Throwing an exception...
+Exception thrown in request init hook: Oops!
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Request init hook ignores exceptions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -13,3 +15,4 @@ echo "Request start" . PHP_EOL;
 Throwing an exception...
 Exception thrown in request init hook: Oops!
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Request init hook ignores fatal errors
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50600) die('skip: Cannot recover from fatal errors until PHP 5.6'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/raises_fatal_error.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+Calling a function that does not exist...
+Error %s in request init hook: Call to undefined function this_function_does_not_%s
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -2,6 +2,7 @@
 Request init hook ignores fatal errors
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50600) die('skip: Cannot recover from fatal errors until PHP 5.6'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -15,3 +16,4 @@ echo "Request start" . PHP_EOL;
 Calling a function that does not exist...
 Error %s in request init hook: Call to undefined function this_function_does_not_%s
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox-prehook/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,36 @@
+--TEST--
+[Prehook] API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+# Functions
+var_dump(DDTrace\trace_function('foo', [
+    'prehook' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'prehook' => new stdClass(),
+]));
+
+# Methods
+echo PHP_EOL;
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'prehook' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'prehook' => new stdClass(),
+]));
+?>
+--EXPECT--
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)
+
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -2,6 +2,7 @@
 [Prehook] API error cases
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -33,3 +34,4 @@ Expected 'prehook' to be an instance of Closure
 bool(false)
 Expected 'prehook' to be an instance of Closure
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox-prehook/dd_trace_method-legacy.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method-legacy.phpt
@@ -1,0 +1,173 @@
+--TEST--
+[Prehook Regression] DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        echo "Test::testFoo()\n";
+    }
+}
+
+class TestService
+{
+    public function testServiceFoo()
+    {
+        echo "TestService::testServiceFoo()\n";
+    }
+}
+
+class Foo
+{
+    public function bar($thoughts, array $bar = [])
+    {
+        echo "Foo::bar()\n";
+        return [
+            'thoughts' => $thoughts,
+            'first' => isset($bar[0]) ? $bar[0] : '(none)',
+            'rand' => mt_rand(42, 999)
+        ];
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+}]);
+DDTrace\trace_method(
+    'Foo', 'bar',
+    ['prehook' => function (SpanData $span, $args) {
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }]
+);
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span, $args) {
+    $span->name = 'MT';
+    $span->meta = [
+        'rand.range' => $args[0] . ' - ' . $args[1],
+    ];
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+$testService = new TestService();
+$testService->testServiceFoo();
+
+$foo = new Foo();
+$ret = $foo->bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+Test::testFoo()
+TestService::testServiceFoo()
+Foo::bar()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(3) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(2) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      string(7) "foo-red"
+      ["bar"]=>
+      string(9) "bar-green"
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
+    ["meta"]=>
+    array(1) {
+      ["rand.range"]=>
+      string(8) "42 - 999"
+    }
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -2,8 +2,10 @@
 [Prehook Regression] DDTrace\trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -118,11 +120,13 @@ array(3) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       string(7) "foo-red"
       ["bar"]=>
       string(9) "bar-green"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox-prehook/exception_error_log-legacy.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log-legacy.phpt
@@ -1,0 +1,19 @@
+--TEST--
+[Prehook Regression] Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', ['prehook' => function () {
+    throw new RuntimeException("This exception is expected");
+}]);
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
+int(9)

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -2,6 +2,7 @@
 [Prehook Regression] Exception in tracing closure gets logged
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -16,3 +17,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
@@ -1,0 +1,60 @@
+--TEST--
+[Prehook Regression] Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5');
+if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans');
+?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        mt_srand(42);
+        printf(
+            "Test::testFoo() fav num: %d\n",
+            mt_rand()
+        );
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+    $span->service = $this_normally_raises_an_error;
+}]);
+
+DDTrace\trace_function('mt_srand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTSeed';
+    throw new Exception('This should be ignored');
+}]);
+
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTRand';
+    htmlentities('<b>', 0, 'BIG5'); // E_STRICT
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECTF--
+%s in ddtrace's closure for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+Exception thrown in ddtrace's closure for mt_srand(): This should be ignored
+Error raised in ddtrace's closure for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+Test::testFoo() fav num: %d
+TestFoo
+MTRand
+MTSeed
+NULL

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -1,7 +1,10 @@
 --TEST--
 [Prehook Regression] Exceptions and errors are ignored when inside a tracing closure
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php
+if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5');
+if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans');
+?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
@@ -55,3 +58,4 @@ TestFoo
 MTRand
 MTSeed
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -3,6 +3,7 @@
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_SPANS_LIMIT=5
 --FILE--
 <?php

--- a/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
@@ -35,3 +35,4 @@ HOOK 1
 Cannot overwrite existing dispatch for 'm()'
 METHOD
 HOOK 1
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
@@ -51,3 +51,4 @@ METHOD 1
 HOOK 11
 METHOD 10
 HOOK 20
+Successfully triggered auto-flush with trace of size 4

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -3,6 +3,7 @@
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 DDTrace\trace_function('array_sum', function () {});

--- a/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
+++ b/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
@@ -56,3 +56,4 @@ METHOD
 METHOD HOOK
 FUNCTION
 FUNCTION HOOK
+Successfully triggered auto-flush with trace of size 5

--- a/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
@@ -25,3 +25,4 @@ Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_a
 Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_b
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/sandbox/auto_flush-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush-legacy.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+DDTrace\trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main (main)
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main (main)
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main (main)
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
@@ -34,24 +35,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Flushing tracer...
-main (main)
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 10
 15
-Flushing tracer...
-main (main)
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 21
 28
-Flushing tracer...
-main (main)
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_attach_exception-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception-legacy.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Auto-flushing will attach an exception during exception cleanup
+--DESCRIPTION--
+@see https://github.com/DataDog/dd-trace-php/issues/879
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer...
+Foo.bar (Foo.bar) (error: Oops!)
+Tracer reset
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -2,14 +2,14 @@
 Auto-flushing will attach an exception during exception cleanup
 --DESCRIPTION--
 @see https://github.com/DataDog/dd-trace-php/issues/879
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 class Foo
 {
@@ -36,7 +36,6 @@ try {
 }
 ?>
 --EXPECT--
-Flushing tracer...
-Foo.bar (Foo.bar) (error: Oops!)
-Tracer reset
 Caught exception: Oops!
+Successfully triggered auto-flush with trace of size 2
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_disables_tracing-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing-legacy.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Auto-flushing will not instrument while flushing
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+// This is called from the flush() method of the fake tracer
+DDTrace\trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
+    $span->name = 'fake_curl_exec';
+});
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+DDTrace\trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main (main)
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main (main)
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main (main)
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Auto-flushing will not instrument while flushing
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 // This is called from the flush() method of the fake tracer
 DDTrace\trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
@@ -39,24 +40,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Flushing tracer...
-main (main)
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 10
 15
-Flushing tracer...
-main (main)
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 21
 28
-Flushing tracer...
-main (main)
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_sandbox_exception-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception-legacy.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Auto-flushing will sandbox an exception thrown from the tracer flush
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer_exception.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer with exception...
+Unable to auto flush the tracer
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Auto-flushing will sandbox an exception thrown from the tracer flush
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer_exception.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 class Foo
 {
@@ -35,6 +35,6 @@ try {
 }
 ?>
 --EXPECT--
-Flushing tracer with exception...
-Unable to auto flush the tracer
+Successfully triggered auto-flush with trace of size 1
 Caught exception: Oops!
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_userland_root_span-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span-legacy.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Userland root spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+function main($max) {
+    // Emulate opening a userland span
+    dd_trace_push_span_id();
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+    echo 'Has not flushed yet.' . PHP_EOL;
+    // Emulate closing a userland span
+    dd_trace_pop_span_id();
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Has not flushed yet.
+Flushing tracer...
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Has not flushed yet.
+Flushing tracer...
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Has not flushed yet.
+Flushing tracer...
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Userland root spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
@@ -36,23 +37,16 @@ echo PHP_EOL;
 3
 6
 Has not flushed yet.
-Flushing tracer...
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
 
 10
 15
 Has not flushed yet.
-Flushing tracer...
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
 
 21
 28
 Has not flushed yet.
-Flushing tracer...
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,73 @@
+--TEST--
+DDTrace\trace_function() and DDTrace\trace_method() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+# Functions
+var_dump(DDTrace\trace_function('foo', 'bar'));
+var_dump(DDTrace\trace_function('foo', ['bar']));
+var_dump(DDTrace\trace_function('foo', [
+    'bar' => 'baz',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'posthook' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'posthook' => new stdClass(),
+]));
+var_dump(DDTrace\trace_function('foo', []));
+
+# Methods
+echo PHP_EOL;
+var_dump(DDTrace\trace_method('foo', 'foo', 'bar'));
+var_dump(DDTrace\trace_method('foo', 'foo', ['bar']));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'bar' => 'baz',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'posthook' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'posthook' => new stdClass(),
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', []));
+?>
+--EXPECT--
+Unexpected parameters, expected (function_name, tracing_closure | config_array)
+bool(false)
+Expected config_array to be an associative array
+bool(false)
+Unknown option 'bar' in config_array
+bool(false)
+Expected 'instrument_when_limited' to be an int
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Required key 'posthook' or 'prehook' not found in config_array
+bool(false)
+
+Unexpected parameters, expected (class_name, method_name, tracing_closure | config_array)
+bool(false)
+Expected config_array to be an associative array
+bool(false)
+Unknown option 'bar' in config_array
+bool(false)
+Expected 'instrument_when_limited' to be an int
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Required key 'posthook' or 'prehook' not found in config_array
+bool(false)

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\trace_function() and DDTrace\trace_method() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -69,3 +71,4 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 Required key 'posthook' or 'prehook' not found in config_array
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_function() is aliased to DDTrace\trace_function()
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_function_complex-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex-legacy.phpt
@@ -1,0 +1,212 @@
+--TEST--
+DDTrace\trace_function() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function testFoo()
+{
+    echo "testFoo()\n";
+}
+
+function addOne($num)
+{
+    echo "addOne()\n";
+    return $num + 1;
+}
+
+function bar($thoughts, array $bar = [])
+{
+    echo "bar()\n";
+    return [
+        'thoughts' => $thoughts,
+        'first' => isset($bar[0]) ? $bar[0] : '(none)',
+        'rand' => array_sum([
+            mt_rand(0, 100),
+            addOne(mt_rand(0, 100)),
+        ])
+    ];
+}
+
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'ArraySum';
+}));
+var_dump(DDTrace\trace_function('mt_rand', null));
+var_dump(DDTrace\trace_function('testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+}));
+var_dump(DDTrace\trace_function('addOne', function (SpanData $span) {
+    $span->name = 'AddOne';
+}));
+var_dump(DDTrace\trace_function(
+    'bar',
+    function (SpanData $span, $args, $retval) {
+        $span->name = 'BarName';
+        $span->resource = 'BarResource';
+        $span->service = 'BarService';
+        $span->type = 'BarType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+            'retval.thoughts' => isset($retval['thoughts']) ? $retval['thoughts'] : '',
+            'retval.first' => isset($retval['first']) ? $retval['first'] : '',
+            'retval.rand' => isset($retval['rand']) ? $retval['rand'] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }
+));
+
+testFoo();
+var_dump(addOne(0));
+$ret = bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+testFoo()
+addOne()
+int(1)
+bar()
+addOne()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(5) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "BarName"
+    ["resource"]=>
+    string(11) "BarResource"
+    ["service"]=>
+    string(10) "BarService"
+    ["type"]=>
+    string(7) "BarType"
+    ["meta"]=>
+    array(5) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["retval.thoughts"]=>
+      string(18) "tracing is awesome"
+      ["retval.first"]=>
+      string(5) "first"
+      ["retval.rand"]=>
+      string(%d) "%d"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      string(7) "foo-red"
+      ["bar"]=>
+      string(9) "bar-green"
+    }
+  }
+  [1]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(8) "ArraySum"
+    ["resource"]=>
+    string(8) "ArraySum"
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
+  }
+  [3]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+  [4]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_function() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php
@@ -123,11 +126,13 @@ array(5) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       string(7) "foo-red"
       ["bar"]=>
       string(9) "bar-green"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_function_internal-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal-legacy.phpt
@@ -1,0 +1,50 @@
+--TEST--
+DDTrace\trace_function() can trace internal functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'ArraySum';
+}));
+
+var_dump(array_sum([1, 3, 5]));
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+int(9)
+---
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(8) "ArraySum"
+    ["resource"]=>
+    string(8) "ArraySum"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_function() can trace internal functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
@@ -23,7 +26,7 @@ int(9)
 ---
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -40,6 +43,11 @@ array(1) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_userland-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland-legacy.phpt
@@ -1,0 +1,64 @@
+--TEST--
+DDTrace\trace_function() can trace userland functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(DDTrace\trace_function('filter_to_array', function (SpanData $span) {
+    $span->name = 'filter_to_array';
+}));
+
+function filter_to_array($fn, $input) {
+    $output = array();
+    foreach ($input as $x) {
+        if (call_user_func($fn, $x)) {
+            $output[] = $x;
+        }
+    }
+    return $output;
+}
+
+$is_odd = function ($x) {
+    return $x % 2 == 1;
+};
+
+var_export(filter_to_array($is_odd, array(1, 2, 3)));
+
+echo "\n---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+array (
+  0 => 1,
+  1 => 3,
+)
+---
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(15) "filter_to_array"
+    ["resource"]=>
+    string(15) "filter_to_array"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\trace_function() can trace userland functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -38,10 +40,12 @@ array (
 ---
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
     string(%d) "%d"
     ["start"]=>
     int(%d)
@@ -51,10 +55,10 @@ array(1) {
     string(15) "filter_to_array"
     ["resource"]=>
     string(15) "filter_to_array"
-    ["meta"]=>
+    ["metrics"]=>
     array(1) {
-      ["system.pid"]=>
-      string(%d) "%d"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_method-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_method-legacy.phpt
@@ -1,0 +1,190 @@
+--TEST--
+DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        echo "Test::testFoo()\n";
+    }
+}
+
+class TestService
+{
+    public function testServiceFoo()
+    {
+        echo "TestService::testServiceFoo()\n";
+    }
+}
+
+class Foo
+{
+    public function bar($thoughts, array $bar = [])
+    {
+        echo "Foo::bar()\n";
+        return [
+            'thoughts' => $thoughts,
+            'first' => isset($bar[0]) ? $bar[0] : '(none)',
+            'rand' => mt_rand(42, 999)
+        ];
+    }
+}
+
+var_dump(DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+}));
+var_dump(DDTrace\trace_method('TestService', 'testServiceFoo', null));
+var_dump(DDTrace\trace_method(
+    'Foo', 'bar',
+    function (SpanData $span, $args, $retval) {
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+            'retval.thoughts' => isset($retval['thoughts']) ? $retval['thoughts'] : '',
+            'retval.first' => isset($retval['first']) ? $retval['first'] : '',
+            'retval.rand' => isset($retval['rand']) ? $retval['rand'] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }
+));
+var_dump(DDTrace\trace_function('mt_rand', function (SpanData $span, $args, $retval) {
+    $span->name = 'MT';
+    $span->meta = [
+        'rand.range' => $args[0] . ' - ' . $args[1],
+        'rand.value' => $retval,
+    ];
+}));
+
+$test = new Test();
+$test->testFoo();
+
+$testService = new TestService();
+$testService->testServiceFoo();
+
+$foo = new Foo();
+$ret = $foo->bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+Test::testFoo()
+TestService::testServiceFoo()
+Foo::bar()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(3) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(5) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["retval.thoughts"]=>
+      string(18) "tracing is awesome"
+      ["retval.first"]=>
+      string(5) "first"
+      ["retval.rand"]=>
+      string(%d) "%d"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      string(7) "foo-red"
+      ["bar"]=>
+      string(9) "bar-green"
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
+    ["meta"]=>
+    array(2) {
+      ["rand.range"]=>
+      string(8) "42 - 999"
+      ["rand.value"]=>
+      string(%d) "%d"
+    }
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
 --FILE--
 <?php
@@ -131,11 +134,13 @@ array(3) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       string(7) "foo-red"
       ["bar"]=>
       string(9) "bar-green"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_method() is aliased to DDTrace\trace_method()
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_push_span_id.phpt
+++ b/tests/ext/sandbox/dd_trace_push_span_id.phpt
@@ -1,6 +1,7 @@
 --TEST--
 dd_trace_push_span_id() Generates a 63-bit unsigned int as a string and stores on a stack
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_DEBUG_PRNG_SEED=42
 --FILE--
 <?php

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -3,6 +3,7 @@ Set the trace ID from userland
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -2,6 +2,7 @@
 Span properties defaults to values if not explicitly set (functions)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,range
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -2,6 +2,7 @@
 Span properties defaults to values if not explicitly set (methods)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::__construct,DateTime::format
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once-legacy.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once-legacy.phpt
@@ -1,0 +1,45 @@
+--TEST--
+deferred loading only happens once, even if dispatch is not overwritten
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+_DD_LOAD_TEST_INTEGRATIONS=1
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/deferred_loading_helper.php
+--FILE--
+<?php
+
+namespace DDTrace\Test
+{
+    use DDTrace\Integrations\Integration;
+
+    class TestSandboxedIntegration extends Integration
+    {
+        function init()
+        {
+            echo "autoload_attempted" . PHP_EOL;
+            return Integration::LOADED;
+        }
+    }
+}
+
+namespace
+{
+    class Test
+    {
+        public static function public_static_method()
+        {
+            echo "PUBLIC STATIC METHOD" . PHP_EOL;
+        }
+    }
+
+    Test::public_static_method();
+    Test::public_static_method();
+}
+?>
+--EXPECT--
+autoload_attempted
+PUBLIC STATIC METHOD
+PUBLIC STATIC METHOD

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
@@ -2,6 +2,7 @@
 deferred loading only happens once, even if dispatch is not overwritten
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_TRACE_DEBUG=1
@@ -42,3 +43,4 @@ namespace
 autoload_attempted
 PUBLIC STATIC METHOD
 PUBLIC STATIC METHOD
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/errors_are_flagged_from_userland-legacy.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland-legacy.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Errors from userland will be flagged on span
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function testErrorFromUserland()
+{
+    echo "testErrorFromUserland()\n";
+}
+
+DDTrace\trace_function('testErrorFromUserland', function (SpanData $span) {
+    $span->name = 'testErrorFromUserland';
+    $span->meta = ['error.msg' => 'Foo error'];
+});
+
+testErrorFromUserland();
+
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+testErrorFromUserland()
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(21) "testErrorFromUserland"
+    ["resource"]=>
+    string(21) "testErrorFromUserland"
+    ["error"]=>
+    int(1)
+    ["meta"]=>
+    array(2) {
+      ["error.msg"]=>
+      string(9) "Foo error"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Errors from userland will be flagged on span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -22,7 +26,7 @@ var_dump(dd_trace_serialize_closed_spans());
 testErrorFromUserland()
 array(1) {
   [0]=>
-  array(8) {
+  array(9) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -43,6 +47,11 @@ array(1) {
       string(9) "Foo error"
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
+++ b/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
@@ -50,7 +50,7 @@ echo main() . PHP_EOL;
 list($mainSpan, $handleSpan, $handleExceptionSpan) = dd_trace_serialize_closed_spans();
 
 echo $mainSpan['name'] . $mainSpan['resource'] . PHP_EOL;
-var_dump(!isset($mainSpan['parent_id']));
+var_dump((PHP_VERSION_ID >= 80000) == isset($mainSpan['parent_id'])); // root span
 
 echo $handleSpan['name'] . $handleSpan['resource'] . PHP_EOL;
 var_dump($handleSpan['parent_id'] === $mainSpan['span_id']);

--- a/tests/ext/sandbox/exception_error_log-legacy.phpt
+++ b/tests/ext/sandbox/exception_error_log-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', function () {
+    throw new RuntimeException("This exception is expected");
+});
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
+int(9)

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -14,3 +16,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        mt_srand(42);
+        printf(
+            "Test::testFoo() fav num: %d\n",
+            mt_rand()
+        );
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+    $span->service = $this_normally_raises_an_error;
+});
+
+DDTrace\trace_function('mt_srand', function (SpanData $span) {
+    $span->name = 'MTSeed';
+    throw new Exception('This should be ignored');
+});
+
+DDTrace\trace_function('mt_rand', function (SpanData $span) {
+    $span->name = 'MTRand';
+    htmlentities('<b>', 0, 'BIG5'); // E_STRICT
+});
+
+$test = new Test();
+$test->testFoo();
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECTF--
+Exception thrown in ddtrace's closure for mt_srand(): This should be ignored
+Error raised in ddtrace's closure for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+Test::testFoo() fav num: %d
+%s in ddtrace's closure for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+TestFoo
+MTRand
+MTSeed
+NULL

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
@@ -53,3 +55,4 @@ TestFoo
 MTRand
 MTSeed
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown-legacy.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown-legacy.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Fatal errors are ignored in shutdown handler
+--DESCRIPTION--
+This is how the tracer sandboxes the flushing functionality in userland
+--SKIPIF--
+<?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--INI--
+memory_limit=2M
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+function flushTracer() {
+    // Flushing happens in sandboxed tracing closure after the call.
+    // Return a value from runtime to prevent Opcache from skipping the call.
+    return mt_rand();
+}
+
+register_shutdown_function(function () {
+    // Fatal errors will cause the same behavior as an "exit" (zend_bailout)
+    // which prevents the rest of the shutdown handlers from being run.
+    // We register the shutdown handler during shutdown to ensure this one is
+    // the last one to run.
+    // This will ensure that:
+    // 1) Code in shutdown hooks can be instrumented
+    // 2) If a fatal error occurs during flush, it will not affect the user's shutdown hooks
+    register_shutdown_function(function () {
+        // We wrap the call in a closure to prevent Opcache from skipping the call.
+        flushTracer();
+    });
+});
+
+register_shutdown_function(function () {
+    echo 'Some user\'s shutdown' . PHP_EOL;
+    var_dump(array_sum([10, 10, 10]));
+    var_dump(error_get_last());
+});
+
+DDTrace\trace_function('flushTracer', function () {
+    echo 'Flushing...' . PHP_EOL;
+    array_map(function($span) {
+        echo $span['name'] . PHP_EOL;
+    }, dd_trace_serialize_closed_spans());
+    // Trigger a fatal error (hit the memory limit)
+    $a = str_repeat('.', 1024 * 1024 * 3); // 3MB
+    echo 'You should not see this.' . PHP_EOL;
+    var_dump(error_get_last());
+});
+
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum';
+});
+
+var_dump(array_sum([1, 2, 3]));
+var_dump(array_sum([4, 5, 6]));
+var_dump(array_sum([7, 8, 9]));
+?>
+--EXPECT--
+int(6)
+int(15)
+int(24)
+Some user's shutdown
+int(30)
+NULL
+Flushing...
+array_sum
+array_sum
+array_sum
+array_sum

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -4,6 +4,7 @@ Fatal errors are ignored in shutdown handler
 This is how the tracer sandboxes the flushing functionality in userland
 --SKIPIF--
 <?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --INI--
 memory_limit=2M
 --ENV--
@@ -68,3 +69,4 @@ array_sum
 array_sum
 array_sum
 array_sum
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7-legacy.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7-legacy.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Fatal errors are ignored inside a tracing closure (PHP 7)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum';
+    this_function_does_not_exist();
+});
+
+var_dump(array_sum([1, 99]));
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECT--
+Error thrown in ddtrace's closure for array_sum(): Call to undefined function this_function_does_not_exist()
+int(100)
+array_sum
+NULL

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
@@ -2,6 +2,7 @@
 Fatal errors are ignored inside a tracing closure (PHP 7)
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -24,3 +25,4 @@ Error thrown in ddtrace's closure for array_sum(): Call to undefined function th
 int(100)
 array_sum
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/hook_function/03-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/03-legacy.phpt
@@ -1,0 +1,23 @@
+--TEST--
+DDTrace\hook_function returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+var_dump(DDTrace\hook_function('greet'));
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECT--
+DDTrace\hook_function was given neither prehook nor posthook.
+bool(false)
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_function/03.phpt
+++ b/tests/ext/sandbox/hook_function/03.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -19,3 +21,4 @@ greet('Datadog');
 DDTrace\hook_function was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02-legacy.phpt
@@ -1,0 +1,31 @@
+--TEST--
+DDTrace\hook_function posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    null,
+    function ($args, $retval) {
+        echo "greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECTF--
+Hello, Datadog.
+greet hooked.
+%s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s

--- a/tests/ext/sandbox/hook_function/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -27,3 +29,4 @@ greet('Datadog');
 Hello, Datadog.
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04-legacy.phpt
@@ -1,0 +1,35 @@
+--TEST--
+DDTrace\hook_function posthook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('array_sum',
+    null,
+    function ($args, $retval) {
+        echo "array_sum hooked.\n";
+        assert($args == [[1, 3]]);
+        assert($retval === 4);
+        throw new Exception('!');
+    }
+);
+
+try {
+    $sum = array_sum([1, 3]);
+    echo "Sum = {$sum}.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+array_sum hooked.
+Exception thrown in ddtrace's closure for array_sum(): !
+Sum = 4.

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function posthook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -31,3 +33,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02-legacy.phpt
@@ -1,0 +1,30 @@
+--TEST--
+DDTrace\hook_function prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    function ($args) {
+        echo "greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECTF--
+greet hooked.
+%s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_function/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -26,3 +28,4 @@ greet('Datadog');
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02-legacy.phpt
@@ -1,0 +1,38 @@
+--TEST--
+DDTrace\hook_function prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    function ($args) {
+        echo "greet hooked.\n";
+        assert($args == ['Datadog']);
+        throw new Exception('!');
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+try {
+    greet('Datadog');
+    echo "Done.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+greet hooked.
+Exception thrown in ddtrace's closure for greet(): !
+Hello, Datadog.
+Done.

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -34,3 +36,4 @@ greet hooked.
 Exception thrown in ddtrace's closure for greet(): !
 Hello, Datadog.
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04-legacy.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DDTrace\hook_function prehook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('array_sum',
+    function ($args) {
+        echo "array_sum hooked.\n";
+        assert($args == [[1, 3]]);
+        throw new Exception('!');
+    }
+);
+
+try {
+    $sum = array_sum([1, 3]);
+    echo "Sum = {$sum}.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+array_sum hooked.
+Exception thrown in ddtrace's closure for array_sum(): !
+Sum = 4.

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -29,3 +31,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/03-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/03-legacy.phpt
@@ -1,0 +1,26 @@
+--TEST--
+DDTrace\hook_method returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+var_dump(DDTrace\hook_method('Greeter', 'greet'));
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECT--
+DDTrace\hook_method was given neither prehook nor posthook.
+bool(false)
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_method/03.phpt
+++ b/tests/ext/sandbox/hook_method/03.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -22,3 +24,4 @@ Greeter::greet('Datadog');
 DDTrace\hook_method was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/posthook_07-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07-legacy.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Nested closure targeting method call 02 (posthook)
+--DESCRIPTION--
+In PHP 5 you cannot bind a static closure to an object. It's not always
+obvious when a closure is automatically static.
+
+In this one, we're making sure that a tracing closure still works when:
+  - It is defined inside another closure that does have a scope.
+  - It is targeting a method.
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+final class Integration
+{
+    public function init()
+    {
+        /* calling hook_method from method scope, not global, is important for
+         * this particular test
+         */
+        DDTrace\hook_method('App', '__construct',
+            null,
+            function () {
+                DDTrace\trace_method('App', 'run',
+                    function () {
+                        echo "App::run traced.\n";
+                    }
+                );
+                echo "App::__construct hooked.\n";
+            }
+        );
+    }
+}
+
+final class App
+{
+    public function __construct()
+    {
+    }
+
+    public function run()
+    {
+        echo __METHOD__, "\n";
+    }
+}
+
+$integration = new Integration();
+$integration->init();
+
+$app = new App();
+$app->run();
+
+?>
+--EXPECT--
+App::__construct hooked.
+App::run
+App::run traced.

--- a/tests/ext/sandbox/hook_method/posthook_07.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07.phpt
@@ -7,6 +7,8 @@ obvious when a closure is automatically static.
 In this one, we're making sure that a tracing closure still works when:
   - It is defined inside another closure that does have a scope.
   - It is targeting a method.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -56,3 +58,4 @@ $app->run();
 App::__construct hooked.
 App::run
 App::run traced.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/hook_method/posthook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DDTrace\hook_method posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    null,
+    function ($args, $retval) {
+        echo "Greeter::greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECTF--
+Hello, Datadog.
+Greeter::greet hooked.
+%s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s

--- a/tests/ext/sandbox/hook_method/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -30,3 +32,4 @@ Greeter::greet('Datadog');
 Hello, Datadog.
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
@@ -52,3 +52,4 @@ Cannot overwrite existing dispatch for 'greet()'
 bool(false)
 Greeter::greet hooked.
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DDTrace\hook_method prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    function ($args) {
+        echo "Greeter::greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECTF--
+Greeter::greet hooked.
+%s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_method/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -30,3 +32,4 @@ Greeter::greet('Datadog');
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02-legacy.phpt
@@ -1,0 +1,39 @@
+--TEST--
+DDTrace\hook_method prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    function ($This, $scope, $args) {
+        echo "Greeter::greet hooked.\n";
+        throw new Exception('!');
+    }
+);
+
+final class Greeter
+{
+    public function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+
+try {
+    $greeter = new Greeter();
+    $greeter->greet('Datadog');
+    echo "Done.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+Greeter::greet hooked.
+Exception thrown in ddtrace's closure for Greeter::greet(): !
+Hello, Datadog.
+Done.

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -35,3 +37,4 @@ Greeter::greet hooked.
 Exception thrown in ddtrace's closure for Greeter::greet(): !
 Hello, Datadog.
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (internal functions)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (internal methods)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::format,DateTime::setTime
 --FILE--
 <?php

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (userland functions)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 function myFunc1($foo) {

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (userland methods)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 class MyClass

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -16,8 +16,10 @@ ddtrace.request_init_hook=
 <?php
 register_shutdown_function(function () {
     echo 'Flushing...' . PHP_EOL;
-    dd_trace_serialize_closed_spans();
-    echo 'You should not see this.' . PHP_EOL;
+    if (PHP_VERSION_ID < 80000) {
+        dd_trace_serialize_closed_spans();
+        echo 'You should not see this.' . PHP_EOL;
+    }
 });
 
 DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/retval_is_null_with_exception-legacy.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The return value is null when an exception is thrown in the original call
+--DESCRIPTION--
+We enable debug mode to ensure this does not raise an "Undefined variable" E_NOTICE in the tracing closure
+https://github.com/DataDog/dd-trace-php/issues/788
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function foo()
+{
+    throw new Exception('Oops!');
+    return 42;
+}
+
+DDTrace\trace_function('foo', function (SpanData $span, array $args, $retval, $ex) {
+    var_dump($ex instanceof Exception);
+    var_dump($retval);
+});
+
+try {
+    foo();
+} catch (Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+bool(true)
+NULL
+Oops!

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -3,6 +3,8 @@ The return value is null when an exception is thrown in the original call
 --DESCRIPTION--
 We enable debug mode to ensure this does not raise an "Undefined variable" E_NOTICE in the tracing closure
 https://github.com/DataDog/dd-trace-php/issues/788
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -30,3 +32,4 @@ try {
 bool(true)
 NULL
 Oops!
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/spans_out_of_sync_01-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01-legacy.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [internal]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'dd_trace_serialize_closed_spans';
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_01.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans from traced function [internal]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
@@ -21,3 +23,4 @@ Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of s
 array(0) {
 }
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_02-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02-legacy.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [internal][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_02.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans from traced function [internal][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
@@ -20,3 +22,4 @@ Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of s
 array(0) {
 }
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_05-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05-legacy.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    $span->name = 'shutdown_and_flush';
+
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_05.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans in closure itself [user]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -21,3 +23,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/spans_out_of_sync_06-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06-legacy.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_06.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans in closure itself [user][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -19,3 +21,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this-legacy.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this-legacy.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Static tracing closures will not bind $this
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=true
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function test()
+    {
+        echo "Foo::test()\n";
+    }
+}
+
+DDTrace\trace_method('Foo', 'test', static function () {
+    echo "TRACED Foo::test()\n";
+});
+
+$foo = new Foo();
+$foo->test();
+?>
+--EXPECT--
+Foo::test()
+Cannot trace non-static method with static tracing closure

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Static tracing closures will not bind $this
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=true
 --FILE--
@@ -24,3 +26,4 @@ $foo->test();
 --EXPECT--
 Foo::test()
 Cannot trace non-static method with static tracing closure
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Set DDTrace\start_span() properties
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+
+$original_span = DDTrace\active_span();
+
+$time = time();
+
+$span = DDTrace\start_span();
+// avoid interned strings
+$span->name = ($_ = "d") . "ata";
+$span->resource = ($_ = "d") . "og";
+$span->service = ($_ = "t") . "est";
+$span->type = ($_ = "r") . "unner";
+$span->meta = [($_ = "a") . "a" => ($_ = "b") . "b"];
+$span->metrics = [($_ = "c") . "c" => ($_ = "d") . "d"];
+
+var_dump($span->getDuration());
+var_dump($start_time = $span->getStartTime());
+if ($start_time < $time * 1000000000 || $start_time > ($time + 2) * 1000000000) {
+    echo "$start_time not in expected bounds of $time to $time + 2\n";
+}
+
+var_dump(DDTrace\active_span() == $span);
+
+DDTrace\close_span();
+
+var_dump($original_span == DDTrace\active_span());
+
+var_dump($start_time = $span->getStartTime());
+if ($start_time < $time * 1000000000 || $start_time > ($time + 2) * 1000000000) {
+    echo "$start_time not in expected bounds of $time to $time + 2\n";
+}
+var_dump($span->getDuration() > 0);
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+int(0)
+int(%d)
+bool(true)
+bool(true)
+int(%d)
+bool(true)
+array(1) {
+  [0]=>
+  array(11) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "data"
+    ["resource"]=>
+    string(3) "dog"
+    ["service"]=>
+    string(4) "test"
+    ["type"]=>
+    string(6) "runner"
+    ["meta"]=>
+    array(1) {
+      ["aa"]=>
+      string(2) "bb"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["cc"]=>
+      string(2) "dd"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Use DDTrace\close_span() on span started within internal span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function test() { }
+
+DDTrace\trace_function("test", function($s) {
+    $span = DDTrace\start_span();
+    $span->name = "my precious span";
+});
+
+test();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+// has no effect
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(5) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}
+There is no user-span on the top of the stack. Cannot close.
+array(0) {
+}
+No finished traces to be sent to the agent

--- a/tests/ext/start_span_without_closing_autofinish.phpt
+++ b/tests/ext/start_span_without_closing_autofinish.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Use DDTrace\close_span() on span started within internal span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_AUTOFINISH_SPANS=1
+--FILE--
+<?php
+
+function test() { }
+
+DDTrace\trace_function("test", function($s) {
+    $span = DDTrace\start_span();
+    $span->name = "my precious span";
+});
+
+test();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+// has no effect
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(16) "my precious span"
+    ["resource"]=>
+    string(16) "my precious span"
+  }
+}
+There is no user-span on the top of the stack. Cannot close.
+array(0) {
+}
+No finished traces to be sent to the agent

--- a/tests/ext/startup_logging_json_config.phpt
+++ b/tests/ext/startup_logging_json_config.phpt
@@ -84,3 +84,4 @@ traced_internal_functions: "array_sum,mt_rand,DateTime::add"
 auto_prepend_file_configured: true
 integrations_disabled: "curl,mysqli"
 enabled_from_env: false
+No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

Doing a lot of things:
 - Nearly everything happening in Tracer->flush() is now in the extension
 - Spans are allocated and closed directly instead of their ids
 - Spans now expose duration and start time via methods
 - The root span is (if there is configured to be one) allocated and closed from within the extension - close at the very last moment: RSHUTDOWN

Also note: DRAFT, UNTESTED AND BROKEN.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
