### PR TITLE
Skip test ext/sockets/tests/socket_create_listen-nobind.phpt on PHP 5.4..7.3

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -109,6 +109,7 @@ ext/simplexml/tests/SimpleXMLElement_addAttribute_basic.phpt
 ext/simplexml/tests/bug66084_0.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_first.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_last.phpt

--- a/dockerfiles/ci/xfail_tests/5.5.list
+++ b/dockerfiles/ci/xfail_tests/5.5.list
@@ -117,6 +117,7 @@ ext/simplexml/tests/bug66084_0.phpt
 ext/simplexml/tests/bug69491.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_first.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_last.phpt

--- a/dockerfiles/ci/xfail_tests/5.6.list
+++ b/dockerfiles/ci/xfail_tests/5.6.list
@@ -143,6 +143,7 @@ ext/simplexml/tests/bug66084_0.phpt
 ext/simplexml/tests/bug69491.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_first.phpt
 ext/spl/tests/SplDoublylinkedlist_offsetunset_last.phpt

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -180,6 +180,7 @@ ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt
 ext/spl/tests/ArrayObject_dump_during_sort.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -193,6 +193,7 @@ ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt
 ext/spl/tests/ArrayObject_dump_during_sort.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -175,6 +175,7 @@ ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/sodium/tests/utils.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -191,6 +191,7 @@ ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
+ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/sodium/tests/utils.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt


### PR DESCRIPTION
* Disabled on versions: `5.4 --> 7.3`.
* [Broken CI build example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/6016/workflows/dd24ea85-1ec4-47ea-9311-080a66d045a5/jobs/497177)

This test runs succesfully only if a socket CANNOT be created on port 80 in the environment where the test is executed. With recent changes to CircleCI is now possible to create a socket on port 80. As a proof of it, ssh-ing into a CircleCI runner:

```
$ TEST_PHP_EXECUTABLE=$(which php) php run-tests.php --show-out --show-diff ext/sockets/tests/socket_create_listen-nobind.phpt
...
001+ resource(4) of type (Socket)   <<<< dumping the returned socket [here](https://github.com/php/php-src/blob/53ea910d1760c87b6110a461f13ebe0e244c9914/ext/sockets/tests/socket_create_listen-nobind.phpt#L17), it is supposed to return `false` instead.
...
```

The reason why this test is not failing on PHP 7.4+ if because it is skipped by this [extra check](https://github.com/php/php-src/blob/9db3eda2cbaa01529d807b2326be13e7b0e5e496/ext/sockets/tests/socket_create_listen-nobind.phpt#L16-L18).

As a confirmation, running the previous test on a 7.4 runner would result in:

```
$ TEST_PHP_EXECUTABLE=$(which php) php run-tests.php --show-out --show-diff ext/sockets/tests/socket_create_listen-nobind.phpt
...
SKIP Test if socket_create_listen() returns false, when it cannot bind to the port. [ext/sockets/tests/socket_create_listen-nobind.phpt] reason: Test cannot be run in environment that will allow binding to port 80 (azure)
...
```

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
