### PR TITLE
Release 0.64.0

### DIFF
--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.64.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -42,7 +42,20 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    **WARNING**: With this release the file `_generated.php` is not used anymore and files `_generated_api.php` and `_generated_internal.php` are generated instead. This only impacts users having a very custom installation procedure that requires custom builds and manual copy of files.
+
+    ### Added
+    - Bring ZAI config, internal spans, and improved exception handling to PHP 7 #1293
+    - Add properties and exceptions ZAI implementations for PHP 5 #1306
+
+    ### Fixed
+    - Disable flaky ext/ftp tests on PHP < 8.1 #1296
+    - Compatibility with PHP 7.4+ preloading #1298 (thank you @olsavmic for the investigation and reproduction case)
+    - Check for php8 binary in package/post-install.sh script #1301 (thank you for the contribution @daiwai)
+    - Support userland spans with custom root spans created internally #1303
+    - Fix memory leak of already defined global tags #1304
+    </notes>
     <contents>
         <dir name="/">
             <!-- components -->

--- a/package.xml
+++ b/package.xml
@@ -47,7 +47,6 @@
 
     ### Added
     - Bring ZAI config, internal spans, and improved exception handling to PHP 7 #1293
-    - Add properties and exceptions ZAI implementations for PHP 5 #1306
 
     ### Fixed
     - Disable flaky ext/ftp tests on PHP &#60;8.1 #1296

--- a/package.xml
+++ b/package.xml
@@ -50,7 +50,7 @@
     - Add properties and exceptions ZAI implementations for PHP 5 #1306
 
     ### Fixed
-    - Disable flaky ext/ftp tests on PHP < 8.1 #1296
+    - Disable flaky ext/ftp tests on PHP &#60;8.1 #1296
     - Compatibility with PHP 7.4+ preloading #1298 (thank you @olsavmic for the investigation and reproduction case)
     - Check for php8 binary in package/post-install.sh script #1301 (thank you for the contribution @daiwai)
     - Support userland spans with custom root spans created internally #1303

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -30,7 +30,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.64.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Description

**WARNING**: With this release the file `_generated.php` is not used anymore and files `_generated_api.php` and `_generated_internal.php` are generated instead. This only impacts users having a very custom installation procedure that requires custom builds and manual copy of files.

### Added
- Bring ZAI config, internal spans, and improved exception handling to PHP 7 #1293

### Fixed
- Disable flaky ext/ftp tests on PHP < 8.1 #1296
- Compatibility with PHP 7.4+ preloading #1298 (thank you @olsavmic for the investigation and reproduction case)
- Check for php8 binary in package/post-install.sh script #1301 (thank you for the contribution @daiwai)
- Support userland spans with custom root spans created internally #1303
- Fix memory leak of already defined global tags #1304

### Readiness checklist
- [ ] ~(only for Members) Changelog has been added to the release document.~
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
