### PR TITLE
Xfail php-src tests accessing a shutdown http2 server

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -78,6 +78,8 @@ Zend/tests/type_declarations/scalar_strict_64bit.phpt
 Zend/tests/type_declarations/self_on_closure_in_method.phpt
 ext/curl/tests/bug45161.phpt
 ext/curl/tests/bug64267.phpt
+ext/curl/tests/bug76675.phpt
+ext/curl/tests/bug77535.phpt
 ext/date/tests/012.phpt
 ext/date/tests/013.phpt
 ext/date/tests/DateTimeZone_serialize_type_3.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -85,6 +85,8 @@ Zend/tests/type_declarations/scalar_strict_64bit.phpt
 Zend/tests/type_declarations/self_on_closure_in_method.phpt
 ext/curl/tests/bug45161.phpt
 ext/curl/tests/bug64267.phpt
+ext/curl/tests/bug76675.phpt
+ext/curl/tests/bug77535.phpt
 ext/curl/tests/bug79033.phpt
 ext/date/tests/012.phpt
 ext/date/tests/013.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -139,6 +139,8 @@ Zend/tests/type_declarations/variance/class_order_autoload_error6.phpt
 Zend/tests/weakrefs/weakrefs_001.phpt
 ext/curl/tests/bug45161.phpt
 ext/curl/tests/bug64267.phpt
+ext/curl/tests/bug76675.phpt
+ext/curl/tests/bug77535.phpt
 ext/curl/tests/bug79033.phpt
 ext/date/tests/012.phpt
 ext/date/tests/013.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -171,6 +171,8 @@ ext/curl/tests/bug45161.phpt
 ext/curl/tests/bug48514.phpt
 ext/curl/tests/bug64267.phpt
 ext/curl/tests/bug72202.phpt
+ext/curl/tests/bug76675.phpt
+ext/curl/tests/bug77535.phpt
 ext/curl/tests/bug79033.phpt
 ext/curl/tests/curl_basic_014.phpt
 ext/curl/tests/curl_close_basic.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -31,6 +31,7 @@ Zend/tests/weakrefs/weakmap_basic_map_behavior.phpt
 Zend/tests/weakrefs/weakmap_error_conditions.phpt
 ext/curl/tests/bug45161.phpt
 ext/curl/tests/bug64267.phpt
+ext/curl/tests/bug76675.phpt
 ext/curl/tests/bug77535.phpt
 ext/curl/tests/bug79033.phpt
 ext/curl/tests/curl_int_cast.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -56,6 +56,10 @@ The following tests assert the output of `var_dump($obj)` and fail because we ad
 
 Tests memory limits, which we exceed due to tracer being loaded.
 
+## `ext/curl/tests/bug76675.phpt`, `ext/curl/tests/bug77535.phpt`
+
+Test does http request to shut down server.
+
 ## `ext/pcntl/tests/pcntl_unshare_01.phpt`
 
 Disabled on versions: `7.4` (it wasn't there on [7.3-](https://github.com/php/php-src/tree/PHP-7.3/ext/pcntl/tests)).


### PR DESCRIPTION
### Description

Fixing our CI

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
