### PR TITLE
Update outdated release artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://577339-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.65.1_amd64.deb"
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.67.0/datadog-php-tracer_0.67.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"


### PR DESCRIPTION
### Description

The previous release was using the CircleCI artifacts, which expire. This bumps the release version used and switches to GitHub, which will be much more reliable.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
