### PR TITLE
Fix debug/prod Makefile options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,10 +167,10 @@ sudo:
 	$(eval SUDO:=sudo)
 
 debug:
-	$(eval CFLAGS="$(CFLAGS) -O0 -g")
+	$(eval CFLAGS=$(CFLAGS) -O0 -g)
 
 prod:
-	$(eval CFLAGS="$(CFLAGS) -O2 -g0")
+	$(eval CFLAGS=$(CFLAGS) -O2 -g0)
 
 strict:
 	$(eval CFLAGS=-Wall -Werror -Wextra)


### PR DESCRIPTION
Trivial fix for bogus behavior introduced in 6e1dccff9d69b3e913be764ad661e3a965bd662e:

```
make: Nothing to be done for 'prod'.
make: invalid option -- 'g'
make: invalid option -- 'g'
make: invalid option -- '0'
```