### PR TITLE
Disable ext/standard/tests/filters/bug54350.phpt on 8.1

### DIFF
--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -112,6 +112,7 @@ ext/standard/tests/array/array_reverse_variation4.phpt
 ext/standard/tests/array/array_unique_variation3.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/filters/bug54350.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/floatval.phpt
 ext/standard/tests/general_functions/floatval_variation1.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -11,6 +11,7 @@ This file explains why we decided to disable specific PHP language tests. Invest
 The following tests are marked as skipped due to the test relying on a hard-coded resource ID. All of these IDs change when the PHP tracer is enabled due to the resources created in the `ddtrace.request_init_hook`.
 
 - `ext/sockets/tests/socket_create_pair.phpt`
+- `ext/standard/tests/filters/bug54350.phpt`
 - `Zend/tests/type_declarations/scalar_return_basic_64bit.phpt`
 - `Zend/tests/weakrefs/weakmap_basic_map_behaviour.phpt`
 


### PR DESCRIPTION
### Description

The test relies on hard coded resource ids.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
