### PR TITLE
Default internal span service to DD_SERVICE

### DIFF
--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -507,6 +507,14 @@ static ddtrace_span_fci *dd_fcall_begin_tracing_hook(zend_execute_data *call, dd
     span_fci->dispatch = dispatch;
     ddtrace_open_span(span_fci);
 
+    // default service to env var DD_SERVICE
+    zend_string *service = get_DD_SERVICE();
+    if (service && ZSTR_LEN(service)) {
+        zval *prop_service = ddtrace_spandata_property_service(&span_fci->span);
+        // todo: do we need to copy this?
+        ZVAL_STR_COPY(prop_service, service);
+    }
+
     return span_fci;
 }
 

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -378,6 +378,14 @@ static ddtrace_span_fci *dd_fcall_begin_tracing_hook(zend_execute_data *call, dd
     span_fci->dispatch = dispatch;
     ddtrace_open_span(span_fci);
 
+    // default service to env var DD_SERVICE
+    zend_string *service = get_DD_SERVICE();
+    if (service && ZSTR_LEN(service)) {
+        zval *prop_service = ddtrace_spandata_property_service(&span_fci->span);
+        // todo: do we need to copy this?
+        ZVAL_STR_COPY(prop_service, service);
+    }
+
     return span_fci;
 }
 

--- a/package.xml
+++ b/package.xml
@@ -445,6 +445,8 @@
             <file name="tests/ext/sandbox/dd_trace_method_binds_called_object.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_push_span_id.phpt" role="test" />
             <file name="tests/ext/sandbox/dd_trace_set_trace_id.phpt" role="test" />
+            <file name="tests/ext/sandbox/default_service_set.phpt" role="test" />
+            <file name="tests/ext/sandbox/default_service_unset.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties.phpt" role="test" />
             <file name="tests/ext/sandbox/default_span_properties_method.phpt" role="test" />
             <file name="tests/ext/sandbox/deferred_load_attempt_loading_once.phpt" role="test" />

--- a/tests/ext/sandbox/default_service_set.phpt
+++ b/tests/ext/sandbox/default_service_set.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Span service defaults to DD_SERVICE
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_SERVICE=datadog-php-test
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_DEBUG=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+DDTrace\trace_method(
+    'Application',
+    'prehook',
+    [
+        'prehook' => function (DDTrace\SpanData $span) {
+            echo 'Service: ', $span->service, "\n";
+        },
+    ]
+);
+
+DDTrace\trace_method(
+    'Application',
+    'posthook',
+    [
+        'posthook' => function (DDTrace\SpanData $span) {
+            echo 'Service: ', $span->service, "\n";
+        },
+    ]
+);
+
+final class Application
+{
+    public static function prehook()
+    {
+        echo __METHOD__, "\n";
+    }
+
+    public static function posthook()
+    {
+        echo __METHOD__, "\n";
+    }
+}
+
+Application::prehook();
+Application::posthook();
+
+?>
+--EXPECT--
+Service: datadog-php-test
+Application::prehook
+Application::posthook
+Service: datadog-php-test
+

--- a/tests/ext/sandbox/default_service_unset.phpt
+++ b/tests/ext/sandbox/default_service_unset.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Span service does not default to DD_SERVICE if unset or empty
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: Test requires internal spans'); ?>
+--ENV--
+DD_SERVICE=
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_DEBUG=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+DDTrace\trace_method(
+    'Application',
+    'prehook',
+    [
+        'prehook' => function (DDTrace\SpanData $span) {
+            if (!isset($span->service) || $span->service === "") {
+                echo "Service: (unset)\n";
+            } else {
+                echo "Service: {$span->service}\n";
+            }
+        },
+    ]
+);
+
+DDTrace\trace_method(
+    'Application',
+    'posthook',
+    [
+        'posthook' => function (DDTrace\SpanData $span) {
+            if (!isset($span->service) || $span->service === "") {
+                echo "Service: (unset)\n";
+            } else {
+                echo "Service: {$span->service}\n";
+            }
+        },
+    ]
+);
+
+final class Application
+{
+    public static function prehook()
+    {
+        echo __METHOD__, "\n";
+    }
+
+    public static function posthook()
+    {
+        echo __METHOD__, "\n";
+    }
+}
+
+Application::prehook();
+Application::posthook();
+
+?>
+--EXPECT--
+Service: (unset)
+Application::prehook
+Application::posthook
+Service: (unset)
+


### PR DESCRIPTION
### Description

As reported in #1317, internal spans are not defaulting their service property to the value of the environment variable `DD_SERVICE`.

I'm not sure if `dd_fcall_begin_tracing_hook` is the right place to stick this, but it worked locally on PHP 8 so I'm opening a draft PR to see how it goes.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.
