### PR TITLE
Apply original curl headers when curl_setopt_array() fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,23 @@ jobs:
             fi
       - run:
           name: Run << parameters.ext_name >> integration tests with ext/<< parameters.ext_name >> as shared lib + leak detection
-          command: make test_extension_ci BUILD_DIR=$(pwd)/tmp/build_extension JUNIT_RESULTS_DIR=$(pwd)/test-results TESTS='-d extension=<< parameters.ext_name >>.so ./tests/ext/integrations/<< parameters.ext_name >>'
+          command: |
+            make test_extension_ci \
+              BUILD_DIR=$(pwd)/tmp/build_extension \
+              JUNIT_RESULTS_DIR=$(pwd)/test-results \
+              RUN_TESTS_EXTRA_ARGS="-d extension=<< parameters.ext_name >>.so" \
+              TESTS="tests/ext/integrations/<< parameters.ext_name >>"
+            if [ "<< parameters.ext_name >>" = "curl" ]
+            then
+              for curlVersion in 7.72.0 7.77.0
+              do
+                make test_c \
+                  BUILD_DIR=$(pwd)/tmp/build_extension \
+                  JUNIT_RESULTS_DIR=$(pwd)/test-results \
+                  RUN_TESTS_EXTRA_ARGS="-d extension=<< parameters.ext_name >>-${curlVersion}.so" \
+                  TESTS="tests/ext/integrations/<< parameters.ext_name >>"
+              done
+            fi
       - <<: *STEP_STORE_TEST_RESULTS
       - run:
           command: |

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ VERSION:=$(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
-RUN_TESTS_CMD := REPORT_EXIT_STATUS=1 TEST_PHP_SRCDIR=$(PROJECT_ROOT) USE_TRACKED_ALLOC=1 php -n -d 'memory_limit=-1' $(BUILD_DIR)/run-tests.php --show-diff -n -p $(shell which php) -q
+RUN_TESTS_EXTRA_ARGS :=
+RUN_TESTS_CMD := REPORT_EXIT_STATUS=1 TEST_PHP_SRCDIR=$(PROJECT_ROOT) USE_TRACKED_ALLOC=1 php -n -d 'memory_limit=-1' $(BUILD_DIR)/run-tests.php --show-diff -n -p $(shell which php) -q $(RUN_TESTS_EXTRA_ARGS)
 
 C_FILES := $(shell find components ext src/dogstatsd zend_abstract_interface -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES := $(shell find tests/ext -name '*.php*' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
@@ -72,7 +72,7 @@ RUN set -eux; \
         curl -L -o curl.tar.gz https://curl.se/download/curl-${curlVer}.tar.gz; \
         tar -xf curl.tar.gz && rm curl.tar.gz; \
         cd curl-${curlVer}; \
-        ./configure --with-openssl --prefix=/usr/local/src/curl/${curlVer}; \
+        ./configure --with-openssl --prefix=/opt/curl/${curlVer}; \
         make; make install; \
     done;
 
@@ -96,7 +96,7 @@ RUN set -eux; \
         for curlVer in ${CURL_VERSIONS}; \
         do \
             echo "Building ext/curl ${curlVer}..."; \
-            PKG_CONFIG_PATH=/usr/local/src/curl/${curlVer}/lib/pkgconfig/ \
+            PKG_CONFIG_PATH=/opt/curl/${curlVer}/lib/pkgconfig/ \
             ./configure; make; \
             mv ./modules/curl.so $(php-config --extension-dir)/curl-${curlVer}.so; \
             make clean; \

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile_shared_ext
@@ -62,6 +62,20 @@ COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR_DEBUG_
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR_DEBUG_NTS $PHP_INSTALL_DIR_DEBUG_NTS
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR_NTS $PHP_INSTALL_DIR_NTS
 
+# Build curl versions
+ENV CURL_VERSIONS="7.72.0 7.77.0"
+RUN set -eux; \
+    for curlVer in ${CURL_VERSIONS}; \
+    do \
+        echo "Build curl ${curlVer}..."; \
+        cd /tmp; \
+        curl -L -o curl.tar.gz https://curl.se/download/curl-${curlVer}.tar.gz; \
+        tar -xf curl.tar.gz && rm curl.tar.gz; \
+        cd curl-${curlVer}; \
+        ./configure --with-openssl --prefix=/usr/local/src/curl/${curlVer}; \
+        make; make install; \
+    done;
+
 # Build core extensions as shared libraries.
 # We intentionally do not run 'make install' here so that we can test the
 # scenario where headers are not installed for the shared library.
@@ -73,11 +87,21 @@ RUN set -eux; \
         mkdir -p $(php-config --extension-dir); \
         \
         # ext/curl
-        echo "Building ext/curl..."; \
+        echo "Building ext/curl (system version)..."; \
         cd ${PHP_SRC_DIR}/ext/curl; \
         phpize; ./configure; make; \
         mv ./modules/*.so $(php-config --extension-dir); \
-        make clean; phpize --clean; \
+        make clean; \
+        \
+        for curlVer in ${CURL_VERSIONS}; \
+        do \
+            echo "Building ext/curl ${curlVer}..."; \
+            PKG_CONFIG_PATH=/usr/local/src/curl/${curlVer}/lib/pkgconfig/ \
+            ./configure; make; \
+            mv ./modules/curl.so $(php-config --extension-dir)/curl-${curlVer}.so; \
+            make clean; \
+        done; \
+        phpize --clean; \
         \
         # ext/pdo
         echo "Building ext/pdo..."; \

--- a/ext/php5/handlers_curl.c
+++ b/ext/php5/handlers_curl.c
@@ -401,10 +401,35 @@ ZEND_FUNCTION(ddtrace_curl_setopt_array) {
     dd_curl_setopt_array_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
     if (dd_load_curl_integration(TSRMLS_C) &&
-        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "ra", &zid, &arr) == SUCCESS &&
-        Z_BVAL_P(return_value)) {
+        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "ra", &zid, &arr) == SUCCESS
+        /* We still want to apply the original headers even if the this call
+         * returns false. The call will (mostly) only ever fail for reasons
+         * unrelated to setting CURLOPT_HTTPHEADER (see comment below).
+         */
+        /* && Z_BVAL_P(return_value) */) {
         zval **value;
         if (zend_hash_index_find(Z_ARRVAL_P(arr), dd_const_curlopt_httpheader, (void **)&value) == SUCCESS) {
+            /* Although curl_setopt_array() can return false, it is unlikely to
+             * be related to setting CURLOPT_HTTPHEADER. On the PHP side, the
+             * values in the header array are converted to string before passing
+             * to libcurl.
+             * @see https://github.com/php/php-src/blob/b63ea10/ext/curl/interface.c#L2684-L2704
+             *
+             * On the libcurl side, curl_slist_append will only fail when malloc
+             * or strdup fails.
+             * @see https://github.com/curl/curl/blob/ac0a88f/lib/slist.c#L82-L102
+             *
+             * Additionally curl_easy_setopt is unlikely to fail in this case
+             * also, since it is simply updating the pointer to the slist.
+             * @see https://github.com/curl/curl/blob/4d2f800/lib/setopt.c#L672-L677
+             *
+             * The only other reasons curl_easy_setopt can fail appear to be API
+             * related.
+             * @see https://github.com/curl/curl/blob/4d2f800/lib/setopt.c#L2917-L2940
+             *
+             * For these reasons we do not validate the headers before storing
+             * them.
+             */
             dd_ch_store_headers(zid, Z_ARRVAL_PP(value) TSRMLS_CC);
         }
     }

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -343,10 +343,35 @@ ZEND_FUNCTION(ddtrace_curl_setopt_array) {
     dd_curl_setopt_array_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
     if (dd_load_curl_integration() &&
-        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "Oa", &ch, curl_ce, &arr) == SUCCESS &&
-        Z_TYPE_P(return_value) == IS_TRUE) {
+        zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "Oa", &ch, curl_ce, &arr) == SUCCESS
+        /* We still want to apply the original headers even if the this call
+         * returns false. The call will (mostly) only ever fail for reasons
+         * unrelated to setting CURLOPT_HTTPHEADER (see comment below).
+         */
+        /* && Z_TYPE_P(return_value) == IS_TRUE */) {
         zval *value = zend_hash_index_find(Z_ARRVAL_P(arr), dd_const_curlopt_httpheader);
         if (value && Z_TYPE_P(value) == IS_ARRAY) {
+            /* Although curl_setopt_array() can return false, it is unlikely to
+             * be related to setting CURLOPT_HTTPHEADER. On the PHP side, the
+             * values in the header array are converted to string before passing
+             * to libcurl.
+             * @see https://github.com/php/php-src/blob/b63ea10/ext/curl/interface.c#L2684-L2704
+             *
+             * On the libcurl side, curl_slist_append will only fail when malloc
+             * or strdup fails.
+             * @see https://github.com/curl/curl/blob/ac0a88f/lib/slist.c#L82-L102
+             *
+             * Additionally curl_easy_setopt is unlikely to fail in this case
+             * also, since it is simply updating the pointer to the slist.
+             * @see https://github.com/curl/curl/blob/4d2f800/lib/setopt.c#L672-L677
+             *
+             * The only other reasons curl_easy_setopt can fail appear to be API
+             * related.
+             * @see https://github.com/curl/curl/blob/4d2f800/lib/setopt.c#L2917-L2940
+             *
+             * For these reasons we do not validate the headers before storing
+             * them.
+             */
             dd_ch_store_headers(ch, Z_ARRVAL_P(value));
         }
     }

--- a/package.xml
+++ b/package.xml
@@ -347,6 +347,7 @@
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt" role="test" />
+            <file name="tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_inject.inc" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_inject_exception.inc" role="test" />
             <file name="tests/ext/integrations/curl/distributed_tracing_curl_missing_fn.phpt" role="test" />

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Distributed tracing headers propagate existing headers on error: curl_setopt_array()
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--INI--
+ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
+--DESCRIPTION--
+Some libraries do not check the return stats when setting curl opts.
+@see https://github.com/stripe/stripe-php/blob/33317c9/lib/HttpClient/CurlClient.php#L441
+
+The original headers should still be applied even when there is an error from
+setting the curl opts.
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+--FILE--
+<?php
+DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
+    $span->name = 'curl_exec';
+});
+
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+$ch = curl_init();
+
+$res = curl_setopt_array($ch, [
+    CURLOPT_URL => $url,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        'x-orig-header: foo',
+    ],
+    /* This is at the end because it generates an error from the libcurl
+     * curl_easy_setopt call. curl_setopt_array() will stop traversing the
+     * array once an error has ocurred, but the previous opts in the array will
+     * remain set.
+     *
+     * This should hopefully never be a valid enum value in curl.h.
+     * @see https://github.com/curl/curl/blob/cfaa035/include/curl/curl.h#L2150-L2164
+     */
+    CURLOPT_HTTP_VERSION => -42,
+]);
+if (false === $res) {
+    echo "Successfully triggered error from curl_setopt_array()", PHP_EOL, PHP_EOL;
+}
+
+$responses = [];
+$responses[] = curl_exec($ch);
+$responses[] = curl_exec($ch);
+curl_close($ch);
+
+include 'distributed_tracing.inc';
+foreach ($responses as $key => $response) {
+    echo 'Response #' . $key . PHP_EOL;
+    $headers = dt_decode_headers_from_httpbin($response);
+    dt_dump_headers_from_httpbin($headers, [
+        'x-datadog-parent-id',
+        'x-datadog-origin',
+        'x-orig-header',
+    ]);
+    echo PHP_EOL;
+}
+
+echo 'Done.' . PHP_EOL;
+
+if (PHP_VERSION_ID < 80000) {
+    echo "Successfully triggered flush with trace of size 3", PHP_EOL;
+}
+
+?>
+--EXPECTF--
+Successfully triggered error from curl_setopt_array()
+
+Response #0
+x-datadog-origin: phpt-test
+x-datadog-parent-id: %d
+x-orig-header: foo
+
+Response #1
+x-datadog-origin: phpt-test
+x-datadog-parent-id: %d
+x-orig-header: foo
+
+Done.
+Successfully triggered flush with trace of size 3


### PR DESCRIPTION
### Description

This PR fixes a bug that would not apply the original curl headers to a request when `curl_setopt_array()` returns false. Although not strictly necessary, the `datadog/dd-trace-ci:php-8.0-shared-ext` container has been updated with two additional curl versions to test with the curl-related phpt tests in CI. The original bug was discovered due to a curl version upgrade, but the included test will trigger the same behavior on all curl versions.

This PR also fixes the `PHP 80 curl integration tests a shared lib` tests in CI; they [were failing and returning a successful exit code](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/6033/workflows/c9add20d-11af-422c-bc14-fb89c2e11415/jobs/501437).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
