### PR TITLE
Support userland spans with custom root spans created internally

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -33,6 +33,7 @@
         <exclude-pattern>tests/api/bootstrap.php</exclude-pattern>
         <exclude-pattern>tests/Integration/CurrentContextAccess/</exclude-pattern>
         <exclude-pattern>tests/Integration/LongRunning/long_running_script_manual.php</exclude-pattern>
+        <exclude-pattern>tests/Integration/LongRunning/long_running_script_with_trace_function.php</exclude-pattern>
         <exclude-pattern>tests/Integration/ErrorReporting/scripts/</exclude-pattern>
         <exclude-pattern>tests/Integrations/PHPRedis/V3/*Test.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/PHPRedis/V4/*Test.php</exclude-pattern>

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -1355,6 +1355,23 @@ static PHP_FUNCTION(active_span) {
     RETURN_OBJ_COPY(&DDTRACE_G(open_spans_top)->span.std);
 }
 
+/* {{{ proto string DDTrace\root_span() */
+static PHP_FUNCTION(root_span) {
+    UNUSED(execute_data);
+    if (!DDTRACE_G(open_spans_top)) {
+        if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
+            ddtrace_push_root_span();  // ensure root span always exists, especially after serialization for testing
+        } else {
+            RETURN_NULL();
+        }
+    }
+    ddtrace_span_fci *root_span = DDTRACE_G(open_spans_top);
+    while (root_span->next) {
+        root_span = root_span->next;
+    }
+    RETURN_OBJ_COPY(&root_span->span.std);
+}
+
 /* {{{ proto string DDTrace\start_span() */
 static PHP_FUNCTION(start_span) {
     double start_time_seconds = 0;
@@ -1505,6 +1522,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_NS_FE(start_span, arginfo_dd_trace_start_span),
     DDTRACE_NS_FE(close_span, arginfo_dd_trace_close_span),
     DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(root_span, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_peek_span_id, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_pop_span_id, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -61,9 +61,9 @@ final class Bootstrap
                         // this also gets set when creating a root span, but may not have the latest up-to-date data
                         if (
                             'cli' !== PHP_SAPI && \ddtrace_config_url_resource_name_enabled()
-                            && $rootScope = $tracer->getRootScope()
+                            && $rootSpan = $tracer->getSafeRootSpan()
                         ) {
-                            $tracer->addUrlAsResourceNameToSpan($rootScope->getSpan());
+                            $tracer->addUrlAsResourceNameToSpan($rootSpan);
                         }
                         /*
                          * Having this priority sampling here is actually a bug (should happen after service name

--- a/tests/Integration/LongRunning/LongRunningScriptTest.php
+++ b/tests/Integration/LongRunning/LongRunningScriptTest.php
@@ -3,12 +3,15 @@
 namespace DDTrace\Tests\Integration\LongRunning;
 
 use DDTrace\Tests\Common\CLITestCase;
+use DDTrace\Tests\Common\SpanAssertion;
 
 final class LongRunningScriptTest extends CLITestCase
 {
+    private $script = '';
+
     protected function getScriptLocation()
     {
-        return __DIR__ . '/long_running_script_manual.php';
+        return __DIR__ . '/' . $this->script;
     }
 
     public function testMultipleTracesFromLongRunningScriptSetCorrectTraceCountHeader()
@@ -17,6 +20,8 @@ final class LongRunningScriptTest extends CLITestCase
             $this->markTestSkipped('We do not officially support and test long running scripts on PHP 5');
             return;
         }
+
+        $this->script = 'long_running_script_manual.php';
         $agentRequest = $this->getAgentRequestFromCommand('', [
             'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
             'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
@@ -25,5 +30,49 @@ final class LongRunningScriptTest extends CLITestCase
 
         $this->assertSame('3', $agentRequest['headers']['X-Datadog-Trace-Count']);
         $this->assertCount(3, json_decode($agentRequest['body'], true));
+    }
+
+    public function testTracesFromLongRunningFunctionWithMixedTracing()
+    {
+        if (5 === \PHP_MAJOR_VERSION) {
+            $this->markTestSkipped('We do not officially support and test long running scripts on PHP 5');
+            return;
+        }
+
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Requires internal spans');
+        }
+
+        $this->script = 'long_running_script_with_trace_function.php';
+        $traces = $this->getTracesFromCommand('', [
+            'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
+            'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
+            'DD_TRACE_BGS_TIMEOUT' => 3000,
+            'DD_TRACE_TRACED_INTERNAL_FUNCTIONS' => 'array_sum',
+        ]);
+
+        $this->assertNotEquals($traces[1][0]["trace_id"], $traces[2][0]["trace_id"], "The trace id is reused");
+
+        $rootTraceAssertion = function ($i) {
+            return SpanAssertion::exists("do_manual_instrumentation_within_root_trace_function", "run $i")
+                ->withChildren([
+                    SpanAssertion::exists("first-sub-operation")->withChildren(
+                        SpanAssertion::exists("array_sum")
+                    )->withExactTags(["result" => "42"]),
+                    SpanAssertion::exists("second-sub-operation")->withChildren(
+                        SpanAssertion::exists("array_sum")
+                    )->withExactTags(["result" => "42"]),
+                ]);
+        };
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::exists("custom-root-operation")->withChildren(
+                SpanAssertion::exists("do_manual_instrumentation_subspan")->withChildren(
+                    SpanAssertion::exists("sub-operation")
+                )
+            ),
+            $rootTraceAssertion(1),
+            $rootTraceAssertion(2),
+        ]);
     }
 }

--- a/tests/Integration/LongRunning/long_running_script_with_trace_function.php
+++ b/tests/Integration/LongRunning/long_running_script_with_trace_function.php
@@ -1,0 +1,53 @@
+<?php
+
+use DDTrace\GlobalTracer;
+
+function do_manual_instrumentation_subspan()
+{
+    $tracer = GlobalTracer::get();
+    $subScope = $tracer->startActiveSpan('sub-operation');
+    $subScope->close();
+}
+
+DDTrace\trace_function('do_manual_instrumentation_subspan', function () {
+});
+
+function do_manual_instrumentation_root_before()
+{
+    $tracer = GlobalTracer::get();
+    $rootScope = $tracer->startRootSpan("custom-root-operation");
+
+    do_manual_instrumentation_subspan();
+
+    $rootScope->close();
+}
+
+do_manual_instrumentation_root_before();
+
+error_log('Custom root is done');
+
+function do_manual_instrumentation_within_root_trace_function()
+{
+    $tracer = GlobalTracer::get();
+    $subScope = $tracer->startActiveSpan('second-sub-operation');
+    $subScope->getSpan()->setTag('result', array_sum([1, 41]));
+    $subScope->close();
+}
+
+DDTrace\trace_function('array_sum', function () {
+});
+
+$i = 0;
+DDTrace\trace_function('do_manual_instrumentation_within_root_trace_function', function ($span) use (&$i) {
+    $tracer = GlobalTracer::get();
+    $subScope = $tracer->startActiveSpan('first-sub-operation');
+    $subScope->getSpan()->setTag('result', array_sum([1, 41]));
+    $subScope->close();
+    $span->resource = "run " . ++$i;
+});
+
+do_manual_instrumentation_within_root_trace_function();
+
+do_manual_instrumentation_within_root_trace_function();
+
+error_log('Implicit root is done');


### PR DESCRIPTION
### Description

Fix for #1302: root spans which are created internally were recognized as an overall root span and "absorbed" when a span was started instead of a new span being started.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
