### PR TITLE
Add log component

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -60,6 +60,7 @@ else ()
 endif ()
 
 add_subdirectory(container_id)
+add_subdirectory(log)
 add_subdirectory(queue)
 add_subdirectory(sapi)
 

--- a/components/log/CMakeLists.txt
+++ b/components/log/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(datadog-php-log OBJECT log.c)
+
+target_include_directories(datadog-php-log
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-log
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+target_link_libraries(datadog-php-log PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -1,0 +1,159 @@
+#include "log.h"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+// The names are long, so let's add a convenience helpers
+typedef datadog_php_logger logger_t;
+typedef datadog_php_log_level log_level_t;
+typedef datadog_php_string_view string_view_t;
+
+/**
+ * Ensures the logger looks like it should be logging anything at all.
+ *
+ * # Safety
+ * Mutex must exist and be locked prior to calling this function if used in a
+ * multi-threaded context.
+ * `logger` must not be null.
+ */
+__attribute__((nonnull)) static bool logger_valid(datadog_php_logger *logger) {
+    return logger->descriptor >= 0 && logger->log_level >= DATADOG_PHP_LOG_OFF &&
+           logger->log_level <= DATADOG_PHP_LOG_DEBUG;
+}
+
+__attribute__((nonnull)) bool datadog_php_logger_ctor(logger_t *logger, int descriptor, log_level_t log_level,
+                                                      pthread_mutex_t *mutex) {
+    *logger = (logger_t){
+        .descriptor = descriptor < 0 ? -1 : descriptor,  // normalize invalid
+        .log_level = log_level,
+        .mutex = mutex,
+    };
+    return logger_valid(logger);
+}
+
+void datadog_php_logger_dtor(logger_t *logger) {
+    logger->descriptor = -1;
+    logger->log_level = DATADOG_PHP_LOG_UNKNOWN;
+    logger->mutex = NULL;
+}
+
+static int64_t durable_write(const logger_t *logger, string_view_t message) {
+    /* We attempt to handle some of the error conditions possible:
+     *  1. Partial writes
+     *  2. EAGAIN and EWOULDBLOCK
+     *  3. EINTR
+     * We limit the number of times we'll retry an operation for the above.
+     * For other errors we stop attempting to log and move on.
+     * todo: should we set the fd to -1 for some errors like EIO/EPIPE?
+     */
+    size_t written = 0;
+    unsigned tries = 0, max_tries = 3;  // arbitrarily chosen
+    while (written < message.len && tries++ < max_tries) {
+        ssize_t n = write(logger->descriptor, message.ptr + written, message.len - written);
+        if (n < 0) {
+            /* POSIX.1-2001 allows either error to be returned for this case, and does
+             * not require these constants to have the same value, so a portable
+             * application should check for both possibilities.
+             */
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                continue;
+            } else {
+                break;
+            }
+        }
+        written += n;
+    }
+    return written == message.len ? (int64_t)written : -1;
+}
+
+static int64_t log_writev(logger_t *logger, log_level_t level, size_t n_messages,
+                          string_view_t messages[static n_messages]) {
+    if (logger->log_level < level) {
+        return 0;
+    }
+
+    int64_t written = 0;
+    for (size_t i = 0; i != n_messages; ++i) {
+        int64_t result = durable_write(logger, messages[i]);
+        if (result < 0) break;
+        written += result;
+    }
+
+    // try to append a newline
+    ssize_t result = write(logger->descriptor, "\n", 1);
+    if (result > 0) written += result;
+    return written;
+}
+
+void datadog_php_log(logger_t *logger, log_level_t level, string_view_t message) {
+    (void)datadog_php_logv(logger, level, 1, &message);
+}
+
+int64_t datadog_php_logv(datadog_php_logger *logger, datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[static n_messages]) {
+    if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+        int64_t result = logger_valid(logger) ? log_writev(logger, level, n_messages, messages) : -1;
+        (void)pthread_mutex_unlock(logger->mutex);
+        return result;
+    }
+    return -1;
+}
+
+static char datadog_tolower_ascii(char c) { return (char)(c >= 'A' && c <= 'Z' ? (c - ('A' - 'a')) : c); }
+
+static void datadog_copy_tolower(char *restrict dst, const char *restrict src, size_t len) {
+    for (size_t i = 0; i != len; ++i) {
+        *(dst++) = datadog_tolower_ascii(src[i]);
+    }
+}
+
+log_level_t datadog_php_log_level_detect(string_view_t val) {
+    // Treat nullptr and a string of length 0 the same: default to off.
+    if (!val.ptr || val.len == 0) return DATADOG_PHP_LOG_OFF;
+
+    // If the level string's length is greater than 5, it's definitely unknown.
+    if (val.len > 5) return DATADOG_PHP_LOG_UNKNOWN;
+
+    // 8 chars is more than enough to hold the remaining strings.
+    _Alignas(8) char buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    // lowercase to make this a case-insensitive operation
+    datadog_copy_tolower(buffer, val.ptr, val.len);
+    string_view_t level_string = {.len = val.len, .ptr = buffer};
+
+    struct {
+        string_view_t str;
+        log_level_t level;
+    } options[] = {
+        {{3, "off"}, DATADOG_PHP_LOG_OFF},
+        {{5, "error"}, DATADOG_PHP_LOG_ERROR},
+        {{4, "warn"}, DATADOG_PHP_LOG_WARN},
+        {{4, "info"}, DATADOG_PHP_LOG_INFO},
+        {{5, "debug"}, DATADOG_PHP_LOG_DEBUG},
+
+        /* This case goes last. We've already ruled out this case above; this is
+         * for unifying known and unknown code paths below.
+         */
+        {{0, ""}, DATADOG_PHP_LOG_UNKNOWN},
+    };
+
+    // the last option is only used for its enum, so take off 1
+    unsigned i, n_options = (sizeof options / sizeof *options) - 1;
+    for (i = 0; i != n_options; ++i) {
+        if (datadog_php_string_view_equal(options[i].str, level_string)) {
+            break;
+        }
+    }
+    return options[i].level;
+}
+
+/**
+ * Sets the current log level of the application.
+ */
+void datadog_php_log_level_set(logger_t *logger, log_level_t level) {
+    if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+        logger->log_level = level;
+        pthread_mutex_unlock(logger->mutex);
+    }
+}

--- a/components/log/log.h
+++ b/components/log/log.h
@@ -1,0 +1,102 @@
+#ifndef DATADOG_PHP_PROFILER_LOG_H
+#define DATADOG_PHP_PROFILER_LOG_H
+
+#include <components/string_view/string_view.h>
+#include <pthread.h>
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+typedef enum {
+    DATADOG_PHP_LOG_UNKNOWN = -1,
+    DATADOG_PHP_LOG_OFF = 0,
+    DATADOG_PHP_LOG_ERROR,
+    DATADOG_PHP_LOG_WARN,
+    DATADOG_PHP_LOG_INFO,
+    DATADOG_PHP_LOG_DEBUG,
+} datadog_php_log_level;
+
+// This is for the compiler to use; please do not use it directly!
+typedef struct datadog_php_logger_s {
+    int descriptor;  // borrowed, not owned
+    int log_level;
+    pthread_mutex_t *mutex;  // borrowed, not owned
+} datadog_php_logger;
+
+#define DATADOG_PHP_LOGGER_INIT \
+    { -1, DATADOG_PHP_LOG_UNKNOWN, NULL }
+
+/**
+ * Creates a logger instance in `logger`. The result may be valid or invalid;
+ * check the return value: `true` for valid.
+ *
+ * For now, only file descriptors are expected to work, but other types are
+ * expected to work in the future.
+ */
+__attribute__((nonnull)) bool datadog_php_logger_ctor(datadog_php_logger *logger, int descriptor,
+                                                      datadog_php_log_level log_level, pthread_mutex_t *mutex);
+
+/**
+ * Sets the .descriptor to -1, .log_level to `DATADOG_PROFILER_LOG_UNKNOWN`,
+ * and the .mutex to NULL.
+ *
+ * This is not threadsafe! It also doesn't close the descriptor nor destroy the
+ * mutex, as they are borrowed, not owned. Only do this when the program is
+ * back in single-threaded mode, or you risk a race condition.
+ *
+ * @param logger
+ */
+void datadog_php_logger_dtor(datadog_php_logger *logger);
+
+/**
+ * If the `logger` is set to at least `level`, then the message will be logged.
+ * Otherwise it will be ignored.
+ * @param logger
+ * @param level
+ * @param message
+ */
+void datadog_php_log(datadog_php_logger *logger, datadog_php_log_level level, datadog_php_string_view message);
+
+/**
+ * If the `logger` is set to at least `level`, then the messages will be logged.
+ * Otherwise they will be ignored.
+ * @param logger
+ * @param level
+ * @param n_messages
+ * @param messages
+ * @return Bytes written
+ */
+int64_t datadog_php_logv(datadog_php_logger *logger, datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[C_STATIC(n_messages)]);
+
+/**
+ * Sets the current `.log_level` of the logger.
+ * Inputs of UNKNOWN are ignored, and the logger retain its current values.
+ *
+ * Generally the `.log_level` should be set at construction and remain
+ * unchanged. However, there may be reasons to change it. Here are a few:
+ *   - A logger may need to be be constructed so it can be shared by multiple
+ *     objects prior to knowing the runtime setting of the log level.
+ *   - At a certain point during datadog_php_log_plugin_shutdown, logging may
+ * need to be set to off but since the logger is still being borrowed by other
+ * objects it cannot be destructed.
+ */
+void datadog_php_log_level_set(datadog_php_logger *, datadog_php_log_level);
+
+/**
+ * Converts `val` to a recognized log level.
+ * Returns `DATADOG_PROFILER_LOG_UNKNOWN` if it does not recognize a level.
+ * Accepted strings are the following, comparison is case insensitive:
+ *   "" (defaults to off), "off", "error", "warn", "info", "debug"
+ * @param val
+ * @return The detected log_level (may be DATADOG_PROFILER_LOG_UNKNOWN).
+ */
+datadog_php_log_level datadog_php_log_level_detect(datadog_php_string_view val);
+
+#undef C_STATIC
+
+#endif  // DATADOG_PHP_PROFILER_LOG_H

--- a/components/log/tests/CMakeLists.txt
+++ b/components/log/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test-datadog-php-log log.cc)
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(test-datadog-php-log
+  PRIVATE Catch2::Catch2WithMain datadog-php-log datadog_php_string_view Threads::Threads
+)
+
+catch_discover_tests(test-datadog-php-log)

--- a/components/log/tests/log.cc
+++ b/components/log/tests/log.cc
@@ -1,0 +1,71 @@
+extern "C" {
+#include <components/log/log.h>
+}
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <catch2/catch.hpp>
+#include <cerrno>
+#include <climits>
+#include <cstring>
+
+int generate_memfd(void **mem, size_t len) {
+    if (len > INT_MAX) return -1;
+
+    FILE *file = tmpfile();
+    int fd = fileno(file);
+    *mem = nullptr;
+    if (fd != -1) {
+        // int cast is guarded above
+        if (ftruncate(fd, (int)len)) {
+            fclose(file);
+            return -1;
+        }
+
+        int prot = PROT_READ | PROT_WRITE;
+        int flags = MAP_SHARED | MAP_FILE;
+        *mem = mmap(nullptr, len, prot, flags, fd, 0);
+        if (*mem == MAP_FAILED) {
+            fprintf(stderr, "%s\n", strerror(errno));
+            *mem = nullptr;
+            fclose(file);
+            return -1;
+        }
+    }
+    return fd;
+}
+
+TEST_CASE("logv", "[log]") {
+    char *mem;
+    size_t mem_len = 32;
+    int fd = generate_memfd((void **)&mem, mem_len);
+    REQUIRE(fd != -1);
+    REQUIRE(mem);
+    REQUIRE(mem != MAP_FAILED);
+
+    pthread_mutex_t mutex;
+    REQUIRE(pthread_mutex_init(&mutex, nullptr) == 0);
+
+    datadog_php_logger logger = DATADOG_PHP_LOGGER_INIT;
+    REQUIRE(datadog_php_logger_ctor(&logger, fd, DATADOG_PHP_LOG_DEBUG, &mutex));
+
+    datadog_php_string_view messages[3] = {
+        {datadog_php_string_view_from_cstr("[Datadog Profiling] ")},
+        {datadog_php_string_view_from_cstr("Stack Collector failed to join; ")},
+        {datadog_php_string_view_from_cstr("EDEADLK")},
+    };
+    auto written = datadog_php_logv(&logger, DATADOG_PHP_LOG_ERROR, 3, messages);
+    CHECK(written >= 0);
+
+    auto expect = datadog_php_string_view_from_cstr("[Datadog Profiling] Stack Collector failed to join; EDEADLK\n");
+    auto actual = datadog_php_string_view{static_cast<size_t>(written), mem};
+    CHECK(datadog_php_string_view_equal(expect, actual));
+
+    datadog_php_logger_dtor(&logger);
+    CHECK(munmap(mem, mem_len) == 0);
+    CHECK(close(fd) == 0);
+    CHECK(pthread_mutex_destroy(&mutex) == 0);
+}


### PR DESCRIPTION
### Description

The log component can write to a file or to stdout/stderr. It is not
threadsafe, and borrows the mutex and file descriptor used. It could
theoretically be used to write to other file descriptors without much
work, but since logging as written is a blocking operation this would
be risky.

It supports these log levels:
  - off
  - error
  - warn
  - info
  - debug

The profiler uses the component to build a thread-safe-ish abstraction
for a global profiler logger. The profiler uses the log levels to mean
roughly the following:
  - off: nothing will be logged
  - error: an error that will likely stop the profiler, such as failing
    to spawn a worker thread.
  - warn: an error that will likely not stop the profiler, such as
    an HTTP 5xx error on upload. The profile will be dropped, but the
    profiler will continue to gather samples and upload profiles.
  - info: a notable event that occurs infrequently, such as profiles
    being uploaded (happens once about every minute). If something
    happens once per request, that would be too noisy for this level.
  - debug: information intended for developers to understand internal
    order of events. May be very noisy.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
