### PR TITLE
Prevent flushing traces of requests without actual PHP code

### DIFF
--- a/tests/Integrations/Custom/Autoloaded/NonExecutingEndpointsTracingTest.php
+++ b/tests/Integrations/Custom/Autoloaded/NonExecutingEndpointsTracingTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\Autoloaded;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class NonExecutingEndpointsTracingTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Autoloaded/public/index.php';
+    }
+
+    public function testStatusPageDoesNotGenerateTraces()
+    {
+        if (\getenv('DD_TRACE_TEST_SAPI') != 'fpm-fcgi') {
+            $this->markTestSkipped('Only run under fpm-fcgi SAPI');
+        }
+
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('No spans from status page', '/status'));
+        });
+
+        self::assertEmpty($traces);
+    }
+}

--- a/tests/Nginx/nginx-default.conf
+++ b/tests/Nginx/nginx-default.conf
@@ -39,7 +39,7 @@ http {
 
         error_page 404 /{{index_file}};
 
-        location ~ \.php$ {
+        location ~ (/status|\.php)$ {
             fastcgi_pass {{fcgi_host}}:{{fcgi_port}};
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
 

--- a/tests/Sapi/PhpFpm/www.conf
+++ b/tests/Sapi/PhpFpm/www.conf
@@ -6,6 +6,7 @@ listen = {{fcgi_host}}:{{fcgi_port}}
 
 pm = static
 pm.max_children = 1
+pm.status_path = /status
 catch_workers_output = yes
 
 {{envs}}


### PR DESCRIPTION
### Description

This should prevent any unnamed-php-service coming from "meta" requests like fpm-status page and requests in general which lead to traces without proper information as no PHP code is executed.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
