### PR TITLE
SpanData::$parent property

### DIFF
--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -255,6 +255,18 @@ static zend_object_value ddtrace_span_data_clone_obj(zval *old_zv TSRMLS_DC) {
     return new_obj_val;
 }
 
+static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, const zend_literal *key TSRMLS_DC) {
+    if ((Z_TYPE_P(member) == IS_STRING) &&
+        (Z_STRLEN_P(member) == sizeof("parent")-1) &&
+        (SUCCESS == memcmp(Z_STRVAL_P(member), "parent", sizeof("parent")-1))) {
+        zend_throw_exception_ex(NULL, 0 TSRMLS_CC,
+            "Cannot modify readonly property %s::$%s", Z_OBJCE_P(object)->name, Z_STRVAL_P(member));
+        return;
+    }
+
+    zend_std_write_property(object, member, value, key TSRMLS_CC);
+}
+
 static PHP_METHOD(DDTrace_SpanData, getDuration) {
     UNUSED(ht, return_value_used, this_ptr, return_value_ptr);
     ddtrace_span_fci *span_fci = (ddtrace_span_fci *)zend_object_store_get_object(getThis() TSRMLS_CC);
@@ -278,6 +290,8 @@ const zend_function_entry class_DDTrace_SpanData_methods[] = {
 static void dd_register_span_data_ce(TSRMLS_D) {
     memcpy(&ddtrace_span_data_handlers, &std_object_handlers, sizeof(zend_object_handlers));
     ddtrace_span_data_handlers.clone_obj = ddtrace_span_data_clone_obj;
+    ddtrace_span_data_handlers.write_property = ddtrace_span_data_readonly;
+
     zend_class_entry ce_span_data;
     INIT_NS_CLASS_ENTRY(ce_span_data, "DDTrace", "SpanData", class_DDTrace_SpanData_methods);
     ddtrace_ce_span_data = zend_register_internal_class(&ce_span_data TSRMLS_CC);
@@ -296,6 +310,7 @@ static void dd_register_span_data_ce(TSRMLS_D) {
     zend_declare_property_null(ddtrace_ce_span_data, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ddtrace_ce_span_data, "exception", sizeof("exception") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ddtrace_ce_span_data, "parent", sizeof("parent") - 1, ZEND_ACC_PUBLIC TSRMLS_CC);
 }
 
 static zval *OBJ_PROP_NUM(zend_object *obj, uint32_t offset) {
@@ -358,6 +373,9 @@ zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) { return OBJ_PROP_
 // SpanData::$exception
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 6); }
 zval **ddtrace_spandata_property_exception_write(ddtrace_span_t *span) { return OBJ_PROP_NUM_write(&span->std, 6); }
+// SpanData::$parent
+zval *ddtrace_spandata_property_parent(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 7); }
+zval **ddtrace_spandata_property_parent_write(ddtrace_span_t *span) { return OBJ_PROP_NUM_write(&span->std, 7); }
 
 static zend_object_handlers ddtrace_fatal_error_handlers;
 /* The goal is to mimic zend_default_exception_new_ex except for adding

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -256,11 +256,10 @@ static zend_object_value ddtrace_span_data_clone_obj(zval *old_zv TSRMLS_DC) {
 }
 
 static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, const zend_literal *key TSRMLS_DC) {
-    if ((Z_TYPE_P(member) == IS_STRING) &&
-        (Z_STRLEN_P(member) == sizeof("parent")-1) &&
-        (SUCCESS == memcmp(Z_STRVAL_P(member), "parent", sizeof("parent")-1))) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC,
-            "Cannot modify readonly property %s::$%s", Z_OBJCE_P(object)->name, Z_STRVAL_P(member));
+    if ((Z_TYPE_P(member) == IS_STRING) && (Z_STRLEN_P(member) == sizeof("parent") - 1) &&
+        (SUCCESS == memcmp(Z_STRVAL_P(member), "parent", sizeof("parent") - 1))) {
+        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "Cannot modify readonly property %s::$%s", Z_OBJCE_P(object)->name,
+                                Z_STRVAL_P(member));
         return;
     }
 

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -27,6 +27,8 @@ zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span);
 zval **ddtrace_spandata_property_exception_write(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_parent(ddtrace_span_t *span);
+zval **ddtrace_spandata_property_parent_write(ddtrace_span_t *span);
 
 bool ddtrace_fetch_prioritySampling_from_root(int *priority TSRMLS_DC);
 

--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -86,7 +86,7 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
             MAKE_COPY_ZVAL(&last_type, *type);
         }
         zval **parent = ddtrace_spandata_property_parent_write(&span_fci->span);
-	MAKE_STD_ZVAL(*parent);
+        MAKE_STD_ZVAL(*parent);
         Z_TYPE_PP(parent) = IS_OBJECT;
         Z_OBJVAL_PP(parent) = span_fci->next->span.obj_value;
         zend_objects_store_add_ref(*parent TSRMLS_CC);

--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -89,7 +89,7 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
 	MAKE_STD_ZVAL(*parent);
         Z_TYPE_PP(parent) = IS_OBJECT;
         Z_OBJVAL_PP(parent) = span_fci->next->span.obj_value;
-        zend_objects_store_add_ref(*parent);
+        zend_objects_store_add_ref(*parent TSRMLS_CC);
     }
     ddtrace_set_global_span_properties(&span_fci->span TSRMLS_CC);
 }

--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -85,6 +85,11 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
             MAKE_STD_ZVAL(*type);
             MAKE_COPY_ZVAL(&last_type, *type);
         }
+        zval **parent = ddtrace_spandata_property_parent_write(&span_fci->span);
+	MAKE_STD_ZVAL(*parent);
+        Z_TYPE_PP(parent) = IS_OBJECT;
+        Z_OBJVAL_PP(parent) = span_fci->next->span.obj_value;
+        zend_objects_store_add_ref(*parent);
     }
     ddtrace_set_global_span_properties(&span_fci->span TSRMLS_CC);
 }

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -282,6 +282,28 @@ static zend_object *ddtrace_span_data_clone_obj(zval *old_zv) {
     return new_obj;
 }
 
+#if PHP_VERSION_ID >= 70400
+static zval* ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
+#else
+static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
+#endif
+    if (Z_TYPE_P(member) == IS_STRING && zend_string_equals_literal(Z_STR_P(member), "parent")) {
+        zend_throw_error(zend_ce_error,
+            "Cannot modify readonly property %s::%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
+#if PHP_VERSION_ID >= 70400
+        return &EG(uninitialized_zval);
+#else
+        return;
+#endif
+    }
+
+#if PHP_VERSION_ID >= 70400
+    return zend_std_write_property(object, member, value, cache_slot);
+#else
+    zend_std_write_property(object, member, value, cache_slot);
+#endif
+}
+
 static PHP_METHOD(DDTrace_SpanData, getDuration) {
     ddtrace_span_fci *span_fci = (ddtrace_span_fci *)Z_OBJ_P(getThis());
     RETURN_LONG(span_fci->span.duration);
@@ -304,6 +326,7 @@ static void dd_register_span_data_ce(void) {
     memcpy(&ddtrace_span_data_handlers, &std_object_handlers, sizeof(zend_object_handlers));
     ddtrace_span_data_handlers.clone_obj = ddtrace_span_data_clone_obj;
     ddtrace_span_data_handlers.free_obj = ddtrace_span_data_free_storage;
+    ddtrace_span_data_handlers.write_property = ddtrace_span_data_readonly;
 
     zend_class_entry ce_span_data;
     INIT_NS_CLASS_ENTRY(ce_span_data, "DDTrace", "SpanData", class_DDTrace_SpanData_methods);
@@ -324,6 +347,7 @@ static void dd_register_span_data_ce(void) {
     zend_declare_property_null(ddtrace_ce_span_data, "meta", sizeof("meta") - 1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(ddtrace_ce_span_data, "metrics", sizeof("metrics") - 1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(ddtrace_ce_span_data, "exception", sizeof("exception") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ddtrace_ce_span_data, "parent", sizeof("parent") - 1, ZEND_ACC_PUBLIC);
 }
 
 #pragma GCC diagnostic push
@@ -342,6 +366,8 @@ zval *ddtrace_spandata_property_meta(ddtrace_span_t *span) { return OBJ_PROP_NUM
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 5); }
 // SpanData::$exception
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 6); }
+// SpanData::$parent
+zval *ddtrace_spandata_property_parent(ddtrace_span_t *span) { return OBJ_PROP_NUM(&span->std, 7); }
 #pragma GCC diagnostic pop
 
 bool ddtrace_fetch_prioritySampling_from_root(int *priority) {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -288,7 +288,7 @@ static zval* ddtrace_span_data_readonly(zval *object, zval *member, zval *value,
 static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #endif
     if (Z_TYPE_P(member) == IS_STRING && zend_string_equals_literal(Z_STR_P(member), "parent")) {
-        zend_throw_exception_ex(zend_ce_exception, 0,
+        zend_throw_error(zend_ce_error,
             "Cannot modify readonly property %s::$%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
 #if PHP_VERSION_ID >= 70400
         return &EG(uninitialized_zval);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -288,7 +288,7 @@ static zval* ddtrace_span_data_readonly(zval *object, zval *member, zval *value,
 static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #endif
     if (Z_TYPE_P(member) == IS_STRING && zend_string_equals_literal(Z_STR_P(member), "parent")) {
-        zend_throw_error(zend_ce_exception,
+        zend_throw_exception_ex(zend_ce_exception, 0,
             "Cannot modify readonly property %s::$%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
 #if PHP_VERSION_ID >= 70400
         return &EG(uninitialized_zval);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -288,8 +288,8 @@ static zval* ddtrace_span_data_readonly(zval *object, zval *member, zval *value,
 static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #endif
     if (Z_TYPE_P(member) == IS_STRING && zend_string_equals_literal(Z_STR_P(member), "parent")) {
-        zend_throw_error(zend_ce_error,
-            "Cannot modify readonly property %s::%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
+        zend_throw_error(zend_ce_exception,
+            "Cannot modify readonly property %s::$%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
 #if PHP_VERSION_ID >= 70400
         return &EG(uninitialized_zval);
 #else

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -283,13 +283,13 @@ static zend_object *ddtrace_span_data_clone_obj(zval *old_zv) {
 }
 
 #if PHP_VERSION_ID >= 70400
-static zval* ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
+static zval *ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #else
 static void ddtrace_span_data_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #endif
     if (Z_TYPE_P(member) == IS_STRING && zend_string_equals_literal(Z_STR_P(member), "parent")) {
-        zend_throw_error(zend_ce_error,
-            "Cannot modify readonly property %s::$%s", ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
+        zend_throw_error(zend_ce_error, "Cannot modify readonly property %s::$%s", ZSTR_VAL(Z_OBJCE_P(object)->name),
+                         Z_STRVAL_P(member));
 #if PHP_VERSION_ID >= 70400
         return &EG(uninitialized_zval);
 #else

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -22,6 +22,7 @@ zval *ddtrace_spandata_property_type(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_parent(ddtrace_span_t *span);
 
 bool ddtrace_fetch_prioritySampling_from_root(int *priority);
 

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -77,6 +77,8 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
                   ddtrace_spandata_property_service(&span_fci->next->span));
         ZVAL_COPY(ddtrace_spandata_property_type(&span_fci->span),
                   ddtrace_spandata_property_type(&span_fci->next->span));
+        ZVAL_OBJ(ddtrace_spandata_property_parent(&span_fci->span), &span_fci->next->span.std);
+        Z_ADDREF_P(ddtrace_spandata_property_parent(&span_fci->span));
     }
     ddtrace_set_global_span_properties(&span_fci->span);
 }

--- a/ext/php7/span.h
+++ b/ext/php7/span.h
@@ -16,7 +16,7 @@ struct ddtrace_dispatch_t;
 
 struct ddtrace_span_t {
     zend_object std;
-    zval properties_table_placeholder[6];
+    zval properties_table_placeholder[7];
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -246,7 +246,7 @@ static void ddtrace_span_data_free_storage(zend_object *object) {
 
 static zval* ddtrace_span_data_readonly(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
     if (zend_string_equals_literal(member, "parent")) {
-        zend_throw_error(zend_ce_exception,
+        zend_throw_exception_ex(zend_ce_exception, 0,
             "Cannot modify readonly property %s::$%s", ZSTR_VAL(object->ce->name), ZSTR_VAL(member));
         return &EG(uninitialized_zval);
     }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -246,8 +246,8 @@ static void ddtrace_span_data_free_storage(zend_object *object) {
 
 static zval* ddtrace_span_data_readonly(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
     if (zend_string_equals_literal(member, "parent")) {
-        zend_throw_error(zend_ce_error,
-            "Cannot modify readonly property %s::%s", ZSTR_VAL(object->ce->name), ZSTR_VAL(member));
+        zend_throw_error(zend_ce_exception,
+            "Cannot modify readonly property %s::$%s", ZSTR_VAL(object->ce->name), ZSTR_VAL(member));
         return &EG(uninitialized_zval);
     }
 

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -246,7 +246,7 @@ static void ddtrace_span_data_free_storage(zend_object *object) {
 
 static zval* ddtrace_span_data_readonly(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
     if (zend_string_equals_literal(member, "parent")) {
-        zend_throw_exception_ex(zend_ce_exception, 0,
+        zend_throw_error(zend_ce_error,
             "Cannot modify readonly property %s::$%s", ZSTR_VAL(object->ce->name), ZSTR_VAL(member));
         return &EG(uninitialized_zval);
     }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -244,10 +244,10 @@ static void ddtrace_span_data_free_storage(zend_object *object) {
     memset(object->properties_table, 0, sizeof(((ddtrace_span_t *)NULL)->properties_table_placeholder));
 }
 
-static zval* ddtrace_span_data_readonly(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
+static zval *ddtrace_span_data_readonly(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
     if (zend_string_equals_literal(member, "parent")) {
-        zend_throw_error(zend_ce_error,
-            "Cannot modify readonly property %s::$%s", ZSTR_VAL(object->ce->name), ZSTR_VAL(member));
+        zend_throw_error(zend_ce_error, "Cannot modify readonly property %s::$%s", ZSTR_VAL(object->ce->name),
+                         ZSTR_VAL(member));
         return &EG(uninitialized_zval);
     }
 

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -22,6 +22,7 @@ zval *ddtrace_spandata_property_type(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_meta(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span);
 zval *ddtrace_spandata_property_exception(ddtrace_span_t *span);
+zval *ddtrace_spandata_property_parent(ddtrace_span_t *span);
 
 bool ddtrace_fetch_prioritySampling_from_root(int *priority);
 

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -77,8 +77,7 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
                   ddtrace_spandata_property_service(&span_fci->next->span));
         ZVAL_COPY(ddtrace_spandata_property_type(&span_fci->span),
                   ddtrace_spandata_property_type(&span_fci->next->span));
-        ZVAL_OBJ_COPY(ddtrace_spandata_property_parent(&span_fci->span),
-                  &span_fci->next->span.std);
+        ZVAL_OBJ_COPY(ddtrace_spandata_property_parent(&span_fci->span), &span_fci->next->span.std);
     }
     ddtrace_set_global_span_properties(&span_fci->span);
 }

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -77,6 +77,8 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
                   ddtrace_spandata_property_service(&span_fci->next->span));
         ZVAL_COPY(ddtrace_spandata_property_type(&span_fci->span),
                   ddtrace_spandata_property_type(&span_fci->next->span));
+        ZVAL_OBJ_COPY(ddtrace_spandata_property_parent(&span_fci->span),
+                  &span_fci->next->span.std);
     }
     ddtrace_set_global_span_properties(&span_fci->span);
 }

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -16,7 +16,7 @@ struct ddtrace_dispatch_t;
 
 struct ddtrace_span_t {
     zend_object std;
-    zval properties_table_placeholder[6];
+    zval properties_table_placeholder[7];
     uint64_t trace_id;
     uint64_t parent_id;
     uint64_t span_id;

--- a/package.xml
+++ b/package.xml
@@ -672,6 +672,7 @@
             <file name="tests/ext/request_timeout_01.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_disabled.phpt" role="test" />
             <file name="tests/ext/segfault_backtrace_enabled.phpt" role="test" />
+            <file name="tests/ext/span_with_parent_property_access.phpt" role="test" />
             <file name="tests/ext/span_with_removed_exception.phpt" role="test" />
             <file name="tests/ext/start_span_with_all_properties.phpt" role="test" />
             <file name="tests/ext/start_span_without_closing.phpt" role="test" />

--- a/tests/ext/span_with_parent_property_access.phpt
+++ b/tests/ext/span_with_parent_property_access.phpt
@@ -8,7 +8,7 @@ $root = DDTrace\start_span();
 
 $span = DDTrace\start_span();
 
-if ($span->parent === $root) {
+if (!isset($root->parent) && $span->parent === $root) {
     echo "OK\n";
 
     try {

--- a/tests/ext/span_with_parent_property_access.phpt
+++ b/tests/ext/span_with_parent_property_access.phpt
@@ -15,10 +15,6 @@ if (!isset($root->parent) && $span->parent === $root) {
         $span->parent = null;
     } catch (\Exception $error) {
         print $error->getMessage() . PHP_EOL;
-    } finally {
-        if ($span->parent === null) {
-            echo "FAIL\n";
-        }
     }
 } else {
     var_dump($root, $span);

--- a/tests/ext/span_with_parent_property_access.phpt
+++ b/tests/ext/span_with_parent_property_access.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test DDTrace\SpanData::$parent
+--FILE--
+<?php
+$root = DDTrace\start_span();
+
+$span = DDTrace\start_span();
+
+if ($span->parent === $root) {
+    echo "OK\n";
+
+    try {
+        $span->parent = null;
+    } catch (\Error $error) {
+        print $error->getMessage() . PHP_EOL;
+    } finally {
+        if ($span->parent === null) {
+            echo "FAIL\n";
+        }
+    }
+} else {
+    var_dump($root, $span);
+}
+?>
+--EXPECT--
+OK
+Cannot modify readonly property DDTrace\SpanData::parent

--- a/tests/ext/span_with_parent_property_access.phpt
+++ b/tests/ext/span_with_parent_property_access.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test DDTrace\SpanData::$parent
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 $root = DDTrace\start_span();
@@ -11,7 +13,7 @@ if ($span->parent === $root) {
 
     try {
         $span->parent = null;
-    } catch (\Error $error) {
+    } catch (\Exception $error) {
         print $error->getMessage() . PHP_EOL;
     } finally {
         if ($span->parent === null) {
@@ -24,4 +26,4 @@ if ($span->parent === $root) {
 ?>
 --EXPECT--
 OK
-Cannot modify readonly property DDTrace\SpanData::parent
+Cannot modify readonly property DDTrace\SpanData::$parent

--- a/tests/ext/span_with_parent_property_access.phpt
+++ b/tests/ext/span_with_parent_property_access.phpt
@@ -15,6 +15,8 @@ if (!isset($root->parent) && $span->parent === $root) {
         $span->parent = null;
     } catch (\Exception $error) {
         print $error->getMessage() . PHP_EOL;
+    } catch (\Throwable $error) {
+        print $error->getMessage() . PHP_EOL;
     }
 } else {
     var_dump($root, $span);


### PR DESCRIPTION
Implement access to SpanData::$parent.

  - This does not yet use ZEND_ACC_READONLY to keep the source simple (php9 will use ZEND_ACC_READONLY)
  - This does not prohibit indirect modification, that would be costly to all other reads and doesn't seem worth it
