### PR TITLE
Fix parsing of urls without schema into host name

### DIFF
--- a/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/DDTrace/Integrations/Guzzle/GuzzleIntegration.php
@@ -2,7 +2,6 @@
 
 namespace DDTrace\Integrations\Guzzle;
 
-use DDTrace\Format;
 use DDTrace\GlobalTracer;
 use DDTrace\Http\Urls;
 use DDTrace\Integrations\Integration;

--- a/src/api/Http/Urls.php
+++ b/src/api/Http/Urls.php
@@ -74,7 +74,7 @@ class Urls
         if (\substr($path, 0, 1) === '/') {
             // If the user by mistake directly provided an abs path, guzzle and curl
             // will let a request go through, but there will be an error.
-            return 'empty_url';
+            return 'unknown_host';
         }
 
         $pathFragments = \explode('/', $path);

--- a/src/api/Http/Urls.php
+++ b/src/api/Http/Urls.php
@@ -56,7 +56,29 @@ class Urls
      */
     public static function hostname($url)
     {
-        return (string) parse_url($url, PHP_URL_HOST);
+        $unparsableUrl = 'unparsable_url';
+        $parts = \parse_url($url);
+        if (!$parts) {
+            return $unparsableUrl;
+        }
+
+        if (isset($parts['host'])) {
+            return $parts['host'];
+        }
+
+        if (empty($parts['path'])) {
+            return $unparsableUrl;
+        }
+
+        $path = $parts['path'];
+        if (\substr($path, 0, 1) === '/') {
+            // If the user by mistake directly provided an abs path, guzzle and curl
+            // will let a request go through, but there will be an error.
+            return 'empty_url';
+        }
+
+        $pathFragments = \explode('/', $path);
+        return $pathFragments[0];
     }
 
     /**

--- a/src/api/Http/Urls.php
+++ b/src/api/Http/Urls.php
@@ -56,7 +56,7 @@ class Urls
      */
     public static function hostname($url)
     {
-        $unparsableUrl = 'unparsable_url';
+        $unparsableUrl = 'unparsable-host';
         $parts = \parse_url($url);
         if (!$parts) {
             return $unparsableUrl;
@@ -74,7 +74,7 @@ class Urls
         if (\substr($path, 0, 1) === '/') {
             // If the user by mistake directly provided an abs path, guzzle and curl
             // will let a request go through, but there will be an error.
-            return 'unknown_host';
+            return 'unknown-host';
         }
 
         $pathFragments = \explode('/', $path);
@@ -83,14 +83,39 @@ class Urls
 
     /**
      * Metadata keys must start with [a-zA-Z:] so IP addresses,
-     * for example, need to be prefixed with a valid character
+     * for example, need to be prefixed with a valid character.
+     *
+     * Note: then name of this function is misleading, as it should actually be normalizeUrlForService(), but since this
+     * part of the public API, we keep it like this and discuss a future deprecation.
      *
      * @param string $url
      * @return string
      */
     public static function hostnameForTag($url)
     {
+        $url = \trim($url);
+
+        // Common UDS protocols are treated differently as they are not recognized by parse_url()
+        $knownUnixProtocols = ['uds', 'unix', 'http+unix', 'https+unix'];
+        foreach ($knownUnixProtocols as $protocol) {
+            $length = \strlen($protocol);
+            if ($protocol . '://' === \substr($url, 0, $length + 3)) {
+                return 'socket-' . Urls::normalizeFileSystemPath(\substr($url, $length + 3));
+            }
+        }
+
         return 'host-' . self::hostname($url);
+    }
+
+    /**
+     * Replaces all groups of non-(alphabetical chatacters|numbers|dots) with character '-'.
+     *
+     * @param string $url
+     * @return string
+     */
+    private static function normalizeFileSystemPath($url)
+    {
+        return \trim(\preg_replace('/[^0-9a-zA-Z\.]+/', '-', \trim($url)), '-');
     }
 
     /**

--- a/tests/Unit/Http/UrlsTest.php
+++ b/tests/Unit/Http/UrlsTest.php
@@ -104,8 +104,6 @@ final class UrlsTest extends BaseTestCase
         return [
             [null, 'unparsable_url'],
             ['', 'unparsable_url'],
-            ['/', 'empty_url'],
-            ['/path', 'empty_url'],
 
             // no schema
             ['example.com', 'example.com'],
@@ -128,6 +126,12 @@ final class UrlsTest extends BaseTestCase
             ['http://no_dots_in_host/path', 'no_dots_in_host'],
             ['http://no_dots_in_host/path?key=value', 'no_dots_in_host'],
             ['http://no_dots_in_host/path?key=value#fragment', 'no_dots_in_host'],
+
+            // absolute paths
+            ['/', 'unknown_host'],
+            ['/path', 'unknown_host'],
+            ['/path?key=value', 'unknown_host'],
+            ['/path?key=value#fragment', 'unknown_host'],
         ];
     }
 }

--- a/tests/Unit/Http/UrlsTest.php
+++ b/tests/Unit/Http/UrlsTest.php
@@ -87,4 +87,47 @@ final class UrlsTest extends BaseTestCase
             ['/secret/one/two/three/test', '/?/one/two/three/test'],
         ];
     }
+
+    /**
+     * @dataProvider dataProviderHostname
+     * @param string $url
+     * @param string $expected
+     * @return void
+     */
+    public function testHostname($url, $expected)
+    {
+        $this->assertSame($expected, Urls::hostname($url));
+    }
+
+    public function dataProviderHostname()
+    {
+        return [
+            [null, 'unparsable_url'],
+            ['', 'unparsable_url'],
+            ['/', 'empty_url'],
+            ['/path', 'empty_url'],
+
+            // no schema
+            ['example.com', 'example.com'],
+            ['example.com/', 'example.com'],
+            ['example.com/path', 'example.com'],
+            ['example.com/path?key=value', 'example.com'],
+            ['example.com/path?key=value#fragment', 'example.com'],
+
+            // with schema
+            ['http://example.com', 'example.com'],
+            ['http://example.com/', 'example.com'],
+            ['http://example.com/path', 'example.com'],
+            ['http://example.com/path?key=value', 'example.com'],
+            ['http://example.com/path?key=value#fragment', 'example.com'],
+
+            // no dots in host name
+            ['no_dots_in_host', 'no_dots_in_host'],
+            ['http://no_dots_in_host', 'no_dots_in_host'],
+            ['http://no_dots_in_host/', 'no_dots_in_host'],
+            ['http://no_dots_in_host/path', 'no_dots_in_host'],
+            ['http://no_dots_in_host/path?key=value', 'no_dots_in_host'],
+            ['http://no_dots_in_host/path?key=value#fragment', 'no_dots_in_host'],
+        ];
+    }
 }

--- a/tests/Unit/Http/UrlsTest.php
+++ b/tests/Unit/Http/UrlsTest.php
@@ -102,8 +102,8 @@ final class UrlsTest extends BaseTestCase
     public function dataProviderHostname()
     {
         return [
-            [null, 'unparsable_url'],
-            ['', 'unparsable_url'],
+            [null, 'unparsable-host'],
+            ['', 'unparsable-host'],
 
             // no schema
             ['example.com', 'example.com'],
@@ -128,10 +128,70 @@ final class UrlsTest extends BaseTestCase
             ['http://no_dots_in_host/path?key=value#fragment', 'no_dots_in_host'],
 
             // absolute paths
-            ['/', 'unknown_host'],
-            ['/path', 'unknown_host'],
-            ['/path?key=value', 'unknown_host'],
-            ['/path?key=value#fragment', 'unknown_host'],
+            ['/', 'unknown-host'],
+            ['/path', 'unknown-host'],
+            ['/path?key=value', 'unknown-host'],
+            ['/path?key=value#fragment', 'unknown-host'],
+
+            // uds-style sockets should not generate an error but be converted to unparsable-host,
+            // as there is now a dedicated function for them.
+            ['uds:///tmp/socket.file', 'unparsable-host'],
+            ['http+unix:///tmp/socket.file', 'unparsable-host'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderHostnameForTag
+     * @param string $url
+     * @param string $expected
+     * @return void
+     */
+    public function testHostnameForTag($url, $expected)
+    {
+        $this->assertSame($expected, Urls::hostnameForTag($url));
+    }
+
+    public function dataProviderHostnameForTag()
+    {
+        return [
+            [null, 'host-unparsable-host'],
+            ['', 'host-unparsable-host'],
+
+            // no schema
+            ['example.com', 'host-example.com'],
+            ['example.com/', 'host-example.com'],
+            ['example.com/path', 'host-example.com'],
+            ['example.com/path?key=value', 'host-example.com'],
+            ['example.com/path?key=value#fragment', 'host-example.com'],
+
+            // with schema
+            ['http://example.com', 'host-example.com'],
+            ['http://example.com/', 'host-example.com'],
+            ['http://example.com/path', 'host-example.com'],
+            ['http://example.com/path?key=value', 'host-example.com'],
+            ['http://example.com/path?key=value#fragment', 'host-example.com'],
+
+            // no dots in host name
+            ['no_dots_in_host', 'host-no_dots_in_host'],
+            ['http://no_dots_in_host', 'host-no_dots_in_host'],
+            ['http://no_dots_in_host/', 'host-no_dots_in_host'],
+            ['http://no_dots_in_host/path', 'host-no_dots_in_host'],
+            ['http://no_dots_in_host/path?key=value', 'host-no_dots_in_host'],
+            ['http://no_dots_in_host/path?key=value#fragment', 'host-no_dots_in_host'],
+
+            // absolute paths
+            ['/', 'host-unknown-host'],
+            ['/path', 'host-unknown-host'],
+            ['/path?key=value', 'host-unknown-host'],
+            ['/path?key=value#fragment', 'host-unknown-host'],
+
+            // Common UDS urls
+            ['uds:///tmp/socket.file', 'socket-tmp-socket.file'],
+            ['unix:///tmp/socket.file', 'socket-tmp-socket.file'],
+            ['http+unix:///tmp/socket.file', 'socket-tmp-socket.file'],
+            ['https+unix:///tmp/socket.file', 'socket-tmp-socket.file'],
+            ['https+unix:///tmp/s!o!c!k!e!t.file', 'socket-tmp-s-o-c-k-e-t.file'],
+            ['https+unix:///   tmp/soc   ket.file    ', 'socket-tmp-soc-ket.file'],
         ];
     }
 }


### PR DESCRIPTION
### Description

Previously, host names without a schema were not correctly parsed while setting resource names, tags and service name when split by domain was enabled.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
