### PR TITLE
Enforce metrics to be floats in internal serializer

### DIFF
--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -607,8 +607,19 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
     _serialize_meta(el, span_fci);
 
     zval *metrics = ddtrace_spandata_property_metrics(span->span_data);
-    if (Z_TYPE_P(metrics) == IS_ARRAY) {
-        _add_assoc_zval_copy(el, "metrics", metrics);
+    ZVAL_DEREF(metrics);
+    if (Z_TYPE_P(metrics) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(metrics))) {
+        zval metrics_zv;
+        array_init(&metrics_zv);
+        zend_string *str_key;
+        zval *val;
+        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR_P(metrics), str_key, val) {
+            if (str_key) {
+                add_assoc_double(&metrics_zv, ZSTR_VAL(str_key), zval_get_double(val));
+            }
+        }
+        ZEND_HASH_FOREACH_END();
+        add_assoc_zval(el, "metrics", &metrics_zv);
     }
 
     add_next_index_zval(array, el);

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -70,7 +70,7 @@ $testService = new TestService();
 $testService->testServiceFoo();
 
 $foo = new Foo();
-$ret = $foo->bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+$ret = $foo->bar('tracing is awesome', ['first', '100', false]);
 var_dump($ret);
 
 echo "---\n";
@@ -120,9 +120,9 @@ array(3) {
     ["metrics"]=>
     array(2) {
       ["foo"]=>
-      string(7) "foo-red"
+      float(100)
       ["bar"]=>
-      string(9) "bar-green"
+      float(0)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -62,7 +62,7 @@ var_dump(DDTrace\trace_function(
 
 testFoo();
 var_dump(addOne(0));
-$ret = bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+$ret = bar('tracing is awesome', ['first', 1.2, '25']);
 var_dump($ret);
 
 echo "---\n";
@@ -125,9 +125,9 @@ array(5) {
     ["metrics"]=>
     array(2) {
       ["foo"]=>
-      string(7) "foo-red"
+      float(1.2)
       ["bar"]=>
-      string(9) "bar-green"
+      float(25)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -73,7 +73,7 @@ $testService = new TestService();
 $testService->testServiceFoo();
 
 $foo = new Foo();
-$ret = $foo->bar('tracing is awesome', ['first', 'foo-red', 'bar-green']);
+$ret = $foo->bar('tracing is awesome', ['first', '100', false]);
 var_dump($ret);
 
 echo "---\n";
@@ -133,9 +133,9 @@ array(3) {
     ["metrics"]=>
     array(2) {
       ["foo"]=>
-      string(7) "foo-red"
+      float(100)
       ["bar"]=>
-      string(9) "bar-green"
+      float(0)
     }
   }
   [1]=>


### PR DESCRIPTION
### Description

Internal serializer is currently preserving the metrics array as-is. I'm now only preserving string keys and converting them to double as mandated by the agent. This is especially important when cutting out userland from serializing.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
