### PR TITLE
Bump version 0.68.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.67.0/datadog-php-tracer_0.67.0_amd64.deb"
+    value: "https://809973-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_1.0.0-nightly_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 	bash ./tooling/bin/generate-final-artifact.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR) \
-		https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0-rc.4/datadog-profiling.tar.gz
+		https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0-rc.5/datadog-profiling.tar.gz
 
 build_pecl_package:
 	BUILD_DIR='$(BUILD_DIR)/'; \

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.68.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,37 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ### Added
+    - Bring priority sampling to internal #1366
+    - SpanData::$parent property #1369
+    - Add queue and channel components #1388
+    - Add log component #1390
+    - Add arena component #1391
+    - Add stack sample component #1392
+    - Add uuid component #1393
+    - Add time component #1394, #1408
+    - Add profiler installation #1422
+    - Zai/json #1378, #1397
+    - Add Code Coverage #1389
+
+    ### Changed
+    - (PHP 8) Migrate ObjectKVStore to WeakMap internally #1362
+    - Adjust components #1387
+    - Export only specific symbols #1407
+    - Sanitize user information from urls #1396
+    - Split INI setting in installer so they can be added separately when missing #1415
+    - Use the new targz bundle format with the new PHP installer #1421
+    - Have both legacy and new installer to fail when json PHP extension is not enabled #1410
+
+    ### Fixed
+    - Fix Laravel unnamed route with caching and domain specification #1364
+    - Fix http.url of internal root span #1360
+    - Add small framework to stress test our internal API with bogus inputs #1365
+    - PDOIntegration::parseDSN fails to parse some DSN #1373
+    - Fix constructor of OpenTracing wrapper when no Datadog tracer is provided #1406 - thanks @OGKevin for the reproduction case
+    - Fix parsing of urls without schema into host name #1385
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -25,7 +25,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.68.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Added
- Bring priority sampling to internal #1366
- SpanData::$parent property #1369
- Add queue and channel components #1388
- Add log component #1390
- Add arena component #1391
- Add stack sample component #1392
- Add uuid component #1393
- Add time component #1394, #1408
- Add profiler installation #1422
- Zai/json #1378, #1397
- Add Code Coverage #1389

### Changed
- (PHP 8) Migrate ObjectKVStore to WeakMap internally #1362
- Adjust components #1387
- Export only specific symbols #1407
- Sanitize user information from urls #1396
- Split INI setting in installer so they can be added separately when missing #1415
- Use the new targz bundle format with the new PHP installer #1421
- Have both legacy and new installer to fail when json PHP extension is not enabled #1410

### Fixed
- Fix Laravel unnamed route with caching and domain specification #1364
- Fix http.url of internal root span #1360
- Add small framework to stress test our internal API with bogus inputs #1365
- PDOIntegration::parseDSN fails to parse some DSN #1373
- Fix constructor of OpenTracing wrapper when no Datadog tracer is provided #1406 - thanks @OGKevin for the reproduction case
- Fix parsing of urls without schema into host name #1385