### PR TITLE
Pass artifacts to reliability env from dd-trace-php project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
 
 build:
   stage: build
-  image: ubuntu:18.04
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/base:bionic
   tags: [ "runner:main", "size:large" ]
   script:
     - echo $LATEST_URL | sed -E 's/.+_(.+)_.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://567840-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.65.0_amd64.deb"
+    value: "https://577339-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.65.1_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ build:
 
 deploy_to_reliability_env:
   stage: deploy
+  when: manual
   trigger:
     project: DataDog/datadog-reliability-env
     branch: $DOWNSTREAM_REL_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,6 @@ build:
 
 deploy_to_reliability_env:
   stage: deploy
-  when: manual
   trigger:
     project: DataDog/datadog-reliability-env
     branch: $DOWNSTREAM_REL_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - deploy
 
 variables:
-  LATEST_URL: 
+  LATEST_URL:
     value: "https://567840-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.65.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+stages:
+  - build
+  - deploy
+
+variables:
+  LATEST_URL: 
+    value: "https://567840-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.65.0_amd64.deb"
+    description: "Location where to download latest built package"
+  DOWNSTREAM_REL_BRANCH:
+    value: "master"
+    description: "Run a specific datadog-reliability-env branch downstream"
+  FORCE_TRIGGER:
+    value: "false"
+    description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
+
+build:
+  stage: build
+  image: ubuntu:18.04
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - echo $LATEST_URL | sed -E 's/.+_(.+)_.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
+    - curl --fail --location --output php-linux-tracer-deb-latest.deb $LATEST_URL
+  artifacts:
+    paths:
+      - 'upstream.env'
+      - 'php-linux-tracer-deb-latest.deb'
+
+deploy_to_reliability_env:
+  stage: deploy
+  trigger:
+    project: DataDog/datadog-reliability-env
+    branch: $DOWNSTREAM_REL_BRANCH
+  variables:
+    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+#    COMMIT_SHA would be wrong because the artifact is not built here
+#    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+    FORCE_TRIGGER: $FORCE_TRIGGER


### PR DESCRIPTION
### Description

This PR changes where the latest PHP build is defined. Instead of being defined in the reliability project, it is defined in this project (via a simple `curl` execution). This change gives two benefits:

1. If the artifact URL expires, it doesn't break the reliability build
2. If/when `dd-trace-php` is built inside of gitlab, no changes are needed in the reliability project.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
