### PR TITLE
Fix resource name not registering ZF1 module name

### DIFF
--- a/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
@@ -25,13 +25,15 @@ class TraceRequest extends Zend_Controller_Plugin_Abstract
         $integration = new ZendFrameworkIntegration();
         // Overwriting the default web integration
         $integration->addTraceAnalyticsIfEnabledLegacy($span);
+        $module = $request->getModuleName() ?: 'default';
         $controller = $request->getControllerName();
         $action = $request->getActionName();
         $route = Zend_Controller_Front::getInstance()->getRouter()->getCurrentRouteName();
+        $span->setTag('zf1.module', $module);
         $span->setTag('zf1.controller', $controller);
         $span->setTag('zf1.action', $action);
         $span->setTag('zf1.route_name', $route);
-        $span->setResource($controller . '@' . $action . ' ' . $route);
+        $span->setResource($module . '/' . $controller . '@' . $action . ' ' . $route);
         $span->setTag(Tag::HTTP_METHOD, $request->getMethod());
         $span->setTag(
             Tag::HTTP_URL,

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -33,8 +33,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
         return $this->buildDataProvider(
             [
                 'A simple GET request returning a string' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@index default')
+                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'default/simple@index default')
                         ->withExactTags([
+                            'zf1.module' => 'default',
                             'zf1.controller' => 'simple',
                             'zf1.action' => 'index',
                             'zf1.route_name' => 'default',
@@ -44,8 +45,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                 ],
                 'A simple GET request with a view' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@view my_simple_view_route')
+                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'default/simple@view my_simple_view_route')
                         ->withExactTags([
+                            'zf1.module' => 'default',
                             'zf1.controller' => 'simple',
                             'zf1.action' => 'view',
                             'zf1.route_name' => 'my_simple_view_route',
@@ -55,8 +57,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                 ],
                 'A GET request with an exception' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'error@error default')
+                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'default/error@error default')
                         ->withExactTags([
+                            'zf1.module' => 'default',
                             'zf1.controller' => 'error',
                             'zf1.action' => 'error',
                             'zf1.route_name' => 'default',

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -33,8 +33,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
         $this->assertExpectedSpans(
             $traces,
             [
-                SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@index default')
+                SpanAssertion::build('zf1.request', 'zf1', 'web', 'default/simple@index default')
                     ->withExactTags([
+                        'zf1.module' => 'default',
                         'zf1.controller' => 'simple',
                         'zf1.action' => 'index',
                         'zf1.route_name' => 'default',


### PR DESCRIPTION
### Description

ZF1 allows do organize the application on modules and place controllers and actions under them. The current implementation ignores the modules and for so controllers and actions with the same name in different modules are treated as the same.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
