### PR TITLE
Honor DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED in Lumen resource naming

### DIFF
--- a/src/DDTrace/Integrations/Lumen/LumenIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenIntegration.php
@@ -86,8 +86,7 @@ class LumenIntegration extends Integration
                         $rootSpan->setTag('lumen.route.name', $routeInfo[1]['as']);
                         $resourceName = $routeInfo[1]['as'];
                     }
-
-                    if (null !== $resourceName) {
+                    if (null !== $resourceName && !\ddtrace_config_url_resource_name_enabled()) {
                         $rootSpan->setTag(
                             Tag::RESOURCE_NAME,
                             $rootSpan->getTag(Tag::HTTP_METHOD) . ' ' . $resourceName

--- a/src/DDTrace/Integrations/Lumen/LumenIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenIntegration.php
@@ -82,13 +82,12 @@ class LumenIntegration extends Integration
                         $action = $routeInfo[1]['uses'];
                         $rootSpan->setTag('lumen.route.action', $action);
                         $span->meta['lumen.route.action'] = $action;
-                        $resourceName = $routeInfo[1]['uses'];
                     }
                     if (isset($routeInfo[1]['as'])) {
                         $routeAlias = $routeInfo[1]['as'];
                         $rootSpan->setTag('lumen.route.name', $routeAlias);
-                        $span->meta['lumen.route.name'] = $routeAlias;
-                        $resourceName = $routeInfo[1]['as'];
+                        $span->resource = $routeAlias;
+                        $resourceName = $routeAlias;
                     }
                     if (null !== $resourceName && !\ddtrace_config_url_resource_name_enabled()) {
                         $rootSpan->setTag(

--- a/src/DDTrace/Integrations/Lumen/LumenIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenIntegration.php
@@ -79,11 +79,15 @@ class LumenIntegration extends Integration
                     $routeInfo = $args[0];
                     $resourceName = null;
                     if (isset($routeInfo[1]['uses'])) {
-                        $rootSpan->setTag('lumen.route.action', $routeInfo[1]['uses']);
+                        $action = $routeInfo[1]['uses'];
+                        $rootSpan->setTag('lumen.route.action', $action);
+                        $span->meta['lumen.route.action'] = $action;
                         $resourceName = $routeInfo[1]['uses'];
                     }
                     if (isset($routeInfo[1]['as'])) {
-                        $rootSpan->setTag('lumen.route.name', $routeInfo[1]['as']);
+                        $routeAlias = $routeInfo[1]['as'];
+                        $rootSpan->setTag('lumen.route.name', $routeAlias);
+                        $span->meta['lumen.route.name'] = $routeAlias;
                         $resourceName = $routeInfo[1]['as'];
                     }
                     if (null !== $resourceName && !\ddtrace_config_url_resource_name_enabled()) {

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -148,9 +148,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     'Laravel\Lumen\Application.handleFoundRoute',
                     'lumen_test_app',
                     'web',
-                    'Laravel\Lumen\Application.handleFoundRoute'
+                    'simple_route'
                 )->withExactTags([
-                    'lumen.route.name' => 'simple_route',
                     'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                 ]),
             ]),

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -57,7 +57,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'lumen_test_app',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        )->withExactTags([])
+                        )->withExactTags([
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
+                        ])
                         ->withChildren([
                             SpanAssertion::build(
                                 'laravel.view.render',
@@ -109,7 +111,10 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'lumen_test_app',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        )->withExistingTagsNames([
+                        )->withExactTags([
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                        ])
+                        ->withExistingTagsNames([
                             'error.stack'
                         ])->setError('Exception', 'Controller error'),
                         SpanAssertion::build(
@@ -144,7 +149,10 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     'lumen_test_app',
                     'web',
                     'Laravel\Lumen\Application.handleFoundRoute'
-                ),
+                )->withExactTags([
+                    'lumen.route.name' => 'simple_route',
+                    'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                ]),
             ]),
         ];
     }
@@ -169,7 +177,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'lumen_test_app',
                         '',
                         'Laravel\Lumen\Application.handleFoundRoute'
-                    )->withExistingTagsNames([
+                    )->withExactTags([
+                        'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                    ])->withExistingTagsNames([
                         'error.stack'
                     ])->setError('Exception', 'Controller error'),
                 ]),

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -45,7 +45,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'lumen.request',
                         'lumen_test_app',
                         'web',
-                        'GET App\Http\Controllers\ExampleController@simpleView'
+                        'GET /simple_view'
                     )->withExactTags([
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
                         'http.method' => 'GET',
@@ -93,7 +93,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'lumen.request',
                         'lumen_test_app',
                         'web',
-                        'GET App\Http\Controllers\ExampleController@error'
+                        'GET /error'
                     )->withExactTags([
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
                         'http.method' => 'GET',
@@ -131,7 +131,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'lumen.request',
                 'lumen_test_app',
                 'web',
-                'GET simple_route'
+                'GET /simple'
             )->withExactTags([
                 'lumen.route.name' => 'simple_route',
                 'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
@@ -156,7 +156,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'lumen.request',
                 'lumen_test_app',
                 'web',
-                'GET App\Http\Controllers\ExampleController@error'
+                'GET /error'
             )->withExactTags([
                 'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
                 'http.method' => 'GET',

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -57,7 +57,10 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'lumen',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        ),
+                        )->withExactTags([
+                            'lumen.route.name' => 'simple_route',
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                        ]),
                     ])
             ]
         );

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -37,7 +37,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'lumen.request',
                     'lumen',
                     'web',
-                    'GET simple_route'
+                    'GET /simple'
                 )
                     ->withExactTags([
                         'lumen.route.name' => 'simple_route',

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -56,9 +56,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen',
                             'web',
-                            'Laravel\Lumen\Application.handleFoundRoute'
+                            'simple_route'
                         )->withExactTags([
-                            'lumen.route.name' => 'simple_route',
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                         ]),
                     ])

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -56,9 +56,8 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen_test_app',
                             'web',
-                            'Laravel\Lumen\Application.handleFoundRoute'
+                            'simple_route'
                         )->withExactTags([
-                            'lumen.route.name' => 'simple_route',
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                         ]),
                     ]),

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -57,7 +57,10 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'lumen_test_app',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        )
+                        )->withExactTags([
+                            'lumen.route.name' => 'simple_route',
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                        ]),
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -77,7 +80,9 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'lumen_test_app',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        )->withChildren([
+                        )->withExactTags([
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
+                        ])->withChildren([
                             SpanAssertion::build(
                                 'laravel.view.render',
                                 'lumen_test_app',
@@ -114,7 +119,9 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'lumen_test_app',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        )->withExistingTagsNames([
+                        )->withExactTags([
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                        ])->withExistingTagsNames([
                             'error.stack',
                         ])->setError('Exception', 'Controller error'),
                         SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -44,7 +44,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'lumen.request',
                         'lumen_test_app',
                         'web',
-                        'GET simple_route'
+                        'GET /simple'
                     )->withExactTags([
                         'lumen.route.name' => 'simple_route',
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
@@ -65,7 +65,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'lumen.request',
                         'lumen_test_app',
                         'web',
-                        'GET App\Http\Controllers\ExampleController@simpleView'
+                        'GET /simple_view'
                     )->withExactTags([
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
                         'http.method' => 'GET',
@@ -99,7 +99,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'lumen.request',
                         'lumen_test_app',
                         'web',
-                        'GET App\Http\Controllers\ExampleController@error'
+                        'GET /error'
                     )->withExactTags([
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
                         'http.method' => 'GET',

--- a/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
+++ b/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
@@ -51,7 +51,10 @@ class DeprecatedResourceNameTest extends WebFrameworkTestCase
                             'lumen',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        ),
+                        )->withExactTags([
+                            'lumen.route.name' => 'simple_route',
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                        ]),
                     ]),
             ]
         );

--- a/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
+++ b/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
@@ -50,9 +50,8 @@ class DeprecatedResourceNameTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen',
                             'web',
-                            'Laravel\Lumen\Application.handleFoundRoute'
+                            'simple_route'
                         )->withExactTags([
-                            'lumen.route.name' => 'simple_route',
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                         ]),
                     ]),

--- a/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
+++ b/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
@@ -6,7 +6,7 @@ use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
-class TraceSearchConfigTest extends WebFrameworkTestCase
+class DeprecatedResourceNameTest extends WebFrameworkTestCase
 {
     protected static function getAppIndexScript()
     {
@@ -16,8 +16,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_ANALYTICS_ENABLED' => 'true',
-            'DD_LUMEN_ANALYTICS_SAMPLE_RATE' => '0.3',
+            'DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED' => 'false',
         ]);
     }
 
@@ -27,7 +26,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
     public function testScenario()
     {
         $traces = $this->tracesFromWebRequest(function () {
-            $this->call(GetSpec::create('Testing trace analytics config metric', '/simple'));
+            $this->call(GetSpec::create('Testing the legacy way to name resources after the controller', '/simple'));
         });
 
         $this->assertFlameGraph(
@@ -37,7 +36,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'lumen.request',
                     'lumen',
                     'web',
-                    'GET /simple'
+                    'GET simple_route'
                 )
                     ->withExactTags([
                         'lumen.route.name' => 'simple_route',
@@ -45,11 +44,6 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
-                    ])
-                    ->withExactMetrics([
-                        '_dd1.sr.eausr' => 0.3,
-                        '_dd.rule_psr' => 1,
-                        '_sampling_priority_v1' => 1,
                     ])
                     ->withChildren([
                         SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -57,7 +57,10 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'lumen',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        ),
+                        )->withExactTags([
+                            'lumen.route.name' => 'simple_route',
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                        ]),
                     ]),
             ]
         );

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -56,9 +56,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen',
                             'web',
-                            'Laravel\Lumen\Application.handleFoundRoute'
+                            'simple_route'
                         )->withExactTags([
-                            'lumen.route.name' => 'simple_route',
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                         ]),
                     ]),

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -57,7 +57,10 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'lumen',
                             'web',
                             'Laravel\Lumen\Application.handleFoundRoute'
-                        ),
+                        )->withExactTags([
+                            'lumen.route.name' => 'simple_route',
+                            'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                        ]),
                     ]),
             ]
         );

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -56,9 +56,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute',
                             'lumen',
                             'web',
-                            'Laravel\Lumen\Application.handleFoundRoute'
+                            'simple_route'
                         )->withExactTags([
-                            'lumen.route.name' => 'simple_route',
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
                         ]),
                     ]),

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -37,7 +37,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'lumen.request',
                     'lumen',
                     'web',
-                    'GET simple_route'
+                    'GET /simple'
                 )
                     ->withExactTags([
                         'lumen.route.name' => 'simple_route',


### PR DESCRIPTION
### Description

With this PR, we honor the value of `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED` when setting resource names.

This means that with the default value of `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED` (`true`), automatically users will have resources as `GET /actual/uri/path` instead of `GET action_name` or `GET App\Controller@action_method`.

This PR requires a **WARNING** to be added to the release notes, since resource names (thus possibly monitors) might have to be adjusted.

Users can go back to their default behavior setting `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=false`.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
