### PR TITLE
Have both legacy and new installer to fail when json PHP extension is not enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -915,6 +915,21 @@ jobs:
           name: Validate .tar.gz package
           command: PHP_VERSION=<< parameters.php_major_minor >> bash ./dockerfiles/verify_packages/verify_tar_gz_root.sh
 
+  verify_no_json_ext:
+    working_directory: ~/datadog
+    resource_class: small
+    docker:
+      - image: alpine:3.12
+    steps:
+      - run:
+          # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
+          name: Install ca-certificates
+          command: apk add --no-cache ca-certificates
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Test
+          command: ./dockerfiles/verify_packages/verify_no_ext_json.sh
+
   installer_tests:
     working_directory: ~/datadog
     machine:
@@ -1801,6 +1816,9 @@ workflows:
                 - "8.0"
                 # There is little value in testing several versions, since all the packages are already verified on the
                 # respective platforms using the native packages. Let's save some CPU cycles.
+
+      - verify_no_json_ext:
+          requires: [ "package extension" ]
 
       - pecl_tests:
           requires: [ "Build PECL" ]

--- a/dd-library-php-setup.php
+++ b/dd-library-php-setup.php
@@ -327,7 +327,7 @@ function check_php_ext_prerequisite_or_exit($binary, $extName)
 {
     $lastLine = execute_or_exit(
         "Cannot retrieve extensions list",
-        // '|| true' is necessary because grep exists with 1 if the pattern was not found.
+        // '|| true' is necessary because grep exits with 1 if the pattern was not found.
         "$binary -m | grep '$extName' || true"
     );
 

--- a/dd-library-php-setup.php
+++ b/dd-library-php-setup.php
@@ -112,6 +112,9 @@ function install($options)
     foreach ($selectedBinaries as $command => $fullPath) {
         $binaryForLog = ($command === $fullPath) ? $fullPath : "$command ($fullPath)";
         echo "Installing to binary: $binaryForLog\n";
+
+        check_php_ext_prerequisite_or_exit($fullPath, 'json');
+
         $phpProperties = ini_values($fullPath);
 
         // Copying the extension
@@ -314,6 +317,27 @@ function check_library_prerequisite_or_exit($requiredLibrary)
 }
 
 /**
+ * Checks if an extension is enabled or not.
+ *
+ * @param string $binary
+ * @param string $requiredLibrary E.g. json
+ * @return void
+ */
+function check_php_ext_prerequisite_or_exit($binary, $extName)
+{
+    $lastLine = execute_or_exit(
+        "Cannot retrieve extensions list",
+        // '|| true' is necessary because grep exists with 1 if the pattern was not found.
+        "$binary -m | grep '$extName' || true"
+    );
+
+
+    if (empty($lastLine)) {
+        print_error_and_exit("Required PHP extension '$extName' not found.\n");
+    }
+}
+
+/**
  * @return bool
  */
 function is_alpine()
@@ -500,7 +524,7 @@ function execute_or_exit($exitMessage, $command)
     if (false === $lastLine || $returnCode > 0) {
         print_error_and_exit(
             $exitMessage .
-                "\nFailed command: $command\n---- Output ----\n" .
+                "\nFailed command (return code $returnCode): $command\n---- Output ----\n" .
                 implode("\n", $output) .
                 "\n---- End of output ----\n"
         );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,3 +135,9 @@ services:
     - DD_API_KEY=${DATADOG_API_KEY}
     - DD_APM_ENABLED=true
     - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
+
+  packager:
+    image: datadog/docker-library:ddtrace_php_fpm_packaging
+    working_dir: /app
+    volumes:
+      - .:/app

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -63,6 +63,9 @@ verify_tar_root:
 		tar_gz \
 		bash dockerfiles/verify_packages/verify_tar_gz_root.sh
 
+test_legacy_installer_no_ext_json:
+	docker run --rm -ti -v $(shell pwd)/../../:/app --workdir=/app alpine:3.12 sh dockerfiles/verify_packages/verify_no_ext_json.sh
+
 test_installer: $(shell find installer -name 'test_*.sh' -exec basename {} \;)
 
 test_first_install.sh \

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -78,6 +78,7 @@ test_upgrade_from_php_installer.sh \
 	:
 	docker run --rm -ti -v $(shell pwd)/../../:/app --workdir=/app php:7.4-cli sh dockerfiles/verify_packages/installer/$(@)
 
+test_alpine_no_ext_json.sh \
 test_alpine_no_libcurl.sh \
 test_install_no_ext_curl_no_curl_cli.sh \
 test_install_no_ext_curl_yes_curl_cli.sh \

--- a/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
@@ -24,10 +24,10 @@ else
     exit 1
 fi
 
-if [ -z "${output##*json*}" ]; then
+output_last_line=$(echo "${output}" | tail -1)
+if [ -z "${output_last_line##*json*}" ]; then
     printf "Ok: output contains text 'json'\n"
 else
-    output_last_line=$(echo "${output}" | tail -1)
     printf "Error: Output does not contain text 'json'. Output is\n---\n${output_last_line}\n---\n"
     exit 1
 fi

--- a/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+apk add php7 curl libexecinfo
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+# Install using the php installer
+new_version="0.65.1"
+
+set +e
+output=$(php dd-library-php-setup.php --php-bin php --tracer-version "${new_version}")
+exit_status=$?
+set -e
+
+if [ "${exit_status}" = "1" ]; then
+    printf "Ok: expected exit status 1\n"
+else
+    printf "Error: Unexpected exit status ${exit_status}. Should be 1\n"
+    exit 1
+fi
+
+if [ -z "${output##*json*}" ]; then
+    printf "Ok: output contains text 'json'\n"
+else
+    output_last_line=$(echo "${output}" | tail -1)
+    printf "Error: Output does not contain text 'json'. Output is\n---\n${output_last_line}\n---\n"
+    exit 1
+fi

--- a/dockerfiles/verify_packages/installer/test_install_no_ext_curl_no_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_install_no_ext_curl_no_curl_cli.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
-apk add php7 libcurl libexecinfo php7-openssl
+apk add php7 php7-json libcurl libexecinfo php7-openssl
 
 # Initially no ddtrace
 assert_no_ddtrace

--- a/dockerfiles/verify_packages/installer/test_install_no_ext_curl_yes_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_install_no_ext_curl_yes_curl_cli.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
-apk add php7 libcurl libexecinfo curl
+apk add php7 php7-json libcurl libexecinfo curl
 
 # Initially no ddtrace
 assert_no_ddtrace

--- a/dockerfiles/verify_packages/verify_no_ext_json.sh
+++ b/dockerfiles/verify_packages/verify_no_ext_json.sh
@@ -18,10 +18,10 @@ else
     exit 1
 fi
 
-if [ -z "${output##*json*}" ]; then
+output_last_line=$(echo "${output}" | tail -1)
+if [ -z "${output_last_line##*json*}" ]; then
     printf "Ok: output contains text 'json'\n"
 else
-    output_last_line=$(echo "${output}" | tail -1)
     printf "Error: Output does not contain text 'json'. Output is\n---\n${output_last_line}\n---\n"
     exit 1
 fi

--- a/dockerfiles/verify_packages/verify_no_ext_json.sh
+++ b/dockerfiles/verify_packages/verify_no_ext_json.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+set -e
+
+apk add --no-cache bash curl libexecinfo php7
+
+echo "Installing dd-trace-php using the OS-specific package installer"
+
+set +e
+apk add --no-cache $(pwd)/build/packages/*.apk --allow-untrusted
+exit_status=$?
+set -e
+
+if [ "${exit_status}" = "1" ]; then
+    printf "Ok: expected exit status 1 (json module is missing)\n"
+else
+    printf "Error: Unexpected exit status ${exit_status}. Should be 1\n"
+    exit 1
+fi
+
+if [ -z "${output##*json*}" ]; then
+    printf "Ok: output contains text 'json'\n"
+else
+    output_last_line=$(echo "${output}" | tail -1)
+    printf "Error: Output does not contain text 'json'. Output is\n---\n${output_last_line}\n---\n"
+    exit 1
+fi

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -6,7 +6,7 @@
 # (fpm 1.14.0, ruby 3.0, tar 1.34).
 # Packing fails if this script size in bytes is between <unknown> and 7680. This value has been found empirically and
 # measured via `wc -c`.
-# The issue seems related to this very specific file size ony, as generating a package that includes only this script
+# The issue seems related to this very specific file size only, as generating a package that includes only this script
 # (no binaries and sources) will result in the very same error.
 # Issue reported to the fpm project (https://github.com/jordansissel/fpm/issues/1866), see there for more details and
 # a reproduction case.

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -153,6 +153,19 @@ function verify_installation() {
         fail_print_and_exit
 }
 
+function verify_required_ext() {
+    ext_name="$1"
+    printf "Checking for extension: ${ext_name}\n"
+    output=$(invoke_php -m | grep "${ext_name}" || true)
+
+    if [ "${output}" == "${ext_name}" ]; then
+        printf "Extension '${ext_name}' was found.\n"
+    else
+        printf "Error: PHP extension '${ext_name}' was not found.\n"
+        exit 1
+    fi
+}
+
 println "PHP version"
 invoke_php -v
 
@@ -194,6 +207,8 @@ extension=${EXTENSION_FILE_PATH}
 datadog.trace.request_init_hook=${EXTENSION_AUTO_INSTRUMENTATION_FILE}
 EOF
 )
+
+verify_required_ext json
 
 if [[ ! -e $PHP_CFG_DIR ]]; then
     println

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -154,6 +154,10 @@ function verify_installation() {
 }
 
 function verify_required_ext() {
+    # This comment has been added because without it the number of bytes of this script is 7432
+    # and the apk module of fpm generates a broken tar.
+    # For some reasons we have to reach at least a number of bytes greater or equal 7681 so I need
+    # keep writing this few more words.
     ext_name="$1"
     printf "Checking for extension: ${ext_name}\n"
     output=$(invoke_php -m | grep "${ext_name}" || true)


### PR DESCRIPTION
### Description

The latest version (on `master`, not released yet) cannot be loaded if the json extension is not enabled and it fails with a warning:

```
[Tue Dec  7 06:05:46 2021] PHP Warning:  Cannot load module 'ddtrace' because required module 'json' is not loaded ...
```

This is the case for default installation of PHP, which does not include `json`, unless a user also add `php7-json`, for example.

This PR adds checks (and tests) to both legacy and new installers to make sure that if the extension is not installed we fail with a proper and explanatory message.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
