### PR TITLE
Refactor internal span objects to be allocated together with their internal data

### DIFF
--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -214,17 +214,63 @@ static PHP_GINIT_FUNCTION(ddtrace) {
 
 /* DDTrace\SpanData */
 zend_class_entry *ddtrace_ce_span_data;
+zend_object_handlers ddtrace_span_data_handlers;
+
+static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
+    ddtrace_span_fci *span_fci = ecalloc(1, sizeof(*span_fci));
+    zend_object_std_init(&span_fci->span.std, class_type);
+    span_fci->span.std.handlers = &ddtrace_span_data_handlers;
+    return &span_fci->span.std;
+}
+
+static void ddtrace_span_data_free_storage(zend_object *object) {
+    ddtrace_span_fci *span_fci = (ddtrace_span_fci *)object;
+    if (span_fci->exception) {
+        OBJ_RELEASE(span_fci->exception);
+    }
+    zend_object_std_dtor(object);
+}
+
+static zend_object *ddtrace_span_data_clone_obj(zend_object *old_obj) {
+    zend_object *new_obj = ddtrace_span_data_create(old_obj->ce);
+    zend_objects_clone_members(new_obj, old_obj);
+    return new_obj;
+}
+
+static PHP_METHOD(DDTrace_SpanData, getDuration) {
+    ddtrace_span_fci *span_fci = (ddtrace_span_fci *)Z_OBJ_P(ZEND_THIS);
+    RETURN_LONG(span_fci->span.duration);
+}
+
+static PHP_METHOD(DDTrace_SpanData, getStartTime) {
+    ddtrace_span_fci *span_fci = (ddtrace_span_fci *)Z_OBJ_P(ZEND_THIS);
+    RETURN_LONG(span_fci->span.start);
+}
+
+const zend_function_entry class_DDTrace_SpanData_methods[] = {
+    // clang-format off
+    PHP_ME(DDTrace_SpanData, getDuration, arginfo_ddtrace_void, ZEND_ACC_PUBLIC)
+    PHP_ME(DDTrace_SpanData, getStartTime, arginfo_ddtrace_void, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+    // clang-format on
+};
 
 static void dd_register_span_data_ce(void) {
+    memcpy(&ddtrace_span_data_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    ddtrace_span_data_handlers.clone_obj = ddtrace_span_data_clone_obj;
+    ddtrace_span_data_handlers.free_obj = ddtrace_span_data_free_storage;
+
     zend_class_entry ce_span_data;
-    INIT_NS_CLASS_ENTRY(ce_span_data, "DDTrace", "SpanData", NULL);
+    INIT_NS_CLASS_ENTRY(ce_span_data, "DDTrace", "SpanData", class_DDTrace_SpanData_methods);
     ddtrace_ce_span_data = zend_register_internal_class(&ce_span_data);
+    ddtrace_ce_span_data->create_object = ddtrace_span_data_create;
 
     // trace_id, span_id, parent_id, start & duration are stored directly on
     // ddtrace_span_t so we don't need to make them properties on DDTrace\SpanData
     /*
      * ORDER MATTERS: If you make any changes to the properties below, update the
      * corresponding ddtrace_spandata_property_*() function with the proper offset.
+     * ALSO: Update the properties_table_placeholder size of ddtrace_span_t to property count - 1.
      */
     zend_declare_property_null(ddtrace_ce_span_data, "name", sizeof("name") - 1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(ddtrace_ce_span_data, "resource", sizeof("resource") - 1, ZEND_ACC_PUBLIC);
@@ -234,18 +280,21 @@ static void dd_register_span_data_ce(void) {
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"  // useful compiler does not like the struct hack
 // SpanData::$name
-zval *ddtrace_spandata_property_name(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 0); }
+zval *ddtrace_spandata_property_name(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 0); }
 // SpanData::$resource
-zval *ddtrace_spandata_property_resource(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 1); }
+zval *ddtrace_spandata_property_resource(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 1); }
 // SpanData::$service
-zval *ddtrace_spandata_property_service(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 2); }
+zval *ddtrace_spandata_property_service(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 2); }
 // SpanData::$type
-zval *ddtrace_spandata_property_type(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 3); }
+zval *ddtrace_spandata_property_type(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 3); }
 // SpanData::$meta
-zval *ddtrace_spandata_property_meta(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 4); }
+zval *ddtrace_spandata_property_meta(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 4); }
 // SpanData::$metrics
-zval *ddtrace_spandata_property_metrics(zval *spandata) { return OBJ_PROP_NUM(Z_OBJ_P(spandata), 5); }
+zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 5); }
+#pragma GCC diagnostic pop
 
 /* DDTrace\FatalError */
 zend_class_entry *ddtrace_ce_fatal_error;
@@ -1249,6 +1298,15 @@ static PHP_FUNCTION(dd_trace_peek_span_id) {
     return_span_id(return_value, ddtrace_peek_span_id());
 }
 
+/* {{{ proto string DDTrace\active_span() */
+static PHP_FUNCTION(active_span) {
+    UNUSED(execute_data);
+    if (DDTRACE_G(open_spans_top)) {
+        RETURN_OBJ_COPY(&DDTRACE_G(open_spans_top)->span.std);
+    }
+    RETURN_NULL();
+}
+
 /* {{{ proto string \DDTrace\trace_id() */
 static PHP_FUNCTION(trace_id) {
     UNUSED(execute_data);
@@ -1344,6 +1402,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_FE(dd_trace_internal_fn, arginfo_dd_trace_internal_fn),
     DDTRACE_FE(dd_trace_noop, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_peek_span_id, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_pop_span_id, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -14,13 +14,14 @@ extern zend_class_entry *ddtrace_ce_fatal_error;
 
 typedef struct ddtrace_span_ids_t ddtrace_span_ids_t;
 typedef struct ddtrace_span_fci ddtrace_span_fci;
+typedef struct ddtrace_span_t ddtrace_span_t;
 
-zval *ddtrace_spandata_property_name(zval *spandata);
-zval *ddtrace_spandata_property_resource(zval *spandata);
-zval *ddtrace_spandata_property_service(zval *spandata);
-zval *ddtrace_spandata_property_type(zval *spandata);
-zval *ddtrace_spandata_property_meta(zval *spandata);
-zval *ddtrace_spandata_property_metrics(zval *spandata);
+zval *ddtrace_spandata_property_name(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_resource(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_service(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_type(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 
 BOOL_T ddtrace_tracer_is_limited(void);
 

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -292,12 +292,12 @@ static bool dd_execute_tracing_closure(zval *callable, zval *span_data, zend_exe
 static bool dd_call_sandboxed_tracing_closure(ddtrace_span_fci *span_fci, zval *callable, zval *user_retval) {
     zend_execute_data *call = span_fci->execute_data;
     ddtrace_span_t *span = &span_fci->span;
-    zval user_args;
+    zval user_args, span_zv;
 
+    ZVAL_OBJ(&span_zv, &span->std);
     dd_copy_args(&user_args, call);
 
-    bool keep_span =
-        dd_execute_tracing_closure(callable, span->span_data, call, &user_args, user_retval, EG(exception));
+    bool keep_span = dd_execute_tracing_closure(callable, &span_zv, call, &user_args, user_retval, EG(exception));
 
     zval_dtor(&user_args);
 
@@ -374,7 +374,7 @@ static ZEND_RESULT_CODE dd_do_hook_method_prehook(zend_execute_data *call, ddtra
 }
 
 static ddtrace_span_fci *dd_fcall_begin_tracing_hook(zend_execute_data *call, ddtrace_dispatch_t *dispatch) {
-    ddtrace_span_fci *span_fci = ecalloc(1, sizeof(*span_fci));
+    ddtrace_span_fci *span_fci = ddtrace_init_span();
     span_fci->execute_data = call;
     span_fci->dispatch = dispatch;
     ddtrace_open_span(span_fci);
@@ -410,7 +410,7 @@ static ddtrace_span_fci *dd_create_duplicate_span(zend_execute_data *call, ddtra
      * We want any children to be inherited by the currently active span, not
      * this fake one, so we duplicate the span_id.
      */
-    ddtrace_span_fci *span_fci = ecalloc(1, sizeof(*span_fci));
+    ddtrace_span_fci *span_fci = ddtrace_init_span();
     span_fci->execute_data = call;
     span_fci->dispatch = dispatch;
 
@@ -482,21 +482,19 @@ void dd_set_fqn(zval *zv, zend_execute_data *ex) {
 
 static void dd_set_default_properties(void) {
     ddtrace_span_fci *span_fci = DDTRACE_G(open_spans_top);
-    if (span_fci == NULL || span_fci->span.span_data == NULL || span_fci->execute_data == NULL) {
+    if (span_fci == NULL || span_fci->execute_data == NULL) {
         return;
     }
 
     ddtrace_span_t *span = &span_fci->span;
     // SpanData::$name defaults to fully qualified called name
     // The other span property defaults are set at serialization time
-    zval *prop_name = ddtrace_spandata_property_name(span->span_data);
-    if (prop_name && Z_TYPE_P(prop_name) == IS_NULL) {
+    zval *prop_name = ddtrace_spandata_property_name(span);
+    if (prop_name && Z_TYPE_P(prop_name) <= IS_NULL) {
         zval prop_name_default;
         ZVAL_NULL(&prop_name_default);
         dd_set_fqn(&prop_name_default, span_fci->execute_data);
         ZVAL_COPY_VALUE(prop_name, &prop_name_default);
-        zval_copy_ctor(prop_name);
-        zval_dtor(&prop_name_default);
     }
 }
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -290,7 +290,7 @@ static zend_result dd_add_meta_array(void *context, ddtrace_string key, ddtrace_
 
 static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
     ddtrace_span_t *span = &span_fci->span;
-    zval meta_zv, *meta = ddtrace_spandata_property_meta(span->span_data);
+    zval meta_zv, *meta = ddtrace_spandata_property_meta(span);
 
     array_init(&meta_zv);
     if (meta && Z_TYPE_P(meta) == IS_ARRAY) {
@@ -359,40 +359,40 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
     add_assoc_long(el, "duration", span->duration);
 
     // SpanData::$name defaults to fully qualified called name (set at span close)
-    zval *prop_name = ddtrace_spandata_property_name(span->span_data);
+    zval *prop_name = ddtrace_spandata_property_name(span);
     zval prop_name_as_string;
-    if (Z_TYPE_P(prop_name) != IS_NULL) {
+    if (Z_TYPE_P(prop_name) > IS_NULL) {
         ddtrace_convert_to_string(&prop_name_as_string, prop_name);
         _add_assoc_zval_copy(el, "name", &prop_name_as_string);
     }
 
     // SpanData::$resource defaults to SpanData::$name
-    zval *prop_resource = ddtrace_spandata_property_resource(span->span_data);
-    if (Z_TYPE_P(prop_resource) != IS_NULL) {
+    zval *prop_resource = ddtrace_spandata_property_resource(span);
+    if (Z_TYPE_P(prop_resource) > IS_FALSE && (Z_TYPE_P(prop_resource) != IS_STRING || Z_STRLEN_P(prop_resource) > 0)) {
         _dd_add_assoc_zval_as_string(el, "resource", prop_resource);
-    } else {
+    } else if (Z_TYPE_P(prop_name) > IS_NULL) {
         _add_assoc_zval_copy(el, "resource", &prop_name_as_string);
     }
 
-    if (Z_TYPE_P(prop_name) != IS_NULL) {
+    if (Z_TYPE_P(prop_name) > IS_NULL) {
         zval_dtor(&prop_name_as_string);
     }
 
     // TODO: SpanData::$service defaults to parent SpanData::$service or DD_SERVICE if root span
-    zval *prop_service = ddtrace_spandata_property_service(span->span_data);
-    if (Z_TYPE_P(prop_service) != IS_NULL) {
+    zval *prop_service = ddtrace_spandata_property_service(span);
+    if (Z_TYPE_P(prop_service) > IS_NULL) {
         _dd_add_assoc_zval_as_string(el, "service", prop_service);
     }
 
     // SpanData::$type is optional and defaults to 'custom' at the Agent level
-    zval *prop_type = ddtrace_spandata_property_type(span->span_data);
-    if (Z_TYPE_P(prop_type) != IS_NULL) {
+    zval *prop_type = ddtrace_spandata_property_type(span);
+    if (Z_TYPE_P(prop_type) > IS_NULL) {
         _dd_add_assoc_zval_as_string(el, "type", prop_type);
     }
 
     _serialize_meta(el, span_fci);
 
-    zval *metrics = ddtrace_spandata_property_metrics(span->span_data);
+    zval *metrics = ddtrace_spandata_property_metrics(span);
     if (Z_TYPE_P(metrics) == IS_ARRAY) {
         _add_assoc_zval_copy(el, "metrics", metrics);
     }
@@ -439,15 +439,11 @@ void ddtrace_observer_error_cb(int type, const char *error_filename, uint32_t er
             dd_fatal_error_to_meta(&DDTRACE_G(additional_trace_meta), error);
             ddtrace_span_fci *span;
             for (span = DDTRACE_G(open_spans_top); span; span = span->next) {
-                if (span->exception || !span->span.span_data) {
+                if (span->exception) {
                     continue;
                 }
 
-                zval *meta = ddtrace_spandata_property_meta(span->span.span_data);
-                if (!meta) {
-                    continue;
-                }
-
+                zval *meta = ddtrace_spandata_property_meta(&span->span);
                 if (Z_TYPE_P(meta) != IS_ARRAY) {
                     zval_ptr_dtor(meta);
                     array_init_size(meta, ddtrace_num_error_tags);

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -14,25 +14,23 @@ static const int ddtrace_num_error_tags = 3;
 struct ddtrace_dispatch_t;
 
 struct ddtrace_span_t {
-    zval *span_data;
+    zend_object std;
+    zval properties_table_placeholder[5];
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;
     uint64_t start;
-    union {
-        uint64_t duration_start;
-        uint64_t duration;
-    };
+    uint64_t duration_start;
+    uint64_t duration;
     pid_t pid;
 };
-typedef struct ddtrace_span_t ddtrace_span_t;
 
 struct ddtrace_span_fci {
+    ddtrace_span_t span;
     zend_execute_data *execute_data;
     struct ddtrace_dispatch_t *dispatch;
     ddtrace_exception_t *exception;
     struct ddtrace_span_fci *next;
-    ddtrace_span_t span;
 };
 typedef struct ddtrace_span_fci ddtrace_span_fci;
 
@@ -41,6 +39,7 @@ void ddtrace_free_span_stacks(void);
 
 void ddtrace_push_span(ddtrace_span_fci *span_fci);
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
+ddtrace_span_fci *ddtrace_init_span();
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 void ddtrace_close_span(void);
 void ddtrace_drop_top_open_span(void);

--- a/package.xml
+++ b/package.xml
@@ -528,6 +528,8 @@
             <file name="tests/ext/sandbox/safe_to_string_metadata.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_properties.phpt" role="test" />
+            <file name="tests/ext/sandbox/span_clone.phpt" role="test" />
+            <file name="tests/ext/sandbox/span_resource_serialization.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_01.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_02.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_03_php5.phpt" role="test" />
@@ -604,6 +606,7 @@
             <file name="tests/ext/sandbox-regression/with_params_function_hook.phpt" role="test" />
             <file name="tests/ext/sandbox-regression/with_params_method_hook.phpt" role="test" />
 
+            <file name="tests/ext/active_span.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_default.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_high_limit.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_high_user_limit.phpt" role="test" />

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -1,0 +1,30 @@
+--TEST--
+DDTrace\active_span basic functionality
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+
+DDTrace\trace_function('greet',
+    function ($span) {
+        echo "greet tracer.\n";
+        $span->name = "foo";
+        var_dump($span == DDTrace\active_span());
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+var_dump(DDTrace\active_span());
+
+?>
+--EXPECT--
+Hello, Datadog.
+greet tracer.
+bool(true)
+NULL

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Clone DDTrace\SpanData
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function dummy() { }
+
+DDTrace\trace_function('dummy', function (SpanData $span) {
+    $span->resource = "abc";
+    $span_copy = clone $span;
+    $span->name = "foo";
+    var_dump($span);
+    var_dump($span_copy);
+});
+
+dummy();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+object(DDTrace\SpanData)#2 (2) {
+  ["name"]=>
+  string(3) "foo"
+  ["resource"]=>
+  string(3) "abc"
+}
+object(DDTrace\SpanData)#3 (1) {
+  ["resource"]=>
+  string(3) "abc"
+}
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(3) "foo"
+    ["resource"]=>
+    string(3) "abc"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}

--- a/tests/ext/sandbox/span_resource_serialization.phpt
+++ b/tests/ext/sandbox/span_resource_serialization.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Resource is replaced by name if null-ish
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+DDTrace\trace_function('with_nothing', function (SpanData $span) { });
+
+DDTrace\trace_function('with_null', function (SpanData $span) {
+    $span->resource = null;
+});
+
+DDTrace\trace_function('with_false', function (SpanData $span) {
+    $span->resource = false;
+});
+
+DDTrace\trace_function('with_empty_string', function (SpanData $span) {
+    $span->resource = "";
+});
+
+DDTrace\trace_function('with_value', function (SpanData $span) {
+    $span->resource = "abc";
+});
+
+function with_nothing() {}
+function with_null() {}
+function with_false() {}
+function with_empty_string() {}
+function with_value() {}
+
+with_nothing();
+with_null();
+with_false();
+with_empty_string();
+with_value();
+
+foreach (dd_trace_serialize_closed_spans() as $span) {
+    echo "name: {$span['name']}; resource: {$span['resource']}\n";
+}
+
+?>
+--EXPECT--
+name: with_value; resource: abc
+name: with_empty_string; resource: with_empty_string
+name: with_false; resource: with_false
+name: with_null; resource: with_null
+name: with_nothing; resource: with_nothing


### PR DESCRIPTION
### Description

Also already exposes DDTrace\active_span() and getStartTime() / getDuration(). (Which are crucial for the #1251 internal spans, where this PR was split off.)

The refactor itself is needed to access time info from the fci from the object.

Note that there are currently no proper tests for the two methods, but in PR #1251 there are some; properly (i.e. in a meaningful way) testing this needs start_span() functions.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
