### PR TITLE
Add embed SAPI to shared-ext containers

### DIFF
--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       dockerfile: Dockerfile_shared_ext
       args:
         phpVersion: 8.0
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.8.tar.gz
-        phpSha256Hash: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.13.tar.gz
+        phpSha256Hash: b4c2d27c954e1b0d84fd4bfef4d252e154ba479e7db11abd89358f2164ee7cc8
 
   php-7.4:
     image: datadog/dd-trace-ci:php-7.4_buster

--- a/dockerfiles/ci/buster/php-7.4/configure_shared_ext.sh
+++ b/dockerfiles/ci/buster/php-7.4/configure_shared_ext.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --disable-all \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-pcntl=shared \
     --enable-phpdbg \

--- a/dockerfiles/ci/buster/php-8.0/configure_shared_ext.sh
+++ b/dockerfiles/ci/buster/php-8.0/configure_shared_ext.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --disable-all \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-pcntl=shared \
     --enable-phpdbg \


### PR DESCRIPTION
### Description

Adding the embed SAPI exposes `libphp` so that we can run ZAI SAPI in the shared-ext containers.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
