### PR TITLE
PHP 7.4: Shared-extension Buster container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
   '7.2-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.2_buster' }
   '7.3-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.3_buster' }
   '7.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4_buster' }
+  '7.4-buster-shared-ext': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.4-shared-ext' }
   '8.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_buster' }
   '8.0-buster-shared-ext': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0-shared-ext' }
   '8.1-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.1_buster' }

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -44,6 +44,16 @@ services:
         phpTarGzUrl: https://www.php.net/distributions/php-7.4.21.tar.gz
         phpSha256Hash: 4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db
 
+  php-7.4-shared-ext:
+    image: datadog/dd-trace-ci:php-7.4-shared-ext
+    build:
+      context: ./php-7.4
+      dockerfile: Dockerfile_shared_ext
+      args:
+        phpVersion: 7.4
+        phpTarGzUrl: https://www.php.net/distributions/php-7.4.26.tar.gz
+        phpSha256Hash: 890a7e730f96708a68a77b19fd57fec33cc81573f7249111c870edac42b91a72
+
   php-7.3:
     image: datadog/dd-trace-ci:php-7.3_buster
     build:

--- a/dockerfiles/ci/buster/php-7.4/Dockerfile_shared_ext
+++ b/dockerfiles/ci/buster/php-7.4/Dockerfile_shared_ext
@@ -1,0 +1,132 @@
+FROM datadog/dd-trace-ci:buster AS base
+
+ARG phpVersion
+ENV PHP_INSTALL_DIR_DEBUG_ZTS_ASAN=${PHP_INSTALL_DIR}/debug-zts-asan
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
+ENV PHP_VERSION=${phpVersion}
+
+FROM base as build
+ARG phpTarGzUrl
+ARG phpSha256Hash
+RUN set -eux; \
+    curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
+    (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
+    tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
+    rm -f /tmp/php.tar.gz; \
+    cd ${PHP_SRC_DIR}; \
+    ./buildconf --force;
+COPY configure_shared_ext.sh /home/circleci/configure.sh
+
+FROM build as php-debug-zts-asan
+ENV CFLAGS='-fsanitize=address -DZEND_TRACK_ARENA_ALLOC'
+ENV LDFLAGS='-fsanitize=address'
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --enable-debug \
+        --enable-maintainer-zts \
+        --prefix=${PHP_INSTALL_DIR_DEBUG_ZTS_ASAN} \
+        --with-config-file-path=${PHP_INSTALL_DIR_DEBUG_ZTS_ASAN} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS_ASAN}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS_ASAN}/conf.d;
+
+FROM build as php-debug
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --enable-debug \
+        --prefix=${PHP_INSTALL_DIR_DEBUG_NTS} \
+        --with-config-file-path=${PHP_INSTALL_DIR_DEBUG_NTS} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
+
+FROM build as php-nts
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --prefix=${PHP_INSTALL_DIR_NTS} \
+        --with-config-file-path=${PHP_INSTALL_DIR_NTS} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
+
+FROM base as final
+COPY --chown=circleci:circleci --from=build $PHP_SRC_DIR $PHP_SRC_DIR
+COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR_DEBUG_ZTS_ASAN $PHP_INSTALL_DIR_DEBUG_ZTS_ASAN
+COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR_DEBUG_NTS $PHP_INSTALL_DIR_DEBUG_NTS
+COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR_NTS $PHP_INSTALL_DIR_NTS
+
+# Build curl versions
+ENV CURL_VERSIONS="7.72.0 7.77.0"
+RUN set -eux; \
+    for curlVer in ${CURL_VERSIONS}; \
+    do \
+        echo "Build curl ${curlVer}..."; \
+        cd /tmp; \
+        curl -L -o curl.tar.gz https://curl.se/download/curl-${curlVer}.tar.gz; \
+        tar -xf curl.tar.gz && rm curl.tar.gz; \
+        cd curl-${curlVer}; \
+        ./configure --with-openssl --prefix=/opt/curl/${curlVer}; \
+        make; make install; \
+    done;
+
+# Build core extensions as shared libraries.
+# We intentionally do not run 'make install' here so that we can test the
+# scenario where headers are not installed for the shared library.
+RUN set -eux; \
+    for phpVer in $(ls ${PHP_INSTALL_DIR}); \
+    do \
+        echo "Build shared extensions for PHP ${phpVer}..."; \
+        switch-php ${phpVer}; \
+        mkdir -p $(php-config --extension-dir); \
+        \
+        # ext/curl
+        echo "Building ext/curl (system version)..."; \
+        cd ${PHP_SRC_DIR}/ext/curl; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; \
+        \
+        for curlVer in ${CURL_VERSIONS}; \
+        do \
+            echo "Building ext/curl ${curlVer}..."; \
+            PKG_CONFIG_PATH=/opt/curl/${curlVer}/lib/pkgconfig/ \
+            ./configure; make; \
+            mv ./modules/curl.so $(php-config --extension-dir)/curl-${curlVer}.so; \
+            make clean; \
+        done; \
+        phpize --clean; \
+        \
+        # ext/json
+        echo "Building ext/json..."; \
+        cd ${PHP_SRC_DIR}/ext/json; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; phpize --clean; \
+        \
+        # ext/pdo
+        echo "Building ext/pdo..."; \
+        cd ${PHP_SRC_DIR}/ext/pdo; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; phpize --clean; \
+        \
+        # TODO Add ext/pdo_mysql, ext/pdo_pgsql, and ext/pdo_sqlite
+    done;
+
+RUN set -eux; \
+# Set the default PHP version
+    switch-php debug;
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+COPY welcome /etc/motd
+
+CMD ["php-fpm", "-F"]

--- a/dockerfiles/ci/buster/php-7.4/configure_shared_ext.sh
+++ b/dockerfiles/ci/buster/php-7.4/configure_shared_ext.sh
@@ -1,0 +1,17 @@
+if [ -z "${PHP_SRC_DIR}" ]; then
+    echo "Please set PHP_SRC_DIR"
+    exit 1
+fi
+
+${PHP_SRC_DIR}/configure \
+    --disable-all \
+    --enable-cgi \
+    --enable-fpm \
+    --enable-pcntl=shared \
+    --enable-phpdbg \
+    --enable-option-checking=fatal \
+    --with-ffi=shared \
+    --with-fpm-user=www-data \
+    --with-fpm-group=www-data \
+    --without-pear \
+    $@


### PR DESCRIPTION
### Description

We already have a minimum build of PHP (`--disable-all`) for PHP 8.0 (`datadog/dd-trace-ci:php-8.0-shared-ext`) to run tests when extensions are loaded as shared libraries. This PR adds a PHP 7.4 minimum build (`datadog/dd-trace-ci:php-7.4-shared-ext`) with the json extension loaded as a shared library. This will help us to test the changes in #1366 & #1378 which impacts how the tracer interacts with the json extension.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
