### PR TITLE
Fix static analysis execution on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,9 @@ jobs:
       scenario:
         type: string
         default: ""
+      composer_root:
+        type: string
+        default: "~/.composer"
     working_directory: ~/datadog
     docker:
       - image: << parameters.docker_image >>
@@ -315,7 +318,7 @@ jobs:
             composer scenario:update
       - run:
           name: Running phpstan
-          command: composer scenario << parameters.scenario >> ; PATH=$PATH:~/.composer/vendor/bin composer static-analyze
+          command: composer scenario << parameters.scenario >> ; PATH=$PATH:<< parameters.composer_root >>/vendor/bin composer static-analyze
 
   "Post-Install Hook":
     working_directory: ~/datadog
@@ -2000,7 +2003,8 @@ workflows:
       - static_analysis:
           requires: [ 'Prepare Code' ]
           name: "Static Analysis 80"
-          docker_image: circleci/php:8.0
+          docker_image: cimg/php:8.0
+          composer_root: ~/.config/composer
           scenario: opentracing10
       - "Post-Install Hook":
           requires: [ 'Prepare Code' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,9 +299,6 @@ jobs:
       scenario:
         type: string
         default: ""
-      composer_root:
-        type: string
-        default: "~/.composer"
     working_directory: ~/datadog
     docker:
       - image: << parameters.docker_image >>
@@ -316,9 +313,10 @@ jobs:
             composer global require phpstan/phpstan:0.12.*
             composer global require psr/log
             composer scenario:update
+            export PATH=$PATH:$(composer --global config home)/vendor/bin
       - run:
           name: Running phpstan
-          command: composer scenario << parameters.scenario >> ; PATH=$PATH:<< parameters.composer_root >>/vendor/bin composer static-analyze
+          command: composer scenario << parameters.scenario >> ; composer static-analyze
 
   "Post-Install Hook":
     working_directory: ~/datadog
@@ -2004,7 +2002,6 @@ workflows:
           requires: [ 'Prepare Code' ]
           name: "Static Analysis 80"
           docker_image: cimg/php:8.0
-          composer_root: ~/.config/composer
           scenario: opentracing10
       - "Post-Install Hook":
           requires: [ 'Prepare Code' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,9 @@ jobs:
             composer scenario:update
             export PATH=$PATH:$(composer --global config home)/vendor/bin
       - run:
+          name: Show path
+          command: echo $PATH
+      - run:
           name: Running phpstan
           command: composer scenario << parameters.scenario >> ; composer static-analyze
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,13 +313,9 @@ jobs:
             composer global require phpstan/phpstan:0.12.*
             composer global require psr/log
             composer scenario:update
-            export PATH=$PATH:$(composer --global config home)/vendor/bin
-      - run:
-          name: Show path
-          command: echo $PATH
       - run:
           name: Running phpstan
-          command: composer scenario << parameters.scenario >> ; composer static-analyze
+          command: composer scenario << parameters.scenario >> ; PATH=$PATH:$(composer --global config home)/vendor/bin composer static-analyze
 
   "Post-Install Hook":
     working_directory: ~/datadog

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
             "@static-analyze-ddtrace"
         ],
         "static-analyze-api": "phpstan analyse --configuration=./phpstan.api.neon --level=2 src/api",
-        "static-analyze-api-clear-cache": [
+        "static-analyze-clear-cache": [
             "phpstan clear-result-cache --configuration=./phpstan.api.neon",
             "phpstan clear-result-cache --configuration=./phpstan.ddtrace.neon"
         ],


### PR DESCRIPTION
Recently static analysis started to fail because composer would install binaries, specifically phpstan binary, to
~/.config/composer/vendor/bin instead of ~/.composer/vendor/bin

In addition to fix this path, we also now use the most modern cimg/php images as recommended by circleci:
https://circleci.com/developer/images/image/cimg/php

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

### Readiness checklist
~- [ ] (only for Members) Changelog has been added to the release document.~
~- [ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
