### PR TITLE
Implement x-datadog-tag propagation and _dd.p.upstream_services

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -85,6 +85,7 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php5/signals.c \
       ext/php5/span.c \
       ext/php5/startup_logging.c \
+      ext/php5/tracer_tag_propagation/tracer_tag_propagation.c \
     "
 
     ZAI_SOURCES="\
@@ -135,6 +136,7 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php5/signals.c \
       ext/php5/span.c \
       ext/php5/startup_logging.c \
+      ext/php5/tracer_tag_propagation/tracer_tag_propagation.c \
     "
 
     ZAI_SOURCES="\
@@ -342,6 +344,7 @@ if test "$PHP_DDTRACE" != "no"; then
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/php5_4])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/priority_sampling])
+    PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/tracer_tag_propagation])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/integrations])
     PHP_ADD_INCLUDE([$ext_builddir/ext/php5/integrations])
   elif test $PHP_VERSION_ID -lt 70000; then
@@ -350,6 +353,7 @@ if test "$PHP_DDTRACE" != "no"; then
     dnl Temp dir until we merge dispatch.c and engine_hooks.c
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/php5])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/priority_sampling])
+    PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/tracer_tag_propagation])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php5/integrations])
     PHP_ADD_INCLUDE([$ext_builddir/ext/php5/integrations])
   elif test $PHP_VERSION_ID -lt 80000; then

--- a/config.m4
+++ b/config.m4
@@ -190,6 +190,7 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php7/signals.c \
       ext/php7/span.c \
       ext/php7/startup_logging.c \
+      ext/php7/tracer_tag_propagation/tracer_tag_propagation.c \
     "
 
     ZAI_SOURCES="\
@@ -357,6 +358,7 @@ if test "$PHP_DDTRACE" != "no"; then
     dnl Temp dir until we merge dispatch.c and engine_hooks.c
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php7/php7])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php7/priority_sampling])
+    PHP_ADD_BUILD_DIR([$ext_builddir/ext/php7/tracer_tag_propagation])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php7/integrations])
     PHP_ADD_INCLUDE([$ext_builddir/ext/php7/integrations])
   elif test $PHP_VERSION_ID -lt 90000; then

--- a/config.m4
+++ b/config.m4
@@ -244,6 +244,7 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php8/signals.c \
       ext/php8/span.c \
       ext/php8/startup_logging.c \
+      ext/php8/tracer_tag_propagation/tracer_tag_propagation.c \
       ext/php8/weakrefs.c \
     "
 
@@ -364,6 +365,7 @@ if test "$PHP_DDTRACE" != "no"; then
     dnl Temp dir until we merge dispatch.c and engine_hooks.c
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php8/php8])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php8/priority_sampling])
+    PHP_ADD_BUILD_DIR([$ext_builddir/ext/php8/tracer_tag_propagation])
     PHP_ADD_BUILD_DIR([$ext_builddir/ext/php8/integrations])
     PHP_ADD_INCLUDE([$ext_builddir/ext/php8/integrations])
   fi

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                  \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -86,6 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
+    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -52,6 +52,8 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     HashTable *function_lookup;
     zval additional_trace_meta; // IS_ARRAY
     HashTable additional_global_tags;
+    HashTable root_span_tags_preset;
+    HashTable propagated_root_span_tags;
     zend_bool log_backtrace;
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
@@ -80,6 +82,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 
     uint64_t trace_id;
     long default_priority_sampling;
+    long propagated_priority_sampling;
     ddtrace_span_ids_t *span_ids_top;
     ddtrace_span_fci *open_spans_top;
     ddtrace_span_fci *closed_spans_top;

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -35,7 +35,7 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     long sampling_priority = ddtrace_fetch_prioritySampling_from_root(TSRMLS_C);
     if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
         sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-        if (current_services) {
+        if (strlen(current_services)) {
             add_assoc_string(meta, "_dd.p.upstream_services", current_services, 1);
         } else {
             zend_hash_del(Z_ARRVAL_P(meta), "_dd.p.upstream_services", sizeof("_dd.p.upstream_services"));

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -3,11 +3,73 @@
 #include <mt19937-64.h>
 
 #include <ext/pcre/php_pcre.h>
+#include <ext/standard/base64.h>
 
 #include "../configuration.h"
 #include "../span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+enum dd_sampling_mechanism {
+    DD_MECHANISM_AGENT_RATE = 1,
+    DD_MECHANISM_REMOTE_RATE = 2,
+    DD_MECHANISM_RULE = 3,
+    DD_MECHANISM_MANUAL = 4,
+};
+
+static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci *deciding_span,
+                                        enum dd_sampling_mechanism mechanism TSRMLS_DC) {
+    zval *meta = ddtrace_spandata_property_meta(&span->span);
+    if (Z_TYPE_P(meta) != IS_ARRAY) {
+        zval_ptr_dtor(&meta);
+        array_init(meta);
+    }
+
+    zval **current_services_zv = NULL;
+
+    zend_hash_find(&DDTRACE_G(root_span_tags_preset), "_dd.p.upstream_services", sizeof("_dd.p.upstream_services"),
+                   (void **)&current_services_zv);
+
+    char *current_services = current_services_zv ? Z_STRVAL_PP(current_services_zv) : "";
+
+    long sampling_priority = ddtrace_fetch_prioritySampling_from_root(TSRMLS_C);
+    if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
+        sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
+        if (current_services) {
+            add_assoc_string(meta, "_dd.p.upstream_services", current_services, 1);
+        } else {
+            zend_hash_del(Z_ARRVAL_P(meta), "_dd.p.upstream_services", sizeof("_dd.p.upstream_services"));
+        }
+        return;
+    }
+
+    zval *service = ddtrace_spandata_property_service(&deciding_span->span);
+
+    int b64_servicename_length = 0;
+    unsigned char *b64_servicename =
+        php_base64_encode((unsigned char *)Z_STRVAL_P(service), Z_STRLEN_P(service), &b64_servicename_length);
+    while (b64_servicename_length > 0 && b64_servicename[b64_servicename_length - 1] == '=') {
+        b64_servicename[--b64_servicename_length] = 0;  // remove padding
+    }
+
+    char sampling_rate[7] = {0};
+    zval *metrics = ddtrace_spandata_property_metrics(&span->span), **sample_rate;
+    if (Z_TYPE_P(metrics) == IS_ARRAY && (zend_hash_find(Z_ARRVAL_P(metrics), "_dd.rule_psr", sizeof("_dd.rule_psr"),
+                                                         (void **)&sample_rate) == SUCCESS)) {
+        snprintf(sampling_rate, 6, "%f", Z_DVAL_PP(sample_rate));
+    }
+
+    char *new_services;
+    spprintf(&new_services, 0, "%s%s%s|%d|%d|%s",
+             current_services_zv && Z_TYPE_PP(current_services_zv) == IS_STRING ? Z_STRVAL_PP(current_services_zv) : "",
+             current_services_zv && (Z_TYPE_PP(current_services_zv) == IS_STRING) && Z_STRLEN_PP(current_services_zv)
+                 ? ";"
+                 : "",
+             b64_servicename, (int)sampling_priority, mechanism, sampling_rate);
+    add_assoc_string(meta, "_dd.p.upstream_services", new_services, 0);
+
+    efree(b64_servicename);
+}
 
 static bool dd_rule_matches(zval *pattern, zval *prop TSRMLS_DC) {
     if (Z_TYPE_P(pattern) != IS_STRING) {
@@ -28,6 +90,7 @@ static bool dd_rule_matches(zval *pattern, zval *prop TSRMLS_DC) {
 
 static void dd_decide_on_sampling(ddtrace_span_fci *span TSRMLS_DC) {
     int priority = DDTRACE_G(default_priority_sampling);
+    enum dd_sampling_mechanism mechanism = DD_MECHANISM_MANUAL;
     if (priority == DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
         double sample_rate = get_DD_TRACE_SAMPLE_RATE();
         bool explicit_rule = zai_config_memoized_entries[DDTRACE_CONFIG_DD_TRACE_SAMPLE_RATE].name_index >= 0;
@@ -70,13 +133,17 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span TSRMLS_DC) {
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
         if (explicit_rule) {
+            mechanism = DD_MECHANISM_RULE;
             priority = sampling ? PRIORITY_SAMPLING_USER_KEEP : PRIORITY_SAMPLING_USER_REJECT;
         } else {
+            mechanism = DD_MECHANISM_AGENT_RATE;
             priority = sampling ? PRIORITY_SAMPLING_AUTO_KEEP : PRIORITY_SAMPLING_AUTO_REJECT;
         }
     }
     add_assoc_long_ex(ddtrace_spandata_property_metrics(&span->span), "_sampling_priority_v1",
                       sizeof("_sampling_priority_v1"), priority);
+
+    dd_update_upstream_services(span, span, mechanism TSRMLS_CC);
 }
 
 long ddtrace_fetch_prioritySampling_from_root(TSRMLS_D) {
@@ -123,5 +190,7 @@ void ddtrace_set_prioritySampling_on_root(long priority TSRMLS_DC) {
         ZVAL_LONG(zv, priority);
         zend_hash_update(root_metrics, "_sampling_priority_v1", sizeof("_sampling_priority_v1"), &zv, sizeof(zval *),
                          NULL);
+
+        dd_update_upstream_services(root_span, DDTRACE_G(open_spans_top), DD_MECHANISM_MANUAL TSRMLS_CC);
     }
 }

--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -459,6 +459,9 @@ static smart_str dd_build_req_url(TSRMLS_D) {
 void ddtrace_set_root_span_properties(ddtrace_span_t *span TSRMLS_DC) {
     zval *meta = ddtrace_spandata_property_meta(span);
 
+    zend_hash_copy(Z_ARRVAL_P(meta), &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref, NULL,
+                   sizeof(zval *));
+
     add_assoc_long(meta, "system.pid", (long)getpid());
 
     const char *method = SG(request_info).request_method;

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
@@ -1,0 +1,104 @@
+#include "tracer_tag_propagation.h"
+
+#include <ext/standard/php_smart_str.h>
+
+#include "../compat_string.h"
+#include "../configuration.h"
+#include "../ddtrace.h"
+#include "../logging.h"
+#include "../priority_sampling/priority_sampling.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+void ddtrace_add_tracer_tags_from_header(zai_string_view *headerstr TSRMLS_DC) {
+    char *header = (char *)headerstr->ptr, *headerend = header + headerstr->len;
+
+    for (char *tagstart = header; header < headerend; ++header) {
+        if (*header == '=') {
+            zai_string_view tag_name = {header - tagstart, tagstart};
+            char *valuestart = ++header;
+
+            while (header < headerend && *header != ',') {
+                ++header;
+            }
+
+            zval *zv;
+            MAKE_STD_ZVAL(zv);
+            Z_TYPE_P(zv) = IS_STRING;
+            Z_STRLEN_P(zv) = header - valuestart;
+            Z_STRVAL_P(zv) = emalloc(Z_STRLEN_P(zv) + 1);
+            memcpy(Z_STRVAL_P(zv), valuestart, header - valuestart);
+            Z_STRVAL_P(zv)[Z_STRLEN_P(zv)] = 0;
+
+            char *key = emalloc(tag_name.len + 1);
+
+            memcpy(key, tag_name.ptr, tag_name.len);
+
+            key[tag_name.len] = 0;
+
+            zend_hash_update(&DDTRACE_G(root_span_tags_preset), key, tag_name.len + 1, &zv, sizeof(zval *), NULL);
+            zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), key, tag_name.len + 1);
+            efree(key);
+        }
+        // we skip invalid tags without = within
+        if (*header == ',') {
+            tagstart = ++header;
+        }
+    }
+}
+
+zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
+    // we propagate all tags on the current root span which were originally propagated, including the explicitly
+    // defined tags here
+    zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), "_dd.p.upstream_services",
+                                sizeof("_dd.p.upstream_services"));
+
+    HashTable *tags = &DDTRACE_G(root_span_tags_preset);
+    if (DDTRACE_G(root_span)) {
+        zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+        if (Z_TYPE_P(meta) == IS_ARRAY) {
+            tags = Z_ARRVAL_P(meta);
+        }
+    }
+
+    smart_str taglist = {0};
+    HashPosition pos;
+    char *key;
+    uint klen;
+    ulong kidx;
+
+    zend_hash_internal_pointer_reset_ex(&DDTRACE_G(propagated_root_span_tags), &pos);
+    while (zend_hash_get_current_key_ex(&DDTRACE_G(propagated_root_span_tags), (char **)&key, (uint *)&klen, &kidx, 0,
+                                        &pos) == HASH_KEY_IS_STRING) {
+        zval **tag;
+
+        if (zend_hash_find(tags, key, klen, (void **)&tag) == SUCCESS) {
+            if ((taglist.c ? taglist.len : 0) + (klen - 1) + Z_STRLEN_PP(tag) + 2 <=
+                (size_t)get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH()) {
+                if (taglist.c) {
+                    smart_str_appendc(&taglist, ',');
+                }
+                smart_str_appendl(&taglist, key, klen - 1);
+                smart_str_appendc(&taglist, '=');
+                smart_str_appendl(&taglist, Z_STRVAL_PP(tag), Z_STRLEN_PP(tag));
+            } else {
+                ddtrace_log_errf(
+                    "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of %ld characters and is thus dropped.",
+                    key, Z_STRLEN_PP(tag), Z_STRVAL_PP(tag), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+
+                zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+                if (Z_TYPE_P(meta) != IS_ARRAY) {
+                    zval_ptr_dtor(&meta);
+                    array_init(meta);
+                }
+                add_assoc_string_ex(meta, "_dd.propagation_error", sizeof("_dd.propagation_error"), "encoding_error",
+                                    1);
+            }
+        }
+        zend_hash_move_forward_ex(&DDTRACE_G(propagated_root_span_tags), &pos);
+    }
+
+    smart_str_0(&taglist);
+
+    return (zai_string_view){taglist.len, taglist.c};
+}

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
@@ -42,6 +42,8 @@ void ddtrace_add_tracer_tags_from_header(zai_string_view *headerstr TSRMLS_DC) {
         }
         // we skip invalid tags without = within
         if (*header == ',') {
+            ddtrace_log_debugf("Found x-datadog-tags header without key-separating equals character; raw input: %.*s",
+                               headerstr->len, headerstr->ptr);
             tagstart = ++header;
         }
     }
@@ -55,10 +57,7 @@ zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
 
     HashTable *tags = &DDTRACE_G(root_span_tags_preset);
     if (DDTRACE_G(root_span)) {
-        zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
-        if (Z_TYPE_P(meta) == IS_ARRAY) {
-            tags = Z_ARRVAL_P(meta);
-        }
+        tags = Z_ARRVAL_P(ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span));
     }
 
     smart_str taglist = {0};
@@ -67,35 +66,57 @@ zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
     uint klen;
     ulong kidx;
 
-    zend_hash_internal_pointer_reset_ex(&DDTRACE_G(propagated_root_span_tags), &pos);
-    while (zend_hash_get_current_key_ex(&DDTRACE_G(propagated_root_span_tags), (char **)&key, (uint *)&klen, &kidx, 0,
-                                        &pos) == HASH_KEY_IS_STRING) {
+    for (zend_hash_internal_pointer_reset_ex(&DDTRACE_G(propagated_root_span_tags), &pos); zend_hash_get_current_key_ex(&DDTRACE_G(propagated_root_span_tags), (char **)&key, (uint *)&klen, &kidx, 0, &pos) == HASH_KEY_IS_STRING; zend_hash_move_forward_ex(&DDTRACE_G(propagated_root_span_tags), &pos)) {
         zval **tag;
 
         if (zend_hash_find(tags, key, klen, (void **)&tag) == SUCCESS) {
-            if ((taglist.c ? taglist.len : 0) + (klen - 1) + Z_STRLEN_PP(tag) + 2 <=
-                (size_t)get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH()) {
+            zval str;
+            char *error = NULL;
+            ddtrace_convert_to_string(&str, *tag TSRMLS_CC);
+
+            for (char *cur = key, *end = cur + klen - 1; cur < end; ++cur) {
+                if (*cur < 0x20 || *cur > 0x7E || *cur == '=' || *cur == ',') {
+                    ddtrace_log_errf("The to be propagated tag name '%s' is invalid and is thus dropped.", key);
+                    error = "encoding_error";
+                    goto error;
+                }
+            }
+
+            for (char *cur = Z_STRVAL(str), *end = cur + Z_STRLEN(str); cur < end; ++cur) {
+                if (*cur < 0x20 || *cur > 0x7E || *cur == ',') {
+                    ddtrace_log_errf("The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.",
+                                     key, Z_STRLEN(str), Z_STRVAL(str));
+                    error = "encoding_error";
+                    goto error;
+                }
+            }
+
+            if ((taglist.c ? taglist.len : 0) + (klen - 1) + Z_STRLEN(str) + 2 <=
+                (size_t)get_DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH()) {
                 if (taglist.c) {
                     smart_str_appendc(&taglist, ',');
                 }
                 smart_str_appendl(&taglist, key, klen - 1);
                 smart_str_appendc(&taglist, '=');
-                smart_str_appendl(&taglist, Z_STRVAL_PP(tag), Z_STRLEN_PP(tag));
+                smart_str_appendl(&taglist, Z_STRVAL(str), Z_STRLEN(str));
             } else {
                 ddtrace_log_errf(
                     "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of %ld characters and is thus dropped.",
-                    key, Z_STRLEN_PP(tag), Z_STRVAL_PP(tag), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+                    key, Z_STRLEN(str), Z_STRVAL(str), get_DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH());
 
-                zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
-                if (Z_TYPE_P(meta) != IS_ARRAY) {
-                    zval_ptr_dtor(&meta);
-                    array_init(meta);
-                }
-                add_assoc_string_ex(meta, "_dd.propagation_error", sizeof("_dd.propagation_error"), "encoding_error",
-                                    1);
+                error = "max_size";
+            }
+
+            error:
+            zval_dtor(&str);
+
+            if (error) {
+                zval *error_zv;
+                MAKE_STD_ZVAL(error_zv);
+                ZVAL_STRING(error_zv, error, 1);
+                zend_hash_update(tags, "_dd.propagation_error", sizeof("_dd.propagation_error"), (void *) &error_zv, sizeof(zval *), NULL);
             }
         }
-        zend_hash_move_forward_ex(&DDTRACE_G(propagated_root_span_tags), &pos);
     }
 
     smart_str_0(&taglist);

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.c
@@ -66,7 +66,10 @@ zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
     uint klen;
     ulong kidx;
 
-    for (zend_hash_internal_pointer_reset_ex(&DDTRACE_G(propagated_root_span_tags), &pos); zend_hash_get_current_key_ex(&DDTRACE_G(propagated_root_span_tags), (char **)&key, (uint *)&klen, &kidx, 0, &pos) == HASH_KEY_IS_STRING; zend_hash_move_forward_ex(&DDTRACE_G(propagated_root_span_tags), &pos)) {
+    for (zend_hash_internal_pointer_reset_ex(&DDTRACE_G(propagated_root_span_tags), &pos);
+         zend_hash_get_current_key_ex(&DDTRACE_G(propagated_root_span_tags), (char **)&key, (uint *)&klen, &kidx, 0,
+                                      &pos) == HASH_KEY_IS_STRING;
+         zend_hash_move_forward_ex(&DDTRACE_G(propagated_root_span_tags), &pos)) {
         zval **tag;
 
         if (zend_hash_find(tags, key, klen, (void **)&tag) == SUCCESS) {
@@ -84,8 +87,8 @@ zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
 
             for (char *cur = Z_STRVAL(str), *end = cur + Z_STRLEN(str); cur < end; ++cur) {
                 if (*cur < 0x20 || *cur > 0x7E || *cur == ',') {
-                    ddtrace_log_errf("The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.",
-                                     key, Z_STRLEN(str), Z_STRVAL(str));
+                    ddtrace_log_errf("The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.", key,
+                                     Z_STRLEN(str), Z_STRVAL(str));
                     error = "encoding_error";
                     goto error;
                 }
@@ -107,14 +110,15 @@ zai_string_view ddtrace_format_propagated_tags(TSRMLS_D) {
                 error = "max_size";
             }
 
-            error:
+        error:
             zval_dtor(&str);
 
             if (error) {
                 zval *error_zv;
                 MAKE_STD_ZVAL(error_zv);
                 ZVAL_STRING(error_zv, error, 1);
-                zend_hash_update(tags, "_dd.propagation_error", sizeof("_dd.propagation_error"), (void *) &error_zv, sizeof(zval *), NULL);
+                zend_hash_update(tags, "_dd.propagation_error", sizeof("_dd.propagation_error"), (void *)&error_zv,
+                                 sizeof(zval *), NULL);
             }
         }
     }

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
@@ -2,7 +2,6 @@
 #define DDTRACE_TRACER_TAG_PROPAGATION_H
 
 #include <php.h>
-
 #include <zai_string/string.h>
 
 void ddtrace_add_tracer_tags_from_header(zai_string_view *headerstr TSRMLS_DC);

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
@@ -1,0 +1,11 @@
+#ifndef DDTRACE_TRACER_TAG_PROPAGATION_H
+#define DDTRACE_TRACER_TAG_PROPAGATION_H
+
+#include <php.h>
+
+#include <zai_string/string.h>
+
+void ddtrace_add_tracer_tags_from_header(zai_string_view *headerstr TSRMLS_DC);
+zai_string_view ddtrace_format_propagated_tags(TSRMLS_D);
+
+#endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                  \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -86,6 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
+    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -48,6 +48,7 @@
 #include "signals.h"
 #include "span.h"
 #include "startup_logging.h"
+#include "tracer_tag_propagation/tracer_tag_propagation.h"
 
 bool ddtrace_has_excluded_module;
 
@@ -503,6 +504,9 @@ static void dd_initialize_request() {
     array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
     DDTRACE_G(additional_global_tags) = zend_new_array(0);
     DDTRACE_G(default_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
+    DDTRACE_G(propagated_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
+    zend_hash_init(&DDTRACE_G(root_span_tags_preset), 8, shhhht, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&DDTRACE_G(propagated_root_span_tags), 8, shhhht, ZVAL_PTR_DTOR, 0);
 
     // Things that should only run on the first RINIT
     pthread_once(&dd_rinit_once_control, dd_rinit_once);
@@ -574,6 +578,8 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 static void dd_clean_globals() {
     zval_dtor(&DDTRACE_G(additional_trace_meta));
     zend_array_destroy(DDTRACE_G(additional_global_tags));
+    zend_hash_destroy(&DDTRACE_G(root_span_tags_preset));
+    zend_hash_destroy(&DDTRACE_G(propagated_root_span_tags));
     ZVAL_NULL(&DDTRACE_G(additional_trace_meta));
 
     if (DDTRACE_G(dd_origin)) {
@@ -1764,7 +1770,7 @@ zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
 void dd_prepare_for_new_trace(void) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
 
 void dd_read_distributed_tracing_ids(void) {
-    zend_string *trace_id_str, *parent_id_str, *priority_str;
+    zend_string *trace_id_str, *parent_id_str, *priority_str, *propagated_tags;
     bool success = true;
 
     if (zai_read_header_literal("X_DATADOG_TRACE_ID", &trace_id_str) == ZAI_HEADER_SUCCESS) {
@@ -1794,6 +1800,11 @@ void dd_read_distributed_tracing_ids(void) {
     }
 
     if (zai_read_header_literal("X_DATADOG_SAMPLING_PRIORITY", &priority_str) == ZAI_HEADER_SUCCESS) {
-        DDTRACE_G(default_priority_sampling) = strtol(ZSTR_VAL(priority_str), NULL, 10);
+        DDTRACE_G(propagated_priority_sampling) = DDTRACE_G(default_priority_sampling) =
+            strtol(ZSTR_VAL(priority_str), NULL, 10);
+    }
+
+    if (zai_read_header_literal("X_DATADOG_TAGS", &propagated_tags) == ZAI_HEADER_SUCCESS) {
+        ddtrace_add_tracer_tags_from_header(propagated_tags);
     }
 }

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -82,6 +82,8 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     HashTable *function_lookup;
     zval additional_trace_meta; // IS_ARRAY
     zend_array *additional_global_tags;
+    zend_array root_span_tags_preset;
+    zend_array propagated_root_span_tags;
     zend_bool log_backtrace;
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
@@ -92,6 +94,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 
     uint64_t trace_id;
     zend_long default_priority_sampling;
+    zend_long propagated_priority_sampling;
     ddtrace_span_ids_t *span_ids_top;
     ddtrace_span_fci *open_spans_top;
     ddtrace_span_fci *closed_spans_top;

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -28,9 +28,10 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     zend_long sampling_priority = ddtrace_fetch_prioritySampling_from_root();
     if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
         sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-        if (current_services) {
+        if (ZSTR_LEN(current_services)) {
             zval_addref_p(current_services_zv);
-            zend_hash_str_update(meta, "_dd.p.upstream_services", sizeof("_dd.p.upstream_services") - 1, current_services_zv);
+            zend_hash_str_update(meta, "_dd.p.upstream_services", sizeof("_dd.p.upstream_services") - 1,
+                                 current_services_zv);
         } else {
             zend_hash_str_del(meta, ZEND_STRL("_dd.p.upstream_services"));
         }

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -3,11 +3,68 @@
 #include <mt19937-64.h>
 
 #include <ext/pcre/php_pcre.h>
+#include <ext/standard/base64.h>
 
+#include "../compat_string.h"
 #include "../configuration.h"
-#include "../span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+enum dd_sampling_mechanism {
+    DD_MECHANISM_AGENT_RATE = 1,
+    DD_MECHANISM_REMOTE_RATE = 2,
+    DD_MECHANISM_RULE = 3,
+    DD_MECHANISM_MANUAL = 4,
+};
+
+static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci *deciding_span,
+                                        enum dd_sampling_mechanism mechanism) {
+    zval *meta = ddtrace_spandata_property_meta(&span->span);
+    ZVAL_DEREF(meta);
+    if (Z_TYPE_P(meta) != IS_ARRAY) {
+        zval_ptr_dtor(meta);
+        array_init(meta);
+    }
+    SEPARATE_ARRAY(meta);
+
+    zval *current_services_zv =
+        zend_hash_str_find(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.upstream_services"));
+    zend_string *current_services = current_services_zv ? Z_STR_P(current_services_zv) : ZSTR_EMPTY_ALLOC();
+
+    zend_long sampling_priority = ddtrace_fetch_prioritySampling_from_root();
+    if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
+        sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
+        if (current_services) {
+            add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), zend_string_copy(current_services));
+        } else {
+            zend_hash_str_del(Z_ARR_P(meta), ZEND_STRL("_dd.p.upstream_services"));
+        }
+        return;
+    }
+
+    zend_string *servicename = ddtrace_convert_to_str(ddtrace_spandata_property_service(&deciding_span->span));
+    zend_string *b64_servicename =
+        php_base64_encode((const unsigned char *)ZSTR_VAL(servicename), ZSTR_LEN(servicename));
+    while (ZSTR_LEN(b64_servicename) > 0 && ZSTR_VAL(b64_servicename)[ZSTR_LEN(b64_servicename) - 1] == '=') {
+        ZSTR_VAL(b64_servicename)[--ZSTR_LEN(b64_servicename)] = 0;  // remove padding
+    }
+
+    char sampling_rate[7] = {0};
+    zval *metrics = ddtrace_spandata_property_metrics(&span->span), *sample_rate;
+    ZVAL_DEREF(metrics);
+    if (Z_TYPE_P(metrics) == IS_ARRAY &&
+        (sample_rate = zend_hash_str_find(Z_ARR_P(metrics), ZEND_STRL("_dd.rule_psr")))) {
+        snprintf(sampling_rate, 6, "%f", Z_DVAL_P(sample_rate));
+    }
+
+    zend_string *new_services =
+        zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
+                        ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate);
+    add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), new_services);
+
+    zend_string_release(servicename);
+    zend_string_release(b64_servicename);
+}
 
 static bool dd_rule_matches(zval *pattern, zval *prop) {
     if (Z_TYPE_P(pattern) != IS_STRING) {
@@ -31,6 +88,8 @@ static bool dd_rule_matches(zval *pattern, zval *prop) {
 
 static void dd_decide_on_sampling(ddtrace_span_fci *span) {
     int priority = DDTRACE_G(default_priority_sampling);
+    // manual if it's not just inherited, otherwise this value is irrelevant (as sampling priority will be default)
+    enum dd_sampling_mechanism mechanism = DD_MECHANISM_MANUAL;
     if (priority == DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
         zval *rule;
         bool explicit_rule = zai_config_memoized_entries[DDTRACE_CONFIG_DD_TRACE_SAMPLE_RATE].name_index >= 0;
@@ -67,8 +126,10 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
         if (explicit_rule) {
+            mechanism = DD_MECHANISM_RULE;
             priority = sampling ? PRIORITY_SAMPLING_USER_KEEP : PRIORITY_SAMPLING_USER_REJECT;
         } else {
+            mechanism = DD_MECHANISM_AGENT_RATE;
             priority = sampling ? PRIORITY_SAMPLING_AUTO_KEEP : PRIORITY_SAMPLING_AUTO_REJECT;
         }
     }
@@ -77,6 +138,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
     ZVAL_LONG(&priority_zv, priority);
     zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_sampling_priority_v1",
                          sizeof("_sampling_priority_v1") - 1, &priority_zv);
+
+    dd_update_upstream_services(span, span, mechanism);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {
@@ -96,6 +159,7 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
             return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
         }
 
+        SEPARATE_ARRAY(root_metrics);
         dd_decide_on_sampling(root_span);
         priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     }
@@ -117,5 +181,7 @@ void ddtrace_set_prioritySampling_on_root(zend_long priority) {
         zval zv;
         ZVAL_LONG(&zv, priority);
         zend_hash_str_update(root_metrics, "_sampling_priority_v1", sizeof("_sampling_priority_v1") - 1, &zv);
+
+        dd_update_upstream_services(root_span, DDTRACE_G(open_spans_top), DD_MECHANISM_MANUAL);
     }
 }

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -19,13 +19,7 @@ enum dd_sampling_mechanism {
 
 static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci *deciding_span,
                                         enum dd_sampling_mechanism mechanism) {
-    zval *meta = ddtrace_spandata_property_meta(&span->span);
-    ZVAL_DEREF(meta);
-    if (Z_TYPE_P(meta) != IS_ARRAY) {
-        zval_ptr_dtor(meta);
-        array_init(meta);
-    }
-    SEPARATE_ARRAY(meta);
+    zend_array *meta = ddtrace_spandata_property_meta(&span->span);
 
     zval *current_services_zv =
         zend_hash_str_find(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.upstream_services"));
@@ -35,9 +29,10 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
         sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
         if (current_services) {
-            add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), zend_string_copy(current_services));
+            zval_addref_p(current_services_zv);
+            zend_hash_str_update(meta, "_dd.p.upstream_services", sizeof("_dd.p.upstream_services") - 1, current_services_zv);
         } else {
-            zend_hash_str_del(Z_ARR_P(meta), ZEND_STRL("_dd.p.upstream_services"));
+            zend_hash_str_del(meta, ZEND_STRL("_dd.p.upstream_services"));
         }
         return;
     }
@@ -50,17 +45,16 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     }
 
     char sampling_rate[7] = {0};
-    zval *metrics = ddtrace_spandata_property_metrics(&span->span), *sample_rate;
-    ZVAL_DEREF(metrics);
-    if (Z_TYPE_P(metrics) == IS_ARRAY &&
-        (sample_rate = zend_hash_str_find(Z_ARR_P(metrics), ZEND_STRL("_dd.rule_psr")))) {
+    zend_array *metrics = ddtrace_spandata_property_metrics(&span->span);
+    zval *sample_rate, new_services;
+    if ((sample_rate = zend_hash_str_find(metrics, ZEND_STRL("_dd.rule_psr")))) {
         snprintf(sampling_rate, 6, "%f", Z_DVAL_P(sample_rate));
     }
 
-    zend_string *new_services =
-        zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
-                        ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate);
-    add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), new_services);
+    ZVAL_STR(&new_services,
+             zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
+                             ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate));
+    zend_hash_str_update(meta, "_dd.p.upstream_services", sizeof("_dd.p.upstream_services") - 1, &new_services);
 
     zend_string_release(servicename);
     zend_string_release(b64_servicename);
@@ -159,7 +153,6 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
             return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
         }
 
-        SEPARATE_ARRAY(root_metrics);
         dd_decide_on_sampling(root_span);
         priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     }

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -456,7 +456,7 @@ static zend_string *dd_build_req_url() {
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
-    zend_hash_copy(Z_ARR_P(meta), &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
+    zend_hash_copy(meta, &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
 
     zval pid;
     ZVAL_LONG(&pid, (long)getpid());

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -456,6 +456,8 @@ static zend_string *dd_build_req_url() {
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
+    zend_hash_copy(Z_ARR_P(meta), &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
+
     zval pid;
     ZVAL_LONG(&pid, (long)getpid());
     zend_hash_str_add_new(meta, "system.pid", sizeof("system.pid") - 1, &pid);

--- a/ext/php7/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php7/tracer_tag_propagation/tracer_tag_propagation.c
@@ -89,7 +89,7 @@ zend_string *ddtrace_format_propagated_tags(void) {
                 ZVAL_STRING(&error_zv, "max_size");
             }
 
-            error:
+        error:
             zend_string_release(str);
 
             if (!Z_ISUNDEF(error_zv)) {

--- a/ext/php7/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php7/tracer_tag_propagation/tracer_tag_propagation.c
@@ -1,0 +1,90 @@
+#include "tracer_tag_propagation.h"
+
+#include <Zend/zend_smart_str.h>
+
+#include "../compat_string.h"
+#include "../configuration.h"
+#include "../ddtrace.h"
+#include "../logging.h"
+#include "../priority_sampling/priority_sampling.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr) {
+    char *header = ZSTR_VAL(headerstr), *headerend = header + ZSTR_LEN(headerstr);
+
+    for (char *tagstart = header; header < headerend; ++header) {
+        if (*header == '=') {
+            zend_string *tag_name = zend_string_init(tagstart, header - tagstart, 0);
+            char *valuestart = ++header;
+
+            while (header < headerend && *header != ',') {
+                ++header;
+            }
+
+            zval zv;
+            ZVAL_STRINGL(&zv, valuestart, header - valuestart);
+            zend_hash_update(&DDTRACE_G(root_span_tags_preset), tag_name, &zv);
+            zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), tag_name);
+            zend_string_release(tag_name);
+        }
+        // we skip invalid tags without = within
+        if (*header == ',') {
+            tagstart = ++header;
+        }
+    }
+}
+
+zend_string *ddtrace_format_propagated_tags(void) {
+    // we propagate all tags on the current root span which were originally propagated, including the explicitly
+    // defined tags here
+    zend_hash_str_add_empty_element(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.upstream_services"));
+
+    zend_array *tags = &DDTRACE_G(root_span_tags_preset);
+    if (DDTRACE_G(root_span)) {
+        zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+        ZVAL_DEREF(meta);
+        if (Z_TYPE_P(meta) == IS_ARRAY) {
+            tags = Z_ARRVAL_P(meta);
+        }
+    }
+
+    smart_str taglist = {0};
+
+    zend_string *tagname;
+    ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
+        zval *tag = zend_hash_find(tags, tagname);
+        if (tag) {
+            zend_string *str = ddtrace_convert_to_str(tag);
+
+            if ((taglist.s ? ZSTR_LEN(taglist.s) : 0) + ZSTR_LEN(tagname) + ZSTR_LEN(str) + 2 <=
+                (size_t)get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH()) {
+                if (taglist.s) {
+                    smart_str_appendc(&taglist, ',');
+                }
+                smart_str_append(&taglist, tagname);
+                smart_str_appendc(&taglist, '=');
+                smart_str_append(&taglist, str);
+            } else {
+                ddtrace_log_errf(
+                    "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
+                    " characters and is thus dropped.",
+                    ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+
+                zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+                ZVAL_DEREF(meta);
+                if (Z_TYPE_P(meta) != IS_ARRAY) {
+                    zval_ptr_dtor(meta);
+                    array_init(meta);
+                }
+                SEPARATE_ARRAY(meta);
+                add_assoc_string_ex(meta, ZEND_STRL("_dd.propagation_error"), "encoding_error");
+            }
+            zend_string_release(str);
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    smart_str_0(&taglist);
+    return taglist.s;
+}

--- a/ext/php7/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php7/tracer_tag_propagation/tracer_tag_propagation.h
@@ -1,0 +1,9 @@
+#ifndef DDTRACE_TRACER_TAG_PROPAGATION_H
+#define DDTRACE_TRACER_TAG_PROPAGATION_H
+
+#include <php.h>
+
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr);
+zend_string *ddtrace_format_propagated_tags(void);
+
+#endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                  \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -86,7 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
+    CONFIG(INT, DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -86,6 +86,7 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
+    CONFIG(INT, DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH, "512")                                                   \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -48,6 +48,7 @@
 #include "signals.h"
 #include "span.h"
 #include "startup_logging.h"
+#include "tracer_tag_propagation/tracer_tag_propagation.h"
 
 bool ddtrace_has_excluded_module;
 
@@ -462,6 +463,9 @@ static void dd_initialize_request() {
     array_init_size(&DDTRACE_G(additional_trace_meta), ddtrace_num_error_tags);
     DDTRACE_G(additional_global_tags) = zend_new_array(0);
     DDTRACE_G(default_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
+    DDTRACE_G(propagated_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
+    zend_hash_init(&DDTRACE_G(root_span_tags_preset), 8, shhhht, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&DDTRACE_G(propagated_root_span_tags), 8, shhhht, ZVAL_PTR_DTOR, 0);
 
     if (ZSTR_LEN(get_DD_TRACE_REQUEST_INIT_HOOK())) {
         dd_request_init_hook_rinit();
@@ -526,6 +530,8 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 static void dd_clean_globals() {
     zval_dtor(&DDTRACE_G(additional_trace_meta));
     zend_array_destroy(DDTRACE_G(additional_global_tags));
+    zend_hash_destroy(&DDTRACE_G(root_span_tags_preset));
+    zend_hash_destroy(&DDTRACE_G(propagated_root_span_tags));
     ZVAL_NULL(&DDTRACE_G(additional_trace_meta));
 
     if (DDTRACE_G(dd_origin)) {
@@ -1705,7 +1711,7 @@ zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
 void dd_prepare_for_new_trace(void) { DDTRACE_G(traces_group_id) = ddtrace_coms_next_group_id(); }
 
 void dd_read_distributed_tracing_ids(void) {
-    zend_string *trace_id_str, *parent_id_str, *priority_str;
+    zend_string *trace_id_str, *parent_id_str, *priority_str, *propagated_tags;
     bool success = true;
 
     if (zai_read_header_literal("X_DATADOG_TRACE_ID", &trace_id_str) == ZAI_HEADER_SUCCESS) {
@@ -1735,6 +1741,11 @@ void dd_read_distributed_tracing_ids(void) {
     }
 
     if (zai_read_header_literal("X_DATADOG_SAMPLING_PRIORITY", &priority_str) == ZAI_HEADER_SUCCESS) {
-        DDTRACE_G(default_priority_sampling) = strtol(ZSTR_VAL(priority_str), NULL, 10);
+        DDTRACE_G(propagated_priority_sampling) = DDTRACE_G(default_priority_sampling) =
+            strtol(ZSTR_VAL(priority_str), NULL, 10);
+    }
+
+    if (zai_read_header_literal("X_DATADOG_TAGS", &propagated_tags) == ZAI_HEADER_SUCCESS) {
+        ddtrace_add_tracer_tags_from_header(propagated_tags);
     }
 }

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -82,6 +82,8 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     HashTable *function_lookup;
     zval additional_trace_meta; // IS_ARRAY
     zend_array *additional_global_tags;
+    zend_array root_span_tags_preset;
+    zend_array propagated_root_span_tags;
     zend_bool log_backtrace;
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
@@ -92,6 +94,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 
     uint64_t trace_id;
     zend_long default_priority_sampling;
+    zend_long propagated_priority_sampling;
     ddtrace_span_ids_t *span_ids_top;
     ddtrace_span_fci *open_spans_top;
     ddtrace_span_fci *closed_spans_top;

--- a/ext/php8/priority_sampling/priority_sampling.c
+++ b/ext/php8/priority_sampling/priority_sampling.c
@@ -28,7 +28,7 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     zend_long sampling_priority = ddtrace_fetch_prioritySampling_from_root();
     if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
         sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-        if (current_services) {
+        if (ZSTR_LEN(current_services)) {
             zval_addref_p(current_services_zv);
             zend_hash_str_update(meta, ZEND_STRL("_dd.p.upstream_services"), current_services_zv);
         } else {
@@ -51,8 +51,8 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     }
 
     ZVAL_STR(&new_services,
-        zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
-                        ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate));
+             zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
+                             ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate));
     zend_hash_str_update(meta, ZEND_STRL("_dd.p.upstream_services"), &new_services);
 
     zend_string_release(servicename);

--- a/ext/php8/priority_sampling/priority_sampling.c
+++ b/ext/php8/priority_sampling/priority_sampling.c
@@ -3,11 +3,67 @@
 #include <mt19937-64.h>
 
 #include <ext/pcre/php_pcre.h>
+#include <ext/standard/base64.h>
 
+#include "../compat_string.h"
 #include "../configuration.h"
-#include "../span.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+enum dd_sampling_mechanism {
+    DD_MECHANISM_AGENT_RATE = 1,
+    DD_MECHANISM_REMOTE_RATE = 2,
+    DD_MECHANISM_RULE = 3,
+    DD_MECHANISM_MANUAL = 4,
+};
+
+static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci *deciding_span,
+                                        enum dd_sampling_mechanism mechanism) {
+    zval *meta = ddtrace_spandata_property_meta(&span->span);
+    ZVAL_DEREF(meta);
+    if (Z_TYPE_P(meta) != IS_ARRAY) {
+        zval_ptr_dtor(meta);
+        array_init(meta);
+    }
+    SEPARATE_ARRAY(meta);
+
+    zval *current_services_zv =
+        zend_hash_str_find(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.upstream_services"));
+    zend_string *current_services = current_services_zv ? Z_STR_P(current_services_zv) : ZSTR_EMPTY_ALLOC();
+
+    zend_long sampling_priority = ddtrace_fetch_prioritySampling_from_root();
+    if (DDTRACE_G(propagated_priority_sampling) == sampling_priority ||
+        sampling_priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
+        if (current_services) {
+            add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), zend_string_copy(current_services));
+        } else {
+            zend_hash_str_del(Z_ARR_P(meta), ZEND_STRL("_dd.p.upstream_services"));
+        }
+        return;
+    }
+
+    zend_string *servicename = ddtrace_convert_to_str(ddtrace_spandata_property_service(&deciding_span->span));
+    zend_string *b64_servicename = php_base64_encode_str(servicename);
+    while (ZSTR_LEN(b64_servicename) > 0 && ZSTR_VAL(b64_servicename)[ZSTR_LEN(b64_servicename) - 1] == '=') {
+        ZSTR_VAL(b64_servicename)[--ZSTR_LEN(b64_servicename)] = 0;  // remove padding
+    }
+
+    char sampling_rate[7] = {0};
+    zval *metrics = ddtrace_spandata_property_metrics(&span->span), *sample_rate;
+    ZVAL_DEREF(metrics);
+    if (Z_TYPE_P(metrics) == IS_ARRAY &&
+        (sample_rate = zend_hash_str_find(Z_ARR_P(metrics), ZEND_STRL("_dd.rule_psr")))) {
+        snprintf(sampling_rate, 6, "%f", Z_DVAL_P(sample_rate));
+    }
+
+    zend_string *new_services =
+        zend_strpprintf(0, "%s%s%s|%d|%d|%s", ZSTR_VAL(current_services), ZSTR_LEN(current_services) ? ";" : "",
+                        ZSTR_VAL(b64_servicename), (int)sampling_priority, mechanism, sampling_rate);
+    add_assoc_str_ex(meta, ZEND_STRL("_dd.p.upstream_services"), new_services);
+
+    zend_string_release(servicename);
+    zend_string_release(b64_servicename);
+}
 
 static bool dd_rule_matches(zval *pattern, zval *prop) {
     if (Z_TYPE_P(pattern) != IS_STRING) {
@@ -27,6 +83,8 @@ static bool dd_rule_matches(zval *pattern, zval *prop) {
 
 static void dd_decide_on_sampling(ddtrace_span_fci *span) {
     int priority = DDTRACE_G(default_priority_sampling);
+    // manual if it's not just inherited, otherwise this value is irrelevant (as sampling priority will be default)
+    enum dd_sampling_mechanism mechanism = DD_MECHANISM_MANUAL;
     if (priority == DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
         zval *rule;
         bool explicit_rule = zai_config_memoized_entries[DDTRACE_CONFIG_DD_TRACE_SAMPLE_RATE].name_index >= 0;
@@ -63,8 +121,10 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
         if (explicit_rule) {
+            mechanism = DD_MECHANISM_RULE;
             priority = sampling ? PRIORITY_SAMPLING_USER_KEEP : PRIORITY_SAMPLING_USER_REJECT;
         } else {
+            mechanism = DD_MECHANISM_AGENT_RATE;
             priority = sampling ? PRIORITY_SAMPLING_AUTO_KEEP : PRIORITY_SAMPLING_AUTO_REJECT;
         }
     }
@@ -73,6 +133,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
     ZVAL_LONG(&priority_zv, priority);
     zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"),
                          &priority_zv);
+
+    dd_update_upstream_services(span, span, mechanism);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {
@@ -86,9 +148,6 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
     zend_array *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
     if (!(priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1")))) {
         if (DDTRACE_G(default_priority_sampling) == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-            if (DDTRACE_G(default_priority_sampling) == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-                return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
-            }
             return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
         }
 
@@ -113,5 +172,7 @@ void ddtrace_set_prioritySampling_on_root(zend_long priority) {
         zval zv;
         ZVAL_LONG(&zv, priority);
         zend_hash_str_update(root_metrics, ZEND_STRL("_sampling_priority_v1"), &zv);
+
+        dd_update_upstream_services(root_span, DDTRACE_G(open_spans_top), DD_MECHANISM_MANUAL);
     }
 }

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -451,6 +451,8 @@ static zend_string *dd_build_req_url() {
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
+    zend_hash_copy(meta, &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
+
     zval pid;
     ZVAL_LONG(&pid, (long)getpid());
     zend_hash_str_add_new(meta, ZEND_STRL("system.pid"), &pid);

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
@@ -67,7 +67,7 @@ zend_string *ddtrace_format_propagated_tags(void) {
             for (char *cur = ZSTR_VAL(str), *end = cur + ZSTR_LEN(str); cur < end; ++cur) {
                 if (*cur < 0x20 || *cur > 0x7E || *cur == ',') {
                     ddtrace_log_errf("The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.",
-                            ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str));
+                                     ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str));
                     ZVAL_STRING(&error_zv, "encoding_error");
                     goto error;
                 }
@@ -90,7 +90,7 @@ zend_string *ddtrace_format_propagated_tags(void) {
                 ZVAL_STRING(&error_zv, "max_size");
             }
 
-            error:
+        error:
             zend_string_release(str);
 
             if (!Z_ISUNDEF(error_zv)) {

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
@@ -70,6 +70,15 @@ zend_string *ddtrace_format_propagated_tags(void) {
                     "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
                     " characters and is thus dropped.",
                     ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+
+                zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+                ZVAL_DEREF(meta);
+                if (Z_TYPE_P(meta) != IS_ARRAY) {
+                    zval_ptr_dtor(meta);
+                    array_init(meta);
+                }
+                SEPARATE_ARRAY(meta);
+                add_assoc_string_ex(meta, ZEND_STRL("_dd.propagation_error"), "encoding_error");
             }
 
             zend_string_release(str);

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
@@ -1,0 +1,82 @@
+#include "tracer_tag_propagation.h"
+
+#include <Zend/zend_smart_str.h>
+
+#include "../compat_string.h"
+#include "../configuration.h"
+#include "../ddtrace.h"
+#include "../logging.h"
+#include "../priority_sampling/priority_sampling.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr) {
+    char *header = ZSTR_VAL(headerstr), *headerend = header + ZSTR_LEN(headerstr);
+
+    for (char *tagstart = header; header < headerend; ++header) {
+        if (*header == '=') {
+            zend_string *tag_name = zend_string_init(tagstart, header - tagstart, 0);
+            char *valuestart = ++header;
+
+            while (header < headerend && *header != ',') {
+                ++header;
+            }
+
+            zval zv;
+            ZVAL_STRINGL(&zv, valuestart, header - valuestart);
+            zend_hash_update(&DDTRACE_G(root_span_tags_preset), tag_name, &zv);
+            zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), tag_name);
+            zend_string_release(tag_name);
+        }
+        // we skip invalid tags without = within
+        if (*header == ',') {
+            tagstart = ++header;
+        }
+    }
+}
+
+zend_string *ddtrace_format_propagated_tags(void) {
+    // we propagate all tags on the current root span which were originally propagated, including the explicitly
+    // defined tags here
+    zend_hash_str_add_empty_element(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.upstream_services"));
+
+    zend_array *tags = &DDTRACE_G(root_span_tags_preset);
+    if (DDTRACE_G(root_span)) {
+        zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
+        ZVAL_DEREF(meta);
+        if (Z_TYPE_P(meta) == IS_ARRAY) {
+            tags = Z_ARRVAL_P(meta);
+        }
+    }
+
+    smart_str taglist = {0};
+
+    zend_string *tagname;
+    ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
+        zval *tag = zend_hash_find(tags, tagname);
+        if (tag) {
+            zend_string *str = ddtrace_convert_to_str(tag);
+
+            if ((taglist.s ? ZSTR_LEN(taglist.s) : 0) + ZSTR_LEN(tagname) + ZSTR_LEN(str) + 2 <=
+                (size_t)get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH()) {
+                if (taglist.s) {
+                    smart_str_appendc(&taglist, ',');
+                }
+                smart_str_append(&taglist, tagname);
+                smart_str_appendc(&taglist, '=');
+                smart_str_append(&taglist, str);
+            } else {
+                ddtrace_log_errf(
+                    "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
+                    " characters and is thus dropped.",
+                    ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+            }
+
+            zend_string_release(str);
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    smart_str_0(&taglist);
+    return taglist.s;
+}

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.c
@@ -30,6 +30,8 @@ void ddtrace_add_tracer_tags_from_header(zend_string *headerstr) {
         }
         // we skip invalid tags without = within
         if (*header == ',') {
+            ddtrace_log_debugf("Found x-datadog-tags header without key-separating equals character; raw input: %.*s",
+                               ZSTR_LEN(headerstr), ZSTR_VAL(headerstr));
             tagstart = ++header;
         }
     }
@@ -42,23 +44,37 @@ zend_string *ddtrace_format_propagated_tags(void) {
 
     zend_array *tags = &DDTRACE_G(root_span_tags_preset);
     if (DDTRACE_G(root_span)) {
-        zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
-        ZVAL_DEREF(meta);
-        if (Z_TYPE_P(meta) == IS_ARRAY) {
-            tags = Z_ARRVAL_P(meta);
-        }
+        tags = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
     }
 
     smart_str taglist = {0};
 
     zend_string *tagname;
     ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
-        zval *tag = zend_hash_find(tags, tagname);
+        zval *tag = zend_hash_find(tags, tagname), error_zv = {0};
         if (tag) {
             zend_string *str = ddtrace_convert_to_str(tag);
 
+            for (char *cur = ZSTR_VAL(tagname), *end = cur + ZSTR_LEN(tagname); cur < end; ++cur) {
+                if (*cur < 0x20 || *cur > 0x7E || *cur == '=' || *cur == ',') {
+                    ddtrace_log_errf("The to be propagated tag name '%s' is invalid and is thus dropped.",
+                                     ZSTR_VAL(tagname));
+                    ZVAL_STRING(&error_zv, "encoding_error");
+                    goto error;
+                }
+            }
+
+            for (char *cur = ZSTR_VAL(str), *end = cur + ZSTR_LEN(str); cur < end; ++cur) {
+                if (*cur < 0x20 || *cur > 0x7E || *cur == ',') {
+                    ddtrace_log_errf("The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.",
+                            ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str));
+                    ZVAL_STRING(&error_zv, "encoding_error");
+                    goto error;
+                }
+            }
+
             if ((taglist.s ? ZSTR_LEN(taglist.s) : 0) + ZSTR_LEN(tagname) + ZSTR_LEN(str) + 2 <=
-                (size_t)get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH()) {
+                (size_t)get_DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH()) {
                 if (taglist.s) {
                     smart_str_appendc(&taglist, ',');
                 }
@@ -69,19 +85,19 @@ zend_string *ddtrace_format_propagated_tags(void) {
                 ddtrace_log_errf(
                     "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
                     " characters and is thus dropped.",
-                    ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_MAX_PROPAGATED_TAGS_LENGTH());
+                    ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH());
 
-                zval *meta = ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span);
-                ZVAL_DEREF(meta);
-                if (Z_TYPE_P(meta) != IS_ARRAY) {
-                    zval_ptr_dtor(meta);
-                    array_init(meta);
-                }
-                SEPARATE_ARRAY(meta);
-                add_assoc_string_ex(meta, ZEND_STRL("_dd.propagation_error"), "encoding_error");
+                ZVAL_STRING(&error_zv, "max_size");
             }
 
+            error:
             zend_string_release(str);
+
+            if (!Z_ISUNDEF(error_zv)) {
+                zend_hash_str_update(tags, ZEND_STRL("_dd.propagation_error"), &error_zv);
+                smart_str_free(&taglist);
+                return NULL;
+            }
         }
     }
     ZEND_HASH_FOREACH_END();

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.h
@@ -1,0 +1,9 @@
+#ifndef DDTRACE_TRACER_TAG_PROPAGATION_H
+#define DDTRACE_TRACER_TAG_PROPAGATION_H
+
+#include <php.h>
+
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr);
+zend_string *ddtrace_format_propagated_tags(void);
+
+#endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -358,6 +358,10 @@ final class SpanChecker
 
             $filtered = $out;
             $expectedTags = $exp->getExactTags();
+            // Ignore _dd.p.upstream_services unless explicitly tested
+            if (!isset($expectedTags['_dd.p.upstream_services'])) {
+                unset($filtered['_dd.p.upstream_services']);
+            }
             foreach ($expectedTags as $tagName => $tagValue) {
                 TestCase::assertArrayHasKey(
                     $tagName,

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -36,11 +36,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.origin"]=>
       string(7) "datadog"
+      ["_dd.p.upstream_services"]=>
+      string(52) "ZGlzdHJpYnV0ZWRfdHJhY2VfYm9ndXNfaWRzLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -4,6 +4,8 @@ Transmit distributed header information to spans
 HTTP_X_DATADOG_TRACE_ID=42
 HTTP_X_DATADOG_PARENT_ID=10
 HTTP_X_DATADOG_ORIGIN=datadog
+HTTP_X_DATADOG_SAMPLING_PRIORITY=3
+HTTP_X_DATADOG_TAGS=custom_tag=inherited,dropped,other_tag=also,drop
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
@@ -42,7 +44,11 @@ array(2) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(4) {
+      ["custom_tag"]=>
+      string(9) "inherited"
+      ["other_tag"]=>
+      string(4) "also"
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.origin"]=>

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -55,11 +55,9 @@ array(2) {
       string(7) "datadog"
     }
     ["metrics"]=>
-    array(3) {
-      ["_dd.rule_psr"]=>
-      float(1)
+    array(2) {
       ["_sampling_priority_v1"]=>
-      float(1)
+      float(3)
       ["php.compilation.total_time_ms"]=>
       float(%f)
     }

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -7,7 +7,6 @@ Distributed tracing headers propagate with curl_exec()
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
-DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -7,7 +7,9 @@ Distributed tracing headers propagate with curl_exec()
 ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
 HTTP_X_DATADOG_ORIGIN=phpt-test
+HTTP_X_DATADOG_TAGS=extreeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeemely=loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
 --FILE--
 <?php
 include 'curl_helper.inc';
@@ -34,13 +36,16 @@ dt_dump_headers_from_httpbin($headers, [
 
 $spans = dd_trace_serialize_closed_spans();
 var_dump($headers['x-datadog-parent-id'] === (string) $spans[0]['span_id']);
+var_dump($spans[0]["meta"]["_dd.propagation_error"]);
 
 echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
+The to be propagated tag 'extreeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeemely=loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong' is too long and exceeds the maximum limit of 512 characters and is thus dropped.
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)
+string(14) "encoding_error"
 Done.
 No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -46,6 +46,6 @@ The to be propagated tag 'extreeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)
-string(14) "encoding_error"
+string(8) "max_size"
 Done.
 No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -57,6 +57,7 @@ foreach ($responses as $key => $response) {
         'x-datadog-trace-id',
         'x-datadog-parent-id',
         'x-datadog-sampling-priority',
+        'x-datadog-tags',
         'x-foo',
         'x-bar',
     ]);
@@ -71,6 +72,7 @@ Response #0
 x-bar: theory
 x-datadog-parent-id: %d
 x-datadog-sampling-priority: 1
+x-datadog-tags: _dd.p.upstream_services=ZGlzdHJpYnV0ZWRfdHJhY2luZ19jdXJsX2NvcHlfaGFuZGxlLnBocA|1|1|1.000
 x-datadog-trace-id: %d
 x-foo: before-the-copy
 
@@ -78,6 +80,7 @@ Response #1
 x-bar: theory
 x-datadog-parent-id: %d
 x-datadog-sampling-priority: 1
+x-datadog-tags: _dd.p.upstream_services=ZGlzdHJpYnV0ZWRfdHJhY2luZ19jdXJsX2NvcHlfaGFuZGxlLnBocA|1|1|1.000
 x-datadog-trace-id: %d
 x-foo: before-the-copy
 
@@ -85,6 +88,7 @@ Response #2
 x-bar: theory
 x-datadog-parent-id: %d
 x-datadog-sampling-priority: 1
+x-datadog-tags: _dd.p.upstream_services=ZGlzdHJpYnV0ZWRfdHJhY2luZ19jdXJsX2NvcHlfaGFuZGxlLnBocA|1|1|1.000
 x-datadog-trace-id: %d
 x-foo: before-the-copy
 
@@ -92,6 +96,7 @@ Response #3
 x-bar: linguistics
 x-datadog-parent-id: %d
 x-datadog-sampling-priority: 1
+x-datadog-tags: _dd.p.upstream_services=ZGlzdHJpYnV0ZWRfdHJhY2luZ19jdXJsX2NvcHlfaGFuZGxlLnBocA|1|1|1.000
 x-datadog-trace-id: %d
 x-foo: after-the-copy
 

--- a/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Distributed tracing header tags propagate with curl_exec()
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+HTTP_X_DATADOG_TAGS=custom_tag=inherited,to_remove=,foo=bar,_dd.p.upstream_services=abcdef|0|2|1.000
+--FILE--
+<?php
+
+include 'distributed_tracing.inc';
+
+function query_headers() {
+    $port = getenv('HTTPBIN_PORT') ?: '80';
+    $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return dt_decode_headers_from_httpbin($response);
+}
+
+$meta = &DDTrace\root_span()->meta;
+unset($meta["to_remove"]);
+$meta["foo"] = "buzz";
+
+$span = DDTrace\start_span();
+$span->service = "dd";
+
+DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_USER_REJECT);
+
+dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-tags']);
+
+?>
+--EXPECT--
+x-datadog-tags: custom_tag=inherited,foo=buzz,_dd.p.upstream_services=abcdef|0|2|1.000;ZGQ|-1|4|

--- a/tests/ext/priority_sampling/001-default-sampling.phpt
+++ b/tests/ext/priority_sampling/001-default-sampling.phpt
@@ -29,7 +29,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK

--- a/tests/ext/priority_sampling/001-default-sampling.phpt
+++ b/tests/ext/priority_sampling/001-default-sampling.phpt
@@ -29,9 +29,11 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK
 metrics[_sampling_priority_v1] OK
 metrics[_dd.rule_psr] OK
 \DDTrace\get_priority_sampling() OK
+_dd.p.upstream_services = MDAxLWRlZmF1bHQtc2FtcGxpbmcucGhw|1|1|1.000

--- a/tests/ext/priority_sampling/002-user-reject.phpt
+++ b/tests/ext/priority_sampling/002-user-reject.phpt
@@ -30,7 +30,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_REJECT)
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK

--- a/tests/ext/priority_sampling/002-user-reject.phpt
+++ b/tests/ext/priority_sampling/002-user-reject.phpt
@@ -30,9 +30,11 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_REJECT)
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK
 metrics[_sampling_priority_v1] OK
 metrics[_dd.rule_psr] OK
 \DDTrace\get_priority_sampling() OK
+_dd.p.upstream_services = MDAyLXVzZXItcmVqZWN0LnBocA|-1|3|0.000

--- a/tests/ext/priority_sampling/003-user-keep.phpt
+++ b/tests/ext/priority_sampling/003-user-keep.phpt
@@ -30,7 +30,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK

--- a/tests/ext/priority_sampling/003-user-keep.phpt
+++ b/tests/ext/priority_sampling/003-user-keep.phpt
@@ -30,9 +30,11 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK
 metrics[_sampling_priority_v1] OK
 metrics[_dd.rule_psr] OK
 \DDTrace\get_priority_sampling() OK
+_dd.p.upstream_services = MDAzLXVzZXIta2VlcC5waHA|2|3|1.000

--- a/tests/ext/priority_sampling/004-rule-basic.phpt
+++ b/tests/ext/priority_sampling/004-rule-basic.phpt
@@ -10,10 +10,12 @@ $root = \DDTrace\root_span();
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] == 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
---EXPECT--
+--EXPECTREGEX--
 Rule OK
+_dd.p.upstream_services = MDA0LXJ1bGUtYmFzaWMucGhw\|(-1|2)\|3\|0.300

--- a/tests/ext/priority_sampling/004-rule-basic.phpt
+++ b/tests/ext/priority_sampling/004-rule-basic.phpt
@@ -14,7 +14,7 @@ if ($root->metrics["_dd.rule_psr"] == 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECTREGEX--
 Rule OK

--- a/tests/ext/priority_sampling/005-rule-name.phpt
+++ b/tests/ext/priority_sampling/005-rule-name.phpt
@@ -15,7 +15,7 @@ if ($root->metrics["_dd.rule_psr"] == 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECTREGEX--
 Rule OK

--- a/tests/ext/priority_sampling/005-rule-name.phpt
+++ b/tests/ext/priority_sampling/005-rule-name.phpt
@@ -11,10 +11,12 @@ $root->name = "fooname";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] == 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
---EXPECT--
+--EXPECTREGEX--
 Rule OK
+_dd.p.upstream_services = MDA1LXJ1bGUtbmFtZS5waHA\|(-1|2)\|3\|0.300

--- a/tests/ext/priority_sampling/006-rule-name-reject.phpt
+++ b/tests/ext/priority_sampling/006-rule-name-reject.phpt
@@ -15,7 +15,7 @@ if ($root->metrics["_dd.rule_psr"] != 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 Rule OK

--- a/tests/ext/priority_sampling/006-rule-name-reject.phpt
+++ b/tests/ext/priority_sampling/006-rule-name-reject.phpt
@@ -11,10 +11,12 @@ $root->name = "fooname";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] != 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 Rule OK
+_dd.p.upstream_services = MDA2LXJ1bGUtbmFtZS1yZWplY3QucGhw|1|1|1.000

--- a/tests/ext/priority_sampling/007-rule-service.phpt
+++ b/tests/ext/priority_sampling/007-rule-service.phpt
@@ -21,7 +21,7 @@ if ($root->metrics["_dd.rule_psr"] == 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECTREGEX--
 Rule OK

--- a/tests/ext/priority_sampling/007-rule-service.phpt
+++ b/tests/ext/priority_sampling/007-rule-service.phpt
@@ -17,10 +17,12 @@ $root->service = "fooservice";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] == 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
---EXPECT--
+--EXPECTREGEX--
 Rule OK
+_dd.p.upstream_services = Zm9vc2VydmljZQ\|(-1|2)\|3\|0.300

--- a/tests/ext/priority_sampling/008-rule-service-reject.phpt
+++ b/tests/ext/priority_sampling/008-rule-service-reject.phpt
@@ -17,10 +17,12 @@ $root->service = "barservice";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] != 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 Rule OK
+_dd.p.upstream_services = YmFyc2VydmljZQ|1|1|1.000

--- a/tests/ext/priority_sampling/008-rule-service-reject.phpt
+++ b/tests/ext/priority_sampling/008-rule-service-reject.phpt
@@ -21,7 +21,7 @@ if ($root->metrics["_dd.rule_psr"] != 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 Rule OK

--- a/tests/ext/priority_sampling/009-rule-name-service.phpt
+++ b/tests/ext/priority_sampling/009-rule-name-service.phpt
@@ -16,7 +16,7 @@ if ($root->metrics["_dd.rule_psr"] == 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECTREGEX--
 Rule OK

--- a/tests/ext/priority_sampling/009-rule-name-service.phpt
+++ b/tests/ext/priority_sampling/009-rule-name-service.phpt
@@ -12,10 +12,12 @@ $root->service = "barservice";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] == 0.3) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
---EXPECT--
+--EXPECTREGEX--
 Rule OK
+_dd.p.upstream_services = YmFyc2VydmljZQ\|(-1|2)\|3\|0.300

--- a/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
+++ b/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
@@ -18,10 +18,12 @@ $root->service = "barservice";
 \DDTrace\get_priority_sampling();
 
 if ($root->metrics["_dd.rule_psr"] == 0.7) {
-    echo "Rule OK";
+    echo "Rule OK\n";
 } else {
     var_dump($root->metrics);
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
---EXPECT--
+--EXPECTREGEX--
 Rule OK
+_dd.p.upstream_services = YmFyc2VydmljZQ\|(-1|2)\|3\|0.700

--- a/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
+++ b/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
@@ -22,7 +22,7 @@ if ($root->metrics["_dd.rule_psr"] == 0.7) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECTREGEX--
 Rule OK

--- a/tests/ext/priority_sampling/011-preset.phpt
+++ b/tests/ext/priority_sampling/011-preset.phpt
@@ -12,10 +12,12 @@ $root = \DDTrace\root_span();
 \DDTrace\get_priority_sampling();
 
 if (!isset($root->metrics["_dd.rule_psr"])) {
-    echo "OK";
+    echo "OK\n";
 } else {
     echo "metrics[_dd.rule_psr] = {$root->metrics["_dd.rule_psr"]}\n";
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 OK
+_dd.p.upstream_services = MDExLXByZXNldC5waHA|-1|4|

--- a/tests/ext/priority_sampling/011-preset.phpt
+++ b/tests/ext/priority_sampling/011-preset.phpt
@@ -16,7 +16,7 @@ if (!isset($root->metrics["_dd.rule_psr"])) {
 } else {
     echo "metrics[_dd.rule_psr] = {$root->metrics["_dd.rule_psr"]}\n";
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
 ?>
 --EXPECT--
 OK

--- a/tests/ext/priority_sampling/012-default.phpt
+++ b/tests/ext/priority_sampling/012-default.phpt
@@ -16,8 +16,10 @@ if (!isset($root->metrics["_dd.rule_psr"])) {
 } else {
     echo "metrics[_dd.rule_psr] = {$root->metrics["_dd.rule_psr"]}\n";
 }
-echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
+
+if (isset($root->meta["_dd.p.upstream_services"])) {
+    echo "_dd.p.upstream_services = {$root->meta["_dd.p.upstream_services"]}\n";
+}
 ?>
 --EXPECT--
 OK
-_dd.p.upstream_services = (null)

--- a/tests/ext/priority_sampling/012-default.phpt
+++ b/tests/ext/priority_sampling/012-default.phpt
@@ -12,10 +12,12 @@ DD_TRACE_GENERATE_ROOT_SPAN=1
 $root = \DDTrace\root_span();
 
 if (!isset($root->metrics["_dd.rule_psr"])) {
-    echo "OK";
+    echo "OK\n";
 } else {
     echo "metrics[_dd.rule_psr] = {$root->metrics["_dd.rule_psr"]}\n";
 }
+echo "_dd.p.upstream_services = " . ($root->meta["_dd.p.upstream_services"] ?? "(null)") . "\n";
 ?>
 --EXPECT--
 OK
+_dd.p.upstream_services = (null)

--- a/tests/ext/root_span_add_tag.phpt
+++ b/tests/ext/root_span_add_tag.phpt
@@ -39,11 +39,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["after"]=>
       string(9) "root_span"
+      ["_dd.p.upstream_services"]=>
+      string(38) "cm9vdF9zcGFuX2FkZF90YWcucGhw|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -20,13 +20,15 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(4) {
+array(5) {
   ["system.pid"]=>
   %s
   ["http.method"]=>
   string(3) "GET"
   ["http.url"]=>
   string(26) "https://localhost:9999/foo"
+  ["_dd.p.upstream_services"]=>
+  string(25) "d2ViLnJlcXVlc3Q|1|1|1.000"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -18,13 +18,15 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(4) {
+array(5) {
   ["system.pid"]=>
   %s
   ["http.method"]=>
   string(3) "GET"
   ["http.url"]=>
   string(25) "http://localhost:8888/foo"
+  ["_dd.p.upstream_services"]=>
+  string(25) "d2ViLnJlcXVlc3Q|1|1|1.000"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -112,11 +112,13 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
+      ["_dd.p.upstream_services"]=>
+      string(24) "Rm9vU2VydmljZQ|1|1|1.000"
     }
     ["metrics"]=>
     array(5) {
@@ -177,9 +179,11 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(36) "ZGRfdHJhY2VfbWV0aG9kLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -26,4 +26,5 @@ bar(hello)
 spans(\DDTrace\SpanData) (1) {
   bar (alias, bar, cli)
     system.pid => %d
+    _dd.p.upstream_services => YWxpYXM|1|1|1.000
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -111,7 +111,7 @@ array(5) {
     ["type"]=>
     string(7) "BarType"
     ["meta"]=>
-    array(5) {
+    array(6) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
@@ -122,6 +122,8 @@ array(5) {
       string(5) "first"
       ["retval.rand"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(24) "QmFyU2VydmljZQ|1|1|1.000"
     }
     ["metrics"]=>
     array(5) {
@@ -198,9 +200,11 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(49) "ZGRfdHJhY2VfZnVuY3Rpb25fY29tcGxleC5waHA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {
@@ -231,9 +235,11 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(49) "ZGRfdHJhY2VfZnVuY3Rpb25fY29tcGxleC5waHA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -42,9 +42,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(50) "ZGRfdHJhY2VfZnVuY3Rpb25faW50ZXJuYWwucGhw|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -119,7 +119,7 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(5) {
+    array(6) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
@@ -130,6 +130,8 @@ array(3) {
       string(5) "first"
       ["retval.rand"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(24) "Rm9vU2VydmljZQ|1|1|1.000"
     }
     ["metrics"]=>
     array(5) {
@@ -192,9 +194,11 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(36) "ZGRfdHJhY2VfbWV0aG9kLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -30,4 +30,5 @@ Foo::bar(hello)
 spans(\DDTrace\SpanData) (1) {
   Foo.bar (alias, Foo.bar, cli)
     system.pid => %d
+    _dd.p.upstream_services => YWxpYXM|1|1|1.000
 }

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -35,6 +35,7 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (5) {
   main (default_span_properties.php, main, cli)
     max => 6
+    _dd.p.upstream_services => ZGVmYXVsdF9zcGFuX3Byb3BlcnRpZXMucGhw|1|1|1.000
   array_sum (default_span_properties.php, array_sum, cli)
     retval => 28
   MyRange (default_span_properties.php, MyRange, cli)

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -42,6 +42,7 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (3) {
   Foo.main (default_span_properties_method.php, Foo.main, cli)
     year => 2020
+    _dd.p.upstream_services => ZGVmYXVsdF9zcGFuX3Byb3BlcnRpZXNfbWV0aG9kLnBocA|1|1|1.000
   MyDateTimeFormat (default_span_properties_method.php, MyDateTimeFormat, cli)
     format => m
   DateTime.__construct (default_span_properties_method.php, DateTime.__construct, cli)

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -44,11 +44,13 @@ array(1) {
     ["error"]=>
     int(1)
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["error.msg"]=>
       string(9) "Foo error"
+      ["_dd.p.upstream_services"]=>
+      string(58) "ZXJyb3JzX2FyZV9mbGFnZ2VkX2Zyb21fdXNlcmxhbmQucGhw|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -78,9 +78,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(29) "c3Bhbl9jbG9uZS5waHA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -61,9 +61,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(52) "c3Bhbl93aXRoX3JlbW92ZWRfZXhjZXB0aW9uLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {
@@ -96,9 +98,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(52) "c3Bhbl93aXRoX3JlbW92ZWRfZXhjZXB0aW9uLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {
@@ -131,9 +135,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(52) "c3Bhbl93aXRoX3JlbW92ZWRfZXhjZXB0aW9uLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -73,9 +73,11 @@ array(2) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(56) "c3RhcnRfc3Bhbl93aXRoX2FsbF9wcm9wZXJ0aWVzLnBocA|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {
@@ -106,11 +108,13 @@ array(2) {
     ["type"]=>
     string(6) "runner"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["aa"]=>
       string(2) "bb"
+      ["_dd.p.upstream_services"]=>
+      string(16) "dGVzdA|1|1|1.000"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -44,9 +44,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(1) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
+      ["_dd.p.upstream_services"]=>
+      string(50) "c3RhcnRfc3Bhbl93aXRob3V0X2Nsb3NpbmcucGhw|1|1|1.000"
     }
     ["metrics"]=>
     array(3) {

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -17,7 +17,7 @@ typedef uint16_t zai_config_id;
 
 #include "config_ini.h"
 
-#define ZAI_CONFIG_ENTRIES_COUNT_MAX 120
+#define ZAI_CONFIG_ENTRIES_COUNT_MAX 128
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
 #define ZAI_CONFIG_NAME_BUFSIZ 60
 


### PR DESCRIPTION
### Description

Implementation of first version of tag propagation for 5/7/8, with tests as phpt.

This will be followed up with a minor change in 5/7/8 to conform to spec as it is now - the spec changed between initial implementation and completion.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
