### PR TITLE
Add arena component

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -53,6 +53,8 @@ add_library(datadog_php_components INTERFACE)
 
 add_subdirectory(string_view)
 
+add_subdirectory(arena)
+
 if (TARGET PkgConfig::UV)
   add_subdirectory(channel)
 else ()

--- a/components/arena/CMakeLists.txt
+++ b/components/arena/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(datadog-php-arena OBJECT arena.c)
+
+target_include_directories(datadog-php-arena
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-arena
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/arena/arena.c
+++ b/components/arena/arena.c
@@ -1,0 +1,64 @@
+#include "arena.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct datadog_php_arena_s {
+    uint32_t offset, capacity;
+    uint8_t *start;
+};
+
+void datadog_php_arena_delete(datadog_php_arena *arena) { (void)arena; }
+void datadog_php_arena_reset(datadog_php_arena *arena) { arena->offset = 0; }
+
+static uint32_t align_diff(uintptr_t ptr, uint32_t align) {
+    uintptr_t diff = (~ptr + 1) & (align - 1);
+    return diff;
+}
+
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align) {
+    uint32_t diff = align_diff(ptr, align);
+    return diff;
+}
+
+datadog_php_arena *datadog_php_arena_new(uint32_t len, uint8_t buffer[static len]) {
+    if (!len) {
+        return NULL;
+    }
+
+    uint32_t diff = align_diff((uintptr_t)buffer, _Alignof(datadog_php_arena));
+    uint8_t *obj = buffer + diff;
+
+    // ensure the alignment + size fits
+    if ((diff + sizeof(datadog_php_arena)) > len) {
+        return NULL;
+    }
+
+    datadog_php_arena *allocator = (datadog_php_arena *)obj;
+    allocator->offset = 0;
+    allocator->capacity = len - sizeof(datadog_php_arena) - diff;
+    allocator->start = obj + sizeof(datadog_php_arena);
+
+    return allocator;
+}
+
+uint8_t *datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size, uint32_t align) {
+    // minimum allocation size is 1 byte
+    size = size ? size : 1;
+
+    // align the offset
+    uint8_t *begin = arena->start + arena->offset;
+    uint32_t diff = align_diff((uintptr_t)begin, align);
+    ptrdiff_t offset = arena->offset + diff;
+
+    // ensure it doesn't go out of bounds
+    if (offset + size > arena->capacity) {
+        return NULL;
+    }
+
+    unsigned char *obj = arena->start + offset;
+
+    // bump the offset
+    arena->offset = offset + size;
+    return obj;
+}

--- a/components/arena/arena.h
+++ b/components/arena/arena.h
@@ -1,0 +1,79 @@
+#ifndef DATADOG_PHP_ARENA_H
+#define DATADOG_PHP_ARENA_H
+
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+#if __GNUC__
+#if __GNUC__ >= 11
+#define HAVE_ATTRIBUTE_MALLOC_EXTENDED 1
+#endif
+#endif
+
+#if HAVE_ATTRIBUTE_MALLOC_EXTENDED
+/* Note that GCC 11 doesn't yet do a good job with this attribute, but
+ * experimenting with it to report bugs so it hopefully gets better.
+ */
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...) __attribute__((malloc(__VA_ARGS__)))
+#else
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...)
+#endif
+
+/**
+ * This arena is used to do bump pointer style allocations inside of a
+ * previously allocated block, such as stack memory, static storage, or heap
+ * memory.
+ *
+ * Individual allocations made by the arena are not tracked and are not freed.
+ * The use-case is allocating a bunch of data which has the same lifetime, and
+ * then everything can be freed at once by freeing the arena. This means that
+ * care must be taken to either not store types which have custom destructors,
+ * or that they should be tracked and dtor'd outside of the arena.
+ */
+typedef struct datadog_php_arena_s datadog_php_arena;
+
+/**
+ * This is a no-op at present, but it theoretically helps the GCC analyzer to
+ * understand the lifetime of the arena.
+ * Note that it cannot be inline, as deallocator functions cannot be inline.
+ */
+void datadog_php_arena_delete(datadog_php_arena *arena);
+
+/**
+ * Creates a new arena from the provided `buffer` + `len`. This function may
+ * return NULL, such as if `len` is not large enough to hold the arena object.
+ *
+ * # Safety
+ * The `buffer` object must have at least `len` contiguous bytes and must not
+ * be null.
+ */
+DATADOG_PHP__ATTR_MALLOC_EXTENDED(datadog_php_arena_delete)
+datadog_php_arena *datadog_php_arena_new(uint32_t len, uint8_t buffer[C_STATIC(len)]);
+
+/**
+ * Resets the arena contents, but the arena object itself stays valid. All other
+ * objects that have been allocated by the arena are now invalid.
+ */
+__attribute__((nonnull(1))) void datadog_php_arena_reset(datadog_php_arena *arena);
+
+/**
+ * Returns the number of bytes to add to `ptr` to align it to `align`. Only
+ * pass powers of 2 for `align`!
+ */
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align);
+
+/**
+ * Allocates at least `size` bytes from the `arena`, aligned to `align`. May
+ * return NULL, such as if `align` is not a power of two or if there is not
+ * enough remaining space in the `arena` storage.
+ */
+__attribute__((nonnull(1))) uint8_t *datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size, uint32_t align);
+
+#undef C_STATIC
+
+#endif  // DATADOG_PHP_ARENA_H

--- a/components/arena/tests/CMakeLists.txt
+++ b/components/arena/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-arena arena.cc)
+target_link_libraries(test-datadog-php-arena
+  PRIVATE Catch2::Catch2WithMain datadog-php-arena
+)
+
+catch_discover_tests(test-datadog-php-arena)

--- a/components/arena/tests/arena.cc
+++ b/components/arena/tests/arena.cc
@@ -1,0 +1,105 @@
+extern "C" {
+#include <components/arena/arena.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("new and delete", "[arena]") {
+    alignas(32) static uint8_t buffer[1024];
+
+    datadog_php_arena *arena = datadog_php_arena_new(sizeof buffer, buffer);
+    REQUIRE(arena);
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("generic alignment", "[arena]") {
+    uintptr_t addr = 8u;
+
+    CHECK(datadog_php_arena_align_diff(addr + 0, 4) == 0u);
+    CHECK(datadog_php_arena_align_diff(addr + 1, 4) == 3u);
+    CHECK(datadog_php_arena_align_diff(addr + 2, 4) == 2u);
+    CHECK(datadog_php_arena_align_diff(addr + 3, 4) == 1u);
+    CHECK(datadog_php_arena_align_diff(addr + 4, 4) == 0u);
+    CHECK(datadog_php_arena_align_diff(addr + 5, 4) == 3u);
+}
+
+TEST_CASE("allocator self-alignment", "[arena]") {
+    alignas(16) uint8_t bytes[24];
+
+    /* Since buffer is aligned to an even byte boundary, by passing in a pointer
+     * + 1 (and taking 1 off the size to match), we can test that the arena
+     * object itself gets correctly aligned in the buffer, since there is no
+     * guarantee that the buffer has suitable alignment.
+     */
+    datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes - 1, &bytes[1]);
+    REQUIRE(arena);
+
+    // uses some implementation-specific knowledge
+    REQUIRE(((uint8_t *)arena) == bytes + alignof(uintptr_t));
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("capacity and reset", "[arena]") {
+    // This requires implementation-specific knowledge of datadog_php_arena
+    alignas(8) uint8_t bytes[20];
+
+    datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+    REQUIRE(arena);
+
+    uint8_t *i = datadog_php_arena_alloc(arena, 4, 1);
+    REQUIRE(i);
+
+    // This allocation should fail; no more room.
+    uint8_t *j = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(!j);
+
+    datadog_php_arena_reset(arena);
+
+    // Since we have reset the arena, this should allocate the same address
+    uint8_t *k = datadog_php_arena_alloc(arena, 4, 1);
+    REQUIRE(i == k);
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment", "[arena]") {
+    // This requires implementation-specific knowledge of datadog_php_arena
+    alignas(16) uint8_t bytes[24];
+
+    datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+    REQUIRE(arena);
+
+    /* Intentionally use a size and align combo that will set up the next alloc
+     * to start misaligned.
+     */
+    uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(i);
+
+    uint8_t *j = datadog_php_arena_alloc(arena, 4, 4);
+    REQUIRE(j);
+    REQUIRE(i + 4 == j);
+
+    // This allocation should fail; no more room.
+    uint8_t *k = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(!k);
+
+    datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment capacity", "[arena]") {
+    // This requires implementation-specific knowledge of datadog_php_arena
+    alignas(16) uint8_t bytes[24];
+
+    datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+    REQUIRE(arena);
+
+    uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+    REQUIRE(i);
+
+    // This allocation would fit except for its alignment
+    uint8_t *j = datadog_php_arena_alloc(arena, 7, 2);
+    REQUIRE(!j);
+
+    datadog_php_arena_delete(arena);
+}


### PR DESCRIPTION
### Description

This arena is used to do bump pointer style allocations inside of a
previously allocated block, such as stack memory, static storage, or
heap memory.

Individual allocations made by the arena are not tracked and are not
freed. The use-case is allocating a bunch of data which has the same
lifetime, and then everything can be freed at once by resetting the
arena. This means that care must be taken to either not store types
which have custom destructors, or that they should be tracked and dtor'd
outside of the arena before resetting it.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
