### PR TITLE
Add time component

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,8 +1,9 @@
 #[[ Need CMake 3.14 so that `install(TARGETS)` uses better defaults, which
     saves us from repeating configuration in every file (and must be the same).
-    Need CMake 3.15+ because the channel component fails on 3.14. Instead of
-    just bumping incrementally, I've bumped this to the latest version that's
-    been tested in CI for a while: 3.19.
+    Need CMake 3.15+ because the channel component fails on 3.14, as does the
+    time component's feature check. Instead of just bumping incrementally, I've
+    bumped this to the latest version that's been tested in CI for a while:
+    version 3.19.
 ]]
 cmake_minimum_required(VERSION 3.19)
 
@@ -69,6 +70,7 @@ add_subdirectory(log)
 add_subdirectory(queue)
 add_subdirectory(sapi)
 add_subdirectory(stack-sample)
+add_subdirectory(time)
 add_subdirectory(uuid)
 
 install(EXPORT DatadogPhpComponentsTargets

--- a/components/time/CMakeLists.txt
+++ b/components/time/CMakeLists.txt
@@ -1,0 +1,75 @@
+add_library(datadog-php-time OBJECT time.c time.h)
+
+target_include_directories(datadog-php-time
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+include(CheckCSourceRuns)
+include(CMakePushCheckState)
+
+find_package(Threads)
+
+#[[ Prior to glibc 2.17, librt was required for clock_gettime.
+    Check for it without flags first.
+    clock_gettime gets used with pthread_getcpuclockid if the platform has it.
+]]
+cmake_push_check_state(RESET)
+set(CLOCK_GETTIME_PROGRAM "#include <time.h>
+int main(void) {
+  struct timespec ts;
+  return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;
+}
+")
+check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME)
+cmake_pop_check_state()
+
+if (NOT DATADOG_HAVE_CLOCK_GETTIME)
+  # Try again with -lrt; use a different cache variable name or it won't run.
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES -lrt)
+  check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME_RT)
+
+  if (DATADOG_HAVE_CLOCK_GETTIME_RT)
+    target_link_libraries(datadog-php-time PRIVATE -lrt)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_CLOCK_GETTIME=1)
+
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+  check_c_source_runs("
+  #include <pthread.h>
+  #include <time.h>
+
+  int main(void) {
+    clockid_t clockid;
+    // consider the fact the API exists good enough; it may still fail at runtime,
+    // and that's okay; it just needs to exist.
+    (void)pthread_getcpuclockid(pthread_self(), &clockid);
+    return 0;
+  }
+  " DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+  if (DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+    target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+check_c_source_runs("#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+int main(void) {
+	mach_port_t thread = mach_thread_self();
+	mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+	thread_basic_info_data_t info;
+	(void)thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);
+	return 0;
+}
+" DATADOG_HAVE_THREAD_INFO)
+
+if (DATADOG_HAVE_THREAD_INFO)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
+endif ()

--- a/components/time/time.c
+++ b/components/time/time.c
@@ -1,0 +1,64 @@
+#include "time.h"
+
+#if DATADOG_HAVE_PTHREAD_GETCPUCLOCKID
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+    struct timespec timespec;
+    clockid_t clockid;  //  todo: cache this?
+
+    if (pthread_getcpuclockid(pthread_self(), &clockid)) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = strerror(errno),
+        };
+    }
+
+    if (clock_gettime(clockid, &timespec)) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = strerror(errno),
+        };
+    }
+
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_OK,
+        .ok = timespec,
+    };
+}
+
+#elif DATADOG_HAVE_THREAD_INFO
+
+#include <mach/mach_error.h>
+#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+    mach_port_t thread = mach_thread_self();
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    thread_basic_info_data_t info;
+    kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+
+    if (kr != KERN_SUCCESS) {
+        return (datadog_php_cpu_time_result){
+            .tag = DATADOG_PHP_CPU_TIME_ERR,
+            .err = mach_error_string(kr),
+        };
+    }
+
+    struct timespec timespec = {
+        .tv_sec = info.user_time.seconds + info.system_time.seconds,
+        .tv_nsec = (info.user_time.microseconds + info.system_time.microseconds) * 1000,
+    };
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_OK,
+        .ok = timespec,
+    };
+}
+
+#else
+#error Unhandled platform for cpu time
+#endif

--- a/components/time/time.h
+++ b/components/time/time.h
@@ -1,0 +1,28 @@
+#ifndef DATADOG_PHP_SYSTEM_TIME_H
+#define DATADOG_PHP_SYSTEM_TIME_H
+
+#include <stdint.h>
+#include <time.h>
+
+/* This component exists to paper over differences in time across platforms.
+ * In the past, this included monotonic, system, and cpu time. It seems feasible
+ * that we would re-introduce those other types, so I left the name as a
+ * generic "time" component instead of renaming to cpu-time.
+ */
+
+typedef enum datadog_php_cpu_time_result_tag {
+    DATADOG_PHP_CPU_TIME_OK,
+    DATADOG_PHP_CPU_TIME_ERR,
+} datadog_php_cpu_time_result_tag;
+
+typedef struct datadog_php_cpu_time_result_s {
+    datadog_php_cpu_time_result_tag tag;
+    union {
+        struct timespec ok;
+        const char *err;  // c-string describing error; static lifetime
+    };
+} datadog_php_cpu_time_result;
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void);
+
+#endif  // DATADOG_PHP_SYSTEM_TIME_H


### PR DESCRIPTION
### Description

The time component accounts for differences in cpu-time calls in
different platforms. In the past it was also used for monotonic and
system time, which is why it is called "time" instead of "cpu-time".

There are no tests for this component -- I could not think of any tests
that would be meaningful.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
