### PR TITLE
Fix CLI processes emitting empty root spans when CLI tracing is not enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,7 @@ jobs:
           name: Run xdebug tests
           command: |
             export REPORT_EXIT_STATUS=1
+            export DD_TRACE_CLI_ENABLED=1
             cd tmp/build_extension
             php run-tests.php -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_one >>.so ../../tests/xdebug/<< parameters.xdebug_version_one >>
             if [[ ! "<<parameters.xdebug_version_two>>" == "none" ]]; then
@@ -926,6 +927,7 @@ jobs:
             TERM=dumb \
             HTTPBIN_HOSTNAME=httpbin_integration \
             DATADOG_HAVE_DEV_ENV=1 \
+            DD_TRACE_CLI_ENABLED=1 \
             pecl run-tests <<# parameters.showdiff >> --showdiff <</ parameters.showdiff >> --ini=" -d ddtrace.request_init_hook=" -p datadog_trace
       - run:
           name: Gather .diff files for artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,7 @@ jobs:
           name: Run tests
           command: |
             set -euo pipefail
-            make << parameters.make_target >> PHPUNIT_OPTS="--log-junit test-results/php-unit/results.xml" 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total .* memory leaks detected ==="; }
+            make << parameters.make_target >> PHPUNIT_OPTS="--log-junit test-results/php-unit/results.xml" 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }
       - <<: *STEP_PERSIST_TO_WORKSPACE
       - <<: *STEP_STORE_TEST_RESULTS
       - run:
@@ -1142,7 +1142,7 @@ jobs:
                       ~/datadog/zend_abstract_interface
                     make -j all
                     make test
-                    grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
+                    grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
                   done
 
       # Builds that do not support ASan
@@ -1173,7 +1173,7 @@ jobs:
                       ~/datadog/zend_abstract_interface
                     make -j all
                     make test
-                    grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
+                    grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
                   done
 
       - run:
@@ -1191,7 +1191,7 @@ jobs:
               ~/datadog/zend_abstract_interface
             make -j all
             make test
-            grep -e "=== Total .* memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
+            grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
 
       - run:
           command: |
@@ -1802,6 +1802,7 @@ workflows:
                 - test_unit
                 - test_api_unit
                 - test_c2php
+                - test_c_disabled
 
       - asan:
           requires: [ 'Prepare Code' ]

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,14 @@ test_c: export DD_TRACE_CLI_ENABLED=1
 test_c: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(BUILD_DIR)/$(TESTS)
 
+test_c_disabled: export DD_TRACE_CLI_ENABLED=0
+test_c_disabled: export DD_TRACE_DEBUG=1
+test_c_disabled: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
+	( \
+	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(BUILD_DIR)/$(TESTS) || true; \
+	! grep -E 'Successfully triggered flush with trace of size|=== Total [0-9]+ memory leaks detected ===|Segmentation fault' $$(find $(BUILD_DIR)/$(TESTS) -name "*.out" | grep -v segfault_backtrace_enabled.out); \
+	)
+
 test_c_mem: export DD_TRACE_CLI_ENABLED=1
 test_c_mem: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -m $(BUILD_DIR)/$(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ test_c_asan: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	( \
 	set -xe; \
+	export DD_TRACE_CLI_ENABLED=1; \
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/normal-extension-test.xml; \
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
 	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(BUILD_DIR)/$(TESTS); \

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -443,8 +443,6 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
 }
 
 static void dd_rinit_once(void) {
-    ddtrace_config_first_rinit();
-
     /* The env vars are memoized on MINIT before the SAPI env vars are available.
      * We use the first RINIT to bust the env var cache and use the SAPI env vars.
      * TODO Audit/remove config usages before RINIT and move config init to RINIT.
@@ -456,6 +454,7 @@ static void dd_rinit_once(void) {
     ddtrace_coms_init_and_start_writer();
 }
 
+static pthread_once_t dd_rinit_config_once_control = PTHREAD_ONCE_INIT;
 static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 
 static PHP_RINIT_FUNCTION(ddtrace) {
@@ -465,9 +464,15 @@ static PHP_RINIT_FUNCTION(ddtrace) {
         DDTRACE_G(disable) = 1;
     }
 
+    // ZAI config is always set up
+    pthread_once(&dd_rinit_config_once_control, ddtrace_config_first_rinit);
+    zai_config_rinit();
+
+    if (strcmp(sapi_module.name, "cli") == 0 && !get_DD_TRACE_CLI_ENABLED()) {
+        DDTRACE_G(disable) = 1;
+    }
+
     if (DDTRACE_G(disable)) {
-        pthread_once(&dd_rinit_once_control, ddtrace_config_first_rinit);
-        zai_config_rinit();
         return SUCCESS;
     }
 
@@ -476,8 +481,6 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     // Things that should only run on the first RINIT
     pthread_once(&dd_rinit_once_control, dd_rinit_once);
-
-    zai_config_rinit();
 
     DDTRACE_G(request_init_hook_loaded) = 0;
     if (ZSTR_LEN(get_DD_TRACE_REQUEST_INIT_HOOK())) {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -890,6 +890,10 @@ static PHP_FUNCTION(add_global_tag) {
         RETURN_NULL();
     }
 
+    if (DDTRACE_G(disable)) {
+        RETURN_NULL();
+    }
+
     zval value_zv;
     ZVAL_STR_COPY(&value_zv, val);
     zend_hash_update(DDTRACE_G(additional_global_tags), key, &value_zv);
@@ -1392,6 +1396,9 @@ static PHP_FUNCTION(dd_trace_peek_span_id) {
 /* {{{ proto string DDTrace\active_span() */
 static PHP_FUNCTION(active_span) {
     UNUSED(execute_data);
+    if (DDTRACE_G(disable)) {
+        RETURN_NULL();
+    }
     if (!DDTRACE_G(open_spans_top)) {
         if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
             ddtrace_push_root_span();  // ensure root span always exists, especially after serialization for testing
@@ -1407,6 +1414,9 @@ static PHP_FUNCTION(active_span) {
 /* {{{ proto string DDTrace\root_span() */
 static PHP_FUNCTION(root_span) {
     UNUSED(execute_data);
+    if (DDTRACE_G(disable)) {
+        RETURN_NULL();
+    }
     if (!DDTRACE_G(open_spans_top)) {
         if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
             ddtrace_push_root_span();  // ensure root span always exists, especially after serialization for testing
@@ -1432,15 +1442,17 @@ static PHP_FUNCTION(start_span) {
     }
 
     ddtrace_span_fci *span_fci = ddtrace_init_span();
-    ddtrace_open_span(span_fci);
+
+    if (!DDTRACE_G(disable)) {
+        GC_ADDREF(&span_fci->span.std);
+        ddtrace_open_span(span_fci);
+    }
 
     if (start_time_seconds > 0) {
         span_fci->span.start = (uint64_t)(start_time_seconds * 1000000000);
     }
 
-    zend_object *obj = &DDTRACE_G(open_spans_top)->span.std;
-    GC_ADDREF(obj);
-    RETURN_OBJ(obj);
+    RETURN_OBJ(&span_fci->span.std);
 }
 
 /* {{{ proto string DDTrace\close_span() */

--- a/ext/php7/handlers_curl.c
+++ b/ext/php7/handlers_curl.c
@@ -40,7 +40,7 @@ static void (*dd_curl_setopt_handler)(INTERNAL_FUNCTION_PARAMETERS) = NULL;
 static void (*dd_curl_setopt_array_handler)(INTERNAL_FUNCTION_PARAMETERS) = NULL;
 
 static bool dd_load_curl_integration(void) {
-    if (!dd_ext_curl_loaded || DDTRACE_G(disable_in_current_request)) {
+    if (!dd_ext_curl_loaded || DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request)) {
         return false;
     }
     return get_DD_DISTRIBUTED_TRACING();

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -80,7 +80,7 @@ ddtrace_span_fci *ddtrace_init_span(void) {
 void ddtrace_push_root_span(void) { ddtrace_open_span(ddtrace_init_span()); }
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {
-    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value)) {
+    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value) || DDTRACE_G(disable)) {
         return true;
     }
 

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -38,7 +38,7 @@ static void (*dd_curl_setopt_handler)(INTERNAL_FUNCTION_PARAMETERS) = NULL;
 static void (*dd_curl_setopt_array_handler)(INTERNAL_FUNCTION_PARAMETERS) = NULL;
 
 static bool dd_load_curl_integration(void) {
-    if (!dd_ext_curl_loaded || DDTRACE_G(disable_in_current_request)) {
+    if (!dd_ext_curl_loaded || DDTRACE_G(disable) || DDTRACE_G(disable_in_current_request)) {
         return false;
     }
     return get_DD_DISTRIBUTED_TRACING();

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -80,7 +80,7 @@ ddtrace_span_fci *ddtrace_init_span(void) {
 void ddtrace_push_root_span(void) { ddtrace_open_span(ddtrace_init_span()); }
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {
-    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value)) {
+    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value) || DDTRACE_G(disable)) {
         return true;
     }
 

--- a/tests/Common/AgentReplayerTrait.php
+++ b/tests/Common/AgentReplayerTrait.php
@@ -25,7 +25,7 @@ trait AgentReplayerTrait
     public function getLastAgentRequest()
     {
         $allRequests = $this->getAllAgentRequests();
-        if (count($allRequests) === 0) {
+        if (!$allRequests) {
             return [];
         }
         return $allRequests[count($allRequests) - 1];

--- a/tests/Integration/DisabledTest.php
+++ b/tests/Integration/DisabledTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DDTrace\Tests\Integration;
+
+use DDTrace\Tests\Common\CLITestCase;
+use DDTrace\Tests\Common\SpanAssertion;
+
+final class DisabledTest extends CLITestCase
+{
+    private $script = '';
+
+    protected function getScriptLocation()
+    {
+        return __DIR__ . '/' . $this->script;
+    }
+
+    public function testDisablingCLI()
+    {
+        $this->script = 'LongRunning/long_running_script_manual.php';
+        $agentRequest = $this->getAgentRequestFromCommand('', [
+            'DD_TRACE_CLI_ENABLED' => 'false',
+        ]);
+
+        $this->assertEmpty($agentRequest);
+    }
+}


### PR DESCRIPTION
### Description

Fixes #1314.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
