### PR TITLE
Export only specific symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ JUNIT_RESULTS_DIR := $(shell pwd)
 
 all: $(BUILD_DIR)/configure $(SO_FILE)
 
-$(BUILD_DIR)/config.m4: $(M4_FILES)
+$(BUILD_DIR)/config.m4: $(M4_FILES) $(BUILD_DIR)/ddtrace.sym
 
 $(BUILD_DIR)/configure: $(BUILD_DIR)/config.m4
 	$(Q) (cd $(BUILD_DIR); phpize && sed -i 's/\/FAILED/\/\\bFAILED/' $(BUILD_DIR)/run-tests.php) # Fix PHP 5.4 exit code bug when running selected tests (FAILED vs XFAILED)

--- a/config.m4
+++ b/config.m4
@@ -34,8 +34,6 @@ if test "$PHP_DDTRACE" != "no"; then
   if test "$PHP_DDTRACE_SANITIZE" != "no"; then
     EXTRA_LDFLAGS="-fsanitize=address"
     EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
-    PHP_SUBST(EXTRA_CFLAGS)
-    PHP_SUBST(EXTRA_LDFLAGS)
   fi
 
   DD_TRACE_VENDOR_SOURCES="\
@@ -272,6 +270,13 @@ if test "$PHP_DDTRACE" != "no"; then
     [AC_MSG_ERROR([cannot find or include curl])])
 
   AC_CHECK_HEADER(time.h, [], [AC_MSG_ERROR([Cannot find or include time.h])])
+
+  dnl Only export symbols defined in ddtrace.sym, which should all be marked as
+  dnl DDTRACE_PUBLIC in their source files as well.
+  EXTRA_CFLAGS="$EXTRA_CFLAGS -fvisibility=hidden"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -export-symbols $ext_srcdir/ddtrace.sym"
+
+  PHP_SUBST(EXTRA_CFLAGS)
   PHP_SUBST(EXTRA_LDFLAGS)
 
   PHP_ADD_INCLUDE([$ext_srcdir])

--- a/ddtrace.sym
+++ b/ddtrace.sym
@@ -1,0 +1,2 @@
+ddtrace_root_span_add_tag
+get_module

--- a/dockerfiles/compile_extension/build-dd-trace-php
+++ b/dockerfiles/compile_extension/build-dd-trace-php
@@ -1,10 +1,35 @@
 #!/usr/bin/env sh
 
-set -ex
+# Print out commands as they are executing.
+set -x
+
+# Stop process on non-zero return codes.
+set -e
+
+# Assign default value for temporary directory.
+if [ "z$TMPDIR" = "z" ] ; then
+    TMPDIR="/tmp"
+fi
+
+# Check early for a better user-experience {{{
+if [ "z$PHP_API" = "z" ] ; then
+    >&2 echo 'ERROR: expected environment variable $PHP_API to be set'
+    exit 1
+fi
+
+if [ ! -f "ddtrace.sym" ] ; then
+    >&2 echo "ERROR: expected 'ddtrace.sym' to exist"
+    exit 1
+fi
+# }}}
+
+# Env vars have been processed; treat unset parameters as an error.
+set -u
 
 apk add --no-cache \
     autoconf \
     bash \
+    coreutils \
     g++ \
     gcc \
     libexecinfo-dev \
@@ -12,6 +37,40 @@ apk add --no-cache \
 
 make all CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror" ECHO_ARG="-e"
 
+sofile="tmp/build_extension/.libs/ddtrace.so"
+actual_symbols=`mktemp "$TMPDIR/actual_symbols.XXXXXXXX"`
+
+# nm -g will only print the extern symbols, so most types can be ignored.
+# nm output legend of symbol types encountered so far:
+#     T is in text (code) section
+#     U is undefined (needed but not included)
+#     w is a weak symbol
+nm -gC "$sofile" \
+    | awk '$1 == "U" || $1 == "w" { next } $2 == "T" { print $3 }' \
+    | sort > "$actual_symbols"
+
+expected_symbols=`mktemp "$TMPDIR/expected_symbols.XXXXXXXX"`
+sort "ddtrace.sym" > "$expected_symbols"
+
+unexpected_symbols=`mktemp "$TMPDIR/unexpected_symbols.XXXXXXXX"`
+# comm -13 will show lines that exist in file 2 that do not exist in file 1.
+# comm expects the inputs to be sorted.
+comm -13 "$expected_symbols" "$actual_symbols" > "$unexpected_symbols"
+
+lines=`wc -l < "$unexpected_symbols"`
+
+if [ $lines -gt 0 ] ; then
+    >&2 echo "ERROR: unexpected symbols! Printing diagnostics."
+
+    # tail -n +1 is kind of like cat but prints file names before contents
+    >&2 tail -n +1 "$expected_symbols" "$actual_symbols" "$unexpected_symbols"
+
+    rm "$expected_symbols" "$actual_symbols" "$unexpected_symbols"
+    exit 1
+else
+    rm "$expected_symbols" "$actual_symbols" "$unexpected_symbols"
+fi
+
 mkdir -p extensions
 
-cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-${PHP_API}-alpine.so
+cp "$sofile" "extensions/ddtrace-${PHP_API}-alpine.so"

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -52,6 +52,10 @@ atomic_int ddtrace_warn_legacy_api;
 
 ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 
+#ifdef COMPILE_DL_DDTRACE
+ZEND_GET_MODULE(ddtrace)
+#endif
+
 PHP_INI_BEGIN()
 STD_PHP_INI_BOOLEAN("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals,
                     ddtrace_globals)
@@ -486,7 +490,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * {{{ */
     Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-    dladdr(ZEND_MODULE_STARTUP_N(ddtrace), &infos);
+    // The symbol used needs to be public on Alpine.
+    dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
     /* }}} */
 
@@ -1832,13 +1837,6 @@ zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           PHP_DDTRACE_VERSION,       PHP_MODULE_GLOBALS(ddtrace),
                                           PHP_GINIT(ddtrace),        NULL,
                                           ddtrace_post_deactivate,   STANDARD_MODULE_PROPERTIES_EX};
-
-#ifdef COMPILE_DL_DDTRACE
-ZEND_GET_MODULE(ddtrace)
-#if defined(ZTS) && PHP_VERSION_ID >= 70000
-ZEND_TSRMLS_CACHE_DEFINE();
-#endif
-#endif
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -54,6 +54,13 @@ atomic_int ddtrace_warn_legacy_api;
 
 ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 
+#ifdef COMPILE_DL_DDTRACE
+ZEND_GET_MODULE(ddtrace)
+#if defined(ZTS) && PHP_VERSION_ID >= 70000
+ZEND_TSRMLS_CACHE_DEFINE();
+#endif
+#endif
+
 PHP_INI_BEGIN()
 STD_PHP_INI_BOOLEAN("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals,
                     ddtrace_globals)
@@ -445,7 +452,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * {{{ */
     Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-    dladdr(ZEND_MODULE_STARTUP_N(ddtrace), &infos);
+    // The symbol used needs to be public on Alpine.
+    dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
     /* }}} */
 
@@ -1740,13 +1748,6 @@ zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           PHP_DDTRACE_VERSION,       PHP_MODULE_GLOBALS(ddtrace),
                                           PHP_GINIT(ddtrace),        NULL,
                                           ddtrace_post_deactivate,   STANDARD_MODULE_PROPERTIES_EX};
-
-#ifdef COMPILE_DL_DDTRACE
-ZEND_GET_MODULE(ddtrace)
-#if defined(ZTS) && PHP_VERSION_ID >= 70000
-ZEND_TSRMLS_CACHE_DEFINE();
-#endif
-#endif
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id

--- a/ext/php7/ddtrace_export.h
+++ b/ext/php7/ddtrace_export.h
@@ -1,0 +1,27 @@
+#ifndef DDTRACE_EXPORT_H
+#define DDTRACE_EXPORT_H
+
+// clang-format off
+/* Define DDTRACE_STATIC before including this header to avoid exporting the
+ * functions, which usually is what is desired when building a static lib,
+ * hence the name.
+ */
+#ifdef DDTRACE_STATIC
+#  define DDTRACE_PUBLIC
+#  define DDTRACE_LOCAL
+#else
+#  ifndef DDTRACE_PUBLIC
+#    define DDTRACE_PUBLIC __attribute__((visibility("default")))
+#  endif
+
+#  ifndef DDTRACE_LOCAL
+#    define DDTRACE_LOCAL __attribute__((visibility("hidden")))
+#  endif
+#endif
+
+#ifndef DDTRACE_DEPRECATED
+#  define DDTRACE_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+// clang-format on
+
+#endif /* DDTRACE_EXPORT_H */

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -92,7 +92,7 @@ ddtrace_span_fci *ddtrace_init_span(void) {
 
 void ddtrace_push_root_span(void) { ddtrace_open_span(ddtrace_init_span()); }
 
-bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
+DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
     // Find the root span
     ddtrace_span_fci *root = DDTRACE_G(open_spans_top);
     if (root == NULL) {

--- a/ext/php7/span.h
+++ b/ext/php7/span.h
@@ -8,6 +8,7 @@
 
 #include "compatibility.h"
 #include "ddtrace.h"
+#include "ddtrace_export.h"
 
 // error.type, error.type, error.stack
 static const int ddtrace_num_error_tags = 3;
@@ -40,8 +41,10 @@ void ddtrace_push_span(ddtrace_span_fci *span_fci);
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
 ddtrace_span_fci *ddtrace_init_span(void);
 void ddtrace_push_root_span(void);
+
 // Note that this function is used externally by the appsec extension.
-bool ddtrace_root_span_add_tag(zend_string *tag, zval *value);
+DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value);
+
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 bool ddtrace_has_top_internal_span(ddtrace_span_fci *end);
 void ddtrace_close_userland_spans_until(ddtrace_span_fci *until);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -54,6 +54,13 @@ atomic_int ddtrace_warn_legacy_api;
 
 ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
 
+#ifdef COMPILE_DL_DDTRACE
+ZEND_GET_MODULE(ddtrace)
+#if defined(ZTS) && PHP_VERSION_ID >= 70000
+ZEND_TSRMLS_CACHE_DEFINE();
+#endif
+#endif
+
 PHP_INI_BEGIN()
 STD_PHP_INI_BOOLEAN("ddtrace.disable", "0", PHP_INI_SYSTEM, OnUpdateBool, disable, zend_ddtrace_globals,
                     ddtrace_globals)
@@ -401,7 +408,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * {{{ */
     Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-    dladdr(ZEND_MODULE_STARTUP_N(ddtrace), &infos);
+    // The symbol used needs to be public on Alpine.
+    dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
     /* }}} */
 
@@ -1681,13 +1689,6 @@ zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           PHP_DDTRACE_VERSION,       PHP_MODULE_GLOBALS(ddtrace),
                                           PHP_GINIT(ddtrace),        NULL,
                                           ddtrace_post_deactivate,   STANDARD_MODULE_PROPERTIES_EX};
-
-#ifdef COMPILE_DL_DDTRACE
-ZEND_GET_MODULE(ddtrace)
-#if defined(ZTS) && PHP_VERSION_ID >= 70000
-ZEND_TSRMLS_CACHE_DEFINE();
-#endif
-#endif
 
 // the following operations are performed in order to put the tracer in a state when a new trace can be started:
 //   - set a new trace (group) id

--- a/ext/php8/ddtrace_export.h
+++ b/ext/php8/ddtrace_export.h
@@ -1,0 +1,27 @@
+#ifndef DDTRACE_EXPORT_H
+#define DDTRACE_EXPORT_H
+
+// clang-format off
+/* Define DDTRACE_STATIC before including this header to avoid exporting the
+ * functions, which usually is what is desired when building a static lib,
+ * hence the name.
+ */
+#ifdef DDTRACE_STATIC
+#  define DDTRACE_PUBLIC
+#  define DDTRACE_LOCAL
+#else
+#  ifndef DDTRACE_PUBLIC
+#    define DDTRACE_PUBLIC __attribute__((visibility("default")))
+#  endif
+
+#  ifndef DDTRACE_LOCAL
+#    define DDTRACE_LOCAL __attribute__((visibility("hidden")))
+#  endif
+#endif
+
+#ifndef DDTRACE_DEPRECATED
+#  define DDTRACE_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+// clang-format on
+
+#endif /* DDTRACE_EXPORT_H */

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -91,7 +91,7 @@ ddtrace_span_fci *ddtrace_init_span(void) {
 
 void ddtrace_push_root_span(void) { ddtrace_open_span(ddtrace_init_span()); }
 
-bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
+DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
     // Find the root span
     ddtrace_span_fci *root = DDTRACE_G(open_spans_top);
     if (root == NULL) {

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -8,6 +8,7 @@
 
 #include "compatibility.h"
 #include "ddtrace.h"
+#include "ddtrace_export.h"
 
 // error.type, error.type, error.stack
 static const int ddtrace_num_error_tags = 3;
@@ -40,8 +41,10 @@ void ddtrace_push_span(ddtrace_span_fci *span_fci);
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
 ddtrace_span_fci *ddtrace_init_span(void);
 void ddtrace_push_root_span(void);
+
 // Note that this function is used externally by the appsec extension.
-bool ddtrace_root_span_add_tag(zend_string *tag, zval *value);
+DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value);
+
 void dd_trace_stop_span_time(ddtrace_span_t *span);
 bool ddtrace_has_top_internal_span(ddtrace_span_fci *end);
 void ddtrace_close_userland_spans_until(ddtrace_span_fci *until);

--- a/package.xml
+++ b/package.xml
@@ -53,6 +53,7 @@
         <dir name="/">
             <!-- code and test files -->${codefiles}
             <file name="config.m4" role="src" />
+            <file name="ddtrace.sym" role="src" />
 
             <!-- Docs -->
             <file name="CHANGELOG.md" role="doc" />


### PR DESCRIPTION
### Description

There are only two symbols which need to be exported:

1. `get_module`, needed by all PHP modules.
2. `ddtrace_root_span_add_tag`, needed by the appsec product.

Symbols which should be exported should be marked DDTRACE_PUBLIC, which
comes from the new `ddtrace_export.h` header. The symbols should also
be added to the `ddtrace.sym` file, one per line.

Using `-fvisibility=hidden` will hide our own symbols, reduce object
size, and to a mild degree improve performance. However, it won't hide
symbols from static libraries, which is why libtool's `-export-symbols`
is also used.

Note that for the hybrid extension hack that the symbol needs to be
public on Alpine, so it was switched to use `get_module` which is
always available on correctly built modules.

Note: this is a new PR because GH automatically closed #1395.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
