### PR TITLE
Add 8.1 support to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -49,17 +49,17 @@
 
     ### Added
 
-    - Migrate _dd.origin and distributed header sending to internal (#1267)
-    - Add headers ZAI implementation for PHP 5 (#1308)
+    - (PHP 8) Migrate _dd.origin and distributed header sending to internal (#1267)
+    - (PHP 5) Add headers ZAI implementation (#1308)
     - Add support for PHP 8.1 (#1297)
 
     ### Changed
-    - Internal (root) span initialization (#1329)
+    - (PHP 7, 8) Internal (root) span initialization (#1329)
 
     ### Fixed
 
-    - Remove all lines containing zai_sapi from config.m4 (#1333)
-    - Fix unnamed service spans caused by improper handling of `DD_TRACE_ENABLED` (#1332)
+    - (PHP 5, 7, 8) Remove all lines containing zai_sapi from config.m4 (#1333)
+    - (PHP 7, 8) Fix unnamed service spans caused by improper handling of `DD_TRACE_ENABLED` (#1332)
 
 
     </notes>


### PR DESCRIPTION
### Description

Update `package.xml` with PHP 8.1 support

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
