### PR TITLE
Merge profiling components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1066,6 +1066,9 @@ jobs:
           name: Build and test Datadog::Php::Components (ASan)
           command: |
             export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+            if [ -f "/opt/libuv/lib/pkgconfig/libuv.pc" ] ; then
+              export PKG_CONFIG_PATH="/opt/libuv/lib/pkgconfig:$PKG_CONFIG_PATH"
+            fi
             mkdir -p /tmp/build/datadog_php_components_asan
             cd /tmp/build/datadog_php_components_asan
             if [ -f "/etc/debian_version" ]
@@ -1097,7 +1100,12 @@ jobs:
               -DDATADOG_PHP_TESTING=ON \
               ~/datadog/components
             make -j all
-            make test
+
+            # channel is non-deterministic, so run tests a few more times. At
+            # the moment, Catch2 tests are not automatically adding labels, so
+            # run all tests instead of just channel's:
+            # https://github.com/catchorg/Catch2/issues/1590
+            make test ARGS="--output-on-failure --repeat until-fail:10"
 
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1075,7 +1075,7 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               $toolchain \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_COMPONENTS_TESTING=ON \
+              -DDATADOG_PHP_TESTING=ON \
               ~/datadog/components
             make -j all
             make test
@@ -1094,7 +1094,7 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               -DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/ubsan.cmake \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_COMPONENTS_TESTING=ON \
+              -DDATADOG_PHP_TESTING=ON \
               ~/datadog/components
             make -j all
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1411,8 +1411,8 @@ workflows:
                 - "datadog/dd-trace-ci:alpine"
                 - "datadog/dd-trace-ci:buster"
               cmake_version:
-                - "3.14.7"
-                - "3.19.6"
+                - "3.19.8"
+                - "3.21.4"
               catch2_version:
                 - "2.13.7"
 

--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle: Google
 Language: Cpp
 ColumnLimit: 120
 IndentWidth: 4
+BreakStringLiterals: false
 ---

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -8,25 +8,39 @@ project(datadog-php-components
   LANGUAGES C
 )
 
-option(BUILD_COMPONENTS_TESTING "Enable tests" OFF)
-if (${BUILD_COMPONENTS_TESTING})
-  # Tests uses the C++ testing framework Catch2
+option(DATADOG_PHP_TESTING "Enable Datadog PHP tests" OFF)
+if (${DATADOG_PHP_TESTING})
+
+  # Tests use the C++ testing framework Catch2
   enable_language(CXX)
 
   # The Catch2::Catch2 target has been available since 2.1.2
   # We are unsure of the true minimum, but have tested 2.4
   find_package(Catch2 2.4 REQUIRED)
 
-  #[[ This file takes a while to build, so we do it once here and every test
-      executable can link to it to save time.
-  ]]
-  add_library(catch2_main catch2_main.cc)
-  target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
-  target_compile_features(catch2_main PUBLIC cxx_std_11)
-
   include(Catch)
+
+  if (NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
+    #[[ The build of catch2 we are using wasn't configured with
+        `CATCH_BUILD_STATIC_LIBRARY`; let's polyfill it.
+    ]]
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc
+      "#define CATCH_CONFIG_MAIN\n"
+      "#include <catch2/catch.hpp>\n"
+    )
+
+    add_library(Catch2WithMain ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc)
+    target_compile_features(Catch2WithMain INTERFACE cxx_std_11)
+    target_link_libraries(Catch2WithMain PUBLIC Catch2::Catch2)
+    add_library(Catch2::Catch2WithMain ALIAS Catch2WithMain)
+  endif ()
+
+  if (NOT TARGET Catch2::Catch2WithMain)
+    message(FATAL_ERROR "Catch2WithMain not found and polyfill failed.")
+  endif ()
+
   enable_testing()
-endif()
+endif ()
 
 include(GNUInstallDirs)
 

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -8,6 +8,11 @@ project(datadog-php-components
   LANGUAGES C
 )
 
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(UV IMPORTED_TARGET libuv)
+endif ()
+
 option(DATADOG_PHP_TESTING "Enable Datadog PHP tests" OFF)
 if (${DATADOG_PHP_TESTING})
 
@@ -48,10 +53,15 @@ add_library(datadog_php_components INTERFACE)
 
 add_subdirectory(string_view)
 
-# sapi depends on string_view
-add_subdirectory(sapi)
+if (TARGET PkgConfig::UV)
+  add_subdirectory(channel)
+else ()
+  message(WARNING "component channel was skipped because libuv is missing")
+endif ()
 
 add_subdirectory(container_id)
+add_subdirectory(queue)
+add_subdirectory(sapi)
 
 install(EXPORT DatadogPhpComponentsTargets
   FILE DatadogPhpComponentsTargets.cmake

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,7 +1,10 @@
 #[[ Need CMake 3.14 so that `install(TARGETS)` uses better defaults, which
     saves us from repeating configuration in every file (and must be the same).
+    Need CMake 3.15+ because the time component feature checks fail on 3.14;
+    instead of just bumping incrementally, I've bumped this to the latest
+    version that's been tested in CI: 3.19.
 ]]
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 
 project(datadog-php-components
   VERSION 0.1.0
@@ -53,6 +56,8 @@ add_library(datadog_php_components INTERFACE)
 
 add_subdirectory(string_view)
 
+add_subdirectory(arena)
+
 if (TARGET PkgConfig::UV)
   add_subdirectory(channel)
 else ()
@@ -60,8 +65,12 @@ else ()
 endif ()
 
 add_subdirectory(container_id)
+add_subdirectory(log)
 add_subdirectory(queue)
 add_subdirectory(sapi)
+add_subdirectory(stack-sample)
+add_subdirectory(time)
+add_subdirectory(uuid)
 
 install(EXPORT DatadogPhpComponentsTargets
   FILE DatadogPhpComponentsTargets.cmake

--- a/components/README.md
+++ b/components/README.md
@@ -31,7 +31,7 @@ avoided by using components.
 ## Components should be tested
 
 Components must have a tests subdirectory which gets added to the CMake project
-when the `BUILD_COMPONENTS_TESTING` option is set to true/on. The tests need to
+when the `DATADOG_PHP_TESTING` option is set to true/on. The tests need to
 integrate with CMake so that when the main `test` target is run that the
 component's tests are run as well.
 

--- a/components/arena/CMakeLists.txt
+++ b/components/arena/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(datadog-php-arena OBJECT arena.c)
+
+target_include_directories(datadog-php-arena
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-arena
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/arena/arena.c
+++ b/components/arena/arena.c
@@ -1,0 +1,64 @@
+#include "arena.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct datadog_php_arena_s {
+    uint32_t offset, capacity;
+    uint8_t *start;
+};
+
+void datadog_php_arena_delete(datadog_php_arena *arena) { (void)arena; }
+void datadog_php_arena_reset(datadog_php_arena *arena) { arena->offset = 0; }
+
+static uint32_t align_diff(uintptr_t ptr, uint32_t align) {
+    uintptr_t diff = (~ptr + 1) & (align - 1);
+    return diff;
+}
+
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align) {
+    uint32_t diff = align_diff(ptr, align);
+    return diff;
+}
+
+datadog_php_arena *datadog_php_arena_new(uint8_t *buffer, uint32_t len) {
+    if (!buffer || !len) {
+        return NULL;
+    }
+
+    uint32_t diff = align_diff((uintptr_t)buffer, _Alignof(datadog_php_arena));
+    uint8_t *obj = buffer + diff;
+
+    // ensure the alignment + size fits
+    if ((diff + sizeof(datadog_php_arena)) > len) {
+        return NULL;
+    }
+
+    datadog_php_arena *allocator = (datadog_php_arena *)obj;
+    allocator->offset = 0;
+    allocator->capacity = len - sizeof(datadog_php_arena) - diff;
+    allocator->start = obj + sizeof(datadog_php_arena);
+
+    return allocator;
+}
+
+uint8_t *datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size, uint32_t align) {
+    // minimum allocation size is 1 byte
+    size = !size ? 1 : size;
+
+    // align the offset
+    uint8_t *begin = arena->start + arena->offset;
+    uint32_t diff = align_diff((uintptr_t)begin, align);
+    ptrdiff_t offset = arena->offset + diff;
+
+    // ensure it doesn't go out of bounds
+    if (offset + size > arena->capacity) {
+        return NULL;
+    }
+
+    unsigned char *obj = arena->start + offset;
+
+    // bump the offset
+    arena->offset = offset + size;
+    return obj;
+}

--- a/components/arena/arena.h
+++ b/components/arena/arena.h
@@ -1,0 +1,59 @@
+#ifndef DATADOG_PHP_ARENA_H
+#define DATADOG_PHP_ARENA_H
+
+#include <stdint.h>
+
+#if __GNUC__
+#if __GNUC__ >= 11
+#define HAVE_ATTRIBUTE_MALLOC_EXTENDED 1
+#endif
+#endif
+
+#if HAVE_ATTRIBUTE_MALLOC_EXTENDED
+/* Note that GCC 11 doesn't yet do a good job with this attribute, but
+ * experimenting with it to report bugs so it hopefully gets better.
+ */
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...) __attribute__((malloc(__VA_ARGS__)))
+#else
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...)
+#endif
+
+typedef struct datadog_php_arena_s datadog_php_arena;
+
+/**
+ * This is a no-op at present, but it theoretically helps the GCC analyzer to
+ * understand the lifetime of the arena.
+ * Note that it cannot be inline, as deallocator functions cannot be inline.
+ */
+void datadog_php_arena_delete(datadog_php_arena *arena);
+
+/**
+ * Creates a new arena from the provided `buffer` + `len`. This function may
+ * return NULL, such as if `len` is not large enough to hold the arena object.
+ *
+ * # Safety
+ * The `buffer` object must have at least `len` contiguous bytes.
+ */
+DATADOG_PHP__ATTR_MALLOC_EXTENDED(datadog_php_arena_delete)
+datadog_php_arena *datadog_php_arena_new(uint8_t *buffer, uint32_t len);
+
+/**
+ * Resets the arena contents, but the arena object itself stays valid. All
+ * objects that have been allocated by the arena are now invalid.
+ */
+__attribute__((nonnull(1))) void datadog_php_arena_reset(datadog_php_arena *arena);
+
+/**
+ * Returns the number of bytes to add to `ptr` to align it to `align`. Only
+ * pass powers of 2!
+ */
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align);
+
+/**
+ * Allocates at least `size` bytes from the `arena`, aligned to `align`. May
+ * return NULL, such as if `align` is not a power of two or if there is not
+ * enough remaining space in the `arena` storage.
+ */
+__attribute__((nonnull(1))) uint8_t *datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size, uint32_t align);
+
+#endif  // DATADOG_PHP_ARENA_H

--- a/components/arena/tests/CMakeLists.txt
+++ b/components/arena/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-arena arena.cc)
+target_link_libraries(test-datadog-php-arena
+  PRIVATE Catch2::Catch2WithMain datadog-php-arena
+)
+
+catch_discover_tests(test-datadog-php-arena)

--- a/components/arena/tests/arena.cc
+++ b/components/arena/tests/arena.cc
@@ -1,0 +1,103 @@
+extern "C" {
+#include <components/arena/arena.h>
+}
+
+#include <catch2/catch.hpp>
+
+// Generic buffer -- used when you don't need to test specific capacities
+alignas(32) static uint8_t buffer[1024];
+
+TEST_CASE("new and delete", "[arena]") {
+    datadog_php_arena *arena = datadog_php_arena_new(&buffer[0], sizeof buffer);
+    REQUIRE(arena);
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("generic alignment", "[arena]") {
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 0), 4) == 0u);
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 1), 4) == 3u);
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 2), 4) == 2u);
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 3), 4) == 1u);
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 4), 4) == 0u);
+    CHECK(datadog_php_arena_align_diff(reinterpret_cast<uintptr_t>(buffer + 5), 4) == 3u);
+}
+
+TEST_CASE("allocator self-alignment", "[arena]") {
+    alignas(16) uint8_t bytes[24];
+
+    /* Since buffer is aligned to an even byte boundary, by passing in a pointer
+     * + 1 (and taking 1 off the size to match), we can test that the arena
+     * object itself gets correctly aligned in the buffer, since there is no
+     * guarantee that the buffer has suitable alignment.
+     */
+    datadog_php_arena *arena = datadog_php_arena_new(&bytes[1], sizeof bytes - 1);
+    REQUIRE(arena);
+
+    REQUIRE(((uint8_t *)arena) == bytes + 8);
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("capacity and reset", "[arena]") {
+    // UNSAFE: this requires knowledge of size of datadog_php_arena
+    alignas(8) uint8_t bytes[20];
+
+    datadog_php_arena *arena = datadog_php_arena_new(bytes + 0, sizeof bytes);
+    REQUIRE(arena);
+
+    uint8_t *i = datadog_php_arena_alloc(arena, 4, 1);
+    REQUIRE(i);
+
+    // This allocation should fail; no more room.
+    uint8_t *j = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(!j);
+
+    datadog_php_arena_reset(arena);
+
+    // Since we have reset the arena, this should allocate the same address
+    uint8_t *k = datadog_php_arena_alloc(arena, 4, 1);
+    REQUIRE(i == k);
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment", "[arena]") {
+    // UNSAFE: this requires knowledge of size of datadog_php_arena
+    alignas(16) uint8_t bytes[24];
+
+    datadog_php_arena *arena = datadog_php_arena_new(bytes + 0, sizeof bytes);
+    REQUIRE(arena);
+
+    /* Intentionally use a size and align combo that will set up the next alloc
+     * to start misaligned.
+     */
+    uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(i);
+
+    uint8_t *j = datadog_php_arena_alloc(arena, 4, 4);
+    REQUIRE(j);
+    REQUIRE(i + 4 == j);
+
+    // This allocation should fail; no more room.
+    uint8_t *k = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(!k);
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment capacity", "[arena]") {
+    // UNSAFE: this requires knowledge of size of datadog_php_arena
+    alignas(16) uint8_t bytes[24];
+
+    datadog_php_arena *arena = datadog_php_arena_new(bytes + 0, sizeof bytes);
+    REQUIRE(arena);
+
+    uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(i);
+
+    // This allocation would fit except for its alignment
+    uint8_t *j = datadog_php_arena_alloc(arena, 7, 2);
+    REQUIRE(!j);
+
+    datadog_php_arena_delete(arena);
+}

--- a/components/catch2_main.cc
+++ b/components/catch2_main.cc
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/components/channel/CMakeLists.txt
+++ b/components/channel/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(datadog-php-channel channel.c)
+target_include_directories(datadog-php-channel
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-channel
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+# libuv's pc file doesn't put -pthread into its link line, but it depends on it
+# for all our current platforms.
+find_package(Threads REQUIRED)
+target_link_libraries(datadog-php-channel
+  PRIVATE datadog-php-queue PkgConfig::UV Threads::Threads
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/channel/channel.c
+++ b/components/channel/channel.c
@@ -1,0 +1,178 @@
+#include "channel.h"
+
+#include <components/queue/queue.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uv.h>
+
+struct datadog_php_channel_impl_s {
+    datadog_php_queue queue;
+
+    // enforce single consumer (refcount should be 0 or 1)
+    uint32_t receiver_count;
+
+    /* Multiple producers are fine. When there aren't any items in the queue, the
+     * consumer will use this info to determine whether to try waiting for more
+     * data or to return empty handed. If there is a known producer, it will wait;
+     * otherwise it will return without waiting.
+     */
+    uint32_t sender_count;
+
+    uv_mutex_t mutex;
+    uv_cond_t condvar;
+    void *buffer[];
+};
+
+/**
+ * Destroys the channel. _NOT_ thread safe.
+ */
+static void channel_dtor(datadog_php_channel_impl *channel) {
+    uv_mutex_destroy(&channel->mutex);
+    uv_cond_destroy(&channel->condvar);
+    free(channel);
+}
+
+static bool receiver_recv(struct datadog_php_receiver_s *receiver, void **data, uint64_t timeout_nanos) {
+    if (!receiver || !receiver->channel) {
+        return false;
+    }
+
+    datadog_php_channel_impl *channel = receiver->channel;
+    uv_mutex_lock(&channel->mutex);
+    datadog_php_queue *queue = &channel->queue;
+    bool succeeded = queue->try_pop(queue, data);
+
+    // If there wasn't an item but there are known producers, wait and try again
+    if (!succeeded && channel->sender_count && timeout_nanos) {
+        uint64_t now = uv_hrtime();
+        uint64_t timeout_target = now + timeout_nanos;
+        do {
+            // Handle being signalled, waking up spuriously, and timing out the same.
+            (void)uv_cond_timedwait(&channel->condvar, &channel->mutex, timeout_target - now);
+            succeeded = queue->try_pop(queue, data);
+            if (succeeded) {
+                break;
+            }
+
+            now = uv_hrtime();
+        } while (channel->sender_count && now < timeout_target);
+    }
+
+    uv_mutex_unlock(&channel->mutex);
+    return succeeded;
+}
+
+static void receiver_dtor(struct datadog_php_receiver_s *receiver) {
+    if (receiver && receiver->channel) {
+        datadog_php_channel_impl *channel = receiver->channel;
+        receiver->channel = NULL;
+        uv_mutex_lock(&channel->mutex);
+        // todo: underflow checks
+        bool dtor = !(--channel->receiver_count | channel->sender_count);
+        uv_mutex_unlock(&channel->mutex);
+
+        // Cannot dtor the mutex while it is held.
+        if (dtor) {
+            channel_dtor(channel);
+        }
+    }
+}
+
+static bool sender_send(struct datadog_php_sender_s *sender, void *data) {
+    if (!sender || !sender->channel) {
+        return false;
+    }
+
+    datadog_php_channel_impl *channel = sender->channel;
+    uv_mutex_lock(&channel->mutex);
+    datadog_php_queue *queue = &channel->queue;
+    bool sent = queue->try_push(queue, data);
+    if (sent) {
+        uv_cond_signal(&channel->condvar);
+    }
+    uv_mutex_unlock(&channel->mutex);
+    return sent;
+}
+
+static void sender_dtor(struct datadog_php_sender_s *sender) {
+    if (sender && sender->channel) {
+        datadog_php_channel_impl *channel = sender->channel;
+        sender->channel = NULL;
+        uv_mutex_lock(&channel->mutex);
+        // todo: underflow check
+        bool dtor = !(channel->receiver_count | --channel->sender_count);
+        uv_mutex_unlock(&channel->mutex);
+
+        // Cannot dtor the mutex while it is held.
+        if (dtor) {
+            channel_dtor(channel);
+        }
+    }
+}
+
+static bool sender_clone(datadog_php_sender *self, datadog_php_sender *clone) {
+    if (!self || !clone || !self->channel) {
+        return false;
+    }
+
+    datadog_php_channel_impl *channel = self->channel;
+    uv_mutex_lock(&channel->mutex);
+    // todo: overflow checks
+    ++channel->sender_count;
+    uv_mutex_unlock(&channel->mutex);
+
+    *clone = *self;
+
+    return true;
+}
+
+// not thread safe
+static void receiver_ctor(datadog_php_receiver *receiver, datadog_php_channel_impl *channel) {
+    receiver->recv = receiver_recv;
+    receiver->dtor = receiver_dtor;
+    receiver->channel = channel;
+}
+
+// not thread safe
+static void sender_ctor(datadog_php_sender *sender, datadog_php_channel_impl *channel) {
+    sender->send = sender_send;
+    sender->clone = sender_clone;
+    sender->dtor = sender_dtor;
+    sender->channel = channel;
+}
+
+bool datadog_php_channel_ctor(datadog_php_channel *channel, uint16_t capacity) {
+    size_t bytes = offsetof(datadog_php_channel_impl, buffer) + sizeof(void *) * capacity;
+    datadog_php_channel_impl *impl = malloc(bytes);
+    if (!impl) {
+        return false;
+    }
+
+    receiver_ctor(&channel->receiver, impl);
+    sender_ctor(&channel->sender, impl);
+
+    if (!datadog_php_queue_ctor(&impl->queue, capacity, impl->buffer)) {
+        goto cleanup_impl;
+    }
+
+    impl->receiver_count = 1;
+    impl->sender_count = 1;
+
+    if (uv_mutex_init(&impl->mutex) != 0) {
+        goto cleanup_impl;
+    }
+
+    if (uv_cond_init(&impl->condvar) != 0) {
+        goto cleanup_mutex;
+    }
+
+    return true;
+
+cleanup_mutex:
+    uv_mutex_destroy(&impl->mutex);
+
+cleanup_impl:
+    free(impl);
+    return false;
+}

--- a/components/channel/channel.h
+++ b/components/channel/channel.h
@@ -1,0 +1,78 @@
+#ifndef DATADOG_PHP_CHANNEL_H
+#define DATADOG_PHP_CHANNEL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct datadog_php_receiver_s datadog_php_receiver;
+typedef struct datadog_php_sender_s datadog_php_sender;
+typedef struct datadog_php_channel_s datadog_php_channel;
+typedef struct datadog_php_channel_impl_s datadog_php_channel_impl;
+
+struct datadog_php_receiver_s {
+    /**
+     * Receives on item, waiting for a send to the channel if necessary.
+     * However, it may return empty-handed and return false, such as if there are
+     * no senders left, or the timeout is reached, or if it is interrupted.
+     */
+    bool (*recv)(datadog_php_receiver *self, void **data, uint64_t timeout_nanos);
+
+    /**
+     * Destructs the receiver.
+     */
+    void (*dtor)(datadog_php_receiver *self);
+
+    // private:
+    datadog_php_channel_impl *channel;
+};
+
+struct datadog_php_sender_s {
+    /**
+     * Sends data through the channel. May fail, in which case the caller is
+     * responsible for dtor'ing the data if applicable. Does not wait for the
+     * data to be received, only enqueued.
+     */
+    bool (*send)(datadog_php_sender *self, void *data);
+
+    /**
+     * Clones the sender. Can fail if there are too many senders already, in
+     * which false is returned and the caller should not dtor the clone.
+     */
+    bool (*clone)(datadog_php_sender *self, datadog_php_sender *clone);
+
+    /**
+     * Destructs the sender. Must be done on each successful clone as well.
+     */
+    void (*dtor)(datadog_php_sender *self);
+
+    // private:
+    datadog_php_channel_impl *channel;
+};
+
+/**
+ * datadog_php_channel is a bounded, multiple-producer, single-consumer channel
+ * suitable for inter-thread communication.
+ *
+ * The caller is responsible for any additional cleanup of contents; it does
+ * not assume pointers are malloc'd.
+ *
+ * The channel is not destructed directly. It must outlive any senders and
+ * receivers, and the last sender/receiver must dtor the channel when the
+ * last sender/receiver is destructed.
+ *
+ * In the end, I hope this is migrated to Rust, and then we can stop writing
+ * our own concurrency primitives and have better lifetime management.
+ */
+struct datadog_php_channel_s {
+    // public:
+    datadog_php_receiver receiver;
+    datadog_php_sender sender;
+};
+
+/**
+ * Creates a channel with the sender and receiver members fully initialized.
+ * The sender and receiver must be .dtor'd.
+ */
+bool datadog_php_channel_ctor(datadog_php_channel *channel, uint16_t capacity);
+
+#endif  // DATADOG_PHP_CHANNEL_H

--- a/components/channel/tests/CMakeLists.txt
+++ b/components/channel/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test-datadog-php-channel channel.cc)
+
+target_link_libraries(test-datadog-php-channel
+  PRIVATE Catch2::Catch2WithMain datadog-php-channel PkgConfig::UV
+)
+
+# Channels have deadlock opportunities, so set a timeout
+catch_discover_tests(test-datadog-php-channel PROPERTIES TIMEOUT 20)

--- a/components/channel/tests/channel.cc
+++ b/components/channel/tests/channel.cc
@@ -1,0 +1,149 @@
+extern "C" {
+#include <components/channel/channel.h>
+}
+
+#include <uv.h>
+
+#include <catch2/catch.hpp>
+
+static void print_assert(const char *expr, const char *file, int line) {
+    fprintf(stderr, "assertion \"%s\" failed: in file \"%s\", on line %d\n", expr, file, line);
+}
+
+// avoid UINT64_MAX due to likely math overflow logic errors
+static const uint64_t TIMEOUT = UINT64_C(10000000000);
+
+// Catch2's macros are not thread-safe, so return a bool for status
+struct args {
+    bool succeeded;
+    datadog_php_sender *sender;
+    datadog_php_receiver *receiver;
+};
+
+static void basic_receiver_job(args *args) {
+    datadog_php_receiver *receiver = args->receiver;
+    int *item;
+    // clang-format off
+#define ASSERT(EXPR) (void)((EXPR) || (print_assert(#EXPR, __FILE__, __LINE__), args->succeeded = false))
+    // clang-format on
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 1);
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 2);
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 3);
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 4);
+#undef ASSERT
+}
+
+TEST_CASE("basic channel operations", "[channel]") {
+    uv_thread_t receiver_thread;
+
+    constexpr const uint16_t n = 4;
+    int values[n] = {1, 2, 3, 4};
+
+    datadog_php_channel channel;
+    REQUIRE(datadog_php_channel_ctor(&channel, n));
+
+    datadog_php_receiver *receiver = &channel.receiver;
+    datadog_php_sender *sender = &channel.sender;
+
+    args args = {
+        true,
+        nullptr,
+        receiver,
+    };
+    REQUIRE(uv_thread_create(&receiver_thread, reinterpret_cast<uv_thread_cb>(basic_receiver_job), &args) == 0);
+
+    REQUIRE(sender->send(sender, &values[0]));
+    REQUIRE(sender->send(sender, &values[1]));
+    REQUIRE(sender->send(sender, &values[2]));
+    REQUIRE(sender->send(sender, &values[3]));
+
+    REQUIRE(uv_thread_join(&receiver_thread) == 0);
+
+    REQUIRE(args.succeeded);
+
+    receiver->dtor(receiver);
+    sender->dtor(sender);
+}
+
+static void stream_channel_ops(args *args) {
+    datadog_php_receiver *receiver = args->receiver;
+    datadog_php_sender *sender = args->sender;
+    int *item;
+
+    // clang-format off
+#define ASSERT(EXPR) (void)((EXPR) || (print_assert(#EXPR, __FILE__, __LINE__), args->succeeded = false))
+    // clang-format on
+
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 1);
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 2);
+
+    // notify the other channel we've recv'd the first two items
+    ASSERT(sender->send(sender, nullptr));
+
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 2);
+    ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    ASSERT(*item == 1);
+#undef ASSERT
+}
+
+TEST_CASE("stream channel operations", "[channel]") {
+    uv_thread_t receiver_thread;
+
+    constexpr const uint16_t n = 2;
+    int values[n] = {1, 2};
+
+    datadog_php_channel A, B;
+    REQUIRE(datadog_php_channel_ctor(&A, n));
+    REQUIRE(datadog_php_channel_ctor(&B, n));
+
+    args ops = {
+        true,
+        &B.sender,
+        &A.receiver,
+    };
+    REQUIRE(uv_thread_create(&receiver_thread, reinterpret_cast<uv_thread_cb>(stream_channel_ops), &ops) == 0);
+    REQUIRE(A.sender.send(&A.sender, &values[0]));
+    REQUIRE(A.sender.send(&A.sender, &values[1]));
+
+    /* Since the buffer is only 2 in size, we need to make sure the other values
+     * have been recv'd before sending new ones, or new ones will fail to send.
+     * This is the purpose of the second channel.
+     */
+    void *item;
+    REQUIRE(B.receiver.recv(&B.receiver, &item, TIMEOUT));
+
+    // The previous sends have been recv'd; we are clear to send new values.
+    A.sender.send(&A.sender, &values[1]);
+    A.sender.send(&A.sender, &values[0]);
+
+    REQUIRE(uv_thread_join(&receiver_thread) == 0);
+
+    REQUIRE(ops.succeeded);
+
+    A.receiver.dtor(&A.receiver);
+    A.sender.dtor(&A.sender);
+    B.receiver.dtor(&B.receiver);
+    B.sender.dtor(&B.sender);
+}
+
+TEST_CASE("channel empty recv does not wait if no producers", "[channel]") {
+    constexpr const uint16_t n = 1;
+    datadog_php_channel channel;
+    REQUIRE(datadog_php_channel_ctor(&channel, n));
+
+    // close the sender so when the receiver recvs there aren't any senders
+    channel.sender.dtor(&channel.sender);
+
+    void *item;
+    REQUIRE(!channel.receiver.recv(&channel.receiver, &item, TIMEOUT));
+    // todo: if this doesn't pass, it will likely run until the caller kills it
+
+    channel.receiver.dtor(&channel.receiver);
+}

--- a/components/container_id/CMakeLists.txt
+++ b/components/container_id/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_container_id container_id.c)
 
 target_include_directories(datadog_php_container_id
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -19,9 +19,9 @@ add_library(Datadog::Php::ContainerId
   ALIAS datadog_php_container_id
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/container_id.h

--- a/components/container_id/tests/CMakeLists.txt
+++ b/components/container_id/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(container_id
 )
 
 target_link_libraries(container_id
-  PUBLIC catch2_main Datadog::Php::ContainerId
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::ContainerId
 )
 
 file(

--- a/components/container_id/tests/container_id_from_file.cc
+++ b/components/container_id/tests/container_id_from_file.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 }
 
 #include <catch2/catch.hpp>

--- a/components/container_id/tests/container_id_parser.cc
+++ b/components/container_id/tests/container_id_parser.cc
@@ -1,10 +1,9 @@
 extern "C" {
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 }
 
-#include <cstring>
-
 #include <catch2/catch.hpp>
+#include <cstring>
 
 #define MAX_ID_LEN DATADOG_PHP_CONTAINER_ID_MAX_LEN
 
@@ -36,12 +35,7 @@ TEST_CASE("parser: invalid cgroup lines", "[container_id_parser]") {
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
 
     const char *lines[] = {
-        "foo line",
-        "a4:perf_event:/",
-        ":perf_event:/",
-        "1:perf_event",
-        "\n",
-        "",
+        "foo line", "a4:perf_event:/", ":perf_event:/", "1:perf_event", "\n", "",
     };
 
     for (const char *line : lines) {
@@ -84,7 +78,7 @@ TEST_CASE("parser: fail to parse a container ID", "[container_id_parser]") {
 
     const char *lines[] = {
         "d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",  // 63 characters
-        "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",  // Task ID
+        "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",                      // Task ID
         "",
         "a",
         "zd5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",
@@ -183,7 +177,7 @@ TEST_CASE("parser: fail to parse a task ID", "[container_id_parser]") {
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
 
     const char *lines[] = {
-        "4dc0b5e626f2c5c4c5170e34b10e765-1234567890",  // 31 hex characters
+        "4dc0b5e626f2c5c4c5170e34b10e765-1234567890",                        // 31 hex characters
         "9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",  // Container ID
         "34dc0b5e626f2c5c4c5170e34b10e765-",
         "a-0",
@@ -212,7 +206,8 @@ TEST_CASE("parser: fail to parse a task ID", "[container_id_parser]") {
 TEST_CASE("parser: successfully parse a Kubernetes container ID", "[container_id_parser]") {
     dd_parser parser;
     char buf[MAX_ID_LEN + 1] = {0};
-    const char line[] = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope";
+    const char line[] =
+        "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope";
 
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
     REQUIRE(parser.extract_container_id(&parser, buf, line));

--- a/components/log/CMakeLists.txt
+++ b/components/log/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(datadog-php-log OBJECT log.c)
+
+target_include_directories(datadog-php-log
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-log
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+target_link_libraries(datadog-php-log PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -1,0 +1,159 @@
+#include "log.h"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+// The names are long, so let's add a convenience helpers
+typedef datadog_php_logger logger_t;
+typedef datadog_php_log_level log_level_t;
+typedef datadog_php_string_view string_view_t;
+
+/**
+ * Ensures the logger looks like it should be logging anything at all.
+ *
+ * # Safety
+ * Mutex must exist and be locked prior to calling this function if used in a
+ * multi-threaded context.
+ * `logger` must not be null.
+ */
+__attribute__((nonnull)) static bool logger_valid(datadog_php_logger *logger) {
+    return logger->descriptor >= 0 && logger->log_level >= DATADOG_PHP_LOG_OFF &&
+           logger->log_level <= DATADOG_PHP_LOG_DEBUG;
+}
+
+__attribute__((nonnull)) bool datadog_php_logger_ctor(logger_t *logger, int descriptor, log_level_t log_level,
+                                                      pthread_mutex_t *mutex) {
+    *logger = (logger_t){
+        .descriptor = descriptor < 0 ? -1 : descriptor,  // normalize invalid
+        .log_level = log_level,
+        .mutex = mutex,
+    };
+    return logger_valid(logger);
+}
+
+void datadog_php_logger_dtor(logger_t *logger) {
+    logger->descriptor = -1;
+    logger->log_level = DATADOG_PHP_LOG_UNKNOWN;
+    logger->mutex = NULL;
+}
+
+static int64_t durable_write(const logger_t *logger, string_view_t message) {
+    /* We attempt to handle some of the error conditions possible:
+     *  1. Partial writes
+     *  2. EAGAIN and EWOULDBLOCK
+     *  3. EINTR
+     * We limit the number of times we'll retry an operation for the above.
+     * For other errors we stop attempting to log and move on.
+     * todo: should we set the fd to -1 for some errors like EIO/EPIPE?
+     */
+    size_t written = 0;
+    unsigned tries = 0, max_tries = 3;  // arbitrarily chosen
+    while (written < message.len && tries++ < max_tries) {
+        ssize_t n = write(logger->descriptor, message.ptr + written, message.len - written);
+        if (n < 0) {
+            /* POSIX.1-2001 allows either error to be returned for this case, and does
+             * not require these constants to have the same value, so a portable
+             * application should check for both possibilities.
+             */
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                continue;
+            } else {
+                break;
+            }
+        }
+        written += n;
+    }
+    return written == message.len ? (int64_t)written : -1;
+}
+
+static int64_t log_writev(logger_t *logger, log_level_t level, size_t n_messages,
+                          string_view_t messages[static n_messages]) {
+    if (logger->log_level < level) {
+        return 0;
+    }
+
+    int64_t written = 0;
+    for (size_t i = 0; i != n_messages; ++i) {
+        int64_t result = durable_write(logger, messages[i]);
+        if (result < 0) break;
+        written += result;
+    }
+
+    // try to append a newline
+    ssize_t result = write(logger->descriptor, "\n", 1);
+    if (result > 0) written += result;
+    return written;
+}
+
+void datadog_php_log(logger_t *logger, log_level_t level, string_view_t message) {
+    (void)datadog_php_logv(logger, level, 1, &message);
+}
+
+int64_t datadog_php_logv(datadog_php_logger *logger, datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[static n_messages]) {
+    if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+        int64_t result = logger_valid(logger) ? log_writev(logger, level, n_messages, messages) : -1;
+        (void)pthread_mutex_unlock(logger->mutex);
+        return result;
+    }
+    return -1;
+}
+
+static char datadog_tolower_ascii(char c) { return (char)(c >= 'A' && c <= 'Z' ? (c - ('A' - 'a')) : c); }
+
+static void datadog_copy_tolower(char *restrict dst, const char *restrict src, size_t len) {
+    for (size_t i = 0; i != len; ++i) {
+        *(dst++) = datadog_tolower_ascii(src[i]);
+    }
+}
+
+log_level_t datadog_php_log_level_detect(string_view_t val) {
+    // Treat nullptr and a string of length 0 the same: default to off.
+    if (!val.ptr || val.len == 0) return DATADOG_PHP_LOG_OFF;
+
+    // If the level string's length is greater than 5, it's definitely unknown.
+    if (val.len > 5) return DATADOG_PHP_LOG_UNKNOWN;
+
+    // 8 chars is more than enough to hold the remaining strings.
+    _Alignas(8) char buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    // lowercase to make this a case-insensitive operation
+    datadog_copy_tolower(buffer, val.ptr, val.len);
+    string_view_t level_string = {.len = val.len, .ptr = buffer};
+
+    struct {
+        string_view_t str;
+        log_level_t level;
+    } options[] = {
+        {{3, "off"}, DATADOG_PHP_LOG_OFF},
+        {{5, "error"}, DATADOG_PHP_LOG_ERROR},
+        {{4, "warn"}, DATADOG_PHP_LOG_WARN},
+        {{4, "info"}, DATADOG_PHP_LOG_INFO},
+        {{5, "debug"}, DATADOG_PHP_LOG_DEBUG},
+
+        /* This case goes last. We've already ruled out this case above; this is
+         * for unifying known and unknown code paths below.
+         */
+        {{0, ""}, DATADOG_PHP_LOG_UNKNOWN},
+    };
+
+    // the last option is only used for its enum, so take off 1
+    unsigned i, n_options = (sizeof options / sizeof *options) - 1;
+    for (i = 0; i != n_options; ++i) {
+        if (datadog_php_string_view_equal(options[i].str, level_string)) {
+            break;
+        }
+    }
+    return options[i].level;
+}
+
+/**
+ * Sets the current log level of the application.
+ */
+void datadog_php_log_level_set(logger_t *logger, log_level_t level) {
+    if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+        logger->log_level = level;
+        pthread_mutex_unlock(logger->mutex);
+    }
+}

--- a/components/log/log.h
+++ b/components/log/log.h
@@ -1,0 +1,102 @@
+#ifndef DATADOG_PHP_PROFILER_LOG_H
+#define DATADOG_PHP_PROFILER_LOG_H
+
+#include <components/string_view/string_view.h>
+#include <pthread.h>
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+typedef enum {
+    DATADOG_PHP_LOG_UNKNOWN = -1,
+    DATADOG_PHP_LOG_OFF = 0,
+    DATADOG_PHP_LOG_ERROR,
+    DATADOG_PHP_LOG_WARN,
+    DATADOG_PHP_LOG_INFO,
+    DATADOG_PHP_LOG_DEBUG,
+} datadog_php_log_level;
+
+// This is for the compiler to use; please do not use it directly!
+typedef struct datadog_php_logger_s {
+    int descriptor;  // borrowed, not owned
+    int log_level;
+    pthread_mutex_t *mutex;  // borrowed, not owned
+} datadog_php_logger;
+
+#define DATADOG_PHP_LOGGER_INIT \
+    { -1, DATADOG_PHP_LOG_UNKNOWN, NULL }
+
+/**
+ * Creates a logger instance in `logger`. The result may be valid or invalid;
+ * check the return value: `true` for valid.
+ *
+ * For now, only file descriptors are expected to work, but other types are
+ * expected to work in the future.
+ */
+__attribute__((nonnull)) bool datadog_php_logger_ctor(datadog_php_logger *logger, int descriptor,
+                                                      datadog_php_log_level log_level, pthread_mutex_t *mutex);
+
+/**
+ * Sets the .descriptor to -1, .log_level to `DATADOG_PROFILER_LOG_UNKNOWN`,
+ * and the .mutex to NULL.
+ *
+ * This is not threadsafe! It also doesn't close the descriptor nor destroy the
+ * mutex, as they are borrowed, not owned. Only do this when the program is
+ * back in single-threaded mode, or you risk a race condition.
+ *
+ * @param logger
+ */
+void datadog_php_logger_dtor(datadog_php_logger *logger);
+
+/**
+ * If the `logger` is set to at least `level`, then the message will be logged.
+ * Otherwise it will be ignored.
+ * @param logger
+ * @param level
+ * @param message
+ */
+void datadog_php_log(datadog_php_logger *logger, datadog_php_log_level level, datadog_php_string_view message);
+
+/**
+ * If the `logger` is set to at least `level`, then the messages will be logged.
+ * Otherwise they will be ignored.
+ * @param logger
+ * @param level
+ * @param n_messages
+ * @param messages
+ * @return Bytes written
+ */
+int64_t datadog_php_logv(datadog_php_logger *logger, datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[C_STATIC(n_messages)]);
+
+/**
+ * Sets the current `.log_level` of the logger.
+ * Inputs of UNKNOWN are ignored, and the logger retain its current values.
+ *
+ * Generally the `.log_level` should be set at construction and remain
+ * unchanged. However, there may be reasons to change it. Here are a few:
+ *   - A logger may need to be be constructed so it can be shared by multiple
+ *     objects prior to knowing the runtime setting of the log level.
+ *   - At a certain point during datadog_php_log_plugin_shutdown, logging may
+ * need to be set to off but since the logger is still being borrowed by other
+ * objects it cannot be destructed.
+ */
+void datadog_php_log_level_set(datadog_php_logger *, datadog_php_log_level);
+
+/**
+ * Converts `val` to a recognized log level.
+ * Returns `DATADOG_PROFILER_LOG_UNKNOWN` if it does not recognize a level.
+ * Accepted strings are the following, comparison is case insensitive:
+ *   "" (defaults to off), "off", "error", "warn", "info", "debug"
+ * @param val
+ * @return The detected log_level (may be DATADOG_PROFILER_LOG_UNKNOWN).
+ */
+datadog_php_log_level datadog_php_log_level_detect(datadog_php_string_view val);
+
+#undef C_STATIC
+
+#endif  // DATADOG_PHP_PROFILER_LOG_H

--- a/components/log/tests/CMakeLists.txt
+++ b/components/log/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test-datadog-php-log log.cc)
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(test-datadog-php-log
+  PRIVATE Catch2::Catch2WithMain datadog-php-log datadog_php_string_view Threads::Threads
+)
+
+catch_discover_tests(test-datadog-php-log)

--- a/components/log/tests/log.cc
+++ b/components/log/tests/log.cc
@@ -1,0 +1,71 @@
+extern "C" {
+#include <components/log/log.h>
+}
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <catch2/catch.hpp>
+#include <cerrno>
+#include <climits>
+#include <cstring>
+
+int generate_memfd(void **mem, size_t len) {
+    if (len > INT_MAX) return -1;
+
+    FILE *file = tmpfile();
+    int fd = fileno(file);
+    *mem = nullptr;
+    if (fd != -1) {
+        // int cast is guarded above
+        if (ftruncate(fd, (int)len)) {
+            fclose(file);
+            return -1;
+        }
+
+        int prot = PROT_READ | PROT_WRITE;
+        int flags = MAP_SHARED | MAP_FILE;
+        *mem = mmap(nullptr, len, prot, flags, fd, 0);
+        if (*mem == MAP_FAILED) {
+            fprintf(stderr, "%s\n", strerror(errno));
+            *mem = nullptr;
+            fclose(file);
+            return -1;
+        }
+    }
+    return fd;
+}
+
+TEST_CASE("logv", "[log]") {
+    char *mem;
+    size_t mem_len = 32;
+    int fd = generate_memfd((void **)&mem, mem_len);
+    REQUIRE(fd != -1);
+    REQUIRE(mem);
+    REQUIRE(mem != MAP_FAILED);
+
+    pthread_mutex_t mutex;
+    REQUIRE(pthread_mutex_init(&mutex, nullptr) == 0);
+
+    datadog_php_logger logger = DATADOG_PHP_LOGGER_INIT;
+    REQUIRE(datadog_php_logger_ctor(&logger, fd, DATADOG_PHP_LOG_DEBUG, &mutex));
+
+    datadog_php_string_view messages[3] = {
+        {datadog_php_string_view_from_cstr("[Datadog Profiling] ")},
+        {datadog_php_string_view_from_cstr("Stack Collector failed to join; ")},
+        {datadog_php_string_view_from_cstr("EDEADLK")},
+    };
+    auto written = datadog_php_logv(&logger, DATADOG_PHP_LOG_ERROR, 3, messages);
+    CHECK(written >= 0);
+
+    auto expect = datadog_php_string_view_from_cstr("[Datadog Profiling] Stack Collector failed to join; EDEADLK\n");
+    auto actual = datadog_php_string_view{static_cast<size_t>(written), mem};
+    CHECK(datadog_php_string_view_equal(expect, actual));
+
+    datadog_php_logger_dtor(&logger);
+    CHECK(munmap(mem, mem_len) == 0);
+    CHECK(close(fd) == 0);
+    CHECK(pthread_mutex_destroy(&mutex) == 0);
+}

--- a/components/queue/CMakeLists.txt
+++ b/components/queue/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(datadog-php-queue queue.c)
+target_include_directories(datadog-php-queue
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-queue
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/queue/queue.c
+++ b/components/queue/queue.c
@@ -1,0 +1,39 @@
+#include "queue.h"
+
+static bool queue_try_push(struct datadog_php_queue_s *queue, void *item) {
+    if (queue->size == queue->capacity) {
+        return false;
+    }
+    ++queue->size;
+    queue->buffer[queue->head] = item;
+    queue->head = (queue->head + 1) % queue->capacity;
+    return true;
+}
+
+static bool queue_try_pop(struct datadog_php_queue_s *queue, void **item_ref) {
+    bool has_item = queue->size;
+    if (has_item) {
+        *item_ref = queue->buffer[queue->tail];
+        --queue->size;
+        queue->tail = (queue->tail + 1) % queue->capacity;
+    }
+    return has_item;
+}
+
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[]) {
+    if (!queue || (capacity && !buffer)) {
+        return false;
+    }
+
+    datadog_php_queue q = {
+        .size = 0,
+        .capacity = capacity,
+        .head = 0,
+        .tail = 0,
+        .buffer = buffer,
+        .try_push = queue_try_push,
+        .try_pop = queue_try_pop,
+    };
+    *queue = q;
+    return true;
+}

--- a/components/queue/queue.h
+++ b/components/queue/queue.h
@@ -1,0 +1,29 @@
+#ifndef DATADOG_PHP_QUEUE_H
+#define DATADOG_PHP_QUEUE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * A bounded, NOT thread-safe queue.
+ * If you are interested in thread-safety, look at datadog_php_channel.
+ *
+ * Since this is C, ergonomic, data-type generic queues are beyond us.
+ * Instead, we assume the caller will to dtor/free the items in the queue as
+ * necessary.
+ */
+typedef struct datadog_php_queue_s {
+    /* We track size instead of computing it from head and tail so that we can
+     * use all buffer slots for storage.
+     */
+    uint16_t size, capacity;
+    uint16_t head, tail;
+    void **buffer;  // borrowed, not owned
+
+    bool (*try_push)(struct datadog_php_queue_s *queue, void *item);
+    bool (*try_pop)(struct datadog_php_queue_s *queue, void **item_ref);
+} datadog_php_queue;
+
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[]);
+
+#endif  // DATADOG_PHP_QUEUE_H

--- a/components/queue/tests/CMakeLists.txt
+++ b/components/queue/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-queue queue.cc)
+target_link_libraries(test-datadog-php-queue
+  PRIVATE Catch2::Catch2WithMain datadog-php-queue
+)
+
+catch_discover_tests(test-datadog-php-queue)

--- a/components/queue/tests/queue.cc
+++ b/components/queue/tests/queue.cc
@@ -1,0 +1,57 @@
+extern "C" {
+#include <components/queue/queue.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("empty queue operations", "[queue]") {
+    datadog_php_queue queue;
+    REQUIRE(datadog_php_queue_ctor(&queue, 0, nullptr));
+
+    void *item = nullptr;
+    REQUIRE(!queue.try_push(&queue, item));
+    REQUIRE(!queue.try_pop(&queue, &item));
+}
+
+TEST_CASE("basic queue operations", "[queue]") {
+    datadog_php_queue queue;
+    constexpr const unsigned n = 4;
+    void *buffer[n];
+    REQUIRE(datadog_php_queue_ctor(&queue, n, buffer));
+
+    // we are just pushing in addresses; these values never get dereferenced
+    void *item;
+    void *items[n];
+
+    // by iterating a few times, we may have wrapped (depending on impl)
+    for (unsigned i = 0; i != n; ++i) {
+        REQUIRE(queue.try_push(&queue, items + 0));
+        REQUIRE(queue.try_push(&queue, items + 1));
+        REQUIRE(queue.try_push(&queue, items + 2));
+        REQUIRE(queue.try_push(&queue, items + 3));
+
+        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(item == items + 0);
+
+        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(item == items + 1);
+
+        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(item == items + 2);
+
+        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(item == items + 3);
+    }
+}
+
+TEST_CASE("full queue push", "[queue]") {
+    datadog_php_queue queue;
+    constexpr const unsigned n = 1;
+    void *buffer[n];
+    REQUIRE(datadog_php_queue_ctor(&queue, n, buffer));
+
+    void *items[n];
+
+    REQUIRE(queue.try_push(&queue, items + 0));
+    REQUIRE(!queue.try_push(&queue, items + 0));
+}

--- a/components/sapi/CMakeLists.txt
+++ b/components/sapi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_sapi sapi.c)
 
 target_include_directories(datadog_php_sapi
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -23,9 +23,9 @@ add_library(Datadog::Php::Sapi
   ALIAS datadog_php_sapi
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sapi.h

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -1,4 +1,4 @@
-#include "sapi/sapi.h"
+#include "sapi.h"
 
 typedef datadog_php_sapi sapi_t;
 typedef datadog_php_string_view string_view_t;
@@ -6,6 +6,10 @@ typedef datadog_php_string_view string_view_t;
 #define SV(cstr) DATADOG_PHP_STRING_VIEW_LITERAL(cstr)
 
 sapi_t datadog_php_sapi_from_name(string_view_t module) {
+    if (!module.ptr || module.len == 0) {
+        return DATADOG_PHP_SAPI_UNKNOWN;
+    }
+
     struct {
         string_view_t str;
         sapi_t type;
@@ -29,3 +33,5 @@ sapi_t datadog_php_sapi_from_name(string_view_t module) {
 
     return DATADOG_PHP_SAPI_UNKNOWN;
 }
+
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module) { return datadog_php_sapi_from_name(module); }

--- a/components/sapi/sapi.h
+++ b/components/sapi/sapi.h
@@ -1,7 +1,7 @@
 #ifndef DATADOG_PHP_SAPI_H
 #define DATADOG_PHP_SAPI_H
 
-#include "string_view/string_view.h"
+#include <components/string_view/string_view.h>
 
 typedef enum {
     DATADOG_PHP_SAPI_UNKNOWN = 0,
@@ -16,5 +16,6 @@ typedef enum {
 } datadog_php_sapi;
 
 datadog_php_sapi datadog_php_sapi_from_name(datadog_php_string_view module);
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module);
 
 #endif  // DATADOG_PHP_SAPI_H

--- a/components/sapi/tests/CMakeLists.txt
+++ b/components/sapi/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(sapi sapi.cc)
 
 target_link_libraries(sapi
-  PUBLIC catch2_main Datadog::Php::Sapi
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::Sapi
 )
 
 catch_discover_tests(sapi)

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "sapi/sapi.h"
+#include <components/sapi/sapi.h>
 }
 
 #include <catch2/catch.hpp>

--- a/components/stack-sample/CMakeLists.txt
+++ b/components/stack-sample/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(datadog-php-stack-sample OBJECT stack-sample.c stack-sample.h)
+
+target_include_directories(datadog-php-stack-sample
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-stack-sample PUBLIC c_std_11)
+
+target_link_libraries(datadog-php-stack-sample PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/stack-sample/stack-sample.c
+++ b/components/stack-sample/stack-sample.c
@@ -1,0 +1,113 @@
+#include "stack-sample.h"
+
+#include <string.h>
+
+/* Done in the impl instead of the header because on CentOS 6 in gnu++11 mode
+ * it fails in the header. The header gets included in C++ mode for testing. */
+_Static_assert(sizeof(struct datadog_php_stack_sample_s) <= 8192u,
+               "datadog_php_stack_sample should be less than or equal to 8KiB");
+
+typedef datadog_php_stack_sample stack_sample_t;
+typedef datadog_php_stack_sample_frame stack_sample_frame_t;
+typedef datadog_php_stack_sample_iterator stack_sample_iterator_t;
+typedef datadog_php_string_view string_view_t;
+
+static void stack_sample_default_ctor(stack_sample_t *sample) {
+    memset(sample, 0, sizeof *sample);
+
+    // we store an empty string with null terminator at position 0
+    sample->buffer_len = 1;
+}
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *sample) { stack_sample_default_ctor(sample); }
+
+uint16_t datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample) { return sample->depth; }
+
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *sample) { stack_sample_default_ctor(sample); }
+
+static bool try_add_string(stack_sample_t *sample, string_view_t string, uint16_t *offset) {
+    // we pack all empty strings into offset 0
+    if (string.len == 0) {
+        *offset = 0;
+        return true;
+    }
+
+    // ensure there is room for the string
+    if (sample->buffer_len + string.len + 1 <= sizeof(sample->buffer)) {
+        uint16_t off = sample->buffer_len;
+        memcpy(&sample->buffer[off], string.ptr, string.len);
+
+        // null-terminate the string; we rely on ctor's memzero for this and just +1
+        sample->buffer_len += string.len + 1;
+        *offset = off;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool datadog_php_stack_sample_try_add(stack_sample_t *sample, stack_sample_frame_t frame) {
+    uint16_t depth = sample->depth;
+    if (depth >= datadog_php_stack_sample_max_depth) {
+        return false;
+    }
+
+    uint16_t function_off;
+    if (!try_add_string(sample, frame.function, &function_off)) {
+        return false;
+    }
+    sample->function_off[depth] = function_off;
+    sample->function_len[depth] = frame.function.len;
+
+    uint16_t file_off;
+    if (!try_add_string(sample, frame.file, &file_off)) {
+        return false;
+    }
+    sample->file_off[depth] = file_off;
+    sample->file_len[depth] = frame.file.len;
+
+    sample->lineno[depth] = frame.lineno;
+    ++sample->depth;
+
+    return true;
+}
+
+stack_sample_iterator_t datadog_php_stack_sample_iterator_ctor(const stack_sample_t *sample) {
+    stack_sample_iterator_t iterator = {
+        .sample = sample,
+        .depth = 0,
+    };
+    return iterator;
+}
+
+void datadog_php_stack_sample_iterator_dtor(stack_sample_iterator_t *iterator) {
+    iterator->sample = NULL;
+    iterator->depth = 0;
+}
+
+void datadog_php_stack_sample_iterator_rewind(stack_sample_iterator_t *iterator) { iterator->depth = 0; }
+
+bool datadog_php_stack_sample_iterator_valid(stack_sample_iterator_t *iterator) {
+    return iterator->sample && iterator->depth < iterator->sample->depth;
+}
+
+uint16_t datadog_php_stack_sample_iterator_depth(const stack_sample_iterator_t *iterator) { return iterator->depth; }
+
+stack_sample_frame_t datadog_php_stack_sample_iterator_frame(stack_sample_iterator_t *iterator) {
+    const stack_sample_t *sample = iterator->sample;
+    uint16_t depth = iterator->depth;
+
+    const char *function = &sample->buffer[sample->function_off[depth]];
+    size_t function_len = sample->function_len[depth];
+
+    const char *file = &sample->buffer[sample->file_off[depth]];
+    size_t file_len = sample->file_len[depth];
+    stack_sample_frame_t frame = {
+        .function = {function_len, function},
+        .file = {file_len, file},
+        .lineno = sample->lineno[depth],
+    };
+    return frame;
+}
+
+void datadog_php_stack_sample_iterator_next(stack_sample_iterator_t *iterator) { ++iterator->depth; }

--- a/components/stack-sample/stack-sample.h
+++ b/components/stack-sample/stack-sample.h
@@ -1,0 +1,68 @@
+#ifndef DATADOG_PHP_STACK_SAMPLE_H
+#define DATADOG_PHP_STACK_SAMPLE_H
+
+#include <components/string_view/string_view.h>
+#include <stdint.h>
+
+#define DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH 101u
+static const uint16_t datadog_php_stack_sample_max_depth = DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH;
+
+/* Keep the sizes in sync with datadog_php_stack_sample_max_depth.
+ * C doesn't allow for static const variables to be used as array sizes and I
+ * really don't want to use macros.
+ *
+ * Treat this as opaque so as it's easier to test structure-of-arrays vs
+ * array-of-structures and other layout optimizations.
+ */
+typedef struct datadog_php_stack_sample_s {
+    uint16_t depth;
+    uint16_t buffer_len;
+
+    /* We save quite a bit of space by using offsets into the buffer instead of
+     * storing full pointers (16 bit vs 64 bit).
+     * We leave room for 1 more frame than datadog_php_stack_sample_max_depth for
+     * a summary frame ($x more frames).
+     */
+    uint16_t function_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t function_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t file_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t file_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    int64_t lineno[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+
+    /* The strings need to point into this buffer. It's sized so that there are
+     * 64 bytes per entry, which on average may not be enough, but does allow for
+     * deeper stacks if the function and file names are on the shorter side.
+     */
+    char buffer[(DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1) * 64u];
+} datadog_php_stack_sample;
+
+typedef struct datadog_php_stack_sample_frame_s {
+    datadog_php_string_view function;
+    datadog_php_string_view file;
+    int64_t lineno;
+} datadog_php_stack_sample_frame;
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *);
+uint16_t datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample);
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *);
+
+bool datadog_php_stack_sample_try_add(datadog_php_stack_sample *, datadog_php_stack_sample_frame);
+
+typedef struct datadog_php_stack_sample_iterator {
+    const datadog_php_stack_sample *sample;
+    uint16_t depth;
+} datadog_php_stack_sample_iterator;
+
+datadog_php_stack_sample_iterator datadog_php_stack_sample_iterator_ctor(const datadog_php_stack_sample *);
+
+void datadog_php_stack_sample_iterator_dtor(datadog_php_stack_sample_iterator *iterator);
+
+bool datadog_php_stack_sample_iterator_valid(datadog_php_stack_sample_iterator *iterator);
+
+uint16_t datadog_php_stack_sample_iterator_depth(const datadog_php_stack_sample_iterator *iterator);
+
+datadog_php_stack_sample_frame datadog_php_stack_sample_iterator_frame(datadog_php_stack_sample_iterator *iterator);
+
+void datadog_php_stack_sample_iterator_next(datadog_php_stack_sample_iterator *iterator);
+
+#endif  // DATADOG_PHP_STACK_SAMPLE_H

--- a/components/stack-sample/tests/CMakeLists.txt
+++ b/components/stack-sample/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-stack-sample stack-sample.cc)
+target_link_libraries(test-datadog-php-stack-sample
+  PRIVATE Catch2::Catch2WithMain datadog-php-stack-sample datadog_php_string_view
+)
+
+catch_discover_tests(test-datadog-php-stack-sample)

--- a/components/stack-sample/tests/stack-sample.cc
+++ b/components/stack-sample/tests/stack-sample.cc
@@ -1,0 +1,61 @@
+extern "C" {
+#include <components/stack-sample/stack-sample.h>
+#include <components/string_view/string_view.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("empty ctor and dtor", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_depth(&sample) == 0u);
+
+    datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("empty iterator ctor and dtor", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    datadog_php_stack_sample_iterator iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    for (iterator = datadog_php_stack_sample_iterator_ctor(&sample); datadog_php_stack_sample_iterator_valid(&iterator);
+         datadog_php_stack_sample_iterator_next(&iterator)) {
+    }
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    datadog_php_stack_sample_iterator_dtor(&iterator);
+    datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("iterator", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    const datadog_php_stack_sample_frame main_frame = {datadog_php_string_view_from_cstr("{main}"),
+                                                       datadog_php_string_view_from_cstr("/srv/public/index.php"), 3};
+    CHECK(datadog_php_stack_sample_try_add(&sample, main_frame));
+
+    CHECK(datadog_php_stack_sample_depth(&sample) == 1u);
+
+    auto iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    for (iterator = datadog_php_stack_sample_iterator_ctor(&sample); datadog_php_stack_sample_iterator_valid(&iterator);
+         datadog_php_stack_sample_iterator_next(&iterator)) {
+        auto frame = datadog_php_stack_sample_iterator_frame(&iterator);
+        CHECK(datadog_php_string_view_equal(frame.function, main_frame.function));
+        CHECK(datadog_php_string_view_equal(frame.file, main_frame.file));
+        CHECK(frame.lineno == main_frame.lineno);
+    }
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 1u);
+
+    datadog_php_stack_sample_iterator_dtor(&iterator);
+    datadog_php_stack_sample_dtor(&sample);
+}

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_string_view string_view.c)
 
 target_include_directories(datadog_php_string_view
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -19,9 +19,9 @@ add_library(Datadog::Php::StringView
   ALIAS datadog_php_string_view
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h

--- a/components/string_view/string_view.c
+++ b/components/string_view/string_view.c
@@ -2,12 +2,12 @@
 
 #include <string.h>
 
-datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]) {
-    datadog_php_string_view string_view = {
-        .len = cstr ? strlen(cstr) : 0,
-        .ptr = cstr ? cstr : "",
-    };
-    return string_view;
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr) {
+    if (cstr) {
+        return (datadog_php_string_view){.len = strlen(cstr), .ptr = cstr};
+    } else {
+        return (datadog_php_string_view){.len = 0, .ptr = ""};
+    }
 }
 
 bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b) {

--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -32,11 +32,11 @@ typedef struct datadog_php_string_view {
     { sizeof(cstr) - 1, cstr }
 
 /**
- * Creates a string view from a C string, which is an array of char which is
- * terminated by a null byte. Derives the length from strlen. `cstr` may be
- * null, in which case the `.len` will be 0.
+ * Converts the C string `cstr` into a string view by getting its length from
+ * `strlen`. Null is permitted and will become an empty string.
+ * @param cstr May be nullptr.
  */
-datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]);
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr);
 
 /**
  * Compares the views `a` and `b` for equality. Note that the `.ptr` value of

--- a/components/string_view/tests/CMakeLists.txt
+++ b/components/string_view/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(string_view string_view.cc)
 
 target_link_libraries(string_view
-  PUBLIC catch2_main Datadog::Php::StringView
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::StringView
 )
 
 catch_discover_tests(string_view)

--- a/components/string_view/tests/string_view.cc
+++ b/components/string_view/tests/string_view.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "string_view/string_view.h"
+#include <components/string_view/string_view.h>
 }
 
 #include <catch2/catch.hpp>
@@ -28,7 +28,7 @@ TEST_CASE("string_view cstrings", "[string_view]") {
     const char buff[5] = "four";
     datadog_php_string_view four = datadog_php_string_view_from_cstr(buff);
     REQUIRE(four.len == 4);
-    REQUIRE((const void*)four.ptr == (const void*)&buff);
+    REQUIRE((const void *)four.ptr == (const void *)&buff);
 }
 
 TEST_CASE("string_view empty equal", "[string_view]") {
@@ -46,7 +46,7 @@ TEST_CASE("string_view empty equal", "[string_view]") {
 TEST_CASE("string_view equal", "[string_view]") {
     const char buff1[] = "asdf";
     char buff2[sizeof buff1];
-    memcpy((void*)buff2, buff1, sizeof buff1);
+    memcpy((void *)buff2, buff1, sizeof buff1);
 
     datadog_php_string_view str1 = datadog_php_string_view_from_cstr(buff1);
     datadog_php_string_view str2 = datadog_php_string_view_from_cstr(buff2);
@@ -54,6 +54,35 @@ TEST_CASE("string_view equal", "[string_view]") {
     REQUIRE(datadog_php_string_view_equal(str1, str2));
 
     // identity cases
-    REQUIRE(datadog_php_string_view_equal(str1, str1));
-    REQUIRE(datadog_php_string_view_equal(str2, str2));
+    CHECK(datadog_php_string_view_equal(str1, str1));
+    CHECK(datadog_php_string_view_equal(str2, str2));
+
+    char a[] = "aBcDE01234";
+    char b[] = "abcde01234";
+
+    auto x = datadog_php_string_view_from_cstr(a);
+    auto y = datadog_php_string_view_from_cstr(b);
+    CHECK(!datadog_php_string_view_equal(x, y));
+
+    for (auto &ch : a) {
+        ch = (char)(unsigned char)tolower((unsigned char)ch);
+    }
+
+    CHECK(datadog_php_string_view_equal(x, y));
+}
+
+TEST_CASE("string_view equal different lengths", "[string_view]") {
+    char a[] = "aBcDE0";
+    char b[] = "abcde01234";
+
+    auto x = datadog_php_string_view_from_cstr(a);
+    auto y = datadog_php_string_view_from_cstr(b);
+    CHECK(!datadog_php_string_view_equal(x, y));
+
+    for (auto &ch : a) {
+        ch = (char)(unsigned char)tolower((unsigned char)ch);
+    }
+
+    // still not equal after lower-casing
+    CHECK(!datadog_php_string_view_equal(x, y));
 }

--- a/components/time/CMakeLists.txt
+++ b/components/time/CMakeLists.txt
@@ -1,0 +1,94 @@
+add_library(datadog-php-time OBJECT time.c time.h)
+
+target_include_directories(datadog-php-time
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+include(CheckCSourceRuns)
+include(CMakePushCheckState)
+
+find_package(Threads)
+
+check_c_source_runs("
+#include <time.h>
+
+int main(void) {
+  struct timespec ts;
+  return timespec_get(&ts, TIME_UTC) == TIME_UTC ? 0 : 1;
+}
+" DATADOG_HAVE_TIMESPEC_GET)
+
+if (DATADOG_HAVE_TIMESPEC_GET)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_TIMESPEC_GET=1)
+endif ()
+
+#[[ Prior to glibc 2.17, librt was required for clock_gettime.
+    Check for it without flags first.
+]]
+cmake_push_check_state(RESET)
+check_c_source_runs("#include <time.h>
+
+int main(void) {
+struct timespec ts;
+return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;
+}
+" DATADOG_HAVE_CLOCK_GETTIME)
+
+cmake_pop_check_state()
+
+if (NOT DATADOG_HAVE_CLOCK_GETTIME)
+  # Try again with -lrt
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES -lrt)
+  check_c_source_runs("#include <time.h>
+
+int main(void) {
+struct timespec ts;
+return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;
+}
+" DATADOG_HAVE_CLOCK_GETTIME_RT)
+
+  if (DATADOG_HAVE_CLOCK_GETTIME_RT)
+    target_link_libraries(datadog-php-time PRIVATE -lrt)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_CLOCK_GETTIME=1)
+
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+  check_c_source_runs("
+  #include <pthread.h>
+  #include <time.h>
+
+  int main(void) {
+    clockid_t clockid;
+    // consider the fact the API exists good enough; it may still fail at runtime,
+    // and that's okay; it just needs to exist.
+    (void)pthread_getcpuclockid(pthread_self(), &clockid);
+    return 0;
+  }
+  " DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+  if (DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+    target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+check_c_source_runs("#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+int main(void) {
+	mach_port_t thread = mach_thread_self();
+	mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+	thread_basic_info_data_t info;
+	(void)thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);
+	return 0;
+}
+" DATADOG_HAVE_THREAD_INFO)
+
+if (DATADOG_HAVE_THREAD_INFO)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
+endif ()

--- a/components/time/time.c
+++ b/components/time/time.c
@@ -1,0 +1,91 @@
+#include "time.h"
+
+typedef datadog_php_system_time_result system_time_result_t;
+
+#if DATADOG_HAVE_TIMESPEC_GET
+/* timespec_get is from C11 and is supposed to be available on:
+ * Linux on glibc 2.16+
+ * Windows ... can't tell exactly, but at least VS 2019
+ * Mac 10.15
+ */
+system_time_result_t datadog_php_system_time_now(struct timespec *now) {
+    return timespec_get(now, TIME_UTC) == TIME_UTC ? DATADOG_PHP_SYSTEM_TIME_OK : DATADOG_PHP_SYSTEM_TIME_ERR;
+}
+#elif DATADOG_HAVE_CLOCK_GETTIME
+/* clock_gettime is from POSIX:
+ * Linux
+ * Windows (unsupported at time of writing)
+ * Mac 10.12+
+ */
+system_time_result_t datadog_php_system_time_now(struct timespec *now) {
+    return clock_gettime(CLOCK_REALTIME, now) == 0 ? DATADOG_PHP_SYSTEM_TIME_OK : DATADOG_PHP_SYSTEM_TIME_ERR;
+}
+#else
+#error Unhandled platform for system time
+#endif
+
+#if DATADOG_HAVE_PTHREAD_GETCPUCLOCKID
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+// will probably syntax error if false
+_Static_assert(DATADOG_HAVE_CLOCK_GETTIME, "HAVE_PTHREAD_GETCPUCLOCKID assumes DATADOG_HAVE_CLOCK_GETTIME");
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+    struct timespec timespec;
+    clockid_t clockid;  //  todo: cache this?
+
+    if (pthread_getcpuclockid(pthread_self(), &clockid)) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = strerror(errno),
+        };
+    }
+
+    if (clock_gettime(clockid, &timespec)) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = strerror(errno),
+        };
+    }
+
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_OK,
+        .ok = timespec,
+    };
+}
+
+#elif DATADOG_HAVE_THREAD_INFO
+
+#include <mach/mach_error.h>
+#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+    mach_port_t thread = mach_thread_self();
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    thread_basic_info_data_t info;
+    kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+
+    if (kr != KERN_SUCCESS) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = mach_error_string(kr),
+        };
+    }
+
+    struct timespec timespec = {
+        .tv_sec = info.user_time.seconds + info.system_time.seconds,
+        .tv_nsec = (info.user_time.microseconds + info.system_time.microseconds) * 1000,
+    };
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_OK,
+        .ok = timespec,
+    };
+}
+
+#else
+#error Unhandled platform for cpu time
+#endif

--- a/components/time/time.h
+++ b/components/time/time.h
@@ -1,0 +1,31 @@
+#ifndef DATADOG_PHP_SYSTEM_TIME_H
+#define DATADOG_PHP_SYSTEM_TIME_H
+
+#include <stdint.h>
+#include <time.h>
+
+// This component exists to paper over differences in time across platforms.
+
+typedef enum datadog_php_system_time_result {
+    DATADOG_PHP_SYSTEM_TIME_OK = 0,
+    DATADOG_PHP_SYSTEM_TIME_ERR,
+} datadog_php_system_time_result;
+
+datadog_php_system_time_result datadog_php_system_time_now(struct timespec *ts);
+
+typedef enum datadog_php_cpu_time_result_tag {
+    DATADOG_PHP_CPU_TIME_OK,
+    DATADOG_PHP_CPU_TIME_ERR,
+} datadog_php_cpu_time_result_tag;
+
+typedef struct datadog_php_cpu_time_result_s {
+    datadog_php_cpu_time_result_tag tag;
+    union {
+        struct timespec ok;
+        const char *err;  // c-string describing error; static lifetime
+    };
+} datadog_php_cpu_time_result;
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void);
+
+#endif  // DATADOG_PHP_SYSTEM_TIME_H

--- a/components/uuid/CMakeLists.txt
+++ b/components/uuid/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_library(datadog-php-uuid uuid.c)
+
+target_include_directories(datadog-php-uuid
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(datadog-php-uuid
+  PUBLIC c_std_11
+)
+
+set_target_properties(datadog-php-uuid PROPERTIES
+  EXPORT_NAME Uuid
+  VERSION ${PROJECT_VERSION}
+)
+
+add_library(Datadog::Php::Uuid
+  ALIAS datadog-php-uuid
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/uuid.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uuid/
+)
+
+target_link_libraries(datadog_php_components
+  INTERFACE datadog-php-uuid
+)
+
+install(TARGETS datadog-php-uuid
+  EXPORT DatadogPhpComponentsTargets
+)

--- a/components/uuid/tests/CMakeLists.txt
+++ b/components/uuid/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test-datadog-php-uuid uuid.cc)
+
+target_link_libraries(test-datadog-php-uuid
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::Uuid
+)
+
+catch_discover_tests(test-datadog-php-uuid)

--- a/components/uuid/tests/uuid.cc
+++ b/components/uuid/tests/uuid.cc
@@ -1,0 +1,85 @@
+extern "C" {
+#include <components/uuid/uuid.h>
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("uuid encode32 nil", "[uuid]") {
+    datadog_php_uuid uuid;
+    datadog_php_uuid_default_ctor(&uuid);
+
+    alignas(16) char dest[32];
+    datadog_php_uuid_encode32(uuid, dest);
+
+    alignas(16) char expect[33] = "00000000000000000000000000000000";
+    CHECK(memcmp(expect, dest, 32) == 0);
+}
+
+TEST_CASE("uuid encode32", "[uuid]") {
+    datadog_php_uuid uuid = {
+        {29, 202, 33, 60, 217, 201, 77, 49, 162, 30, 13, 192, 25, 215, 90, 236},
+    };
+
+    alignas(32) char dest[32];
+    datadog_php_uuid_encode32(uuid, dest);
+
+    alignas(32) char expect[33] = "1dca213cd9c94d31a21e0dc019d75aec";
+    CHECK(memcmp(expect, dest, 32) == 0);
+}
+
+TEST_CASE("uuid encode36", "[uuid]") {
+    datadog_php_uuid uuid = {
+        {190, 40, 194, 233, 78, 82, 76, 113, 164, 20, 69, 167, 221, 234, 5, 240},
+    };
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuid, dest);
+
+    alignas(32) char expect[37] = "be28c2e9-4e52-4c71-a414-45a7ddea05f0";
+    CHECK(memcmp(expect, dest, 36) == 0);
+}
+
+TEST_CASE("uuidv4 encode36 easy", "[uuid]") {
+    // this byte pattern is already a valid UUIDv4, so we won't change it
+    alignas(16) uint8_t bytes[16] = {190, 40, 194, 233, 78, 82, 76, 113, 164, 20, 69, 167, 221, 234, 5, 240};
+    datadog_php_uuid uuidv4;
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect[37] = "be28c2e9-4e52-4c71-a414-45a7ddea05f0";
+    CHECK(memcmp(expect, dest, 36) == 0);
+}
+
+TEST_CASE("uuidv4 encode36 bytes 6", "[uuid]") {
+    datadog_php_uuid uuidv4;
+
+    /* These tests are valid UUIDv4s except for byte 6, which we are testing
+     * that it alters correctly.
+     */
+
+    /* byte 6 is 10111111; upper bits are flipped, lower all 1s which shouldn't
+     * change at all.
+     */
+    alignas(16) uint8_t bytes[16] = {190, 40, 194, 233, 78, 82, 191, 113, 164, 20, 69, 167, 221, 234, 5, 240};
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    alignas(32) char dest[36];
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect1[37] = "be28c2e9-4e52-4f71-a414-45a7ddea05f0";
+    CHECK(memcmp(expect1, dest, 36) == 0);
+
+    /* byte 6 is 10110000; upper bits are flipped, lower all 0s which shouldn't
+     * change at all.
+     */
+    bytes[6] = 176;
+    datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+
+    datadog_php_uuid_encode36(uuidv4, dest);
+
+    alignas(32) char expect2[37] = "be28c2e9-4e52-4071-a414-45a7ddea05f0";
+    CHECK(memcmp(expect2, dest, 36) == 0);
+}

--- a/components/uuid/uuid.c
+++ b/components/uuid/uuid.c
@@ -1,0 +1,102 @@
+#include "uuid.h"
+
+/**
+ * @param byte A number in the range 0 to 15, inclusive. If the value is out of
+ *             this range, the result is undefined.
+ * @return The equivalent hex char [0-9a-f].
+ */
+static char nibble_to_hex(uint8_t byte) {
+    /* Simple algorithm:
+     *   if byte > 9 then byte + 'a' - 10
+     *   else byte + '0'
+     * We can make this branchless using this known pattern for turning
+     * conditional assignments into cmov* instructions.
+     *   x = ( a > b ) ? C : D;
+     * into:
+     *   x = D;
+     *   if ( a > b ) x += C - D;
+     * Check the asm output to ensure it, of course.
+     */
+    uint8_t C = 'a' - 10;
+    uint8_t D = '0';
+    uint8_t x = D + byte;
+    if (byte > 9) x += C - D;
+    return x;
+}
+
+void datadog_php_uuid_default_ctor(datadog_php_uuid *uuid) {
+    for (unsigned i = 0; i != 16; ++i) {
+        uuid->data[i] = 0;
+    }
+}
+
+void datadog_php_uuidv4_bytes_ctor(datadog_php_uuid *uuid, const uint8_t src[static 16]) {
+    for (unsigned i = 0; i != 16; ++i) {
+        uuid->data[i] = src[i];
+    }
+
+    /* See RFC 4122, section 4.4
+     * Algorithms for Creating a UUID from Truly Random or Pseudo-Random Numbers
+     */
+
+    /* Set the four most significant bits (bits 12 through 15) of the
+     * time_hi_and_version field to the 4-bit version number from
+     * Section 4.1.3.
+     * ----
+     * We want this pattern, where X preserves what is there.
+     * 0100XXXX
+     */
+    uuid->data[6] = 0x40 | (uuid->data[6] & 0xf);
+
+    /* Set the two most significant bits (bits 6 and 7) of the
+     * clock_seq_hi_and_reserved to zero and one, respectively.
+     * -----
+     * We want this pattern, where X preserves what is there.
+     * 10XXXXXX
+     */
+    uuid->data[8] = 0x80 | (uuid->data[8] & 0x3f);
+}
+
+void datadog_php_uuid_encode32(datadog_php_uuid uuid, char dest[static 32]) {
+    char *out = dest;
+    for (unsigned i = 0; i < 16; ++i, out += 2) {
+        uint8_t in = uuid.data[i];
+        char first = nibble_to_hex(in >> UINT8_C(4));
+        char second = nibble_to_hex(in & UINT8_C(15));
+        *out = first;
+        *(out + 1) = second;
+    }
+}
+
+void datadog_php_uuid_encode36(datadog_php_uuid uuid, char dest[static 36]) {
+    /* This could be more efficient if we didn't call to encode32 and then
+     * fix it up after, but this is not performance sensitive.
+     */
+    _Alignas(16) char src[32];
+    datadog_php_uuid_encode32(uuid, src);
+
+    unsigned dest_offset = 0, src_offset = 0;
+    for (unsigned i = 0; i++ != 8; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 4; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+
+    dest[dest_offset++] = '-';
+    for (unsigned i = 0; i++ != 12; ++dest_offset, ++src_offset) {
+        dest[dest_offset] = src[src_offset];
+    }
+}

--- a/components/uuid/uuid.h
+++ b/components/uuid/uuid.h
@@ -1,0 +1,59 @@
+#ifndef DATADOG_PHP_UUID
+#define DATADOG_PHP_UUID
+
+#include <stdalign.h>
+#include <stdint.h>
+
+#if __cplusplus
+/* C++ doesn't support this form of static: char src[static 16]
+ * so we expand it to nothing. */
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+typedef struct datadog_php_uuid {
+    // Since this is a 16-byte type, let's use a 16 byte alignment
+    alignas(16) uint8_t data[16];
+} datadog_php_uuid;
+
+#define DATADOG_PHP_UUID_INIT                              \
+    {                                                      \
+        { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } \
+    }
+
+void datadog_php_uuid_default_ctor(datadog_php_uuid *);
+
+/**
+ * Creates a UUIDv4 from the provided bytes. This decouples the UUIDv4
+ * invariants from the algorithm that generates random numbers, so be cautious
+ * that you pass random bytes to it (or are testing specific bit patterns).
+ *
+ * @param uuid
+ * @param src At least 16 random bytes
+ */
+void datadog_php_uuidv4_bytes_ctor(datadog_php_uuid *uuid, const uint8_t src[C_STATIC(16)]);
+
+/**
+ * Encodes the `uuid` into a 32 character ASCII string. This is the same as the
+ * 36 character ASCII string defined by RFC 4122 except with the '-' chars
+ * removed. A null terminator is NOT written.
+ *
+ * @param uuid The UUID to encode.
+ * @param dest A char buffer at least 32 chars in length.
+ */
+void datadog_php_uuid_encode32(datadog_php_uuid uuid, char dest[C_STATIC(32)]);
+
+/**
+ * Encodes the `uuid` into a 36 character ASCII string as defined by RFC 4122
+ * (https://tools.ietf.org/html/rfc4122#section-4.1), and stores the result in
+ * `dest`. A null terminator is NOT written.
+ *
+ * @param uuid The UUID to encode.
+ * @param dest A char buffer at least 36 chars in length.
+ */
+void datadog_php_uuid_encode36(datadog_php_uuid uuid, char dest[C_STATIC(36)]);
+
+#undef C_STATIC
+
+#endif  // DATADOG_PHP_UUID

--- a/config.m4
+++ b/config.m4
@@ -277,7 +277,6 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_INCLUDE([$ext_srcdir])
   PHP_ADD_INCLUDE([$ext_srcdir/ext])
 
-  PHP_ADD_INCLUDE([$ext_srcdir/components])
   PHP_ADD_BUILD_DIR([$ext_builddir/components])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/container_id])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/sapi])

--- a/ext/php5/ddshared.c
+++ b/ext/php5/ddshared.c
@@ -1,6 +1,6 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php5/ddshared.h
+++ b/ext/php5/ddshared.h
@@ -3,8 +3,6 @@
 
 #include <TSRM/TSRM.h>
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(TSRMLS_D);
 
 char *ddshared_container_id(void);

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -40,7 +41,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"

--- a/ext/php7/ddshared.c
+++ b/ext/php7/ddshared.c
@@ -1,6 +1,7 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
+
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php7/ddshared.h
+++ b/ext/php7/ddshared.h
@@ -1,8 +1,6 @@
 #ifndef DD_TRACE_SHARED_H
 #define DD_TRACE_SHARED_H
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(void);
 
 char *ddshared_container_id(void);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_smart_str.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -42,7 +43,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"

--- a/ext/php8/ddshared.c
+++ b/ext/php8/ddshared.c
@@ -1,6 +1,7 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
+
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php8/ddshared.h
+++ b/ext/php8/ddshared.h
@@ -1,8 +1,6 @@
 #ifndef DD_TRACE_SHARED_H
 #define DD_TRACE_SHARED_H
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(void);
 
 char *ddshared_container_id(void);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_smart_str.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -42,7 +43,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"


### PR DESCRIPTION
### Description

This merges the profiling components and gets them running in CI. They
aren't used yet, so I haven't modified config.m4.

This will make the code review for the upcoming profiling PR easier by
reducing the amount of code looked at it in each PR.

Also rename `BUILD_COMPONENTS_TESTING` to `DATADOG_PHP_TESTING`.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
