### PR TITLE
Fix http.url of internal root span

### DIFF
--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -418,33 +418,58 @@ void ddtrace_set_global_span_properties(ddtrace_span_t *span) {
     ZEND_HASH_FOREACH_END();
 }
 
+static zend_string *dd_build_req_url() {
+    const char *uri = NULL;
+    int uri_len;
+    zval *_server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (Z_TYPE_P(_server) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+        zval *req_uri = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("REQUEST_URI"));
+        if (req_uri && Z_TYPE_P(req_uri) == IS_STRING) {
+            uri = Z_STRVAL_P(req_uri);
+            uri_len = Z_STRLEN_P(req_uri);
+        }
+    }
+
+    if (!uri) {
+        uri = SG(request_info).request_uri;
+        if (uri) {
+            uri_len = strlen(uri);
+        } else {
+            return ZSTR_EMPTY_ALLOC();
+        }
+    }
+
+    zend_bool is_https = zend_hash_str_exists(Z_ARRVAL_P(_server), ZEND_STRL("HTTPS"));
+
+    zval *host_zv;
+    if ((!(host_zv = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("HTTP_HOST"))) &&
+         !(host_zv = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("SERVER_NAME")))) ||
+        Z_TYPE_P(host_zv) != IS_STRING) {
+        return ZSTR_EMPTY_ALLOC();
+    }
+
+    return zend_strpprintf(0, "http%s://%s%.*s", is_https ? "s" : "", Z_STRVAL_P(host_zv), uri_len, uri);
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zval *meta = ddtrace_spandata_property_meta(span);
 
     add_assoc_long(meta, "system.pid", (long)getpid());
 
-    const char *uri = SG(request_info).request_uri, *method = SG(request_info).request_method;
+    const char *method = SG(request_info).request_method;
     if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED() && method) {
         zval http_method;
         ZVAL_STR(&http_method, zend_string_init(method, strlen(method), 0));
         add_assoc_zval(meta, "http.method", &http_method);
 
-        zval http_url = {0};
-        if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
-            zval *urizv;
-            if ((urizv = zend_hash_str_find(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), ZEND_STRL("REQUEST_URI")))) {
-                ZVAL_DEREF(urizv);
-                ZVAL_COPY(&http_url, urizv);
-            }
-        }
-        if (Z_ISUNDEF(http_url) && uri) {
-            ZVAL_STR(&http_url, zend_string_init(uri, strlen(uri), 0));
+        zend_string *http_url = dd_build_req_url();
+        if (ZSTR_LEN(http_url)) {
+            add_assoc_str(meta, "http.url", http_url);
         }
 
+        const char *uri = SG(request_info).request_uri;
         zval *prop_resource = ddtrace_spandata_property_resource(span);
-        if (!Z_ISUNDEF(http_url)) {
-            add_assoc_zval(meta, "http.url", &http_url);
-
+        if (uri) {
             zend_string *path = zend_string_init(uri, strlen(uri), 0);
             zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
             ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s", method, ZSTR_VAL(normalized)));

--- a/package.xml
+++ b/package.xml
@@ -670,6 +670,8 @@
             <file name="tests/ext/get_memory_limit_unlimited_set_by_percentage.phpt" role="test" />
             <file name="tests/ext/read_c_configuration.phpt" role="test" />
             <file name="tests/ext/request_timeout_01.phpt" role="test" />
+            <file name="tests/ext/root_span_url_as_resource_names.phpt" role="test" />
+            <file name="tests/ext/root_span_url_as_resource_names_no_host.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
             <file name="tests/ext/span_with_removed_exception.phpt" role="test" />

--- a/tests/Composer/ComposerInteroperabilityTest.php
+++ b/tests/Composer/ComposerInteroperabilityTest.php
@@ -94,7 +94,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-manual-tracing')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-manual-tracing',
+                    'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -128,7 +128,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /manual-tracing')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/manual-tracing',
+                    'http.url' => 'http://127.0.0.1:6666/manual-tracing',
                     'http.status_code' => '200',
                 ])
                 ->withChildren([
@@ -168,7 +168,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-manual-tracing')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-manual-tracing',
+                    'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -202,7 +202,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /manual-tracing')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/manual-tracing',
+                    'http.url' => 'http://127.0.0.1:6666/manual-tracing',
                     'http.status_code' => '200',
                 ])
                 ->withChildren([
@@ -236,7 +236,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-manual-tracing')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-manual-tracing',
+                    'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -264,7 +264,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-composer')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-composer',
+                    'http.url' => 'http://127.0.0.1:6666/no-composer',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -297,7 +297,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-composer')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-composer',
+                    'http.url' => 'http://127.0.0.1:6666/no-composer',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -332,7 +332,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /no-composer-autoload-fails')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/no-composer-autoload-fails',
+                    'http.url' => 'http://127.0.0.1:6666/no-composer-autoload-fails',
                     'http.status_code' => '200',
                 ]),
         ]);
@@ -367,7 +367,7 @@ class ComposerInteroperabilityTest extends BaseTestCase
             SpanAssertion::build('web.request', 'web.request', 'web', 'GET /composer-autoload-fails')
                 ->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/composer-autoload-fails',
+                    'http.url' => 'http://127.0.0.1:6666/composer-autoload-fails',
                     'http.status_code' => '200',
                 ]),
         ]);

--- a/tests/DistributedTracing/SyntheticsTest.php
+++ b/tests/DistributedTracing/SyntheticsTest.php
@@ -53,7 +53,7 @@ class SyntheticsTest extends WebFrameworkTestCase
                 'GET /index.php'
             )->withExactTags([
                 'http.method' => 'GET',
-                'http.url' => '/index.php',
+                'http.url' => 'http://localhost:9999/index.php',
                 'http.status_code' => '200',
                 '_dd.origin' => 'synthetics-browser',
             ])->withExactMetrics([

--- a/tests/Integration/ResponseStatusCodeTest.php
+++ b/tests/Integration/ResponseStatusCodeTest.php
@@ -37,7 +37,7 @@ class ResponseStatusCodeTest extends WebFrameworkTestCase
             [
                 SpanAssertion::build('web.request', 'web.request', 'web', 'GET /success')->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/success',
+                    'http.url' => 'http://localhost:' . self::PORT . '/success',
                     'http.status_code' => '200',
                 ]),
             ]
@@ -62,7 +62,7 @@ class ResponseStatusCodeTest extends WebFrameworkTestCase
                 SpanAssertion::build('web.request', 'web.request', 'web', 'GET /error')->withExactTags(
                     [
                         'http.method'      => 'GET',
-                        'http.url'         => '/error',
+                        'http.url'         => 'http://localhost:' . self::PORT . '/error',
                         'http.status_code' => '500',
                     ]
                 )->setError(),

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -52,7 +52,7 @@ final class CircuitBreakerTest extends WebFrameworkTestCase
                     'GET /circuit_breaker'
                 )->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/circuit_breaker',
+                    'http.url' => 'http://localhost:' . self::PORT . '/circuit_breaker',
                     'http.status_code' => '200',
                 ]),
             ]

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -47,7 +47,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'GET /simple'
                     )->withExactTags([
                         'http.method' => 'GET',
-                        'http.url' => '/simple',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple',
                         'http.status_code' => '200',
                     ]),
                 ],
@@ -59,7 +59,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'GET /simple_view'
                     )->withExactTags([
                         'http.method' => 'GET',
-                        'http.url' => '/simple_view',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple_view',
                         'http.status_code' => '200',
                     ]),
                 ],
@@ -71,7 +71,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'GET /error'
                     )->withExactTags([
                         'http.method' => 'GET',
-                        'http.url' => '/error',
+                        'http.url' => 'http://localhost:' . self::PORT . '/error',
                         'http.status_code' => '500',
                     ])->setError(),
                 ],

--- a/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
+++ b/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
@@ -41,7 +41,7 @@ final class FatalErrorTest extends WebFrameworkTestCase
                     'GET /fatal'
                 )->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/fatal',
+                    'http.url' => 'http://localhost:' . self::PORT . '/fatal',
                     'http.status_code' => '200',
                 ])
                 ->setError("E_ERROR", "Intentional E_ERROR")

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -40,7 +40,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     'GET /simple'
                 )->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/simple',
+                    'http.url' => 'http://localhost:' . self::PORT . '/simple',
                     'http.status_code' => '200',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -46,7 +46,7 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
                     'GET /'
                 )->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/',
+                    'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
                     'http.request.headers.first-header' => 'some value: with colon',
                     'http.request.headers.forth-header' => '123',

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
@@ -44,7 +44,7 @@ final class HttpHeadersNotConfiguredTest extends WebFrameworkTestCase
                     'GET /'
                 )->withExactTags([
                     'http.method' => 'GET',
-                    'http.url' => '/',
+                    'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
                 ]),
             ]

--- a/tests/Integrations/Nette/V2_4/NetteTest.php
+++ b/tests/Integrations/Nette/V2_4/NetteTest.php
@@ -52,7 +52,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'simple',
                         'http.method' => 'GET',
-                        'http.url' => '/simple',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple',
                         'http.status_code' => '200',
                     ])->withChildren([
                         SpanAssertion::build(
@@ -86,7 +86,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'simpleView',
                         'http.method' => 'GET',
-                        'http.url' => '/simple_view',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple_view',
                         'http.status_code' => '200',
                     ])->withChildren([
                         SpanAssertion::build(
@@ -131,7 +131,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'errorView',
                         'http.method' => 'GET',
-                        'http.url' => '/error',
+                        'http.url' => 'http://localhost:' . self::PORT . '/error',
                         'http.status_code' => '500',
                     ])
                     ->setError('Internal Server Error')

--- a/tests/Integrations/Nette/V3_0/NetteTest.php
+++ b/tests/Integrations/Nette/V3_0/NetteTest.php
@@ -52,7 +52,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'simple',
                         'http.method' => 'GET',
-                        'http.url' => '/simple',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple',
                         'http.status_code' => '200',
                     ])->withChildren([
                         SpanAssertion::build(
@@ -86,7 +86,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'simpleView',
                         'http.method' => 'GET',
-                        'http.url' => '/simple_view',
+                        'http.url' => 'http://localhost:' . self::PORT . '/simple_view',
                         'http.status_code' => '200',
                     ])->withChildren([
                         SpanAssertion::build(
@@ -131,7 +131,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'errorView',
                         'http.method' => 'GET',
-                        'http.url' => '/error',
+                        'http.url' => 'http://localhost:' . self::PORT . '/error',
                         'http.status_code' => '500',
                     ])
                     ->setError(

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -50,7 +50,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'GET simple-route'
                         )->withExactTags([
                             'http.method' => 'GET',
-                            'http.url' => '/simple',
+                            'http.url' => 'http://localhost:' . self::PORT . '/simple',
                             'http.status_code' => '200',
                         ]),
                     ],
@@ -62,7 +62,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'GET /simple_view'
                         )->withExactTags([
                             'http.method' => 'GET',
-                            'http.url' => '/simple_view',
+                            'http.url' => 'http://localhost:' . self::PORT . '/simple_view',
                             'http.status_code' => '200',
                         ])->withChildren([
                             SpanAssertion::build(
@@ -83,7 +83,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'GET /error'
                         )->withExactTags([
                             'http.method' => 'GET',
-                            'http.url' => '/error',
+                            'http.url' => 'http://localhost:' . self::PORT . '/error',
                             'http.status_code' => '500',
                         ])->setError(null, null /* On PHP 5.6 slim error messages are not traced on sandboxed */),
                     ],

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -34,7 +34,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([
                 'http.method' => 'GET',
-                'http.url' => '/app.php',
+                'http.url' => 'http://localhost:' . self::PORT . '/app.php',
                 'http.status_code' => '200',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -31,7 +31,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([
                 'http.method' => 'GET',
-                'http.url' => '/app.php',
+                'http.url' => 'http://localhost:' . self::PORT . '/app.php',
                 'http.status_code' => '200',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -1,0 +1,32 @@
+--TEST--
+root span with DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED
+--SKIPIF--
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=1
+HTTPS=on
+SERVER_NAME=localhost:8888
+HTTP_HOST=localhost:9999
+SCRIPT_NAME=/foo.php
+REQUEST_URI=/foo
+METHOD=GET
+--GET--
+foo=bar
+--FILE--
+<?php
+DDTrace\start_span();
+DDTrace\close_span();
+$spans = dd_trace_serialize_closed_spans();
+var_dump($spans[0]['meta']);
+?>
+--EXPECTF--
+array(4) {
+  ["system.pid"]=>
+  %s
+  ["http.method"]=>
+  string(3) "GET"
+  ["http.url"]=>
+  string(26) "https://localhost:9999/foo"
+  ["http.status_code"]=>
+  string(3) "200"
+}

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -1,0 +1,30 @@
+--TEST--
+root span with DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED (variant using SERVER_NAME)
+--SKIPIF--
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=1
+SERVER_NAME=localhost:8888
+SCRIPT_NAME=/foo.php
+REQUEST_URI=/foo
+METHOD=GET
+--GET--
+foo=bar
+--FILE--
+<?php
+DDTrace\start_span();
+DDTrace\close_span();
+$spans = dd_trace_serialize_closed_spans();
+var_dump($spans[0]['meta']);
+?>
+--EXPECTF--
+array(4) {
+  ["system.pid"]=>
+  %s
+  ["http.method"]=>
+  string(3) "GET"
+  ["http.url"]=>
+  string(25) "http://localhost:8888/foo"
+  ["http.status_code"]=>
+  string(3) "200"
+}


### PR DESCRIPTION
### Description

The internal root span defines (when `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED` is on) `http.url` as `$_SERVER['REQUEST_URI']`. This is incorrect according to the [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/trace-http-client-tagging/rfc.md) and other implementations. This PR build `http.url` as http(s)://<http_host or server_name><request uri>.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
