### PR TITLE
Fix Laravel unnamed route with caching and domain specification

### DIFF
--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -255,7 +255,6 @@ class LaravelIntegration extends Integration
         // https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/AbstractRouteCollection.php#L227
         //
         // It can also be prefixed with domain name when caching is specified as Route::domain()->group(...);
-        // https://github.com/laravel/framework/blob/2049de73aa099a113a287587df4cc522c90961f5/src/Illuminate/Routing/Route.php#L1209
         if (\strpos($routeName, 'generated::') !== false) {
             return LaravelIntegration::UNNAMED_ROUTE;
         }

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -254,7 +254,7 @@ class LaravelIntegration extends Integration
         // normalize:
         // https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/AbstractRouteCollection.php#L227
         //
-        // Can be prefixed with domain name when caching if specified as Route::domain()->group(...);
+        // It can also be prefixed with domain name when caching is specified as Route::domain()->group(...);
         // https://github.com/laravel/framework/blob/2049de73aa099a113a287587df4cc522c90961f5/src/Illuminate/Routing/Route.php#L1209
         if (\strpos($routeName, 'generated::') !== false) {
             return LaravelIntegration::UNNAMED_ROUTE;

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -2,6 +2,7 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V8_x;
 
+use DDTrace\Integrations\Laravel\LaravelIntegration;
 use DDTrace\Tests\Common\SpanAssertion;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
@@ -78,6 +79,23 @@ class RouteCachingTest extends WebFrameworkTestCase
                     ]),
             ]
         );
+    }
+
+    public function testRouteNameNormalization()
+    {
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName(null));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName(''));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName('     '));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName(123));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName(true));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName([]));
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName(new \stdClass()));
+        // Laravel cached route names after version 7
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName('generated::abcdef0912'));
+        // Laravel cached route when Route::domain('domain.com')->group(...)
+        $this->assertSame('unnamed_route', LaravelIntegration::normalizeRouteName('domain.com.generated::abcdef0912'));
+
+        $this->assertSame('my_route', LaravelIntegration::normalizeRouteName('my_route'));
     }
 
     private function routeCache()


### PR DESCRIPTION
### Description

When route caching is enabled in Laravel 7.x+ [routes are given a name](https://github.com/laravel/framework/blob/cada3d21c7f127ba01bb949b2fa045b7faaedbca/src/Illuminate/Routing/AbstractRouteCollection.php#L227) in any case that is randomly generated and follows two patterns:
- `generated:<random string>`: this was already handled by our instrumentation
- `some.domain.com.generated::<random string>`: when `Route::domain('some.domain.com')->group(...)` is used to register a route. We did not handle this case.

This PR adds support for this secondo case and refactors the route normalization code to make it more testable from the outside.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
