### PR TITLE
ZAI methods on PHP 5: Args and retval

### DIFF
--- a/zend_abstract_interface/methods/CMakeLists.txt
+++ b/zend_abstract_interface/methods/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(zai_methods "${PHP_VERSION_DIRECTORY}/methods.c")
+if(PHP_VERSION_DIRECTORY STREQUAL "php7" OR PHP_VERSION_DIRECTORY STREQUAL "php8")
+  set(PHP_METHODS_VERSION_DIRECTORY "php7-8")
+else()
+  set(PHP_METHODS_VERSION_DIRECTORY "${PHP_VERSION_DIRECTORY}")
+endif()
+
+add_library(zai_methods "${PHP_METHODS_VERSION_DIRECTORY}/methods.c")
 
 target_include_directories(zai_methods PUBLIC
                                        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -30,12 +30,13 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len ZAI_TS
  * Methods cannot be called outside of a request context so this MUST be called
  * from within a request context (after RINIT and before RSHUTDOWN).
  */
-bool zai_call_method_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC, int argc, ...);
+bool zai_call_method_ex(zval *object, const char *method, size_t method_len, zval **retval ZAI_TSRMLS_DC, int argc,
+                        ...);
 
 /* Calls a static method on a class entry 'ce'. Return value handling is the
  * same as zai_call_method().
  */
-bool zai_call_static_method_ex(zend_class_entry *ce, const char *method, size_t method_len, zval **retval TSRMLS_DC,
+bool zai_call_static_method_ex(zend_class_entry *ce, const char *method, size_t method_len, zval **retval ZAI_TSRMLS_DC,
                                int argc, ...);
 
 /* A convenience wrapper to call zai_class_lookup() using a string literal. This

--- a/zend_abstract_interface/methods/methods.h
+++ b/zend_abstract_interface/methods/methods.h
@@ -4,6 +4,8 @@
 #include <main/php.h>
 #include <stdbool.h>
 
+#include "../zai_compat.h"
+
 /* Work in progress
  *
  * The long-term goal is to provide ZAI data-structure shims so that the
@@ -18,30 +20,39 @@
  * from the compiler globals, this can be called safely outside of a request
  * context.
  */
-zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC);
+zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len ZAI_TSRMLS_DC);
 
-/* Calls a method on an instance of 'object' without passing any arguments.
- * Caller must pass in a NULL pointer-pointer for the return value 'retval'.
- * Caller must dtor a non-NULL 'retval' after the call:
+/* Calls a method on an instance of 'object'. In error cases, 'retval' will be
+ * allocated and set to IS_NULL. Caller must dtor the 'retval' after the call:
  *
- *   if (retval) {
- *     zval_ptr_dtor(&retval);
- *   }
+ *   zval_ptr_dtor(&retval);
  *
  * Methods cannot be called outside of a request context so this MUST be called
  * from within a request context (after RINIT and before RSHUTDOWN).
  */
-bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC);
+bool zai_call_method_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC, int argc, ...);
 
-/* Calls a static method on a class entry 'ce' without passing any arguments.
- * Return value handling is the same as zai_call_method_without_args().
+/* Calls a static method on a class entry 'ce'. Return value handling is the
+ * same as zai_call_method().
  */
-bool zai_call_static_method_without_args_ex(zend_class_entry *ce, const char *method, size_t method_len,
-                                            zval **retval TSRMLS_DC);
+bool zai_call_static_method_ex(zend_class_entry *ce, const char *method, size_t method_len, zval **retval TSRMLS_DC,
+                               int argc, ...);
 
-/* Mask away the TSRMLS_* macros with more macros */
-#define zai_class_lookup(...) zai_class_lookup_ex(__VA_ARGS__ TSRMLS_CC)
-#define zai_call_method_without_args(...) zai_call_method_without_args_ex(__VA_ARGS__ TSRMLS_CC)
-#define zai_call_static_method_without_args(...) zai_call_static_method_without_args_ex(__VA_ARGS__ TSRMLS_CC)
+/* A convenience wrapper to call zai_class_lookup() using a string literal. This
+ * API only works when the class name is a string literal. If the class name
+ * exists as a 'const char *', use zai_class_lookup_ex() directly.
+ */
+#define zai_class_lookup_literal(cname) zai_class_lookup_ex(cname, (sizeof(cname) - 1) ZAI_TSRMLS_CC)
+
+/* Convenience wrappers for string literals and populates 'argc'. */
+#define zai_call_method_literal(object, method_name, retval, ...)                          \
+    zai_call_method_ex(object, method_name, sizeof(method_name) - 1, retval ZAI_TSRMLS_CC, \
+                       ZAI_CALL_METHOD_VA_ARG_COUNT(__VA_ARGS__), ##__VA_ARGS__)
+#define zai_call_static_method_literal(ce, method_name, retval, ...)                          \
+    zai_call_static_method_ex(ce, method_name, sizeof(method_name) - 1, retval ZAI_TSRMLS_CC, \
+                              ZAI_CALL_METHOD_VA_ARG_COUNT(__VA_ARGS__), ##__VA_ARGS__)
+
+#define ZAI_CALL_METHOD_VA_ARG_COUNT(...) ZAI_CALL_METHOD_VA_ARG_MAX(ignore, ##__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define ZAI_CALL_METHOD_VA_ARG_MAX(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, ...) arg10
 
 #endif  // ZAI_METHODS_H

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -2,7 +2,10 @@
 
 #include <Zend/zend_interfaces.h>
 #include <sandbox/sandbox.h>
+#include <stdint.h>
 #include <zai_assert/zai_assert.h>
+
+#define MAX_ARGS 3
 
 zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS_DC) {
     if (!cname || !cname_len) return NULL;
@@ -21,23 +24,17 @@ zend_class_entry *zai_class_lookup_ex(const char *cname, size_t cname_len TSRMLS
     return (zend_hash_find(CG(class_table), cname, (cname_len + 1), (void **)&ce) == SUCCESS) ? *ce : NULL;
 }
 
-static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, const char *method, size_t method_len,
-                                          zval **retval TSRMLS_DC) {
-    if (!ce || !method || !method_len || !retval) return false;
+static bool z_vcall_method_ex(zval *object, zend_class_entry *ce, const char *method, size_t method_len,
+                              zval **retval TSRMLS_DC, int argc, va_list argv) {
+    assert(argc <= MAX_ARGS && "Increase MAX_ARGS to support more arguments.");
+
+    if (!ce || !method || !method_len || argc < 0 || argc > MAX_ARGS) goto error_exit;
 
     /* Methods cannot be called outside of a request context.
      * PG(modules_activated) indicates that all of the module RINITs have been
      * called and we are in a request context.
      */
-    if (!PG(modules_activated)) return false;
-
-    /* Prevent a potential dangling pointer in case the caller accidentally
-     * sent in an allocated retval.
-     */
-    if (*retval != NULL) return false;
-
-    /* If 'object' is NULL, the caller wants to call this method statically. */
-    zval **obj = object ? &object : NULL;
+    if (!PG(modules_activated)) goto error_exit;
 
     /* This one gets me all the time. Trying to save myself 5 minutes for the
      * next time it inevitably happens.
@@ -45,26 +42,27 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
     zai_assert_is_lower(method, "Don't forget to send those method names in all lowercase. ;)");
 
     /* There is an important ZEND_ACC_ALLOW_STATIC check that occurs within the
-     * VM that is circumvented when calling a method outside of a VM context
-     * via zend_call_method(). Bypassing this check can result in an
-     * application crash therefore we must look up the function handler and
-     * perform the check manually here.
+     * VM that is circumvented when calling a method outside of a VM context.
+     * Bypassing this check can result in an application crash therefore we must
+     * look up the function handler and perform the check manually here.
      *
      * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_vm_def.h#L2639-L2642
      */
     zend_function *func = NULL;
-    if (zend_hash_find(&ce->function_table, method, (method_len + 1), (void **)&func) == FAILURE) return false;
+    if (zend_hash_find(&ce->function_table, method, (method_len + 1), (void **)&func) == FAILURE) {
+        /* "Couldn't find implementation for method %s" */
+        goto error_exit;
+    }
 
     /* Calling a non-static method statically can result in a SIGSEGV because
      * the VM acts as a NULL check on the object before calling the function
-     * handler and we are bypassing that check with a direct call to
-     * zend_call_method(). We only want to allow this behavior on a non-static
-     * method if the function has been explicitly marked with
-     * ZEND_ACC_ALLOW_STATIC signifying that it is safe to do so.
+     * handler and we are bypassing the VM context. We only want to allow this
+     * behavior on a non-static method if the function has been explicitly
+     * marked with ZEND_ACC_ALLOW_STATIC signifying that it is safe to do so.
      */
-    if (!obj && func->common.scope && !(func->common.fn_flags & (ZEND_ACC_STATIC | ZEND_ACC_ALLOW_STATIC))) {
+    if (!object && func->common.scope && !(func->common.fn_flags & (ZEND_ACC_STATIC | ZEND_ACC_ALLOW_STATIC))) {
         // "Non-static method %s::%s() cannot be called statically"
-        return false;
+        goto error_exit;
     }
 
     /* The ZEND_ACC_ABSTRACT check still occurs when calling zend_call_method()
@@ -76,27 +74,77 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
      */
     if (func->common.fn_flags & ZEND_ACC_ABSTRACT) {
         // "Cannot call abstract method %s::%s()"
-        return false;
+        goto error_exit;
     }
 
-    bool ret = false;
+    zend_fcall_info_cache fcc = {0};
+    fcc.initialized = 1;
+    fcc.function_handler = func;
+    fcc.calling_scope = ce;
+    if (!object && (EG(called_scope) && instanceof_function(EG(called_scope), ce TSRMLS_CC))) {
+        fcc.called_scope = EG(called_scope);
+    } else {
+        fcc.called_scope = ce;
+    }
+
+    zend_fcall_info fci = {0};
+    fci.size = sizeof(zend_fcall_info);
+    fci.no_separation = 1;
+    fci.retval_ptr_ptr = retval;
+
+    /* If 'object' is NULL, the caller wants to call this method statically. */
+    if (object) {
+        fci.object_ptr = object;
+        fcc.object_ptr = object;
+    }
+
+    /* Marking these as 'volatile' will ensure they survive a possible long jump
+     * from a zend_bailout without getting clobbered.
+     */
+    volatile bool should_bail = false;
+    volatile int call_fn_result = FAILURE;
 
     zai_sandbox sandbox;
     zai_sandbox_open(&sandbox);
 
-    zend_try {
-        /* We cannot use zend_call_method_with_0_params() here since it is a
-         * macro that masks sizeof() and therefore does not calculate the
-         * method len correctly without using a string literal.
+    /* We add the zval args directly from the variable arguments, va_arg(),
+     * instead of using zend_fcall_info_argv() because:
+     *
+     *   - We can NULL-check each arg.
+     *   - We circumvent an unnecessary reference count increase;
+     *     zend_call_function() already copies the zvals and increments the RC.
+     *   - We avoid an unnecessary heap allocation for the params.
+     *   - We avoid unnecessary calls to zend_fcall_info_args_clear().
+     */
+    if (argc > 0) {
+        zval *params[MAX_ARGS];
+        zval **param_ptrs[MAX_ARGS];
+        for (uint32_t i = 0; i < (uint32_t)argc; ++i) {
+            zval *arg = va_arg(argv, zval *);
+            if (!arg) {
+                zai_sandbox_close(&sandbox);
+                goto error_exit;
+            }
+            params[i] = arg;
+            param_ptrs[i] = &params[i];
+        }
+
+        fci.param_count = (uint32_t)argc;
+        fci.params = param_ptrs;
+
+        /* The zend_call_method() API only supports up to two arguments so we
+         * use zend_call_function() instead.
          */
-        zend_call_method(obj, ce, &func, method, method_len, retval, 0, NULL, NULL TSRMLS_CC);
-        /* An unhandled exception will not result in a zend_bailout if there is
-         * an active execution context. This is a failed call if an exception
-         * was thrown. The sandbox will clean up our mess when it closes.
-         */
-        ret = !EG(exception);
+        zend_try { call_fn_result = zend_call_function(&fci, &fcc TSRMLS_CC); }
+        zend_catch { should_bail = true; }
+        zend_end_try();
+    } else {
+        zend_try { call_fn_result = zend_call_function(&fci, &fcc TSRMLS_CC); }
+        zend_catch { should_bail = true; }
+        zend_end_try();
     }
-    zend_catch {
+
+    if (should_bail) {
         /* An unclean shutdown from a zend_bailout can occur deep within a
          * userland call stack (e.g. from 'exit') which will long jump over
          * dtors and frees. If we caught an arbitrary zend_bailout here and
@@ -108,20 +156,51 @@ static bool z_call_method_without_args_ex(zval *object, zend_class_entry *ce, co
         zai_sandbox_close(&sandbox);
         zend_bailout();
     }
-    zend_end_try();
 
+    /* An unhandled exception will not result in a zend_bailout if there is an
+     * active execution context. This is a failed call if an exception was
+     * thrown. The sandbox will clean up our mess when it closes.
+     */
+    bool no_exception = !EG(exception);
     zai_sandbox_close(&sandbox);
+    if (call_fn_result == SUCCESS && no_exception) {
+        return true;
+    }
 
-    return ret;
+error_exit:
+    /* For additional safety this wrapper sets the retval to IS_NULL so that the
+     * caller can expect a valid retval zval in the error cases.
+     */
+    ALLOC_INIT_ZVAL(*retval);
+    ZVAL_NULL(*retval);
+    return false;
 }
 
-bool zai_call_method_without_args_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC) {
-    if (!object || Z_TYPE_P(object) != IS_OBJECT) return false;
-    return z_call_method_without_args_ex(object, Z_OBJCE_P(object), method, method_len, retval TSRMLS_CC);
+bool zai_call_method_ex(zval *object, const char *method, size_t method_len, zval **retval TSRMLS_DC, int argc, ...) {
+    if (!retval) return false;
+    if (!object || Z_TYPE_P(object) != IS_OBJECT) {
+        ALLOC_INIT_ZVAL(*retval);
+        ZVAL_NULL(*retval);
+        return false;
+    }
+    va_list argv;
+    va_start(argv, argc);
+    bool status = z_vcall_method_ex(object, Z_OBJCE_P(object), method, method_len, retval TSRMLS_CC, argc, argv);
+    va_end(argv);
+    return status;
 }
 
-bool zai_call_static_method_without_args_ex(zend_class_entry *ce, const char *method, size_t method_len,
-                                            zval **retval TSRMLS_DC) {
-    if (!ce) return false;
-    return z_call_method_without_args_ex(NULL, ce, method, method_len, retval TSRMLS_CC);
+bool zai_call_static_method_ex(zend_class_entry *ce, const char *method, size_t method_len, zval **retval TSRMLS_DC,
+                               int argc, ...) {
+    if (!retval) return false;
+    if (!ce) {
+        ALLOC_INIT_ZVAL(*retval);
+        ZVAL_NULL(*retval);
+        return false;
+    }
+    va_list argv;
+    va_start(argv, argc);
+    bool status = z_vcall_method_ex(NULL, ce, method, method_len, retval TSRMLS_CC, argc, argv);
+    va_end(argv);
+    return status;
 }

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -77,7 +77,7 @@ static bool z_vcall_method_ex(zval *object, zend_class_entry *ce, const char *me
         goto error_exit;
     }
 
-    zend_fcall_info_cache fcc = {0};
+    zend_fcall_info_cache fcc = empty_fcall_info_cache;
     fcc.initialized = 1;
     fcc.function_handler = func;
     fcc.calling_scope = ce;
@@ -87,7 +87,7 @@ static bool z_vcall_method_ex(zval *object, zend_class_entry *ce, const char *me
         fcc.called_scope = ce;
     }
 
-    zend_fcall_info fci = {0};
+    zend_fcall_info fci = empty_fcall_info;
     fci.size = sizeof(zend_fcall_info);
     fci.no_separation = 1;
     fci.retval_ptr_ptr = retval;

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -81,11 +81,22 @@ static bool z_vcall_method_ex(zval *object, zend_class_entry *ce, const char *me
     fcc.initialized = 1;
     fcc.function_handler = func;
     fcc.calling_scope = ce;
+
+    /* Late static binding is intentionally not supported here. Since ZAI
+     * methods will be used primarily to call userland methods at atypical
+     * points in the VM execution, there might be an edge case where a call to
+     * 'static::method_name();' might result in the wrong target class.
+     */
+#define DD_SUPPORT_LSB 0
+#if DD_SUPPORT_LSB
     if (!object && (EG(called_scope) && instanceof_function(EG(called_scope), ce TSRMLS_CC))) {
         fcc.called_scope = EG(called_scope);
     } else {
         fcc.called_scope = ce;
     }
+#else
+    fcc.called_scope = ce;
+#endif
 
     zend_fcall_info fci = empty_fcall_info;
     fci.size = sizeof(zend_fcall_info);

--- a/zend_abstract_interface/methods/php5/methods.c
+++ b/zend_abstract_interface/methods/php5/methods.c
@@ -135,7 +135,7 @@ static bool z_vcall_method_ex(zval *object, zend_class_entry *ce, const char *me
 
     /* The zend_call_method() API only supports up to two arguments so we use
      * zend_call_function() instead.
-    */
+     */
     zend_try { call_fn_result = zend_call_function(&fci, &fcc TSRMLS_CC); }
     zend_catch { should_bail = true; }
     zend_end_try();

--- a/zend_abstract_interface/methods/tests/CMakeLists.txt
+++ b/zend_abstract_interface/methods/tests/CMakeLists.txt
@@ -1,7 +1,4 @@
-#[[ TODO When we have a consistent API across all PHP versions with ZAI
-    data-structure shims, move these tests out of PHP-versioned directories.
- ]]
-add_executable(methods "${PHP_VERSION_DIRECTORY}/methods.cc")
+add_executable(methods "methods.cc")
 
 target_link_libraries(methods PUBLIC catch2_main Zai::Sapi Zai::Methods)
 

--- a/zend_abstract_interface/methods/tests/methods.cc
+++ b/zend_abstract_interface/methods/tests/methods.cc
@@ -7,8 +7,6 @@ extern "C" {
 #include <cstring>
 #include <ext/spl/spl_dllist.h> // For 'SplDoublyLinkedList' class entry
 
-#define ZAI_STRL(str) (str), (sizeof(str) - 1)
-
 #define REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE()            \
     REQUIRE(false == zai_sapi_unhandled_exception_exists()); \
     REQUIRE(zai_sapi_last_error_is_empty())
@@ -19,6 +17,16 @@ extern "C" {
 #define SKIP_TEST_IN_DEBUG_MODE
 #endif
 
+#if PHP_VERSION_ID >= 70000
+zval zval_used_for_init = {0};
+#define RETPTR &retzv
+#else
+#define IS_UNDEF IS_NULL
+#define RETPTR &retval
+#undef ZVAL_STRING
+#define ZVAL_STRING(z, s) ZVAL_STRINGL(z, s, strlen(s), 1)
+#endif
+
 static zval *zai_instantiate_object_from_ce(zend_class_entry *ce) {
     TSRMLS_FETCH();
     zval *obj = NULL;
@@ -27,17 +35,43 @@ static zval *zai_instantiate_object_from_ce(zend_class_entry *ce) {
     object_init_ex(obj, ce);
     Z_SET_REFCOUNT_P(obj, 1);
     Z_SET_ISREF_P(obj);
+
+    // Only calls constructors without passing any args
+    if (ce->constructor && (ce->constructor->common.fn_flags & ZEND_ACC_PUBLIC)) {
+        zval *retval_ptr = NULL;
+
+        zend_fcall_info fci = {0};
+        fci.size = sizeof(zend_fcall_info);
+        fci.object_ptr = obj;
+        fci.retval_ptr_ptr = &retval_ptr;
+        fci.no_separation = 1;
+
+        zend_fcall_info_cache fcc = {0};
+        fcc.initialized = 1;
+        fcc.function_handler = ce->constructor;
+        fcc.calling_scope = ce;
+        fcc.called_scope = Z_OBJCE_P(obj);
+        fcc.object_ptr = obj;
+
+        // TODO Use zend_call_known_function on PHP 8
+        int status = zend_call_function(&fci, &fcc TSRMLS_CC);
+        if (retval_ptr) {
+            zval_ptr_dtor(&retval_ptr);
+        }
+        REQUIRE(status == SUCCESS);
+    }
+
     return obj;
 }
 
-/***************************** zai_class_lookup() ****************************/
+/************************** zai_class_lookup_literal() ************************/
 
 TEST_CASE("class lookup: (internal)", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+    zend_class_entry *ce = zai_class_lookup_literal("spldoublylinkedlist");
 
     REQUIRE(ce == spl_ce_SplDoublyLinkedList);
 
@@ -51,7 +85,7 @@ TEST_CASE("class lookup: (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
 
     REQUIRE(ce != NULL);
     REQUIRE(strcmp("Zai\\Methods\\Test", ce->name) == 0);
@@ -65,7 +99,7 @@ TEST_CASE("class lookup: root-scope prefix", "[zai_methods]" SKIP_TEST_IN_DEBUG_
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("\\spldoublylinkedlist"));
+    zend_class_entry *ce = zai_class_lookup_literal("\\spldoublylinkedlist");
 
     REQUIRE(ce == NULL);
 
@@ -78,7 +112,7 @@ TEST_CASE("class lookup: wrong case", "[zai_methods]" SKIP_TEST_IN_DEBUG_MODE) {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("SplDoublyLinkedList"));
+    zend_class_entry *ce = zai_class_lookup_literal("SplDoublyLinkedList");
 
     REQUIRE(ce == NULL);
 
@@ -93,7 +127,7 @@ TEST_CASE("class lookup: disable_classes INI", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+    zend_class_entry *ce = zai_class_lookup_literal("spldoublylinkedlist");
     REQUIRE(ce == spl_ce_SplDoublyLinkedList);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -110,7 +144,7 @@ TEST_CASE("class lookup: outside of request context", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("spldoublylinkedlist"));
+    zend_class_entry *ce = zai_class_lookup_literal("spldoublylinkedlist");
     REQUIRE(ce == spl_ce_SplDoublyLinkedList);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
@@ -123,7 +157,7 @@ TEST_CASE("class lookup: NULL class name", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(NULL, 42);
+    zend_class_entry *ce = zai_class_lookup_ex(NULL, 42 ZAI_TSRMLS_CC);
 
     REQUIRE(ce == NULL);
 
@@ -136,7 +170,7 @@ TEST_CASE("class lookup: 0 class len", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup("spldoublylinkedlist", 0);
+    zend_class_entry *ce = zai_class_lookup_ex("spldoublylinkedlist", 0 ZAI_TSRMLS_CC);
 
     REQUIRE(ce == NULL);
 
@@ -144,7 +178,7 @@ TEST_CASE("class lookup: 0 class len", "[zai_methods]") {
     zai_sapi_spindown();
 }
 
-/*********************** zai_call_method_without_args() **********************/
+/************************* zai_call_method_literal() **************************/
 
 TEST_CASE("call method: (internal)", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
@@ -152,17 +186,47 @@ TEST_CASE("call method: (internal)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // SplDoublyLinkedList::count()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
+    bool result = zai_call_method_literal(obj, "count", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_LONG);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: int args (internal)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    zend_class_entry *ce = zai_class_lookup_literal("datetime");
+    REQUIRE((ce != NULL && "ext/date required"));
+    zval *obj = zai_instantiate_object_from_ce(ce);
+
+    zval retzv = zval_used_for_init, *retval = &retzv;
+    zval year = zval_used_for_init;
+    zval month = zval_used_for_init;
+    zval day = zval_used_for_init;
+    ZVAL_LONG(&year, 2021);
+    ZVAL_LONG(&month, 11);
+    ZVAL_LONG(&day, 29);
+
+    // DateTime::setDate()
+    bool result = zai_call_method_literal(obj, "setdate", RETPTR, &year, &month, &day);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE_P(retval) == IS_OBJECT);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -174,21 +238,107 @@ TEST_CASE("call method: (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::returnsTrue()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("returnstrue"), &retval);
+    bool result = zai_call_method_literal(obj, "returnstrue", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: int args (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval retzv = zval_used_for_init, *retval = &retzv;
+    zval arg = zval_used_for_init;
+    ZVAL_LONG(&arg, 42);
+
+    // Zai\Methods\Test::returnsArg()
+    bool result = zai_call_method_literal(obj, "returnsarg", RETPTR, &arg);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE_P(retval) == IS_LONG);
+    REQUIRE(Z_LVAL_P(retval) == 42);
+
+    zval_ptr_dtor(RETPTR);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: string args (userland)", "[zai_methods]") {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval retzv = zval_used_for_init, *retval = &retzv;
+    zval arg = zval_used_for_init;
+    ZVAL_STRING(&arg, "foo string");
+
+    // Zai\Methods\Test::returnsArg()
+    bool result = zai_call_method_literal(obj, "returnsarg", RETPTR, &arg);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == true);
+    REQUIRE(Z_TYPE_P(retval) == IS_STRING);
+    REQUIRE(strcmp("foo string", Z_STRVAL_P(retval)) == 0);
+
+    zval_dtor(&arg);
+    zval_ptr_dtor(RETPTR);
+
+    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
+    zai_sapi_spindown();
+}
+
+TEST_CASE("call method: more than MAX_ARGS", "[zai_methods]" SKIP_TEST_IN_DEBUG_MODE) {
+    REQUIRE(zai_sapi_spinup());
+    ZAI_SAPI_TSRMLS_FETCH();
+    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
+
+    REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
+    REQUIRE(ce != NULL);
+
+    zval *obj = zai_instantiate_object_from_ce(ce);
+    zval retzv = zval_used_for_init, *retval = &retzv;
+    zval arg = zval_used_for_init;
+    ZVAL_STRING(&arg, "foo string");
+
+    // Zai\Methods\Test::returnsTrue()
+    bool result = zai_call_method_literal(obj, "returnstrue", RETPTR, &arg, &arg, &arg, &arg);
+    zval_ptr_dtor(&obj);
+
+    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
+    REQUIRE(result == false);
+
+    zval_dtor(&arg);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -200,14 +350,16 @@ TEST_CASE("call method: does not exist on object (internal)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // SplDoublyLinkedList::iDoNotExist()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("idonotexist"), &retval);
+    bool result = zai_call_method_literal(obj, "idonotexist", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -219,18 +371,20 @@ TEST_CASE("call method: does not exist on object (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::iDoNotExist()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("idonotexist"), &retval);
+    bool result = zai_call_method_literal(obj, "idonotexist", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -242,21 +396,20 @@ TEST_CASE("call method: accesses $this (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::usesThis()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("usesthis"), &retval);
+    bool result = zai_call_method_literal(obj, "usesthis", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -268,7 +421,7 @@ TEST_CASE("call method: throws exception (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\exceptiontest");
     REQUIRE(ce != NULL);
 
     /* Add a fake base/main frame to prevent the uncaught exception from
@@ -278,14 +431,16 @@ TEST_CASE("call method: throws exception (userland)", "[zai_methods]") {
     REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\ExceptionTest::throwsException()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexception"), &retval);
+    bool result = zai_call_method_literal(obj, "throwsexception", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -299,7 +454,7 @@ TEST_CASE("call method: throws exception with active frame (userland)", "[zai_me
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\exceptiontest");
     REQUIRE(ce != NULL);
 
     /* Simulate an active execution context. */
@@ -307,14 +462,16 @@ TEST_CASE("call method: throws exception with active frame (userland)", "[zai_me
     REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\ExceptionTest::throwsException()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexception"), &retval);
+    bool result = zai_call_method_literal(obj, "throwsexception", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -329,16 +486,18 @@ TEST_CASE("call method: non-object", "[zai_methods]") {
 
     zval *nonobj = NULL;
     MAKE_STD_ZVAL(nonobj);
-    ZVAL_STRING(nonobj, "spldoublylinkedlist", 1);
+    ZVAL_STRING(nonobj, "spldoublylinkedlist");
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // SplDoublyLinkedList::count()
-    bool result = zai_call_method_without_args(nonobj, ZAI_STRL("count"), &retval);
+    bool result = zai_call_method_literal(nonobj, "count", RETPTR);
     zval_ptr_dtor(&nonobj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -349,13 +508,15 @@ TEST_CASE("call method: NULL object", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // {NULL}::count()
-    bool result = zai_call_method_without_args(NULL, ZAI_STRL("count"), &retval);
+    bool result = zai_call_method_literal(NULL, "count", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -367,14 +528,16 @@ TEST_CASE("call method: NULL method name", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // SplDoublyLinkedList::{NULL}()
-    bool result = zai_call_method_without_args(obj, NULL, 42, &retval);
+    bool result = zai_call_method_ex(obj, NULL, 42, RETPTR ZAI_TSRMLS_CC, 0);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -386,33 +549,16 @@ TEST_CASE("call method: 0 len method name", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // SplDoublyLinkedList::()
-    bool result = zai_call_method_without_args(obj, "count", 0, &retval);
+    bool result = zai_call_method_ex(obj, "count", 0, RETPTR ZAI_TSRMLS_CC, 0);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
 
-    ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
-    zai_sapi_spindown();
-}
-
-TEST_CASE("call method: non-NULL retval", "[zai_methods]") {
-    REQUIRE(zai_sapi_spinup());
-    ZAI_SAPI_TSRMLS_FETCH();
-    ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
-
-    zval *obj = zai_instantiate_object_from_ce(spl_ce_SplDoublyLinkedList);
-    zval *retval = (zval *)(void *)1;
-    // SplDoublyLinkedList::count()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("count"), &retval);
-    zval_ptr_dtor(&obj);
-
-    REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
-    REQUIRE(result == false);
-    REQUIRE(retval == (zval *)(void *)1);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -423,21 +569,20 @@ TEST_CASE("call method: static method (internal)", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    zend_class_entry *ce = zai_class_lookup_literal("datetime");
     REQUIRE((ce != NULL && "ext/date required"));
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // DateTime::getLastErrors()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("getlasterrors"), &retval);
+    bool result = zai_call_method_literal(obj, "getlasterrors", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE((Z_TYPE_P(retval) == IS_BOOL || Z_TYPE_P(retval) == IS_ARRAY));
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -449,47 +594,45 @@ TEST_CASE("call method: static method (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::returns42()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("returns42"), &retval);
+    bool result = zai_call_method_literal(obj, "returns42", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_LONG);
     REQUIRE(Z_LVAL_P(retval) == 42);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
 }
 
-/******************* zai_call_static_method_without_args() *******************/
+/********************** zai_call_static_method_literal() **********************/
 
 TEST_CASE("call static method: (internal)", "[zai_methods]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    zend_class_entry *ce = zai_class_lookup_literal("datetime");
     REQUIRE((ce != NULL && "ext/date required"));
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // DateTime::getLastErrors()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("getlasterrors"), &retval);
+    bool result = zai_call_static_method_literal(ce, "getlasterrors", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE((Z_TYPE_P(retval) == IS_BOOL || Z_TYPE_P(retval) == IS_ARRAY));
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -501,20 +644,19 @@ TEST_CASE("call static method: (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::returns42()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("returns42"), &retval);
+    bool result = zai_call_static_method_literal(ce, "returns42", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_LONG);
     REQUIRE(Z_LVAL_P(retval) == 42);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -526,12 +668,12 @@ TEST_CASE("call static method: call method on retval (userland)", "[zai_methods]
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
     zval *retval_self = NULL;
     // Zai\Methods\Test::newSelf()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("newself"), &retval_self);
+    bool result = zai_call_static_method_literal(ce, "newself", &retval_self);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
@@ -541,7 +683,7 @@ TEST_CASE("call static method: call method on retval (userland)", "[zai_methods]
 
     zval *retval_true = NULL;
     // Zai\Methods\Test::usesThis()
-    bool result2 = zai_call_method_without_args(retval_self, ZAI_STRL("usesthis"), &retval_true);
+    bool result2 = zai_call_method_literal(retval_self, "usesthis", &retval_true);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result2 == true);
@@ -560,16 +702,18 @@ TEST_CASE("call static method: outside of request context", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    zend_class_entry *ce = zai_class_lookup_literal("datetime");
     REQUIRE((ce != NULL && "ext/date required"));
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // DateTime::getLastErrors()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("getlasterrors"), &retval);
+    bool result = zai_call_static_method_literal(ce, "getlasterrors", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_mshutdown();
@@ -581,16 +725,18 @@ TEST_CASE("call static method: does not exist on class (internal)", "[zai_method
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("datetime"));
+    zend_class_entry *ce = zai_class_lookup_literal("datetime");
     REQUIRE((ce != NULL && "ext/date required"));
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // DateTime::iDoNotExist()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("idonotexist"), &retval);
+    bool result = zai_call_static_method_literal(ce, "idonotexist", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -602,16 +748,18 @@ TEST_CASE("call static method: does not exist on class (userland)", "[zai_method
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\Test::iDoNotExist()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("idonotexist"), &retval);
+    bool result = zai_call_static_method_literal(ce, "idonotexist", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -623,7 +771,7 @@ TEST_CASE("call static method: throws exception (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\exceptiontest");
     REQUIRE(ce != NULL);
 
     /* Add a fake base/main frame to prevent the uncaught exception from
@@ -633,14 +781,16 @@ TEST_CASE("call static method: throws exception (userland)", "[zai_methods]") {
     REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\ExceptionTest::throwsExceptionFromStatic()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexceptionfromstatic"), &retval);
+    bool result = zai_call_method_literal(obj, "throwsexceptionfromstatic", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -654,7 +804,7 @@ TEST_CASE("call static method: throws exception with active frame (userland)", "
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/ExceptionTest.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\exceptiontest"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\exceptiontest");
     REQUIRE(ce != NULL);
 
     /* Simulate an active execution context. */
@@ -662,14 +812,16 @@ TEST_CASE("call static method: throws exception with active frame (userland)", "
     REQUIRE(zai_sapi_fake_frame_push(&fake_frame));
 
     zval *obj = zai_instantiate_object_from_ce(ce);
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\ExceptionTest::throwsExceptionFromStatic()
-    bool result = zai_call_method_without_args(obj, ZAI_STRL("throwsexceptionfromstatic"), &retval);
+    bool result = zai_call_method_literal(obj, "throwsexceptionfromstatic", RETPTR);
     zval_ptr_dtor(&obj);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     zai_sapi_fake_frame_pop(&fake_frame);
 
@@ -682,12 +834,14 @@ TEST_CASE("call static method: NULL ce", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zval *retval = NULL;
-    bool result = zai_call_static_method_without_args(NULL, ZAI_STRL("count"), &retval);
+    zval retzv = zval_used_for_init, *retval = &retzv;
+    bool result = zai_call_static_method_literal(NULL, "count", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -698,17 +852,19 @@ TEST_CASE("call static method: non-static method (internal)", "[zai_methods]") {
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     /* This call will fail because SplDoublyLinkedList::count() is not marked
      * with ZEND_ACC_ALLOW_STATIC.
      *
      * https://github.com/php/php-src/blob/PHP-5.4/ext/spl/spl_dllist.c#L1324
      */
-    bool result = zai_call_static_method_without_args(spl_ce_SplDoublyLinkedList, ZAI_STRL("count"), &retval);
+    bool result = zai_call_static_method_literal(spl_ce_SplDoublyLinkedList, "count", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -720,24 +876,23 @@ TEST_CASE("call static method: non-static method (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\test");
     REQUIRE(ce != NULL);
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     /* Calling the non-static method Zai\Methods\Test::returnsTrue() statically
      * is allowed here because the compiler marks non-static userland methods
      * with ZEND_ACC_ALLOW_STATIC.
      *
      * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_compile.c#L1679
      */
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("returnstrue"), &retval);
+    bool result = zai_call_static_method_literal(ce, "returnstrue", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == true);
-    REQUIRE(retval != NULL);
     REQUIRE(Z_TYPE_P(retval) == IS_BOOL);
 
-    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();
@@ -750,7 +905,7 @@ TEST_CASE("call static method: non-static method that accesses $this (userland)"
     zend_class_entry *ce;
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
     REQUIRE(zai_sapi_execute_script("./stubs/Test.php"));
-    ce = zai_class_lookup(ZAI_STRL("zai\\methods\\test"));
+    ce = zai_class_lookup_literal("zai\\methods\\test");
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     REQUIRE(ce != NULL);
 
@@ -758,14 +913,14 @@ TEST_CASE("call static method: non-static method that accesses $this (userland)"
      * bubble up after closing the sandbox.
      */
     ZAI_SAPI_BAILOUT_EXPECTED_OPEN()
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     /* Although the compiler marks this non-static userland method
      * Zai\Methods\Test::usesThis() with ZEND_ACC_ALLOW_STATIC, the call will
      * fail when '$this' is accessed from a static context.
      *
      * https://github.com/php/php-src/blob/PHP-5.4/Zend/zend_execute.c#L460-L506
      */
-    (void)zai_call_static_method_without_args(ce, ZAI_STRL("usesthis"), &retval);
+    (void)zai_call_static_method_literal(ce, "usesthis", RETPTR);
     ZAI_SAPI_BAILOUT_EXPECTED_CLOSE()
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
@@ -779,16 +934,18 @@ TEST_CASE("call static method: abstract method (userland)", "[zai_methods]") {
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
 
     REQUIRE(zai_sapi_execute_script("./stubs/AbstractTest.php"));
-    zend_class_entry *ce = zai_class_lookup(ZAI_STRL("zai\\methods\\abstracttest"));
+    zend_class_entry *ce = zai_class_lookup_literal("zai\\methods\\abstracttest");
     REQUIRE(ce != NULL);
 
-    zval *retval = NULL;
+    zval retzv = zval_used_for_init, *retval = &retzv;
     // Zai\Methods\AbstractTest::abstractMethod()
-    bool result = zai_call_static_method_without_args(ce, ZAI_STRL("abstractmethod"), &retval);
+    bool result = zai_call_static_method_literal(ce, "abstractmethod", RETPTR);
 
     REQUIRE_ERROR_AND_EXCEPTION_CLEAN_SLATE();
     REQUIRE(result == false);
-    REQUIRE(retval == NULL);
+    REQUIRE(Z_TYPE_P(retval) == IS_UNDEF);
+
+    zval_ptr_dtor(RETPTR);
 
     ZAI_SAPI_ABORT_ON_BAILOUT_CLOSE()
     zai_sapi_spindown();

--- a/zend_abstract_interface/methods/tests/methods.cc
+++ b/zend_abstract_interface/methods/tests/methods.cc
@@ -40,13 +40,13 @@ static zval *zai_instantiate_object_from_ce(zend_class_entry *ce) {
     if (ce->constructor && (ce->constructor->common.fn_flags & ZEND_ACC_PUBLIC)) {
         zval *retval_ptr = NULL;
 
-        zend_fcall_info fci = {0};
+        zend_fcall_info fci = empty_fcall_info;
         fci.size = sizeof(zend_fcall_info);
         fci.object_ptr = obj;
         fci.retval_ptr_ptr = &retval_ptr;
         fci.no_separation = 1;
 
-        zend_fcall_info_cache fcc = {0};
+        zend_fcall_info_cache fcc = empty_fcall_info_cache;
         fcc.initialized = 1;
         fcc.function_handler = ce->constructor;
         fcc.calling_scope = ce;

--- a/zend_abstract_interface/methods/tests/stubs/Test.php
+++ b/zend_abstract_interface/methods/tests/stubs/Test.php
@@ -25,4 +25,9 @@ class Test
     {
         return new static;
     }
+
+    public function returnsArg($arg)
+    {
+        return $arg;
+    }
 }

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -10,6 +10,7 @@
 #include "../zai_sapi_io.h"
 
 #define DEFAULT_INI        \
+    "date.timezone=UTC\n"  \
     "html_errors=0\n"      \
     "implicit_flush=1\n"   \
     "output_buffering=0\n" \


### PR DESCRIPTION
### Description

Before adding ZAI methods for PHP 7 and 8 we needed to update the API on PHP 5 to support calling methods with arguments. The retval handling has also been updated to work more similar to the ZAI functions API. This also will also make it easier to share the same tests on PHP 7 & 8.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
