### PR TITLE
Add small framework to stress test our internal API with bogus inputs

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -43,6 +43,7 @@
         <exclude-pattern>tests/Integrations/PHPRedis/V3/*Test.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/PHPRedis/V4/*Test.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/PHPRedis/V5/*Test.php</exclude-pattern>
+        <exclude-pattern>tests/internal-api-stress-test.php</exclude-pattern>
         <exclude-pattern>tests/randomized/analyze-results.php</exclude-pattern>
         <exclude-pattern>tests/randomized/generate-scenarios.php</exclude-pattern>
         <exclude-pattern>tests/randomized/lib/RequestTargetsGenerator.php</exclude-pattern>

--- a/ext/php5/arrays.c
+++ b/ext/php5/arrays.c
@@ -29,7 +29,7 @@ void *ddtrace_hash_find_ptr_lc(const HashTable *ht, const char *str, size_t len)
      *   - 5.6: https://app.circleci.com/jobs/github/DataDog/dd-trace-php/142298
      * So we always use an emalloc path until this is resolved.
      */
-    char *lc_str = zend_str_tolower_dup(str, len);
+    char *lc_str = zend_str_tolower_dup(str, len - 1);
     result = ddtrace_hash_find_ptr(ht, lc_str, len);
     efree(lc_str);
     return result;

--- a/ext/php5/compat_string.c
+++ b/ext/php5/compat_string.c
@@ -55,22 +55,6 @@ void ddtrace_convert_to_string(zval *dst, zval *src TSRMLS_DC) {
             break;
 
         case IS_OBJECT: {
-            if (Z_OBJ_HANDLER_P(src, cast_object)) {
-                if (Z_OBJ_HANDLER_P(src, cast_object)(src, dst, IS_STRING TSRMLS_CC) == SUCCESS) {
-                    return;
-                }
-            } else if (Z_OBJ_HANDLER_P(src, get)) {
-                zval *newop = Z_OBJ_HANDLER_P(src, get)(src TSRMLS_CC);
-                if (Z_TYPE_P(newop) != IS_OBJECT) {
-                    /* for safety - avoid loop */
-                    ddtrace_convert_to_string(dst, newop TSRMLS_CC);
-
-                    // I think?
-                    zval_dtor(newop);
-                    return;
-                }
-            }
-
             char *class_name;
             zend_uint class_name_len;
             Z_OBJ_HANDLER_P(src, get_class_name)(src, (const char **)&class_name, &class_name_len, 0 TSRMLS_CC);

--- a/ext/php5/compat_string.h
+++ b/ext/php5/compat_string.h
@@ -15,9 +15,9 @@ int ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
  * dst will be IS_STRING after the call; caller must dtor.
  * Uses semantics similar to casting to string, except that:
  *   1. It will not emit warnings or throw exceptions
- *   2. Objects which cannot be converted using norm rules are in the form
- *      object(%s)#%d, where %s is the class name and %d is the object handle
- *      (like var_dump).
+ *   2. Objects are in the form object(%s)#%d, where %s is the class name and %d is the object handle (like var_dump).
+ *      The we avoid the __toString cast here to not execute user code at this place. Also avoids possible stack
+ *      overflows due to recursion stemming from our own code as the root.
  **/
 void ddtrace_convert_to_string(zval *dst, zval *src TSRMLS_DC);
 

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -328,10 +328,10 @@ static zval *OBJ_PROP_NUM_array_init(zend_object *obj, uint32_t offset) {
         return *zv;
     }
     if (*zv) {
-        zval **oldzv = zv;
+        zval *oldzv = *zv;
         MAKE_STD_ZVAL(*zv);
         array_init(*zv);
-        zval_ptr_dtor(oldzv);
+        zval_ptr_dtor(&oldzv);
     } else {
         MAKE_STD_ZVAL(*zv);
         array_init(*zv);
@@ -624,7 +624,6 @@ static void dd_clean_globals(TSRMLS_D) {
     ddtrace_internal_handlers_rshutdown(TSRMLS_C);
     ddtrace_dogstatsd_client_rshutdown(TSRMLS_C);
 
-    ddtrace_free_span_id_stack(TSRMLS_C);
     ddtrace_free_span_stacks(TSRMLS_C);
     ddtrace_coms_rshutdown();
 
@@ -638,6 +637,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
 
     if (!get_DD_TRACE_ENABLED()) {
         ddtrace_dispatch_destroy(TSRMLS_C);
+        ddtrace_free_span_id_stack(TSRMLS_C);
 
         return SUCCESS;
     }
@@ -655,6 +655,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     dd_clean_globals(TSRMLS_C);
 
     ddtrace_dispatch_destroy(TSRMLS_C);
+    ddtrace_free_span_id_stack(TSRMLS_C);
 
     return SUCCESS;
 }
@@ -876,6 +877,10 @@ static PHP_FUNCTION(dd_trace) {
     }
 
     if (ddtrace_should_warn_legacy()) {
+        if (class_name) {
+            convert_to_string(class_name);
+        }
+        convert_to_string(function);
         char *message =
             "dd_trace DEPRECATION NOTICE: the function `dd_trace` (target: %s%s%s) is deprecated and has become a "
             "no-op since 0.48.0, and will eventually be removed. Please follow "
@@ -1145,7 +1150,7 @@ static PHP_FUNCTION(dd_untrace) {
     }
 
     if (DDTRACE_G(function_lookup)) {
-        zend_hash_del(DDTRACE_G(function_lookup), Z_STRVAL_P(function), Z_STRLEN_P(function));
+        zend_hash_del(DDTRACE_G(function_lookup), Z_STRVAL_P(function), Z_STRLEN_P(function) + 1);
     }
 
     RETURN_BOOL(1);

--- a/ext/php5/dispatch.c
+++ b/ext/php5/dispatch.c
@@ -21,7 +21,7 @@ extern inline void ddtrace_dispatch_release(ddtrace_dispatch_t *dispatch);
 
 static bool dd_try_find_function_dispatch(HashTable *ht, zval *fname, ddtrace_dispatch_t **dispatch_ptr,
                                           HashTable **function_table) {
-    ddtrace_dispatch_t *dispatch = ddtrace_hash_find_ptr_lc(ht, Z_STRVAL_P(fname), Z_STRLEN_P(fname));
+    ddtrace_dispatch_t *dispatch = ddtrace_hash_find_ptr_lc(ht, Z_STRVAL_P(fname), Z_STRLEN_P(fname) + 1);
     if (dispatch) {
         *dispatch_ptr = dispatch;
         *function_table = ht;
@@ -39,7 +39,7 @@ static bool dd_try_find_method_dispatch(zend_class_entry *class, zval *fname, dd
     const char *class_name = class->name;
     size_t class_name_length = class->name_length;
 
-    class_lookup = ddtrace_hash_find_ptr_lc(DDTRACE_G(class_lookup), class_name, class_name_length);
+    class_lookup = ddtrace_hash_find_ptr_lc(DDTRACE_G(class_lookup), class_name, class_name_length + 1);
     if (class_lookup) {
         if (dd_try_find_function_dispatch(class_lookup, fname, dispatch_ptr, function_table)) {
             return true;
@@ -114,7 +114,7 @@ static HashTable *_get_lookup_for_target(zval *class_name TSRMLS_DC) {
         ZVAL_STRINGL(class_name, Z_STRVAL_P(class_name_prev), Z_STRLEN_P(class_name_prev), 1);
         ddtrace_downcase_zval(class_name);
         overridable_lookup =
-            ddtrace_hash_find_ptr(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name));
+            ddtrace_hash_find_ptr(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name) + 1);
         if (!overridable_lookup) {
             overridable_lookup = ddtrace_new_class_lookup(class_name TSRMLS_CC);
         }

--- a/ext/php5/php5/dispatch.c
+++ b/ext/php5/php5/dispatch.c
@@ -33,7 +33,7 @@ HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
     ALLOC_HASHTABLE(class_lookup);
     zend_hash_init(class_lookup, 8, NULL, ddtrace_class_lookup_release_compat, 0);
 
-    zend_hash_update(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name), &class_lookup,
+    zend_hash_update(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name) + 1, &class_lookup,
                      sizeof(HashTable *), NULL);
     return class_lookup;
 }
@@ -44,6 +44,6 @@ zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
 
     ddtrace_dispatch_copy(dispatch);
-    return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
+    return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name) + 1, &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/ext/php5/php5_4/dispatch.c
+++ b/ext/php5/php5_4/dispatch.c
@@ -44,7 +44,7 @@ HashTable *ddtrace_new_class_lookup(zval *class_name TSRMLS_DC) {
     ALLOC_HASHTABLE(class_lookup);
     zend_hash_init(class_lookup, 8, NULL, ddtrace_class_lookup_release_compat, 0);
 
-    zend_hash_update(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name), &class_lookup,
+    zend_hash_update(DDTRACE_G(class_lookup), Z_STRVAL_P(class_name), Z_STRLEN_P(class_name) + 1, &class_lookup,
                      sizeof(HashTable *), NULL);
     return class_lookup;
 }
@@ -55,6 +55,6 @@ zend_bool ddtrace_dispatch_store(HashTable *lookup, ddtrace_dispatch_t *dispatch
     memcpy(dispatch, dispatch_orig, sizeof(ddtrace_dispatch_t));
 
     ddtrace_dispatch_copy(dispatch);
-    return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name), &dispatch,
+    return zend_hash_update(lookup, Z_STRVAL(dispatch->function_name), Z_STRLEN(dispatch->function_name) + 1, &dispatch,
                             sizeof(ddtrace_dispatch_t *), NULL) == SUCCESS;
 }

--- a/ext/php7/compat_string.h
+++ b/ext/php7/compat_string.h
@@ -15,10 +15,11 @@ size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
  * dst will be IS_STRING after the call; caller must dtor.
  * Uses semantics similar to casting to string, except that:
  *   1. It will not emit warnings or throw exceptions
- *   2. Objects which cannot be converted using norm rules are in the form
- *      object(%s)#%d, where %s is the class name and %d is the object handle
- *      (like var_dump).
+ *   2. Objects are in the form object(%s)#%d, where %s is the class name and %d is the object handle (like var_dump).
+ *      The we avoid the __toString cast here to not execute user code at this place. Also avoids possible stack
+ *      overflows due to recursion stemming from our own code as the root.
  **/
 void ddtrace_convert_to_string(zval *dst, zval *src);
+zend_string *ddtrace_convert_to_str(zval *op);
 
 #endif  // COMPAT_STRING_H

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -571,7 +571,6 @@ static void dd_clean_globals() {
     ddtrace_dogstatsd_client_rshutdown();
 
     ddtrace_dispatch_destroy();
-    ddtrace_free_span_id_stack();
     ddtrace_free_span_stacks();
     ddtrace_coms_rshutdown();
 
@@ -584,6 +583,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
     if (!get_DD_TRACE_ENABLED()) {
+        ddtrace_free_span_id_stack();
         return SUCCESS;
     }
 
@@ -598,6 +598,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     }
 
     dd_clean_globals();
+    ddtrace_free_span_id_stack();
 
     return SUCCESS;
 }
@@ -808,6 +809,10 @@ static PHP_FUNCTION(dd_trace) {
     }
 
     if (ddtrace_should_warn_legacy()) {
+        if (class_name) {
+            convert_to_string(class_name);
+        }
+        convert_to_string(function);
         char *message =
             "dd_trace DEPRECATION NOTICE: the function `dd_trace` (target: %s%s%s) is deprecated and has become a "
             "no-op since 0.48.0, and will eventually be removed. Please follow "

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -38,22 +38,30 @@ static int msgpack_write_zval(mpack_writer_t *writer, zval *trace);
 static int write_hash_table(mpack_writer_t *writer, HashTable *ht) {
     zval *tmp;
     zend_string *string_key;
-    int is_assoc = -1;
+    zend_long num_key;
+    bool is_assoc = 0;
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, string_key, tmp) {
-        if (is_assoc == -1) {
-            is_assoc = string_key != NULL ? 1 : 0;
-            if (is_assoc == 1) {
-                mpack_start_map(writer, zend_hash_num_elements(ht));
-            } else {
-                mpack_start_array(writer, zend_hash_num_elements(ht));
-            }
-        }
+    Bucket *bucket;
+    ZEND_HASH_FOREACH_BUCKET(ht, bucket) { is_assoc = is_assoc || bucket->key != NULL; }
+    ZEND_HASH_FOREACH_END();
 
+    if (is_assoc) {
+        mpack_start_map(writer, zend_hash_num_elements(ht));
+    } else {
+        mpack_start_array(writer, zend_hash_num_elements(ht));
+    }
+
+    ZEND_HASH_FOREACH_KEY_VAL_IND(ht, num_key, string_key, tmp) {
         // Writing the key, if associative
         bool zval_string_as_uint64 = false;
         if (is_assoc == 1) {
-            char *key = ZSTR_VAL(string_key);
+            char num_str_buf[MAX_ID_BUFSIZ], *key;
+            if (string_key) {
+                key = ZSTR_VAL(string_key);
+            } else {
+                key = num_str_buf;
+                sprintf(num_str_buf, ZEND_LONG_FMT, num_key);
+            }
             mpack_write_cstr(writer, key);
             // If the key is trace_id, span_id or parent_id then strings have to be converted to uint64 when packed.
             if (0 == strcmp(KEY_TRACE_ID, key) || 0 == strcmp(KEY_SPAN_ID, key) || 0 == strcmp(KEY_PARENT_ID, key)) {
@@ -70,10 +78,7 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht) {
     }
     ZEND_HASH_FOREACH_END();
 
-    if (is_assoc == -1) {
-        mpack_start_array(writer, 0);
-        mpack_finish_array(writer);
-    } else if (is_assoc) {
+    if (is_assoc) {
         mpack_finish_map(writer);
     } else {
         mpack_finish_array(writer);
@@ -174,7 +179,7 @@ typedef ZEND_RESULT_CODE (*add_tag_fn_t)(void *context, ddtrace_string key, ddtr
 static ZEND_RESULT_CODE dd_exception_to_error_msg(zend_object *exception, void *context, add_tag_fn_t add_tag) {
     zend_string *msg = zai_exception_message(exception);
     zend_long line = zval_get_long(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_LINE));
-    zend_string *file = zval_get_string(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_FILE));
+    zend_string *file = ddtrace_convert_to_str(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_FILE));
 
     char *error_text, *status_line;
     zend_bool caught = SG(sapi_headers).http_response_code >= 500;
@@ -265,7 +270,7 @@ static ZEND_RESULT_CODE ddtrace_exception_to_meta(zend_object *exception, void *
 
         zend_string *msg = zai_exception_message(exception);
         zend_long line = zval_get_long(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_LINE));
-        zend_string *file = zval_get_string(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_FILE));
+        zend_string *file = ddtrace_convert_to_str(ZAI_EXCEPTION_PROPERTY(exception, ZEND_STR_FILE));
 
         zend_string *complete_trace =
             zend_strpprintf(0, "%s\n\nNext %s%s%s in %s:" ZEND_LONG_FMT "\nStack trace:\n%s", ZSTR_VAL(trace_string),

--- a/ext/php8/compat_string.c
+++ b/ext/php8/compat_string.c
@@ -26,9 +26,7 @@ void ddtrace_downcase_zval(zval *src) {
     zend_string_release(str);
 }
 
-/* zend_operators.h wrongfully defines _convert_to_string, so use the ddtrace
- * prefix even though its private to this translation unit */
-static zend_string *_ddtrace_convert_to_string(zval *op) {
+zend_string *ddtrace_convert_to_str(zval *op) {
 try_again:
     switch (Z_TYPE_P(op)) {
         case IS_UNDEF:
@@ -56,10 +54,6 @@ try_again:
             return ZSTR_KNOWN(ZEND_STR_ARRAY_CAPITALIZED);
 
         case IS_OBJECT: {
-            zval tmp;
-            if (Z_OBJ_HT_P(op)->cast_object(Z_OBJ_P(op), &tmp, IS_STRING) == SUCCESS) {
-                return Z_STR(tmp);
-            }
             zend_string *class_name = Z_OBJ_HANDLER_P(op, get_class_name)(Z_OBJ_P(op));
             zend_string *message = strpprintf(0, "object(%s)#%d", ZSTR_VAL(class_name), Z_OBJ_HANDLE_P(op));
             zend_string_release(class_name);
@@ -78,7 +72,7 @@ try_again:
 }
 
 void ddtrace_convert_to_string(zval *dst, zval *src) {
-    zend_string *str = _ddtrace_convert_to_string(src);
+    zend_string *str = ddtrace_convert_to_str(src);
     if (str) {
         ZVAL_STR(dst, str);
     } else {

--- a/ext/php8/compat_string.h
+++ b/ext/php8/compat_string.h
@@ -15,10 +15,11 @@ size_t ddtrace_spprintf(char **message, size_t max_len, char *format, ...);
  * dst will be IS_STRING after the call; caller must dtor.
  * Uses semantics similar to casting to string, except that:
  *   1. It will not emit warnings or throw exceptions
- *   2. Objects which cannot be converted using norm rules are in the form
- *      object(%s)#%d, where %s is the class name and %d is the object handle
- *      (like var_dump).
+ *   2. Objects are in the form object(%s)#%d, where %s is the class name and %d is the object handle (like var_dump).
+ *      The we avoid the __toString cast here to not execute user code at this place. Also avoids possible stack
+ *      overflows due to recursion stemming from our own code as the root.
  **/
 void ddtrace_convert_to_string(zval *dst, zval *src);
+zend_string *ddtrace_convert_to_str(zval *op);
 
 #endif  // COMPAT_STRING_H

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -535,7 +535,6 @@ static void dd_clean_globals() {
     ddtrace_dogstatsd_client_rshutdown();
 
     ddtrace_dispatch_destroy();
-    ddtrace_free_span_id_stack();
     ddtrace_free_span_stacks();
     ddtrace_coms_rshutdown();
 
@@ -548,6 +547,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
     if (!get_DD_TRACE_ENABLED()) {
+        ddtrace_free_span_id_stack();
         return SUCCESS;
     }
 
@@ -562,6 +562,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     }
 
     dd_clean_globals();
+    ddtrace_free_span_id_stack();
 
     return SUCCESS;
 }
@@ -770,6 +771,10 @@ static PHP_FUNCTION(dd_trace) {
     }
 
     if (ddtrace_should_warn_legacy()) {
+        if (class_name) {
+            convert_to_string(class_name);
+        }
+        convert_to_string(function);
         char *message =
             "dd_trace DEPRECATION NOTICE: the function `dd_trace` (target: %s%s%s) is deprecated and has become a "
             "no-op since 0.48.0, and will eventually be removed. Please follow "

--- a/src/DDTrace/Integrations/Mongo/MongoIntegration.php
+++ b/src/DDTrace/Integrations/Mongo/MongoIntegration.php
@@ -39,7 +39,7 @@ class MongoIntegration extends Integration
                 $span->meta[Tag::MONGODB_SERVER] = Obfuscation::dsn($args[0]);
                 $dbName = MongoIntegration::extractDatabaseNameFromDsn($args[0]);
                 if (null !== $dbName) {
-                    $span->meta[Tag::MONGODB_DATABASE] = $dbName;
+                    $span->meta[Tag::MONGODB_DATABASE] = Integration::toString($dbName);
                 }
             }
             if (isset($args[1]['db'])) {
@@ -84,10 +84,10 @@ class MongoIntegration extends Integration
         \DDTrace\trace_method('MongoCollection', '__construct', function (SpanData $span, $args) use ($integration) {
             $integration->addSpanDefaultMetadata($span, 'MongoCollection', '__construct');
             if (isset($args[0])) {
-                $span->meta[Tag::MONGODB_DATABASE] = $args[0];
+                $span->meta[Tag::MONGODB_DATABASE] = Integration::toString($args[0]);
             }
             if (isset($args[1])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $args[1];
+                $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($args[1]);
             }
         });
 
@@ -100,10 +100,10 @@ class MongoIntegration extends Integration
                     return;
                 }
                 if (isset($return['$id'])) {
-                    $span->meta[Tag::MONGODB_BSON_ID] = $return['$id'];
+                    $span->meta[Tag::MONGODB_BSON_ID] = Integration::toString($return['$id']);
                 }
                 if (isset($return['$ref'])) {
-                    $span->meta[Tag::MONGODB_COLLECTION] = $return['$ref'];
+                    $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($return['$ref']);
                 }
             }
         );
@@ -196,31 +196,31 @@ class MongoIntegration extends Integration
         \DDTrace\trace_method('MongoDB', 'createDBRef', function (SpanData $span, $args, $return) use ($integration) {
             $integration->addSpanDefaultMetadata($span, 'MongoDB', 'createDBRef');
             if (isset($args[0])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $args[0];
+                $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($args[0]);
             }
             if (isset($return['$id'])) {
-                $span->meta[Tag::MONGODB_BSON_ID] = $return['$id'];
+                $span->meta[Tag::MONGODB_BSON_ID] = Integration::toString($return['$id']);
             }
         });
 
         \DDTrace\trace_method('MongoDB', 'getDBRef', function (SpanData $span, $args) use ($integration) {
             $integration->addSpanDefaultMetadata($span, 'MongoDB', 'getDBRef');
             if (isset($args[0]['$ref'])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $args[0]['$ref'];
+                $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($args[0]['$ref']);
             }
         });
 
         \DDTrace\trace_method('MongoDB', 'createCollection', function (SpanData $span, $args) use ($integration) {
             $integration->addSpanDefaultMetadata($span, 'MongoDB', 'createCollection');
             if (isset($args[0])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $args[0];
+                $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($args[0]);
             }
         });
 
         \DDTrace\trace_method('MongoDB', 'selectCollection', function (SpanData $span, $args) use ($integration) {
             $integration->addSpanDefaultMetadata($span, 'MongoDB', 'selectCollection');
             if (isset($args[0])) {
-                $span->meta[Tag::MONGODB_COLLECTION] = $args[0];
+                $span->meta[Tag::MONGODB_COLLECTION] = Integration::toString($args[0]);
             }
         });
 

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -47,7 +47,7 @@ class PDOIntegration extends Integration
             $span->name = 'PDO.exec';
             $span->service = 'pdo';
             $span->type = Type::SQL;
-            $span->resource = $args[0];
+            $span->resource = Integration::toString($args[0]);
             if (is_numeric($retval)) {
                 $span->meta = [
                     'db.rowcount' => $retval,
@@ -67,7 +67,7 @@ class PDOIntegration extends Integration
             $span->name = 'PDO.query';
             $span->service = 'pdo';
             $span->type = Type::SQL;
-            $span->resource = $args[0];
+            $span->resource = Integration::toString($args[0]);
             if ($retval instanceof \PDOStatement) {
                 $span->meta = [
                     'db.rowcount' => $retval->rowCount(),
@@ -92,7 +92,7 @@ class PDOIntegration extends Integration
             $span->name = 'PDO.prepare';
             $span->service = 'pdo';
             $span->type = Type::SQL;
-            $span->resource = $args[0];
+            $span->resource = Integration::toString($args[0]);
             PDOIntegration::setConnectionTags($this, $span);
             PDOIntegration::storeStatementFromConnection($this, $retval);
         });

--- a/src/api/Http/Urls.php
+++ b/src/api/Http/Urls.php
@@ -45,7 +45,7 @@ class Urls
      */
     public static function sanitize($url)
     {
-        return strstr($url, '?', true) ?: $url;
+        return strstr($url, '?', true) ?: (string) $url;
     }
 
     /**

--- a/tests/ext/sandbox/safe_to_string_metadata.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata.phpt
@@ -114,7 +114,7 @@ object(MyDt)#%d (3) {
   ["timezone"]=>
   string(3) "UTC"
 }
-string(10) "2019-09-10"
+string(%d) "object(MyDt)#%d"
 
 array(1) {
   ["foo"]=>

--- a/tests/ext/sandbox/safe_to_string_properties.phpt
+++ b/tests/ext/sandbox/safe_to_string_properties.phpt
@@ -79,10 +79,10 @@ object(MyDt)#%d (3) {
   ["timezone"]=>
   string(3) "UTC"
 }
-string(10) "2019-09-10"
-string(10) "2019-09-10"
-string(10) "2019-09-10"
-string(10) "2019-09-10"
+string(%d) "object(MyDt)#%d"
+string(%d) "object(MyDt)#%d"
+string(%d) "object(MyDt)#%d"
+string(%d) "object(MyDt)#%d"
 
 object(DateTime)#%d (3) {
   ["date"]=>

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -1,0 +1,123 @@
+<?php
+
+ini_set("datadog.trace.generate_root_span", 0);
+
+$seed = getenv("SEED") ?: crc32(microtime());
+print "SEED=$seed\n";
+srand($seed);
+
+set_error_handler(function ($str) {
+    return !strpos($str, " expects ");
+});
+
+function generate_garbage()
+{
+    $garbage = $primary_garbage = [
+        null,
+        0,
+        1,
+        NAN,
+        PHP_INT_MIN,
+        PHP_INT_MAX,
+        "",
+        "DDTrace\hook_method",
+        "call_function",
+        [],
+        new stdClass(),
+        function () {
+            ob_start();
+            var_dump(func_get_args());
+            ob_end_clean();
+        }
+    ];
+    $garbage[] = [
+        "" => $primary_garbage[array_rand($primary_garbage)],
+        1 => $primary_garbage[array_rand($primary_garbage)],
+    ];
+    $garbage[] = [
+        "foo" => $primary_garbage[array_rand($primary_garbage)],
+    ];
+    return $garbage;
+}
+
+function call_function(ReflectionFunction $function)
+{
+    $invocations = [[]];
+    for ($i = 0; $i < $function->getNumberOfParameters(); ++$i) {
+        foreach ($invocations as $invocation) {
+            foreach (generate_garbage() as $garbage) {
+                $newInvocation = $invocation;
+                $newInvocation[] = $garbage;
+                $invocations[] = $newInvocation;
+            }
+        }
+    }
+    foreach ($invocations as $invocation) {
+        try {
+            $function->invokeArgs($invocation);
+        } catch (ArgumentCountError $e) {
+        } catch (TypeError $e) {
+        }
+    }
+}
+
+function runOneIteration()
+{
+    $ext = new ReflectionExtension("ddtrace");
+    $functions = array_filter($ext->getFunctions(), function ($f) {
+        return $f->name != "dd_trace_internal_fn"
+            && !strpos($f->name, "Testing")
+            && $f->name != "dd_trace_disable_in_request";
+    });
+
+    $return_span = [
+        function () {
+            return new DDTrace\SpanData();
+        },
+        function () {
+            return DDTrace\start_span();
+        },
+        function () {
+            return DDTrace\root_span();
+        },
+        function () {
+            return DDTrace\active_span();
+        },
+    ];
+    $props = (new ReflectionClass('DDTrace\SpanData'))->getProperties();
+
+    shuffle($functions);
+    foreach ($functions as $function) {
+        $garbages = generate_garbage();
+        $e = new Exception("");
+        $exceptionClass = new ReflectionClass("Exception");
+        foreach ($exceptionClass->getProperties() as $prop) {
+            $prop->setAccessible(true);
+            try {
+                $prop->setValue($e, rand(1, 5) == 1 ? $e : $garbages[array_rand($garbages)]);
+            } catch (TypeError $e) {
+            }
+        }
+        $garbages[] = $e;
+        foreach (array_slice($return_span, 0, rand(0, count($return_span))) as $spanreturner) {
+            $span = $spanreturner();
+            foreach ($props as $prop) {
+                try {
+                    $prop->setValue($span, $garbages[array_rand($garbages)]);
+                } catch (TypeError $e) {
+                }
+            }
+        }
+        if (rand(0, 1)) {
+            DDTrace\close_span();
+        }
+        call_function($function);
+    }
+}
+
+for ($i = 0; $i < 3; ++$i) {
+    runOneIteration();
+}
+
+dd_trace_disable_in_request();
+runOneIteration();


### PR DESCRIPTION
Fixed these crashes and leaks:
- PHP_FUNCTION(dd_trace) assumed some zvals to be strings when printing the error message without checking
- span_id stack leaked if the tracer was disabled
- msgpack array writing function write_hash_table had problems with string+integer keys mixed
- use-after-free in PHP 5 if meta or metrics properties on SpanData were assigned non-array values
- hooking or tracing a function, with a name of an empty string on PHP 5 got an assertion failure
- Object of class %s could not be converted to string style exceptions could occur in our serialization code, removing object casting logic completely

I'm mostly unsure about the last point, I'm emulating it in our integration tracing hooks for now...

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
