### PR TITLE
Fix owner of files included in the distributed .tar.gz archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,6 +800,19 @@ jobs:
           name: Validate debian package
           command: << parameters.configuration >> bash ./dockerfiles/verify_packages/verify.sh
 
+  verify_tar_gz:
+    working_directory: ~/datadog
+    parameters:
+      php_major_minor:
+        type: string
+    docker:
+      - image: debian:buster
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Validate .tar.gz package
+          command: PHP_VERSION=<< parameters.php_major_minor >> bash ./dockerfiles/verify_packages/verify_tar_gz_root.sh
+
   randomized_tests:
     working_directory: ~/datadog
     machine:
@@ -1616,6 +1629,15 @@ workflows:
                   # https://www.linuxcompatible.org/story/suryorg-has-discontinued-debian-8-support/
                   # So we just test the PHP version in the default repo (5.6)
                 - PHP_PACKAGE="php5 php5-fpm libapache2-mod-php5" PHP_FPM_BIN="php5-fpm"
+
+      - verify_tar_gz:
+          requires: [ "package extension" ]
+          matrix:
+            parameters:
+              php_major_minor:
+                - "8.0"
+                # There is little value in testing several versions, since all the packages are already verified on the
+                # respective platforms using the native packages. Let's save some CPU cycles.
 
       - pecl_tests:
           requires: [ "Build PECL" ]

--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,12 @@ $(PACKAGES_BUILD_DIR):
 .apk: $(PACKAGES_BUILD_DIR)
 	fpm -p $(PACKAGES_BUILD_DIR) -t apk $(FPM_OPTS) --depends=bash --depends=curl --depends=libexecinfo $(FPM_FILES)
 .tar.gz: $(PACKAGES_BUILD_DIR)
-	fpm -p $(PACKAGES_BUILD_DIR)/$(PACKAGE_NAME)-$(VERSION).x86_64.tar.gz -t tar $(FPM_OPTS) $(FPM_FILES)
+	mkdir -p /tmp/$(PACKAGES_BUILD_DIR)
+	fpm -p /tmp/$(PACKAGES_BUILD_DIR)/$(PACKAGE_NAME)-$(VERSION) -t dir $(FPM_OPTS) $(FPM_FILES)
+	tar zcf $(PACKAGES_BUILD_DIR)/$(PACKAGE_NAME)-$(VERSION).x86_64.tar.gz -C /tmp/$(PACKAGES_BUILD_DIR)/$(PACKAGE_NAME)-$(VERSION) . --owner=0 --group=0
 
 packages: .apk .rpm .deb .tar.gz
-	tar -zcf packages.tar.gz $(PACKAGES_BUILD_DIR)
+	tar zcf packages.tar.gz $(PACKAGES_BUILD_DIR) --owner=0 --group=0
 
 verify_pecl_file_definitions:
 	@for i in $(C_FILES) $(TEST_FILES) $(TEST_STUB_FILES) $(M4_FILES); do\

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -46,3 +46,9 @@ verify_centos:
 
 # Centos 6 is verified using the existing images due to difficulties building it after the repos have been disabled.
 verify_centos_6: $(CENTOS6_PHP_VERSIONS)
+
+verify_tar_root:
+	docker-compose run --rm \
+		-e PHP_VERSION="$(PHP_VERSION)" \
+		tar_gz \
+		bash dockerfiles/verify_packages/verify_tar_gz_root.sh

--- a/dockerfiles/verify_packages/docker-compose.yml
+++ b/dockerfiles/verify_packages/docker-compose.yml
@@ -58,5 +58,11 @@ services:
     depends_on:
       - request-replayer
 
+  tar_gz:
+    image: debian:buster
+    working_dir: /datadog
+    volumes:
+      - ../../:/datadog
+
   request-replayer:
     image: datadog/dd-trace-ci:php-request-replayer

--- a/dockerfiles/verify_packages/tar_gz/install.sh
+++ b/dockerfiles/verify_packages/tar_gz/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Common installations
+apt update
+apt install -y \
+    apt-transport-https \
+    lsb-release \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    nginx \
+    apache2 \
+    procps \
+    gnupg
+
+curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+apt update
+apt install -y \
+    php${PHP_VERSION}-cli \
+    php${PHP_VERSION}-curl \
+    php${PHP_VERSION}-fpm \
+    php${PHP_VERSION}-opcache \
+    libapache2-mod-php${PHP_VERSION}
+    WWW_CONF=/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
+    PHP_FPM_BIN=php-fpm${PHP_VERSION}
+
+echo "PHP installation completed successfully"

--- a/dockerfiles/verify_packages/verify_tar_gz_root.sh
+++ b/dockerfiles/verify_packages/verify_tar_gz_root.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+set -e
+
+DD_TRACE_ROOT=$(pwd)
+sh ${DD_TRACE_ROOT}/dockerfiles/verify_packages/tar_gz/install.sh
+
+tar -xf ${DD_TRACE_ROOT}/build/packages/*.tar.gz -C /
+
+OPT_USER=$(stat -c '%U' /opt)
+echo "Owner of /opt: ${OPT_USER}"
+if [ "${OPT_USER}" != "root" ]; then
+    echo "Wrong user for /opt: ${OPT_USER}"
+    exit 1
+fi
+
+DD_USER=$(stat -c '%U' /opt/datadog-php)
+echo "Owner of /opt: ${DD_USER}"
+if [ "${DD_USER}" != "root" ]; then
+    echo "Wrong user for /opt/datadog-php: ${DD_USER}"
+    exit 1
+fi
+
+echo "Permissions are correct"
+
+echo "Installing as per https://docs.datadoghq.com/tracing/faq/php-tracer-manual-installation/#automatic-ini-file-setup"
+/opt/datadog-php/bin/post-install.sh
+
+php --ri=ddtrace
+
+echo ".tar.gz archive correctly installed"

--- a/dockerfiles/verify_packages/verify_tar_gz_root.sh
+++ b/dockerfiles/verify_packages/verify_tar_gz_root.sh
@@ -15,7 +15,7 @@ if [ "${OPT_USER}" != "root" ]; then
 fi
 
 DD_USER=$(stat -c '%U' /opt/datadog-php)
-echo "Owner of /opt: ${DD_USER}"
+echo "Owner of /opt/datadog-php: ${DD_USER}"
 if [ "${DD_USER}" != "root" ]; then
     echo "Wrong user for /opt/datadog-php: ${DD_USER}"
     exit 1


### PR DESCRIPTION
### Description

Our `.tar.gz` archive had files in it owned by user `3434:3434`, which is the `circleci` user from the docker images we use from our CI provider, including for `.` and `..` paths.

As a consequence, when installed, it changed ownership of the root directory to user `3434`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
