### PR TITLE
Rename .phpcs.xml to phpcs.xml as the first one is not recognized by VSCode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@ dockerfiles         export-ignore
 .editorconfig       export-ignore
 .gitattributes      export-ignore
 .gitignore          export-ignore
-.phpcs.xml          export-ignore
+phpcs.xml          export-ignore
 CONTRIBUTING.md     export-ignore
 phpunit.xml         export-ignore
 RELEASING.md        export-ignore

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
         <severity>0</severity>
     </rule>
     <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>dd-library-php-setup.php</exclude-pattern>
         <exclude-pattern>tests/Integration/ErrorReporting/ErrorReportingTest.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/*</exclude-pattern>
     </rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,6 @@
         <severity>0</severity>
     </rule>
     <rule ref="Generic.Files.LineLength.TooLong">
-        <exclude-pattern>dd-library-php-setup.php</exclude-pattern>
         <exclude-pattern>tests/Integration/ErrorReporting/ErrorReportingTest.php</exclude-pattern>
         <exclude-pattern>tests/Integrations/*</exclude-pattern>
     </rule>


### PR DESCRIPTION
### Description

VSCode phpcs extension does not recognize `.phpcs.xml` as a file name.

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
