### PR TITLE
Add debug symbols to the Laravel 5.7 rel env images

### DIFF
--- a/dockerfiles/testing-environment/Laravel57/Makefile
+++ b/dockerfiles/testing-environment/Laravel57/Makefile
@@ -6,7 +6,7 @@ publish: 7.3.publish
 	@docker build --build-arg PHP_VERSION="$*" -t registry.ddbuild.io/apm-integrations-testing/handmade/php-laravel:$* .
 
 %.shell: %.build
-	@docker run --rm -ti registry.ddbuild.io/apm-integrations-testing/handmade/php-laravel:$* bash
+	@docker-compose run --rm $* bash
 
 %.publish: %.build
 	@docker push registry.ddbuild.io/apm-integrations-testing/handmade/php-laravel:$*

--- a/dockerfiles/testing-environment/Laravel57/docker-compose.yml
+++ b/dockerfiles/testing-environment/Laravel57/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 7777:80
     environment:
       - DD_AGENT_HOST=agent
-      - TRACER_DOWNLOAD_URL=https://github.com/DataDog/dd-trace-php/releases/download/0.46.0/datadog-php-tracer_0.46.0_amd64.deb
+      - TRACER_DOWNLOAD_URL=https://598250-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_1.0.0-nightly_amd64.deb
       # - DD_TRACE_DEBUG=true
     # volumes:
     #   - ./app:/var/www/html/

--- a/dockerfiles/testing-environment/Laravel57/docker-scripts/install-common.sh
+++ b/dockerfiles/testing-environment/Laravel57/docker-scripts/install-common.sh
@@ -10,19 +10,21 @@ apt-get install -y \
     bison \
     build-essential \
     curl \
+    gdb \
     gettext \
     git \
     libcurl4-gnutls-dev \
+    libfcgi0ldbl \
     libssl-dev \
     libtool \
     libxml2-dev \
-    libfcgi0ldbl \
     nginx \
     re2c \
     supervisor \
     unzip \
-    wget \
+    valgrind \
     vim \
+    wget \
     zip
 
 rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/testing-environment/Laravel57/docker-scripts/install-php-and-composer.sh
+++ b/dockerfiles/testing-environment/Laravel57/docker-scripts/install-php-and-composer.sh
@@ -7,16 +7,29 @@ apt update
 apt install -y software-properties-common
 add-apt-repository -y ppa:ondrej/php
 
+# Enabling ondrej debug symbols repo
+sed -i 's/deb \(.\+\)/deb \1 main\/debug/g' /etc/apt/sources.list.d/ondrej-ubuntu-php-bionic.list
+
+cat /etc/apt/sources.list.d/ondrej-ubuntu-php-bionic.list
+
 # Installing PHP
-apt install -y \
+apt update && apt install -y \
     php${PHP_VERSION}-cli \
+    php${PHP_VERSION}-cli-dbgsym \
     php${PHP_VERSION}-curl \
+    php${PHP_VERSION}-curl-dbgsym \
     php${PHP_VERSION}-fpm \
+    php${PHP_VERSION}-fpm-dbgsym \
     php${PHP_VERSION}-mbstring \
+    php${PHP_VERSION}-mbstring-dbgsym \
     php${PHP_VERSION}-mysql \
+    php${PHP_VERSION}-mysql-dbgsym \
     php${PHP_VERSION}-opcache \
+    php${PHP_VERSION}-opcache-dbgsym \
     php${PHP_VERSION}-xml \
-    php${PHP_VERSION}-zip
+    php${PHP_VERSION}-xml-dbgsym \
+    php${PHP_VERSION}-zip \
+    php${PHP_VERSION}-zip-dbgsym
 # remove unused php-fpm files that will be provided from outside
 rm -rf \
     /etc/php/${PHP_VERSION}/fpm/php-fpm.conf \


### PR DESCRIPTION
### Description

Add debug symbols to the Laravel 5.7 rel env images.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
