### PR TITLE
Use internal root spans in Integrations in place of using the legacy API

### DIFF
--- a/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/DDTrace/Integrations/CakePHP/CakePHPIntegration.php
@@ -3,7 +3,6 @@
 namespace DDTrace\Integrations\CakePHP;
 
 use CakeRequest;
-use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -2,8 +2,6 @@
 
 namespace DDTrace\Integrations\CodeIgniter\V2;
 
-use DDTrace\Contracts\Span;
-use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
@@ -27,11 +25,10 @@ class CodeIgniterIntegration extends Integration
     public function init()
     {
 
-        $tracer = GlobalTracer::get();
 
         $integration = $this;
-        $rootScope = $tracer->getRootScope();
-        if (!$rootScope) {
+        $rootSpan = \DDTrace\root_span();
+        if (null === $rootSpan) {
             return Integration::NOT_LOADED;
         }
         $service = \ddtrace_config_app_name(self::NAME);
@@ -40,7 +37,7 @@ class CodeIgniterIntegration extends Integration
             'CI_Router',
             '_set_routing',
             null,
-            function ($router) use ($integration, $rootScope, $service) {
+            function ($router) use ($integration, $rootSpan, $service) {
                 if (!\defined('CI_VERSION') || !isset($router)) {
                     return;
                 }
@@ -49,7 +46,7 @@ class CodeIgniterIntegration extends Integration
                     /* After _set_routing has been called the class and method
                      * are known, so now we can set up tracing on CodeIgniter.
                      */
-                    $integration->registerIntegration($router, $rootScope->getSpan(), $service);
+                    $integration->registerIntegration($router, $rootSpan, $service);
                 }
             }
         );
@@ -57,20 +54,16 @@ class CodeIgniterIntegration extends Integration
         return parent::LOADED;
     }
 
-    public function registerIntegration(\CI_Router $router, Span $root, $service)
+    public function registerIntegration(\CI_Router $router, SpanData $rootSpan, $service)
     {
-        $this->addTraceAnalyticsIfEnabledLegacy($root);
-        $root->overwriteOperationName('codeigniter.request');
-        $root->setTag(Tag::SERVICE_NAME, $service);
-        $root->setTag(Tag::SPAN_TYPE, Type::WEB_SERVLET);
+        $this->addTraceAnalyticsIfEnabled($rootSpan);
+        $rootSpan->name = 'codeigniter.request';
+        $rootSpan->service = $service;
+        $rootSpan->type = Type::WEB_SERVLET;
 
         if ('cli' !== PHP_SAPI) {
             $normalizedPath = \DDtrace\Private_\util_uri_normalize_incoming_path($_SERVER['REQUEST_URI']);
-            $root->setTag(
-                Tag::RESOURCE_NAME,
-                "{$_SERVER['REQUEST_METHOD']} $normalizedPath",
-                true
-            );
+            $rootSpan->resource = "{$_SERVER['REQUEST_METHOD']} $normalizedPath";
         }
 
         $controller = $router->fetch_class();
@@ -79,15 +72,15 @@ class CodeIgniterIntegration extends Integration
         \DDTrace\trace_method(
             $controller,
             $method,
-            function (SpanData $span) use ($root, $method, $service) {
+            function (SpanData $span) use ($rootSpan, $method, $service) {
                 $class = \get_class($this);
                 $span->name = $span->resource = "{$class}.{$method}";
                 $span->service = $service;
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $root->setTag(Tag::HTTP_URL, base_url(uri_string()));
-                $root->setTag('app.endpoint', "{$class}::{$method}");
+                $rootSpan->meta[Tag::HTTP_URL] = base_url(uri_string());
+                $rootSpan->meta['app.endpoint'] = "{$class}::{$method}";
             }
         );
 
@@ -101,7 +94,7 @@ class CodeIgniterIntegration extends Integration
         \DDTrace\trace_method(
             $controller,
             '_remap',
-            function (SpanData $span, $args, $retval, $ex) use ($root, $service) {
+            function (SpanData $span, $args, $retval, $ex) use ($rootSpan, $service) {
                 $class = \get_class($this);
 
                 $span->name = "{$class}._remap";
@@ -110,8 +103,8 @@ class CodeIgniterIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $root->setTag(Tag::HTTP_URL, base_url(uri_string()));
-                $root->setTag('app.endpoint', "{$class}::_remap");
+                $rootSpan->meta[Tag::HTTP_URL] = base_url(uri_string());
+                $rootSpan->meta['app.endpoint'] = "{$class}::_remap";
             }
         );
 

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -79,7 +79,7 @@ class CodeIgniterIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $rootSpan->meta[Tag::HTTP_URL] = base_url(uri_string());
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(base_url(uri_string()));
                 $rootSpan->meta['app.endpoint'] = "{$class}::{$method}";
             }
         );
@@ -103,7 +103,7 @@ class CodeIgniterIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $rootSpan->meta[Tag::HTTP_URL] = base_url(uri_string());
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(base_url(uri_string()));
                 $rootSpan->meta['app.endpoint'] = "{$class}::_remap";
             }
         );

--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Guzzle;
 
-use DDTrace\GlobalTracer;
 use DDTrace\Http\Urls;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
@@ -25,9 +24,8 @@ class GuzzleIntegration extends Integration
             return Integration::NOT_LOADED;
         }
 
-        $tracer = GlobalTracer::get();
-        $rootScope = $tracer->getRootScope();
-        if (!$rootScope) {
+        $rootSpan = \DDTrace\root_span();
+        if (!$rootSpan) {
             return Integration::NOT_LOADED;
         }
 

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -184,7 +184,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Foundation\Http\Kernel',
             'renderException',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (!$rootSpan->exception) {
+                if (empty($rootSpan->exception)) {
                     $integration->setError($rootSpan, $args[1]);
                 }
             }
@@ -194,7 +194,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Routing\Pipeline',
             'handleException',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (!$rootSpan->exception) {
+                if (empty($rootSpan->exception)) {
                     $integration->setError($rootSpan, $args[1]);
                 }
             }

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Laravel;
 
-use DDTrace\Contracts\Span;
 use DDTrace\SpanData;
 use DDTrace\Integrations\Integration;
 use DDTrace\Tag;
@@ -219,7 +218,7 @@ class LaravelIntegration extends Integration
     /**
      * Tells whether a span is a lumen request.
      *
-     * @param Span $rootSpan
+     * @param SpanData $rootSpan
      * @return bool
      */
     public function isLumen(SpanData $rootSpan)

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -92,7 +92,7 @@ class LaravelIntegration extends Integration
 
                 $rootSpan->meta['laravel.route.name'] = $routeName;
                 $rootSpan->meta['laravel.route.action'] = $route->getActionName();
-                $rootSpan->meta[Tag::HTTP_URL] = $request->url();
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize($request->url());
                 $rootSpan->meta[Tag::HTTP_METHOD] = $request->method();
             }
         );

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -92,8 +92,8 @@ class LaravelIntegration extends Integration
 
                 $rootSpan->meta['laravel.route.name'] = $routeName;
                 $rootSpan->meta['laravel.route.action'] = $route->getActionName();
-                $rootSpan->meta['http.url'] = $request->url();
-                $rootSpan->meta['http.method'] = $request->method();
+                $rootSpan->meta[Tag::HTTP_URL] = $request->url();
+                $rootSpan->meta[Tag::HTTP_METHOD] = $request->method();
             }
         );
 

--- a/src/DDTrace/Integrations/Lumen/LumenIntegration.php
+++ b/src/DDTrace/Integrations/Lumen/LumenIntegration.php
@@ -55,7 +55,7 @@ class LumenIntegration extends Integration
                 $rootSpan->name = 'lumen.request';
                 $rootSpan->service = $appName;
                 $integration->addTraceAnalyticsIfEnabled($rootSpan);
-                $rootSpan->meta[Tag::HTTP_URL] = $request->getUri();
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize($request->getUri());
                 $rootSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
                 return false;
             }

--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -108,7 +108,7 @@ class SlimIntegration extends Integration
 
                     /** @var ServerRequestInterface $request */
                     $request = $args[1];
-                    $rootSpan->meta[Tag::HTTP_URL] = (string) $request->getUri();
+                    $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize((string) $request->getUri());
 
                     if ('4' === $majorVersion) {
                         $span->name = 'slim.route';

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -156,8 +156,9 @@ class SymfonyIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $integration->symfonyRequestSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
-                $integration->symfonyRequestSpan->meta[Tag::HTTP_URL] =
-                    $request->getUriForPath($request->getPathInfo());
+                $integration->symfonyRequestSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(
+                    $request->getUriForPath($request->getPathInfo())
+                );
                 if (isset($response)) {
                     $integration->symfonyRequestSpan->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
                 }

--- a/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
@@ -2,12 +2,8 @@
 
 namespace DDTrace\Integrations\WordPress\V4;
 
-use DDTrace\Contracts\Scope;
-use DDTrace\GlobalTracer;
-use DDTrace\Http\Urls;
 use DDTrace\Integrations\WordPress\WordPressIntegration;
 use DDTrace\Integrations\Integration;
-use DDTrace\Contracts\Span;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
@@ -15,30 +11,25 @@ use DDTrace\Type;
 class WordPressIntegrationLoader
 {
     /**
-     * @var Span
+     * @var SpanData
      */
     public $rootSpan;
 
     public function load(WordPressIntegration $integration)
     {
-        $scope = GlobalTracer::get()->getRootScope();
-        if (!$scope instanceof Scope) {
+        $this->rootSpan = \DDTrace\root_span();
+        if (!$this->rootSpan) {
             return Integration::NOT_LOADED;
         }
-        $this->rootSpan = $scope->getSpan();
         // Overwrite the default web integration
-        $integration->addTraceAnalyticsIfEnabledLegacy($this->rootSpan);
-        $this->rootSpan->overwriteOperationName('wordpress.request');
+        $integration->addTraceAnalyticsIfEnabled($this->rootSpan);
+        $this->rootSpan->name = 'wordpress.request';
         $service = \ddtrace_config_app_name(WordPressIntegration::NAME);
-        $this->rootSpan->setTag(Tag::SERVICE_NAME, $service);
+        $this->rootSpan->service = $service;
         if ('cli' !== PHP_SAPI) {
             $normalizedPath = \DDtrace\Private_\util_uri_normalize_incoming_path($_SERVER['REQUEST_URI']);
-            $this->rootSpan->setTag(
-                Tag::RESOURCE_NAME,
-                $_SERVER['REQUEST_METHOD'] . ' ' . $normalizedPath,
-                true
-            );
-            $this->rootSpan->setTag(Tag::HTTP_URL, home_url(add_query_arg($_GET)));
+            $this->rootSpan->resource = $_SERVER['REQUEST_METHOD'] . ' ' . $normalizedPath;
+            $this->rootSpan->meta[Tag::HTTP_URL] = home_url(add_query_arg($_GET));
         }
 
         // Core

--- a/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/V4/WordPressIntegrationLoader.php
@@ -29,7 +29,7 @@ class WordPressIntegrationLoader
         if ('cli' !== PHP_SAPI) {
             $normalizedPath = \DDtrace\Private_\util_uri_normalize_incoming_path($_SERVER['REQUEST_URI']);
             $this->rootSpan->resource = $_SERVER['REQUEST_METHOD'] . ' ' . $normalizedPath;
-            $this->rootSpan->meta[Tag::HTTP_URL] = home_url(add_query_arg($_GET));
+            $this->rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(home_url(add_query_arg($_GET)));
         }
 
         // Core

--- a/src/DDTrace/Integrations/Yii/YiiIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiIntegration.php
@@ -2,8 +2,6 @@
 
 namespace DDTrace\Integrations\Yii;
 
-use DDTrace\Contracts\Scope;
-use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
@@ -54,12 +52,12 @@ class YiiIntegration extends Integration
 
     public function loadV2()
     {
-        $scope = GlobalTracer::get()->getRootScope();
-        if (!$scope instanceof Scope) {
-            return;
+        $rootSpan = \DDTrace\root_span();
+        if (!$rootSpan) {
+            return Integration::NOT_LOADED;
         }
-        $root = $scope->getSpan();
-        $this->addTraceAnalyticsIfEnabledLegacy($root);
+
+        $this->addTraceAnalyticsIfEnabled($rootSpan);
         $service = \ddtrace_config_app_name(YiiIntegration::NAME);
 
         \DDTrace\trace_method(
@@ -96,31 +94,31 @@ class YiiIntegration extends Integration
                 $span->name = \get_class($this) . '.runAction';
                 $span->type = Type::WEB_SERVLET;
                 $span->service = $service;
-                $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ? : $span->name;
+                $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ?: $span->name;
             }
         );
 
         \DDTrace\trace_method(
             'yii\base\Controller',
             'runAction',
-            function (SpanData $span, $args) use (&$firstController, $service, $root) {
+            function (SpanData $span, $args) use (&$firstController, $service, $rootSpan) {
                 $span->name = \get_class($this) . '.runAction';
                 $span->type = Type::WEB_SERVLET;
                 $span->service = $service;
-                $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ? : $span->name;
+                $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ?: $span->name;
 
                 if (
                     $firstController === $this
-                    && $root->getTag('app.endpoint') === null
+                    && $rootSpan->meta['app.endpoint'] === null
                     && isset($this->action->actionMethod)
                 ) {
                     $controller = \get_class($this);
                     $endpoint = "{$controller}::{$this->action->actionMethod}";
-                    $root->setTag("app.endpoint", $endpoint);
-                    $root->setTag(Tag::HTTP_URL, Url::base(true) . Url::current());
+                    $rootSpan->meta["app.endpoint"] = $endpoint;
+                    $rootSpan->meta[Tag::HTTP_URL] = Url::base(true) . Url::current();
                 }
 
-                if ($root->getTag('app.route.path') === null) {
+                if ($rootSpan->meta['app.route.path'] === null) {
                     $route = $this->module->requestedRoute;
                     $namedParams = [$route];
                     $placeholders = [$route];
@@ -132,10 +130,10 @@ class YiiIntegration extends Integration
                     }
 
                     $routePath = \urldecode(Url::toRoute($namedParams));
-                    $root->setTag('app.route.path', $routePath);
+                    $rootSpan->meta['app.route.path'] = $routePath;
 
                     $resourceName = \urldecode(Url::toRoute($placeholders));
-                    $root->setTag(Tag::RESOURCE_NAME, "{$_SERVER['REQUEST_METHOD']} {$resourceName}", true);
+                    $rootSpan->resource = "{$_SERVER['REQUEST_METHOD']} {$resourceName}";
                 }
             }
         );

--- a/src/DDTrace/Integrations/Yii/YiiIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiIntegration.php
@@ -109,7 +109,7 @@ class YiiIntegration extends Integration
 
                 if (
                     $firstController === $this
-                    && $rootSpan->meta['app.endpoint'] === null
+                    && empty($rootSpan->meta['app.endpoint'])
                     && isset($this->action->actionMethod)
                 ) {
                     $controller = \get_class($this);
@@ -118,7 +118,7 @@ class YiiIntegration extends Integration
                     $rootSpan->meta[Tag::HTTP_URL] = Url::base(true) . Url::current();
                 }
 
-                if ($rootSpan->meta['app.route.path'] === null) {
+                if (empty($rootSpan->meta['app.route.path'])) {
                     $route = $this->module->requestedRoute;
                     $namedParams = [$route];
                     $placeholders = [$route];

--- a/src/DDTrace/Integrations/Yii/YiiIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiIntegration.php
@@ -115,7 +115,8 @@ class YiiIntegration extends Integration
                     $controller = \get_class($this);
                     $endpoint = "{$controller}::{$this->action->actionMethod}";
                     $rootSpan->meta["app.endpoint"] = $endpoint;
-                    $rootSpan->meta[Tag::HTTP_URL] = Url::base(true) . Url::current();
+                    $rootSpan->meta[Tag::HTTP_URL] =
+                        \DDTrace\Private_\util_url_sanitize(Url::base(true) . Url::current());
                 }
 
                 if (empty($rootSpan->meta['app.route.path'])) {

--- a/src/DDTrace/Integrations/Yii/YiiIntegration.php
+++ b/src/DDTrace/Integrations/Yii/YiiIntegration.php
@@ -123,17 +123,23 @@ class YiiIntegration extends Integration
                     $route = $this->module->requestedRoute;
                     $namedParams = [$route];
                     $placeholders = [$route];
+                    $placeholder = '__dd_route_param';
                     if (isset($args[1]) && \is_array($args[1]) && !empty($args[1])) {
                         foreach ($args[1] as $param => $unused) {
                             $namedParams[$param] = ":{$param}";
-                            $placeholders[$param] = '?';
+                            $placeholders[$param] = $placeholder;
                         }
                     }
 
-                    $routePath = \urldecode(Url::toRoute($namedParams));
+                    $routePath = \DDTrace\Private_\util_url_sanitize(\urldecode(Url::toRoute($namedParams)));
                     $rootSpan->meta['app.route.path'] = $routePath;
 
-                    $resourceName = \urldecode(Url::toRoute($placeholders));
+                    error_log('Url to route: ' . var_export(\urldecode(Url::toRoute($placeholders)), true));
+                    $resourceName = \str_replace(
+                        $placeholder,
+                        '?',
+                        \DDTrace\Private_\util_url_sanitize(\urldecode(Url::toRoute($placeholders)))
+                    );
                     $rootSpan->resource = "{$_SERVER['REQUEST_METHOD']} {$resourceName}";
                 }
             }

--- a/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/Ddtrace.php
@@ -2,20 +2,12 @@
 
 require __DIR__ . '/../../../autoload.php';
 
-use DDTrace\GlobalTracer;
 use DDTrace\Integrations\Integration;
 use DDTrace\Integrations\ZendFramework\V1\TraceRequest;
-use DDTrace\Tag;
-use DDTrace\Tracer;
 
 class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
 {
     const NAME = 'zf1';
-
-    /**
-     * @var Tracer
-     */
-    private $tracer;
 
     public function init()
     {
@@ -25,12 +17,9 @@ class DDTrace_Ddtrace extends Zend_Application_Resource_ResourceAbstract
         $front = Zend_Controller_Front::getInstance();
         $front->registerPlugin(new TraceRequest());
 
-        $tracer = GlobalTracer::get();
-        $span = $tracer->getRootScope()->getSpan();
-        $span->overwriteOperationName(self::getOperationName());
-        $span->setTag(Tag::SERVICE_NAME, \ddtrace_config_app_name(self::NAME));
-
-        return $this->tracer;
+        $span = \DDTrace\root_span();
+        $span->name = self::getOperationName();
+        $span->service = \ddtrace_config_app_name(self::NAME);
     }
 
     /**

--- a/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
@@ -42,7 +42,7 @@ class TraceRequest extends Zend_Controller_Plugin_Abstract
      */
     public function postDispatch(Zend_Controller_Request_Abstract $request)
     {
-        $span = \DDTrace\root_span();;
+        $span = \DDTrace\root_span();
         if (null === $span) {
             return;
         }

--- a/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
+++ b/src/DDTrace/Integrations/ZendFramework/V1/TraceRequest.php
@@ -31,10 +31,11 @@ class TraceRequest extends Zend_Controller_Plugin_Abstract
         $span->meta['zf1.route_name'] = $route;
         $span->resource = $controller . '@' . $action . ' ' . $route;
         $span->meta[Tag::HTTP_METHOD] = $request->getMethod();
-        $span->meta[Tag::HTTP_URL] =
+        $span->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(
             $request->getScheme() . '://' .
             $request->getHttpHost() .
-            $request->getRequestUri();
+            $request->getRequestUri()
+        );
     }
 
     /**

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\ZendFramework;
 
-use DDTrace\GlobalTracer;
 use DDTrace\Tag;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;

--- a/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
+++ b/src/DDTrace/Integrations/ZendFramework/ZendFrameworkIntegration.php
@@ -78,10 +78,11 @@ class ZendFrameworkIntegration extends Integration
                     $rootSpan->meta['zf1.route_name'] = $route;
                     $rootSpan->resource = $controller . '@' . $action . ' ' . $route;
                     $rootSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
-                    $rootSpan->meta[Tag::HTTP_URL] =
+                    $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Private_\util_url_sanitize(
                         $request->getScheme() . '://' .
                         $request->getHttpHost() .
-                        $request->getRequestUri();
+                        $request->getRequestUri()
+                    );
                 } catch (\Exception $e) {
                 }
 

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -74,6 +74,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             // Short flush interval by default or our tests will take all day
             'DD_TRACE_AGENT_FLUSH_INTERVAL' => static::FLUSH_INTERVAL_MS,
             'DD_AUTOLOAD_NO_COMPILE' => getenv('DD_AUTOLOAD_NO_COMPILE'),
+            'DD_TRACE_DEBUG' => 0,
         ];
 
         return $envs;

--- a/tests/Frameworks/TestScenarios.php
+++ b/tests/Frameworks/TestScenarios.php
@@ -9,10 +9,10 @@ class TestScenarios
     public static function all()
     {
         return [
-            GetSpec::create('A simple GET request returning a string', '/simple'),
-            GetSpec::create('A simple GET request with a view', '/simple_view'),
-            GetSpec::create('A GET request with an exception', '/error')->expectStatusCode(500),
-            GetSpec::create('A GET request to a missing route', '/does_not_exist'),
+            GetSpec::create('A simple GET request returning a string', '/simple?should_be=removed'),
+            GetSpec::create('A simple GET request with a view', '/simple_view?should_be=removed'),
+            GetSpec::create('A GET request with an exception', '/error?should_be=removed')->expectStatusCode(500),
+            GetSpec::create('A GET request to a missing route', '/does_not_exist?should_be=removed'),
         ];
     }
 }

--- a/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
@@ -25,7 +25,7 @@ class ParameterizedRouteTest extends WebFrameworkTestCase
     public function testGet()
     {
         $traces = $this->tracesFromWebRequest(function () {
-            $spec  = GetSpec::create('homes get', '/homes/new-york/new-york/manhattan');
+            $spec  = GetSpec::create('homes get', '/homes/new-york/new-york/manhattan?should_be=removed');
             $this->call($spec);
         });
 


### PR DESCRIPTION
### Description

As an additional step away from our hybrid approach (legacy ve internal api), this PR:
- removes usage of `DDTrace\GlobalTracer` from `src/DDTrace/Integrations`;
- removes usage of `DDTrace\Contracts\Span` from `src/DDTrace/Integrations` with the exception of `DDTrace\Integrations\Integration` as it might cause backward compatibility issues if users have inherited from this class - even if it has always been considered internal;

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
