### PR TITLE
Disable flaky ext/ftp tests on PHP < 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
               cp "<<parameters.xfail_list>>" /usr/local/src/php/xfail_tests.list
               (
                 cd /usr/local/src/php
-                cat xfail_tests.list | xargs -n 1 rm -f || true
+                cat xfail_tests.list | xargs -n 1 rm -rf || true
               )
             fi
             cd /usr/local/src/php

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
               cp "<<parameters.xfail_list>>" /usr/local/src/php/xfail_tests.list
               (
                 cd /usr/local/src/php
-                cat xfail_tests.list | xargs -n 1 rm -rf || true
+                cat xfail_tests.list | xargs -n 1 -I{} find {} -name "*.phpt" -delete || true
               )
             fi
             cd /usr/local/src/php

--- a/dockerfiles/ci/xfail_tests/5.6.list
+++ b/dockerfiles/ci/xfail_tests/5.6.list
@@ -82,6 +82,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/iconv/tests/iconv_basic_001.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -108,6 +108,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -118,6 +118,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -100,6 +100,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/pass001.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -107,6 +107,7 @@ ext/date/tests/date_time_set_variation3.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/json_decode_exceptions.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -159,6 +159,7 @@ ext/date/tests/date_time_fractions_serialize.phpt
 ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/json_decode_exceptions.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -199,6 +199,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/dom/tests/bug55700.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
+ext/ftp/tests
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/json_decode_exceptions.phpt
@@ -448,9 +449,9 @@ ext/standard/tests/serialize/bug72785.phpt
 ext/standard/tests/serialize/overwrite_untyped_ref.phpt
 ext/standard/tests/serialize/serialize_globals_var_refs.phpt
 ext/standard/tests/serialize/sleep_uninitialized_typed_prop.phpt
-ext/standard/tests/serialize/typed_property_refs.phpt
 ext/standard/tests/serialize/typed_property_ref_overwrite.phpt
 ext/standard/tests/serialize/typed_property_ref_overwrite2.phpt
+ext/standard/tests/serialize/typed_property_refs.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt
 ext/standard/tests/streams/stream_context_tcp_nodelay_fopen.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -74,7 +74,7 @@ Building again the container without `pcntl` enabled AND not even building the t
 
 ## `ext/ftp/tests`
 
-Disabled on versions: `5.4`, `5.5`.
+Disabled on versions less than 8.1, which switches to ephemeral ports.
 
 Links to sample broken executions: [5.4](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/5626/workflows/6f8ee4d1-f2dd-4465-b3a0-44f8fde1a18f/jobs/396668/tests#failed-test-0).
 


### PR DESCRIPTION
### Description

PHP 8.1 switches to using ephemeral ports. Prior to this, these
tests are flaky and will fail because a port is already in use:

php/php-src@08eb917fd5d5f62eb2c3403ac41e576325a0b519

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ This _removes_ tests because of flakiness.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
