### PR TITLE
Fix msgpack serialization of empty arrays

### DIFF
--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -33,7 +33,7 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht TSRMLS_DC) {
     uint str_len;
     HashPosition iterator;
     zend_ulong num_key;
-    int key_type;
+    int key_type = HASH_KEY_NON_EXISTANT;
     bool first_time = true;
 
     zend_hash_internal_pointer_reset_ex(ht, &iterator);
@@ -69,7 +69,10 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht TSRMLS_DC) {
         zend_hash_move_forward_ex(ht, &iterator);
     }
 
-    if (key_type == HASH_KEY_IS_STRING) {
+    if (key_type == HASH_KEY_NON_EXISTANT) {
+        mpack_start_array(writer, 0);
+        mpack_finish_array(writer);
+    } else if (key_type == HASH_KEY_IS_STRING) {
         mpack_finish_map(writer);
     } else {
         mpack_finish_array(writer);

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -63,7 +63,10 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht) {
     }
     ZEND_HASH_FOREACH_END();
 
-    if (is_assoc) {
+    if (is_assoc == -1) {
+        mpack_start_array(writer, 0);
+        mpack_finish_array(writer);
+    } else if (is_assoc) {
         mpack_finish_map(writer);
     } else {
         mpack_finish_array(writer);

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -64,7 +64,10 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht) {
     }
     ZEND_HASH_FOREACH_END();
 
-    if (is_assoc) {
+    if (is_assoc == -1) {
+        mpack_start_array(writer, 0);
+        mpack_finish_array(writer);
+    } else if (is_assoc) {
         mpack_finish_map(writer);
     } else {
         mpack_finish_array(writer);

--- a/tests/ext/dd_trace_serialize_msgpack.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack.phpt
@@ -27,6 +27,7 @@ $traces = [[
         "service" => "test_service",
         "start" => 1518038421211969000,
         "error" => 0,
+        "meta" => [],
     ],
 ]];
 echo json_encode($traces) . "\n";
@@ -35,5 +36,5 @@ $encoded = dd_trace_serialize_msgpack($traces);
 echo dd_trace_unserialize_trace_hex($encoded) . "\n";
 ?>
 --EXPECT--
-[[{"trace_id":"1589331357723252209","span_id":"1589331357723252210","name":"test_name","resource":"test_resource","service":"test_service","start":1518038421211969000,"error":0}]]
-91 91 87 a8 74 72 61 63 65 5f 69 64 cf 16 0e 70 72 ff 7b d5 f1 a7 73 70 61 6e 5f 69 64 cf 16 0e 70 72 ff 7b d5 f2 a4 6e 61 6d 65 a9 74 65 73 74 5f 6e 61 6d 65 a8 72 65 73 6f 75 72 63 65 ad 74 65 73 74 5f 72 65 73 6f 75 72 63 65 a7 73 65 72 76 69 63 65 ac 74 65 73 74 5f 73 65 72 76 69 63 65 a5 73 74 61 72 74 cf 15 11 27 e6 b3 bb f5 e8 a5 65 72 72 6f 72 00
+[[{"trace_id":"1589331357723252209","span_id":"1589331357723252210","name":"test_name","resource":"test_resource","service":"test_service","start":1518038421211969000,"error":0,"meta":[]}]]
+91 91 88 a8 74 72 61 63 65 5f 69 64 cf 16 0e 70 72 ff 7b d5 f1 a7 73 70 61 6e 5f 69 64 cf 16 0e 70 72 ff 7b d5 f2 a4 6e 61 6d 65 a9 74 65 73 74 5f 6e 61 6d 65 a8 72 65 73 6f 75 72 63 65 ad 74 65 73 74 5f 72 65 73 6f 75 72 63 65 a7 73 65 72 76 69 63 65 ac 74 65 73 74 5f 73 65 72 76 69 63 65 a5 73 74 61 72 74 cf 15 11 27 e6 b3 bb f5 e8 a5 65 72 72 6f 72 00 a4 6d 65 74 61 90


### PR DESCRIPTION
### Description

Trying to serialize empty meta arrays lead to invalid message pack data.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
