### PR TITLE
Add linux/securebits.h to CentOS docker container, to have it present in linux build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ strict:
 
 clang_find_files_to_lint:
 	@find . \( \
+	-path ./.git -prune -o \
 	-path ./tmp -prune -o \
 	-path ./vendor -prune -o \
 	-path ./tests -prune -o \

--- a/dockerfiles/ci/centos/6/Dockerfile
+++ b/dockerfiles/ci/centos/6/Dockerfile
@@ -82,6 +82,8 @@ RUN source scl_source enable devtoolset-7; \
     mkdir build && cd build; \
     cmake .. && make && make install;
 
+RUN echo '#define SECBIT_NO_SETUID_FIXUP (1 << 2)' > '/usr/include/linux/securebits.h'
+
 ENV PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 
 ENV PHP_SRC_DIR=/usr/local/src/php


### PR DESCRIPTION
linux/securebits.h was not present in the CentOS container, leading to 026d4d304c32489a846fb56291fe036dd3894953 being inactive in our release artifacts.