### PR TITLE
Add stack sample component

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(container_id)
 add_subdirectory(log)
 add_subdirectory(queue)
 add_subdirectory(sapi)
+add_subdirectory(stack-sample)
 
 install(EXPORT DatadogPhpComponentsTargets
   FILE DatadogPhpComponentsTargets.cmake

--- a/components/stack-sample/CMakeLists.txt
+++ b/components/stack-sample/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(datadog-php-stack-sample OBJECT stack-sample.c stack-sample.h)
+
+target_include_directories(datadog-php-stack-sample
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-stack-sample PUBLIC c_std_11)
+
+target_link_libraries(datadog-php-stack-sample PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/stack-sample/stack-sample.c
+++ b/components/stack-sample/stack-sample.c
@@ -1,0 +1,113 @@
+#include "stack-sample.h"
+
+#include <string.h>
+
+/* Done in the impl instead of the header because on CentOS 6 in gnu++11 mode
+ * it fails in the header. The header gets included in C++ mode for testing. */
+_Static_assert(sizeof(struct datadog_php_stack_sample_s) <= 8192u,
+               "datadog_php_stack_sample should be less than or equal to 8KiB");
+
+typedef datadog_php_stack_sample stack_sample_t;
+typedef datadog_php_stack_sample_frame stack_sample_frame_t;
+typedef datadog_php_stack_sample_iterator stack_sample_iterator_t;
+typedef datadog_php_string_view string_view_t;
+
+static void stack_sample_default_ctor(stack_sample_t *sample) {
+    memset(sample, 0, sizeof *sample);
+
+    // we store an empty string with null terminator at position 0
+    sample->buffer_len = 1;
+}
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *sample) { stack_sample_default_ctor(sample); }
+
+uint16_t datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample) { return sample->depth; }
+
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *sample) { stack_sample_default_ctor(sample); }
+
+static bool try_add_string(stack_sample_t *sample, string_view_t string, uint16_t *offset) {
+    // we pack all empty strings into offset 0
+    if (string.len == 0) {
+        *offset = 0;
+        return true;
+    }
+
+    // ensure there is room for the string
+    if (sample->buffer_len + string.len + 1 <= sizeof(sample->buffer)) {
+        uint16_t off = sample->buffer_len;
+        memcpy(&sample->buffer[off], string.ptr, string.len);
+
+        // null-terminate the string; we rely on ctor's memzero for this and just +1
+        sample->buffer_len += string.len + 1;
+        *offset = off;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool datadog_php_stack_sample_try_add(stack_sample_t *sample, stack_sample_frame_t frame) {
+    uint16_t depth = sample->depth;
+    if (depth >= datadog_php_stack_sample_max_depth) {
+        return false;
+    }
+
+    uint16_t function_off;
+    if (!try_add_string(sample, frame.function, &function_off)) {
+        return false;
+    }
+    sample->function_off[depth] = function_off;
+    sample->function_len[depth] = frame.function.len;
+
+    uint16_t file_off;
+    if (!try_add_string(sample, frame.file, &file_off)) {
+        return false;
+    }
+    sample->file_off[depth] = file_off;
+    sample->file_len[depth] = frame.file.len;
+
+    sample->lineno[depth] = frame.lineno;
+    ++sample->depth;
+
+    return true;
+}
+
+stack_sample_iterator_t datadog_php_stack_sample_iterator_ctor(const stack_sample_t *sample) {
+    stack_sample_iterator_t iterator = {
+        .sample = sample,
+        .depth = 0,
+    };
+    return iterator;
+}
+
+void datadog_php_stack_sample_iterator_dtor(stack_sample_iterator_t *iterator) {
+    iterator->sample = NULL;
+    iterator->depth = 0;
+}
+
+void datadog_php_stack_sample_iterator_rewind(stack_sample_iterator_t *iterator) { iterator->depth = 0; }
+
+bool datadog_php_stack_sample_iterator_valid(stack_sample_iterator_t *iterator) {
+    return iterator->sample && iterator->depth < iterator->sample->depth;
+}
+
+uint16_t datadog_php_stack_sample_iterator_depth(const stack_sample_iterator_t *iterator) { return iterator->depth; }
+
+stack_sample_frame_t datadog_php_stack_sample_iterator_frame(stack_sample_iterator_t *iterator) {
+    const stack_sample_t *sample = iterator->sample;
+    uint16_t depth = iterator->depth;
+
+    const char *function = &sample->buffer[sample->function_off[depth]];
+    size_t function_len = sample->function_len[depth];
+
+    const char *file = &sample->buffer[sample->file_off[depth]];
+    size_t file_len = sample->file_len[depth];
+    stack_sample_frame_t frame = {
+        .function = {function_len, function},
+        .file = {file_len, file},
+        .lineno = sample->lineno[depth],
+    };
+    return frame;
+}
+
+void datadog_php_stack_sample_iterator_next(stack_sample_iterator_t *iterator) { ++iterator->depth; }

--- a/components/stack-sample/stack-sample.h
+++ b/components/stack-sample/stack-sample.h
@@ -1,0 +1,74 @@
+#ifndef DATADOG_PHP_STACK_SAMPLE_H
+#define DATADOG_PHP_STACK_SAMPLE_H
+
+#include <components/string_view/string_view.h>
+#include <stdint.h>
+
+#define DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH 101u
+static const uint16_t datadog_php_stack_sample_max_depth = DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH;
+
+/**
+ * A stack sample represents a stack sample in a serialized form that is not
+ * aware of any language runtime specific things. This layout could be more
+ * efficient. Each frame holds the function/method name, file, and line. Not all
+ * frames will have all members.
+ *
+ * Treat this as opaque so as it's easier to test structure-of-arrays vs
+ * array-of-structures and other layout optimizations.
+ */
+typedef struct datadog_php_stack_sample_s {
+    uint16_t depth;
+    uint16_t buffer_len;
+
+    /* We save quite a bit of space by using offsets into the buffer instead of
+     * storing full pointers (16 bit vs 64 bit).
+     * We leave room for 1 more frame than datadog_php_stack_sample_max_depth for
+     * a summary frame ($x more frames).
+     */
+    uint16_t function_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t function_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t file_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    uint16_t file_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+    int64_t lineno[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+
+    /* The strings need to point into this buffer. It's sized so that there are
+     * 64 bytes per entry, which on average may not be enough, but does allow for
+     * deeper stacks if the function and file names are on the shorter side.
+     */
+    char buffer[(DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1) * 64u];
+} datadog_php_stack_sample;
+
+typedef struct datadog_php_stack_sample_frame_s {
+    datadog_php_string_view function;
+    datadog_php_string_view file;
+    int64_t lineno;
+} datadog_php_stack_sample_frame;
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *);
+uint16_t datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample);
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *);
+
+bool datadog_php_stack_sample_try_add(datadog_php_stack_sample *, datadog_php_stack_sample_frame);
+
+/**
+ * A stack sample iterator can be used to iterate across a sample, re-assembling
+ * each frame from its serialized layout.
+ */
+typedef struct datadog_php_stack_sample_iterator {
+    const datadog_php_stack_sample *sample;
+    uint16_t depth;
+} datadog_php_stack_sample_iterator;
+
+datadog_php_stack_sample_iterator datadog_php_stack_sample_iterator_ctor(const datadog_php_stack_sample *);
+
+void datadog_php_stack_sample_iterator_dtor(datadog_php_stack_sample_iterator *iterator);
+
+bool datadog_php_stack_sample_iterator_valid(datadog_php_stack_sample_iterator *iterator);
+
+uint16_t datadog_php_stack_sample_iterator_depth(const datadog_php_stack_sample_iterator *iterator);
+
+datadog_php_stack_sample_frame datadog_php_stack_sample_iterator_frame(datadog_php_stack_sample_iterator *iterator);
+
+void datadog_php_stack_sample_iterator_next(datadog_php_stack_sample_iterator *iterator);
+
+#endif  // DATADOG_PHP_STACK_SAMPLE_H

--- a/components/stack-sample/tests/CMakeLists.txt
+++ b/components/stack-sample/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-stack-sample stack-sample.cc)
+target_link_libraries(test-datadog-php-stack-sample
+  PRIVATE Catch2::Catch2WithMain datadog-php-stack-sample datadog_php_string_view
+)
+
+catch_discover_tests(test-datadog-php-stack-sample)

--- a/components/stack-sample/tests/stack-sample.cc
+++ b/components/stack-sample/tests/stack-sample.cc
@@ -1,0 +1,61 @@
+extern "C" {
+#include <components/stack-sample/stack-sample.h>
+#include <components/string_view/string_view.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("empty ctor and dtor", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_depth(&sample) == 0u);
+
+    datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("empty iterator ctor and dtor", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    datadog_php_stack_sample_iterator iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    for (iterator = datadog_php_stack_sample_iterator_ctor(&sample); datadog_php_stack_sample_iterator_valid(&iterator);
+         datadog_php_stack_sample_iterator_next(&iterator)) {
+    }
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    datadog_php_stack_sample_iterator_dtor(&iterator);
+    datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("iterator", "[stack-sample]") {
+    datadog_php_stack_sample sample;
+    datadog_php_stack_sample_ctor(&sample);
+
+    const datadog_php_stack_sample_frame main_frame = {datadog_php_string_view_from_cstr("{main}"),
+                                                       datadog_php_string_view_from_cstr("/srv/public/index.php"), 3};
+    CHECK(datadog_php_stack_sample_try_add(&sample, main_frame));
+
+    CHECK(datadog_php_stack_sample_depth(&sample) == 1u);
+
+    auto iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+    for (iterator = datadog_php_stack_sample_iterator_ctor(&sample); datadog_php_stack_sample_iterator_valid(&iterator);
+         datadog_php_stack_sample_iterator_next(&iterator)) {
+        auto frame = datadog_php_stack_sample_iterator_frame(&iterator);
+        CHECK(datadog_php_string_view_equal(frame.function, main_frame.function));
+        CHECK(datadog_php_string_view_equal(frame.file, main_frame.file));
+        CHECK(frame.lineno == main_frame.lineno);
+    }
+
+    CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 1u);
+
+    datadog_php_stack_sample_iterator_dtor(&iterator);
+    datadog_php_stack_sample_dtor(&sample);
+}


### PR DESCRIPTION
### Description

Represents a stack trace with function/method name, file, and
line-number information, up to a bounded depth. Frames are not required
to have all members; for instance, there may be a frame that has no
function but exists in file X on line Y, and there may be a frame that
has function Z but no file nor line information.

This isn't collecting data from the Zend Engine; this just represents
the relevant information gathered.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
