### PR TITLE
Register SpanData->exception property and store exception info there instead of internally

### DIFF
--- a/ext/php8/compatibility.h
+++ b/ext/php8/compatibility.h
@@ -49,6 +49,4 @@
 #define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval*)list)[arg_num]))
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
 
-typedef zend_object ddtrace_exception_t;
-
 #endif  // DD_COMPATIBILITY_H

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -236,9 +236,6 @@ static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
 
 static void ddtrace_span_data_free_storage(zend_object *object) {
     ddtrace_span_fci *span_fci = (ddtrace_span_fci *)object;
-    if (span_fci->exception) {
-        OBJ_RELEASE(span_fci->exception);
-    }
     if (span_fci->dispatch) {
         ddtrace_dispatch_release(span_fci->dispatch);
         span_fci->dispatch = NULL;
@@ -293,6 +290,7 @@ static void dd_register_span_data_ce(void) {
     zend_declare_property_null(ddtrace_ce_span_data, "type", sizeof("type") - 1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(ddtrace_ce_span_data, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ddtrace_ce_span_data, "exception", sizeof("exception") - 1, ZEND_ACC_PUBLIC);
 }
 
 #pragma GCC diagnostic push
@@ -309,6 +307,8 @@ zval *ddtrace_spandata_property_type(ddtrace_span_t *span) { return OBJ_PROP_NUM
 zval *ddtrace_spandata_property_meta(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 4); }
 // SpanData::$metrics
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 5); }
+// SpanData::$exception
+zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 6); }
 #pragma GCC diagnostic pop
 
 /* DDTrace\FatalError */

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -22,6 +22,7 @@ zval *ddtrace_spandata_property_service(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_type(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_exception(ddtrace_span_t *span);
 
 BOOL_T ddtrace_tracer_is_limited(void);
 // prepare the tracer state to start handling a new trace

--- a/ext/php8/engine_hooks.h
+++ b/ext/php8/engine_hooks.h
@@ -39,7 +39,7 @@ typedef struct ddtrace_error_handling ddtrace_error_handling;
 
 struct ddtrace_sandbox_backup {
     ddtrace_error_handling eh;
-    ddtrace_exception_t *exception, *prev_exception;
+    zend_object *exception, *prev_exception;
 };
 typedef struct ddtrace_sandbox_backup ddtrace_sandbox_backup;
 
@@ -105,7 +105,7 @@ extern void (*ddtrace_prev_error_cb)(DDTRACE_ERROR_CB_PARAMETERS);
 
 zend_observer_fcall_handlers ddtrace_observer_fcall_init(zend_execute_data *execute_data);
 void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS);
-void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, ddtrace_exception_t *exception);
+void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, zend_object *exception);
 void ddtrace_close_all_open_spans(void);
 
 #endif  // DD_ENGINE_HOOKS_H

--- a/ext/php8/handlers_exception.c
+++ b/ext/php8/handlers_exception.c
@@ -42,7 +42,7 @@ static void dd_check_exception_in_header(int old_response_code) {
         root_span = root_span->next;
     }
 
-    if (root_span->exception) {
+    if (Z_TYPE_P(ddtrace_spandata_property_exception(&root_span->span)) > IS_FALSE) {
         return;
     }
 
@@ -102,8 +102,7 @@ static void dd_check_exception_in_header(int old_response_code) {
                 ZVAL_DEREF(exception);
                 if (Z_TYPE_P(exception) == IS_OBJECT &&
                     instanceof_function(Z_OBJ_P(exception)->ce, zend_ce_throwable)) {
-                    Z_ADDREF_P(exception);
-                    root_span->exception = Z_OBJ_P(exception);
+                    ZVAL_COPY(ddtrace_spandata_property_exception(&root_span->span), exception);
                 }
 
                 break;
@@ -215,7 +214,9 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
         DDTRACE_G(active_error).type = 0;
     } else {
         ddtrace_span_fci *root_span = DDTRACE_G(open_spans_top);
-        zend_object *exception, *volatile old_exception;
+        zend_object *exception;
+        zval *volatile span_exception;
+        volatile zval old_exception = {0};
 
         ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_OBJ(exception)
@@ -225,9 +226,9 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
 
         // Assign early so that exceptions thrown inside the exception handler won't gain priority
         if (root_span) {
-            old_exception = root_span->exception;
-            GC_ADDREF(exception);
-            root_span->exception = exception;
+            span_exception = ddtrace_spandata_property_exception(&root_span->span);
+            ZVAL_COPY_VALUE((zval *)&old_exception, span_exception);
+            ZVAL_OBJ_COPY(span_exception, exception);
         }
 
         // Evaluate whether we shall start some span here to show the exception handler
@@ -253,7 +254,7 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
         // Note that the change will leak into shutdown sequence though, but this is a minor tradeoff we make here.
         // If this ever tunrs out to be problematic, we have to store it somewhere in DDTRACE_G()
         // and delay attaching until serialization.
-        if (root_span && old_exception) {
+        if (root_span && Z_TYPE_P((zval *)&old_exception) > IS_FALSE) {
             zval *previous = ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_PREVIOUS);
             while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous) &&
                    instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
@@ -261,12 +262,12 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
                 previous = ZAI_EXCEPTION_PROPERTY(Z_OBJ_P(previous), ZEND_STR_PREVIOUS);
             }
 
-            if (Z_IS_RECURSIVE_P(previous) || !Z_ISNULL_P(previous)) {
+            if (Z_IS_RECURSIVE_P(previous) || Z_TYPE_P(previous) > IS_FALSE) {
                 // okay, let's not touch this, there's a cycle (or something weird)
                 GC_DELREF(exception);
-                root_span->exception = old_exception;
+                ZVAL_COPY_VALUE(span_exception, (zval *)&old_exception);
             } else {
-                ZVAL_OBJ(previous, old_exception);
+                ZVAL_COPY_VALUE(previous, (zval *)&old_exception);
             }
 
             previous = ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_PREVIOUS);

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -224,9 +224,9 @@ static void dd_copy_args(zval *args, zend_execute_data *call) {
 }
 
 void ddtrace_span_attach_exception(ddtrace_span_fci *span_fci, zend_object *exception) {
-    if (exception && span_fci->exception == NULL && !zend_is_unwind_exit(exception)) {
-        GC_ADDREF(exception);
-        span_fci->exception = exception;
+    zval *exception_zv = ddtrace_spandata_property_exception(&span_fci->span);
+    if (exception && Z_TYPE_P(exception_zv) <= IS_FALSE && !zend_is_unwind_exit(exception)) {
+        ZVAL_OBJ_COPY(exception_zv, exception);
     }
 }
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -369,8 +369,9 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
     }
     meta = &meta_zv;
 
-    if (span_fci->exception) {
-        ddtrace_exception_to_meta(span_fci->exception, meta, dd_add_meta_array);
+    zval *exception_zv = ddtrace_spandata_property_exception(&span_fci->span);
+    if (Z_TYPE_P(exception_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(exception_zv), zend_ce_throwable)) {
+        ddtrace_exception_to_meta(Z_OBJ_P(exception_zv), meta, dd_add_meta_array);
     }
 
     zend_bool error = ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.msg")) ||
@@ -556,7 +557,7 @@ void ddtrace_save_active_error_to_metadata() {
         .stack = dd_fatal_error_stack(),
     };
     for (ddtrace_span_fci *span = DDTRACE_G(open_spans_top); span; span = span->next) {
-        if (span->exception) {  // exceptions take priority
+        if (Z_TYPE_P(ddtrace_spandata_property_exception(&span->span)) == IS_OBJECT) {  // exceptions take priority
             continue;
         }
 
@@ -593,7 +594,7 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
             dd_fatal_error_to_meta(&DDTRACE_G(additional_trace_meta), error);
             ddtrace_span_fci *span;
             for (span = DDTRACE_G(open_spans_top); span; span = span->next) {
-                if (span->exception) {
+                if (Z_TYPE_P(ddtrace_spandata_property_exception(&span->span)) > IS_FALSE) {
                     continue;
                 }
 

--- a/ext/php8/serializer.h
+++ b/ext/php8/serializer.h
@@ -10,7 +10,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array);
 /* "int" return types are SUCCESS=0, anything else is a failure
  * Guarantees that add_tag will only be called once per tag, will stop trying to add tags if one fails.
  */
-int ddtrace_exception_to_meta(ddtrace_exception_t *exception, void *context,
+int ddtrace_exception_to_meta(zend_object *exception, void *context,
                               int (*add_tag)(void *context, ddtrace_string key, ddtrace_string value));
 void ddtrace_save_active_error_to_metadata();
 

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -15,7 +15,7 @@ struct ddtrace_dispatch_t;
 
 struct ddtrace_span_t {
     zend_object std;
-    zval properties_table_placeholder[5];
+    zval properties_table_placeholder[6];
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;
@@ -28,7 +28,6 @@ struct ddtrace_span_fci {
     ddtrace_span_t span;
     zend_execute_data *execute_data;
     struct ddtrace_dispatch_t *dispatch;
-    ddtrace_exception_t *exception;
     struct ddtrace_span_fci *next;
 };
 typedef struct ddtrace_span_fci ddtrace_span_fci;

--- a/package.xml
+++ b/package.xml
@@ -708,6 +708,7 @@
             <file name="tests/ext/request_timeout_01.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
+            <file name="tests/ext/span_with_removed_exception.phpt" role="test" />
             <file name="tests/ext/start_span_with_all_properties.phpt" role="test" />
             <file name="tests/ext/start_span_without_closing.phpt" role="test" />
             <file name="tests/ext/start_span_without_closing_autofinish.phpt" role="test" />

--- a/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
+++ b/tests/ext/sandbox/deferred_load_missing_load_fn.phpt
@@ -1,6 +1,6 @@
 --TEST--
 deferred loading doesn't trigger nor crash if DDTrace\Integrations\load_deferred_integration is missing
-----DESCRIPTION--
+--DESCRIPTION--
 This issue was reported in a GitHub issue:
 https://github.com/DataDog/dd-trace-php/issues/1021
 --SKIPIF--

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -1,0 +1,126 @@
+--TEST--
+Unset, nulled and generally invalid data in exception property is ignored
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: Test requires improved exception handling'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function test() {
+    throw new \Exception;
+}
+
+DDTrace\trace_function("test", function($span) {
+    $span->exception = new \stdClass;
+});
+
+try {
+    test();
+} catch (Exception $e) {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+
+DDTrace\trace_function("test", function($span) {
+    $span->exception = null;
+});
+
+try {
+    test();
+} catch (Exception $e) {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+
+DDTrace\trace_function("test", function($span) {
+    unset($span->exception);
+});
+
+try {
+    test();
+} catch (Exception $e) {
+    var_dump(dd_trace_serialize_closed_spans());
+}
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}
+array(1) {
+  [0]=>
+  array(8) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(4) "test"
+    ["resource"]=>
+    string(4) "test"
+    ["meta"]=>
+    array(1) {
+      ["system.pid"]=>
+      string(%d) "%d"
+    }
+    ["metrics"]=>
+    array(1) {
+      ["php.compilation.total_time_ms"]=>
+      float(%f)
+    }
+  }
+}


### PR DESCRIPTION
### Description

Implements feature request #1231: exceptions are now tracked in the properties instead of internally, in particular so that the exception can be changed or removed within post-tracing hook callbacks.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
