### PR TITLE
Run mongodb-driver testsuite in CI with and without the tracer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1478,6 +1478,14 @@ workflows:
       #     name: "Symfony baseline testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
+          framework_target: mongodb-driver
+          name: "Mongodb driver testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
+          framework_target: mongodb-driver_no_ddtrace
+          name: "Mongodb driver baseline testsuite"
+      - framework_tests:
+          requires: [ "Framework tests" ]
           framework_target: phpredis3
           name: "PHPRedis 3 testsuite"
       - framework_tests:

--- a/dockerfiles/frameworks/contrib/Dockerfile
+++ b/dockerfiles/frameworks/contrib/Dockerfile
@@ -217,3 +217,30 @@ RUN set -xe; \
 WORKDIR /home/phpredis-${PHPREDIS_VERSION_TAG}
 ADD phpredis/${PHPREDIS_VERSION_TAG}/run.sh ./run.sh
 CMD [ "./run.sh" ]
+
+########################################################################################################################
+## mongodb-driver frameworks tests
+########################################################################################################################
+FROM base AS mongodb-driver
+ARG MONGODB_VERSION_TAG
+
+RUN set -xe; \
+    git clone --depth 1 --branch ${MONGODB_VERSION_TAG} https://github.com/mongodb/mongo-php-driver.git \
+        /home/mongodb-driver-${MONGODB_VERSION_TAG};
+
+WORKDIR /home/mongodb-driver-${MONGODB_VERSION_TAG}
+
+ENV DD_SERVICE=mongodb-driver-${MONGODB_VERSION_TAG}
+
+# Building mongodb-driver
+#   https://github.com/mongodb/mongo-php-driver/blob/master/CONTRIBUTING.md
+RUN git submodule update --init
+RUN phpize
+RUN ./configure --enable-mongodb-developer-flags
+RUN make clean
+RUN make all
+RUN make install
+
+ADD mongodb-driver/run.sh ./run.sh
+
+CMD [ "./run.sh" ]

--- a/dockerfiles/frameworks/contrib/mongodb-driver/README.md
+++ b/dockerfiles/frameworks/contrib/mongodb-driver/README.md
@@ -1,0 +1,31 @@
+Run this command to print the list of different reasons why tests are skipped.
+
+```
+make test | grep 'SKIP ' | sed 's/.*reason://' | sort | uniq -c
+```
+
+Here is the current list of reasons why some tests are skipped (<200 out of ~1900):
+
+```
+ 1  Atlas URIs not found
+ 1  DNS seedlist test must be run manually
+ 2  E_WARNING: file_get_contents(http://localhost:8889/v1): failed to open stream: Cannot assign requested address @ /home/mongodb-driver-1.9.1/tests/utils/skipif.php:437
+ 2  OCSP tests not wanted
+ 6  Only for 32-bit platform
+ 1  Server storage engine is 'wiredTiger' (needed 'mmapv1')
+ 7  Server version '4.4.6' >= '3.1'
+ 2  Server version '4.4.6' >= '3.4'
+ 3  Server version '4.4.6' >= '3.6'
+ 1  Server version '4.4.6' >= '4.2'
+ 1  Server version '4.4.6' >= '4.3.4'
+15  URI is not using SSL
+ 3  URI is not using auth
+ 2  libmongocrypt is enabled
+10  test commands are disabled
+18  topology does not support transactions
+ 1  topology is a standalone
+75  topology is not a replica set
+26  topology is not a replica set or sharded cluster with replica set
+ 2  topology is not a sharded cluster
+14  topology is not a sharded cluster with replica set
+```

--- a/dockerfiles/frameworks/contrib/mongodb-driver/run.sh
+++ b/dockerfiles/frameworks/contrib/mongodb-driver/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+switch_php 7.3
+
+make test

--- a/dockerfiles/frameworks/mongodb-driver.yml
+++ b/dockerfiles/frameworks/mongodb-driver.yml
@@ -1,0 +1,29 @@
+version: "3.6"
+
+services:
+  mongodb-driver:
+    depends_on:
+      - nginx_file_server
+      - mongodb
+    environment:
+      - MONGODB_URI=mongodb://mongodb
+      - NO_INTERACTION=1
+    image: datadog/dd-trace-ci:php-framework-mongodb-driver-1.9
+    build:
+      context: contrib
+      target: mongodb-driver
+      args:
+        - MONGODB_VERSION_TAG=1.9.1
+    ulimits:
+      core: 99999999999
+    cap_add:
+      - SYS_PTRACE
+
+  mongodb:
+    image: "circleci/mongo:4"
+    ports:
+      - "27017:27017"
+
+  nginx_file_server:
+    build: nginx_file_server
+    expose: ["80"]


### PR DESCRIPTION
### Description

Run the latest mongodb-drive testsuite in CI (https://github.com/mongodb/mongo-php-driver).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
