### PR TITLE
Skip failing lang test

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -130,6 +130,7 @@ ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_error_string_basic.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -142,6 +142,7 @@ ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_encrypt_ccm.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -124,6 +124,7 @@ ext/openssl/tests/bug77390.phpt
 ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -135,6 +135,7 @@ ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_encrypt_ccm.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -187,6 +187,7 @@ ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_encrypt_ccm.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -229,6 +229,7 @@ ext/openssl/tests/openssl_cms_decrypt_error.phpt
 ext/openssl/tests/openssl_encrypt_ccm.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_pkcs7_decrypt_error.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/openssl_x509_free_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -56,6 +56,7 @@ ext/openssl/tests/bug77390.phpt
 ext/openssl/tests/capture_peer_cert_001.phpt
 ext/openssl/tests/openssl_encrypt_ccm.phpt
 ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
+ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/session_meta_capture.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -93,6 +93,10 @@ Building again the container without `pcntl` enabled AND not even building the t
 
 Tests do not work on PHP 5 with openssl 1.0.2.
 
+## `ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt`
+
+Depends on an expired cert. Was fixed in [php-src/98175fc](https://github.com/php/php-src/commit/98175fc).
+
 ## `ext/ftp/tests`
 
 Disabled on versions less than 8.1, which switches to ephemeral ports.


### PR DESCRIPTION
### Description

Skip a failing lang test due to an expired cert. (Recently fixed in php/php-src#7763)