### PR TITLE
PDOIntegration::parseDSN fails to parse some DSN

### DIFF
--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -156,13 +156,17 @@ class PDOIntegration extends Integration
                 continue;
             }
             list($key, $value) = explode('=', $valString);
-            switch ($key) {
+            switch (strtolower($key)) {
                 case 'charset':
                     $tags['db.charset'] = $value;
                     break;
+                case 'database':
                 case 'dbname':
                     $tags['db.name'] = $value;
                     break;
+                case 'server':
+                case 'unix_socket':
+                case 'hostname':
                 case 'host':
                     $tags[Tag::TARGET_HOST] = $value;
                     break;


### PR DESCRIPTION
### PDOIntegration::parseDSN

This was found to be faulty for various flavours of PDO.

Essentially some keys (discovered from manual entries) are not supported in DSN key value pairs, in addition a driver is allowed to treat keys case insensitively, so that Host=localhost, and host=localhost and HOST=localhost may be treated the same, so we should also ignore key case.