### PR TITLE
Add libuv to Debian containers

### DIFF
--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -27,6 +27,7 @@ ENV RUNTIME_DEPS \
     libzip-dev \
     netbase \
     nginx \
+    strace \
     sudo \
     unzip \
     valgrind \
@@ -195,6 +196,31 @@ RUN set -eux; \
 # Setup php install directory
     mkdir -p $PHP_INSTALL_DIR; \
     chown -R circleci:circleci /opt;
+
+# libuv
+ARG LIBUV_VERSION="1.42.0"
+ARG LIBUV_SHA256="371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764"
+
+RUN set -eux; \
+    cd /usr/local/src; \
+    curl -OL https://github.com/libuv/libuv/archive/refs/tags/v${LIBUV_VERSION}.tar.gz; \
+    (echo "${LIBUV_SHA256} v${LIBUV_VERSION}.tar.gz" | sha256sum -c -); \
+    mv "v${LIBUV_VERSION}.tar.gz" "libuv-${LIBUV_VERSION}.tar.gz";
+
+RUN set -eux; \
+    cd /usr/local/src; \
+    tar -xvf "libuv-${LIBUV_VERSION}.tar.gz"; \
+    cd "libuv-${LIBUV_VERSION}"; \
+    ./autogen.sh; \
+    ./configure --prefix=/opt/libuv \
+        --disable-shared \
+        --enable-static \
+        --with-pic \
+        --disable-dependency-tracking \
+    ; \
+    make -j 4 all install; \
+    cd -; \
+    rm -fr "libuv-${LIBUV_VERSION}";
 
 # Run everything else as circleci user
 USER circleci

--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
         yes '' | pecl install apcu; echo "extension=apcu.so" >> ${iniDir}/apcu.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
         yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
-        pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
+        pecl install mongodb-1.9.2; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
         pecl install xdebug-2.7.2; \


### PR DESCRIPTION
### Description

Add libuv to Debian containers.

Also pin PHP 7.0's mongodb version as support for it has been
dropped.

Also add strace as per Bob's request.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
