### PR TITLE
Moving spans from userland to extension

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -20,6 +20,7 @@
     </rule>
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>
+        <exclude-pattern>*/Span.php</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>bridge/dd_init.php</exclude-pattern>

--- a/bridge/_files.php
+++ b/bridge/_files.php
@@ -20,6 +20,7 @@ return [
     __DIR__ . '/../src/DDTrace/StartSpanOptionsFactory.php',
     __DIR__ . '/../src/DDTrace/Time.php',
     __DIR__ . '/../src/DDTrace/Transport/Http.php',
+    __DIR__ . '/../src/DDTrace/Transport/Internal.php',
     __DIR__ . '/../src/api/Type.php',
     __DIR__ . '/../src/DDTrace/Encoder.php',
     __DIR__ . '/../src/DDTrace/Util/Runtime.php',

--- a/ext/php8/auto_flush.c
+++ b/ext/php8/auto_flush.c
@@ -1,65 +1,50 @@
 #include "auto_flush.h"
 
-#include <php.h>
-
-#include "configuration.h"
-#include "engine_api.h"
-#include "engine_hooks.h"  // for ddtrace_backup_error_handling
+#include "comms_php.h"
+#include "ddtrace_string.h"
+#include "logging.h"
+#include "serializer.h"
+#include "span.h"
 
 ZEND_RESULT_CODE ddtrace_flush_tracer() {
-    zval tracer, retval;
-    zend_class_entry *GlobalTracer_ce = ddtrace_lookup_ce(ZEND_STRL("DDTrace\\GlobalTracer"));
     bool success = true;
 
-    zend_object *exception = NULL, *prev_exception = NULL;
-    if (EG(exception)) {
-        exception = EG(exception);
-        EG(exception) = NULL;
-        prev_exception = EG(prev_exception);
-        EG(prev_exception) = NULL;
-        zend_clear_exception();
+    zval trace, traces;
+    ddtrace_serialize_closed_spans(&trace);
+
+    if (zend_hash_num_elements(Z_ARR(trace)) == 0) {
+        zend_array_destroy(Z_ARR(trace));
+        ddtrace_log_debug("No finished traces to be sent to the agent");
+        return SUCCESS;
     }
 
-    ddtrace_error_handling eh;
-    ddtrace_backup_error_handling(&eh, EH_THROW);
+    // background sender only wants a singular trace
+    array_init(&traces);
+    zend_hash_index_add(Z_ARR(traces), 0, &trace);
 
-    zend_bool orig_disable_in_current_request = DDTRACE_G(disable_in_current_request);
-    DDTRACE_G(disable_in_current_request) = 1;
-
-    // $tracer = \DDTrace\GlobalTracer::get();
-    if (!GlobalTracer_ce ||
-        ddtrace_call_method(NULL, GlobalTracer_ce, NULL, ZEND_STRL("get"), &tracer, 0, NULL) == FAILURE) {
-        DDTRACE_G(disable_in_current_request) = orig_disable_in_current_request;
-
-        ddtrace_restore_error_handling(&eh);
-        ddtrace_maybe_clear_exception();
-        if (exception) {
-            EG(exception) = exception;
-            EG(prev_exception) = prev_exception;
-            zend_throw_exception_internal(NULL);
+    char *payload;
+    size_t size;
+    if (ddtrace_serialize_simple_array_into_c_string(&traces, &payload, &size)) {
+        // The 10MB payload cap is inclusive, thus we use >, not >=
+        // https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/limited_reader.go#L37
+        if (size > AGENT_REQUEST_BODY_LIMIT) {
+            ddtrace_log_errf("Agent request payload of %zu bytes exceeds 10MB limit; dropping request", size);
+            success = false;
+        } else {
+            success = ddtrace_send_traces_via_thread(1, payload, size);
+            if (success) {
+                ddtrace_log_debugf("Successfully triggered auto-flush with trace of size %d",
+                                   zend_hash_num_elements(Z_ARR(trace)));
+            }
+            dd_prepare_for_new_trace();
         }
-        return FAILURE;
+
+        free(payload);
+    } else {
+        success = false;
     }
 
-    if (Z_TYPE(tracer) == IS_OBJECT) {
-        zend_object *obj = Z_OBJ(tracer);
-        zend_class_entry *ce = obj->ce;
-        success = ddtrace_call_method(obj, ce, NULL, ZEND_STRL("flush"), &retval, 0, NULL) == SUCCESS &&
-                  ddtrace_call_method(obj, ce, NULL, ZEND_STRL("reset"), &retval, 0, NULL) == SUCCESS;
-    }
-
-    DDTRACE_G(disable_in_current_request) = orig_disable_in_current_request;
-
-    ddtrace_restore_error_handling(&eh);
-    ddtrace_maybe_clear_exception();
-    if (exception) {
-        EG(exception) = exception;
-        EG(prev_exception) = prev_exception;
-        zend_throw_exception_internal(NULL);
-    }
-
-    zval_dtor(&tracer);
-    zval_dtor(&retval);
+    zval_ptr_dtor(&traces);
 
     return success ? SUCCESS : FAILURE;
 }

--- a/ext/php8/auto_flush.c
+++ b/ext/php8/auto_flush.c
@@ -33,7 +33,7 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
         } else {
             success = ddtrace_send_traces_via_thread(1, payload, size);
             if (success) {
-                ddtrace_log_debugf("Successfully triggered auto-flush with trace of size %d",
+                ddtrace_log_debugf("Successfully triggered flush with trace of size %d",
                                    zend_hash_num_elements(Z_ARR(trace)));
             }
             dd_prepare_for_new_trace();

--- a/ext/php8/comms_php.h
+++ b/ext/php8/comms_php.h
@@ -7,6 +7,8 @@
 
 #include "compatibility.h"
 
+static const size_t AGENT_REQUEST_BODY_LIMIT = 10485760;
+
 bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t payload_len);
 
 #endif  // DDTRACE_COMMS_PHP_H

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -88,6 +88,8 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_distributed_tracing, "DD_DISTRIBUTED_TRACING", true)                                                 \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     CHAR(get_dd_env, "DD_ENV", "")                                                                                   \
+    BOOL(get_dd_autofinish_spans, "DD_AUTOFINISH_SPANS", false)                                                      \
+    BOOL(get_dd_trace_url_as_resource_names, "DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED", true)                         \
     CHAR(get_dd_integrations_disabled, "DD_INTEGRATIONS_DISABLED", "")                                               \
     BOOL(get_dd_priority_sampling, "DD_PRIORITY_SAMPLING", true)                                                     \
     CHAR(get_dd_service, "DD_SERVICE", "")                                                                           \
@@ -120,10 +122,6 @@ void ddtrace_config_shutdown(void);
     BOOL(get_dd_trace_generate_root_span, "DD_TRACE_GENERATE_ROOT_SPAN", true)                                       \
     BOOL(get_dd_trace_sandbox_enabled, "DD_TRACE_SANDBOX_ENABLED", true)                                             \
     INT(get_dd_trace_spans_limit, "DD_TRACE_SPANS_LIMIT", 1000)                                                      \
-    BOOL(get_dd_trace_send_traces_via_thread, "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD", true,                          \
-         "use background thread to send traces to the agent")                                                        \
-    BOOL(get_dd_trace_bgs_enabled, "DD_TRACE_BGS_ENABLED", true,                                                     \
-         "use background sender (BGS) to send traces to the agent")                                                  \
     INT(get_dd_trace_bgs_connect_timeout, "DD_TRACE_BGS_CONNECT_TIMEOUT", DD_TRACE_BGS_CONNECT_TIMEOUT)              \
     INT(get_dd_trace_bgs_timeout, "DD_TRACE_BGS_TIMEOUT", DD_TRACE_BGS_TIMEOUT)                                      \
     INT(get_dd_trace_agent_flush_interval, "DD_TRACE_AGENT_FLUSH_INTERVAL", 5000)                                    \

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_smart_str.h>
 #include <Zend/zend_vm.h>
+#include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
 #include <php_ini.h>
@@ -87,9 +88,6 @@ static void ddtrace_shutdown(struct _zend_extension *extension) {
 static void ddtrace_activate(void) {}
 static void ddtrace_deactivate(void) {}
 
-// prepare the tracer state to start handling a new trace
-static void dd_prepare_for_new_trace(void);
-
 static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   PHP_DDTRACE_VERSION,
                                                   "Datadog",
@@ -151,6 +149,19 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_push_span_id, 0, 0, 0)
 ZEND_ARG_INFO(0, existing_id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_start_span, 0, 0, 0)
+ZEND_ARG_INFO(0, start_time)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_close_span, 0, 0, 0)
+ZEND_ARG_INFO(0, finish_time)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_add_global_tag, 0, 0, 2)
+ZEND_ARG_INFO(0, key)
+ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_internal_fn, 0, 0, 1)
@@ -227,6 +238,10 @@ static void ddtrace_span_data_free_storage(zend_object *object) {
     ddtrace_span_fci *span_fci = (ddtrace_span_fci *)object;
     if (span_fci->exception) {
         OBJ_RELEASE(span_fci->exception);
+    }
+    if (span_fci->dispatch) {
+        ddtrace_dispatch_release(span_fci->dispatch);
+        span_fci->dispatch = NULL;
     }
     zend_object_std_dtor(object);
 }
@@ -327,6 +342,8 @@ static void dd_disable_if_incompatible_sapi_detected(void) {
     }
 }
 
+static void dd_read_distributed_tracing_ids(void);
+
 static PHP_MINIT_FUNCTION(ddtrace) {
     UNUSED(type);
     REGISTER_STRING_CONSTANT("DD_TRACE_VERSION", PHP_DDTRACE_VERSION, CONST_CS | CONST_PERSISTENT);
@@ -411,6 +428,7 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     }
 
     array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
+    DDTRACE_G(additional_global_tags) = zend_new_array(0);
 
     // Things that should only run on the first RINIT
     int expected_first_rinit = 1;
@@ -450,6 +468,12 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     dd_prepare_for_new_trace();
 
+    dd_read_distributed_tracing_ids();
+
+    if (get_dd_trace_generate_root_span()) {
+        ddtrace_push_root_span();
+    }
+
     return SUCCESS;
 }
 
@@ -460,7 +484,18 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_close_all_open_spans();  // All remaining non-internal userland spans
+    if (DDTRACE_G(open_spans_top) && DDTRACE_G(open_spans_top)->execute_data == NULL) {
+        // we have a root span. Close it.
+        dd_trace_stop_span_time(&DDTRACE_G(open_spans_top)->span);
+        ddtrace_close_span(DDTRACE_G(open_spans_top));
+    }
+    if (ddtrace_flush_tracer() == FAILURE) {
+        ddtrace_log_debug("Unable to flush the tracer");
+    }
+
     zval_dtor(&DDTRACE_G(additional_trace_meta));
+    zend_array_destroy(DDTRACE_G(additional_global_tags));
     ZVAL_NULL(&DDTRACE_G(additional_trace_meta));
 
     ddtrace_internal_handlers_rshutdown();
@@ -795,6 +830,23 @@ static PHP_FUNCTION(additional_trace_meta) {
 
     ZVAL_COPY_VALUE(return_value, &DDTRACE_G(additional_trace_meta));
     zval_copy_ctor(return_value);
+}
+
+/* {{{ proto string DDTrace\add_global_tag(string $key, string $value) */
+static PHP_FUNCTION(add_global_tag) {
+    UNUSED(execute_data);
+
+    zend_string *key, *val;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &key, &val) == FAILURE) {
+        ddtrace_log_debug(
+            "Unable to parse parameters for DDTrace\\add_global_tag; expected (string $key, string $value)");
+    }
+
+    zval value_zv;
+    ZVAL_STR_COPY(&value_zv, val);
+    zend_hash_update(DDTRACE_G(additional_global_tags), key, &value_zv);
+
+    RETURN_NULL();
 }
 
 static PHP_FUNCTION(trace_function) {
@@ -1301,9 +1353,58 @@ static PHP_FUNCTION(dd_trace_peek_span_id) {
 /* {{{ proto string DDTrace\active_span() */
 static PHP_FUNCTION(active_span) {
     UNUSED(execute_data);
-    if (DDTRACE_G(open_spans_top)) {
-        RETURN_OBJ_COPY(&DDTRACE_G(open_spans_top)->span.std);
+    if (!DDTRACE_G(open_spans_top)) {
+        if (get_dd_trace_generate_root_span()) {
+            ddtrace_push_root_span();  // ensure root span always exists, especially after serialization for testing
+        } else {
+            RETURN_NULL();
+        }
     }
+    RETURN_OBJ_COPY(&DDTRACE_G(open_spans_top)->span.std);
+}
+
+/* {{{ proto string DDTrace\start_span() */
+static PHP_FUNCTION(start_span) {
+    double start_time_seconds = 0;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &start_time_seconds) != SUCCESS) {
+        ddtrace_log_debug("unexpected parameter. expecting double for start time");
+        RETURN_FALSE;
+    }
+
+    ddtrace_span_fci *span_fci = ddtrace_init_span();
+    ddtrace_open_span(span_fci);
+
+    if (start_time_seconds > 0) {
+        span_fci->span.start = (uint64_t)(start_time_seconds * 1000000000);
+    }
+
+    RETURN_OBJ_COPY(&span_fci->span.std);
+}
+
+/* {{{ proto string DDTrace\close_span() */
+static PHP_FUNCTION(close_span) {
+    double finish_time_seconds = 0;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &finish_time_seconds) != SUCCESS) {
+        ddtrace_log_debug("unexpected parameter. expecting double for finish time");
+        RETURN_FALSE;
+    }
+
+    if (!DDTRACE_G(open_spans_top) || DDTRACE_G(open_spans_top)->execute_data ||
+        (get_dd_trace_generate_root_span() && DDTRACE_G(open_spans_top)->next == NULL)) {
+        ddtrace_log_err("There is no user-span on the top of the stack. Cannot close.");
+        RETURN_NULL();
+    }
+
+    // we do not expose the monotonic time here, so do not use it as reference time to calculate difference
+    uint64_t start_time = DDTRACE_G(open_spans_top)->span.start;
+    uint64_t finish_time = (uint64_t)(finish_time_seconds * 1000000000);
+    if (finish_time < start_time) {
+        dd_trace_stop_span_time(&DDTRACE_G(open_spans_top)->span);
+    } else {
+        DDTRACE_G(open_spans_top)->span.duration = finish_time - start_time;
+    }
+
+    ddtrace_close_span(DDTRACE_G(open_spans_top));
     RETURN_NULL();
 }
 
@@ -1402,6 +1503,8 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_FE(dd_trace_internal_fn, arginfo_dd_trace_internal_fn),
     DDTRACE_FE(dd_trace_noop, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(start_span, arginfo_dd_trace_start_span),
+    DDTRACE_NS_FE(close_span, arginfo_dd_trace_close_span),
     DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_peek_span_id, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_pop_span_id, arginfo_ddtrace_void),
@@ -1425,6 +1528,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(ddtrace_config_integration_enabled, arginfo_ddtrace_config_integration_enabled),
     DDTRACE_FE(ddtrace_config_trace_enabled, arginfo_ddtrace_void),
     DDTRACE_FE(ddtrace_init, arginfo_ddtrace_init),
+    DDTRACE_NS_FE(add_global_tag, arginfo_ddtrace_add_global_tag),
     DDTRACE_NS_FE(additional_trace_meta, arginfo_ddtrace_void),
     DDTRACE_NS_FE(trace_function, arginfo_ddtrace_trace_function),
     DDTRACE_FALIAS(dd_trace_function, trace_function, arginfo_ddtrace_trace_function),
@@ -1464,4 +1568,26 @@ ZEND_TSRMLS_CACHE_DEFINE();
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id
-static void dd_prepare_for_new_trace(void) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
+void dd_prepare_for_new_trace(void) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
+
+void dd_read_distributed_tracing_ids(void) {
+    zend_string *trace_id_str, *parent_id_str;
+    BOOL_T success = true;
+
+    if (zai_read_header_literal("X_DATADOG_TRACE_ID", &trace_id_str) == ZAI_HEADER_SUCCESS) {
+        if (ZSTR_LEN(trace_id_str) != 1 || ZSTR_VAL(trace_id_str)[0] != '0') {
+            zval trace_zv;
+            ZVAL_STR(&trace_zv, trace_id_str);
+            success = ddtrace_set_userland_trace_id(&trace_zv);
+        }
+    }
+
+    if (success && zai_read_header_literal("X_DATADOG_PARENT_ID", &parent_id_str) == ZAI_HEADER_SUCCESS) {
+        zval parent_zv;
+        ZVAL_STR(&parent_zv, parent_id_str);
+        if ((ZSTR_LEN(parent_id_str) != 1 || ZSTR_VAL(parent_id_str)[0] != '0') &&
+            !ddtrace_push_userland_span_id(&parent_zv)) {
+            DDTRACE_G(trace_id) = 0;
+        }
+    }
+}

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -1408,6 +1408,14 @@ static PHP_FUNCTION(close_span) {
     RETURN_NULL();
 }
 
+static PHP_FUNCTION(flush) {
+    UNUSED(execute_data);
+    if (ddtrace_flush_tracer() == FAILURE) {
+        ddtrace_log_debug("Unable to flush the tracer");
+    }
+    RETURN_NULL();
+}
+
 /* {{{ proto string \DDTrace\trace_id() */
 static PHP_FUNCTION(trace_id) {
     UNUSED(execute_data);
@@ -1503,6 +1511,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FALIAS(dd_trace_generate_id, dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_FE(dd_trace_internal_fn, arginfo_dd_trace_internal_fn),
     DDTRACE_FE(dd_trace_noop, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(flush, arginfo_ddtrace_void),
     DDTRACE_NS_FE(start_span, arginfo_dd_trace_start_span),
     DDTRACE_NS_FE(close_span, arginfo_dd_trace_close_span),
     DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -840,6 +840,7 @@ static PHP_FUNCTION(add_global_tag) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &key, &val) == FAILURE) {
         ddtrace_log_debug(
             "Unable to parse parameters for DDTrace\\add_global_tag; expected (string $key, string $value)");
+        RETURN_NULL();
     }
 
     zval value_zv;
@@ -1594,9 +1595,12 @@ void dd_read_distributed_tracing_ids(void) {
     if (success && zai_read_header_literal("X_DATADOG_PARENT_ID", &parent_id_str) == ZAI_HEADER_SUCCESS) {
         zval parent_zv;
         ZVAL_STR(&parent_zv, parent_id_str);
-        if ((ZSTR_LEN(parent_id_str) != 1 || ZSTR_VAL(parent_id_str)[0] != '0') &&
-            !ddtrace_push_userland_span_id(&parent_zv)) {
-            DDTRACE_G(trace_id) = 0;
+        if (ZSTR_LEN(parent_id_str) != 1 || ZSTR_VAL(parent_id_str)[0] != '0') {
+            if (ddtrace_push_userland_span_id(&parent_zv)) {
+                DDTRACE_G(distributed_parent_trace_id) = DDTRACE_G(span_ids_top)->id;
+            } else {
+                DDTRACE_G(trace_id) = 0;
+            }
         }
     }
 }

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -56,6 +56,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     uint32_t open_spans_count;
     uint32_t closed_spans_count;
     int64_t compile_time_microseconds;
+    uint64_t distributed_parent_trace_id;
 
     char *cgroup_file;
 ZEND_END_MODULE_GLOBALS(ddtrace)

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -24,6 +24,8 @@ zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 
 BOOL_T ddtrace_tracer_is_limited(void);
+// prepare the tracer state to start handling a new trace
+void dd_prepare_for_new_trace(void);
 
 // clang-format off
 ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
@@ -39,6 +41,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     HashTable *class_lookup;
     HashTable *function_lookup;
     zval additional_trace_meta; // IS_ARRAY
+    zend_array *additional_global_tags;
     zend_bool log_backtrace;
     zend_bool backtrace_handler_already_run;
     dogstatsd_client dogstatsd_client;

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -8,6 +8,7 @@
 #include "configuration.h"
 #include "ddtrace.h"
 #include "dispatch.h"
+#include "engine_hooks.h"
 #include "logging.h"
 #include "random.h"
 #include "serializer.h"
@@ -24,20 +25,12 @@ void ddtrace_init_span_stacks(void) {
     DDTRACE_G(closed_spans_count) = 0;
 }
 
-void ddtrace_drop_span(ddtrace_span_fci *span_fci) {
-    if (span_fci->dispatch) {
-        ddtrace_dispatch_release(span_fci->dispatch);
-        span_fci->dispatch = NULL;
-    }
-
-    OBJ_RELEASE(&span_fci->span.std);
-}
-
 static void _free_span_stack(ddtrace_span_fci *span_fci) {
     while (span_fci != NULL) {
         ddtrace_span_fci *tmp = span_fci;
         span_fci = tmp->next;
-        ddtrace_drop_span(tmp);
+        tmp->next = NULL;
+        OBJ_RELEASE(&tmp->span.std);
     }
 }
 
@@ -86,15 +79,51 @@ ddtrace_span_fci *ddtrace_init_span() {
     return span_fci;
 }
 
+void ddtrace_push_root_span() { ddtrace_open_span(ddtrace_init_span()); }
+
 void dd_trace_stop_span_time(ddtrace_span_t *span) {
     span->duration = _get_nanoseconds(USE_MONOTONIC_CLOCK) - span->duration_start;
 }
 
-void ddtrace_close_span(void) {
+BOOL_T ddtrace_has_top_internal_span(ddtrace_span_fci *end) {
     ddtrace_span_fci *span_fci = DDTRACE_G(open_spans_top);
-    if (span_fci == NULL) {
+    while (span_fci) {
+        if (span_fci == end) {
+            return true;
+        }
+        if (span_fci->execute_data != NULL) {
+            return false;
+        }
+        span_fci = span_fci->next;
+    }
+    return false;
+}
+
+void ddtrace_close_userland_spans_until(ddtrace_span_fci *until) {
+    ddtrace_span_fci *span_fci;
+    while ((span_fci = DDTRACE_G(open_spans_top)) && span_fci != until &&
+           (span_fci->execute_data != NULL || span_fci->next)) {
+        if (span_fci->execute_data) {
+            ddtrace_log_err("Found internal span data while closing userland spans");
+        }
+
+        if (get_dd_autofinish_spans()) {
+            dd_trace_stop_span_time(&span_fci->span);
+            ddtrace_close_span(span_fci);
+        } else {
+            ddtrace_drop_top_open_span();
+        }
+    }
+    DDTRACE_G(open_spans_top) = span_fci;
+}
+
+void ddtrace_close_span(ddtrace_span_fci *span_fci) {
+    if (span_fci == NULL || !ddtrace_has_top_internal_span(span_fci)) {
         return;
     }
+
+    ddtrace_close_userland_spans_until(span_fci);
+
     DDTRACE_G(open_spans_top) = span_fci->next;
     // Sync with span ID stack
     ddtrace_pop_span_id();
@@ -109,6 +138,7 @@ void ddtrace_close_span(void) {
     }
 
     // A userland span might still be open so we check the span ID stack instead of the internal span stack
+    // In case we have root spans enabled, we need to always flush if we close that one (RSHUTDOWN)
     if (DDTRACE_G(span_ids_top) == NULL && get_dd_trace_auto_flush_enabled()) {
         if (ddtrace_flush_tracer() == FAILURE) {
             ddtrace_log_debug("Unable to auto flush the tracer");
@@ -124,7 +154,7 @@ void ddtrace_drop_top_open_span(void) {
     DDTRACE_G(open_spans_top) = span_fci->next;
     // Sync with span ID stack
     ddtrace_pop_span_id();
-    ddtrace_drop_span(span_fci);
+    OBJ_RELEASE(&span_fci->span.std);
 }
 
 void ddtrace_serialize_closed_spans(zval *serialized) {
@@ -133,10 +163,6 @@ void ddtrace_serialize_closed_spans(zval *serialized) {
     DDTRACE_G(open_spans_top) = NULL;
     DDTRACE_G(open_spans_count) = 0;
     ddtrace_free_span_id_stack();
-    // Clear out additional trace meta; re-initialize it to empty
-    zval_dtor(&DDTRACE_G(additional_trace_meta));
-    array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
-
     ddtrace_span_fci *span_fci = DDTRACE_G(closed_spans_top);
     array_init(serialized);
     while (span_fci != NULL) {
@@ -151,4 +177,48 @@ void ddtrace_serialize_closed_spans(zval *serialized) {
     DDTRACE_G(closed_spans_count) = 0;
     // Reset the span ID stack and trace ID
     ddtrace_free_span_id_stack();
+
+    // root span is always first on the array
+    HashPosition start;
+    zend_hash_internal_pointer_reset_ex(Z_ARR_P(serialized), &start);
+    zval *root = zend_hash_get_current_data_ex(Z_ARR_P(serialized), &start);
+    if (!root) {
+        return;
+    }
+
+    // Assign and clear out additional trace meta; re-initialize it to empty
+    if (Z_TYPE(DDTRACE_G(additional_trace_meta)) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(serialized)) > 0) {
+        zval *meta = zend_hash_str_find(Z_ARR_P(root), ZEND_STRL("meta"));
+        if (meta) {
+            zval *val;
+            zend_long idx;
+            zend_string *key;
+            ZEND_HASH_FOREACH_KEY_VAL(Z_ARR(DDTRACE_G(additional_trace_meta)), idx, key, val) {
+                Z_TRY_ADDREF_P(val);
+                if (key) {
+                    zend_hash_add(Z_ARR_P(root), key, val);
+                } else {
+                    zend_hash_index_add(Z_ARR_P(root), idx, val);
+                }
+            }
+            ZEND_HASH_FOREACH_END();
+        } else if (zend_array_count(Z_ARR(DDTRACE_G(additional_trace_meta)))) {
+            Z_ADDREF(DDTRACE_G(additional_trace_meta));
+            add_assoc_zval(root, "meta", &DDTRACE_G(additional_trace_meta));
+        }
+    }
+    zval_dtor(&DDTRACE_G(additional_trace_meta));
+    array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
+
+    if (get_dd_trace_measure_compile_time()) {
+        zval *metrics = zend_hash_str_find(Z_ARR_P(root), ZEND_STRL("metrics"));
+        if (!metrics) {
+            zval metrics_array;
+            array_init(&metrics_array);
+            metrics = zend_hash_str_add_new(Z_ARR_P(root), ZEND_STRL("metrics"), &metrics_array);
+        } else {
+            SEPARATE_ARRAY(metrics);
+        }
+        add_assoc_double(metrics, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+    }
 }

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -22,7 +22,6 @@ struct ddtrace_span_t {
     uint64_t start;
     uint64_t duration_start;
     uint64_t duration;
-    pid_t pid;
 };
 
 struct ddtrace_span_fci {

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -40,12 +40,13 @@ void ddtrace_free_span_stacks(void);
 void ddtrace_push_span(ddtrace_span_fci *span_fci);
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
 ddtrace_span_fci *ddtrace_init_span();
+void ddtrace_push_root_span();
 void dd_trace_stop_span_time(ddtrace_span_t *span);
-void ddtrace_close_span(void);
+BOOL_T ddtrace_has_top_internal_span(ddtrace_span_fci *end);
+void ddtrace_close_userland_spans_until(ddtrace_span_fci *until);
+void ddtrace_close_span(ddtrace_span_fci *span_fci);
+void ddtrace_close_all_open_spans(void);
 void ddtrace_drop_top_open_span(void);
 void ddtrace_serialize_closed_spans(zval *serialized);
-
-// Prefer ddtrace_drop_top_open_span
-void ddtrace_drop_span(ddtrace_span_fci *span_fci);
 
 #endif  // DD_SPAN_H

--- a/package.xml
+++ b/package.xml
@@ -359,6 +359,7 @@
 
             <file name="tests/ext/pcntl/functions.inc" role="test" />
             <file name="tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt" role="test" />
+            <file name="tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt" role="test" />
             <file name="tests/ext/pcntl/pcntl_fork_long_running_manual.phpt" role="test" />
             <file name="tests/ext/pcntl/pcntl_fork_short_running_multiple.phpt" role="test" />
             <file name="tests/ext/pcntl/pcntl_fork_short_running_nested.phpt" role="test" />
@@ -378,25 +379,36 @@
             <file name="tests/ext/request-init-hook/auto_prepend_file_original_exit.phpt" role="test" />
             <file name="tests/ext/request-init-hook/dd_init_open_basedir.inc" role="test" />
             <file name="tests/ext/request-init-hook/dd_init_open_basedir.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/dd_init_open_basedir-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/error_get_last_is_unaffected.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/error_get_last_is_unaffected-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/raises_e_notice.php" role="test" />
             <file name="tests/ext/request-init-hook/contains_binary_character.php" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_contains_non_printable_character.phpt" role="test" />
             <file name="tests/ext/request-init-hook/raises_fatal_error.php" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_file_not_found.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/request_init_hook_file_not_found-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/request_init_hook_ignores_exceptions-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt" role="test" />
+            <file name="tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors-legacy.phpt" role="test" />
             <file name="tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors_php_54.phpt" role="test" />
             <file name="tests/ext/request-init-hook/run_file_before_request_handling.phpt" role="test" />
             <file name="tests/ext/request-init-hook/shebang.phpt" role="test" />
             <file name="tests/ext/request-init-hook/throws_exception.php" role="test" />
 
             <file name="tests/ext/sandbox/auto_flush.phpt" role="test" />
+            <file name="tests/ext/sandbox/auto_flush-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/auto_flush_attach_exception.phpt" role="test" />
+            <file name="tests/ext/sandbox/auto_flush_attach_exception-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/auto_flush_disables_tracing.phpt" role="test" />
+            <file name="tests/ext/sandbox/auto_flush_disables_tracing-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/auto_flush_sandbox_exception.phpt" role="test" />
+            <file name="tests/ext/sandbox/auto_flush_sandbox_exception-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/auto_flush_userland_root_span.phpt" role="test" />
+            <file name="tests/ext/sandbox/auto_flush_userland_root_span-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/cake_01.phpt" role="test" />
             <file name="tests/ext/sandbox/cake_02.phpt" role="test" />
             <file name="tests/ext/sandbox/close-on-exit.phpt" role="test" />
@@ -404,11 +416,16 @@
             <file name="tests/ext/sandbox/dd_dumper.inc" role="test" />
             <file name="tests/ext/sandbox/dd_trace_closed_spans_count.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_api_error.phpt" role="test" />
+            <file name="tests/ext/sandbox/dd_trace_api_error-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_function_alias.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_function_complex.phpt" role="test" />
+            <file name="tests/ext/sandbox/dd_trace_function_complex-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_function_internal.phpt" role="test" />
+            <file name="tests/ext/sandbox/dd_trace_function_internal-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_function_userland.phpt" role="test" />
+            <file name="tests/ext/sandbox/dd_trace_function_userland-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_method.phpt" role="test" />
+            <file name="tests/ext/sandbox/dd_trace_method-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_method_alias.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_method_binds_called_object.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_push_span_id.phpt" role="test" />
@@ -416,13 +433,16 @@
             <file name="tests/ext/sandbox/default_span_properties.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties_method.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_attempt_loading_once.phpt" role="test" />
+            <file name="tests/ext/sandbox/deferred_load_attempt_loading_once-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_missing_load_fn.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_using_function.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_loading_helper.php" role="test" />
             <file name="tests/ext/sandbox/drop_spans.phpt" role="test" />
             <file name="tests/ext/sandbox/errors_are_flagged_from_userland.phpt" role="test" />
+            <file name="tests/ext/sandbox/errors_are_flagged_from_userland-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_error_log.phpt" role="test" />
+            <file name="tests/ext/sandbox/exception_error_log-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_from_user_error_handler_internal.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_handled_for_correct_catch_block.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_handled_in_correct_catch_frame.phpt" role="test" />
@@ -431,6 +451,7 @@
             <file name="tests/ext/sandbox/exception_handling.phpt" role="test" />
             <file name="tests/ext/sandbox/exception_is_defined.phpt" role="test" />
             <file name="tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
+            <file name="tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure.phpt" role="test" />
             <file name="tests/ext/sandbox/exceptions_are_passed_to_the_tracing_closure_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/exceptions_in_original_call_rethrown_in_tracing_closure.phpt" role="test" />
@@ -444,7 +465,9 @@
             <file name="tests/ext/sandbox/fatal_errors_are_tracked_004.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_are_tracked_005.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt" role="test" />
+            <file name="tests/ext/sandbox/fatal_errors_ignored_in_shutdown-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt" role="test" />
+            <file name="tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/generator.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_not_supported.phpt" role="test" />
             <file name="tests/ext/sandbox/generator_php5.phpt" role="test" />
@@ -459,16 +482,19 @@
             <file name="tests/ext/sandbox/hook_function/01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/03.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/03-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_03.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_access_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_error_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_error_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/posthook_error_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exceptions_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exceptions_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exceptions_03.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/posthook_exceptions_04-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exit_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_exit_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/posthook_limited_01.phpt" role="test" />
@@ -479,14 +505,18 @@
             <file name="tests/ext/sandbox/hook_function/prehook_access_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_error_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_error_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/prehook_error_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_exceptions_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/prehook_exceptions_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_exceptions_03.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_function/prehook_exceptions_04-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_function/prehook_variadic.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/03.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_method/03-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_03.phpt" role="test" />
@@ -494,9 +524,11 @@
             <file name="tests/ext/sandbox/hook_method/posthook_05.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_06.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_07.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_method/posthook_07-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_access_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_error_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_error_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_method/posthook_error_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_exceptions_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_exceptions_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/posthook_exit_01.phpt" role="test" />
@@ -515,8 +547,10 @@
             <file name="tests/ext/sandbox/hook_method/prehook_access_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_error_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_error_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_method/prehook_error_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_exceptions_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/hook_method/prehook_exceptions_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_scope_01.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_scope_02.phpt" role="test" />
             <file name="tests/ext/sandbox/hook_method/prehook_scope_03.phpt" role="test" />
@@ -532,20 +566,26 @@
             <file name="tests/ext/sandbox/preinitialized_tracing_of_method.phpt" role="test" />
             <file name="tests/ext/sandbox/return_by_ref.phpt" role="test" />
             <file name="tests/ext/sandbox/retval_is_null_with_exception.phpt" role="test" />
+            <file name="tests/ext/sandbox/retval_is_null_with_exception-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_metadata.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt" role="test" />
             <file name="tests/ext/sandbox/safe_to_string_properties.phpt" role="test" />
             <file name="tests/ext/sandbox/span_clone.phpt" role="test" />
             <file name="tests/ext/sandbox/span_resource_serialization.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_01.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_01-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_02.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_02-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_03_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_03_php7.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_04_php5.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_04_php7.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_05.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_05-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/spans_out_of_sync_06.phpt" role="test" />
+            <file name="tests/ext/sandbox/spans_out_of_sync_06-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt" role="test" />
+            <file name="tests/ext/sandbox/static_tracing_closures_will_not_bind_this-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox/variadic_args_internal.phpt" role="test" />
             <file name="tests/ext/sandbox/variadic_no_args.phpt" role="test" />
             <file name="tests/ext/sandbox/vm_var_types_return.phpt" role="test" />
@@ -557,14 +597,18 @@
             <file name="tests/ext/sandbox-prehook/closure_arg_exception.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/closure_arg_retval.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/dd_trace_api_error.phpt" role="test" />
+            <file name="tests/ext/sandbox-prehook/dd_trace_api_error-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/dd_trace_function_internal.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/dd_trace_function_userland.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/dd_trace_method.phpt" role="test" />
+            <file name="tests/ext/sandbox-prehook/dd_trace_method-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/dd_trace_method_binds_called_object.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/drop_spans.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/exception_error_log.phpt" role="test" />
+            <file name="tests/ext/sandbox-prehook/exception_error_log-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/exception_handling.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt" role="test" />
+            <file name="tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/exit_and_drop_span.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt" role="test" />
             <file name="tests/ext/sandbox-prehook/new_static.phpt" role="test" />
@@ -614,6 +658,7 @@
             <file name="tests/ext/sandbox-regression/with_params_method_hook.phpt" role="test" />
 
             <file name="tests/ext/active_span.phpt" role="test" />
+            <file name="tests/ext/add_global_tag_on_userland_and_internal_spans.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_default.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_high_limit.phpt" role="test" />
             <file name="tests/ext/check_memory_under_limit_high_user_limit.phpt" role="test" />
@@ -623,6 +668,7 @@
             <file name="tests/ext/circuit_breaker_max_failures.phpt" role="test" />
             <file name="tests/ext/circuit_breaker_retry_time.phpt" role="test" />
             <file name="tests/ext/dd_trace_api_error.phpt" role="test" />
+            <file name="tests/ext/dd_trace_api_error-legacy.phpt" role="test" />
             <file name="tests/ext/dd_trace_coms_empty_stacks_correctly_recycled.phpt" role="test" />
             <file name="tests/ext/dd_trace_current_context.phpt" role="test" />
             <file name="tests/ext/dd_trace_current_context_noenv.phpt" role="test" />
@@ -631,6 +677,7 @@
             <file name="tests/ext/dd_trace_send_traces_via_thread_002.phpt" role="test" />
             <file name="tests/ext/dd_trace_serialize_msgpack.phpt" role="test" />
             <file name="tests/ext/dd_trace_serialize_msgpack_error.phpt" role="test" />
+            <file name="tests/ext/dd_trace_serialize_msgpack_error-legacy.phpt" role="test" />
             <file name="tests/ext/dd_trace_serialize_msgpack_reference.phpt" role="test" />
             <file name="tests/ext/dd_trace_tracer_is_limited_memory.phpt" role="test" />
             <file name="tests/ext/dd_trace_warning.phpt" role="test" />
@@ -650,6 +697,9 @@
             <file name="tests/ext/request_timeout_01.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
+            <file name="tests/ext/start_span_with_all_properties.phpt" role="test" />
+            <file name="tests/ext/start_span_without_closing.phpt" role="test" />
+            <file name="tests/ext/start_span_without_closing_autofinish.phpt" role="test" />
             <file name="tests/ext/startup_logging.inc" role="test" />
             <file name="tests/ext/startup_logging.phpt" role="test" />
             <file name="tests/ext/startup_logging-legacy.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -560,6 +560,7 @@
             <file name="tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt" role="test" />
             <file name="tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt" role="test" />
             <file name="tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt" role="test" />
+            <file name="tests/ext/sandbox/manual_flush.phpt" role="test" />
             <file name="tests/ext/sandbox/memory_limit_graceful_bailout.phpt" role="test" />
             <file name="tests/ext/sandbox/new_static.phpt" role="test" />
             <file name="tests/ext/sandbox/non-zero_duration.phpt" role="test" />

--- a/phpstan.api.neon
+++ b/phpstan.api.neon
@@ -1,1 +1,2 @@
-parameters: {}
+parameters:
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.ddtrace.neon
+++ b/phpstan.ddtrace.neon
@@ -9,3 +9,6 @@ parameters:
 		- src/DDTrace/Integrations
 		- src/DDTrace/OpenTracer
 		- src/dd-doctor.php
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		- '#Access to an undefined property DDTrace\\Span::\$internalSpan#'

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -29,18 +29,21 @@ final class Bootstrap
         self::$bootstrapped = true;
 
         $tracer = self::resetTracer();
+        if (PHP_VERSION_ID < 80000) {
+            \DDTrace\hook_method('DDTrace\\Bootstrap', 'flushTracerShutdown', null, function () {
+                $tracer = GlobalTracer::get();
+                $scopeManager = $tracer->getScopeManager();
+                $scopeManager->close();
+                if (!\dd_trace_env_config('DD_TRACE_AUTO_FLUSH_ENABLED')) {
+                    $tracer->flush();
+                }
+            });
+        }
 
-        \DDTrace\hook_method('DDTrace\\Bootstrap', 'flushTracerShutdown', null, function () {
-            $tracer = GlobalTracer::get();
-            $scopeManager = $tracer->getScopeManager();
-            $scopeManager->close();
-            if (!\dd_trace_env_config('DD_TRACE_AUTO_FLUSH_ENABLED')) {
-                $tracer->flush();
+        if (\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN') || PHP_VERSION_ID < 80000) {
+            if (\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN')) {
+                self::initRootSpan($tracer);
             }
-        });
-
-        if (\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN')) {
-            self::initRootSpan($tracer);
             register_shutdown_function(function () {
                 /*
                 * Register the shutdown handler during shutdown so that it is run after all the other shutdown handlers.
@@ -51,7 +54,26 @@ final class Bootstrap
                 */
                 register_shutdown_function(function () {
                     // We wrap the call in a closure to prevent OPcache from skipping the call.
-                    Bootstrap::flushTracerShutdown();
+                    if (PHP_VERSION_ID < 80000) { // internal handling
+                        Bootstrap::flushTracerShutdown();
+                    } else {
+                        $tracer = GlobalTracer::get();
+                        // this also gets set when creating a root span, but may not have the latest up-to-date data
+                        if (
+                            'cli' !== PHP_SAPI && \ddtrace_config_url_resource_name_enabled()
+                            && $rootScope = $tracer->getRootScope()
+                        ) {
+                            $tracer->addUrlAsResourceNameToSpan($rootScope->getSpan());
+                        }
+                        /*
+                         * Having this priority sampling here is actually a bug (should happen after service name
+                         * substitutions), but it was this way before the refactor, so let's fix this in a
+                         * subsequent release, when we will have ported everything else to the extension.
+                         */
+                        if (method_exists($tracer, "enforcePrioritySamplingOnRootSpan")) {
+                            $tracer->enforcePrioritySamplingOnRootSpan();
+                        }
+                    }
                 });
             });
         }
@@ -125,6 +147,14 @@ final class Bootstrap
             // Adding configured incoming request http headers
             foreach (Private_\util_extract_configured_headers_as_tags($httpHeaders, true) as $tag => $value) {
                 $span->setTag($tag, $value);
+            }
+
+            if (PHP_VERSION_ID >= 80000) {
+                foreach ($httpHeaders as $header => $value) {
+                    if (stripos($header, Propagator::DEFAULT_ORIGIN_HEADER) === 0) {
+                        add_global_tag(Tag::ORIGIN, $value);
+                    }
+                }
             }
         }
         $integration = WebIntegration::getInstance();

--- a/src/DDTrace/Encoders/SpanEncoder.php
+++ b/src/DDTrace/Encoders/SpanEncoder.php
@@ -4,9 +4,7 @@ namespace DDTrace\Encoders;
 
 use DDTrace\Span;
 use DDTrace\Data\Span as DataSpan;
-use DDTrace\GlobalTracer;
 use DDTrace\Log\LoggingTrait;
-use DDTrace\Sampling\PrioritySampling;
 use DDTrace\Tag;
 
 final class SpanEncoder
@@ -60,10 +58,6 @@ final class SpanEncoder
             $metrics[$metricName] = $metricValue;
         }
         if ($span->context->isHostRoot()) {
-            $prioritySampling = GlobalTracer::get()->getPrioritySampling();
-            if ($prioritySampling !== PrioritySampling::UNKNOWN) {
-                $metrics['_sampling_priority_v1'] = $prioritySampling;
-            }
             if (\dd_trace_env_config('DD_TRACE_MEASURE_COMPILE_TIME')) {
                 // Metric expects milliseconds
                 $metrics['php.compilation.total_time_ms'] = (float) dd_trace_compile_time_microseconds() / 1000;

--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -122,6 +122,11 @@ final class TextMap implements Propagator
         if (!$spanId) {
             return '';
         }
+
+        if (PHP_VERSION_ID >= 80000) {
+            return $spanId;
+        }
+
         $pushedSpanId = \dd_trace_push_span_id($spanId);
         if ($pushedSpanId === $spanId) {
             return $spanId;

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -11,413 +11,809 @@ use Exception;
 use InvalidArgumentException;
 use Throwable;
 
-final class Span extends DataSpan
-{
-    private static $metricNames = [ Tag::ANALYTICS_KEY => true ];
-    // associative array for quickly checking if tag has special meaning, should include metric_names
-    private static $specialTags = [
-        Tag::ANALYTICS_KEY => true,
-        Tag::ERROR => true,
-        Tag::ERROR_MSG => true,
-        Tag::SERVICE_NAME => true,
-        Tag::RESOURCE_NAME => true,
-        Tag::SPAN_TYPE => true,
-        Tag::HTTP_URL => true,
-        Tag::HTTP_STATUS_CODE => true,
-        Tag::MANUAL_KEEP => true,
-        Tag::MANUAL_DROP => true,
-        Tag::SERVICE_VERSION => true,
-    ];
-
-    /**
-     * Span constructor.
-     * @param string $operationName
-     * @param SpanContext $context
-     * @param string $service
-     * @param string $resource
-     * @param int|null $startTime
-     */
-    public function __construct(
-        $operationName,
-        SpanContext $context,
-        $service,
-        $resource,
-        $startTime = null
-    ) {
-        $this->context = $context;
-        $this->operationName = (string)$operationName;
-        $this->service = (string)$service;
-        $this->resource = null === $resource ? null : (string)$resource;
-        $this->startTime = $startTime ?: Time::now();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTraceId()
+if (PHP_VERSION_ID < 80000) {
+    final class Span extends DataSpan
     {
-        return $this->context->traceId;
-    }
+        private static $metricNames = [Tag::ANALYTICS_KEY => true];
+        // associative array for quickly checking if tag has special meaning, should include metric_names
+        private static $specialTags = [
+            Tag::ANALYTICS_KEY => true,
+            Tag::ERROR => true,
+            Tag::ERROR_MSG => true,
+            Tag::SERVICE_NAME => true,
+            Tag::RESOURCE_NAME => true,
+            Tag::SPAN_TYPE => true,
+            Tag::HTTP_URL => true,
+            Tag::HTTP_STATUS_CODE => true,
+            Tag::MANUAL_KEEP => true,
+            Tag::MANUAL_DROP => true,
+            Tag::SERVICE_VERSION => true,
+        ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSpanId()
-    {
-        return $this->context->spanId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParentId()
-    {
-        return $this->context->parentId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function overwriteOperationName($operationName)
-    {
-        $this->operationName = $operationName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResource()
-    {
-        return $this->resource;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getService()
-    {
-        return $this->service;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStartTime()
-    {
-        return $this->startTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDuration()
-    {
-        return $this->duration;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setTag($key, $value, $setIfFinished = false)
-    {
-        if ($this->duration !== null && !$setIfFinished) { // if finished
-            return;
-        }
-        if ($key !== (string)$key) {
-            throw InvalidSpanArgument::forTagKey($key);
-        }
-        // Since sub classes can change the return value of a known method,
-        // we quietly ignore values that could cause errors when converting to string
-        if (is_object($value) && $key !== Tag::ERROR) {
-            return;
+        /**
+         * Span constructor.
+         * @param string $operationName
+         * @param SpanContext $context
+         * @param string $service
+         * @param string $resource
+         * @param int|null $startTime
+         */
+        public function __construct(
+            $operationName,
+            SpanContext $context,
+            $service,
+            $resource,
+            $startTime = null
+        ) {
+            $this->context = $context;
+            $this->operationName = (string)$operationName;
+            $this->service = (string)$service;
+            $this->resource = null === $resource ? null : (string)$resource;
+            $this->startTime = $startTime ?: Time::now();
         }
 
-        if (array_key_exists($key, self::$specialTags)) {
-            if ($key === Tag::ERROR) {
-                $this->setError($value);
+        /**
+         * {@inheritdoc}
+         */
+        public function getTraceId()
+        {
+            return $this->context->traceId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getSpanId()
+        {
+            return $this->context->spanId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getParentId()
+        {
+            return $this->context->parentId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function overwriteOperationName($operationName)
+        {
+            $this->operationName = $operationName;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getResource()
+        {
+            return $this->resource;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getService()
+        {
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getStartTime()
+        {
+            return $this->startTime;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDuration()
+        {
+            return $this->duration;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setTag($key, $value, $setIfFinished = false)
+        {
+            if ($this->duration !== null && !$setIfFinished) { // if finished
+                return;
+            }
+            if ($key !== (string)$key) {
+                throw InvalidSpanArgument::forTagKey($key);
+            }
+            // Since sub classes can change the return value of a known method,
+            // we quietly ignore values that could cause errors when converting to string
+            if (is_object($value) && $key !== Tag::ERROR) {
                 return;
             }
 
-            if ($key === Tag::ERROR_MSG) {
-                $this->tags[$key] = (string)$value;
-                $this->setError(true);
-                return;
-            }
+            if (array_key_exists($key, self::$specialTags)) {
+                if ($key === Tag::ERROR) {
+                    $this->setError($value);
+                    return;
+                }
 
-            if ($key === Tag::SERVICE_NAME) {
-                $this->service = $value;
-                return;
-            }
+                if ($key === Tag::ERROR_MSG) {
+                    $this->tags[$key] = (string)$value;
+                    $this->setError(true);
+                    return;
+                }
 
-            if ($key === Tag::MANUAL_KEEP) {
-                GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
-                return;
-            }
+                if ($key === Tag::SERVICE_NAME) {
+                    $this->service = $value;
+                    return;
+                }
 
-            if ($key === Tag::MANUAL_DROP) {
-                GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
-                return;
-            }
+                if ($key === Tag::MANUAL_KEEP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
+                    return;
+                }
 
-            if ($key === Tag::RESOURCE_NAME) {
-                $this->resource = (string)$value;
-                return;
-            }
+                if ($key === Tag::MANUAL_DROP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
+                    return;
+                }
 
-            if ($key === Tag::SPAN_TYPE) {
-                $this->type = $value;
-                return;
-            }
+                if ($key === Tag::RESOURCE_NAME) {
+                    $this->resource = (string)$value;
+                    return;
+                }
 
-            if ($key === Tag::HTTP_URL) {
-                $value = Urls::sanitize((string)$value);
-            }
+                if ($key === Tag::SPAN_TYPE) {
+                    $this->type = $value;
+                    return;
+                }
 
-            if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
-                $this->hasError = true;
-                if (!isset($this->tags[Tag::ERROR_TYPE])) {
-                    $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+                if ($key === Tag::HTTP_URL) {
+                    $value = Urls::sanitize((string)$value);
+                }
+
+                if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
+                    $this->hasError = true;
+                    if (!isset($this->tags[Tag::ERROR_TYPE])) {
+                        $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+                    }
+                }
+
+                if ($key === Tag::SERVICE_VERSION) {
+                    // Also set `version` tag (we want both)
+                    $this->setTag(Tag::VERSION, $value);
+                }
+
+                if (array_key_exists($key, self::$metricNames)) {
+                    $this->setMetric($key, $value);
+                    return;
                 }
             }
 
-            if ($key === Tag::SERVICE_VERSION) {
-                // Also set `version` tag (we want both)
-                $this->setTag(Tag::VERSION, $value);
+            $this->tags[$key] = (string)$value;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTag($key)
+        {
+            if (array_key_exists($key, $this->tags)) {
+                return $this->tags[$key];
             }
 
-            if (array_key_exists($key, self::$metricNames)) {
-                $this->setMetric($key, $value);
+            return null;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllTags()
+        {
+            return $this->tags;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function hasTag($name)
+        {
+            return array_key_exists($name, $this->getAllTags());
+        }
+
+        /**
+         * @param string $key
+         * @param mixed $value
+         */
+        public function setMetric($key, $value)
+        {
+            if ($key === Tag::ANALYTICS_KEY) {
+                TraceAnalyticsProcessor::normalizeAnalyticsValue($this->metrics, $value);
                 return;
             }
+
+            $this->metrics[$key] = $value;
         }
 
-        $this->tags[$key] = (string)$value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTag($key)
-    {
-        if (array_key_exists($key, $this->tags)) {
-            return $this->tags[$key];
+        /**
+         * @return array
+         */
+        public function getMetrics()
+        {
+            return $this->metrics;
         }
 
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAllTags()
-    {
-        return $this->tags;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTag($name)
-    {
-        return array_key_exists($name, $this->getAllTags());
-    }
-
-    /**
-     * @param string $key
-     * @param mixed $value
-     */
-    public function setMetric($key, $value)
-    {
-        if ($key === Tag::ANALYTICS_KEY) {
-            TraceAnalyticsProcessor::normalizeAnalyticsValue($this->metrics, $value);
-            return;
+        /**
+         * {@inheritdoc}
+         */
+        public function setResource($resource)
+        {
+            $this->resource = (string)$resource;
         }
 
-        $this->metrics[$key] = $value;
-    }
+        /**
+         * Stores a Throwable object within the span tags. The error status is
+         * updated and the error.Error() string is included with a default tag key.
+         * If the Span has been finished, it will not be modified by this method.
+         *
+         * @param Throwable|Exception|bool|string|null $error
+         * @throws InvalidArgumentException
+         */
+        public function setError($error)
+        {
+            if (($error instanceof Exception) || ($error instanceof Throwable)) {
+                $this->hasError = true;
+                $this->tags[Tag::ERROR_MSG] = $error->getMessage();
+                $this->tags[Tag::ERROR_TYPE] = get_class($error);
+                $this->tags[Tag::ERROR_STACK] = $error->getTraceAsString();
+                return;
+            }
 
-    /**
-     * @return array
-     */
-    public function getMetrics()
-    {
-        return $this->metrics;
-    }
+            if (is_bool($error)) {
+                $this->hasError = $error;
+                return;
+            }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setResource($resource)
-    {
-        $this->resource = (string)$resource;
-    }
+            if (is_null($error)) {
+                $this->hasError = false;
+            }
 
-    /**
-     * Stores a Throwable object within the span tags. The error status is
-     * updated and the error.Error() string is included with a default tag key.
-     * If the Span has been finished, it will not be modified by this method.
-     *
-     * @param Throwable|Exception|bool|string|null $error
-     * @throws InvalidArgumentException
-     */
-    public function setError($error)
-    {
-        if (($error instanceof Exception) || ($error instanceof Throwable)) {
+            throw InvalidSpanArgument::forError($error);
+        }
+
+        /**
+         * @param string $message
+         * @param string $type
+         */
+        public function setRawError($message, $type)
+        {
             $this->hasError = true;
-            $this->tags[Tag::ERROR_MSG] = $error->getMessage();
-            $this->tags[Tag::ERROR_TYPE] = get_class($error);
-            $this->tags[Tag::ERROR_STACK] = $error->getTraceAsString();
-            return;
+            $this->tags[Tag::ERROR_MSG] = $message;
+            $this->tags[Tag::ERROR_TYPE] = $type;
         }
 
-        if (is_bool($error)) {
-            $this->hasError = $error;
-            return;
+        public function hasError()
+        {
+            return $this->hasError;
         }
 
-        if (is_null($error)) {
-            $this->hasError = false;
+        /**
+         * {@inheritdoc}
+         */
+        public function finish($finishTime = null)
+        {
+            if ($this->duration !== null) { // if finished
+                return;
+            }
+
+            $this->duration = ($finishTime ?: Time::now()) - $this->startTime;
+            // Sync with span ID stack at the C level
+            dd_trace_pop_span_id();
         }
 
-        throw InvalidSpanArgument::forError($error);
-    }
-
-    /**
-     * @param string $message
-     * @param string $type
-     */
-    public function setRawError($message, $type)
-    {
-        $this->hasError = true;
-        $this->tags[Tag::ERROR_MSG] = $message;
-        $this->tags[Tag::ERROR_TYPE] = $type;
-    }
-
-    public function hasError()
-    {
-        return $this->hasError;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function finish($finishTime = null)
-    {
-        if ($this->duration !== null) { // if finished
-            return;
+        /**
+         * @param Throwable|Exception $error
+         * @return void
+         */
+        public function finishWithError($error)
+        {
+            $this->setError($error);
+            $this->finish();
         }
 
-        $this->duration = ($finishTime ?: Time::now()) - $this->startTime;
-        // Sync with span ID stack at the C level
-        dd_trace_pop_span_id();
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function isFinished()
+        {
+            return $this->duration !== null;
+        }
 
-    /**
-     * @param Throwable|Exception $error
-     * @return void
-     */
-    public function finishWithError($error)
-    {
-        $this->setError($error);
-        $this->finish();
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getOperationName()
+        {
+            return $this->operationName;
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isFinished()
-    {
-        return $this->duration !== null;
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getContext()
+        {
+            return $this->context;
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOperationName()
-    {
-        return $this->operationName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getContext()
-    {
-        return $this->context;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function log(array $fields = [], $timestamp = null)
-    {
-        foreach ($fields as $key => $value) {
-            if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
-                $this->setError(true);
-            } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
-                $this->setError($value);
-            } elseif ($key === Tag::LOG_MESSAGE) {
-                // We recently changed our span behavior: when we set an error message, we now mark the span as 'error'.
-                // In order to be backward compatible with this publicly exposed method we manually set the message,
-                // and not the errror, internally.
-                // This should be considered a broken behavior because it would not allow for users to log multiple
-                // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
-                // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
-                // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
-                $this->tags[Tag::ERROR_MSG] = (string)$value;
-            } elseif ($key === Tag::LOG_STACK) {
-                $this->setTag(Tag::ERROR_STACK, $value);
+        /**
+         * {@inheritdoc}
+         */
+        public function log(array $fields = [], $timestamp = null)
+        {
+            foreach ($fields as $key => $value) {
+                if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
+                    $this->setError(true);
+                } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
+                    $this->setError($value);
+                } elseif ($key === Tag::LOG_MESSAGE) {
+                    // We recently changed our span behavior:
+                    // when we set an error message, we now mark the span as 'error'.
+                    // In order to be backward compatible with this publicly exposed method we manually set the message,
+                    // and not the errror, internally.
+                    // This should be considered a broken behavior because it would not allow for users to log multiple
+                    // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
+                    // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
+                    // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
+                    $this->tags[Tag::ERROR_MSG] = (string)$value;
+                } elseif ($key === Tag::LOG_STACK) {
+                    $this->setTag(Tag::ERROR_STACK, $value);
+                }
             }
         }
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addBaggageItem($key, $value)
-    {
-        $this->context = $this->context->withBaggageItem($key, $value);
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function addBaggageItem($key, $value)
+        {
+            $this->context = $this->context->withBaggageItem($key, $value);
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaggageItem($key)
-    {
-        return $this->context->getBaggageItem($key);
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getBaggageItem($key)
+        {
+            return $this->context->getBaggageItem($key);
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAllBaggageItems()
-    {
-        return $this->context->baggageItems;
-    }
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllBaggageItems()
+        {
+            return $this->context->baggageItems;
+        }
 
-    /**
-     * @param bool $value
-     * @return self
-     */
-    public function setTraceAnalyticsCandidate($value = true)
-    {
-        $this->isTraceAnalyticsCandidate = $value;
-        return $this;
-    }
 
-    /**
-     * @return bool
-     */
-    public function isTraceAnalyticsCandidate()
+        /**
+         * @param bool $value
+         * @return self
+         * @deprecated
+         */
+        public function setTraceAnalyticsCandidate($value = true)
+        {
+            return $this;
+        }
+
+        /**
+         * @return bool
+         * @deprecated
+         */
+        public function isTraceAnalyticsCandidate()
+        {
+            return false;
+        }
+    }
+} else {
+    class Span extends DataSpan
     {
-        return $this->isTraceAnalyticsCandidate;
+        private static $metricNames = [ Tag::ANALYTICS_KEY => true ];
+        // associative array for quickly checking if tag has special meaning, should include metric_names
+        private static $specialTags = [
+            Tag::ANALYTICS_KEY => true,
+            Tag::ERROR => true,
+            Tag::ERROR_MSG => true,
+            Tag::SERVICE_NAME => true,
+            Tag::RESOURCE_NAME => true,
+            Tag::SPAN_TYPE => true,
+            Tag::HTTP_URL => true,
+            Tag::HTTP_STATUS_CODE => true,
+            Tag::MANUAL_KEEP => true,
+            Tag::MANUAL_DROP => true,
+            Tag::SERVICE_VERSION => true,
+        ];
+
+        /**
+         * Span constructor.
+         * @param SpanData $internalSpan
+         * @param SpanContext $context
+         */
+        public function __construct(SpanData $internalSpan, SpanContext $context)
+        {
+            $this->internalSpan = $internalSpan;
+            $this->context = $context;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTraceId()
+        {
+            return $this->context->traceId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getSpanId()
+        {
+            return $this->context->spanId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getParentId()
+        {
+            return $this->context->parentId;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function overwriteOperationName($operationName)
+        {
+            $this->internalSpan->name = $operationName;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getResource()
+        {
+            return $this->internalSpan->resource;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getService()
+        {
+            return $this->internalSpan->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getType()
+        {
+            return $this->internalSpan->type;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getStartTime()
+        {
+            // internally we have nanoseconds, but we'll expose microseconds here
+            return (int) ($this->startTime / 1000);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDuration()
+        {
+            // internally we have nanoseconds, but we'll expose microseconds here
+            return (int) ($this->duration / 1000);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setTag($key, $value, $setIfFinished = false)
+        {
+            if ($this->isFinished() && !$setIfFinished) { // if finished
+                return;
+            }
+
+            if ($key !== (string)$key) {
+                throw InvalidSpanArgument::forTagKey($key);
+            }
+            // Since sub classes can change the return value of a known method,
+            // we quietly ignore values that could cause errors when converting to string
+            if (is_object($value) && $key !== Tag::ERROR) {
+                return;
+            }
+
+            if (array_key_exists($key, self::$specialTags)) {
+                if ($key === Tag::ERROR) {
+                    $this->setError($value);
+                    return;
+                }
+
+                if ($key === Tag::ERROR_MSG) {
+                    $this->internalSpan->meta[$key] = (string)$value;
+                    $this->setError(true);
+                    return;
+                }
+
+                if ($key === Tag::SERVICE_NAME) {
+                    $this->internalSpan->service = $value;
+                    return;
+                }
+
+                if ($key === Tag::MANUAL_KEEP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_KEEP);
+                    return;
+                }
+
+                if ($key === Tag::MANUAL_DROP) {
+                    GlobalTracer::get()->setPrioritySampling(Sampling\PrioritySampling::USER_REJECT);
+                    return;
+                }
+
+                if ($key === Tag::RESOURCE_NAME) {
+                    $this->internalSpan->resource = (string)$value;
+                    return;
+                }
+
+                if ($key === Tag::SPAN_TYPE) {
+                    $this->internalSpan->type = $value;
+                    return;
+                }
+
+                if ($key === Tag::HTTP_URL) {
+                    $value = Urls::sanitize((string)$value);
+                }
+
+                if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
+                    $this->hasError = true;
+                    if (!isset($this->internalSpan->meta[Tag::ERROR_TYPE])) {
+                        $this->internalSpan->meta[Tag::ERROR_TYPE] = 'Internal Server Error';
+                    }
+                }
+
+                if ($key === Tag::SERVICE_VERSION) {
+                    // Also set `version` tag (we want both)
+                    $this->setTag(Tag::VERSION, $value);
+                }
+
+                if (array_key_exists($key, self::$metricNames)) {
+                    $this->setMetric($key, $value);
+                    return;
+                }
+            }
+
+            $this->internalSpan->meta[$key] = (string)$value;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTag($key)
+        {
+            if (isset($this->internalSpan->meta) && array_key_exists($key, $this->internalSpan->meta)) {
+                return $this->internalSpan->meta[$key];
+            }
+
+            return null;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllTags()
+        {
+            return isset($this->internalSpan->meta) ? $this->internalSpan->meta : [];
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function hasTag($name)
+        {
+            return array_key_exists($name, $this->getAllTags());
+        }
+
+        /**
+         * @param string $key
+         * @param mixed $value
+         */
+        public function setMetric($key, $value)
+        {
+            if ($key === Tag::ANALYTICS_KEY) {
+                TraceAnalyticsProcessor::normalizeAnalyticsValue($this->internalSpan->metrics, $value);
+                return;
+            }
+
+            $this->internalSpan->metrics[$key] = $value;
+        }
+
+        /**
+         * @return array
+         */
+        public function getMetrics()
+        {
+            return isset($this->internalSpan->metrics) ? $this->internalSpan->metrics : [];
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setResource($resource)
+        {
+            $this->internalSpan->resource = (string)$resource;
+        }
+
+        /**
+         * Stores a Throwable object within the span tags. The error status is
+         * updated and the error.Error() string is included with a default tag key.
+         * If the Span has been finished, it will not be modified by this method.
+         *
+         * @param Throwable|Exception|bool|string|null $error
+         * @throws InvalidArgumentException
+         */
+        public function setError($error)
+        {
+            if (($error instanceof Exception) || ($error instanceof Throwable)) {
+                $this->hasError = true;
+                $this->internalSpan->meta[Tag::ERROR_MSG] = $error->getMessage();
+                $this->internalSpan->meta[Tag::ERROR_TYPE] = get_class($error);
+                $this->internalSpan->meta[Tag::ERROR_STACK] = $error->getTraceAsString();
+                return;
+            }
+
+            if (is_bool($error)) {
+                $this->hasError = $error;
+                return;
+            }
+
+            if (is_null($error)) {
+                $this->hasError = false;
+            }
+
+            throw InvalidSpanArgument::forError($error);
+        }
+
+        /**
+         * @param string $message
+         * @param string $type
+         */
+        public function setRawError($message, $type)
+        {
+            $this->hasError = true;
+            $this->internalSpan->meta[Tag::ERROR_MSG] = $message;
+            $this->internalSpan->meta[Tag::ERROR_TYPE] = $type;
+        }
+
+        public function hasError()
+        {
+            return $this->hasError;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function finish($finishTime = null)
+        {
+            if (!$this->isFinished()) {
+                close_span($finishTime);
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function isFinished()
+        {
+            return $this->duration !== 0;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getOperationName()
+        {
+            return $this->internalSpan->name;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getContext()
+        {
+            return $this->context;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function log(array $fields = [], $timestamp = null)
+        {
+            foreach ($fields as $key => $value) {
+                if ($key === Tag::LOG_EVENT && $value === Tag::ERROR) {
+                    $this->setError(true);
+                } elseif ($key === Tag::LOG_ERROR || $key === Tag::LOG_ERROR_OBJECT) {
+                    $this->setError($value);
+                } elseif ($key === Tag::LOG_MESSAGE) {
+                    // We recently changed our span behavior:
+                    // when we set an error message, we now mark the span as 'error'.
+                    // In order to be backward compatible with this publicly exposed method we manually set the message,
+                    // and not the errror, internally.
+                    // This should be considered a broken behavior because it would not allow for users to log multiple
+                    // messages, and logging multiple messages is not prohibited by the OpenTracing spec:
+                    // https://opentracing.io/docs/overview/tags-logs-baggage/#logs
+                    // We want to deprecate this behavior and change it. In the meantime we apply this workaround.
+                    $this->internalSpan->meta[Tag::ERROR_MSG] = (string)$value;
+                } elseif ($key === Tag::LOG_STACK) {
+                    $this->setTag(Tag::ERROR_STACK, $value);
+                }
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function addBaggageItem($key, $value)
+        {
+            $this->context = $this->context->withBaggageItem($key, $value);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getBaggageItem($key)
+        {
+            return $this->context->getBaggageItem($key);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getAllBaggageItems()
+        {
+            return $this->context->baggageItems;
+        }
+
+        /**
+         * @deprecated
+         * @param bool $value
+         * @return self
+         */
+        public function setTraceAnalyticsCandidate($value = true)
+        {
+            return $this;
+        }
+
+        /**
+         * @deprecated
+         * @return bool
+         */
+        public function isTraceAnalyticsCandidate()
+        {
+            return false;
+        }
     }
 }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -719,6 +719,7 @@ if (PHP_VERSION_ID < 80000) {
         public function finish($finishTime = null)
         {
             if (!$this->isFinished()) {
+                // @phpstan-ignore-next-line
                 close_span($finishTime);
             }
         }

--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -40,10 +40,13 @@ final class SpanContext extends SpanContextData
                 false
             );
         } else {
+            // @phpstan-ignore-next-line
             if (!$parentContext->isDistributedTracingActivationContext() || !active_span()) {
                 if ($startTime) {
+                    // @phpstan-ignore-next-line
                     start_span($startTime);
                 } else {
+                    // @phpstan-ignore-next-line
                     start_span(); // we'll peek at the span stack top later
                 }
             }
@@ -73,7 +76,9 @@ final class SpanContext extends SpanContextData
         // with peek the current span id for the existing root span
 
         if (PHP_VERSION_ID >= 80000) {
+            // @phpstan-ignore-next-line
             if (!active_span()) {
+                // @phpstan-ignore-next-line
                 start_span();
             }
             $nextId = \dd_trace_peek_span_id();

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -527,17 +527,14 @@ final class Tracer implements TracerInterface
     {
         $this->prioritySampling = $prioritySampling;
 
-        $rootScope = $this->getRootScope();
-        if (null === $rootScope) {
-            return;
-        }
-        $rootSpan = $rootScope->getSpan();
+        $rootSpan = $this->getSafeRootSpan();
         if (null === $rootSpan) {
             return;
         }
+
         if ($prioritySampling !== Sampling\PrioritySampling::UNKNOWN) {
             $rootSpan->setMetric('_sampling_priority_v1', $prioritySampling);
-        } elseif (property_exists($rootSpan, "metrics")) { // official API does not allow removal, so...
+        } elseif (isset($rootSpan->metrics)) { // official API does not allow removal, so...
             unset($rootSpan->metrics['_sampling_priority_v1']);
         }
     }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -16,6 +16,7 @@ use DDTrace\Propagators\TextMap;
 use DDTrace\Sampling\ConfigurableSampler;
 use DDTrace\Sampling\Sampler;
 use DDTrace\Transport\Http;
+use DDTrace\Transport\Noop;
 use DDTrace\Transport\Noop as NoopTransport;
 
 final class Tracer implements TracerInterface
@@ -104,7 +105,7 @@ final class Tracer implements TracerInterface
     public function __construct(Transport $transport = null, array $propagators = null, array $config = [])
     {
         $encoder = new MessagePack();
-        $this->transport = $transport ?: new Http($encoder);
+        $this->transport = $transport ?: (PHP_VERSION_ID >= 80000 ? new Noop() : new Http($encoder));
         $textMapPropagator = new TextMap($this);
         $this->propagators = $propagators ?: [
             Format::TEXT_MAP => $textMapPropagator,
@@ -113,6 +114,11 @@ final class Tracer implements TracerInterface
         ];
         $this->config = array_merge($this->config, $config);
         $this->reset();
+        if (PHP_VERSION_ID >= 80000) {
+            foreach ($this->config['global_tags'] as $key => $val) {
+                add_global_tag($key, $val);
+            }
+        }
         $this->config['global_tags'] = array_merge($this->config['global_tags'], \ddtrace_config_global_tags());
         $this->serviceVersion = \ddtrace_config_service_version();
         $this->environment = \ddtrace_config_env();
@@ -167,16 +173,26 @@ final class Tracer implements TracerInterface
         if ($reference === null) {
             $context = SpanContext::createAsRoot();
         } else {
-            $context = SpanContext::createAsChild($reference->getContext());
+            // avoid rounding errors, we only care about microsecond resolution here
+            $roundedStartTime = ($options->getStartTime() + 0.2) / 1000000;
+            $context = SpanContext::createAsChild($reference->getContext(), $roundedStartTime);
         }
 
-        $span = new Span(
-            $operationName,
-            $context,
-            $this->config['service_name'],
-            array_key_exists('resource', $this->config) ? $this->config['resource'] : null,
-            $options->getStartTime()
-        );
+        $resource = array_key_exists('resource', $this->config) ? (string) $this->config['resource'] : null;
+        $service = $this->config['service_name'];
+
+        if (PHP_VERSION_ID >= 80000) {
+            $internalSpan = active_span();
+            $internalSpan->name = (string) $operationName;
+            $internalSpan->service = $service;
+            $internalSpan->resource = $resource;
+            $internalSpan->metrics = [];
+            $internalSpan->meta = [];
+            // @phpstan-ignore-next-line
+            $span = new Span($internalSpan, $context);
+        } else {
+            $span = new Span($operationName, $context, $service, $resource, $options->getStartTime());
+        }
 
         $tags = $options->getTags() + $this->getGlobalTags();
         if ($context->getParentId() === null) {
@@ -185,6 +201,19 @@ final class Tracer implements TracerInterface
 
         foreach ($tags as $key => $value) {
             $span->setTag($key, $value);
+        }
+
+        if ($reference === null) {
+            if (\ddtrace_config_hostname_reporting_enabled()) {
+                $hostname = gethostname();
+                if ($hostname !== false) {
+                    $span->setTag(Tag::HOSTNAME, $hostname);
+                }
+            }
+            // Call it here so that the data is there in any case, even when shutdown fatal errors
+            if ('cli' !== PHP_SAPI && \ddtrace_config_url_resource_name_enabled()) {
+                $this->addUrlAsResourceNameToSpan($span);
+            }
         }
 
         $this->record($span);
@@ -253,7 +282,9 @@ final class Tracer implements TracerInterface
             $span->setTag(Tag::SERVICE_NAME, $parentService);
         }
 
-        return $this->scopeManager->activate($span, $options->shouldFinishSpanOnClose());
+        $shouldFinish = $options->shouldFinishSpanOnClose() && (PHP_VERSION_ID < 80000 || $span->getParentId() != 0
+                || !\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN'));
+        return $this->scopeManager->activate($span, $shouldFinish);
     }
 
     /**
@@ -305,12 +336,14 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        // We should refactor these blocks to use a pre-flush hook
-        if (\ddtrace_config_hostname_reporting_enabled()) {
-            $this->addHostnameToRootSpan();
+        if (PHP_VERSION_ID >= 80000) {
+            // when we explicitly flush to get the closed spans, drop the open spans to trigger an auto-flush
+            // this is needed for minimal compatibility with OpenTracer
+            while (\dd_trace_pop_span_id());
         }
-        if ('cli' !== PHP_SAPI && \ddtrace_config_url_resource_name_enabled()) {
-            $this->addUrlAsResourceNameToRootSpan();
+
+        if ('cli' !== PHP_SAPI && \ddtrace_config_url_resource_name_enabled() && $rootScope = $this->getRootScope()) {
+            $this->addUrlAsResourceNameToSpan($rootScope->getSpan());
         }
 
         if (self::isLogDebugActive()) {
@@ -352,6 +385,11 @@ final class Tracer implements TracerInterface
      */
     public function getTracesAsArray()
     {
+        if (PHP_VERSION_ID >= 80000) {
+            $trace = \dd_trace_serialize_closed_spans();
+            return $trace ? [$trace] : $trace;
+        }
+
         $tracesToBeSent = [];
         $autoFinishSpans = \ddtrace_config_autofinish_span_enabled();
         $serviceMappings = \ddtrace_config_service_mapping();
@@ -430,24 +468,8 @@ final class Tracer implements TracerInterface
         return $tracesToBeSent;
     }
 
-    private function addHostnameToRootSpan()
+    public function addUrlAsResourceNameToSpan(Contracts\Span $span)
     {
-        $hostname = gethostname();
-        if ($hostname !== false) {
-            $span = $this->getRootScope()->getSpan();
-            if ($span !== null) {
-                $span->setTag(Tag::HOSTNAME, $hostname);
-            }
-        }
-    }
-
-    private function addUrlAsResourceNameToRootSpan()
-    {
-        $scope = $this->getRootScope();
-        if (null === $scope) {
-            return;
-        }
-        $span = $scope->getSpan();
         if (null !== $span->getResource()) {
             return;
         }
@@ -494,10 +516,11 @@ final class Tracer implements TracerInterface
             return;
         }
 
-        $this->prioritySampling = $span->getContext()->getPropagatedPrioritySampling();
-        if (null === $this->prioritySampling) {
-            $this->prioritySampling = $this->sampler->getPrioritySampling($span);
+        $prioritySampling = $span->getContext()->getPropagatedPrioritySampling();
+        if (null === $prioritySampling) {
+            $prioritySampling = $this->sampler->getPrioritySampling($span);
         }
+        $this->setPrioritySampling($prioritySampling);
     }
 
     /**
@@ -506,6 +529,20 @@ final class Tracer implements TracerInterface
     public function setPrioritySampling($prioritySampling)
     {
         $this->prioritySampling = $prioritySampling;
+
+        $rootScope = $this->getRootScope();
+        if (null === $rootScope) {
+            return;
+        }
+        $rootSpan = $rootScope->getSpan();
+        if (null === $rootSpan) {
+            return;
+        }
+        if ($prioritySampling !== Sampling\PrioritySampling::UNKNOWN) {
+            $rootSpan->setMetric('_sampling_priority_v1', $prioritySampling);
+        } elseif (property_exists($rootSpan, "metrics")) { // official API does not allow removal, so...
+            unset($rootSpan->metrics['_sampling_priority_v1']);
+        }
     }
 
     /**
@@ -551,7 +588,7 @@ final class Tracer implements TracerInterface
     /**
      * Enforce priority sampling on the root span.
      */
-    private function enforcePrioritySamplingOnRootSpan()
+    public function enforcePrioritySamplingOnRootSpan()
     {
         if ($this->prioritySampling !== Sampling\PrioritySampling::UNKNOWN) {
             return;

--- a/src/DDTrace/Transport/Internal.php
+++ b/src/DDTrace/Transport/Internal.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DDTrace\Transport;
+
+use DDTrace\Contracts\Tracer as TracerInterface;
+use DDTrace\Transport;
+
+final class Internal implements Transport
+{
+    public function send(TracerInterface $tracer)
+    {
+        if (!\dd_trace_env_config('DD_TRACE_GENERATE_ROOT_SPAN')) {
+            // @phpstan-ignore-next-line
+            \DDTrace\flush();
+        }
+    }
+
+    public function setHeader($key, $value)
+    {
+        // No-Op, background sender does not accept headers
+    }
+}

--- a/src/api/Data/Span.php
+++ b/src/api/Data/Span.php
@@ -140,5 +140,10 @@ if (PHP_VERSION_ID < 80000) {
             }
             return $this->internalSpan->$name = $value;
         }
+
+        public function __isset($name)
+        {
+            return $this->__get($name) !== null;
+        }
     }
 }

--- a/src/api/Data/Span.php
+++ b/src/api/Data/Span.php
@@ -6,80 +6,139 @@ use DDTrace\Time;
 use DDTrace\Data\SpanContext as SpanContextData;
 use DDTrace\Contracts\Span as SpanInterface;
 
-abstract class Span implements SpanInterface
-{
-    /**
-     * Operation Name is the name of the operation being measured. Some examples
-     * might be "http.handler", "fileserver.upload" or "video.decompress".
-     * Name should be set on every span.
-     *
-     * @var string
-     */
-    public $operationName;
+if (PHP_VERSION_ID < 80000) {
+    abstract class Span implements SpanInterface
+    {
+        /**
+         * Operation Name is the name of the operation being measured. Some examples
+         * might be "http.handler", "fileserver.upload" or "video.decompress".
+         * Name should be set on every span.
+         *
+         * @var string
+         */
+        public $operationName;
 
-    /**
-     * @var SpanContextData
-     */
-    public $context;
+        /**
+         * @var SpanContextData
+         */
+        public $context;
 
-    /**
-     * Resource is a query to a service. A web application might use
-     * resources like "/user/{user_id}". A sql database might use resources
-     * like "select * from user where id = ?".
-     *
-     * You can track thousands of resources (not millions or billions) so
-     * prefer normalized resources like "/user/{id}" to "/user/123".
-     *
-     * Note that resource name will be inherited from parent if its not set.
-     *
-     * @var string
-     */
-    public $resource;
+        /**
+         * Resource is a query to a service. A web application might use
+         * resources like "/user/{user_id}". A sql database might use resources
+         * like "select * from user where id = ?".
+         *
+         * You can track thousands of resources (not millions or billions) so
+         * prefer normalized resources like "/user/{id}" to "/user/123".
+         *
+         * Note that resource name will be inherited from parent if its not set.
+         *
+         * @var string
+         */
+        public $resource;
 
-    /**
-     * Service is the name of the process doing a particular job. Some
-     * examples might be "user-database" or "datadog-web-app".
-     *
-     * Note that service name will be inherited from parent if its not set.
-     *
-     * @var string
-     */
-    public $service;
+        /**
+         * Service is the name of the process doing a particular job. Some
+         * examples might be "user-database" or "datadog-web-app".
+         *
+         * Note that service name will be inherited from parent if its not set.
+         *
+         * @var string
+         */
+        public $service;
 
-    /**
-     * Protocol associated with the span
-     *
-     * @var string|null
-     */
-    public $type;
+        /**
+         * Protocol associated with the span
+         *
+         * @var string|null
+         */
+        public $type;
 
-    /**
-     * @var int
-     */
-    public $startTime;
+        /**
+         * @var int
+         */
+        public $startTime;
 
-    /**
-     * @var int|null
-     */
-    public $duration;
+        /**
+         * @var int|null
+         */
+        public $duration;
 
-    /**
-     * @var array
-     */
-    public $tags = [];
+        /**
+         * @var array
+         */
+        public $tags = [];
 
-    /**
-     * @var bool
-     */
-    public $hasError = false;
+        /**
+         * @var bool
+         */
+        public $hasError = false;
 
-    /**
-     * @var array
-     */
-    public $metrics = [];
+        /**
+         * @var array
+         */
+        public $metrics = [];
 
+        /**
+         * @var bool Whether or not this trace can be even considered for trace analytics automatic configuration.
+         */
+        public $isTraceAnalyticsCandidate = false;
+    }
+} else {
     /**
-     * @var bool Whether or not this trace can be even considered for trace analytics automatic configuration.
+     * Class Span
+     * @property string $operationName
+     * @property string $resource
+     * @property string $service
+     * @property string $type
+     * @property int $startTime
+     * @property int $duration
+     * @property array $tags
+     * @property array $metrics
      */
-    public $isTraceAnalyticsCandidate = false;
+    abstract class Span implements SpanInterface
+    {
+        /**
+         * @var SpanContextData
+         */
+        public $context;
+
+        /**
+         * @var bool
+         */
+        public $hasError = false;
+
+        /**
+         * @var \DDTrace\SpanData
+         */
+        protected $internalSpan;
+
+        public function &__get($name)
+        {
+            if ($name == "operationName") {
+                $name = "name";
+            } elseif ($name == "tags") {
+                $name = "meta";
+            } elseif ($name == "duration") {
+                // @phpstan-ignore-next-line
+                $duration = $this->internalSpan->getDuration();
+                return $duration;
+            } elseif ($name == "startTime") {
+                // @phpstan-ignore-next-line
+                $startTime = $this->internalSpan->getStartTime();
+                return $startTime;
+            }
+            return $this->internalSpan->$name;
+        }
+
+        public function __set($name, $value)
+        {
+            if ($name == "operationName") {
+                $name = "name";
+            } elseif ($name == "tags") {
+                $name = "meta";
+            }
+            return $this->internalSpan->$name = $value;
+        }
+    }
 }

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -3,6 +3,7 @@
 namespace DDTrace\Tests\Common;
 
 use DDTrace\Integrations\IntegrationsLoader;
+use DDTrace\NoopTracer;
 
 /**
  * A basic class to be extended when testing integrations.
@@ -39,6 +40,7 @@ abstract class IntegrationTestCase extends BaseTestCase
             \PHPUnit_Framework_Error_Warning::$enabled = true;
         }
         \dd_trace_internal_fn('ddtrace_reload_config');
+        \DDTrace\GlobalTracer::set(new NoopTracer());
         parent::ddTearDown();
     }
 

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -353,10 +353,11 @@ trait TracerTestTrait
         foreach ($manyRequests as $uniqueRequest) {
             // error_log('Request: ' . print_r($uniqueRequest, 1));
             $rawTraces = json_decode($uniqueRequest['body'], true);
-            $tracesAllRequests = array_merge($tracesAllRequests, $this->parseRawDumpedTraces($rawTraces));
+            $tracesAllRequests[] = $this->parseRawDumpedTraces($rawTraces);
         }
 
-        return $tracesAllRequests;
+        // We need to handle potential empty flushes (without internal flushing)...
+        return PHP_VERSION_ID >= 80000 ? $tracesAllRequests : array_values(array_filter($tracesAllRequests));
     }
 
     /**

--- a/tests/Composer/ComposerInteroperabilityTest.php
+++ b/tests/Composer/ComposerInteroperabilityTest.php
@@ -21,7 +21,9 @@ class ComposerInteroperabilityTest extends BaseTestCase
                 TestCase::assertSame("OK\n", $output);
             },
             __DIR__ . "/app/index.php",
-            [],
+            [
+                'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
+            ],
             [
                 'ddtrace.request_init_hook' => 'do_not_exists',
             ]
@@ -39,7 +41,9 @@ class ComposerInteroperabilityTest extends BaseTestCase
                 TestCase::assertSame("OK\n", $output);
             },
             __DIR__ . "/app/index.php",
-            [],
+            [
+                'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
+            ],
             [
                 'ddtrace.request_init_hook' => __DIR__ . '/../../bridge/dd_wrap_autoloader.php',
             ]

--- a/tests/Integration/Transport/HttpTest.php
+++ b/tests/Integration/Transport/HttpTest.php
@@ -9,255 +9,257 @@ use DDTrace\Tests\Common\BaseTestCase;
 use DDTrace\Tracer;
 use DDTrace\Transport\Http;
 
-final class HttpTest extends BaseTestCase
-{
-    use AgentReplayerTrait;
-
-    protected function ddSetUp()
+if (PHP_VERSION_ID < 80000) {
+    final class HttpTest extends BaseTestCase
     {
-        parent::ddSetUp();
-        putenv('DD_TRACE_BGS_ENABLED=false');
-        \dd_trace_internal_fn('ddtrace_reload_config');
-    }
+        use AgentReplayerTrait;
 
-    protected function ddTearDown()
-    {
-        // reset the circuit breker consecutive failures count and close it
-        \dd_tracer_circuit_breaker_register_success();
-        putenv('DD_TRACE_BGS_ENABLED');
-        putenv('DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC=default');
-
-        parent::ddTearDown();
-    }
-
-    public function agentUrl()
-    {
-        return 'http://' . ($_SERVER["DDAGENT_HOSTNAME"] ? $_SERVER["DDAGENT_HOSTNAME"] : "localhost") . ':8126';
-    }
-
-    public function agentTracesUrl()
-    {
-        return $this->agentUrl() . '/v0.4/traces';
-    }
-
-    public function testSpanReportingFailsOnUnavailableAgent()
-    {
-        $logger = $this->withDebugLogger();
-
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => 'http://0.0.0.0:8127/v0.4/traces',
-        ]);
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
-
-        $span = $tracer->startSpan('test', [
-            'tags' => [
-                'key1' => 'value1',
-            ],
-        ]);
-
-        $span->finish();
-
-        $httpTransport->send($tracer);
-        $this->assertTrue($logger->has(
-            'error',
-            'Reporting of spans failed: 7 / Failed to connect to 0.0.0.0 port 8127: Connection refused'
-        ));
-    }
-
-    public function testCircuitBreakerBehavingAsExpected()
-    {
-        // We start from a clean state: circuit breaker is closed!
-        \dd_tracer_circuit_breaker_register_success();
-
-        // make the circuit breaker fail fast
-        putenv('DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES=1');
-
-        $logger = $this->withDebugLogger();
-
-        $badHttpTransport = new Http(new MessagePack(), [
-            'endpoint' => 'http://0.0.0.0:8127/v0.4/traces',
-        ]);
-        $goodHttpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->agentTracesUrl(),
-        ]);
-
-        $tracer = new Tracer(null);
-        GlobalTracer::set($tracer);
-        $tracer->startSpan('test', [])->finish();
-
-        $this->assertTrue(\dd_tracer_circuit_breaker_info()['closed']);
-        $badHttpTransport->send($tracer); // bad transport will immediately open the circuit
-        $this->assertFalse(\dd_tracer_circuit_breaker_info()['closed']);
-
-        $goodHttpTransport->send($tracer); // good transport
-        $this->assertFalse(\dd_tracer_circuit_breaker_info()['closed']);
-
-        // should close the circuit once retry time has passed
-        putenv('DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC=0');
-
-        $tracer->startSpan('test', [])->finish();
-        $goodHttpTransport->send($tracer);
-        $this->assertTrue(\dd_tracer_circuit_breaker_info()['closed']);
-
-        $this->assertTrue($logger->has(
-            'error',
-            'Reporting of spans failed: 7 / Failed to connect to 0.0.0.0 port 8127: Connection refused'
-        ));
-
-        $this->assertTrue($logger->has(
-            'error',
-            'Reporting of spans skipped due to open circuit breaker'
-        ));
-    }
-
-    public function testSpanReportingSuccess()
-    {
-        $logger = $this->withDebugLogger();
-
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->agentTracesUrl(),
-        ]);
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
-
-        $span = $tracer->startSpan('test', [
-            'tags' => [
-                'key1' => 'value1',
-            ],
-        ]);
-
-        $childSpan = $tracer->startSpan('child_test', [
-            'child_of' => $span,
-            'tags' => [
-                'key2' => 'value2',
-            ],
-        ]);
-
-        $childSpan->finish();
-
-        $span->finish();
-
-        $httpTransport->send($tracer);
-        $this->assertTrue($logger->has('debug', 'About to send trace(s) to the agent'));
-        $this->assertTrue($logger->has('debug', 'Traces successfully sent to the agent'));
-    }
-
-    public function testSendsMetaHeaders()
-    {
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->getAgentReplayerEndpoint(),
-        ]);
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
-
-        $span = $tracer->startSpan('test');
-        $span->finish();
-
-        $httpTransport->send($tracer);
-
-        $traceRequest = $this->getLastAgentRequest();
-
-        $this->assertEquals('php', $traceRequest['headers']['Datadog-Meta-Lang']);
-        $this->assertEquals(\PHP_VERSION, $traceRequest['headers']['Datadog-Meta-Lang-Version']);
-        $this->assertEquals(\PHP_SAPI, $traceRequest['headers']['Datadog-Meta-Lang-Interpreter']);
-        $this->assertEquals(Tracer::version(), $traceRequest['headers']['Datadog-Meta-Tracer-Version']);
-        $this->assertRegExp('/^[0-9a-f]{64}$/', $traceRequest['headers']['Datadog-Container-Id']);
-        $this->assertEquals('1', $traceRequest['headers']['X-Datadog-Trace-Count']);
-    }
-
-    public function testContentLengthAutomaticallyAddedByCurl()
-    {
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->getAgentReplayerEndpoint(),
-        ]);
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
-
-        $span = $tracer->startSpan('test');
-        $span->finish();
-
-        $httpTransport->send($tracer);
-        $traceRequest = $this->getLastAgentRequest();
-
-        $this->assertArrayHasKey('Content-Length', $traceRequest['headers']);
-    }
-
-    private static function recordContainsPrefixAndSuffix($record, $prefix, $suffix)
-    {
-        if ($record[0] !== 'error') {
-            return false;
+        protected function ddSetUp()
+        {
+            parent::ddSetUp();
+            putenv('DD_TRACE_BGS_ENABLED=false');
+            \dd_trace_internal_fn('ddtrace_reload_config');
         }
 
-        $resultPrefix = \strpos($record[1], $prefix);
-        $resultSuffix = \strpos($record[1], $suffix);
-        return \is_int($resultPrefix) && \is_int($resultSuffix);
-    }
+        protected function ddTearDown()
+        {
+            // reset the circuit breker consecutive failures count and close it
+            \dd_tracer_circuit_breaker_register_success();
+            putenv('DD_TRACE_BGS_ENABLED');
+            putenv('DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC=default');
 
-    public function testSendingTimeoutContainsTimeoutSettings()
-    {
-        $timeout = 1;
-        $curlTimeout = 1;
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->getAgentReplayerEndpoint(),
-            'connect_timeout' => $curlTimeout,
-            'timeout' => $timeout,
-        ]);
-
-        // This helps it timeout more reliably
-        $httpTransport->setHeader('Expect', '100-continue');
-
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
-        $logger = $this->withDebugLogger();
-
-        // Add a few children; the larger payload helps it to timeout more reliably
-        $root = $tracer->startRootSpan('test');
-        /** @var \DDTrace\Contracts\Scope[] $children */
-        $children = [];
-        for ($i = 0; $i < 10; ++$i) {
-            $children[] = $tracer->startActiveSpan("child{$i}");
+            parent::ddTearDown();
         }
-        foreach (\array_reverse($children) as $child) {
-            $child->close();
+
+        public function agentUrl()
+        {
+            return 'http://' . ($_SERVER["DDAGENT_HOSTNAME"] ? $_SERVER["DDAGENT_HOSTNAME"] : "localhost") . ':8126';
         }
-        $root->close();
 
-        $httpTransport->send($tracer);
+        public function agentTracesUrl()
+        {
+            return $this->agentUrl() . '/v0.4/traces';
+        }
 
-        $records = $logger->all();
-        $curlOperationTimedout = \version_compare(\PHP_VERSION, '5.5', '<')
-            ? \CURLE_OPERATION_TIMEOUTED
-            : \CURLE_OPERATION_TIMEDOUT;
-        $prefix = "Reporting of spans failed: {$curlOperationTimedout} / ";
-        $suffix = "(TIMEOUT_MS={$timeout}, CONNECTTIMEOUT_MS={$curlTimeout})";
+        public function testSpanReportingFailsOnUnavailableAgent()
+        {
+            $logger = $this->withDebugLogger();
 
-        $result = \array_filter(
-            $records,
-            function ($record) use ($prefix, $suffix) {
-                return self::recordContainsPrefixAndSuffix($record, $prefix, $suffix);
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => 'http://0.0.0.0:8127/v0.4/traces',
+            ]);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+
+            $span = $tracer->startSpan('test', [
+                'tags' => [
+                    'key1' => 'value1',
+                ],
+            ]);
+
+            $span->finish();
+
+            $httpTransport->send($tracer);
+            $this->assertTrue($logger->has(
+                'error',
+                'Reporting of spans failed: 7 / Failed to connect to 0.0.0.0 port 8127: Connection refused'
+            ));
+        }
+
+        public function testCircuitBreakerBehavingAsExpected()
+        {
+            // We start from a clean state: circuit breaker is closed!
+            \dd_tracer_circuit_breaker_register_success();
+
+            // make the circuit breaker fail fast
+            putenv('DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES=1');
+
+            $logger = $this->withDebugLogger();
+
+            $badHttpTransport = new Http(new MessagePack(), [
+                'endpoint' => 'http://0.0.0.0:8127/v0.4/traces',
+            ]);
+            $goodHttpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->agentTracesUrl(),
+            ]);
+
+            $tracer = new Tracer(null);
+            GlobalTracer::set($tracer);
+            $tracer->startSpan('test', [])->finish();
+
+            $this->assertTrue(\dd_tracer_circuit_breaker_info()['closed']);
+            $badHttpTransport->send($tracer); // bad transport will immediately open the circuit
+            $this->assertFalse(\dd_tracer_circuit_breaker_info()['closed']);
+
+            $goodHttpTransport->send($tracer); // good transport
+            $this->assertFalse(\dd_tracer_circuit_breaker_info()['closed']);
+
+            // should close the circuit once retry time has passed
+            putenv('DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC=0');
+
+            $tracer->startSpan('test', [])->finish();
+            $goodHttpTransport->send($tracer);
+            $this->assertTrue(\dd_tracer_circuit_breaker_info()['closed']);
+
+            $this->assertTrue($logger->has(
+                'error',
+                'Reporting of spans failed: 7 / Failed to connect to 0.0.0.0 port 8127: Connection refused'
+            ));
+
+            $this->assertTrue($logger->has(
+                'error',
+                'Reporting of spans skipped due to open circuit breaker'
+            ));
+        }
+
+        public function testSpanReportingSuccess()
+        {
+            $logger = $this->withDebugLogger();
+
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->agentTracesUrl(),
+            ]);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+
+            $span = $tracer->startSpan('test', [
+                'tags' => [
+                    'key1' => 'value1',
+                ],
+            ]);
+
+            $childSpan = $tracer->startSpan('child_test', [
+                'child_of' => $span,
+                'tags' => [
+                    'key2' => 'value2',
+                ],
+            ]);
+
+            $childSpan->finish();
+
+            $span->finish();
+
+            $httpTransport->send($tracer);
+            $this->assertTrue($logger->has('debug', 'About to send trace(s) to the agent'));
+            $this->assertTrue($logger->has('debug', 'Traces successfully sent to the agent'));
+        }
+
+        public function testSendsMetaHeaders()
+        {
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->getAgentReplayerEndpoint(),
+            ]);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+
+            $span = $tracer->startSpan('test');
+            $span->finish();
+
+            $httpTransport->send($tracer);
+
+            $traceRequest = $this->getLastAgentRequest();
+
+            $this->assertEquals('php', $traceRequest['headers']['Datadog-Meta-Lang']);
+            $this->assertEquals(\PHP_VERSION, $traceRequest['headers']['Datadog-Meta-Lang-Version']);
+            $this->assertEquals(\PHP_SAPI, $traceRequest['headers']['Datadog-Meta-Lang-Interpreter']);
+            $this->assertEquals(Tracer::version(), $traceRequest['headers']['Datadog-Meta-Tracer-Version']);
+            $this->assertRegExp('/^[0-9a-f]{64}$/', $traceRequest['headers']['Datadog-Container-Id']);
+            $this->assertEquals('1', $traceRequest['headers']['X-Datadog-Trace-Count']);
+        }
+
+        public function testContentLengthAutomaticallyAddedByCurl()
+        {
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->getAgentReplayerEndpoint(),
+            ]);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+
+            $span = $tracer->startSpan('test');
+            $span->finish();
+
+            $httpTransport->send($tracer);
+            $traceRequest = $this->getLastAgentRequest();
+
+            $this->assertArrayHasKey('Content-Length', $traceRequest['headers']);
+        }
+
+        private static function recordContainsPrefixAndSuffix($record, $prefix, $suffix)
+        {
+            if ($record[0] !== 'error') {
+                return false;
             }
-        );
 
-        self::assertCount(1, $result);
-    }
+            $resultPrefix = \strpos($record[1], $prefix);
+            $resultSuffix = \strpos($record[1], $suffix);
+            return \is_int($resultPrefix) && \is_int($resultSuffix);
+        }
 
-    public function testSetHeader()
-    {
-        $httpTransport = new Http(new MessagePack(), [
-            'endpoint' => $this->getAgentReplayerEndpoint(),
-        ]);
-        $tracer = new Tracer($httpTransport);
-        GlobalTracer::set($tracer);
+        public function testSendingTimeoutContainsTimeoutSettings()
+        {
+            $timeout = 1;
+            $curlTimeout = 1;
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->getAgentReplayerEndpoint(),
+                'connect_timeout' => $curlTimeout,
+                'timeout' => $timeout,
+            ]);
 
-        $span = $tracer->startSpan('test');
-        $span->finish();
+            // This helps it timeout more reliably
+            $httpTransport->setHeader('Expect', '100-continue');
 
-        $httpTransport->setHeader('X-my-custom-header', 'my-custom-value');
-        $httpTransport->send($tracer);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+            $logger = $this->withDebugLogger();
 
-        $traceRequest = $this->getLastAgentRequest();
+            // Add a few children; the larger payload helps it to timeout more reliably
+            $root = $tracer->startRootSpan('test');
+            /** @var \DDTrace\Contracts\Scope[] $children */
+            $children = [];
+            for ($i = 0; $i < 10; ++$i) {
+                $children[] = $tracer->startActiveSpan("child{$i}");
+            }
+            foreach (\array_reverse($children) as $child) {
+                $child->close();
+            }
+            $root->close();
 
-        $this->assertEquals('my-custom-value', $traceRequest['headers']['X-my-custom-header']);
+            $httpTransport->send($tracer);
+
+            $records = $logger->all();
+            $curlOperationTimedout = \version_compare(\PHP_VERSION, '5.5', '<')
+                ? \CURLE_OPERATION_TIMEOUTED
+                : \CURLE_OPERATION_TIMEDOUT;
+            $prefix = "Reporting of spans failed: {$curlOperationTimedout} / ";
+            $suffix = "(TIMEOUT_MS={$timeout}, CONNECTTIMEOUT_MS={$curlTimeout})";
+
+            $result = \array_filter(
+                $records,
+                function ($record) use ($prefix, $suffix) {
+                    return self::recordContainsPrefixAndSuffix($record, $prefix, $suffix);
+                }
+            );
+
+            self::assertCount(1, $result);
+        }
+
+        public function testSetHeader()
+        {
+            $httpTransport = new Http(new MessagePack(), [
+                'endpoint' => $this->getAgentReplayerEndpoint(),
+            ]);
+            $tracer = new Tracer($httpTransport);
+            GlobalTracer::set($tracer);
+
+            $span = $tracer->startSpan('test');
+            $span->finish();
+
+            $httpTransport->setHeader('X-my-custom-header', 'my-custom-value');
+            $httpTransport->send($tracer);
+
+            $traceRequest = $this->getLastAgentRequest();
+
+            $this->assertEquals('my-custom-value', $traceRequest['headers']['X-my-custom-header']);
+        }
     }
 }

--- a/tests/Integrations/Curl/curl_request_headers.php
+++ b/tests/Integrations/Curl/curl_request_headers.php
@@ -1,0 +1,5 @@
+<?php
+
+$ch = curl_init('http://httpbin_integration/headers');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+echo curl_exec($ch);

--- a/tests/Integrations/Curl/curl_request_headers_with_copied_handle.php
+++ b/tests/Integrations/Curl/curl_request_headers_with_copied_handle.php
@@ -1,0 +1,10 @@
+<?php
+
+$ch1 = curl_init('http://httpbin_integration/headers');
+\curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+\curl_setopt($ch1, CURLOPT_HTTPHEADER, [
+    'honored: preserved_value',
+]);
+$ch2 = \curl_copy_handle($ch1);
+\curl_close($ch1);
+echo curl_exec($ch2);

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ]),
             ]

--- a/tests/Integrations/Guzzle/V5/guzzle_in_distributed_web_request.php
+++ b/tests/Integrations/Guzzle/V5/guzzle_in_distributed_web_request.php
@@ -1,0 +1,34 @@
+<?php
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Ring\Client\CurlMultiHandler;
+
+$curl = new CurlMultiHandler();
+$client = new Client(['handler' => $curl]);
+
+$future1 = $client->get('http://httpbin_integration/headers', [
+    'future' => true,
+    'headers' => [
+        'honored' => 'preserved_value',
+    ],
+]);
+$future1->then(function ($response) use (&$headers1) {
+    $headers1 = $response->json();
+});
+
+$future2 = $client->get('http://httpbin_integration/headers', [
+    'future' => true,
+    'headers' => [
+        'honored' => 'preserved_value',
+    ],
+]);
+$future2->then(function ($response) use (&$headers2) {
+    $headers2 = $response->json();
+});
+
+$future1->wait();
+$future2->wait();
+
+echo json_encode([$headers1, $headers2]);

--- a/tests/Integrations/Guzzle/V6/guzzle_in_distributed_web_request.php
+++ b/tests/Integrations/Guzzle/V6/guzzle_in_distributed_web_request.php
@@ -1,0 +1,39 @@
+<?php
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Psr7\Response;
+
+$curl = new CurlMultiHandler();
+$client = new Client([
+    'handler' => HandlerStack::create($curl)
+]);
+
+$resolver = function (Response $response) use (&$found) {
+    $found[] = $response;
+};
+
+$promise1 = $client->getAsync('http://httpbin_integration/headers', [
+    'headers' => [
+        'honored' => 'preserved_value',
+    ],
+])->then($resolver);
+
+$promise2 = $client->getAsync('http://httpbin_integration/headers', [
+    'headers' => [
+        'honored' => 'preserved_value',
+    ],
+])->then($resolver);
+
+$aggregate = Promise\all([$promise1, $promise2]);
+while (!Promise\is_settled($aggregate)) {
+    $curl->tick();
+}
+
+echo json_encode(array_map(function ($response) {
+    return json_decode($response->getBody(), 1);
+}, $found));

--- a/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
@@ -43,6 +43,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
@@ -48,6 +48,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
@@ -48,6 +48,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
@@ -49,6 +49,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
+                        '_dd.rule_psr' => 1,
                     ])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -48,6 +48,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -48,6 +48,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -48,6 +48,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -198,7 +198,6 @@ final class MemcachedTest extends IntegrationTestCase
             $this->assertFalse($this->client->get('key2'));
         });
 
-        var_dump($traces);
         $this->assertEmpty($traces);
     }
 

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -198,6 +198,7 @@ final class MemcachedTest extends IntegrationTestCase
             $this->assertFalse($this->client->get('key2'));
         });
 
+        var_dump($traces);
         $this->assertEmpty($traces);
     }
 

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -161,12 +161,8 @@ final class PCNTLTest extends IntegrationTestCase
         $requests = $this->parseMultipleRequestsFromDumpedData();
         $this->assertCount(2, $requests);
 
-        // Both requests have 1 trace each
-        $this->assertCount(1, $requests[0]);
-        $this->assertCount(1, $requests[1]);
-
         foreach ($requests as $traces) {
-            $this->assertFlameGraph($traces, [
+            $this->assertFlameGraph([$traces], [
                 SpanAssertion::exists('long_running_entry_point')->withChildren([
                     SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                     SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
@@ -188,9 +184,8 @@ final class PCNTLTest extends IntegrationTestCase
             ]
         );
         $requests = $this->parseMultipleRequestsFromDumpedData();
-        $this->assertCount(1, $requests, 'Traces are buffered into one request');
 
-        $this->assertFlameGraph($requests[0], [
+        $this->assertFlameGraph($requests, [
             SpanAssertion::exists('manual_tracing')->withChildren([
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),

--- a/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
@@ -6,7 +6,7 @@ const ITERATIONS = 2;
 
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     $tracer = DDTrace\GlobalTracer::get();
-    $scope = $tracer->startActiveSpan('manual_tracing');
+    $scope = $tracer->startRootSpan('manual_tracing');
     $span = $scope->getSpan();
     $span->setTag(DDTrace\Tag::SERVICE_NAME, 'manual_service');
     $span->setTag(DDTrace\Tag::SPAN_TYPE, 'custom');

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -47,6 +47,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ]) ->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
@@ -46,6 +46,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
+                    '_dd.rule_psr' => 1,
                     '_sampling_priority_v1' => 1,
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
+                        '_dd.rule_psr' => 1,
                         '_sampling_priority_v1' => 1,
                     ]),
             ]

--- a/tests/Unit/Sampling/AlwaysKeepSamplerTest.php
+++ b/tests/Unit/Sampling/AlwaysKeepSamplerTest.php
@@ -5,6 +5,7 @@ namespace DDTrace\Tests\Unit\Sampling;
 use DDTrace\Sampling\AlwaysKeepSampler;
 use DDTrace\Span;
 use DDTrace\SpanContext;
+use DDTrace\SpanData;
 use DDTrace\Tests\Common\BaseTestCase;
 
 final class AlwaysKeepSamplerTest extends BaseTestCase
@@ -13,6 +14,7 @@ final class AlwaysKeepSamplerTest extends BaseTestCase
     {
         $sampler = new AlwaysKeepSampler();
         $context = new SpanContext('', '');
-        $this->assertSame(1, $sampler->getPrioritySampling(new Span('', $context, '', '')));
+        $span = PHP_VERSION_ID < 80000 ? new Span('', $context, '', '') : new Span(new SpanData(), $context);
+        $this->assertSame(1, $sampler->getPrioritySampling($span));
     }
 }

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -4,6 +4,7 @@ namespace DDTrace\Tests\Unit;
 
 use DDTrace\Span;
 use DDTrace\SpanContext;
+use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Sampling\PrioritySampling;
 use DDTrace\Tracer;
@@ -67,7 +68,7 @@ final class SpanTest extends BaseTestCase
 
     public function testSpanTagsRemainImmutableAfterFinishing()
     {
-        $span = $this->createSpan();
+        $span = $this->createSpan(true);
         $span->finish();
 
         $span->setTag(self::TAG_KEY, self::TAG_VALUE);
@@ -177,7 +178,7 @@ final class SpanTest extends BaseTestCase
 
     public function testSpanErrorRemainsMutableAfterFinishing()
     {
-        $span = $this->createSpan();
+        $span = $this->createSpan(true);
         $span->finish();
 
         $span->setError(new Exception());
@@ -266,16 +267,6 @@ final class SpanTest extends BaseTestCase
         $this->assertSame(1.0, $span->getMetrics()['exists']);
     }
 
-    public function testIsTraceAnalyticsConfigCandidate()
-    {
-        $span = $this->createSpan();
-        $this->assertFalse($span->isTraceAnalyticsCandidate());
-        $span->setTraceAnalyticsCandidate();
-        $this->assertTrue($span->isTraceAnalyticsCandidate());
-        $span->setTraceAnalyticsCandidate(false);
-        $this->assertFalse($span->isTraceAnalyticsCandidate());
-    }
-
     public function testTraceAnalyticsConfigEnabledByTag()
     {
         $span = $this->createSpan();
@@ -333,16 +324,24 @@ final class SpanTest extends BaseTestCase
         $this->assertSame([1710563033, 2041643438], $randInts);
     }
 
-    private function createSpan()
+    private function createSpan($realSpan = false)
     {
         $context = SpanContext::createAsRoot();
 
-        $span = new Span(
-            self::OPERATION_NAME,
-            $context,
-            self::SERVICE,
-            self::RESOURCE
-        );
+        if (PHP_VERSION_ID < 80000) {
+            $span = new Span(
+                self::OPERATION_NAME,
+                $context,
+                self::SERVICE,
+                self::RESOURCE
+            );
+        } else {
+            $internalSpan = $realSpan ? \DDTrace\start_span() : new SpanData();
+            $internalSpan->name = self::OPERATION_NAME;
+            $internalSpan->service = self::SERVICE;
+            $internalSpan->resource = self::RESOURCE;
+            $span = new Span($internalSpan, $context);
+        }
 
         return $span;
     }

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -21,10 +21,13 @@ function greet($name)
 greet('Datadog');
 
 var_dump(DDTrace\active_span());
+var_dump(DDTrace\active_span() == DDTrace\active_span());
 
 ?>
 --EXPECT--
 Hello, Datadog.
 greet tracer.
 bool(true)
-NULL
+object(DDTrace\SpanData)#1 (0) {
+}
+bool(true)

--- a/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
+++ b/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
@@ -31,7 +31,7 @@ var_dump(dd_trace_serialize_closed_spans());
 HOOK METHOD arg
 array(2) {
   [0]=>
-  array(9) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -52,11 +52,6 @@ array(2) {
       string(2) "no"
       ["cubs"]=>
       string(3) "yes"
-    }
-    ["metrics"]=>
-    array(1) {
-      ["php.compilation.total_time_ms"]=>
-      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
+++ b/tests/ext/add_global_tag_on_userland_and_internal_spans.phpt
@@ -1,0 +1,86 @@
+--TEST--
+DDTrace\add_global_tag() on all sorts of spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+
+$span = DDTrace\start_span();
+$span->name = "polar " . ($_ = "bear");
+
+function test($a) {
+    return 'METHOD ' . $a;
+}
+
+DDTrace\trace_function("test", function($s, $a, $retval) {
+    echo 'HOOK ' . $retval . PHP_EOL;
+});
+
+test("arg");
+
+DDTrace\add_global_tag("alone", ($_ = "n") . "o");
+DDTrace\add_global_tag("cubs", ($_ = "n") . "o");
+DDTrace\add_global_tag("cubs", ($_ = "y") . "es"); // overwrites older entries
+
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+HOOK METHOD arg
+array(2) {
+  [0]=>
+  array(9) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(10) "polar bear"
+    ["resource"]=>
+    string(10) "polar bear"
+    ["meta"]=>
+    array(2) {
+      ["alone"]=>
+      string(2) "no"
+      ["cubs"]=>
+      string(3) "yes"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(2) {
+      ["alone"]=>
+      string(2) "no"
+      ["cubs"]=>
+      string(3) "yes"
+    }
+  }
+}

--- a/tests/ext/background-sender/agent_headers.phpt
+++ b/tests/ext/background-sender/agent_headers.phpt
@@ -9,6 +9,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
 DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
@@ -35,6 +36,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -47,3 +53,4 @@ Datadog-Meta-Tracer-Version: %s
 X-Datadog-Trace-Count: 1
 
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id.phpt
@@ -11,6 +11,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
 DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
@@ -33,6 +34,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -41,3 +47,4 @@ Datadog-Container-Id: 9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416
 Datadog-Meta-Lang: php
 
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id_empty.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_empty.phpt
@@ -11,6 +11,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
 DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
@@ -33,6 +34,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -40,3 +46,4 @@ bool(true)
 Datadog-Meta-Lang: php
 
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
@@ -11,6 +11,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
 DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
@@ -32,6 +33,11 @@ echo 'Datadog-Meta-Lang: ' . $headers['Datadog-Meta-Lang'] . PHP_EOL;
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -40,3 +46,4 @@ Datadog-Container-Id: 34dc0b5e626f2c5c4c5170e34b10e765-1234567890
 Datadog-Meta-Lang: php
 
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_ignore_userland.phpt
+++ b/tests/ext/background-sender/agent_headers_ignore_userland.phpt
@@ -9,6 +9,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
 DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
@@ -32,6 +33,11 @@ foreach ($headers as $name => $value) {
 echo PHP_EOL;
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 bool(true)
@@ -39,3 +45,4 @@ bool(true)
 Datadog-Meta-Lang: php
 
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,70 @@
+--TEST--
+dd_trace() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_WARN_LEGACY_DD_TRACE=0
+--FILE--
+<?php
+# Functions
+var_dump(dd_trace('foo', 'bar'));
+var_dump(dd_trace('foo', ['bar']));
+var_dump(dd_trace('foo', [
+    'bar' => 'baz',
+]));
+var_dump(dd_trace('foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(dd_trace('foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace('foo', [
+    'prehook' => new stdClass(),
+]));
+var_dump(dd_trace('foo', [
+    'posthook' => function () {},
+]));
+var_dump(dd_trace('foo', []));
+
+# Methods
+echo PHP_EOL;
+var_dump(dd_trace('foo', 'foo', 'bar'));
+var_dump(dd_trace('foo', 'foo', ['bar']));
+var_dump(dd_trace('foo', 'foo', [
+    'bar' => 'baz',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'prehook' => 'foo',
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'prehook' => new stdClass(),
+]));
+var_dump(dd_trace('foo', 'foo', [
+    'posthook' => function () {},
+]));
+var_dump(dd_trace('foo', 'foo', []));
+?>
+--EXPECT--
+Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+
+Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+bool(false)

--- a/tests/ext/dd_trace_api_error.phpt
+++ b/tests/ext/dd_trace_api_error.phpt
@@ -45,6 +45,11 @@ var_dump(dd_trace('foo', 'foo', [
     'posthook' => function () {},
 ]));
 var_dump(dd_trace('foo', 'foo', []));
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
@@ -66,3 +71,4 @@ bool(false)
 bool(false)
 bool(false)
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/dd_trace_api_error.phpt
+++ b/tests/ext/dd_trace_api_error.phpt
@@ -47,7 +47,7 @@ var_dump(dd_trace('foo', 'foo', [
 var_dump(dd_trace('foo', 'foo', []));
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 1", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 1", PHP_EOL;
 }
 
 ?>
@@ -71,4 +71,4 @@ bool(false)
 bool(false)
 bool(false)
 bool(false)
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/dd_trace_push_span_id_from_userland.phpt
+++ b/tests/ext/dd_trace_push_span_id_from_userland.phpt
@@ -2,6 +2,7 @@
 Push a span ID onto the stack from userland
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 echo dd_trace_push_span_id('42') . PHP_EOL;

--- a/tests/ext/dd_trace_serialize_msgpack_error-legacy.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error-legacy.phpt
@@ -1,0 +1,43 @@
+--TEST--
+dd_trace_serialize_msgpack() error conditions
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+array_map(function ($data) {
+    var_dump($data, dd_trace_serialize_msgpack($data));
+    echo "\n";
+}, [
+    true,
+    'foo',
+    [new stdClass()],
+    ['bar', stream_context_create()],
+]);
+?>
+--EXPECTF--
+Expected argument to dd_trace_serialize_msgpack() to be an array
+bool(true)
+bool(false)
+
+Expected argument to dd_trace_serialize_msgpack() to be an array
+string(3) "foo"
+bool(false)
+
+Serialize values must be of type array, string, int, float, bool or null
+array(1) {
+  [0]=>
+  object(stdClass)#%d (0) {
+  }
+}
+bool(false)
+
+Serialize values must be of type array, string, int, float, bool or null
+array(2) {
+  [0]=>
+  string(3) "bar"
+  [1]=>
+  resource(%d) of type (stream-context)
+}
+bool(false)

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_serialize_msgpack() error conditions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -39,3 +41,5 @@ array(2) {
   resource(%d) of type (stream-context)
 }
 bool(false)
+
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -42,4 +42,4 @@ array(2) {
 }
 bool(false)
 
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -33,9 +33,15 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($headers['x-datadog-parent-id'] === (string) $spans[0]['span_id']);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -59,7 +59,7 @@ foreach ($responses as $key => $response) {
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 5", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 5", PHP_EOL;
 }
 
 ?>
@@ -85,4 +85,4 @@ x-datadog-parent-id: %d
 x-foo: after-the-copy
 
 Done.
-Successfully triggered auto-flush with trace of size 5
+Successfully triggered flush with trace of size 5

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -57,6 +57,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 5", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -80,3 +85,4 @@ x-datadog-parent-id: %d
 x-foo: after-the-copy
 
 Done.
+Successfully triggered auto-flush with trace of size 5

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -47,7 +47,7 @@ foreach ($responses as $key => $response) {
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 3", PHP_EOL;
 }
 
 ?>
@@ -65,4 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -45,6 +45,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -60,3 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -47,7 +47,7 @@ foreach ($responses as $key => $response) {
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 3", PHP_EOL;
 }
 
 ?>
@@ -65,4 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -45,6 +45,11 @@ foreach ($responses as $key => $response) {
 }
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 3", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 Response #0
@@ -60,3 +65,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
@@ -33,7 +33,13 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump(isset($headers['x-datadog-parent-id']));
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "No finished traces to be sent to the agent", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 bool(false)
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -61,7 +61,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -71,4 +71,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -59,6 +59,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -66,3 +71,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -60,6 +60,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -67,3 +72,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -62,7 +62,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -72,4 +72,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -75,7 +75,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -90,4 +90,4 @@ x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 x-foo: not copied
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -73,6 +73,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -85,3 +90,4 @@ x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 x-foo: not copied
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
@@ -74,7 +74,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -89,4 +89,4 @@ Disabled.
 x-foo: foo
 x-foo: foo
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
@@ -72,6 +72,11 @@ echo 'Disabled.' . PHP_EOL;
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-datadog-origin: phpt-test
@@ -84,3 +89,4 @@ Disabled.
 x-foo: foo
 x-foo: foo
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -73,7 +73,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -87,4 +87,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -71,6 +71,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-ch-1-bar: bar
@@ -82,3 +87,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -77,7 +77,7 @@ doMulti($url);
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
@@ -91,4 +91,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -75,6 +75,11 @@ $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
 doMulti($url);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 x-ch-1-bar: bar
@@ -86,3 +91,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
@@ -34,7 +34,13 @@ dt_dump_headers_from_httpbin($headers, [
 ]);
 
 echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+}
+
 ?>
 --EXPECT--
 x-my-custom-header: foo
 Done.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
@@ -36,11 +36,11 @@ dt_dump_headers_from_httpbin($headers, [
 echo 'Done.' . PHP_EOL;
 
 if (PHP_VERSION_ID < 80000) {
-    echo "Successfully triggered auto-flush with trace of size 2", PHP_EOL;
+    echo "Successfully triggered flush with trace of size 2", PHP_EOL;
 }
 
 ?>
 --EXPECT--
 x-my-custom-header: foo
 Done.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Long running autoflush
+--SKIPIF--
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=false
+DD_TRACE_AUTO_FLUSH_ENABLED=true
+--FILE--
+<?php
+
+require 'functions.inc';
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+const ITERATIONS = 2;
+
+\DDTrace\trace_function('long_running_entry_point', function ($span) {
+    $span->type = 'custom';
+    $span->service = 'pcntl-testing-service';
+});
+
+for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
+    long_running_entry_point();
+    sleep(1);
+    $output = ob_get_contents();
+    ob_end_clean();
+    $lines = explode(PHP_EOL, $output);
+    if ((in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) || in_array("Successfully triggered auto-flush with trace of size 1", $lines)) {
+        echo "OK" . PHP_EOL;
+    }
+}
+
+function long_running_entry_point()
+{
+    call_httpbin();
+
+    $forkPid = pcntl_fork();
+
+    ob_start();
+
+    if ($forkPid > 0) {
+        // Main
+        call_httpbin();
+    } else if ($forkPid === 0) {
+        // Child
+        call_httpbin();
+    } else {
+        error_log('Error');
+        exit(-1);
+    }
+    call_httpbin();
+}
+
+?>
+--EXPECTF--
+OK
+OK
+OK
+OK

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush-legacy.phpt
@@ -30,7 +30,7 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     $output = ob_get_contents();
     ob_end_clean();
     $lines = explode(PHP_EOL, $output);
-    if ((in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) || in_array("Successfully triggered auto-flush with trace of size 1", $lines)) {
+    if ((in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) || in_array("Successfully triggered flush with trace of size 1", $lines)) {
         echo "OK" . PHP_EOL;
     }
 }

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -52,12 +52,12 @@ function long_running_entry_point()
 
 ?>
 --EXPECTF--
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1
 Traces are dropped by PID %d because global 'drop_all_spans' is set.
-Successfully triggered auto-flush with trace of size 1
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1
+Successfully triggered flush with trace of size 1
 Traces are dropped by PID %d because global 'drop_all_spans' is set.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1
 No finished traces to be sent to the agent
 No finished traces to be sent to the agent
 No finished traces to be sent to the agent

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -6,15 +6,15 @@ include __DIR__ . '/../includes/skipif_no_dev_env.inc';
 if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
 if (!extension_loaded('curl')) die('skip: curl extension required');
 ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=false
 DD_TRACE_AUTO_FLUSH_ENABLED=true
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 
 require 'functions.inc';
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 const ITERATIONS = 2;
 
@@ -25,13 +25,7 @@ const ITERATIONS = 2;
 
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     long_running_entry_point();
-    sleep(1);
-    $output = ob_get_contents();
-    ob_end_clean();
-    $lines = explode(PHP_EOL, $output);
-    if (in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) {
-        echo "OK" . PHP_EOL;
-    }
+    usleep(200000);
 }
 
 function long_running_entry_point()
@@ -47,6 +41,7 @@ function long_running_entry_point()
         call_httpbin();
     } else if ($forkPid === 0) {
         // Child
+        usleep(100000);
         call_httpbin();
     } else {
         error_log('Error');
@@ -57,7 +52,13 @@ function long_running_entry_point()
 
 ?>
 --EXPECTF--
-OK
-OK
-OK
-OK
+Successfully triggered auto-flush with trace of size 1
+Traces are dropped by PID %d because global 'drop_all_spans' is set.
+Successfully triggered auto-flush with trace of size 1
+Successfully triggered auto-flush with trace of size 1
+Traces are dropped by PID %d because global 'drop_all_spans' is set.
+Successfully triggered auto-flush with trace of size 1
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent
+No finished traces to be sent to the agent

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -13,11 +13,6 @@ echo dd_trace_env_config("DD_TRACE_AGENT_DEBUG_VERBOSE_CURL") ? 'TRUE' : 'FALSE'
 echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_DEBUG_CURL_OUTPUT") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=";
-echo dd_trace_env_config("DD_TRACE_BETA_SEND_TRACES_VIA_THREAD") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
-echo "DD_TRACE_BGS_ENABLED=", dd_trace_env_config("DD_TRACE_BGS_ENABLED") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
 echo dd_trace_env_config("DD_TRACE_MEMORY_LIMIT");
 echo PHP_EOL;
 echo dd_trace_env_config("DD_NON_EXISTING_ENTRY") === NULL ? 'NULL' : 'NOT_NULL' ;
@@ -32,9 +27,6 @@ echo dd_trace_env_config("trace.agent.debug.verbose.curl") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
 echo dd_trace_env_config("trace.debug.curl.output") ? 'TRUE' : 'FALSE';
 echo PHP_EOL;
-echo "trace.beta.send.traces.via.thread=";
-echo dd_trace_env_config("trace.beta.send.traces.via.thread") ? 'TRUE' : 'FALSE';
-echo PHP_EOL;
 echo dd_trace_env_config("trace.memory.limit");
 echo PHP_EOL;
 echo dd_trace_env_config("non.existing.entry") === NULL ? 'NULL' : 'NOT_NULL' ;
@@ -44,14 +36,11 @@ some_known_host
 8126
 FALSE
 FALSE
-DD_TRACE_BETA_SEND_TRACES_VIA_THREAD=TRUE
-DD_TRACE_BGS_ENABLED=TRUE
 9999
 NULL
 some_known_host
 8126
 FALSE
 FALSE
-trace.beta.send.traces.via.thread=TRUE
 9999
 NULL

--- a/tests/ext/request-init-hook/dd_init_open_basedir-legacy.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Calling dd_init.php is confined to open_basedir settings
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+open_basedir={PWD}
+ddtrace.request_init_hook={PWD}/dd_init_open_basedir.inc
+--FILE--
+<?php
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+Calling dd_init.php from parent directory "%s/includes"
+Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
+Error opening request init hook: %s/dd_init.php
+Done.

--- a/tests/ext/request-init-hook/dd_init_open_basedir.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir.phpt
@@ -16,4 +16,4 @@ Calling dd_init.php from parent directory "%s/includes"
 Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
 Error opening request init hook: %s/dd_init.php
 Done.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/dd_init_open_basedir.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Calling dd_init.php is confined to open_basedir settings
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -14,3 +16,4 @@ Calling dd_init.php from parent directory "%s/includes"
 Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
 Error opening request init hook: %s/dd_init.php
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected-legacy.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected-legacy.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Errors in request init hook do not affect error_get_last()
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+ddtrace.request_init_hook={PWD}/raises_e_notice.php
+--FILE--
+<?php
+var_dump(error_get_last());
+?>
+--EXPECTF--
+%s in request init hook: Undefined variable%sthis_does_not_%s
+NULL

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Errors in request init hook do not affect error_get_last()
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -12,3 +14,4 @@ var_dump(error_get_last());
 --EXPECTF--
 %s in request init hook: Undefined variable%sthis_does_not_%s
 NULL
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -14,4 +14,4 @@ var_dump(error_get_last());
 --EXPECTF--
 %s in request init hook: Undefined variable%sthis_does_not_%s
 NULL
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir-legacy.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Request init hook is confined to open_basedir
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+open_basedir=tests/ext/request-init-hook
+ddtrace.request_init_hook={PWD}/../includes/sanity_check.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -15,4 +15,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Request init hook is confined to open_basedir
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -13,3 +15,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found-legacy.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Do not fail when PHP code couldn't be loaded
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/this_file_doesnt_exist.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -14,4 +14,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Do not fail when PHP code couldn't be loaded
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -12,3 +14,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions-legacy.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Request init hook ignores exceptions
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/throws_exception.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Throwing an exception...
+Exception thrown in request init hook: Oops!
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -15,4 +15,4 @@ echo "Request start" . PHP_EOL;
 Throwing an exception...
 Exception thrown in request init hook: Oops!
 Request start
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Request init hook ignores exceptions
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -13,3 +15,4 @@ echo "Request start" . PHP_EOL;
 Throwing an exception...
 Exception thrown in request init hook: Oops!
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors-legacy.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Request init hook ignores fatal errors
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 50600) die('skip: Cannot recover from fatal errors until PHP 5.6'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/raises_fatal_error.php
+--FILE--
+<?php
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECTF--
+Calling a function that does not exist...
+Error %s in request init hook: Call to undefined function this_function_does_not_%s
+Request start

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -16,4 +16,4 @@ echo "Request start" . PHP_EOL;
 Calling a function that does not exist...
 Error %s in request init hook: Call to undefined function this_function_does_not_%s
 Request start
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -2,6 +2,7 @@
 Request init hook ignores fatal errors
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 50600) die('skip: Cannot recover from fatal errors until PHP 5.6'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -15,3 +16,4 @@ echo "Request start" . PHP_EOL;
 Calling a function that does not exist...
 Error %s in request init hook: Call to undefined function this_function_does_not_%s
 Request start
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox-prehook/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,36 @@
+--TEST--
+[Prehook] API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+# Functions
+var_dump(DDTrace\trace_function('foo', [
+    'prehook' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'prehook' => new stdClass(),
+]));
+
+# Methods
+echo PHP_EOL;
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'prehook' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'prehook' => new stdClass(),
+]));
+?>
+--EXPECT--
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)
+
+Expected 'prehook' to be an instance of Closure
+bool(false)
+Expected 'prehook' to be an instance of Closure
+bool(false)

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -2,6 +2,7 @@
 [Prehook] API error cases
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -33,3 +34,4 @@ Expected 'prehook' to be an instance of Closure
 bool(false)
 Expected 'prehook' to be an instance of Closure
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -34,4 +34,4 @@ Expected 'prehook' to be an instance of Closure
 bool(false)
 Expected 'prehook' to be an instance of Closure
 bool(false)
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox-prehook/dd_trace_method-legacy.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method-legacy.phpt
@@ -1,0 +1,173 @@
+--TEST--
+[Prehook Regression] DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        echo "Test::testFoo()\n";
+    }
+}
+
+class TestService
+{
+    public function testServiceFoo()
+    {
+        echo "TestService::testServiceFoo()\n";
+    }
+}
+
+class Foo
+{
+    public function bar($thoughts, array $bar = [])
+    {
+        echo "Foo::bar()\n";
+        return [
+            'thoughts' => $thoughts,
+            'first' => isset($bar[0]) ? $bar[0] : '(none)',
+            'rand' => mt_rand(42, 999)
+        ];
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+}]);
+DDTrace\trace_method(
+    'Foo', 'bar',
+    ['prehook' => function (SpanData $span, $args) {
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }]
+);
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span, $args) {
+    $span->name = 'MT';
+    $span->meta = [
+        'rand.range' => $args[0] . ' - ' . $args[1],
+    ];
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+$testService = new TestService();
+$testService->testServiceFoo();
+
+$foo = new Foo();
+$ret = $foo->bar('tracing is awesome', ['first', '100', false]);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+Test::testFoo()
+TestService::testServiceFoo()
+Foo::bar()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(3) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(2) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      float(100)
+      ["bar"]=>
+      float(0)
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
+    ["meta"]=>
+    array(1) {
+      ["rand.range"]=>
+      string(8) "42 - 999"
+    }
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -152,7 +152,7 @@ array(3) {
     }
   }
   [2]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -169,6 +169,11 @@ array(3) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -2,8 +2,10 @@
 [Prehook Regression] DDTrace\trace_method() can trace with internal spans
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -118,11 +120,13 @@ array(3) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       float(100)
       ["bar"]=>
       float(0)
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox-prehook/exception_error_log-legacy.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log-legacy.phpt
@@ -1,0 +1,19 @@
+--TEST--
+[Prehook Regression] Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', ['prehook' => function () {
+    throw new RuntimeException("This exception is expected");
+}]);
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
+int(9)

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -17,4 +17,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -2,6 +2,7 @@
 [Prehook Regression] Exception in tracing closure gets logged
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -16,3 +17,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
@@ -1,0 +1,60 @@
+--TEST--
+[Prehook Regression] Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5');
+if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans');
+?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        mt_srand(42);
+        printf(
+            "Test::testFoo() fav num: %d\n",
+            mt_rand()
+        );
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', ['prehook' => function (SpanData $span) {
+    $span->name = 'TestFoo';
+    $span->service = $this_normally_raises_an_error;
+}]);
+
+DDTrace\trace_function('mt_srand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTSeed';
+    throw new Exception('This should be ignored');
+}]);
+
+DDTrace\trace_function('mt_rand', ['prehook' => function (SpanData $span) {
+    $span->name = 'MTRand';
+    htmlentities('<b>', 0, 'BIG5'); // E_STRICT
+}]);
+
+$test = new Test();
+$test->testFoo();
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECTF--
+%s in ddtrace's closure for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+Exception thrown in ddtrace's closure for mt_srand(): This should be ignored
+Error raised in ddtrace's closure for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+Test::testFoo() fav num: %d
+TestFoo
+MTRand
+MTSeed
+NULL

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -1,7 +1,10 @@
 --TEST--
 [Prehook Regression] Exceptions and errors are ignored when inside a tracing closure
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php
+if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5');
+if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans');
+?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
@@ -55,3 +58,4 @@ TestFoo
 MTRand
 MTSeed
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox-prehook/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -3,6 +3,7 @@
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_SPANS_LIMIT=5
 --FILE--
 <?php

--- a/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
@@ -35,3 +35,4 @@ HOOK 1
 Cannot overwrite existing dispatch for 'm()'
 METHOD
 HOOK 1
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_accessing_outside_variables_php8.phpt
@@ -35,4 +35,4 @@ HOOK 1
 Cannot overwrite existing dispatch for 'm()'
 METHOD
 HOOK 1
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3

--- a/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
@@ -51,3 +51,4 @@ METHOD 1
 HOOK 11
 METHOD 10
 HOOK 20
+Successfully triggered auto-flush with trace of size 4

--- a/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
+++ b/tests/ext/sandbox-regression/closure_set_inside_object_methods_php8.phpt
@@ -51,4 +51,4 @@ METHOD 1
 HOOK 11
 METHOD 10
 HOOK 20
-Successfully triggered auto-flush with trace of size 4
+Successfully triggered flush with trace of size 4

--- a/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
+++ b/tests/ext/sandbox-regression/dd_trace_tracer_is_limited_hard.phpt
@@ -3,6 +3,7 @@
 --ENV--
 DD_TRACE_SPANS_LIMIT=1000
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 DDTrace\trace_function('array_sum', function () {});

--- a/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
+++ b/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
@@ -56,4 +56,4 @@ METHOD
 METHOD HOOK
 FUNCTION
 FUNCTION HOOK
-Successfully triggered auto-flush with trace of size 5
+Successfully triggered flush with trace of size 5

--- a/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
+++ b/tests/ext/sandbox-regression/reset_configured_overrides_php8.phpt
@@ -56,3 +56,4 @@ METHOD
 METHOD HOOK
 FUNCTION
 FUNCTION HOOK
+Successfully triggered auto-flush with trace of size 5

--- a/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
@@ -25,4 +25,4 @@ Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_a
 Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_b
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3

--- a/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
+++ b/tests/ext/sandbox-regression/used_dispatch_should_not_free_php8.phpt
@@ -25,3 +25,4 @@ Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_a
 Cannot overwrite existing dispatch for 'test()'
 OLD HOOK METHOD exec_b
+Successfully triggered auto-flush with trace of size 3

--- a/tests/ext/sandbox/auto_flush-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush-legacy.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+DDTrace\trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main (main)
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main (main)
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main (main)
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -35,14 +35,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 10
 15
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 21
 28
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
@@ -34,24 +35,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Flushing tracer...
-main (main)
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 10
 15
-Flushing tracer...
-main (main)
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 21
 28
-Flushing tracer...
-main (main)
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_attach_exception-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception-legacy.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Auto-flushing will attach an exception during exception cleanup
+--DESCRIPTION--
+@see https://github.com/DataDog/dd-trace-php/issues/879
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer...
+Foo.bar (Foo.bar) (error: Oops!)
+Tracer reset
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -2,14 +2,14 @@
 Auto-flushing will attach an exception during exception cleanup
 --DESCRIPTION--
 @see https://github.com/DataDog/dd-trace-php/issues/879
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 class Foo
 {
@@ -36,7 +36,6 @@ try {
 }
 ?>
 --EXPECT--
-Flushing tracer...
-Foo.bar (Foo.bar) (error: Oops!)
-Tracer reset
 Caught exception: Oops!
+Successfully triggered auto-flush with trace of size 2
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -37,5 +37,5 @@ try {
 ?>
 --EXPECT--
 Caught exception: Oops!
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_disables_tracing-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing-legacy.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Auto-flushing will not instrument while flushing
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+// This is called from the flush() method of the fake tracer
+DDTrace\trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
+    $span->name = 'fake_curl_exec';
+});
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+DDTrace\trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main($max) {
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Flushing tracer...
+main (main)
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Flushing tracer...
+main (main)
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Flushing tracer...
+main (main)
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Auto-flushing will not instrument while flushing
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 // This is called from the flush() method of the fake tracer
 DDTrace\trace_function('DDTrace\\fake_curl_exec', function (SpanData $span) {
@@ -39,24 +40,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Flushing tracer...
-main (main)
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 10
 15
-Flushing tracer...
-main (main)
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
 
 21
 28
-Flushing tracer...
-main (main)
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 3
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -40,14 +40,14 @@ echo PHP_EOL;
 --EXPECT--
 3
 6
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 10
 15
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 21
 28
-Successfully triggered auto-flush with trace of size 3
+Successfully triggered flush with trace of size 3
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_sandbox_exception-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception-legacy.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Auto-flushing will sandbox an exception thrown from the tracer flush
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer_exception.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+class Foo
+{
+    public function bar()
+    {
+        $this->doException();
+    }
+
+    private function doException()
+    {
+        throw new Exception('Oops!');
+    }
+}
+
+DDTrace\trace_method('Foo', 'bar', function (SpanData $span) {
+    $span->name = 'Foo.bar';
+});
+
+$foo = new Foo();
+try {
+    $foo->bar();
+} catch (Exception $e) {
+    echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Flushing tracer with exception...
+Unable to auto flush the tracer
+Caught exception: Oops!

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Auto-flushing will sandbox an exception thrown from the tracer flush
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer_exception.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 class Foo
 {
@@ -35,6 +35,6 @@ try {
 }
 ?>
 --EXPECT--
-Flushing tracer with exception...
-Unable to auto flush the tracer
+Successfully triggered auto-flush with trace of size 1
 Caught exception: Oops!
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -35,6 +35,6 @@ try {
 }
 ?>
 --EXPECT--
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1
 Caught exception: Oops!
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_userland_root_span-legacy.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span-legacy.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Userland root spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+require __DIR__ . '/../includes/fake_tracer.inc';
+require __DIR__ . '/../includes/fake_global_tracer.inc';
+
+DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
+    $span->name = 'array_sum';
+    $span->resource = $retval;
+});
+
+function main($max) {
+    // Emulate opening a userland span
+    dd_trace_push_span_id();
+    echo array_sum(range(0, $max)) . PHP_EOL;
+    echo array_sum(range(0, $max + 1)) . PHP_EOL;
+    echo 'Has not flushed yet.' . PHP_EOL;
+    // Emulate closing a userland span
+    dd_trace_pop_span_id();
+}
+
+main(2);
+echo PHP_EOL;
+main(4);
+echo PHP_EOL;
+main(6);
+echo PHP_EOL;
+?>
+--EXPECT--
+3
+6
+Has not flushed yet.
+Flushing tracer...
+array_sum (6)
+array_sum (3)
+Tracer reset
+
+10
+15
+Has not flushed yet.
+Flushing tracer...
+array_sum (15)
+array_sum (10)
+Tracer reset
+
+21
+28
+Has not flushed yet.
+Flushing tracer...
+array_sum (28)
+array_sum (21)
+Tracer reset

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -1,14 +1,15 @@
 --TEST--
 Userland root spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_DEBUG=1
 --FILE--
 <?php
 use DDTrace\SpanData;
-
-require __DIR__ . '/../includes/fake_tracer.inc';
-require __DIR__ . '/../includes/fake_global_tracer.inc';
 
 DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
     $span->name = 'array_sum';
@@ -36,23 +37,16 @@ echo PHP_EOL;
 3
 6
 Has not flushed yet.
-Flushing tracer...
-array_sum (6)
-array_sum (3)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
 
 10
 15
 Has not flushed yet.
-Flushing tracer...
-array_sum (15)
-array_sum (10)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
 
 21
 28
 Has not flushed yet.
-Flushing tracer...
-array_sum (28)
-array_sum (21)
-Tracer reset
+Successfully triggered auto-flush with trace of size 2
+
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -37,16 +37,16 @@ echo PHP_EOL;
 3
 6
 Has not flushed yet.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2
 
 10
 15
 Has not flushed yet.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2
 
 21
 28
 Has not flushed yet.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/dd_trace_api_error-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error-legacy.phpt
@@ -1,0 +1,73 @@
+--TEST--
+DDTrace\trace_function() and DDTrace\trace_method() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+# Functions
+var_dump(DDTrace\trace_function('foo', 'bar'));
+var_dump(DDTrace\trace_function('foo', ['bar']));
+var_dump(DDTrace\trace_function('foo', [
+    'bar' => 'baz',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'posthook' => 'foo',
+]));
+var_dump(DDTrace\trace_function('foo', [
+    'posthook' => new stdClass(),
+]));
+var_dump(DDTrace\trace_function('foo', []));
+
+# Methods
+echo PHP_EOL;
+var_dump(DDTrace\trace_method('foo', 'foo', 'bar'));
+var_dump(DDTrace\trace_method('foo', 'foo', ['bar']));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'bar' => 'baz',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'instrument_when_limited' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'posthook' => 'foo',
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', [
+    'posthook' => new stdClass(),
+]));
+var_dump(DDTrace\trace_method('foo', 'foo', []));
+?>
+--EXPECT--
+Unexpected parameters, expected (function_name, tracing_closure | config_array)
+bool(false)
+Expected config_array to be an associative array
+bool(false)
+Unknown option 'bar' in config_array
+bool(false)
+Expected 'instrument_when_limited' to be an int
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Required key 'posthook' or 'prehook' not found in config_array
+bool(false)
+
+Unexpected parameters, expected (class_name, method_name, tracing_closure | config_array)
+bool(false)
+Expected config_array to be an associative array
+bool(false)
+Unknown option 'bar' in config_array
+bool(false)
+Expected 'instrument_when_limited' to be an int
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Expected 'posthook' to be an instance of Closure
+bool(false)
+Required key 'posthook' or 'prehook' not found in config_array
+bool(false)

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -71,4 +71,4 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 Required key 'posthook' or 'prehook' not found in config_array
 bool(false)
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\trace_function() and DDTrace\trace_method() declarative API error cases
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -69,3 +71,4 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 Required key 'posthook' or 'prehook' not found in config_array
 bool(false)
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_function() is aliased to DDTrace\trace_function()
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_function_complex-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex-legacy.phpt
@@ -1,0 +1,212 @@
+--TEST--
+DDTrace\trace_function() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function testFoo()
+{
+    echo "testFoo()\n";
+}
+
+function addOne($num)
+{
+    echo "addOne()\n";
+    return $num + 1;
+}
+
+function bar($thoughts, array $bar = [])
+{
+    echo "bar()\n";
+    return [
+        'thoughts' => $thoughts,
+        'first' => isset($bar[0]) ? $bar[0] : '(none)',
+        'rand' => array_sum([
+            mt_rand(0, 100),
+            addOne(mt_rand(0, 100)),
+        ])
+    ];
+}
+
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'ArraySum';
+}));
+var_dump(DDTrace\trace_function('mt_rand', null));
+var_dump(DDTrace\trace_function('testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+}));
+var_dump(DDTrace\trace_function('addOne', function (SpanData $span) {
+    $span->name = 'AddOne';
+}));
+var_dump(DDTrace\trace_function(
+    'bar',
+    function (SpanData $span, $args, $retval) {
+        $span->name = 'BarName';
+        $span->resource = 'BarResource';
+        $span->service = 'BarService';
+        $span->type = 'BarType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+            'retval.thoughts' => isset($retval['thoughts']) ? $retval['thoughts'] : '',
+            'retval.first' => isset($retval['first']) ? $retval['first'] : '',
+            'retval.rand' => isset($retval['rand']) ? $retval['rand'] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }
+));
+
+testFoo();
+var_dump(addOne(0));
+$ret = bar('tracing is awesome', ['first', 1.2, '25']);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+testFoo()
+addOne()
+int(1)
+bar()
+addOne()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(5) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "BarName"
+    ["resource"]=>
+    string(11) "BarResource"
+    ["service"]=>
+    string(10) "BarService"
+    ["type"]=>
+    string(7) "BarType"
+    ["meta"]=>
+    array(5) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["retval.thoughts"]=>
+      string(18) "tracing is awesome"
+      ["retval.first"]=>
+      string(5) "first"
+      ["retval.rand"]=>
+      string(%d) "%d"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      float(1.2)
+      ["bar"]=>
+      float(25)
+    }
+  }
+  [1]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(8) "ArraySum"
+    ["resource"]=>
+    string(8) "ArraySum"
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
+  }
+  [3]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(6) "AddOne"
+    ["resource"]=>
+    string(6) "AddOne"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+  [4]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -170,7 +170,7 @@ array(5) {
     string(6) "AddOne"
   }
   [3]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -188,9 +188,14 @@ array(5) {
       ["system.pid"]=>
       string(%d) "%d"
     }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
   }
   [4]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -207,6 +212,11 @@ array(5) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_function() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php
@@ -123,11 +126,13 @@ array(5) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       float(1.2)
       ["bar"]=>
       float(25)
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_function_internal-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal-legacy.phpt
@@ -1,0 +1,50 @@
+--TEST--
+DDTrace\trace_function() can trace internal functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(DDTrace\trace_function('array_sum', function (SpanData $span) {
+    $span->name = 'ArraySum';
+}));
+
+var_dump(array_sum([1, 3, 5]));
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+int(9)
+---
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(8) "ArraySum"
+    ["resource"]=>
+    string(8) "ArraySum"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_function() can trace internal functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
 --FILE--
 <?php
@@ -23,7 +26,7 @@ int(9)
 ---
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -40,6 +43,11 @@ array(1) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_function_userland-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland-legacy.phpt
@@ -1,0 +1,64 @@
+--TEST--
+DDTrace\trace_function() can trace userland functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+var_dump(DDTrace\trace_function('filter_to_array', function (SpanData $span) {
+    $span->name = 'filter_to_array';
+}));
+
+function filter_to_array($fn, $input) {
+    $output = array();
+    foreach ($input as $x) {
+        if (call_user_func($fn, $x)) {
+            $output[] = $x;
+        }
+    }
+    return $output;
+}
+
+$is_odd = function ($x) {
+    return $x % 2 == 1;
+};
+
+var_export(filter_to_array($is_odd, array(1, 2, 3)));
+
+echo "\n---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+array (
+  0 => 1,
+  1 => 3,
+)
+---
+array(1) {
+  [0]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(15) "filter_to_array"
+    ["resource"]=>
+    string(15) "filter_to_array"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -40,7 +40,7 @@ array (
 ---
 array(1) {
   [0]=>
-  array(8) {
+  array(7) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -55,11 +55,6 @@ array(1) {
     string(15) "filter_to_array"
     ["resource"]=>
     string(15) "filter_to_array"
-    ["metrics"]=>
-    array(1) {
-      ["php.compilation.total_time_ms"]=>
-      float(%f)
-    }
   }
 }
 array(0) {

--- a/tests/ext/sandbox/dd_trace_function_userland.phpt
+++ b/tests/ext/sandbox/dd_trace_function_userland.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\trace_function() can trace userland functions with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -38,10 +40,12 @@ array (
 ---
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
     string(%d) "%d"
     ["start"]=>
     int(%d)
@@ -51,10 +55,10 @@ array(1) {
     string(15) "filter_to_array"
     ["resource"]=>
     string(15) "filter_to_array"
-    ["meta"]=>
+    ["metrics"]=>
     array(1) {
-      ["system.pid"]=>
-      string(%d) "%d"
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_method-legacy.phpt
+++ b/tests/ext/sandbox/dd_trace_method-legacy.phpt
@@ -1,0 +1,190 @@
+--TEST--
+DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        echo "Test::testFoo()\n";
+    }
+}
+
+class TestService
+{
+    public function testServiceFoo()
+    {
+        echo "TestService::testServiceFoo()\n";
+    }
+}
+
+class Foo
+{
+    public function bar($thoughts, array $bar = [])
+    {
+        echo "Foo::bar()\n";
+        return [
+            'thoughts' => $thoughts,
+            'first' => isset($bar[0]) ? $bar[0] : '(none)',
+            'rand' => mt_rand(42, 999)
+        ];
+    }
+}
+
+var_dump(DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+}));
+var_dump(DDTrace\trace_method('TestService', 'testServiceFoo', null));
+var_dump(DDTrace\trace_method(
+    'Foo', 'bar',
+    function (SpanData $span, $args, $retval) {
+        $span->name = 'FooName';
+        $span->resource = 'FooResource';
+        $span->service = 'FooService';
+        $span->type = 'FooType';
+        $span->meta = [
+            'args.0' => isset($args[0]) ? $args[0] : '',
+            'retval.thoughts' => isset($retval['thoughts']) ? $retval['thoughts'] : '',
+            'retval.first' => isset($retval['first']) ? $retval['first'] : '',
+            'retval.rand' => isset($retval['rand']) ? $retval['rand'] : '',
+        ];
+        $span->metrics = [
+            'foo' => isset($args[1][1]) ? $args[1][1] : '',
+            'bar' => isset($args[1][2]) ? $args[1][2] : '',
+        ];
+    }
+));
+var_dump(DDTrace\trace_function('mt_rand', function (SpanData $span, $args, $retval) {
+    $span->name = 'MT';
+    $span->meta = [
+        'rand.range' => $args[0] . ' - ' . $args[1],
+        'rand.value' => $retval,
+    ];
+}));
+
+$test = new Test();
+$test->testFoo();
+
+$testService = new TestService();
+$testService->testServiceFoo();
+
+$foo = new Foo();
+$ret = $foo->bar('tracing is awesome', ['first', '100', false]);
+var_dump($ret);
+
+echo "---\n";
+
+var_dump(dd_trace_serialize_closed_spans());
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+Test::testFoo()
+TestService::testServiceFoo()
+Foo::bar()
+array(3) {
+  ["thoughts"]=>
+  string(18) "tracing is awesome"
+  ["first"]=>
+  string(5) "first"
+  ["rand"]=>
+  int(%d)
+}
+---
+array(3) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "FooName"
+    ["resource"]=>
+    string(11) "FooResource"
+    ["service"]=>
+    string(10) "FooService"
+    ["type"]=>
+    string(7) "FooType"
+    ["meta"]=>
+    array(5) {
+      ["args.0"]=>
+      string(18) "tracing is awesome"
+      ["retval.thoughts"]=>
+      string(18) "tracing is awesome"
+      ["retval.first"]=>
+      string(5) "first"
+      ["retval.rand"]=>
+      string(%d) "%d"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(2) {
+      ["foo"]=>
+      float(100)
+      ["bar"]=>
+      float(0)
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(2) "MT"
+    ["resource"]=>
+    string(2) "MT"
+    ["meta"]=>
+    array(2) {
+      ["rand.range"]=>
+      string(8) "42 - 999"
+      ["rand.value"]=>
+      string(%d) "%d"
+    }
+  }
+  [2]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(7) "TestFoo"
+    ["resource"]=>
+    string(7) "TestFoo"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}
+array(0) {
+}

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -168,7 +168,7 @@ array(3) {
     }
   }
   [2]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -185,6 +185,11 @@ array(3) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -1,6 +1,9 @@
 --TEST--
 DDTrace\trace_method() can trace with internal spans
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
 --FILE--
 <?php
@@ -131,11 +134,13 @@ array(3) {
       string(%d) "%d"
     }
     ["metrics"]=>
-    array(2) {
+    array(3) {
       ["foo"]=>
       float(100)
       ["bar"]=>
       float(0)
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
   [1]=>

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -1,5 +1,7 @@
 --TEST--
 dd_trace_method() is aliased to DDTrace\trace_method()
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_push_span_id.phpt
+++ b/tests/ext/sandbox/dd_trace_push_span_id.phpt
@@ -1,6 +1,7 @@
 --TEST--
 dd_trace_push_span_id() Generates a 63-bit unsigned int as a string and stores on a stack
 --ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_DEBUG_PRNG_SEED=42
 --FILE--
 <?php

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -3,6 +3,7 @@ Set the trace ID from userland
 --ENV--
 DD_TRACE_DEBUG_PRNG_SEED=42
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -2,6 +2,7 @@
 Span properties defaults to values if not explicitly set (functions)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,range
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -2,6 +2,7 @@
 Span properties defaults to values if not explicitly set (methods)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::__construct,DateTime::format
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once-legacy.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once-legacy.phpt
@@ -1,0 +1,45 @@
+--TEST--
+deferred loading only happens once, even if dispatch is not overwritten
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+_DD_LOAD_TEST_INTEGRATIONS=1
+DD_TRACE_DEBUG=1
+--INI--
+ddtrace.request_init_hook={PWD}/deferred_loading_helper.php
+--FILE--
+<?php
+
+namespace DDTrace\Test
+{
+    use DDTrace\Integrations\Integration;
+
+    class TestSandboxedIntegration extends Integration
+    {
+        function init()
+        {
+            echo "autoload_attempted" . PHP_EOL;
+            return Integration::LOADED;
+        }
+    }
+}
+
+namespace
+{
+    class Test
+    {
+        public static function public_static_method()
+        {
+            echo "PUBLIC STATIC METHOD" . PHP_EOL;
+        }
+    }
+
+    Test::public_static_method();
+    Test::public_static_method();
+}
+?>
+--EXPECT--
+autoload_attempted
+PUBLIC STATIC METHOD
+PUBLIC STATIC METHOD

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
@@ -43,4 +43,4 @@ namespace
 autoload_attempted
 PUBLIC STATIC METHOD
 PUBLIC STATIC METHOD
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
@@ -2,6 +2,7 @@
 deferred loading only happens once, even if dispatch is not overwritten
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip: Prehook not supported on PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_TRACE_DEBUG=1
@@ -42,3 +43,4 @@ namespace
 autoload_attempted
 PUBLIC STATIC METHOD
 PUBLIC STATIC METHOD
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/errors_are_flagged_from_userland-legacy.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland-legacy.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Errors from userland will be flagged on span
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function testErrorFromUserland()
+{
+    echo "testErrorFromUserland()\n";
+}
+
+DDTrace\trace_function('testErrorFromUserland', function (SpanData $span) {
+    $span->name = 'testErrorFromUserland';
+    $span->meta = ['error.msg' => 'Foo error'];
+});
+
+testErrorFromUserland();
+
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+testErrorFromUserland()
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(21) "testErrorFromUserland"
+    ["resource"]=>
+    string(21) "testErrorFromUserland"
+    ["error"]=>
+    int(1)
+    ["meta"]=>
+    array(2) {
+      ["error.msg"]=>
+      string(9) "Foo error"
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+  }
+}

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Errors from userland will be flagged on span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -22,7 +26,7 @@ var_dump(dd_trace_serialize_closed_spans());
 testErrorFromUserland()
 array(1) {
   [0]=>
-  array(8) {
+  array(9) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -43,6 +47,11 @@ array(1) {
       string(9) "Foo error"
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
+++ b/tests/ext/sandbox/exception_does_not_close_span_that_catches.phpt
@@ -50,7 +50,7 @@ echo main() . PHP_EOL;
 list($mainSpan, $handleSpan, $handleExceptionSpan) = dd_trace_serialize_closed_spans();
 
 echo $mainSpan['name'] . $mainSpan['resource'] . PHP_EOL;
-var_dump(!isset($mainSpan['parent_id']));
+var_dump((PHP_VERSION_ID >= 80000) == isset($mainSpan['parent_id'])); // root span
 
 echo $handleSpan['name'] . $handleSpan['resource'] . PHP_EOL;
 var_dump($handleSpan['parent_id'] === $mainSpan['span_id']);

--- a/tests/ext/sandbox/exception_error_log-legacy.phpt
+++ b/tests/ext/sandbox/exception_error_log-legacy.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', function () {
+    throw new RuntimeException("This exception is expected");
+});
+$sum = array_sum([1, 3, 5]);
+var_dump($sum);
+?>
+--EXPECT--
+RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
+int(9)

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Exception in tracing closure gets logged
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -14,3 +16,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -16,4 +16,4 @@ var_dump($sum);
 --EXPECT--
 RuntimeException thrown in ddtrace's closure for array_sum(): This exception is expected
 int(9)
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure-legacy.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Test
+{
+    public function testFoo()
+    {
+        mt_srand(42);
+        printf(
+            "Test::testFoo() fav num: %d\n",
+            mt_rand()
+        );
+    }
+}
+
+DDTrace\trace_method('Test', 'testFoo', function (SpanData $span) {
+    $span->name = 'TestFoo';
+    $span->service = $this_normally_raises_an_error;
+});
+
+DDTrace\trace_function('mt_srand', function (SpanData $span) {
+    $span->name = 'MTSeed';
+    throw new Exception('This should be ignored');
+});
+
+DDTrace\trace_function('mt_rand', function (SpanData $span) {
+    $span->name = 'MTRand';
+    htmlentities('<b>', 0, 'BIG5'); // E_STRICT
+});
+
+$test = new Test();
+$test->testFoo();
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECTF--
+Exception thrown in ddtrace's closure for mt_srand(): This should be ignored
+Error raised in ddtrace's closure for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+Test::testFoo() fav num: %d
+%s in ddtrace's closure for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+TestFoo
+MTRand
+MTSeed
+NULL

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Exceptions and errors are ignored when inside a tracing closure
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand,mt_srand
@@ -53,3 +55,4 @@ TestFoo
 MTRand
 MTSeed
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown-legacy.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown-legacy.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Fatal errors are ignored in shutdown handler
+--DESCRIPTION--
+This is how the tracer sandboxes the flushing functionality in userland
+--SKIPIF--
+<?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--INI--
+memory_limit=2M
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+function flushTracer() {
+    // Flushing happens in sandboxed tracing closure after the call.
+    // Return a value from runtime to prevent Opcache from skipping the call.
+    return mt_rand();
+}
+
+register_shutdown_function(function () {
+    // Fatal errors will cause the same behavior as an "exit" (zend_bailout)
+    // which prevents the rest of the shutdown handlers from being run.
+    // We register the shutdown handler during shutdown to ensure this one is
+    // the last one to run.
+    // This will ensure that:
+    // 1) Code in shutdown hooks can be instrumented
+    // 2) If a fatal error occurs during flush, it will not affect the user's shutdown hooks
+    register_shutdown_function(function () {
+        // We wrap the call in a closure to prevent Opcache from skipping the call.
+        flushTracer();
+    });
+});
+
+register_shutdown_function(function () {
+    echo 'Some user\'s shutdown' . PHP_EOL;
+    var_dump(array_sum([10, 10, 10]));
+    var_dump(error_get_last());
+});
+
+DDTrace\trace_function('flushTracer', function () {
+    echo 'Flushing...' . PHP_EOL;
+    array_map(function($span) {
+        echo $span['name'] . PHP_EOL;
+    }, dd_trace_serialize_closed_spans());
+    // Trigger a fatal error (hit the memory limit)
+    $a = str_repeat('.', 1024 * 1024 * 3); // 3MB
+    echo 'You should not see this.' . PHP_EOL;
+    var_dump(error_get_last());
+});
+
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum';
+});
+
+var_dump(array_sum([1, 2, 3]));
+var_dump(array_sum([4, 5, 6]));
+var_dump(array_sum([7, 8, 9]));
+?>
+--EXPECT--
+int(6)
+int(15)
+int(24)
+Some user's shutdown
+int(30)
+NULL
+Flushing...
+array_sum
+array_sum
+array_sum
+array_sum

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -4,6 +4,7 @@ Fatal errors are ignored in shutdown handler
 This is how the tracer sandboxes the flushing functionality in userland
 --SKIPIF--
 <?php if (getenv('USE_ZEND_ALLOC') === '0') die('skip Zend memory manager required'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --INI--
 memory_limit=2M
 --ENV--
@@ -68,3 +69,4 @@ array_sum
 array_sum
 array_sum
 array_sum
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7-legacy.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7-legacy.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Fatal errors are ignored inside a tracing closure (PHP 7)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--FILE--
+<?php
+DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {
+    $span->name = 'array_sum';
+    this_function_does_not_exist();
+});
+
+var_dump(array_sum([1, 99]));
+
+array_map(function($span) {
+    echo $span['name'] . PHP_EOL;
+}, dd_trace_serialize_closed_spans());
+var_dump(error_get_last());
+?>
+--EXPECT--
+Error thrown in ddtrace's closure for array_sum(): Call to undefined function this_function_does_not_exist()
+int(100)
+array_sum
+NULL

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure_php7.phpt
@@ -2,6 +2,7 @@
 Fatal errors are ignored inside a tracing closure (PHP 7)
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70000) die('skip Fatal errors cannot be ignored in PHP 5'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -24,3 +25,4 @@ Error thrown in ddtrace's closure for array_sum(): Call to undefined function th
 int(100)
 array_sum
 NULL
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/hook_function/03-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/03-legacy.phpt
@@ -1,0 +1,23 @@
+--TEST--
+DDTrace\hook_function returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+var_dump(DDTrace\hook_function('greet'));
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECT--
+DDTrace\hook_function was given neither prehook nor posthook.
+bool(false)
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_function/03.phpt
+++ b/tests/ext/sandbox/hook_function/03.phpt
@@ -21,4 +21,4 @@ greet('Datadog');
 DDTrace\hook_function was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/03.phpt
+++ b/tests/ext/sandbox/hook_function/03.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -19,3 +21,4 @@ greet('Datadog');
 DDTrace\hook_function was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02-legacy.phpt
@@ -1,0 +1,31 @@
+--TEST--
+DDTrace\hook_function posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    null,
+    function ($args, $retval) {
+        echo "greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECTF--
+Hello, Datadog.
+greet hooked.
+%s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s

--- a/tests/ext/sandbox/hook_function/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02.phpt
@@ -29,4 +29,4 @@ greet('Datadog');
 Hello, Datadog.
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -27,3 +29,4 @@ greet('Datadog');
 Hello, Datadog.
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04-legacy.phpt
@@ -1,0 +1,35 @@
+--TEST--
+DDTrace\hook_function posthook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('array_sum',
+    null,
+    function ($args, $retval) {
+        echo "array_sum hooked.\n";
+        assert($args == [[1, 3]]);
+        assert($retval === 4);
+        throw new Exception('!');
+    }
+);
+
+try {
+    $sum = array_sum([1, 3]);
+    echo "Sum = {$sum}.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+array_sum hooked.
+Exception thrown in ddtrace's closure for array_sum(): !
+Sum = 4.

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function posthook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -31,3 +33,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
@@ -33,4 +33,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02-legacy.phpt
@@ -1,0 +1,30 @@
+--TEST--
+DDTrace\hook_function prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    function ($args) {
+        echo "greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+greet('Datadog');
+
+?>
+--EXPECTF--
+greet hooked.
+%s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_function/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -26,3 +28,4 @@ greet('Datadog');
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02.phpt
@@ -28,4 +28,4 @@ greet('Datadog');
 greet hooked.
 %s in ddtrace's closure for greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02-legacy.phpt
@@ -1,0 +1,38 @@
+--TEST--
+DDTrace\hook_function prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('greet',
+    function ($args) {
+        echo "greet hooked.\n";
+        assert($args == ['Datadog']);
+        throw new Exception('!');
+    }
+);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+}
+
+try {
+    greet('Datadog');
+    echo "Done.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+greet hooked.
+Exception thrown in ddtrace's closure for greet(): !
+Hello, Datadog.
+Done.

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
@@ -36,4 +36,4 @@ greet hooked.
 Exception thrown in ddtrace's closure for greet(): !
 Hello, Datadog.
 Done.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -34,3 +36,4 @@ greet hooked.
 Exception thrown in ddtrace's closure for greet(): !
 Hello, Datadog.
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04-legacy.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04-legacy.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DDTrace\hook_function prehook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
+--INI--
+zend.assertions=1
+assert.exception=1
+--FILE--
+<?php
+
+DDTrace\hook_function('array_sum',
+    function ($args) {
+        echo "array_sum hooked.\n";
+        assert($args == [[1, 3]]);
+        throw new Exception('!');
+    }
+);
+
+try {
+    $sum = array_sum([1, 3]);
+    echo "Sum = {$sum}.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+array_sum hooked.
+Exception thrown in ddtrace's closure for array_sum(): !
+Sum = 4.

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
@@ -31,4 +31,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_function prehook exception is sandboxed (debug internal)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
@@ -29,3 +31,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure for array_sum(): !
 Sum = 4.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/03-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/03-legacy.phpt
@@ -1,0 +1,26 @@
+--TEST--
+DDTrace\hook_method returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+var_dump(DDTrace\hook_method('Greeter', 'greet'));
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECT--
+DDTrace\hook_method was given neither prehook nor posthook.
+bool(false)
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_method/03.phpt
+++ b/tests/ext/sandbox/hook_method/03.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method returns false with diagnostic when no hook is passed
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -22,3 +24,4 @@ Greeter::greet('Datadog');
 DDTrace\hook_method was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/03.phpt
+++ b/tests/ext/sandbox/hook_method/03.phpt
@@ -24,4 +24,4 @@ Greeter::greet('Datadog');
 DDTrace\hook_method was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/posthook_07-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07-legacy.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Nested closure targeting method call 02 (posthook)
+--DESCRIPTION--
+In PHP 5 you cannot bind a static closure to an object. It's not always
+obvious when a closure is automatically static.
+
+In this one, we're making sure that a tracing closure still works when:
+  - It is defined inside another closure that does have a scope.
+  - It is targeting a method.
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+final class Integration
+{
+    public function init()
+    {
+        /* calling hook_method from method scope, not global, is important for
+         * this particular test
+         */
+        DDTrace\hook_method('App', '__construct',
+            null,
+            function () {
+                DDTrace\trace_method('App', 'run',
+                    function () {
+                        echo "App::run traced.\n";
+                    }
+                );
+                echo "App::__construct hooked.\n";
+            }
+        );
+    }
+}
+
+final class App
+{
+    public function __construct()
+    {
+    }
+
+    public function run()
+    {
+        echo __METHOD__, "\n";
+    }
+}
+
+$integration = new Integration();
+$integration->init();
+
+$app = new App();
+$app->run();
+
+?>
+--EXPECT--
+App::__construct hooked.
+App::run
+App::run traced.

--- a/tests/ext/sandbox/hook_method/posthook_07.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07.phpt
@@ -7,6 +7,8 @@ obvious when a closure is automatically static.
 In this one, we're making sure that a tracing closure still works when:
   - It is defined inside another closure that does have a scope.
   - It is targeting a method.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -56,3 +58,4 @@ $app->run();
 App::__construct hooked.
 App::run
 App::run traced.
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/hook_method/posthook_07.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07.phpt
@@ -58,4 +58,4 @@ $app->run();
 App::__construct hooked.
 App::run
 App::run traced.
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/sandbox/hook_method/posthook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DDTrace\hook_method posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    null,
+    function ($args, $retval) {
+        echo "Greeter::greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECTF--
+Hello, Datadog.
+Greeter::greet hooked.
+%s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s

--- a/tests/ext/sandbox/hook_method/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02.phpt
@@ -32,4 +32,4 @@ Greeter::greet('Datadog');
 Hello, Datadog.
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method posthook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -30,3 +32,4 @@ Greeter::greet('Datadog');
 Hello, Datadog.
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
@@ -52,4 +52,4 @@ Cannot overwrite existing dispatch for 'greet()'
 bool(false)
 Greeter::greet hooked.
 Hello, Datadog.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_04_php8.phpt
@@ -52,3 +52,4 @@ Cannot overwrite existing dispatch for 'greet()'
 bool(false)
 Greeter::greet hooked.
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_error_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+DDTrace\hook_method prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    function ($args) {
+        echo "Greeter::greet hooked.\n";
+        $i = $this_normally_raises_an_error;
+    }
+);
+
+
+final class Greeter
+{
+    public static function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+Greeter::greet('Datadog');
+
+?>
+--EXPECTF--
+Greeter::greet hooked.
+%s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+Hello, Datadog.

--- a/tests/ext/sandbox/hook_method/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02.phpt
@@ -32,4 +32,4 @@ Greeter::greet('Datadog');
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method prehook error is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --INI--
@@ -30,3 +32,4 @@ Greeter::greet('Datadog');
 Greeter::greet hooked.
 %s in ddtrace's closure for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02-legacy.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02-legacy.phpt
@@ -1,0 +1,39 @@
+--TEST--
+DDTrace\hook_method prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\hook_method('Greeter', 'greet',
+    function ($This, $scope, $args) {
+        echo "Greeter::greet hooked.\n";
+        throw new Exception('!');
+    }
+);
+
+final class Greeter
+{
+    public function greet($name)
+    {
+        echo "Hello, {$name}.\n";
+    }
+}
+
+
+try {
+    $greeter = new Greeter();
+    $greeter->greet('Datadog');
+    echo "Done.\n";
+} catch (Exception $e) {
+    echo "Exception caught.\n";
+}
+
+?>
+--EXPECT--
+Greeter::greet hooked.
+Exception thrown in ddtrace's closure for Greeter::greet(): !
+Hello, Datadog.
+Done.

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
@@ -37,4 +37,4 @@ Greeter::greet hooked.
 Exception thrown in ddtrace's closure for Greeter::greet(): !
 Hello, Datadog.
 Done.
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\hook_method prehook exception is sandboxed (debug)
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -35,3 +37,4 @@ Greeter::greet hooked.
 Exception thrown in ddtrace's closure for Greeter::greet(): !
 Hello, Datadog.
 Done.
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_functions.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (internal functions)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
 --FILE--
 <?php

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_internal_methods.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (internal methods)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::format,DateTime::setTime
 --FILE--
 <?php

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_functions.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (userland functions)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 function myFunc1($foo) {

--- a/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
+++ b/tests/ext/sandbox/keep_spans_in_limited_tracing_userland_methods.phpt
@@ -2,6 +2,7 @@
 Keep spans in limited mode (userland methods)
 --ENV--
 DD_TRACE_SPANS_LIMIT=5
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 class MyClass

--- a/tests/ext/sandbox/manual_flush.phpt
+++ b/tests/ext/sandbox/manual_flush.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Spans are automatically flushed when auto-flushing enabled
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+use DDTrace\SpanData;
+
+DDTrace\trace_function('main', function (SpanData $span) {
+    $span->name = 'main';
+});
+
+function main() {}
+
+main();
+DDTrace\flush();
+main();
+
+?>
+--EXPECT--
+Successfully triggered flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
+++ b/tests/ext/sandbox/memory_limit_graceful_bailout.phpt
@@ -16,8 +16,10 @@ ddtrace.request_init_hook=
 <?php
 register_shutdown_function(function () {
     echo 'Flushing...' . PHP_EOL;
-    dd_trace_serialize_closed_spans();
-    echo 'You should not see this.' . PHP_EOL;
+    if (PHP_VERSION_ID < 80000) {
+        dd_trace_serialize_closed_spans();
+        echo 'You should not see this.' . PHP_EOL;
+    }
 });
 
 DDTrace\trace_function('array_sum', function (DDTrace\SpanData $span) {

--- a/tests/ext/sandbox/retval_is_null_with_exception-legacy.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception-legacy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The return value is null when an exception is thrown in the original call
+--DESCRIPTION--
+We enable debug mode to ensure this does not raise an "Undefined variable" E_NOTICE in the tracing closure
+https://github.com/DataDog/dd-trace-php/issues/788
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+function foo()
+{
+    throw new Exception('Oops!');
+    return 42;
+}
+
+DDTrace\trace_function('foo', function (SpanData $span, array $args, $retval, $ex) {
+    var_dump($ex instanceof Exception);
+    var_dump($retval);
+});
+
+try {
+    foo();
+} catch (Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+bool(true)
+NULL
+Oops!

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -32,4 +32,4 @@ try {
 bool(true)
 NULL
 Oops!
-Successfully triggered auto-flush with trace of size 2
+Successfully triggered flush with trace of size 2

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -3,6 +3,8 @@ The return value is null when an exception is thrown in the original call
 --DESCRIPTION--
 We enable debug mode to ensure this does not raise an "Undefined variable" E_NOTICE in the tracing closure
 https://github.com/DataDog/dd-trace-php/issues/788
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -30,3 +32,4 @@ try {
 bool(true)
 NULL
 Oops!
+Successfully triggered auto-flush with trace of size 2

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -36,7 +36,7 @@ object(DDTrace\SpanData)#3 (1) {
 }
 array(1) {
   [0]=>
-  array(7) {
+  array(8) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -53,6 +53,11 @@ array(1) {
     array(1) {
       ["system.pid"]=>
       string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/sandbox/spans_out_of_sync_01-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01-legacy.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [internal]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+    $span->name = 'dd_trace_serialize_closed_spans';
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_01.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans from traced function [internal]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
@@ -21,3 +23,4 @@ Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of s
 array(0) {
 }
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_02-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02-legacy.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Gracefully handle out-of-sync spans from traced function [internal][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
+--FILE--
+<?php
+// Since dd_trace_serialize_closed_spans() destroys the open span stack,
+// when this closure runs, DDTrace\SpanData will have been freed already.
+DDTrace\trace_function('dd_trace_serialize_closed_spans', function (DDTrace\SpanData $span) {
+    echo 'You should not see this.' . PHP_EOL;
+});
+
+var_dump(dd_trace_serialize_closed_spans());
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+array(0) {
+}
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_02.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans from traced function [internal][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=dd_trace_serialize_closed_spans
@@ -20,3 +22,4 @@ Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of s
 array(0) {
 }
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_05-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05-legacy.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    $span->name = 'shutdown_and_flush';
+
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_05.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans in closure itself [user]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -21,3 +23,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_06-legacy.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06-legacy.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Gracefully handle out-of-sync spans in closure itself [user][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+DDTrace\trace_function('shutdown_and_flush', function (DDTrace\SpanData $span) {
+    /* This frees the struct holding $span; ensure we don't segfault as this is
+     * akin to what we actually do in real scenarios.
+     */
+    dd_trace_serialize_closed_spans();
+});
+
+function shutdown_and_flush() {}
+shutdown_and_flush();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECT--
+Done.

--- a/tests/ext/sandbox/spans_out_of_sync_06.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Gracefully handle out-of-sync spans in closure itself [user][default properties]
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=1
 --FILE--
@@ -19,3 +21,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
+No finished traces to be sent to the agent

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this-legacy.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this-legacy.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Static tracing closures will not bind $this
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test does not work with internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=true
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function test()
+    {
+        echo "Foo::test()\n";
+    }
+}
+
+DDTrace\trace_method('Foo', 'test', static function () {
+    echo "TRACED Foo::test()\n";
+});
+
+$foo = new Foo();
+$foo->test();
+?>
+--EXPECT--
+Foo::test()
+Cannot trace non-static method with static tracing closure

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Static tracing closures will not bind $this
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
 --ENV--
 DD_TRACE_DEBUG=true
 --FILE--
@@ -24,3 +26,4 @@ $foo->test();
 --EXPECT--
 Foo::test()
 Cannot trace non-static method with static tracing closure
+Successfully triggered auto-flush with trace of size 1

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -26,4 +26,4 @@ $foo->test();
 --EXPECT--
 Foo::test()
 Cannot trace non-static method with static tracing closure
-Successfully triggered auto-flush with trace of size 1
+Successfully triggered flush with trace of size 1

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -2,6 +2,8 @@
 Set DDTrace\start_span() properties
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 
@@ -58,12 +60,15 @@ array(2) {
     string(%d) "%d"
     ["span_id"]=>
     string(%d) "%d"
-    ["parent_id"]=>
-    string(%d) "%d"
     ["start"]=>
     int(%d)
     ["duration"]=>
     int(2000000%d)
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
     ["metrics"]=>
     array(1) {
       ["php.compilation.total_time_ms"]=>
@@ -71,12 +76,10 @@ array(2) {
     }
   }
   [1]=>
-  array(11) {
+  array(10) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
-    string(%d) "%d"
-    ["parent_id"]=>
     string(%d) "%d"
     ["start"]=>
     int(%d)
@@ -91,14 +94,18 @@ array(2) {
     ["type"]=>
     string(6) "runner"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["aa"]=>
       string(2) "bb"
+      ["system.pid"]=>
+      string(%d) "%d"
     }
     ["metrics"]=>
-    array(1) {
+    array(2) {
       ["cc"]=>
       float(0)
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
     }
   }
 }

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -1,0 +1,104 @@
+--TEST--
+Set DDTrace\start_span() properties
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--FILE--
+<?php
+
+$original_span = DDTrace\active_span();
+
+$time = time();
+
+$span = DDTrace\start_span();
+// avoid interned strings
+$span->name = ($_ = "d") . "ata";
+$span->resource = ($_ = "d") . "og";
+$span->service = ($_ = "t") . "est";
+$span->type = ($_ = "r") . "unner";
+$span->meta = [($_ = "a") . "a" => ($_ = "b") . "b"];
+$span->metrics = [($_ = "c") . "c" => ($_ = "d") . "d"];
+
+var_dump($span->getDuration());
+var_dump($start_time = $span->getStartTime());
+if ($start_time < $time * 1000000000 || $start_time > ($time + 2) * 1000000000) {
+    echo "$start_time not in expected bounds of $time to $time + 2\n";
+}
+
+var_dump(DDTrace\active_span() == $span);
+
+DDTrace\close_span();
+
+var_dump($original_span == DDTrace\active_span());
+
+var_dump($start_time = $span->getStartTime());
+if ($start_time < $time * 1000000000 || $start_time > ($time + 2) * 1000000000) {
+    echo "$start_time not in expected bounds of $time to $time + 2\n";
+}
+var_dump($span->getDuration() > 0);
+
+$span = DDTrace\start_span();
+DDTrace\close_span($span->getStartTime() / 1000000000 + 2.0000002); // nobody likes the limits of double precision
+var_dump(round($span->getDuration(), -3));
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+int(0)
+int(%d)
+bool(true)
+bool(true)
+int(%d)
+bool(true)
+float(2000000000)
+array(2) {
+  [0]=>
+  array(6) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(2000000%d)
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(11) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "data"
+    ["resource"]=>
+    string(3) "dog"
+    ["service"]=>
+    string(4) "test"
+    ["type"]=>
+    string(6) "runner"
+    ["meta"]=>
+    array(1) {
+      ["aa"]=>
+      string(2) "bb"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["cc"]=>
+      float(0)
+    }
+  }
+}

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Use DDTrace\close_span() on span started within internal span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function test() { }
+
+DDTrace\trace_function("test", function($s) {
+    $span = DDTrace\start_span();
+    $span->name = "my precious span";
+});
+
+test();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+// has no effect
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}
+There is no user-span on the top of the stack. Cannot close.
+array(0) {
+}
+No finished traces to be sent to the agent

--- a/tests/ext/start_span_without_closing_autofinish.phpt
+++ b/tests/ext/start_span_without_closing_autofinish.phpt
@@ -28,7 +28,7 @@ var_dump(dd_trace_serialize_closed_spans());
 --EXPECTF--
 array(2) {
   [0]=>
-  array(8) {
+  array(7) {
     ["trace_id"]=>
     string(%d) "%d"
     ["span_id"]=>
@@ -43,11 +43,6 @@ array(2) {
     string(4) "test"
     ["resource"]=>
     string(4) "test"
-    ["metrics"]=>
-    array(1) {
-      ["php.compilation.total_time_ms"]=>
-      float(%f)
-    }
   }
   [1]=>
   array(7) {

--- a/tests/ext/start_span_without_closing_autofinish.phpt
+++ b/tests/ext/start_span_without_closing_autofinish.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Use DDTrace\close_span() on span started within internal span
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_AUTOFINISH_SPANS=1
+--FILE--
+<?php
+
+function test() { }
+
+DDTrace\trace_function("test", function($s) {
+    $span = DDTrace\start_span();
+    $span->name = "my precious span";
+});
+
+test();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+// has no effect
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(7) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(16) "my precious span"
+    ["resource"]=>
+    string(16) "my precious span"
+  }
+}
+There is no user-span on the top of the stack. Cannot close.
+array(0) {
+}
+No finished traces to be sent to the agent

--- a/tests/ext/startup_logging_json_config.phpt
+++ b/tests/ext/startup_logging_json_config.phpt
@@ -84,3 +84,4 @@ traced_internal_functions: "array_sum,mt_rand,DateTime::add"
 auto_prepend_file_configured: true
 integrations_disabled: "curl,mysqli"
 enabled_from_env: false
+No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

Doing a lot of things:
 - Nearly everything happening in Tracer->flush() is now in the extension
 - Spans are allocated and closed directly instead of their ids (via DDTrace\start_span() and DDTrace\close_span())
 - Spans now expose duration and start time via methods
 - The root span is (if there is configured to be one) allocated and closed from within the extension - close at the very last moment: RSHUTDOWN
 - Manual flushing now happens via a new DDTrace\flush()

(Originally #1251, but github doesn't let me reopen that one.)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
