### PR TITLE
Add ZAI component for reading headers

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -185,6 +185,7 @@ if test "$PHP_DDTRACE" != "no"; then
 
     ZAI_SOURCES="\
       zend_abstract_interface/env/env.c \
+      zend_abstract_interface/headers/php7-8/headers.c \
       zend_abstract_interface/sandbox/php7/sandbox.c \
       zend_abstract_interface/zai_sapi/php7/zai_sapi.c \
       zend_abstract_interface/zai_sapi/zai_sapi_extension.c \
@@ -236,6 +237,7 @@ if test "$PHP_DDTRACE" != "no"; then
       zend_abstract_interface/env/env.c \
       zend_abstract_interface/exceptions/php8/exceptions.c \
       zend_abstract_interface/functions/php8/functions.c \
+      zend_abstract_interface/headers/php7-8/headers.c \
       zend_abstract_interface/properties/php7-8/properties.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \
       zend_abstract_interface/zai_sapi/php8/zai_sapi.c \
@@ -275,6 +277,8 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/exceptions/php8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/functions/php8])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/headers])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/headers/php7-8])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/methods/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/properties])
@@ -288,6 +292,7 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php5])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php7])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_sapi/php8])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_string])
 
   PHP_ADD_INCLUDE([$ext_srcdir/ext/vendor])
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/vendor])

--- a/package.xml
+++ b/package.xml
@@ -56,6 +56,8 @@
             <file name="zend_abstract_interface/exceptions/php8/exceptions.h" role="src" />
             <file name="zend_abstract_interface/functions/functions.h" role="src" />
             <file name="zend_abstract_interface/functions/php8/functions.c" role="src" />
+            <file name="zend_abstract_interface/headers/php7-8/headers.c" role="src" />
+            <file name="zend_abstract_interface/headers/headers.h" role="src" />
             <file name="zend_abstract_interface/methods/methods.h" role="src" />
             <file name="zend_abstract_interface/methods/php5/methods.c" role="src" />
             <file name="zend_abstract_interface/properties/php7-8/properties.c" role="src" />
@@ -78,6 +80,7 @@
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_ini.h" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_io.c" role="src" />
             <file name="zend_abstract_interface/zai_sapi/zai_sapi_io.h" role="src" />
+            <file name="zend_abstract_interface/zai_string/string.h" role="src" />
 
             <!-- Shared -->
             <file name="ext/DatadogArena/arena.c" role="src" />

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -88,11 +88,15 @@ if(PHP_VERSION_DIRECTORY STREQUAL "php5")
   add_subdirectory(methods)
 endif()
 add_subdirectory(sandbox)
+add_subdirectory(zai_string)
 add_subdirectory(zai_assert)
 if(PHP_VERSION_DIRECTORY STREQUAL "php8")
   # should support php7 as well, but depends on functions ZAI to test, disabling for now
   add_subdirectory(properties)
   add_subdirectory(exceptions)
+endif()
+if (PHP_VERSION_DIRECTORY STREQUAL "php7" OR PHP_VERSION_DIRECTORY STREQUAL "php8")
+  add_subdirectory(headers)
 endif()
 
 install(EXPORT ZendAbstractInterfaceTargets

--- a/zend_abstract_interface/env/env.h
+++ b/zend_abstract_interface/env/env.h
@@ -2,6 +2,7 @@
 #define ZAI_ENV_H
 
 #include <stddef.h>
+#include <zai_string/string.h>
 
 /* The upper-bounds limit on the buffer size to hold the value of an arbitrary
  * environment variable.
@@ -44,15 +45,6 @@ typedef struct zai_env_buffer_s {
 #define ZAI_ENV_BUFFER_INIT(name, size) \
     char name##_storage[size];          \
     zai_env_buffer name = {size, name##_storage}
-
-// TODO Move this to Zai::String
-typedef struct zai_string_view_s {
-    size_t len;
-    const char *ptr;
-} zai_string_view;
-
-#define ZAI_STRL_VIEW(cstr) \
-    (zai_string_view) { .len = sizeof(cstr) - 1, .ptr = (cstr) }
 
 /* Fills 'buf.ptr' with the value of a target environment variable identified by
  * 'name'. Must be called after the SAPI envrionment variables are available

--- a/zend_abstract_interface/headers/CMakeLists.txt
+++ b/zend_abstract_interface/headers/CMakeLists.txt
@@ -1,0 +1,33 @@
+if(PHP_VERSION_DIRECTORY STREQUAL "php7" OR PHP_VERSION_DIRECTORY STREQUAL "php8")
+    set(PHP_HEADERS_VERSION_DIRECTORY "php7-8")
+else()
+    set(PHP_HEADERS_VERSION_DIRECTORY PHP_VERSION_DIRECTORY)
+endif()
+
+add_library(zai_headers "${PHP_HEADERS_VERSION_DIRECTORY}/headers.c")
+
+target_include_directories(zai_headers PUBLIC
+                                       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                       $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_headers PUBLIC c_std_99)
+
+target_link_libraries(zai_headers PUBLIC "${PHP_LIB}")
+
+set_target_properties(zai_headers PROPERTIES
+                                  EXPORT_NAME headers
+                                  VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Headers ALIAS zai_headers)
+
+if (${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/headers.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/headers/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_headers)
+
+install(TARGETS zai_headers EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/headers/headers.h
+++ b/zend_abstract_interface/headers/headers.h
@@ -1,0 +1,23 @@
+#ifndef ZAI_HEADERS_H
+#define ZAI_HEADERS_H
+
+#include <Zend/zend.h>
+#include <zai_string/string.h>
+
+typedef enum {
+    /* The header_value pointer now hold reference to a valid zend_string. RC is not increased. */
+    ZAI_HEADER_SUCCESS,
+    /* The function is being called before the _SERVER superglobal may be available. */
+    ZAI_HEADER_NOT_READY,
+    /* The header is not set. */
+    ZAI_HEADER_NOT_SET,
+    /* API usage error. */
+    ZAI_HEADER_ERROR,
+} zai_header_result;
+
+zai_header_result zai_read_header(zai_string_view uppercase_header_name, zend_string **header_value);
+
+#define zai_read_header_literal(uppercase_header_name, header_value) \
+    zai_read_header(ZAI_STRL_VIEW(uppercase_header_name), header_value)
+
+#endif  // ZAI_HEADERS_H

--- a/zend_abstract_interface/headers/php7-8/headers.c
+++ b/zend_abstract_interface/headers/php7-8/headers.c
@@ -1,0 +1,56 @@
+#include "../headers.h"
+
+#include <php.h>
+#include <zai_assert/zai_assert.h>
+
+zai_header_result zai_read_header(zai_string_view uppercase_header_name, zend_string **header_value) {
+    if (!uppercase_header_name.ptr || !uppercase_header_name.len || !header_value) return ZAI_HEADER_ERROR;
+
+    zai_assert_is_upper(uppercase_header_name.ptr, "Header names must be uppercase.");
+
+    if (!PG(modules_activated) && !PG(during_request_startup)) return ZAI_HEADER_NOT_READY;
+
+    if (PG(auto_globals_jit)) {
+        // !!!
+        // This has side effects: while it does not realistically affect anybodys code - it materializes the
+        // $_SERVER array for users with auto_globals_jit On (which is observable from userland).
+        // In reality, it does not affect us much, as we anyway have that sort of side effect as part of initializing
+        // any span.
+        // As long as this function is not called with tracing disabled, this should be fine.
+        //
+        // The alternative would be calling sapi_module_struct.register_server_variables manually, but this has an
+        // unacceptable overhead as that always computes the *whole* _SERVER array, even if we just want to access
+        // a single value.
+        zend_is_auto_global_str(ZEND_STRL("_SERVER"));
+    }
+
+    zval *server_var = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (Z_TYPE_P(server_var) != IS_ARRAY) {
+        return ZAI_HEADER_NOT_READY;  // should be impossible to reach
+    }
+
+    // note that ext/filter stores a raw (unfiltered, unmangled) version of the headers in IF_G(server_array)
+    // but ext/filter is an optional module, so we cannot rely on this. Thus we directly access the _SERVER track vars
+    // array, which may have been tampered with from user side, if called after RINIT, or also by ext/filter if there
+    // is a default filter configured via ini. This should not impact us, but if it turns out to, we may have to
+    // optionally access filter globals in a best-effort attempt at getting the original raw headers.
+
+    // headers are present in HTTP_HEADERNAME from in the _SERVER array
+    ALLOCA_FLAG(use_heap)
+    zend_string *var_name;
+    ZSTR_ALLOCA_ALLOC(var_name, uppercase_header_name.len + sizeof("HTTP_") - 1, use_heap);
+    memcpy(ZSTR_VAL(var_name), "HTTP_", 5);
+    memcpy(ZSTR_VAL(var_name) + 5, uppercase_header_name.ptr, uppercase_header_name.len + 1);  // incl trailing NULL
+
+    zval *header_zv = zend_hash_find(Z_ARR_P(server_var), var_name);
+
+    ZSTR_ALLOCA_FREE(var_name, use_heap);
+
+    if (!header_zv || Z_TYPE_P(header_zv) != IS_STRING) {
+        return ZAI_HEADER_NOT_SET;
+    }
+
+    *header_value = Z_STR_P(header_zv);
+
+    return ZAI_HEADER_SUCCESS;
+}

--- a/zend_abstract_interface/headers/tests/CMakeLists.txt
+++ b/zend_abstract_interface/headers/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(headers "${PHP_HEADERS_VERSION_DIRECTORY}/headers.cc")
+
+target_link_libraries(headers PUBLIC catch2_main Zai::Sapi Zai::Headers)
+
+catch_discover_tests(headers)

--- a/zend_abstract_interface/headers/tests/php7-8/headers.cc
+++ b/zend_abstract_interface/headers/tests/php7-8/headers.cc
@@ -1,0 +1,87 @@
+extern "C" {
+#include "zai_sapi/zai_sapi.h"
+#include "zai_sapi/zai_sapi_extension.h"
+#include "headers/headers.h"
+
+#include <Zend/zend_API.h>
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+#define TEST(name, code) TEST_CASE(name, "[zai headers]") { \
+        REQUIRE(zai_sapi_spinup()); \
+        ZAI_SAPI_TSRMLS_FETCH(); \
+        ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() \
+        { code } \
+        ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE() \
+        zai_sapi_spindown(); \
+        zai_sapi_register_custom_server_variables = NULL; \
+    }
+
+static void define_server_value(zval *arr) {
+    add_assoc_string(arr, "HTTP_MY_HEADER", "Datadog");
+}
+
+TEST("reading defined header value", {
+    zai_sapi_register_custom_server_variables = define_server_value;
+
+    zend_string *header;
+    REQUIRE(zai_read_header_literal("MY_HEADER", &header) == ZAI_HEADER_SUCCESS);
+    REQUIRE(zend_string_equals_literal(header, "Datadog"));
+})
+
+TEST("reading defined header value with autoglobals jit off", {
+    REQUIRE(zai_sapi_append_system_ini_entry("auto_globals_jit", "0"));
+    zai_sapi_register_custom_server_variables = define_server_value;
+
+    zend_string *header;
+    REQUIRE(zai_read_header_literal("MY_HEADER", &header) == ZAI_HEADER_SUCCESS);
+    REQUIRE(zend_string_equals_literal(header, "Datadog"));
+})
+
+TEST("reading undefined header value", {
+    zai_sapi_register_custom_server_variables = define_server_value;
+
+    zend_string *header;
+    REQUIRE(zai_read_header_literal("NOT_MY_HEADER", &header) == ZAI_HEADER_NOT_SET);
+})
+
+TEST("erroneous read_header input", {
+    zend_string *header;
+    REQUIRE(zai_read_header({ 1, nullptr }, &header) == ZAI_HEADER_ERROR);
+    REQUIRE(zai_read_header({ 0, "" }, &header) == ZAI_HEADER_ERROR);
+    REQUIRE(zai_read_header_literal("abc", nullptr) == ZAI_HEADER_ERROR);
+})
+
+/****************************** Access from RINIT *****************************/
+
+zai_header_result zai_rinit_last_res;
+static zend_string *zai_rinit_str;
+
+static PHP_RINIT_FUNCTION(zai_env) {
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zai_rinit_last_res = zai_read_header_literal("MY_HEADER", &zai_rinit_str);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    return SUCCESS;
+}
+
+TEST_CASE("get SAPI header (RINIT): defined header", "[zai headers]") {
+    REQUIRE(zai_sapi_sinit());
+
+    zai_sapi_register_custom_server_variables = define_server_value;
+    zai_rinit_last_res = ZAI_HEADER_ERROR;
+    zai_rinit_str = NULL;
+    zai_sapi_extension.request_startup_func = PHP_RINIT(zai_env);
+
+    REQUIRE(zai_sapi_minit());
+    REQUIRE(zai_sapi_rinit());  // Env var is fetched here
+
+    REQUIRE(zai_rinit_last_res == ZAI_HEADER_SUCCESS);
+    REQUIRE(zend_string_equals_literal(zai_rinit_str, "Datadog"));
+
+    zai_sapi_spindown();
+    zai_sapi_register_custom_server_variables = NULL;
+}

--- a/zend_abstract_interface/zai_assert/zai_assert.h
+++ b/zend_abstract_interface/zai_assert/zai_assert.h
@@ -6,6 +6,7 @@
 #ifndef NDEBUG
 #include <assert.h>
 #include <ctype.h>
+#include <stdbool.h>
 
 #define zai_assert_is_lower(str, message)      \
     do {                                       \
@@ -17,8 +18,20 @@
             p++;                               \
         }                                      \
     } while (0)
+
+#define zai_assert_is_upper(str, message)      \
+    do {                                       \
+        char *p = (char *)str;                 \
+        while (*p) {                           \
+            if (isalpha(*p) && !isupper(*p)) { \
+                assert(false && message);      \
+            }                                  \
+            p++;                               \
+        }                                      \
+    } while (0)
 #else
 #define zai_assert_is_lower(str, message)
+#define zai_assert_is_upper(str, message)
 #endif
 
 #endif  // ZAI_ASSERT_H

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -45,8 +45,13 @@ static char *zs_read_cookies(TSRMLS_D) {
     return NULL;
 }
 
+void (*zai_sapi_register_custom_server_variables)(zval *track_vars_server_array TSRMLS_DC) = NULL;
+
 static void zs_register_variables(zval *track_vars_array TSRMLS_DC) {
     php_import_environment_variables(track_vars_array TSRMLS_CC);
+    if (zai_sapi_register_custom_server_variables) {
+        zai_sapi_register_custom_server_variables(track_vars_array TSRMLS_CC);
+    }
 }
 
 static int zs_io_write_stdout(const char *str, unsigned int str_length TSRMLS_DC) {

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -32,7 +32,14 @@ static void zs_send_header(sapi_header_struct *sapi_header, void *server_context
 
 static char *zs_read_cookies(void) { return NULL; }
 
-static void zs_register_variables(zval *track_vars_array) { php_import_environment_variables(track_vars_array); }
+void (*zai_sapi_register_custom_server_variables)(zval *track_vars_server_array) = NULL;
+
+static void zs_register_variables(zval *track_vars_array) {
+    php_import_environment_variables(track_vars_array);
+    if (zai_sapi_register_custom_server_variables) {
+        zai_sapi_register_custom_server_variables(track_vars_array);
+    }
+}
 
 static size_t zs_io_write_stdout(const char *str, size_t str_length) {
     size_t len = zai_sapi_io_write_stdout(str, str_length);

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -32,7 +32,14 @@ static void zs_send_header(sapi_header_struct *sapi_header, void *server_context
 
 static char *zs_read_cookies(void) { return NULL; }
 
-static void zs_register_variables(zval *track_vars_array) { php_import_environment_variables(track_vars_array); }
+void (*zai_sapi_register_custom_server_variables)(zval *track_vars_server_array) = NULL;
+
+static void zs_register_variables(zval *track_vars_array) {
+    php_import_environment_variables(track_vars_array);
+    if (zai_sapi_register_custom_server_variables) {
+        zai_sapi_register_custom_server_variables(track_vars_array);
+    }
+}
 
 static size_t zs_io_write_stdout(const char *str, size_t str_length) {
     size_t len = zai_sapi_io_write_stdout(str, str_length);

--- a/zend_abstract_interface/zai_sapi/zai_sapi.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi.h
@@ -219,4 +219,11 @@ void zai_sapi_unhandled_exception_ignore(void);
 /********************************** </PHP 5> *********************************/
 #endif
 
+/* Called from sapi_module_struct.register_server_variables */
+#if PHP_VERSION_ID >= 70000
+extern void (*zai_sapi_register_custom_server_variables)(zval *track_vars_server_array);
+#else
+extern void (*zai_sapi_register_custom_server_variables)(zval *track_vars_server_array TSRMLS_DC);
+#endif
+
 #endif  // ZAI_SAPI_H

--- a/zend_abstract_interface/zai_string/CMakeLists.txt
+++ b/zend_abstract_interface/zai_string/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(zai_string INTERFACE)
+
+target_include_directories(zai_string INTERFACE
+                                      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                      $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_string INTERFACE c_std_99)
+
+target_link_libraries(zai_string INTERFACE "${PHP_LIB}")
+
+add_library(Zai::string ALIAS zai_string)
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zai_string/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_string)
+
+install(TARGETS zai_string EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -1,0 +1,12 @@
+#ifndef ZAI_STRING_H
+#define ZAI_STRING_H
+
+typedef struct zai_string_view_s {
+    size_t len;
+    const char *ptr;
+} zai_string_view;
+
+#define ZAI_STRL_VIEW(cstr) \
+    (zai_string_view) { .len = sizeof(cstr) - 1, .ptr = (cstr) }
+
+#endif  // ZAI_STRING_H


### PR DESCRIPTION
### Description

Required for internal spans, to read x-datadog-parent-id and x-datadog-origin-id headers to set parent id & trace id on root spans.

Note: ZAI_HEADER_NOT_READY case is not tested yet, I'm waiting for @SammyK changes to ZAI in #1250 to test this.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
