### PR TITLE
Check for php8 binary in package/post-install.sh script

### DIFF
--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -13,10 +13,14 @@ PATH="${PATH}:/usr/local/bin"
 
 # We attempt in this order the following binary names:
 #    1. php
-#    2. php7 (some alpine versions install php 7.x from main repo to this binary)
-#    3. php5 (some alpine versions install php 5.x from main repo to this binary)
+#    2. php8 (some alpine versions install php 8.x from main repo to this binary)
+#    3. php7 (some alpine versions install php 7.x from main repo to this binary)
+#    4. php5 (some alpine versions install php 5.x from main repo to this binary)
 if [ -z "$DD_TRACE_PHP_BIN" ]; then
     DD_TRACE_PHP_BIN=$(command -v php || true)
+fi
+if [ -z "$DD_TRACE_PHP_BIN" ]; then
+    DD_TRACE_PHP_BIN=$(command -v php8 || true)
 fi
 if [ -z "$DD_TRACE_PHP_BIN" ]; then
     DD_TRACE_PHP_BIN=$(command -v php7 || true)


### PR DESCRIPTION
### Description

When installing the apk on alpine Linux for PHP 8 the post-install.sh script fails because the PHP bin is called `php8` but the script only checks for php7 and php5.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
