### PR TITLE
Add ext/ffi to PHP builds

### DIFF
--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.0.tar.gz
-        phpSha256Hash: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.8.tar.gz
+        phpSha256Hash: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945

--- a/dockerfiles/ci/alpine/php-8.0/configure.sh
+++ b/dockerfiles/ci/alpine/php-8.0/configure.sh
@@ -15,6 +15,7 @@ ${PHP_SRC_DIR}/configure \
     --enable-phpdbg \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -15,6 +15,7 @@ ENV RUNTIME_DEPS \
     less \
     libcurl4-openssl-dev \
     libedit-dev \
+    libffi-dev \
     libmcrypt-dev \
     libmemcached-dev \
     libonig-dev \

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       context: ./php-8.0
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.3.tar.gz
-        phpSha256Hash: e7ecfee901e0843377b64b2d8124132eae75bdb71a2675ba7c5c038d6592383d
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.8.tar.gz
+        phpSha256Hash: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
 
   php-8.0-shared-ext:
     image: datadog/dd-trace-ci:php-8.0-shared-ext
@@ -23,8 +23,8 @@ services:
       dockerfile: Dockerfile_shared_ext
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.3.tar.gz
-        phpSha256Hash: e7ecfee901e0843377b64b2d8124132eae75bdb71a2675ba7c5c038d6592383d
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.8.tar.gz
+        phpSha256Hash: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
 
   php-7.4:
     image: datadog/dd-trace-ci:php-7.4_buster
@@ -32,8 +32,8 @@ services:
       context: ./php-7.4
       args:
         phpVersion: 7.4
-        phpTarGzUrl: https://www.php.net/distributions/php-7.4.16.tar.gz
-        phpSha256Hash: ef2d2b463fc3444895ec599337b663a8832c6ade148d9832417e59aa2b9e93da
+        phpTarGzUrl: https://www.php.net/distributions/php-7.4.21.tar.gz
+        phpSha256Hash: 4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db
 
   php-7.3:
     image: datadog/dd-trace-ci:php-7.3_buster
@@ -41,8 +41,8 @@ services:
       context: ./php-7.3
       args:
         phpVersion: 7.3
-        phpTarGzUrl: https://www.php.net/distributions/php-7.3.27.tar.gz
-        phpSha256Hash: 4b7b9bd0526ad3f2c8d6fd950ea7b0ab2478b5b09755c6a620a4f3bcfbf59154
+        phpTarGzUrl: https://www.php.net/distributions/php-7.3.29.tar.gz
+        phpSha256Hash: ba4de3955b0cbd33baee55a83568acc4347605e210a54b5654e4c1e09b544659
 
   php-7.2:
     image: datadog/dd-trace-ci:php-7.2_buster

--- a/dockerfiles/ci/buster/php-7.4/configure.sh
+++ b/dockerfiles/ci/buster/php-7.4/configure.sh
@@ -15,6 +15,7 @@ ${PHP_SRC_DIR}/configure \
     --enable-pcntl \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/buster/php-8.0/configure.sh
+++ b/dockerfiles/ci/buster/php-8.0/configure.sh
@@ -15,6 +15,7 @@ ${PHP_SRC_DIR}/configure \
     --enable-pcntl \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/buster/php-8.0/configure_shared_ext.sh
+++ b/dockerfiles/ci/buster/php-8.0/configure_shared_ext.sh
@@ -7,9 +7,10 @@ ${PHP_SRC_DIR}/configure \
     --disable-all \
     --enable-cgi \
     --enable-fpm \
-    --enable-pcntl \
+    --enable-pcntl=shared \
     --enable-phpdbg \
     --enable-option-checking=fatal \
+    --with-ffi=shared \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --without-pear \

--- a/dockerfiles/ci/buster/php-master/install-php-master
+++ b/dockerfiles/ci/buster/php-master/install-php-master
@@ -28,6 +28,7 @@ sharedConfig="
     --enable-phpdbg \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/centos/6/CentOS-Base.repo
+++ b/dockerfiles/ci/centos/6/CentOS-Base.repo
@@ -1,0 +1,39 @@
+[C6.10-base]
+name=CentOS-6.10 - Base
+baseurl=http://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-updates]
+name=CentOS-6.10 - Updates
+baseurl=http://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-extras]
+name=CentOS-6.10 - Extras
+baseurl=http://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+metadata_expire=never
+
+[C6.10-contrib]
+name=CentOS-6.10 - Contrib
+baseurl=http://vault.centos.org/6.10/contrib/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+metadata_expire=never
+
+[C6.10-centosplus]
+name=CentOS-6.10 - CentOSPlus
+baseurl=http://vault.centos.org/6.10/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+metadata_expire=never

--- a/dockerfiles/ci/centos/6/CentOS-SCLo-scl-rh.repo
+++ b/dockerfiles/ci/centos/6/CentOS-SCLo-scl-rh.repo
@@ -1,0 +1,33 @@
+# CentOS-SCLo-rh.repo
+#
+# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# information
+
+[centos-sclo-rh]
+name=CentOS-6 - SCLo rh
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/rh/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-testing]
+name=CentOS-6 - SCLo rh Testing
+baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/rh/
+gpgcheck=0
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-source]
+name=CentOS-6 - SCLo rh Sources
+baseurl=http://vault.centos.org/centos/6/sclo/Source/rh/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-rh-debuginfo]
+name=CentOS-6 - SCLo rh Debuginfo
+baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+

--- a/dockerfiles/ci/centos/6/CentOS-SCLo-scl.repo
+++ b/dockerfiles/ci/centos/6/CentOS-SCLo-scl.repo
@@ -1,0 +1,33 @@
+# CentOS-SCLo-sclo.repo
+#
+# Please see http://wiki.centos.org/SpecialInterestGroup/SCLo for more
+# information
+
+[centos-sclo-sclo]
+name=CentOS-6 - SCLo sclo
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/sclo/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-testing]
+name=CentOS-6 - SCLo sclo Testing
+baseurl=http://buildlogs.centos.org/centos/6/sclo/$basearch/sclo/
+gpgcheck=0
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-source]
+name=CentOS-6 - SCLo sclo Sources
+baseurl=http://vault.centos.org/centos/6/sclo/Source/sclo/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+[centos-sclo-sclo-debuginfo]
+name=CentOS-6 - SCLo sclo Debuginfo
+baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+

--- a/dockerfiles/ci/centos/6/Dockerfile
+++ b/dockerfiles/ci/centos/6/Dockerfile
@@ -1,6 +1,9 @@
 FROM centos:6
 
+COPY CentOS-Base.repo /etc/yum.repos.d/
+
 RUN set -eux; \
+    echo 'ip_resolve = IPv4' >>/etc/yum.conf; \
     yum update -y; \
     yum install -y \
         centos-release-scl \
@@ -19,7 +22,12 @@ RUN set -eux; \
         unzip \
         vim \
         xz \
-        zlib-devel; \
+        zlib-devel;
+
+COPY CentOS-SCLo-scl.repo /etc/yum.repos.d/
+COPY CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/
+
+RUN set -eux; \
     yum install -y devtoolset-7; \
     yum clean all;
 
@@ -43,6 +51,10 @@ RUN set -eux; \
 # Required: libcurl >= 7.29.0 (default version is 7.19.7)
     /root/download-src.sh libcurl https://curl.haxx.se/download/curl-7.72.0.tar.gz; \
     cd "${SRC_DIR}/libcurl"; \
+    ./configure && make && make install; \
+# Required: libffi >= 3.0.11 (default version is 3.0.5)
+    /root/download-src.sh libffi https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz; \
+    cd "${SRC_DIR}/libffi"; \
     ./configure && make && make install; \
 # Required: oniguruma (not installed by deafult)
     /root/download-src.sh oniguruma https://github.com/kkos/oniguruma/releases/download/v6.9.5_rev1/onig-6.9.5-rev1.tar.gz; \

--- a/dockerfiles/ci/centos/6/Dockerfile_php5
+++ b/dockerfiles/ci/centos/6/Dockerfile_php5
@@ -13,7 +13,7 @@ RUN set -eux; \
     mkdir -p $PHP_SRC_DIR; \
     mkdir -p $PHP_INSTALL_DIR; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
-    (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
+    (echo "${phpSha256Hash}  /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz;
 
@@ -22,7 +22,7 @@ COPY php-${PHP_VERSION}/configure.sh /root/
 
 FROM build as php-zts
 RUN set -eux; \
-    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    bash -c 'mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-maintainer-zts \
         --prefix=${PHP_INSTALL_DIR_ZTS} \
@@ -30,10 +30,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;'
 
 FROM build as php-debug
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-debug \
@@ -42,10 +42,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;'
 
 FROM build as php-nts
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --prefix=${PHP_INSTALL_DIR_NTS} \
@@ -53,7 +53,7 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;'
 
 FROM base as final
 COPY --from=php-zts $PHP_INSTALL_DIR_ZTS $PHP_INSTALL_DIR_ZTS

--- a/dockerfiles/ci/centos/6/Dockerfile_php7
+++ b/dockerfiles/ci/centos/6/Dockerfile_php7
@@ -13,7 +13,7 @@ RUN set -eux; \
     mkdir -p $PHP_SRC_DIR; \
     mkdir -p $PHP_INSTALL_DIR; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
-    (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
+    (echo "${phpSha256Hash}  /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz;
 
@@ -21,7 +21,7 @@ FROM base as build
 COPY php-${PHP_VERSION}/configure.sh /root/
 
 FROM build as php-zts
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-maintainer-zts \
@@ -30,10 +30,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;'
 
 FROM build as php-debug
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-debug \
@@ -42,10 +42,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;'
 
 FROM build as php-nts
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --prefix=${PHP_INSTALL_DIR_NTS} \
@@ -53,7 +53,7 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;'
 
 FROM base as final
 COPY --from=php-zts $PHP_INSTALL_DIR_ZTS $PHP_INSTALL_DIR_ZTS

--- a/dockerfiles/ci/centos/6/Dockerfile_php8
+++ b/dockerfiles/ci/centos/6/Dockerfile_php8
@@ -13,7 +13,7 @@ RUN set -eux; \
     mkdir -p $PHP_SRC_DIR; \
     mkdir -p $PHP_INSTALL_DIR; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
-    (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
+    (echo "${phpSha256Hash}  /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz; \
     ${PHP_SRC_DIR}/buildconf --force;
@@ -22,7 +22,7 @@ FROM base as build
 COPY php-${PHP_VERSION}/configure.sh /root/
 
 FROM build as php-zts
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-zts \
@@ -31,10 +31,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;'
 
 FROM build as php-debug
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --enable-debug \
@@ -43,10 +43,10 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;'
 
 FROM build as php-nts
-RUN set -eux; \
+RUN bash -c 'set -eux; \
     mkdir -p /tmp/build-php && cd /tmp/build-php; \
     /root/configure.sh \
         --prefix=${PHP_INSTALL_DIR_NTS} \
@@ -54,7 +54,7 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
-    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
+    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;'
 
 FROM base as final
 COPY --from=php-zts $PHP_INSTALL_DIR_ZTS $PHP_INSTALL_DIR_ZTS

--- a/dockerfiles/ci/centos/6/docker-compose.yml
+++ b/dockerfiles/ci/centos/6/docker-compose.yml
@@ -72,8 +72,8 @@ services:
       dockerfile: Dockerfile_php7
       args:
         phpVersion: 7.3
-        phpTarGzUrl: https://www.php.net/distributions/php-7.3.25.tar.gz
-        phpSha256Hash: 097c7a2a2f9189b33799d79ee5a8aac68a4d72696c1cd69c66ef5d0941ce28ad
+        phpTarGzUrl: https://www.php.net/distributions/php-7.3.29.tar.gz
+        phpSha256Hash: ba4de3955b0cbd33baee55a83568acc4347605e210a54b5654e4c1e09b544659
     image: 'datadog/dd-trace-ci:php-7.3_centos-6'
 
   php-7.4:
@@ -82,8 +82,8 @@ services:
       dockerfile: Dockerfile_php7
       args:
         phpVersion: 7.4
-        phpTarGzUrl: https://www.php.net/distributions/php-7.4.13.tar.gz
-        phpSha256Hash: 0865cff41e7210de2537bcd5750377cfe09a9312b9b44c1a166cf372d5204b8f
+        phpTarGzUrl: https://www.php.net/distributions/php-7.4.21.tar.gz
+        phpSha256Hash: 4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db
     image: 'datadog/dd-trace-ci:php-7.4_centos-6'
 
   php-8.0:
@@ -92,6 +92,6 @@ services:
       dockerfile: Dockerfile_php8
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.0.tar.gz
-        phpSha256Hash: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.8.tar.gz
+        phpSha256Hash: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
     image: 'datadog/dd-trace-ci:php-8.0_centos-6'

--- a/dockerfiles/ci/centos/6/php-7.4/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.4/configure.sh
@@ -14,6 +14,7 @@ ${PHP_SRC_DIR}/configure \
     --enable-phpdbg \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/centos/6/php-8.0/configure.sh
+++ b/dockerfiles/ci/centos/6/php-8.0/configure.sh
@@ -14,6 +14,7 @@ ${PHP_SRC_DIR}/configure \
     --enable-phpdbg \
     --enable-sockets \
     --with-curl \
+    --with-ffi \
     --with-fpm-user=www-data \
     --with-fpm-group=www-data \
     --with-libedit \

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -55,6 +55,7 @@ Zend/tests/bug79778.phpt
 Zend/tests/bug79862.phpt
 Zend/tests/bug80037.phpt
 Zend/tests/bug80194.phpt
+Zend/tests/bug81104.phpt
 Zend/tests/class_alias_020.phpt
 Zend/tests/class_name_as_scalar.phpt
 Zend/tests/closure_058.phpt
@@ -80,6 +81,7 @@ Zend/tests/list_keyed_conversions.phpt
 Zend/tests/modify_isref_value_return.phpt
 Zend/tests/multibyte/multibyte_encoding_004.phpt
 Zend/tests/object_array_cast.phpt
+Zend/tests/object_gc_in_shutdown.phpt
 Zend/tests/objects_019.phpt
 Zend/tests/objects_032.phpt
 Zend/tests/offset_array.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -61,6 +61,8 @@ Zend/tests/bug79778.phpt
 Zend/tests/bug79862.phpt
 Zend/tests/bug80037.phpt
 Zend/tests/bug80194.phpt
+Zend/tests/bug81076.phpt
+Zend/tests/bug81104.phpt
 Zend/tests/class_alias_020.phpt
 Zend/tests/class_name_as_scalar.phpt
 Zend/tests/closure_058.phpt
@@ -96,6 +98,7 @@ Zend/tests/multibyte/multibyte_encoding_004.phpt
 Zend/tests/named_params/attributes.phpt
 Zend/tests/nullsafe_operator/019.phpt
 Zend/tests/object_array_cast.phpt
+Zend/tests/object_gc_in_shutdown.phpt
 Zend/tests/objects_019.phpt
 Zend/tests/objects_032.phpt
 Zend/tests/offset_array.phpt
@@ -245,6 +248,9 @@ ext/openssl/tests/tlsv1.0_wrapper.phpt
 ext/openssl/tests/tlsv1.1_wrapper.phpt
 ext/openssl/tests/tlsv1.2_wrapper.phpt
 ext/openssl/tests/tlsv1.3_wrapper.phpt
+ext/pcntl/tests/pcntl_unshare_01.phpt
+ext/pcntl/tests/pcntl_unshare_02.phpt
+ext/pcntl/tests/pcntl_unshare_03.phpt
 ext/pdo_sqlite/tests/pdo_sqlite_lastinsertid.phpt
 ext/phar/tests/031.phpt
 ext/phar/tests/032.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -39,6 +39,10 @@ On PHP 5, certain tests can have intermittently deep call stacks that are deep e
 
 # Specific tests
 
+## `Zend/tests/object_gc_in_shutdown.phpt`, `Zend/tests/bug81104.phpt`
+
+Tests memory limits, which we exceed due to tracer being loaded.
+
 ## `ext/pcntl/tests/pcntl_unshare_01.phpt`
 
 Disabled on versions: `7.4` (it wasn't there on [7.3-](https://github.com/php/php-src/tree/PHP-7.3/ext/pcntl/tests)).

--- a/dockerfiles/compile_extension/docker-compose.yml
+++ b/dockerfiles/compile_extension/docker-compose.yml
@@ -86,8 +86,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 7.3.23
-        php_sha: a21094b9ba2d8fe7fa5838e6566e30cf4bfaf2c8a6dce90ff707c45d0d8d494d
+        php_version: 7.3.29
+        php_sha: ba4de3955b0cbd33baee55a83568acc4347605e210a54b5654e4c1e09b544659
         php_api: 20180731
     command: build-dd-trace-php
     volumes:
@@ -99,8 +99,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 7.4.11
-        php_sha: b4fae5c39ca1eedf5597071996d9c85d0674b83f5003126c39b7b44bbfbcd821
+        php_version: 7.4.21
+        php_sha: 4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db
         php_api: 20190902
     command: build-dd-trace-php
     volumes:
@@ -112,8 +112,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 8.0.0
-        php_sha: 3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71
+        php_version: 8.0.8
+        php_sha: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
         php_api: 20200930
     command: build-dd-trace-php
     volumes:

--- a/dockerfiles/compile_extension/install-php
+++ b/dockerfiles/compile_extension/install-php
@@ -17,6 +17,7 @@ apk add --no-cache --virtual .php-build-deps \
 apk add --no-cache --virtual .php-deps \
     curl-dev \
     libedit-dev \
+    libffi-dev \
     libmcrypt-dev \
     oniguruma-dev \
     libsodium-dev \
@@ -44,6 +45,7 @@ PHP_CONFIG_ARGS=""
     --enable-mbstring \
     --with-sodium=shared \
     --with-curl \
+    --with-ffi \
     --with-libedit \
     --without-pdo-sqlite \
     --without-sqlite3 \


### PR DESCRIPTION
This allows us to try sideeffect-ful syscalls in our testsuite.
Also fix CentOS 6 for now by hardcoding repository files from their vault (repository archive).