### PR TITLE
Change Predis integration type to "redis"

### DIFF
--- a/src/DDTrace/Integrations/Predis/PredisIntegration.php
+++ b/src/DDTrace/Integrations/Predis/PredisIntegration.php
@@ -40,7 +40,7 @@ class PredisIntegration extends Integration
 
         \DDTrace\trace_method('Predis\Client', '__construct', function (SpanData $span, $args) {
             $span->name = 'Predis.Client.__construct';
-            $span->type = Type::CACHE;
+            $span->type = Type::REDIS;
             $span->resource = 'Predis.Client.__construct';
             PredisIntegration::storeConnectionMetaAndService($this, $args);
             PredisIntegration::setMetaAndServiceFromConnection($this, $span);
@@ -48,14 +48,14 @@ class PredisIntegration extends Integration
 
         \DDTrace\trace_method('Predis\Client', 'connect', function (SpanData $span, $args) {
             $span->name = 'Predis.Client.connect';
-            $span->type = Type::CACHE;
+            $span->type = Type::REDIS;
             $span->resource = 'Predis.Client.connect';
             PredisIntegration::setMetaAndServiceFromConnection($this, $span);
         });
 
         \DDTrace\trace_method('Predis\Client', 'executeCommand', function (SpanData $span, $args) use ($integration) {
             $span->name = 'Predis.Client.executeCommand';
-            $span->type = Type::CACHE;
+            $span->type = Type::REDIS;
             PredisIntegration::setMetaAndServiceFromConnection($this, $span);
             $integration->addTraceAnalyticsIfEnabled($span);
 
@@ -78,7 +78,7 @@ class PredisIntegration extends Integration
 
         \DDTrace\trace_method('Predis\Client', 'executeRaw', function (SpanData $span, $args) use ($integration) {
             $span->name = 'Predis.Client.executeRaw';
-            $span->type = Type::CACHE;
+            $span->type = Type::REDIS;
             PredisIntegration::setMetaAndServiceFromConnection($this, $span);
             $integration->addTraceAnalyticsIfEnabled($span);
 
@@ -102,7 +102,7 @@ class PredisIntegration extends Integration
             \DDTrace\trace_method('Predis\Pipeline\Pipeline', 'executePipeline', function (SpanData $span, $args) {
                 $span->name = 'Predis.Pipeline.executePipeline';
                 $span->resource = $span->name;
-                $span->type = Type::CACHE;
+                $span->type = Type::REDIS;
                 PredisIntegration::setMetaAndServiceFromConnection($this, $span);
             });
         } else {
@@ -113,7 +113,7 @@ class PredisIntegration extends Integration
                     'prehook' => function (SpanData $span, $args) {
                         $span->name = 'Predis.Pipeline.executePipeline';
                         $span->resource = $span->name;
-                        $span->type = Type::CACHE;
+                        $span->type = Type::REDIS;
                         PredisIntegration::setMetaAndServiceFromConnection($this, $span);
                         if (\count($args) < 2) {
                             return;

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -126,7 +126,7 @@ final class PredisTest extends IntegrationTestCase
         });
 
         $this->assertFlameGraph($traces, [
-            SpanAssertion::build('Predis.Client.__construct', 'redis', 'cache', 'Predis.Client.__construct')
+            SpanAssertion::build('Predis.Client.__construct', 'redis', 'redis', 'Predis.Client.__construct')
                 ->withExactTags($this->baseTags()),
         ]);
     }
@@ -142,7 +142,7 @@ final class PredisTest extends IntegrationTestCase
 
 
         $this->assertFlameGraph($traces, [
-            SpanAssertion::build('Predis.Client.__construct', 'redis', 'cache', 'Predis.Client.__construct')
+            SpanAssertion::build('Predis.Client.__construct', 'redis', 'redis', 'Predis.Client.__construct')
                 ->withExactTags($this->baseTags()),
         ]);
     }
@@ -156,7 +156,7 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
-            SpanAssertion::build('Predis.Client.connect', 'redis', 'cache', 'Predis.Client.connect')
+            SpanAssertion::build('Predis.Client.connect', 'redis', 'redis', 'Predis.Client.connect')
                 ->withExactTags($this->baseTags()),
         ]);
     }
@@ -172,7 +172,7 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
-            SpanAssertion::build('Predis.Client.connect', 'redis', 'cache', 'Predis.Client.connect')
+            SpanAssertion::build('Predis.Client.connect', 'redis', 'redis', 'Predis.Client.connect')
                 ->withExactTags([]),
         ]);
     }
@@ -186,7 +186,7 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
-            SpanAssertion::build('Predis.Client.executeCommand', 'redis', 'cache', 'SET foo value')
+            SpanAssertion::build('Predis.Client.executeCommand', 'redis', 'redis', 'SET foo value')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'SET foo value',
@@ -206,7 +206,7 @@ final class PredisTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
             SpanAssertion::exists('Predis.Client.executeCommand'),
-            SpanAssertion::build('Predis.Client.executeCommand', 'redis', 'cache', 'GET key')
+            SpanAssertion::build('Predis.Client.executeCommand', 'redis', 'redis', 'GET key')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'GET key',
@@ -224,7 +224,7 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
-            SpanAssertion::build('Predis.Client.executeRaw', 'redis', 'cache', 'SET key value')
+            SpanAssertion::build('Predis.Client.executeRaw', 'redis', 'redis', 'SET key value')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'SET key value',
@@ -255,7 +255,7 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
-            SpanAssertion::build('Predis.Pipeline.executePipeline', 'redis', 'cache', 'Predis.Pipeline.executePipeline')
+            SpanAssertion::build('Predis.Pipeline.executePipeline', 'redis', 'redis', 'Predis.Pipeline.executePipeline')
                 ->withExactTags($exactTags),
         ]);
     }


### PR DESCRIPTION
### Description

The Predis integration is marked as type `cache` but in order for the Agent to properly obfuscate `redis.raw_command`, the integration type needs to be `redis`.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
