### PR TITLE
Fix span start times of userland spans

### DIFF
--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -173,7 +173,8 @@ final class Tracer implements TracerInterface
         $reference = $this->findParent($options->getReferences());
 
         // avoid rounding errors, we only care about microsecond resolution here
-        $roundedStartTime = ($options->getStartTime() + 0.2) / 1000000;
+        // a value of 0 defaults to current time
+        $roundedStartTime = $options->getStartTime() ? ($options->getStartTime() + 0.2) / 1000000 : 0;
         if ($reference === null) {
             $context = SpanContext::createAsRoot([], $roundedStartTime);
         } else {

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -24,6 +24,7 @@ final class SpanAssertion
     private $resource = SpanAssertion::NOT_TESTED;
     private $onlyCheckExistence = false;
     private $isTraceAnalyticsCandidate = false;
+    private $testTime = true;
     /** @var SpanAssertion[] */
     private $children = [];
 
@@ -332,6 +333,14 @@ final class SpanAssertion
     public function getExactMetrics()
     {
         return $this->exactMetrics;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTestTime()
+    {
+        return $this->testTime;
     }
 
     public function __toString()

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -315,6 +315,13 @@ final class SpanChecker
             }
         }
 
+        if ($exp->getTestTime()) {
+            TestCase::assertGreaterThanOrEqual($_SERVER["REQUEST_TIME_FLOAT"] * 1e9, $span['start']);
+            TestCase::assertLessThan(microtime(true) * 1e9, $span['start']);
+            TestCase::assertLessThan((microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]) * 1e9, $span['duration']);
+            TestCase::assertGreaterThan(0, $span['duration']);
+        }
+
         if ($exp->isOnlyCheckExistence()) {
             return;
         }

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -258,6 +258,8 @@ trait TracerTestTrait
                     return;
                 }
 
+                $rawSpan["duration"] = (int)($rawSpan["duration"] / 1000);
+                $rawSpan["start"] = (int)($rawSpan["start"] / 1000);
 
                 if (PHP_VERSION_ID < 70000) {
                     $span = new Span(
@@ -289,8 +291,8 @@ trait TracerTestTrait
                     $internalSpan->meta = isset($rawSpan['meta']) ? $rawSpan['meta'] : [];
                     $internalSpan->metrics = isset($rawSpan['metrics']) ? $rawSpan['metrics'] : [];
                     $span = new FakeSpan($internalSpan, $spanContext);
-                    $span->duration = $rawSpan["duration"] / 1000;
-                    $span->startTime = $rawSpan["start"] / 1000;
+                    $span->duration = $rawSpan["duration"];
+                    $span->startTime = $rawSpan["start"];
                 }
                 $this->setRawPropertyFromArray($span, $rawSpan, 'hasError', 'error', function ($value) {
                     return $value == 1 || $value == true;


### PR DESCRIPTION
### Description

Fix for #1311. We are now implicitly checking timing sanity for every ever tested span.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
