### PR TITLE
Fix constructor of OpenTracing wrapper when no Datadog tracer is provided

### DIFF
--- a/src/DDTrace/OpenTracer/Tracer.php
+++ b/src/DDTrace/OpenTracer/Tracer.php
@@ -3,6 +3,7 @@
 namespace DDTrace\OpenTracer;
 
 use DDTrace\Contracts\Tracer as TracerInterface;
+use DDTrace\GlobalTracer;
 use DDTrace\Propagator;
 use DDTrace\Tracer as DDTracer;
 use DDTrace\Transport;
@@ -27,7 +28,7 @@ final class Tracer implements OTTracer
      */
     public function __construct(TracerInterface $tracer = null)
     {
-        $this->tracer = $tracer ?: self::make();
+        $this->tracer = $tracer ?: GlobalTracer::get();
     }
 
     /**

--- a/src/DDTrace/OpenTracer1/Tracer.php
+++ b/src/DDTrace/OpenTracer1/Tracer.php
@@ -3,6 +3,7 @@
 namespace DDTrace\OpenTracer1;
 
 use DDTrace\Contracts\Tracer as TracerInterface;
+use DDTrace\GlobalTracer;
 use DDTrace\Propagator;
 use DDTrace\Tracer as DDTracer;
 use DDTrace\Transport;
@@ -29,7 +30,7 @@ final class Tracer implements OTTracer
      */
     public function __construct(TracerInterface $tracer = null)
     {
-        $this->tracer = $tracer ?: self::make();
+        $this->tracer = $tracer ?: GlobalTracer::get();
     }
 
     /**

--- a/tests/OpenTracer1Unit/TracerTest.php
+++ b/tests/OpenTracer1Unit/TracerTest.php
@@ -30,6 +30,24 @@ final class TracerTest extends BaseTestCase
         parent::ddSetUp();
     }
 
+    public function testTracerNoConstructorArg()
+    {
+        $tracer = new Tracer();
+
+        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
+        $this->assertNull($span->getTag(Tag::ENV));
+        $this->assertNull($span->getTag(Tag::VERSION));
+    }
+
+    public function testTracerWithConstructorArg()
+    {
+        $tracer = new Tracer(\DDTrace\GlobalTracer::get());
+
+        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
+        $this->assertNull($span->getTag(Tag::ENV));
+        $this->assertNull($span->getTag(Tag::VERSION));
+    }
+
     public function testCreateSpanWithDefaultTags()
     {
         $tracer = Tracer::make(new NoopTransport());

--- a/tests/OpenTracerUnit/TracerTest.php
+++ b/tests/OpenTracerUnit/TracerTest.php
@@ -37,6 +37,24 @@ final class TracerTest extends BaseTestCase
         parent::ddTearDown();
     }
 
+    public function testTracerNoConstructorArg()
+    {
+        $tracer = new Tracer(); //  Tracer::make(new NoopTransport());
+
+        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
+        $this->assertNull($span->getTag(Tag::ENV));
+        $this->assertNull($span->getTag(Tag::VERSION));
+    }
+
+    public function testTracerWithConstructorArg()
+    {
+        $tracer = new Tracer(\DDTrace\GlobalTracer::get());
+
+        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
+        $this->assertNull($span->getTag(Tag::ENV));
+        $this->assertNull($span->getTag(Tag::VERSION));
+    }
+
     public function testCreateSpanWithDefaultTags()
     {
         $tracer = Tracer::make(new NoopTransport());


### PR DESCRIPTION


### Description

Fixes https://github.com/DataDog/dd-trace-php/issues/1384

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
