### PR TITLE
Add simple test for time component

### DIFF
--- a/components/time/CMakeLists.txt
+++ b/components/time/CMakeLists.txt
@@ -54,6 +54,7 @@ if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
   " DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
   if (DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
     target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
+    target_link_libraries(datadog-php-time PRIVATE Threads::Threads)
   endif ()
   cmake_pop_check_state()
 endif ()
@@ -72,4 +73,8 @@ int main(void) {
 
 if (DATADOG_HAVE_THREAD_INFO)
   target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
+endif ()
+
+if (${DATADOG_PHP_TESTING})
+  add_subdirectory(tests)
 endif ()

--- a/components/time/tests/CMakeLists.txt
+++ b/components/time/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test-datadog-php-time time.cc)
+
+target_link_libraries(test-datadog-php-time
+  PRIVATE Catch2::Catch2WithMain datadog-php-time
+)
+
+catch_discover_tests(test-datadog-php-time)

--- a/components/time/tests/time.cc
+++ b/components/time/tests/time.cc
@@ -1,0 +1,14 @@
+extern "C" {
+#include <components/time/time.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("cpu-time returns non-zero value", "[time]") {
+    datadog_php_cpu_time_result result = datadog_php_cpu_time_now();
+    REQUIRE(result.tag == DATADOG_PHP_CPU_TIME_OK);
+
+    struct timespec now = result.ok;
+    bool nonzero = now.tv_sec > 0 || now.tv_nsec > 0;
+    REQUIRE(nonzero);
+}


### PR DESCRIPTION
### Description

This simply checks for a non-zero code. It's not particularly
helpful, but it is something.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
