### PR TITLE
Set SECBIT_NO_SETUID_FIXUP to prevent crashes after setuid() calls

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -28,6 +28,8 @@ if test "$PHP_DDTRACE" != "no"; then
       [PHP_ADD_LIBRARY(execinfo, , EXTRA_LDFLAGS)])
   )
 
+  AC_CHECK_HEADERS([linux/securebits.h])
+
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     EXTRA_LDFLAGS="-fsanitize=address"
     EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"

--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -1,5 +1,9 @@
 #include "coms.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <SAPI.h>
 #include <curl/curl.h>
 #include <errno.h>
@@ -12,6 +16,11 @@
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
+
+#if HAVE_LINUX_SECUREBITS_H
+#include <linux/securebits.h>
+#include <sys/prctl.h>
+#endif
 
 #include "compatibility.h"
 #include "configuration.h"
@@ -274,6 +283,8 @@ struct _writer_loop_data_t {
 
     struct _writer_thread_variables_t *thread;
 
+    bool set_secbit;
+
     _Atomic(bool) running, starting_up;
     _Atomic(pid_t) current_pid;
     _Atomic(bool) shutdown_when_idle, suspended, sending, allocate_new_stacks;
@@ -282,6 +293,7 @@ struct _writer_loop_data_t {
 };
 
 static struct _writer_loop_data_t global_writer = {.thread = NULL,
+                                                   .set_secbit = 0,
                                                    .running = ATOMIC_VAR_INIT(0),
                                                    .current_pid = ATOMIC_VAR_INIT(0),
                                                    .shutdown_when_idle = ATOMIC_VAR_INIT(0),
@@ -835,6 +847,14 @@ static void *_dd_writer_loop(void *_) {
 
     struct _writer_loop_data_t *writer = _dd_get_writer();
 
+#if HAVE_LINUX_SECUREBITS_H
+    if (writer->set_secbit) {
+        // prevent setuid from messing with our effective capabilities
+        // this is necessary to handle scenarios where setuid is only called after starting our thread
+        prctl(PR_SET_SECUREBITS, SECBIT_NO_SETUID_FIXUP);
+    }
+#endif
+
     bool running = true;
     _dd_signal_writer_started(writer);
     do {
@@ -949,6 +969,7 @@ bool ddtrace_coms_init_and_start_writer(void) {
     struct _writer_thread_variables_t *thread = _dd_create_thread_variables();
     writer->thread = thread;
     atomic_store(&writer->starting_up, true);
+    writer->set_secbit = get_dd_trace_retain_thread_capabilities();
     if (pthread_create(&thread->self, NULL, &_dd_writer_loop, NULL) == 0) {
         return true;
     } else {

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -136,6 +136,7 @@ void ddtrace_config_shutdown(void);
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")                                                          \
     BOOL(get_dd_trace_warn_legacy_dd_trace, "DD_TRACE_WARN_LEGACY_DD_TRACE", true)                                   \
+    BOOL(get_dd_trace_retain_thread_capabilities, "DD_TRACE_RETAIN_THREAD_CAPABILITIES", false)                      \
     CHAR(get_dd_version, "DD_VERSION", "")
 
 // render all configuration getters and define memoization struct

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -136,6 +136,7 @@ void ddtrace_config_shutdown(void);
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")                                                          \
     BOOL(get_dd_trace_warn_legacy_dd_trace, "DD_TRACE_WARN_LEGACY_DD_TRACE", true)                                   \
+    BOOL(get_dd_trace_retain_thread_capabilities, "DD_TRACE_RETAIN_THREAD_CAPABILITIES", false)                      \
     CHAR(get_dd_version, "DD_VERSION", "")
 
 // render all configuration getters and define memoization struct

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -134,6 +134,7 @@ void ddtrace_config_shutdown(void);
         "reaching this percent threshold of a span buffer will trigger background thread "                           \
         "to attempt to flush existing data to trace agent")                                                          \
     BOOL(get_dd_trace_warn_legacy_dd_trace, "DD_TRACE_WARN_LEGACY_DD_TRACE", true)                                   \
+    BOOL(get_dd_trace_retain_thread_capabilities, "DD_TRACE_RETAIN_THREAD_CAPABILITIES", false)                      \
     CHAR(get_dd_version, "DD_VERSION", "")
 
 // render all configuration getters and define memoization struct

--- a/package.xml
+++ b/package.xml
@@ -320,6 +320,7 @@
             <file name="tests/ext/background-sender/agent_headers_container_id_empty.phpt" role="test" />
             <file name="tests/ext/background-sender/agent_headers_container_id_fargate.phpt" role="test" />
             <file name="tests/ext/background-sender/agent_headers_ignore_userland.phpt" role="test" />
+            <file name="tests/ext/background-sender/background_sender_survives_setuid.phpt" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.docker" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.empty" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.fargate.1.4" role="test" />

--- a/tests/ext/background-sender/background_sender_survives_setuid.phpt
+++ b/tests/ext/background-sender/background_sender_survives_setuid.phpt
@@ -1,0 +1,74 @@
+--TEST--
+background sender survives setuid
+--DESCRIPTION--
+setuid() will reset the effective capabilities of the thread to zero when it's run. Ensure that we do not crash afterwards.
+To test this we will issue a setgroups() via the libc wrapper (which distributes the setgroups() syscall to all threads of the process).
+--SKIPIF--
+<?php if (PHP_OS != "Linux") die('skip: Linux specific test for setuid(2) behaviour'); ?>
+<?php if (!extension_loaded("ffi")) die("skip: requires ext/ffi"); ?>
+<?php if (posix_getuid() != 0 && getenv("ZEND_DONT_UNLOAD_MODULES")) die("skip: detected ZEND_DONT_UNLOAD_MODULES - the test is most likely executed as non-root via valgrind"); ?>
+<?php if (posix_getuid() != 0 && trim(shell_exec("sudo echo 1")) !== "1") die("skip: user is not root and has no password-less sudo"); ?>
+--ENV--
+DD_TRACE_RETAIN_THREAD_CAPABILITIES=1
+--FILE--
+<?php
+
+if (posix_getuid() != 0) {
+    $sudoPath = trim(`which sudo`);
+    $cmdAndArgs = explode("\0", file_get_contents("/proc/" . getmypid() . "/cmdline"));
+    pcntl_exec($sudoPath, [-2 => '-E', -1 => '--'] + $cmdAndArgs);
+}
+
+$ffi = FFI::cdef(<<<DEFS
+int setgroups(size_t size, const uint32_t *list);
+int setuid(uint32_t uid);
+
+typedef struct {
+    uint32_t version;
+    int pid;
+} cap_user_header_t;
+
+typedef struct {
+    uint32_t effective;
+    uint32_t permitted;
+    uint32_t inheritable;
+} cap_user_data_t;
+
+int prctl(int option, unsigned long arg2);
+int capset(cap_user_header_t *hdrp, const cap_user_data_t *datap);
+DEFS
+, "libc.so.6");
+
+const PR_SET_KEEPCAPS = 8;
+
+$ffi->prctl(PR_SET_KEEPCAPS, 1);
+
+$ffi->setuid(1); // daemon user
+
+const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;
+const CAP_SETGID = 6;
+
+$capheader = $ffi->new("cap_user_header_t");
+$capheader->version = _LINUX_CAPABILITY_VERSION_1;
+
+$capdata = $ffi->new("cap_user_data_t");
+$capdata->inheritable = 0;
+$capdata->effective = $capdata->permitted = 1 << CAP_SETGID;
+
+$ffi->capset(FFI::addr($capheader), FFI::addr($capdata));
+
+$groups = $ffi->new("uint32_t");
+$groups->cdata = 1;
+var_dump($ffi->setgroups(1, FFI::addr($groups)));
+
+// payload = [[]]
+$payload = "\x91\x90";
+
+var_dump(dd_trace_send_traces_via_thread(1, [], $payload));
+
+echo "Done.";
+?>
+--EXPECT--
+int(0)
+bool(true)
+Done.


### PR DESCRIPTION
### Description

Setuid() calls reset the effective capabilities of a thread to zero. This will prevent us from doing some operations. (including the setgroups() syscall where we encountered the crash.)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

_No tests added as I have no idea how to meaningfully test this, especially in a non-privileged docker container ..._

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
