### PR TITLE
Enhance exception reporting on Laravel 5+

### DIFF
--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -76,12 +76,13 @@ class LaravelIntegration extends Integration
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Illuminate\Routing\Router',
             'findRoute',
-            function (SpanData $span, $args, $route) use ($rootSpan, $integration) {
-                if (null === $route) {
-                    return false;
+            null,
+            function ($This, $scope, $args, $route) use ($rootSpan, $integration) {
+                if (!isset($route)) {
+                    return;
                 }
 
                 list($request) = $args;
@@ -105,8 +106,6 @@ class LaravelIntegration extends Integration
                 $rootSpan->setTag('laravel.route.action', $route->getActionName());
                 $rootSpan->setTag('http.url', $request->url());
                 $rootSpan->setTag('http.method', $request->method());
-
-                return false;
             }
         );
 
@@ -121,12 +120,11 @@ class LaravelIntegration extends Integration
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Symfony\Component\HttpFoundation\Response',
             'setStatusCode',
-            function (SpanData $span, $args) use ($rootSpan) {
+            function ($This, $scope, $args) use ($rootSpan) {
                 $rootSpan->setTag(Tag::HTTP_STATUS_CODE, $args[0]);
-                return false;
             }
         );
 
@@ -177,7 +175,7 @@ class LaravelIntegration extends Integration
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Illuminate\Console\Application',
             '__construct',
             function () use ($rootSpan, $integration) {
@@ -186,16 +184,14 @@ class LaravelIntegration extends Integration
                     Tag::RESOURCE_NAME,
                     !empty($_SERVER['argv'][1]) ? 'artisan ' . $_SERVER['argv'][1] : 'artisan'
                 );
-                return false;
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Symfony\Component\Console\Application',
             'renderException',
-            function (SpanData $span, $args) use ($rootSpan) {
+            function ($This, $scope, $args) use ($rootSpan) {
                 $rootSpan->setError($args[0]);
-                return false;
             }
         );
 

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -199,6 +199,24 @@ class LaravelIntegration extends Integration
             }
         );
 
+        \DDTrace\trace_method(
+            'Illuminate\Foundation\Http\Kernel',
+            'renderException',
+            function (SpanData $span, $args) use ($rootSpan) {
+                $rootSpan->setError($args[1]);
+                return false;
+            }
+        );
+
+        \DDTrace\trace_method(
+            'Illuminate\Routing\Pipeline',
+            'handleException',
+            function (SpanData $span, $args) use ($rootSpan) {
+                $rootSpan->setError($args[1]);
+                return false;
+            }
+        );
+
         return Integration::LOADED;
     }
 

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -199,21 +199,23 @@ class LaravelIntegration extends Integration
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Illuminate\Foundation\Http\Kernel',
             'renderException',
-            function (SpanData $span, $args) use ($rootSpan) {
-                $rootSpan->setError($args[1]);
-                return false;
+            function ($This, $scope, $args) use ($rootSpan) {
+                if (!$rootSpan->hasError()) {
+                    $rootSpan->setError($args[1]);
+                }
             }
         );
 
-        \DDTrace\trace_method(
+        \DDTrace\hook_method(
             'Illuminate\Routing\Pipeline',
             'handleException',
-            function (SpanData $span, $args) use ($rootSpan) {
-                $rootSpan->setError($args[1]);
-                return false;
+            function ($This, $scope, $args) use ($rootSpan) {
+                if (!$rootSpan->hasError()) {
+                    $rootSpan->setError($args[1]);
+                }
             }
         );
 

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -110,7 +110,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ])->setError()->withChildren([
+                    ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists(
                             'laravel.provider.load',

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -110,7 +110,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ])->setError()->withChildren([
+                    ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
 
                         SpanAssertion::exists('laravel.view.render')

--- a/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
@@ -110,7 +110,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error',
                         'http.status_code' => '500',
-                    ])->setError()->withChildren([
+                    ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
 
                         SpanAssertion::exists('laravel.view.render')


### PR DESCRIPTION
### Description

The Laravel integration now attaches error information to the root span
in more cases, such as an exception during routing. It also switches
from tracing hooks which drop spans to non-tracing hooks.

Thanks, Luca, for finding which methods should be hooked.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document.
