### PR TITLE
Handle an additional case of capabilities being dropped within our background sender

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -29,6 +29,7 @@ if test "$PHP_DDTRACE" != "no"; then
   )
 
   AC_CHECK_HEADERS([linux/securebits.h])
+  AC_CHECK_HEADERS([linux/capability.h])
 
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     EXTRA_LDFLAGS="-fsanitize=address"

--- a/package.xml
+++ b/package.xml
@@ -321,6 +321,7 @@
             <file name="tests/ext/background-sender/agent_headers_container_id_fargate.phpt" role="test" />
             <file name="tests/ext/background-sender/agent_headers_ignore_userland.phpt" role="test" />
             <file name="tests/ext/background-sender/background_sender_survives_setuid.phpt" role="test" />
+            <file name="tests/ext/background-sender/background_sender_restores_capabilities.phpt" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.docker" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.empty" role="test" />
             <file name="tests/ext/background-sender/stubs/cgroup.fargate.1.4" role="test" />

--- a/tests/ext/background-sender/background_sender_restores_capabilities.phpt
+++ b/tests/ext/background-sender/background_sender_restores_capabilities.phpt
@@ -1,0 +1,76 @@
+--TEST--
+background sender restores effective capabilities from permitted set
+--DESCRIPTION--
+The effective set may be cleared, e.g. when prctl(PR_SET_KEEPCAPS), followed by setuid(2) has been used.
+Hence we exec() ourselves on top of a process with no effective capabilities.
+--SKIPIF--
+<?php if (PHP_OS != "Linux") die('skip: Linux specific test for capabilities(7)'); ?>
+<?php if (!extension_loaded("ffi")) die("skip: requires ext/ffi"); ?>
+<?php if (posix_getuid() != 0 && getenv("ZEND_DONT_UNLOAD_MODULES")) die("skip: detected ZEND_DONT_UNLOAD_MODULES - the test is most likely executed as non-root via valgrind"); ?>
+<?php if (posix_getuid() != 0 && trim(shell_exec("sudo echo 1")) !== "1") die("skip: user is not root and has no password-less sudo"); ?>
+--FILE--
+<?php
+
+if (posix_getuid() != 0) {
+    $sudoPath = trim(`which sudo`);
+    $cmdAndArgs = explode("\0", file_get_contents("/proc/" . getmypid() . "/cmdline"));
+    pcntl_exec($sudoPath, [-2 => '-E', -1 => '--'] + $cmdAndArgs);
+}
+
+$ffi = FFI::cdef(<<<DEFS
+int setgroups(size_t size, const uint32_t *list);
+
+typedef struct {
+    uint32_t version;
+    int pid;
+} cap_user_header_t;
+
+typedef struct {
+    uint32_t effective;
+    uint32_t permitted;
+    uint32_t inheritable;
+} cap_user_data_t;
+
+int capset(cap_user_header_t *hdrp, const cap_user_data_t *datap);
+DEFS
+, "libc.so.6");
+
+const _LINUX_CAPABILITY_VERSION_1 = 0x19980330;
+const CAP_SETGID = 6;
+
+$capheader = $ffi->new("cap_user_header_t");
+$capheader->version = _LINUX_CAPABILITY_VERSION_1;
+
+$capdata = $ffi->new("cap_user_data_t");
+$capdata->inheritable = 0;
+$capdata->effective = 0;
+$capdata->permitted = 1 << CAP_SETGID;
+
+if (!getenv("BACKGROUND_SENDER_RESTORES_CAPABILITIES")) {
+    $ffi->capset(FFI::addr($capheader), FFI::addr($capdata));
+
+    putenv("BACKGROUND_SENDER_RESTORES_CAPABILITIES=1");
+    $cmdAndArgs = explode("\0", file_get_contents("/proc/" . getmypid() . "/cmdline"));
+    pcntl_exec(array_shift($cmdAndArgs), $cmdAndArgs);
+
+    die("exec failed?");
+}
+
+$capdata->effective = $capdata->permitted;
+$ffi->capset(FFI::addr($capheader), FFI::addr($capdata));
+
+$groups = $ffi->new("uint32_t");
+$groups->cdata = 1;
+var_dump($ffi->setgroups(1, FFI::addr($groups)));
+
+// payload = [[]]
+$payload = "\x91\x90";
+
+var_dump(dd_trace_send_traces_via_thread(1, [], $payload));
+
+echo "Done.";
+?>
+--EXPECT--
+int(0)
+bool(true)
+Done.


### PR DESCRIPTION
### Description

Turns out, while re-testing, the order of operations can be different and setuid() called before our MINIT. In this case the background sender will have to reset capabilities...
To test this, we just start the process with capabilities not present in effective set.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
