### PR TITLE
Default to compiled version of files in CI

### DIFF
--- a/tests/DistributedTracing/DistributedTraceTest.php
+++ b/tests/DistributedTracing/DistributedTraceTest.php
@@ -24,7 +24,6 @@ class DistributedTraceTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_DISTRIBUTED_TRACING' => 'true',
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
     }
 

--- a/tests/DistributedTracing/SamplingPriorityTest.php
+++ b/tests/DistributedTracing/SamplingPriorityTest.php
@@ -18,7 +18,6 @@ class SamplingPriorityTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_DISTRIBUTED_TRACING' => 'true',
             'DD_PRIORITY_SAMPLING' => 'true',
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
     }
 

--- a/tests/DistributedTracing/SandboxAndLegacyTest.php
+++ b/tests/DistributedTracing/SandboxAndLegacyTest.php
@@ -24,7 +24,6 @@ class SandboxAndLegacyTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_DISTRIBUTED_TRACING' => 'true',
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
     }
 

--- a/tests/DistributedTracing/SyntheticsTest.php
+++ b/tests/DistributedTracing/SyntheticsTest.php
@@ -23,7 +23,6 @@ class SyntheticsTest extends WebFrameworkTestCase
             'DD_PRIORITY_SAMPLING' => 'true',
             // Disabling distributed tracing will break Synthetic requests
             'DD_DISTRIBUTED_TRACING' => 'true',
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
     }
 

--- a/tests/Integration/BootstrapTest.php
+++ b/tests/Integration/BootstrapTest.php
@@ -17,7 +17,6 @@ final class BootstrapTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_NO_AUTOLOADER' => '1',
             'DD_TRACE_SPANS_LIMIT' => '1',
         ]);
     }

--- a/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
+++ b/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
@@ -16,7 +16,6 @@ final class CurrentContextAccessTest extends IntegrationTestCase
             __DIR__ . '/web.php',
             [
                 'DD_SERVICE' => 'top_level_app',
-                'DD_TRACE_NO_AUTOLOADER' => true,
             ]
         );
 

--- a/tests/Integration/ResponseStatusCodeTest.php
+++ b/tests/Integration/ResponseStatusCodeTest.php
@@ -16,7 +16,6 @@ class ResponseStatusCodeTest extends WebFrameworkTestCase
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_NO_AUTOLOADER' => '1',
         ]);
     }
 

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -179,7 +179,6 @@ final class TracerTest extends BaseTestCase
             },
             __DIR__ . '/TracerTest_files/index.php',
             [
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );
@@ -196,7 +195,6 @@ final class TracerTest extends BaseTestCase
             __DIR__ . '/TracerTest_files/index.php',
             [
                 'DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED' => true,
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );
@@ -213,7 +211,6 @@ final class TracerTest extends BaseTestCase
             __DIR__ . '/TracerTest_files/index.php',
             [
                 'DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED' => false,
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );
@@ -230,7 +227,6 @@ final class TracerTest extends BaseTestCase
             __DIR__ . '/TracerTest_files/index.php',
             [
                 'DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED' => true,
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );
@@ -460,7 +456,6 @@ final class TracerTest extends BaseTestCase
             [
                 'DD_SERVICE_MAPPING' => 'host-httpbin_integration:changed_service',
                 'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );
@@ -478,7 +473,6 @@ final class TracerTest extends BaseTestCase
             [
                 'DD_SERVICE_MAPPING' => 'host-127.0.0.1:changed_service',
                 'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => true,
-                'DD_TRACE_NO_AUTOLOADER' => true,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => true,
             ]
         );

--- a/tests/Integrations/CLI/Custom/NotAutoloaded/NotAutoloadedTestCase.php
+++ b/tests/Integrations/CLI/Custom/NotAutoloaded/NotAutoloadedTestCase.php
@@ -25,7 +25,6 @@ final class NotAutoloadedTestCase extends CLITestCase
     public function testCliCommandNoAutoloaderEnabledByEnv()
     {
         $traces = $this->getTracesFromCommand('', [
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
 
         $this->assertSpans($traces, [

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -192,7 +192,6 @@ final class CurlIntegrationTest extends IntegrationTestCase
             __DIR__ . '/curl_in_web_request.php',
             [
                 'DD_SERVICE' => 'top_level_app',
-                'DD_TRACE_NO_AUTOLOADER' => true,
             ]
         );
 

--- a/tests/Integrations/Custom/NotAutoloaded/FrameworkNoAutoloadedTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/FrameworkNoAutoloadedTest.php
@@ -17,7 +17,6 @@ final class FrameworkNoAutoloadedTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'APP_NAME' => 'custom_no_autoloaded_app',
-            'DD_TRACE_NO_AUTOLOADER' => 'true',
         ]);
     }
 

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -345,7 +345,6 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             __DIR__ . '/guzzle_in_web_request.php',
             [
                 'DD_SERVICE' => 'top_level_app',
-                'DD_TRACE_NO_AUTOLOADER' => true,
             ]
         );
 

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -337,7 +337,6 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             __DIR__ . '/guzzle_in_web_request.php',
             [
                 'DD_SERVICE' => 'top_level_app',
-                'DD_TRACE_NO_AUTOLOADER' => true,
             ]
         );
 

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -58,6 +58,7 @@ final class WebServer
         'DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS' => 1,
         // Short flush interval by default or our tests will take all day
         'DD_TRACE_AGENT_FLUSH_INTERVAL' => 333,
+        'DD_AUTOLOAD_NO_COMPILE' => \getenv('DD_AUTOLOAD_NO_COMPILE'),
     ];
 
     /**

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -58,7 +58,6 @@ final class WebServer
         'DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS' => 1,
         // Short flush interval by default or our tests will take all day
         'DD_TRACE_AGENT_FLUSH_INTERVAL' => 333,
-        'DD_AUTOLOAD_NO_COMPILE' => \getenv('DD_AUTOLOAD_NO_COMPILE'),
     ];
 
     /**
@@ -81,6 +80,7 @@ final class WebServer
         $this->defaultInis['error_log'] = dirname($this->indexFile) .  '/' . self::ERROR_LOG_NAME;
         // Enable auto-instrumentation
         $this->defaultInis['ddtrace.request_init_hook'] = realpath(__DIR__ .  '/../bridge/dd_wrap_autoloader.php');
+        $this->defaultEnvs['DD_AUTOLOAD_NO_COMPILE'] = \getenv('DD_AUTOLOAD_NO_COMPILE');
         $this->host = $host;
         $this->port = $port;
     }


### PR DESCRIPTION
### Description

By default `DD_AUTOLOAD_NO_COMPILE` must be `false` (or not set) so in CI we are sure that we always test the compiled version, that is what we ship to users.

In development, we can constantly avoid recompilation by doing `make >>>dev<<< test_***` which sets `DD_AUTOLOAD_NO_COMPILE=true` while running the tests locally, without having to regenerate PHP files bundles.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
