### PR TITLE
release 0.65.0

### DIFF
--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.65.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -42,7 +42,21 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    **WARNING**: Resource names for “Lumen” applications will change by default to `GET /actual/uri/path` from the previous format `GET action_name` or `GET App\Controller@action_method`. You might need to adjust your monitors and filters for the change. In order to go back to the previous behavior, instead, you can temporarily set `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=false`
+
+    ### Added
+    - Add functions ZAI support for PHP 5 and 7 #1300
+    - Add properties and exceptions ZAI implementations for PHP 5 #1306
+    - Enhance exception reporting on Laravel 5+ #1322
+
+    ### Changed
+    - Remove src/dd-doctor.php #1316
+    - Honor DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED in Lumen resource naming #1318
+
+    ### Fixed
+    -  Fix CLI processes emitting empty root spans when CLI tracing is not enabled #1320
+    </notes>
     <contents>
         <dir name="/">
             <!-- components -->

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -30,7 +30,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.65.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Description

**Second RC after merging #1322**

**WARNING**: Resource names for “Lumen” applications will change by default to `GET /actual/uri/path` from the previous format `GET action_name` or `GET App\Controller@action_method`. You might need to adjust your monitors and filters for the change. In order to go back to the previous behavior, instead, you can temporarily set `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=false`
### Added
- Add functions ZAI support for PHP 5 and 7 #1300
- Add properties and exceptions ZAI implementations for PHP 5 #1306
- Enhance exception reporting on Laravel 5+ #1322

### Changed
- Remove src/dd-doctor.php #1316
- Honor DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED in Lumen resource naming #1318

### Fixed
-  Fix CLI processes emitting empty root spans when CLI tracing is not enabled #1320


### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
