### PR TITLE
Bump CMake version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1457,8 +1457,8 @@ workflows:
                 - "datadog/dd-trace-ci:alpine"
                 - "datadog/dd-trace-ci:buster"
               cmake_version:
-                - "3.14.7"
-                - "3.19.6"
+                - "3.19.8"
+                - "3.21.4"
               catch2_version:
                 - "2.13.7"
 

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,7 +1,10 @@
 #[[ Need CMake 3.14 so that `install(TARGETS)` uses better defaults, which
     saves us from repeating configuration in every file (and must be the same).
+    Need CMake 3.15+ because the channel component fails on 3.14. Instead of
+    just bumping incrementally, I've bumped this to the latest version that's
+    been tested in CI for a while: 3.19.
 ]]
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 
 project(datadog-php-components
   VERSION 0.1.0


### PR DESCRIPTION
### Description

This fixes some failing component tests due to bugs in CMake 3.14
that are fixed in newer versions.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
