### PR TITLE
Adjust components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1075,7 +1075,7 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               $toolchain \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_COMPONENTS_TESTING=ON \
+              -DDATADOG_PHP_TESTING=ON \
               ~/datadog/components
             make -j all
             make test
@@ -1094,7 +1094,7 @@ jobs:
             CMAKE_PREFIX_PATH=/opt/catch2 cmake \
               -DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/ubsan.cmake \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DBUILD_COMPONENTS_TESTING=ON \
+              -DDATADOG_PHP_TESTING=ON \
               ~/datadog/components
             make -j all
             make test

--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle: Google
 Language: Cpp
 ColumnLimit: 120
 IndentWidth: 4
+BreakStringLiterals: false
 ---

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -8,25 +8,39 @@ project(datadog-php-components
   LANGUAGES C
 )
 
-option(BUILD_COMPONENTS_TESTING "Enable tests" OFF)
-if (${BUILD_COMPONENTS_TESTING})
-  # Tests uses the C++ testing framework Catch2
+option(DATADOG_PHP_TESTING "Enable Datadog PHP tests" OFF)
+if (${DATADOG_PHP_TESTING})
+
+  # Tests use the C++ testing framework Catch2
   enable_language(CXX)
 
   # The Catch2::Catch2 target has been available since 2.1.2
   # We are unsure of the true minimum, but have tested 2.4
   find_package(Catch2 2.4 REQUIRED)
 
-  #[[ This file takes a while to build, so we do it once here and every test
-      executable can link to it to save time.
-  ]]
-  add_library(catch2_main catch2_main.cc)
-  target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
-  target_compile_features(catch2_main PUBLIC cxx_std_11)
-
   include(Catch)
+
+  if (NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
+    #[[ The build of catch2 we are using wasn't configured with
+        `CATCH_BUILD_STATIC_LIBRARY`; let's polyfill it.
+    ]]
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc
+      "#define CATCH_CONFIG_MAIN\n"
+      "#include <catch2/catch.hpp>\n"
+    )
+
+    add_library(Catch2WithMain ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc)
+    target_compile_features(Catch2WithMain INTERFACE cxx_std_11)
+    target_link_libraries(Catch2WithMain PUBLIC Catch2::Catch2)
+    add_library(Catch2::Catch2WithMain ALIAS Catch2WithMain)
+  endif ()
+
+  if (NOT TARGET Catch2::Catch2WithMain)
+    message(FATAL_ERROR "Catch2WithMain not found and polyfill failed.")
+  endif ()
+
   enable_testing()
-endif()
+endif ()
 
 include(GNUInstallDirs)
 

--- a/components/README.md
+++ b/components/README.md
@@ -31,7 +31,7 @@ avoided by using components.
 ## Components should be tested
 
 Components must have a tests subdirectory which gets added to the CMake project
-when the `BUILD_COMPONENTS_TESTING` option is set to true/on. The tests need to
+when the `DATADOG_PHP_TESTING` option is set to true/on. The tests need to
 integrate with CMake so that when the main `test` target is run that the
 component's tests are run as well.
 

--- a/components/catch2_main.cc
+++ b/components/catch2_main.cc
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/components/container_id/CMakeLists.txt
+++ b/components/container_id/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_container_id container_id.c)
 
 target_include_directories(datadog_php_container_id
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -19,9 +19,9 @@ add_library(Datadog::Php::ContainerId
   ALIAS datadog_php_container_id
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/container_id.h

--- a/components/container_id/tests/CMakeLists.txt
+++ b/components/container_id/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(container_id
 )
 
 target_link_libraries(container_id
-  PUBLIC catch2_main Datadog::Php::ContainerId
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::ContainerId
 )
 
 file(

--- a/components/container_id/tests/container_id_from_file.cc
+++ b/components/container_id/tests/container_id_from_file.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 }
 
 #include <catch2/catch.hpp>

--- a/components/container_id/tests/container_id_parser.cc
+++ b/components/container_id/tests/container_id_parser.cc
@@ -1,10 +1,9 @@
 extern "C" {
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 }
 
-#include <cstring>
-
 #include <catch2/catch.hpp>
+#include <cstring>
 
 #define MAX_ID_LEN DATADOG_PHP_CONTAINER_ID_MAX_LEN
 
@@ -36,12 +35,7 @@ TEST_CASE("parser: invalid cgroup lines", "[container_id_parser]") {
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
 
     const char *lines[] = {
-        "foo line",
-        "a4:perf_event:/",
-        ":perf_event:/",
-        "1:perf_event",
-        "\n",
-        "",
+        "foo line", "a4:perf_event:/", ":perf_event:/", "1:perf_event", "\n", "",
     };
 
     for (const char *line : lines) {
@@ -84,7 +78,7 @@ TEST_CASE("parser: fail to parse a container ID", "[container_id_parser]") {
 
     const char *lines[] = {
         "d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",  // 63 characters
-        "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",  // Task ID
+        "34dc0b5e626f2c5c4c5170e34b10e765-1234567890",                      // Task ID
         "",
         "a",
         "zd5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",
@@ -183,7 +177,7 @@ TEST_CASE("parser: fail to parse a task ID", "[container_id_parser]") {
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
 
     const char *lines[] = {
-        "4dc0b5e626f2c5c4c5170e34b10e765-1234567890",  // 31 hex characters
+        "4dc0b5e626f2c5c4c5170e34b10e765-1234567890",                        // 31 hex characters
         "9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f",  // Container ID
         "34dc0b5e626f2c5c4c5170e34b10e765-",
         "a-0",
@@ -212,7 +206,8 @@ TEST_CASE("parser: fail to parse a task ID", "[container_id_parser]") {
 TEST_CASE("parser: successfully parse a Kubernetes container ID", "[container_id_parser]") {
     dd_parser parser;
     char buf[MAX_ID_LEN + 1] = {0};
-    const char line[] = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope";
+    const char line[] =
+        "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope";
 
     REQUIRE(datadog_php_container_id_parser_ctor(&parser));
     REQUIRE(parser.extract_container_id(&parser, buf, line));

--- a/components/sapi/CMakeLists.txt
+++ b/components/sapi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_sapi sapi.c)
 
 target_include_directories(datadog_php_sapi
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -23,9 +23,9 @@ add_library(Datadog::Php::Sapi
   ALIAS datadog_php_sapi
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sapi.h

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -1,4 +1,4 @@
-#include "sapi/sapi.h"
+#include "sapi.h"
 
 typedef datadog_php_sapi sapi_t;
 typedef datadog_php_string_view string_view_t;
@@ -6,6 +6,10 @@ typedef datadog_php_string_view string_view_t;
 #define SV(cstr) DATADOG_PHP_STRING_VIEW_LITERAL(cstr)
 
 sapi_t datadog_php_sapi_from_name(string_view_t module) {
+    if (!module.ptr || module.len == 0) {
+        return DATADOG_PHP_SAPI_UNKNOWN;
+    }
+
     struct {
         string_view_t str;
         sapi_t type;
@@ -29,3 +33,5 @@ sapi_t datadog_php_sapi_from_name(string_view_t module) {
 
     return DATADOG_PHP_SAPI_UNKNOWN;
 }
+
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module) { return datadog_php_sapi_from_name(module); }

--- a/components/sapi/sapi.h
+++ b/components/sapi/sapi.h
@@ -1,7 +1,7 @@
 #ifndef DATADOG_PHP_SAPI_H
 #define DATADOG_PHP_SAPI_H
 
-#include "string_view/string_view.h"
+#include <components/string_view/string_view.h>
 
 typedef enum {
     DATADOG_PHP_SAPI_UNKNOWN = 0,
@@ -16,5 +16,6 @@ typedef enum {
 } datadog_php_sapi;
 
 datadog_php_sapi datadog_php_sapi_from_name(datadog_php_string_view module);
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module);
 
 #endif  // DATADOG_PHP_SAPI_H

--- a/components/sapi/tests/CMakeLists.txt
+++ b/components/sapi/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(sapi sapi.cc)
 
 target_link_libraries(sapi
-  PUBLIC catch2_main Datadog::Php::Sapi
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::Sapi
 )
 
 catch_discover_tests(sapi)

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "sapi/sapi.h"
+#include <components/sapi/sapi.h>
 }
 
 #include <catch2/catch.hpp>

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(datadog_php_string_view string_view.c)
 
 target_include_directories(datadog_php_string_view
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -19,9 +19,9 @@ add_library(Datadog::Php::StringView
   ALIAS datadog_php_string_view
 )
 
-if (${BUILD_COMPONENTS_TESTING})
+if (${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif()
+endif ()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h

--- a/components/string_view/string_view.c
+++ b/components/string_view/string_view.c
@@ -2,12 +2,12 @@
 
 #include <string.h>
 
-datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]) {
-    datadog_php_string_view string_view = {
-        .len = cstr ? strlen(cstr) : 0,
-        .ptr = cstr ? cstr : "",
-    };
-    return string_view;
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr) {
+    if (cstr) {
+        return (datadog_php_string_view){.len = strlen(cstr), .ptr = cstr};
+    } else {
+        return (datadog_php_string_view){.len = 0, .ptr = ""};
+    }
 }
 
 bool datadog_php_string_view_equal(datadog_php_string_view a, datadog_php_string_view b) {

--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -32,11 +32,11 @@ typedef struct datadog_php_string_view {
     { sizeof(cstr) - 1, cstr }
 
 /**
- * Creates a string view from a C string, which is an array of char which is
- * terminated by a null byte. Derives the length from strlen. `cstr` may be
- * null, in which case the `.len` will be 0.
+ * Converts the C string `cstr` into a string view by getting its length from
+ * `strlen`. Null is permitted and will become an empty string.
+ * @param cstr May be nullptr.
  */
-datadog_php_string_view datadog_php_string_view_from_cstr(const char cstr[]);
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr);
 
 /**
  * Compares the views `a` and `b` for equality. Note that the `.ptr` value of

--- a/components/string_view/tests/CMakeLists.txt
+++ b/components/string_view/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(string_view string_view.cc)
 
 target_link_libraries(string_view
-  PUBLIC catch2_main Datadog::Php::StringView
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::StringView
 )
 
 catch_discover_tests(string_view)

--- a/components/string_view/tests/string_view.cc
+++ b/components/string_view/tests/string_view.cc
@@ -1,5 +1,5 @@
 extern "C" {
-#include "string_view/string_view.h"
+#include <components/string_view/string_view.h>
 }
 
 #include <catch2/catch.hpp>
@@ -28,7 +28,7 @@ TEST_CASE("string_view cstrings", "[string_view]") {
     const char buff[5] = "four";
     datadog_php_string_view four = datadog_php_string_view_from_cstr(buff);
     REQUIRE(four.len == 4);
-    REQUIRE((const void*)four.ptr == (const void*)&buff);
+    REQUIRE((const void *)four.ptr == (const void *)&buff);
 }
 
 TEST_CASE("string_view empty equal", "[string_view]") {
@@ -46,7 +46,7 @@ TEST_CASE("string_view empty equal", "[string_view]") {
 TEST_CASE("string_view equal", "[string_view]") {
     const char buff1[] = "asdf";
     char buff2[sizeof buff1];
-    memcpy((void*)buff2, buff1, sizeof buff1);
+    memcpy((void *)buff2, buff1, sizeof buff1);
 
     datadog_php_string_view str1 = datadog_php_string_view_from_cstr(buff1);
     datadog_php_string_view str2 = datadog_php_string_view_from_cstr(buff2);
@@ -54,6 +54,35 @@ TEST_CASE("string_view equal", "[string_view]") {
     REQUIRE(datadog_php_string_view_equal(str1, str2));
 
     // identity cases
-    REQUIRE(datadog_php_string_view_equal(str1, str1));
-    REQUIRE(datadog_php_string_view_equal(str2, str2));
+    CHECK(datadog_php_string_view_equal(str1, str1));
+    CHECK(datadog_php_string_view_equal(str2, str2));
+
+    char a[] = "aBcDE01234";
+    char b[] = "abcde01234";
+
+    auto x = datadog_php_string_view_from_cstr(a);
+    auto y = datadog_php_string_view_from_cstr(b);
+    CHECK(!datadog_php_string_view_equal(x, y));
+
+    for (auto &ch : a) {
+        ch = (char)(unsigned char)tolower((unsigned char)ch);
+    }
+
+    CHECK(datadog_php_string_view_equal(x, y));
+}
+
+TEST_CASE("string_view equal different lengths", "[string_view]") {
+    char a[] = "aBcDE0";
+    char b[] = "abcde01234";
+
+    auto x = datadog_php_string_view_from_cstr(a);
+    auto y = datadog_php_string_view_from_cstr(b);
+    CHECK(!datadog_php_string_view_equal(x, y));
+
+    for (auto &ch : a) {
+        ch = (char)(unsigned char)tolower((unsigned char)ch);
+    }
+
+    // still not equal after lower-casing
+    CHECK(!datadog_php_string_view_equal(x, y));
 }

--- a/config.m4
+++ b/config.m4
@@ -277,7 +277,6 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_INCLUDE([$ext_srcdir])
   PHP_ADD_INCLUDE([$ext_srcdir/ext])
 
-  PHP_ADD_INCLUDE([$ext_srcdir/components])
   PHP_ADD_BUILD_DIR([$ext_builddir/components])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/container_id])
   PHP_ADD_BUILD_DIR([$ext_builddir/components/sapi])

--- a/ext/php5/ddshared.c
+++ b/ext/php5/ddshared.c
@@ -1,6 +1,6 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php5/ddshared.h
+++ b/ext/php5/ddshared.h
@@ -3,8 +3,6 @@
 
 #include <TSRM/TSRM.h>
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(TSRMLS_D);
 
 char *ddshared_container_id(void);

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -40,7 +41,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"

--- a/ext/php7/ddshared.c
+++ b/ext/php7/ddshared.c
@@ -1,6 +1,7 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
+
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php7/ddshared.h
+++ b/ext/php7/ddshared.h
@@ -1,8 +1,6 @@
 #ifndef DD_TRACE_SHARED_H
 #define DD_TRACE_SHARED_H
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(void);
 
 char *ddshared_container_id(void);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_smart_str.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -42,7 +43,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"

--- a/ext/php8/ddshared.c
+++ b/ext/php8/ddshared.c
@@ -1,6 +1,7 @@
 #include "ddshared.h"
 
-#include "container_id/container_id.h"
+#include <components/container_id/container_id.h>
+
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php8/ddshared.h
+++ b/ext/php8/ddshared.h
@@ -1,8 +1,6 @@
 #ifndef DD_TRACE_SHARED_H
 #define DD_TRACE_SHARED_H
 
-#include "container_id/container_id.h"
-
 void ddshared_minit(void);
 
 char *ddshared_container_id(void);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -8,6 +8,7 @@
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_smart_str.h>
 #include <Zend/zend_vm.h>
+#include <components/sapi/sapi.h>
 #include <headers/headers.h>
 #include <inttypes.h>
 #include <php.h>
@@ -42,7 +43,6 @@
 #include "memory_limit.h"
 #include "random.h"
 #include "request_hooks.h"
-#include "sapi/sapi.h"
 #include "serializer.h"
 #include "signals.h"
 #include "span.h"


### PR DESCRIPTION
### Description

Change BUILD_COMPONENTS_TESTING to DATADOG_PHP_TESTING.

Require `components/` prefix on includes e.g.

    #include <components/string_view/string_view.h>

This will prevent conflicts in the future like uuid/uuid.h and libuuid.

Set `BreakStringLiterals: false` for clang-format; wrapping string
literals makes for worse grep'ing. Re-format some tests which had
long string literals.

Remove custom catch2_main target for the standard target
Catch2::Catch2WithMain, with a polyfill for older/differently
configured versions.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
