### PR TITLE
Allow for global debug mode, add zai testing to Makefile and more minor testing improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ $ docker-compose run --rm 7.4-buster bash
 $ docker-compose run --rm 8.0-buster bash
 ```
 
+> :memo: **Note:** To run the container in debug mode, pass pass docker-composer an environment variable: `DD_TRACE_DOCKER_DEBUG=1`
+
 Once inside the container, update dependencies with Composer.
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ The easiest way to get the development environment set up is to install [Docker]
 While tests in CI run on all php versions, you typically develop on one version locally. Currently the latest local
 dev environment we support is `8.0`.
 
+Ensure that docker has at least 4 GB of RAM available, otherwise composer may run out of memory.
+
 Execute one the following commands from your command line, this will bring up all required services:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all: $(BUILD_DIR)/configure $(SO_FILE)
 $(BUILD_DIR)/config.m4: $(M4_FILES)
 
 $(BUILD_DIR)/configure: $(BUILD_DIR)/config.m4
-	$(Q) (cd $(BUILD_DIR); phpize)
+	$(Q) (cd $(BUILD_DIR); phpize && sed -i 's/\/FAILED/\/\\bFAILED/' $(BUILD_DIR)/run-tests.php) # Fix PHP 5.4 exit code bug when running selected tests (FAILED vs XFAILED)
 
 $(BUILD_DIR)/Makefile: $(BUILD_DIR)/configure
 	$(Q) (cd $(BUILD_DIR); ./configure)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ WALL_FLAGS := -Wall -Wextra
 EXTRA_CFLAGS :=
 CFLAGS := -O2 $(shell [ -n "${DD_TRACE_DOCKER_DEBUG}" ] && echo -O0 -g) $(EXTRA_CFLAGS) $(WALL_FLAGS)
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+PHP_EXTENSION_DIR=$(shell php -r 'print ini_get("extension_dir");')
 PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
@@ -64,8 +65,10 @@ $(BUILD_DIR)/Makefile: $(BUILD_DIR)/configure
 $(SO_FILE): $(C_FILES) $(BUILD_DIR)/Makefile
 	$(Q) $(MAKE) -C $(BUILD_DIR) CFLAGS="$(CFLAGS)"
 
-install: $(SO_FILE)
+$(PHP_EXTENSION_DIR)/ddtrace.so: $(SO_FILE)
 	$(Q) $(SUDO) $(MAKE) -C $(BUILD_DIR) install
+
+install: $(PHP_EXTENSION_DIR)/ddtrace.so
 
 $(INI_FILE):
 	$(Q) echo "extension=ddtrace.so" | $(SUDO) tee -a $@
@@ -602,8 +605,12 @@ clean_test: clean_test_scenarios
 clean_test_scenarios:
 	$(TESTS_ROOT)/clean-composer-scenario-locks.sh
 
+$(TESTS_ROOT)/composer.lock: composer_tests_update
+
 composer_tests_update:
 	$(COMPOSER_TESTS) update
+
+global_test_run_dependencies: install_all $(TESTS_ROOT)/composer.lock
 
 test_all: \
 	test_unit \
@@ -614,178 +621,178 @@ test_all: \
 	test_integrations \
 	test_web
 
-test:
+test: global_test_run_dependencies
 	$(call run_tests,$(TESTS))
 
-test_unit:
+test_unit: global_test_run_dependencies
 	$(call run_tests,--testsuite=unit $(TESTS))
 
-test_integration:
+test_integration: global_test_run_dependencies
 	$(call run_tests,--testsuite=integration $(TESTS))
 
-test_auto_instrumentation:
+test_auto_instrumentation: global_test_run_dependencies
 	$(call run_tests,--testsuite=auto-instrumentation $(TESTS))
 	# Cleaning up composer.json files in tests/AutoInstrumentation modified for TLS during tests
 	git checkout $(TESTS_ROOT)/AutoInstrumentation/**/composer.json
 
-test_composer:
+test_composer: global_test_run_dependencies
 	$(call run_tests,--testsuite=composer-tests $(TESTS))
 
-test_distributed_tracing:
+test_distributed_tracing: global_test_run_dependencies
 	$(call run_tests,--testsuite=distributed-tracing $(TESTS))
 
-test_metrics:
+test_metrics: global_test_run_dependencies
 	$(call run_tests,--testsuite=metrics $(TESTS))
 
-test_opentracing_beta5:
+test_opentracing_beta5: global_test_run_dependencies
 	$(MAKE) test_scenario_opentracing_beta5
 	$(call run_tests,tests/OpenTracerUnit)
 
-test_opentracing_beta6:
+test_opentracing_beta6: global_test_run_dependencies
 	$(MAKE) test_scenario_opentracing_beta6
 	$(call run_tests,tests/OpenTracerUnit)
 
-test_opentracing_10:
+test_opentracing_10: global_test_run_dependencies
 	$(MAKE) test_scenario_opentracing10
 	$(call run_tests,tests/OpenTracer1Unit)
 
 test_integrations: $(TEST_INTEGRATIONS_$(PHP_MAJOR_MINOR))
 test_web: $(TEST_WEB_$(PHP_MAJOR_MINOR))
 
-test_integrations_deferred_loading:
+test_integrations_deferred_loading: global_test_run_dependencies
 	$(MAKE) test_scenario_predis1
 	$(call run_tests,tests/Integrations/DeferredLoading)
-test_integrations_curl:
+test_integrations_curl: global_test_run_dependencies
 	$(call run_tests,tests/Integrations/Curl)
-test_integrations_elasticsearch1:
+test_integrations_elasticsearch1: global_test_run_dependencies
 	$(MAKE) test_scenario_elasticsearch1
 	$(call run_tests,tests/Integrations/Elasticsearch)
-test_integrations_guzzle5:
+test_integrations_guzzle5: global_test_run_dependencies
 	$(MAKE) test_scenario_guzzle5
 	$(call run_tests,tests/Integrations/Guzzle/V5)
-test_integrations_guzzle6:
+test_integrations_guzzle6: global_test_run_dependencies
 	$(MAKE) test_scenario_guzzle6
 	$(call run_tests,tests/Integrations/Guzzle/V6)
-test_integrations_memcached:
+test_integrations_memcached: global_test_run_dependencies
 	$(MAKE) test_scenario_default
 	$(call run_tests,tests/Integrations/Memcached)
-test_integrations_mysqli:
+test_integrations_mysqli: global_test_run_dependencies
 	$(MAKE) test_scenario_default
 	$(call run_tests,tests/Integrations/Mysqli)
-test_integrations_mongo:
+test_integrations_mongo: global_test_run_dependencies
 	$(MAKE) test_scenario_default
 	$(call run_tests,tests/Integrations/Mongo)
-test_integrations_pcntl:
+test_integrations_pcntl: global_test_run_dependencies
 	$(call run_tests,tests/Integrations/PCNTL)
-test_integrations_pdo:
+test_integrations_pdo: global_test_run_dependencies
 	$(MAKE) test_scenario_default
 	$(call run_tests,tests/Integrations/PDO)
-test_integrations_phpredis3:
+test_integrations_phpredis3: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis3
 	$(call run_tests,tests/Integrations/PHPRedis/V3)
-test_integrations_phpredis4:
+test_integrations_phpredis4: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis4
 	$(call run_tests,tests/Integrations/PHPRedis/V4)
-test_integrations_phpredis5:
+test_integrations_phpredis5: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis5
 	$(call run_tests,tests/Integrations/PHPRedis/V5)
-test_integrations_predis1:
+test_integrations_predis1: global_test_run_dependencies
 	$(MAKE) test_scenario_predis1
 	$(call run_tests,tests/Integrations/Predis)
-test_web_cakephp_28:
+test_web_cakephp_28: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/CakePHP/Version_2_8 update
 	$(call run_tests,--testsuite=cakephp-28-test)
-test_web_codeigniter_22:
+test_web_codeigniter_22: global_test_run_dependencies
 	$(call run_tests,--testsuite=codeigniter-22-test)
-test_web_laravel_42:
+test_web_laravel_42: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_4_2 update
 	php tests/Frameworks/Laravel/Version_4_2/artisan optimize
 	$(call run_tests,tests/Integrations/Laravel/V4)
-test_web_laravel_57:
+test_web_laravel_57: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_5_7 update
 	$(call run_tests,tests/Integrations/Laravel/V5_7)
-test_web_laravel_58:
+test_web_laravel_58: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_5_8 update
 	$(call run_tests,--testsuite=laravel-58-test)
-test_web_laravel_8x:
+test_web_laravel_8x: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_8_x update
 	$(call run_tests,tests/Integrations/Laravel/V8_x)
-test_web_lumen_52:
+test_web_lumen_52: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_2 update
 	$(call run_tests,tests/Integrations/Lumen/V5_2)
-test_web_lumen_56:
+test_web_lumen_56: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_6 update
 	$(call run_tests,tests/Integrations/Lumen/V5_6)
-test_web_lumen_58:
+test_web_lumen_58: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_8 update
 	$(call run_tests,tests/Integrations/Lumen/V5_8)
-test_web_slim_312:
+test_web_slim_312: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_3_12 update
 	$(call run_tests,--testsuite=slim-312-test)
-test_web_slim_4:
+test_web_slim_4: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_4 update
 	$(call run_tests,--testsuite=slim-4-test)
-test_web_symfony_23:
+test_web_symfony_23: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_2_3 update
 	$(call run_tests,tests/Integrations/Symfony/V2_3)
-test_web_symfony_28:
+test_web_symfony_28: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_2_8 update
 	$(call run_tests,tests/Integrations/Symfony/V2_8)
-test_web_symfony_30:
+test_web_symfony_30: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_0 update
 	php tests/Frameworks/Symfony/Version_3_0/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V3_0)
-test_web_symfony_33:
+test_web_symfony_33: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_3 update
 	php tests/Frameworks/Symfony/Version_3_3/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V3_3)
-test_web_symfony_34:
+test_web_symfony_34: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_4 update
 	php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V3_4)
-test_web_symfony_40:
+test_web_symfony_40: global_test_run_dependencies
 	# We hit broken updates in this unmaintained version, so we committed a
 	# working composer.lock and we composer install instead of composer update
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 install
 	php tests/Frameworks/Symfony/Version_4_0/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V4_0)
-test_web_symfony_42:
+test_web_symfony_42: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_2 update
 	php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V4_2)
-test_web_symfony_44:
+test_web_symfony_44: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_4 update
 	php tests/Frameworks/Symfony/Version_4_4/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V4_4)
-test_web_symfony_50:
+test_web_symfony_50: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_0 install # EOL; install from lock
 	php tests/Frameworks/Symfony/Version_5_0/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V5_0)
-test_web_symfony_51:
+test_web_symfony_51: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_1 update
 	php tests/Frameworks/Symfony/Version_5_1/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V5_1)
-test_web_symfony_52:
+test_web_symfony_52: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_2 update
 	php tests/Frameworks/Symfony/Version_5_2/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests,tests/Integrations/Symfony/V5_2)
 
-test_web_wordpress_48:
+test_web_wordpress_48: global_test_run_dependencies
 	$(call run_tests,tests/Integrations/WordPress/V4_8)
-test_web_wordpress_55:
+test_web_wordpress_55: global_test_run_dependencies
 	$(call run_tests,tests/Integrations/WordPress/V5_5)
-test_web_yii_2:
+test_web_yii_2: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Yii/Version_2_0 update
 	$(call run_tests,tests/Integrations/Yii/V2_0)
-test_web_nette_24:
+test_web_nette_24: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Nette/Version_2_4 update
 	$(call run_tests,tests/Integrations/Nette/V2_4)
-test_web_nette_30:
+test_web_nette_30: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Nette/Version_3_0 update
 	$(call run_tests,tests/Integrations/Nette/V3_0)
-test_web_zend_1:
+test_web_zend_1: global_test_run_dependencies
 	$(call run_tests,tests/Integrations/ZendFramework/V1)
-test_web_custom:
+test_web_custom: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Custom/Version_Autoloaded update
 	$(call run_tests,--testsuite=custom-framework-autoloading-test)
 
@@ -795,7 +802,7 @@ test_scenario_%:
 ### Api tests ###
 API_TESTS_ROOT := ./tests/api
 
-test_api_unit: composer.lock
+test_api_unit: composer.lock global_test_run_dependencies
 	$(ENV_OVERRIDE) php $(REQUEST_INIT_HOOK) vendor/bin/phpunit --config=phpunit.xml $(API_TESTS_ROOT)/Unit $(TESTS)
 
 composer.lock: composer.json

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,18 @@ build_zai:
 test_zai: build_zai
 	$(MAKE) -C $(ZAI_BUILD_DIR) test $(shell [ -z "${TESTS}"] || echo "ARGS='--test-dir ${TESTS}'") && ! grep -e "=== Total .* memory leaks detected ===" $(ZAI_BUILD_DIR)/Testing/Temporary/LastTest.log
 
+build_zai_asan:
+	( \
+	mkdir -p "$(ZAI_BUILD_DIR)"; \
+	cd $(ZAI_BUILD_DIR); \
+	CMAKE_PREFIX_PATH=/opt/catch2 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DBUILD_ZAI_ASAN=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
+	$(MAKE) clean $(MAKEFLAGS); \
+	$(MAKE) $(MAKEFLAGS); \
+	)
+
+test_zai_asan: build_zai_asan
+	$(MAKE) -C $(ZAI_BUILD_DIR) test $(shell [ -z "${TESTS}"] || echo "ARGS='--test-dir ${TESTS}'") USE_ZEND_ALLOC=0 USE_TRACKED_ALLOC=1 && ! grep -e "=== Total .* memory leaks detected ===" $(ZAI_BUILD_DIR)/Testing/Temporary/LastTest.log
+
 clean_zai:
 	rm -rf $(ZAI_BUILD_DIR)
 
@@ -808,5 +820,5 @@ test_api_unit: composer.lock global_test_run_dependencies
 composer.lock: composer.json
 	$(Q) composer update
 
-.PHONY: dev dist_clean clean cores all clang_format_check clang_format_fix install sudo_install test_c test_c_mem test_extension_ci test_zai test install_ini install_all \
+.PHONY: dev dist_clean clean cores all clang_format_check clang_format_fix install sudo_install test_c test_c_mem test_extension_ci test_zai test_zai_asan test install_ini install_all \
 	.apk .rpm .deb .tar.gz sudo debug prod strict run-tests.php verify_pecl_file_definitions verify_version verify_package_xml verify_all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ x-aliases:
         - DDAGENT_HOSTNAME=ddagent_integration
         - COMPOSER_MEMORY_LIMIT=-1
         - PHP_IDE_CONFIG=serverName=docker
+        - DD_TRACE_DOCKER_DEBUG
       cap_add:
         - SYS_PTRACE
       # Privileged is requires to run some pcntl tests locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ x-aliases:
         - .:/home/circleci/app
         - .composer:/home/circleci/.composer
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
-      tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec' ]
+      tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec', '/home/circleci/app/tests/vendor:uid=3434,gid=3434,exec' ]
       depends_on:
         - agent
         - ddagent_integration

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -89,6 +89,8 @@ RUN set -eux; \
     (echo "${CMAKE_SHA256} cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c -); \
     mkdir -p /opt/cmake/${CMAKE_VERSION}; \
     tar --strip-components 1 -C /opt/cmake/${CMAKE_VERSION} -xf /tmp/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz; \
+# Currently there's only one version of smake, make it default
+    ln -s /opt/cmake/${CMAKE_VERSION}/bin/cmake /usr/local/bin/cmake; \
 # Install Catch2
     CATCH2_VERSION="2.13.5"; \
     CATCH2_SHA256="7fee7d643599d10680bfd482799709f14ed282a8b7db82f54ec75ec9af32fa76"; \

--- a/tests/Sapi/CliServer/CliServer.php
+++ b/tests/Sapi/CliServer/CliServer.php
@@ -79,7 +79,7 @@ final class CliServer implements Sapi
         $processCmd = "$envs exec $cmd";
 
         // See phpunit_error.log in CircleCI artifacts
-        error_log("[cli-server] Starting: '{$processCmd}'");
+        error_log("[cli-server] Starting: '$envs $processCmd'");
         if (isset($this->inis['error_log'])) {
             error_log("[cli-server] Error log: '" . realpath($this->inis['error_log']) . "'");
         }

--- a/tests/Sapi/PhpCgi/PhpCgi.php
+++ b/tests/Sapi/PhpCgi/PhpCgi.php
@@ -60,7 +60,7 @@ final class PhpCgi implements Sapi
         $processCmd = "$envs exec $cmd";
 
         // See phpunit_error.log in CircleCI artifacts
-        error_log("[php-cgi] Starting: '{$processCmd}'");
+        error_log("[php-cgi] Starting: '$envs $processCmd'");
         if (isset($this->inis['error_log'])) {
             error_log("[php-cgi] Error log: '" . realpath($this->inis['error_log']) . "'");
         }

--- a/tests/Sapi/PhpFpm/PhpFpm.php
+++ b/tests/Sapi/PhpFpm/PhpFpm.php
@@ -69,15 +69,16 @@ final class PhpFpm implements Sapi
     public function start()
     {
         $cmd = sprintf(
-            'exec php-fpm -p %s --fpm-config %s -F',
+            'php-fpm -p %s --fpm-config %s -F',
             __DIR__,
             $this->configFile
         );
+        $processCmd = "exec $cmd";
 
         // See phpunit_error.log in CircleCI artifacts
         error_log("[php-fpm] Starting: '{$cmd}'");
 
-        $this->process = new Process($cmd);
+        $this->process = new Process($processCmd);
         $this->process->start();
     }
 

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -23,6 +23,12 @@ if (${BUILD_ZAI_TESTING})
   enable_testing()
 endif()
 
+option(BUILD_ZAI_ASAN "Enable ASAN" OFF)
+if (${BUILD_ZAI_ASAN})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+endif()
+
 include(GNUInstallDirs)
 
 add_library(zai_zend_abstract_interface INTERFACE)


### PR DESCRIPTION
### Description

See list of commits, in particular it will now be possible to add `export DD_TRACE_DOCKER_DEBUG=1` to your environment (I recommend saving it to `~/.profile`) on the host. This will always imply `dev` and `debug` during make. These can be disabled when needed by `use_generated` and `prod`, respectively.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~~[ ] Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
