### PR TITLE
Disable tracing when PHP is executed during RINIT

### DIFF
--- a/ext/php5/php5/engine_hooks.c
+++ b/ext/php5/php5/engine_hooks.c
@@ -311,6 +311,10 @@ static int dd_exit_handler(zend_execute_data *execute_data TSRMLS_DC) {
 }
 
 static ddtrace_dispatch_t *dd_lookup_dispatch_from_fbc(zend_function *fbc TSRMLS_DC) {
+    if (!PG(modules_activated)) {
+        return false;
+    }
+
     if (!get_DD_TRACE_ENABLED() || DDTRACE_G(class_lookup) == NULL || DDTRACE_G(function_lookup) == NULL) {
         return false;
     }

--- a/ext/php5/php5_4/engine_hooks.c
+++ b/ext/php5/php5_4/engine_hooks.c
@@ -29,6 +29,10 @@ static zend_class_entry *dd_get_called_scope(zend_function *fbc TSRMLS_DC) {
 }
 
 static ddtrace_dispatch_t *dd_lookup_dispatch_from_fbc(zend_function *fbc TSRMLS_DC) {
+    if (!PG(modules_activated)) {
+        return NULL;
+    }
+
     if (!get_DD_TRACE_ENABLED() || !DDTRACE_G(class_lookup) || !DDTRACE_G(function_lookup) || !fbc) {
         return NULL;
     }

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -200,6 +200,10 @@ static bool dd_should_trace_runtime(ddtrace_dispatch_t *dispatch) {
 static bool dd_should_trace_call(zend_execute_data *call, ddtrace_dispatch_t **dispatch) {
     zend_function *fbc = call->func;
 
+    if (!PG(modules_activated)) {
+        return false;
+    }
+
     if (!get_DD_TRACE_ENABLED()) {
         return false;
     }

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -738,6 +738,11 @@ static void dd_observer_end_handler(zend_execute_data *execute_data, zval *retva
 
 zend_observer_fcall_handlers ddtrace_observer_fcall_init(zend_execute_data *execute_data) {
     zend_function *fbc = EX(func);
+
+    if (!PG(modules_activated)) {
+        return (zend_observer_fcall_handlers){NULL, NULL};
+    }
+
     if (!get_DD_TRACE_ENABLED() || ddtrace_op_array_extension == 0 || fbc->common.type != ZEND_USER_FUNCTION) {
         return (zend_observer_fcall_handlers){NULL, NULL};
     }


### PR DESCRIPTION
### Description

Fixes #1428 

dd-trace-php has a requirement that the runtime is properly initialized before tracing is attempted - *all* loaded extensions must have executed their RINIT stage hooks before the tracer can instrument anything safely.

This change enforces that requirement.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
