### PR TITLE
Fix arginfo of error&exception handler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,14 @@ jobs:
             if [[ ! "<<parameters.xdebug_version_two>>" == "none" ]]; then
               php run-tests.php -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_two >>.so ../../tests/xdebug/<< parameters.xdebug_version_two >>
             fi;
+      - run:
+          name: Run unit tests with xdebug
+          command: |
+            if [[ "<<parameters.xdebug_version_one>>" != "2.7.2" ]]; then
+              TEST_EXTRA_INI='-d zend_extension=xdebug-<< parameters.xdebug_version_one >>.so' make test_unit PHPUNIT_OPTS="--log-junit test-results/php-unit/results_unit.xml"
+            fi
+      - <<: *STEP_PERSIST_TO_WORKSPACE
+      - <<: *STEP_STORE_TEST_RESULTS
 
   test: &TEST_BASE
     parameters:
@@ -1900,8 +1908,8 @@ workflows:
           requires: [ 'Prepare Code' ]
           name: "PHP 71 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.1_buster"
-          xdebug_version_one: "2.9.2"
-          xdebug_version_two: "2.9.5"
+          xdebug_version_one: "2.9.5"
+          xdebug_version_two: "2.9.2"
       # - unit_tests: # disabled due to posisbly leaking tests
       #     requires: [ 'Prepare Code' ]
       #     name: "PHP 70 Unit tests-zts"
@@ -1910,20 +1918,20 @@ workflows:
           requires: [ 'Prepare Code' ]
           name: "PHP 72 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.2_buster"
-          xdebug_version_one: "2.9.2"
-          xdebug_version_two: "2.9.5"
+          xdebug_version_one: "2.9.5"
+          xdebug_version_two: "2.9.2"
       - xdebug_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 73 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
-          xdebug_version_one: "2.9.2"
-          xdebug_version_two: "2.9.5"
+          xdebug_version_one: "2.9.5"
+          xdebug_version_two: "2.9.2"
       - xdebug_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 74 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
-          xdebug_version_one: "2.9.2"
-          xdebug_version_two: "2.9.5"
+          xdebug_version_one: "2.9.5"
+          xdebug_version_two: "2.9.2"
       - xdebug_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 80 Xdebug tests"

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ cores:
 ########################################################################################################################
 REQUEST_INIT_HOOK := -d ddtrace.request_init_hook=$(REQUEST_INIT_HOOK_PATH)
 ENV_OVERRIDE := $(shell [ -n "${DD_TRACE_DOCKER_DEBUG}" ] && echo DD_AUTOLOAD_NO_COMPILE=true) DD_TRACE_CLI_ENABLED=true
+TEST_EXTRA_INI ?=
 
 ### DDTrace tests ###
 TESTS_ROOT := ./tests
@@ -601,7 +602,7 @@ TEST_WEB_80 := \
 FILTER := .
 
 define run_tests
-	$(ENV_OVERRIDE) php $(REQUEST_INIT_HOOK) $(PHPUNIT) $(1) --filter=$(FILTER)
+	$(ENV_OVERRIDE) php $(TEST_EXTRA_INI) $(REQUEST_INIT_HOOK) $(PHPUNIT) $(1) --filter=$(FILTER)
 endef
 
 # use this as the first target if you want to use uncompiled files instead of the _generated.php compiled file.

--- a/ext/php8/handlers_exception.c
+++ b/ext/php8/handlers_exception.c
@@ -298,7 +298,7 @@ void ddtrace_exception_handlers_startup(void) {
         .function_name = zend_string_init_interned(ZEND_STRL("ddtrace_exception_handler"), 1),
         .num_args = 1,
         .required_num_args = 1,
-        .arg_info = (zend_internal_arg_info *)arginfo_ddtrace_exception_or_error_handler,
+        .arg_info = (zend_internal_arg_info *)(arginfo_ddtrace_exception_or_error_handler + 1),
         .handler = &zim_DDTrace_ExceptionOrErrorHandler_execute,
     };
 


### PR DESCRIPTION
### Description

Non-registered function arginfo are not inspectable in userland, except by other extensions like xdebug. But it was pointing to the wrong value. And hence crashing with xdebug inspecting it...
This also means that the issue is not directly testable except with an extension intercepting internal fcalls.

Fixes #1290.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug. - impossible to test?

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
