### PR TITLE
allow comparing two versions through DataDog/sirun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ composer.lock
 .libs
 .deps
 .phpunit.result.cache
+.tmp/
 **.code-workspace
 /Makefile*
 acinclude.m4

--- a/tooling/metrics/Makefile
+++ b/tooling/metrics/Makefile
@@ -1,6 +1,6 @@
 # Use this Makefile from within  a <MAJOR>.<MINOR>-buster development images.
 
-TMP_FOLDER := .tmp
+TMP_FOLDER := /tmp/sirun
 RESULTS_FILE := $(TMP_FOLDER)/results.txt
 SIRUN_FILE := $(TMP_FOLDER)/sirun.yml
 PHP_EXTENSION_VERSION := $(shell php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $$NF }')

--- a/tooling/metrics/Makefile
+++ b/tooling/metrics/Makefile
@@ -1,0 +1,36 @@
+# Use this Makefile from within  a <MAJOR>.<MINOR>-buster development images.
+
+TMP_FOLDER := .tmp
+RESULTS_FILE := $(TMP_FOLDER)/results.txt
+SIRUN_FILE := $(TMP_FOLDER)/sirun.yml
+PHP_EXTENSION_VERSION := $(shell php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $$NF }')
+
+memory: run
+	cat $(RESULTS_FILE) | jq '.name , .iterations[]."max.res.size"'
+
+run: prerequisites fresh_tmp_folder download sirun_config
+	@echo "Running iterations, this might take a few minutes"
+	. $(HOME)/.cargo/env && sirun $(SIRUN_FILE) | tee $(RESULTS_FILE)
+
+prerequisites:
+	sudo apt -y update && sudo apt install -y jq
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+	. $(HOME)/.cargo/env && cargo install sirun
+
+fresh_tmp_folder:
+	rm -rf $(TMP_FOLDER)
+	mkdir -p $(TMP_FOLDER)
+
+download:
+# target
+	curl -L --output "$(TMP_FOLDER)/target.tar.gz" "$(TARGET_URL)"
+	mkdir -p "$(TMP_FOLDER)/target"
+	tar -xf "$(TMP_FOLDER)/target.tar.gz" -C "$(TMP_FOLDER)/target"
+# rererence
+	curl -L --output "$(TMP_FOLDER)/reference.tar.gz" "$(REFERENCE_URL)"
+	mkdir -p "$(TMP_FOLDER)/reference"
+	tar -xf "$(TMP_FOLDER)/reference.tar.gz" -C "$(TMP_FOLDER)/reference"
+
+sirun_config:
+	cp sirun.template.yml $(SIRUN_FILE)
+	sed -i 's|{{php-extension-version}}|$(PHP_EXTENSION_VERSION)|g' $(SIRUN_FILE)

--- a/tooling/metrics/README.md
+++ b/tooling/metrics/README.md
@@ -1,0 +1,33 @@
+# Metrics
+
+Calculate metrics using the [sirun](https://github.com/DataDog/sirun) tool.
+
+## Usage
+
+### Memory overhead
+
+```
+# Example: 0.63.0-RC
+export TARGET_URL=https://529832-119990860-gh.circle-artifacts.com/0/datadog-php-tracer-0.63.0.x86_64.tar.gz
+# Example: 0.62.0 release
+export REFERENCE_URL=https://github.com/DataDog/dd-trace-php/releases/download/0.62.0/datadog-php-tracer-0.62.0.x86_64.tar.gz
+make memory
+```
+Output
+```
+"no trace"
+1234 (iteration 1)
+1234 (iteration 2)
+...
+1234 (iteration 40)
+"reference"
+1234 (iteration 1)
+1234 (iteration 2)
+...
+1234 (iteration 40)
+"target"
+1234 (iteration 1)
+1234 (iteration 2)
+...
+1234 (iteration 40)
+```

--- a/tooling/metrics/README.md
+++ b/tooling/metrics/README.md
@@ -6,6 +6,8 @@ Calculate metrics using the [sirun](https://github.com/DataDog/sirun) tool.
 
 ### Memory overhead
 
+Values are in kB: see [`ru_maxrss`](https://man7.org/linux/man-pages/man2/getrusage.2.html#:~:text=ru_maxrss,-(since%20).
+
 ```
 # Example: 0.63.0-RC
 export TARGET_URL=https://529832-119990860-gh.circle-artifacts.com/0/datadog-php-tracer-0.63.0.x86_64.tar.gz

--- a/tooling/metrics/sirun.template.yml
+++ b/tooling/metrics/sirun.template.yml
@@ -8,6 +8,6 @@ variants:
   - name: no-tracer
     run: php synthetic.php
   - name: reference
-    run: php -dextension=".tmp/reference/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/reference/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php
+    run: php -dextension="/tmp/sirun/reference/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/reference/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php
   - name: target
-    run: php -dextension=".tmp/target/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/target/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php
+    run: php -dextension="/tmp/sirun/target/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/target/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php

--- a/tooling/metrics/sirun.template.yml
+++ b/tooling/metrics/sirun.template.yml
@@ -1,0 +1,13 @@
+run: exit 1
+cachegrind: false
+iterations: 40
+env:
+  DD_TRACE_CLI_ENABLED: 'true'
+  DD_AGENT_HOST: 'agent'
+variants:
+  - name: no-tracer
+    run: php synthetic.php
+  - name: reference
+    run: php -dextension=".tmp/reference/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/reference/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php
+  - name: target
+    run: php -dextension=".tmp/target/opt/datadog-php/extensions/ddtrace-{{php-extension-version}}-debug.so" -dddtrace.request_init_hook=".tmp/target/opt/datadog-php/dd-trace-sources/bridge/dd_wrap_autoloader.php" synthetic.php

--- a/tooling/metrics/synthetic.php
+++ b/tooling/metrics/synthetic.php
@@ -1,0 +1,27 @@
+<?php
+
+const CURL_COUNT = 30;
+const QUERY_COUNT = 100;
+const CACHE_COUNT = 100;
+
+for ($curlIndex = 0; $curlIndex < CURL_COUNT; $curlIndex++) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, 'httpbin_integration/get?client=curl');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $output = curl_exec($ch);
+    curl_close($ch);
+}
+
+for ($queryIndex = 0; $queryIndex < QUERY_COUNT; $queryIndex++) {
+    $pdo = new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
+    $stm = $pdo->query("SELECT VERSION()");
+    $version = $stm->fetch();
+    $pdo = null;
+}
+
+for ($cacheIndex = 0; $cacheIndex < CACHE_COUNT; $cacheIndex++) {
+    $redis = new \Redis();
+    $redis->connect('redis_integration', 6379);
+    $redis->set('k1', 'v1');
+    $redis->get('k1');
+}


### PR DESCRIPTION
### Description

Allow measuring memory's max resident size while running the a synthetic script under 3 scenarios: no-tracer, a specific version used as a reference (via a url provided as a `REFERENCE_URL`), the target version that has to be measured (via a url provided as a `TARGET_URL`).

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
