### PR TITLE
Migrate _dd.origin & distributed header sending to internal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,6 +880,9 @@ jobs:
       - run:
           name: Fix PHP-FPM logs permissions before storing artifacts
           command: sudo chown -R circleci:circleci tests/randomized/.tmp.scenarios/.results
+      - run:
+          name: Check permissions
+          command: ls -alR tests/randomized/.tmp.scenarios/.results
       - store_artifacts:
           path: 'tests/randomized/.tmp.scenarios/.results'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -879,7 +879,7 @@ jobs:
           command: make -C tests/randomized analyze
       - run:
           name: Fix PHP-FPM logs permissions before storing artifacts
-          command: sudo chmod -R a+r tests/randomized/.tmp.scenarios/.results
+          command: sudo chown -R circleci:circleci tests/randomized/.tmp.scenarios/.results
       - store_artifacts:
           path: 'tests/randomized/.tmp.scenarios/.results'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -875,14 +875,11 @@ jobs:
           name: Execute tests
           command: make -C tests/randomized test CONCURRENT_JOBS=5 DURATION=1m30s
       - run:
-          name: Analyze results
-          command: make -C tests/randomized analyze
-      - run:
           name: Fix PHP-FPM logs permissions before storing artifacts
           command: sudo chown -R circleci:circleci tests/randomized/.tmp.scenarios/.results
       - run:
-          name: Check permissions
-          command: ls -alR tests/randomized/.tmp.scenarios/.results
+          name: Analyze results
+          command: make -C tests/randomized analyze
       - store_artifacts:
           path: 'tests/randomized/.tmp.scenarios/.results'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,6 +855,8 @@ jobs:
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
+          command: ls -al
+      - run:
           name: Install required packages
           command: sudo apt update && sudo apt install -y php git
       - run:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test_c2php: $(SO_FILE) $(INIT_HOOK_TEST_FILES)
 	export USE_ZEND_ALLOC=0; \
 	export ZEND_DONT_UNLOAD_MODULES=1; \
 	export USE_TRACKED_ALLOC=1; \
-	valgrind -q --tool=memcheck --trace-children=yes --vex-iropt-register-updates=allregs-at-mem-access php -n -d extension=$(SO_FILE) -d ddtrace.request_init_hook=$$(pwd)/bridge/dd_wrap_autoloader.php $(INIT_HOOK_TEST_FILES); \
+	$(shell grep -Pzo '(?<=--ENV--)(?s).+?(?=--)' $(INIT_HOOK_TEST_FILES)) valgrind -q --tool=memcheck --trace-children=yes --vex-iropt-register-updates=allregs-at-mem-access php -n -d extension=$(SO_FILE) -d ddtrace.request_init_hook=$$(pwd)/bridge/dd_wrap_autoloader.php $(INIT_HOOK_TEST_FILES); \
 	)
 
 test_with_init_hook_asan: $(SO_FILE) $(INIT_HOOK_TEST_FILES)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-aliases:
       environment:
         - REDIS_HOSTNAME=redis_integration
         - DDAGENT_HOSTNAME=ddagent_integration
+        - HTTPBIN_HOSTNAME=httpbin_integration
         - COMPOSER_MEMORY_LIMIT=-1
         - PHP_IDE_CONFIG=serverName=docker
         - DD_TRACE_DOCKER_DEBUG

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -1664,6 +1664,7 @@ void dd_read_distributed_tracing_ids(void) {
         }
     }
 
+    DDTRACE_G(distributed_parent_trace_id) = 0;
     if (success && zai_read_header_literal("X_DATADOG_PARENT_ID", &parent_id_str) == ZAI_HEADER_SUCCESS) {
         zval parent_zv;
         ZVAL_STR(&parent_zv, parent_id_str);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -308,6 +308,32 @@ zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) { return OBJ_PROP_
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 6); }
 #pragma GCC diagnostic pop
 
+bool ddtrace_fetch_prioritySampling_from_root(int *priority) {
+    zval *priority_zv;
+    ddtrace_span_fci *root_span = DDTRACE_G(open_spans_top);
+
+    if (!root_span) {
+        return false;
+    }
+
+    while (root_span->next) {
+        root_span = root_span->next;
+    }
+
+    zval *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
+    ZVAL_DEREF(root_metrics);
+    if (Z_TYPE_P(root_metrics) != IS_ARRAY) {
+        return false;
+    }
+
+    if (!(priority_zv = zend_hash_str_find(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1")))) {
+        return false;
+    }
+
+    *priority = (int)zval_get_long(priority_zv);
+    return true;
+}
+
 /* DDTrace\FatalError */
 zend_class_entry *ddtrace_ce_fatal_error;
 
@@ -506,6 +532,10 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     zval_dtor(&DDTRACE_G(additional_trace_meta));
     zend_array_destroy(DDTRACE_G(additional_global_tags));
     ZVAL_NULL(&DDTRACE_G(additional_trace_meta));
+
+    if (DDTRACE_G(dd_origin)) {
+        zend_string_release(DDTRACE_G(dd_origin));
+    }
 
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown();
@@ -1311,12 +1341,6 @@ static PHP_FUNCTION(dd_trace_set_trace_id) {
     RETURN_BOOL(0);
 }
 
-static inline void return_span_id(zval *return_value, uint64_t id) {
-    char buf[DD_TRACE_MAX_ID_LEN + 1];
-    snprintf(buf, sizeof(buf), "%" PRIu64, id);
-    RETURN_STRING(buf);
-}
-
 /* {{{ proto string dd_trace_push_span_id() */
 static PHP_FUNCTION(dd_trace_push_span_id) {
     UNUSED(execute_data);
@@ -1324,12 +1348,11 @@ static PHP_FUNCTION(dd_trace_push_span_id) {
     zval *existing_id = NULL;
     if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "|z!", &existing_id) == SUCCESS) {
         if (ddtrace_push_userland_span_id(existing_id) == true) {
-            return_span_id(return_value, ddtrace_peek_span_id());
-            return;
+            RETURN_STR(ddtrace_span_id_as_string(ddtrace_peek_span_id()));
         }
     }
 
-    return_span_id(return_value, ddtrace_push_span_id(0));
+    RETURN_STR(ddtrace_span_id_as_string(ddtrace_push_span_id(0)));
 }
 
 /* {{{ proto string dd_trace_pop_span_id() */
@@ -1343,13 +1366,13 @@ static PHP_FUNCTION(dd_trace_pop_span_id) {
         }
     }
 
-    return_span_id(return_value, id);
+    RETURN_STR(ddtrace_span_id_as_string(id));
 }
 
 /* {{{ proto string dd_trace_peek_span_id() */
 static PHP_FUNCTION(dd_trace_peek_span_id) {
     UNUSED(execute_data);
-    return_span_id(return_value, ddtrace_peek_span_id());
+    RETURN_STR(ddtrace_span_id_as_string(ddtrace_peek_span_id()));
 }
 
 /* {{{ proto string DDTrace\active_span() */
@@ -1448,7 +1471,7 @@ static PHP_FUNCTION(flush) {
 /* {{{ proto string \DDTrace\trace_id() */
 static PHP_FUNCTION(trace_id) {
     UNUSED(execute_data);
-    return_span_id(return_value, DDTRACE_G(trace_id));
+    RETURN_STR(ddtrace_span_id_as_string(DDTRACE_G(trace_id)));
 }
 
 /* {{{ proto array \DDTrace\current_context() */
@@ -1619,6 +1642,7 @@ void dd_read_distributed_tracing_ids(void) {
         }
     }
 
+    DDTRACE_G(distributed_parent_trace_id) = 0;
     if (success && zai_read_header_literal("X_DATADOG_PARENT_ID", &parent_id_str) == ZAI_HEADER_SUCCESS) {
         zval parent_zv;
         ZVAL_STR(&parent_zv, parent_id_str);
@@ -1629,5 +1653,10 @@ void dd_read_distributed_tracing_ids(void) {
                 DDTRACE_G(trace_id) = 0;
             }
         }
+    }
+
+    DDTRACE_G(dd_origin) = NULL;
+    if (zai_read_header_literal("X_DATADOG_ORIGIN", &DDTRACE_G(dd_origin)) == ZAI_HEADER_SUCCESS) {
+        GC_ADDREF(DDTRACE_G(dd_origin));
     }
 }

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -23,6 +23,8 @@ zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span);
 
+bool ddtrace_fetch_prioritySampling_from_root(int *priority);
+
 bool ddtrace_tracer_is_limited(void);
 // prepare the tracer state to start handling a new trace
 void dd_prepare_for_new_trace(void);
@@ -62,6 +64,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     uint32_t closed_spans_count;
     int64_t compile_time_microseconds;
     uint64_t distributed_parent_trace_id;
+    zend_string *dd_origin;
 
     char *cgroup_file;
 ZEND_END_MODULE_GLOBALS(ddtrace)

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -16,9 +16,6 @@ bool dd_ext_curl_loaded = false;
 zend_long dd_const_curlopt_httpheader = 0;
 
 ZEND_TLS HashTable *dd_headers = NULL;
-ZEND_TLS bool dd_should_save_headers = true;
-ZEND_TLS zend_function *dd_curl_inject_fn_proxy = NULL;
-ZEND_TLS zend_string *dd_inject_func = NULL;
 
 // Multi-handle API: curl_multi_*()
 ZEND_TLS HashTable *dd_multi_handles = NULL;
@@ -79,54 +76,45 @@ static void dd_ch_duplicate_headers(zval *ch_orig, zval *ch_new) {
     }
 }
 
-static void dd_init_headers_arg(zval *arg, zval *ch) {
-    HashTable *retval;
-    ALLOC_HASHTABLE(retval);
-    HashTable *headers = NULL;
-
-    if (dd_headers) {
-        headers = zend_hash_index_find_ptr(dd_headers, Z_OBJ_HANDLE_P(ch));
-        if (headers) {
-            size_t headers_count = zend_hash_num_elements(headers);
-            zend_hash_init(retval, headers_count, NULL, ZVAL_PTR_DTOR, 0);
-            zend_hash_copy(retval, headers, (copy_ctor_func_t)zval_add_ref);
-        }
-    }
-
-    if (!headers) {
-        zend_hash_init(retval, 0, NULL, ZVAL_PTR_DTOR, 0);
-    }
-    ZVAL_ARR(arg, retval);
-}
-
-static void dd_free_headers_arg(zval *arg) { zend_array_destroy(Z_ARRVAL_P(arg)); }
-
 static void dd_inject_distributed_tracing_headers(zval *ch) {
-    if (dd_inject_func == NULL) {
-        dd_inject_func = zend_string_init(ZEND_STRL("ddtrace\\bridge\\curl_inject_distributed_headers"), 0);
+    zval headers;
+    zend_array *dd_header_array;
+    if (dd_headers && (dd_header_array = zend_hash_index_find_ptr(dd_headers, Z_OBJ_HANDLE_P(ch)))) {
+        ZVAL_ARR(&headers, zend_array_dup(dd_header_array));
+    } else {
+        array_init(&headers);
     }
-    if (zend_hash_exists(EG(function_table), dd_inject_func)) {
-        zend_function **fn_proxy = &dd_curl_inject_fn_proxy;
-        zval retval = {.u1.type_info = IS_UNDEF};
 
-        zval headers;
-        dd_init_headers_arg(&headers, ch);
-
-        ddtrace_sandbox_backup backup = ddtrace_sandbox_begin();
-        dd_should_save_headers = false;  // Don't save our own HTTP headers
-        // Arg 0: CurlHandle $ch
-        // Arg 1: mixed $value (array of headers)
-        if (ddtrace_call_function(fn_proxy, ZSTR_VAL(dd_inject_func), ZSTR_LEN(dd_inject_func), &retval, 2, ch,
-                                  &headers) == SUCCESS) {
-            zval_ptr_dtor(&retval);
-        } else {
-            ddtrace_log_debug("Could not inject distributed tracing headers");
+    int sampling_priority;
+    if (ddtrace_fetch_prioritySampling_from_root(&sampling_priority)) {
+        add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-sampling-priority: %d", sampling_priority));
+    }
+    if (DDTRACE_G(trace_id)) {
+        add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-trace-id: %" PRIu64, (DDTRACE_G(trace_id))));
+        if (DDTRACE_G(span_ids_top)) {
+            add_next_index_str(&headers,
+                               zend_strpprintf(0, "x-datadog-parent-id: %" PRIu64, (DDTRACE_G(span_ids_top)->id)));
         }
-        dd_should_save_headers = true;
-        ddtrace_sandbox_end(&backup);
-
-        dd_free_headers_arg(&headers);
+    } else if (DDTRACE_G(span_ids_top)) {
+        ddtrace_log_err("Found span_id without active trace id, skipping sending of x-datadog-parent-id");
     }
+    if (DDTRACE_G(dd_origin)) {
+        add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-origin: %s", ZSTR_VAL(DDTRACE_G(dd_origin))));
+    }
+
+    zend_function *setopt_fn = zend_hash_str_find_ptr(EG(function_table), ZEND_STRL("curl_setopt"));
+
+    // avoiding going through our own function, directly calling curl_setopt
+    zend_execute_data *call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION, setopt_fn, 3, NULL);
+    ZVAL_COPY(ZEND_CALL_ARG(call, 1), ch);
+    ZVAL_LONG(ZEND_CALL_ARG(call, 2), dd_const_curlopt_httpheader);
+    ZVAL_COPY_VALUE(ZEND_CALL_ARG(call, 3), &headers);
+
+    zval ret;
+    dd_curl_setopt_handler(call, &ret);
+
+    zend_vm_stack_free_args(call);
+    zend_vm_stack_free_call_frame(call);
 }
 
 static void dd_obj_dtor(void *pData) {
@@ -331,8 +319,7 @@ ZEND_FUNCTION(ddtrace_curl_setopt) {
     if (dd_load_curl_integration() &&
         zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "Olz", &ch, curl_ce, &option, &zvalue) ==
             SUCCESS &&
-        dd_should_save_headers && Z_TYPE_P(return_value) == IS_TRUE && dd_const_curlopt_httpheader == option &&
-        Z_TYPE_P(zvalue) == IS_ARRAY) {
+        Z_TYPE_P(return_value) == IS_TRUE && dd_const_curlopt_httpheader == option && Z_TYPE_P(zvalue) == IS_ARRAY) {
         dd_ch_store_headers(ch, Z_ARRVAL_P(zvalue));
     }
 }
@@ -467,9 +454,6 @@ void ddtrace_curl_handlers_startup(void) {
 
 void ddtrace_curl_handlers_rinit(void) {
     dd_headers = NULL;
-    dd_should_save_headers = true;
-    dd_curl_inject_fn_proxy = NULL;
-    dd_inject_func = NULL;
 
     dd_multi_handles = NULL;
     dd_multi_handles_cache = NULL;
@@ -481,11 +465,6 @@ void ddtrace_curl_handlers_rshutdown(void) {
         zend_hash_destroy(dd_headers);
         FREE_HASHTABLE(dd_headers);
         dd_headers = NULL;
-    }
-    dd_curl_inject_fn_proxy = NULL;
-    if (dd_inject_func) {
-        zend_string_release(dd_inject_func);
-        dd_inject_func = NULL;
     }
 
     if (dd_multi_handles) {

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -395,6 +395,10 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
         add_assoc_str(meta, "env", zend_string_copy(env));
     }
 
+    if (DDTRACE_G(dd_origin)) {
+        add_assoc_str(meta, "_dd.origin", zend_string_copy(DDTRACE_G(dd_origin)));
+    }
+
     zend_array *global_tags = get_DD_TAGS();
     zend_string *global_key;
     zval *global_val;

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -238,3 +238,5 @@ void ddtrace_serialize_closed_spans(zval *serialized) {
     zval_dtor(&DDTRACE_G(additional_trace_meta));
     array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
 }
+
+zend_string *ddtrace_span_id_as_string(uint64_t id) { return zend_strpprintf(0, "%" PRIu64, id); }

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -47,6 +47,7 @@ void ddtrace_close_span(ddtrace_span_fci *span_fci);
 void ddtrace_close_all_open_spans(void);
 void ddtrace_drop_top_open_span(void);
 void ddtrace_serialize_closed_spans(zval *serialized);
+zend_string *ddtrace_span_id_as_string(uint64_t id);
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value);
 

--- a/package.xml
+++ b/package.xml
@@ -342,6 +342,9 @@
             <file name="tests/ext/call_user_func/not-namespaced-array.phpt" role="test" />
             <file name="tests/ext/call_user_func/not-namespaced.phpt" role="test" />
 
+            <file name="tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt" role="test" />
+            <file name="tests/ext/distributed_tracing/distributed_trace_inherit.phpt" role="test" />
+
             <file name="tests/ext/includes/dd_init.php" role="test" />
             <file name="tests/ext/includes/fake_scope.inc" role="test" />
             <file name="tests/ext/includes/fake_span.inc" role="test" />
@@ -370,6 +373,7 @@
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt" role="test" />
+            <file name="tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt" role="test" />
 
             <file name="tests/ext/pcntl/functions.inc" role="test" />

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -70,9 +70,7 @@ final class Bootstrap
                          * substitutions), but it was this way before the refactor, so let's fix this in a
                          * subsequent release, when we will have ported everything else to the extension.
                          */
-                        if (method_exists($tracer, "enforcePrioritySamplingOnRootSpan")) {
-                            $tracer->enforcePrioritySamplingOnRootSpan();
-                        }
+                        $tracer->setPrioritySampling($tracer->getPrioritySampling());
                     }
                 });
             });

--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -54,7 +54,6 @@ final class TextMap implements Propagator
     {
         $traceId = '';
         $spanId = '';
-        $prioritySampling = null;
         $baggageItems = [];
 
         foreach ($carrier as $key => $value) {

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -251,7 +251,9 @@ final class Tracer implements TracerInterface
      */
     public function startRootSpan($operationName, $options = [])
     {
-        return $this->rootScope = $this->startActiveSpan($operationName, $options);
+        $this->rootScope = $this->startActiveSpan($operationName, $options);
+        $this->setPrioritySamplingFromSpan($this->rootScope->getSpan()); // make it the source of truth
+        return $this->rootScope;
     }
 
     /**
@@ -324,7 +326,7 @@ final class Tracer implements TracerInterface
             throw UnsupportedFormat::forFormat($format);
         }
 
-        $this->enforcePrioritySamplingOnRootSpan();
+        $this->setPrioritySampling($this->getPrioritySampling());
         $this->propagators[$format]->inject($spanContext, $carrier);
     }
 
@@ -361,9 +363,8 @@ final class Tracer implements TracerInterface
         }
 
         // At this time, for sure we need to enforce a decision on priority sampling.
-        // Most probably, especially if a distributed tracing request has been done, priority sampling
-        // will be already defined.
-        $this->enforcePrioritySamplingOnRootSpan();
+        // If the user has removed the priority sampling (e.g. due to directly assigning metrics), put it back.
+        $this->setPrioritySampling($this->getPrioritySampling());
         $this->transport->send($this);
     }
 
@@ -554,6 +555,11 @@ final class Tracer implements TracerInterface
      */
     public function getPrioritySampling()
     {
+        // root span is source of truth for priority sampling (if it exists)
+        // @phpstan-ignore-next-line 'Undefined property $metrics' in an isset() check?! Must be a phpstan bug...
+        if (($rootSpan = $this->getSafeRootSpan()) && isset($rootSpan->metrics['_sampling_priority_v1'])) {
+            return $rootSpan->metrics['_sampling_priority_v1'];
+        }
         return $this->prioritySampling;
     }
 
@@ -593,22 +599,5 @@ final class Tracer implements TracerInterface
     public function getTracesCount()
     {
         return count($this->traces);
-    }
-
-    /**
-     * Enforce priority sampling on the root span.
-     */
-    public function enforcePrioritySamplingOnRootSpan()
-    {
-        if ($this->prioritySampling !== Sampling\PrioritySampling::UNKNOWN) {
-            return;
-        }
-
-        $rootSpan = $this->getSafeRootSpan();
-        if (null === $rootSpan) {
-            return;
-        }
-
-        $this->setPrioritySamplingFromSpan($rootSpan);
     }
 }

--- a/src/api/Contracts/SpanContext.php
+++ b/src/api/Contracts/SpanContext.php
@@ -44,11 +44,15 @@ interface SpanContext extends IteratorAggregate
     public function getAllBaggageItems();
 
     /**
+     * Gets initial priority sampling, upon span creation
+     *
      * @return int
      */
     public function getPropagatedPrioritySampling();
 
     /**
+     * Sets initial priority sampling, to be consumed upon span creation
+     *
      * @param int $propagatedPrioritySampling
      */
     public function setPropagatedPrioritySampling($propagatedPrioritySampling);

--- a/src/api/Data/SpanContext.php
+++ b/src/api/Data/SpanContext.php
@@ -40,6 +40,8 @@ abstract class SpanContext implements SpanContextInterface
     public $isDistributedTracingActivationContext;
 
     /**
+     * Initial priority sampling, upon span creation
+     *
      * @var int
      */
     public $propagatedPrioritySampling;

--- a/tests/C2PHP/get_context_distributed_tracing_test.phpt
+++ b/tests/C2PHP/get_context_distributed_tracing_test.phpt
@@ -1,5 +1,8 @@
 --TEST--
 Distributed tracing context with an origin
+--ENV--
+HTTP_X_DATADOG_ORIGIN=some-origin
+HTTP_X_DATADOG_PRIORITY_SAMPLING=1
 --FILE--
 <?php
 

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -231,6 +231,11 @@ trait TracerTestTrait
      */
     public function tracesFromWebRequest($fn, $tracer = null)
     {
+        if ($tracer === null) {
+            // Avoid phpunits default spans from being acknowledged for distributed tracing
+            $this->resetTracer();
+        }
+
         // Clearing existing dumped file
         $this->resetRequestDumper();
 

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -388,6 +388,10 @@ final class CurlIntegrationTest extends IntegrationTestCase
 
     public function testTracerRunningAtLimitedCapacityCurlWorksWithoutARootSpan()
     {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped("This test is obsolete with curl headers looking at internal root spans");
+        }
+
         $found = [];
         $traces = $this->inWebServer(
             function ($execute) use (&$found) {

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -261,7 +261,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('custom')->getSpan();
+            $span = $tracer->startRootSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers', [
                 'headers' => [

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -257,7 +257,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             /** @var Tracer $tracer */
             $tracer = GlobalTracer::get();
             $tracer->setPrioritySampling(PrioritySampling::AUTO_KEEP);
-            $span = $tracer->startActiveSpan('custom')->getSpan();
+            $span = $tracer->startRootSpan('custom')->getSpan();
 
             $response = $client->get(self::URL . '/headers', [
                 'headers' => [

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -42,10 +42,15 @@ final class SpanTest extends BaseTestCase
         $this->tracer = new Tracer();
         $this->oldTracer = \DDTrace\GlobalTracer::get();
         \DDTrace\GlobalTracer::set($this->tracer);
+        self::putenv('DD_TRACE_GENERATE_ROOT_SPAN=0');
+        dd_trace_internal_fn('ddtrace_reload_config');
     }
+
     protected function ddTearDown()
     {
         \DDTrace\GlobalTracer::set($this->oldTracer);
+        dd_trace_serialize_closed_spans();
+        self::putenv('DD_TRACE_GENERATE_ROOT_SPAN');
     }
 
     public function testCreateSpanSuccess()

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -170,21 +170,23 @@ final class TracerTest extends BaseTestCase
         $tracer->flush();
     }
 
-    public function testPrioritySamplingIsLazilyAssignedOnInject()
+    public function testPrioritySamplingIsEarlyAssignedAndRefreshedOnInject()
     {
         $tracer = new Tracer(new DebugTransport());
         $span = $tracer->startRootSpan(self::OPERATION_NAME)->getSpan();
-        $this->assertNull($tracer->getPrioritySampling());
+        $this->assertSame(PrioritySampling::AUTO_KEEP, $tracer->getPrioritySampling());
+        $span->metrics = [];
         $carrier = [];
         $tracer->inject($span->getContext(), Format::TEXT_MAP, $carrier);
         $this->assertSame(PrioritySampling::AUTO_KEEP, $tracer->getPrioritySampling());
     }
 
-    public function testPrioritySamplingIsLazilyAssignedBeforeFlush()
+    public function testPrioritySamplingIsLazilyAssignedAndRefreshedBeforeFlush()
     {
         $tracer = new Tracer(new DebugTransport());
-        $tracer->startRootSpan(self::OPERATION_NAME);
-        $this->assertNull($tracer->getPrioritySampling());
+        $span = $tracer->startRootSpan(self::OPERATION_NAME)->getSpan();
+        $this->assertSame(PrioritySampling::AUTO_KEEP, $tracer->getPrioritySampling());
+        $span->metrics = [];
         $tracer->flush();
         $this->assertSame(PrioritySampling::AUTO_KEEP, $tracer->getPrioritySampling());
     }

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Transmit distributed header information to spans
+--ENV--
+HTTP_X_DATADOG_TRACE_ID=foo
+HTTP_X_DATADOG_PARENT_ID=bar
+HTTP_X_DATADOG_ORIGIN=datadog
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal distributed tracing handling'); ?>
+--FILE--
+<?php
+
+$span = DDTrace\start_span();
+$span->name = 'span';
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "span"
+    ["resource"]=>
+    string(4) "span"
+    ["meta"]=>
+    array(2) {
+      ["system.pid"]=>
+      string(%d) "%d"
+      ["_dd.origin"]=>
+      string(7) "datadog"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Transmit distributed header information to spans
+--ENV--
+HTTP_X_DATADOG_TRACE_ID=42
+HTTP_X_DATADOG_PARENT_ID=10
+HTTP_X_DATADOG_ORIGIN=datadog
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal distributed tracing handling'); ?>
+--FILE--
+<?php
+
+$outer = DDTrace\start_span();
+$outer->name = 'outer';
+$inner = DDTrace\start_span();
+$inner->name = 'inner';
+
+DDTrace\close_span();
+DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  array(9) {
+    ["trace_id"]=>
+    string(2) "42"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(2) "10"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(5) "outer"
+    ["resource"]=>
+    string(5) "outer"
+    ["meta"]=>
+    array(2) {
+      ["system.pid"]=>
+      string(%d) "%d"
+      ["_dd.origin"]=>
+      string(7) "datadog"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+  [1]=>
+  array(8) {
+    ["trace_id"]=>
+    string(2) "42"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(5) "inner"
+    ["resource"]=>
+    string(5) "inner"
+    ["meta"]=>
+    array(1) {
+      ["_dd.origin"]=>
+      string(7) "datadog"
+    }
+  }
+}

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -8,6 +8,7 @@ ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -50,6 +50,7 @@ foreach ($responses as $key => $response) {
     dt_dump_headers_from_httpbin($headers, [
         'x-datadog-trace-id',
         'x-datadog-parent-id',
+        'x-datadog-sampling-priority',
         'x-foo',
         'x-bar',
     ]);
@@ -67,21 +68,25 @@ if (PHP_VERSION_ID < 70000) {
 Response #0
 x-bar: theory
 x-datadog-parent-id: %d
+x-datadog-trace-id: %d
 x-foo: before-the-copy
 
 Response #1
 x-bar: theory
 x-datadog-parent-id: %d
+x-datadog-trace-id: %d
 x-foo: before-the-copy
 
 Response #2
 x-bar: theory
 x-datadog-parent-id: %d
+x-datadog-trace-id: %d
 x-foo: before-the-copy
 
 Response #3
 x-bar: linguistics
 x-datadog-parent-id: %d
+x-datadog-trace-id: %d
 x-foo: after-the-copy
 
 Done.

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -8,6 +8,7 @@ ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -8,6 +8,7 @@ ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
@@ -14,6 +14,7 @@ setting the curl opts.
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {

--- a/tests/ext/integrations/curl/distributed_tracing_curl_inject.inc
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_inject.inc
@@ -4,6 +4,7 @@ namespace DDTrace\Bridge;
 
 function curl_inject_distributed_headers($ch, array $headers)
 {
+    $headers[] = 'x-datadog-trace-id: ' . \DDTrace\trace_id();
     $headers[] = 'x-datadog-parent-id: ' . \dd_trace_peek_span_id();
     $headers[] = 'x-datadog-origin: phpt-test';
     \curl_setopt($ch, \CURLOPT_HTTPHEADER, $headers);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt
@@ -3,6 +3,7 @@ If curl_inject_distributed_headers helper is missing, we don't sigsegv, right?
 --SKIPIF--
 <?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test obsolete with internal distributed tracing handling'); ?>
 --INI--
 ddtrace.request_init_hook=
 --ENV--

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -7,6 +7,7 @@ Distributed tracing headers propagate with curl_multi_exec()
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -7,6 +7,7 @@ Distributed tracing headers propagate when curl_multi_init() is called before cu
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -8,6 +8,7 @@ Distributed tracing headers propagate with curl_multi_exec() after curl_copy_han
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle_bug_71523.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle_bug_71523.phpt
@@ -8,6 +8,7 @@
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
@@ -7,6 +7,7 @@ Distributed tracing headers do not propagate with curl_multi_exec() after dd_tra
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -7,6 +7,7 @@ Distributed tracing headers propagate with curl_multi_exec() and headers set wit
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -7,6 +7,7 @@ Distributed tracing headers propagate with curl_multi_exec() and headers set wit
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Distributed tracing headers propagate with curl_exec()
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires internal distributed curl header handling'); ?>
+--FILE--
+<?php
+
+include 'distributed_tracing.inc';
+
+function query_headers() {
+    $port = getenv('HTTPBIN_PORT') ?: '80';
+    $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return dt_decode_headers_from_httpbin($response);
+}
+
+$rootSpan = DDTrace\active_span();
+$rootSpan->metrics["_sampling_priority_v1"] = 2;
+
+dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-sampling-priority']);
+
+var_dump(isset($headers['x-datadog-sampling-priority']));
+
+echo 'Done.' . PHP_EOL;
+
+?>
+--EXPECTF--
+x-datadog-sampling-priority: 2
+bool(false)
+Done.

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sandboxed.phpt
@@ -3,6 +3,7 @@ Calls to curl_inject_distributed_headers() are sandboxed
 --SKIPIF--
 <?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+<?php if (PHP_VERSION_ID >= 80000) die('skip: Test obsolete with internal distributed tracing handling'); ?>
 --INI--
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject_exception.inc
 --ENV--

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN \
             php-pecl-redis \
             mod_php \
     && debuginfo-install --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} -y php-fpm \
+    && debuginfo-install -y httpd \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN \
             php-pear \
             php-pecl-redis \
             mod_php \
+    && debuginfo-install --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} -y php-fpm \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/tests/randomized/docker/run.sh
+++ b/tests/randomized/docker/run.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+bash /scripts/enable-coredump.sh
 bash /scripts/prepare.sh
 
 echo "Starting load"

--- a/tests/randomized/lib/templates/Makefile.scenario.template
+++ b/tests/randomized/lib/templates/Makefile.scenario.template
@@ -15,6 +15,7 @@ prepare_results_folders:
 	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/nginx
 	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/php-fpm
 	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/apache
+	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/corefiles
 	@chmod -R a+w $(RESULTS_DIR)/$(SCENARIO)
 
 # keep this line to avoid whitespace errors with generated files

--- a/tests/randomized/lib/templates/Makefile.scenario.template
+++ b/tests/randomized/lib/templates/Makefile.scenario.template
@@ -12,7 +12,9 @@ shell: prepare_results_folders
 
 prepare_results_folders:
 	@rm -rf $(RESULTS_DIR)/$(SCENARIO)
-	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)
+	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/nginx
+	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/php-fpm
+	@mkdir -p $(RESULTS_DIR)/$(SCENARIO)/apache
 	@chmod -R a+w $(RESULTS_DIR)/$(SCENARIO)
 
 # keep this line to avoid whitespace errors with generated files

--- a/tests/randomized/lib/templates/docker-compose.template.yml
+++ b/tests/randomized/lib/templates/docker-compose.template.yml
@@ -49,6 +49,7 @@ services:
       - ../.results/{{identifier}}/nginx:/var/log/nginx
       - ../.results/{{identifier}}/php-fpm:/var/log/php-fpm
       - ../.results/{{identifier}}/apache:/var/log/httpd/
+      - ../.results/{{identifier}}/corefiles:/tmp/corefiles
     environment:
         DURATION: ${DURATION}
         INSTALL_MODE: {{installation_method}}


### PR DESCRIPTION
### Description

- _dd.origin is appended to all spans meta upon serialization
- The userland curl injection has been removed in favour of a completely internal implementation. (Because _dd.origin is now not exposed anymore)
- The sampling priority metric of the root span is the source of truth for distributed tracing (and needs to be initialized early thus).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
