### PR TITLE
Fix json symbol address resolving logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1310,6 +1310,75 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  ZaiSharedExts:
+    working_directory: ~/datadog
+    parameters:
+      php_version:
+        type: string
+    docker:
+      - image: datadog/dd-trace-ci:php-<< parameters.php_version >>-shared-ext
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Switch PHP to nts
+          command: |
+            switch-php nts
+
+      # Starting in PHP 8.0, ext/json is a core extension
+      - when:
+          condition:
+            or:
+              - equal: [ "5.4", << parameters.php_version >> ]
+              - equal: [ "5.5", << parameters.php_version >> ]
+              - equal: [ "5.6", << parameters.php_version >> ]
+              - equal: [ "7.0", << parameters.php_version >> ]
+              - equal: [ "7.1", << parameters.php_version >> ]
+              - equal: [ "7.2", << parameters.php_version >> ]
+              - equal: [ "7.3", << parameters.php_version >> ]
+              - equal: [ "7.4", << parameters.php_version >> ]
+          steps:
+            - run:
+                name: Ensure ext/json is loaded as shared lib
+                command: |
+                  if php --ri=json &> /dev/null
+                  then
+                    echo 'ext/json is enabled but should not be installed'
+                    exit 1
+                  fi
+                  echo "extension=json.so" | sudo tee $(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}')/json.ini
+
+      - run:
+          name: Ensure ext/curl is loaded as shared lib
+          command: |
+            if php --ri=curl &> /dev/null
+            then
+              echo 'ext/curl is enabled but should not be installed'
+              exit 1
+            fi
+            echo "extension=curl.so" | sudo tee $(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}')/curl.ini
+      - run:
+          name: Build and test Zend Abstract Interface (nts)
+          command: |
+            mkdir -p /tmp/build/zai-nts
+            cd /tmp/build/zai-nts
+            CMAKE_PREFIX_PATH=/opt/catch2 cmake \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_ZAI_TESTING=ON \
+              -DPHP_CONFIG=$(which php-config) \
+              -DRUN_SHARED_EXTS_TESTS=1 \
+              ~/datadog/zend_abstract_interface
+            make -j all
+            ZAI_SAPI_PHP_INI_IGNORE=0 make test
+            grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
+
+      - run:
+          command: |
+            mkdir -p /tmp/artifacts
+            cp --parents /tmp/build/zai-*/Testing/Temporary/LastTest.log /tmp/artifacts/
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/artifacts
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -1504,6 +1573,18 @@ workflows:
                 - "3.20.1"
               catch2_version:
                 - "2.13.5"
+
+  zend_abstract_interface_shared_exts:
+    jobs:
+      - "Prepare Code"
+      - ZaiSharedExts:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              php_version:
+                - "5.4"
+                - "7.4"
+                - "8.0"
 
   build_packages:
     jobs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
   '8.0-alpine': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0_alpine' }
   # --- Buster ---
   '5.4-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.4_buster' }
+  '5.4-buster-shared-ext': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.4-shared-ext' }
   '5.5-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.5_buster' }
   '5.6-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-5.6_buster' }
   '7.0-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.0_buster' }

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -117,6 +117,16 @@ services:
         phpTarGzUrl: https://www.php.net/distributions/php-5.4.45.tar.gz
         phpSha256Hash: 25bc4723955f4e352935258002af14a14a9810b491a19400d76fcdfa9d04b28f
 
+  php-5.4-shared-ext:
+    image: datadog/dd-trace-ci:php-5.4-shared-ext
+    build:
+      context: ./php-5.4
+      dockerfile: Dockerfile_shared_ext
+      args:
+        phpVersion: 5.4
+        phpTarGzUrl: https://www.php.net/distributions/php-5.4.45.tar.gz
+        phpSha256Hash: 25bc4723955f4e352935258002af14a14a9810b491a19400d76fcdfa9d04b28f
+
   php-master:
     image: datadog/dd-trace-ci:php-master_buster
     build:

--- a/dockerfiles/ci/buster/php-5.4/Dockerfile_shared_ext
+++ b/dockerfiles/ci/buster/php-5.4/Dockerfile_shared_ext
@@ -1,0 +1,109 @@
+FROM datadog/dd-trace-ci:buster AS base
+
+ARG phpVersion
+ENV PHP_INSTALL_DIR_DEBUG_ZTS=${PHP_INSTALL_DIR}/debug-zts
+ENV PHP_INSTALL_DIR_DEBUG_NTS=${PHP_INSTALL_DIR}/debug
+ENV PHP_INSTALL_DIR_NTS=${PHP_INSTALL_DIR}/nts
+ENV PHP_VERSION=${phpVersion}
+
+FROM base as build
+ARG phpTarGzUrl
+ARG phpSha256Hash
+RUN set -eux; \
+    curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
+    (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
+    tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
+    rm -f /tmp/php.tar.gz; \
+    cd ${PHP_SRC_DIR}; \
+    ./buildconf --force;
+COPY configure_shared_ext.sh /home/circleci/configure.sh
+
+FROM build as php-debug-zts
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --enable-debug \
+        --enable-maintainer-zts \
+        --prefix=${PHP_INSTALL_DIR_DEBUG_ZTS} \
+        --with-config-file-path=${PHP_INSTALL_DIR_DEBUG_ZTS} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d;
+
+FROM build as php-debug
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --enable-debug \
+        --prefix=${PHP_INSTALL_DIR_DEBUG_NTS} \
+        --with-config-file-path=${PHP_INSTALL_DIR_DEBUG_NTS} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
+
+FROM build as php-nts
+RUN set -eux; \
+    mkdir -p /tmp/build-php && cd /tmp/build-php; \
+    /home/circleci/configure.sh \
+        --prefix=${PHP_INSTALL_DIR_NTS} \
+        --with-config-file-path=${PHP_INSTALL_DIR_NTS} \
+        --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
+    make -j "$((`nproc`+1))"; \
+    make install; \
+    mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
+
+FROM base as final
+COPY --chown=circleci:circleci --from=build $PHP_SRC_DIR $PHP_SRC_DIR
+COPY --chown=circleci:circleci --from=php-debug-zts $PHP_INSTALL_DIR_DEBUG_ZTS $PHP_INSTALL_DIR_DEBUG_ZTS
+COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR_DEBUG_NTS $PHP_INSTALL_DIR_DEBUG_NTS
+COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR_NTS $PHP_INSTALL_DIR_NTS
+
+# Build core extensions as shared libraries.
+# We intentionally do not run 'make install' here so that we can test the
+# scenario where headers are not installed for the shared library.
+RUN set -eux; \
+    for phpVer in $(ls ${PHP_INSTALL_DIR}); \
+    do \
+        echo "Build shared extensions for PHP ${phpVer}..."; \
+        switch-php ${phpVer}; \
+        mkdir -p $(php-config --extension-dir); \
+        \
+        # ext/curl
+        echo "Building ext/curl (system version)..."; \
+        # Curl path workaround (PHP 5 was before pkg-config was used)
+        sudo ln -sfn /usr/include/x86_64-linux-gnu/curl /usr/include/curl; \
+        sudo ln -sf /usr/lib/x86_64-linux-gnu/libcurl.a /usr/lib/libcurl.a; \
+        cd ${PHP_SRC_DIR}/ext/curl; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; \
+        \
+        # ext/json
+        echo "Building ext/json..."; \
+        cd ${PHP_SRC_DIR}/ext/json; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; phpize --clean; \
+        \
+        # ext/pdo
+        echo "Building ext/pdo..."; \
+        cd ${PHP_SRC_DIR}/ext/pdo; \
+        phpize; ./configure; make; \
+        mv ./modules/*.so $(php-config --extension-dir); \
+        make clean; phpize --clean; \
+        \
+        # TODO Add ext/pdo_mysql, ext/pdo_pgsql, and ext/pdo_sqlite
+    done;
+
+RUN set -eux; \
+# Set the default PHP version
+    switch-php debug;
+
+# Install Composer
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+
+COPY welcome /etc/motd
+
+CMD ["php-fpm", "-F"]

--- a/dockerfiles/ci/buster/php-5.4/configure_shared_ext.sh
+++ b/dockerfiles/ci/buster/php-5.4/configure_shared_ext.sh
@@ -1,0 +1,14 @@
+if [ -z "${PHP_SRC_DIR}" ]; then
+    echo "Please set PHP_SRC_DIR"
+    exit 1
+fi
+
+${PHP_SRC_DIR}/configure \
+    --disable-all \
+    --enable-cgi \
+    --enable-embed \
+    --enable-fpm \
+    --enable-option-checking=fatal \
+    --with-fpm-user=www-data \
+    --with-fpm-group=www-data \
+    $@

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -12,7 +12,7 @@
 // note: only call this if ddtrace_config_trace_enabled() returns true
 bool ddtrace_config_integration_enabled(ddtrace_integration_name integration_name);
 
-void ddtrace_config_minit(int module_number);
+bool ddtrace_config_minit(int module_number);
 void ddtrace_config_first_rinit();
 
 extern bool runtime_config_first_init;

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -480,7 +480,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     REGISTER_INI_ENTRIES();
 
     // config initialization needs to be at the top
-    ddtrace_config_minit(module_number);
+    if (!ddtrace_config_minit(module_number)) {
+        return FAILURE;
+    }
     dd_disable_if_incompatible_sapi_detected(TSRMLS_C);
     atomic_init(&ddtrace_warn_legacy_api, 1);
 

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -12,7 +12,7 @@
 // note: only call this if ddtrace_config_trace_enabled() returns true
 bool ddtrace_config_integration_enabled(ddtrace_integration_name integration_name);
 
-void ddtrace_config_minit(int module_number);
+bool ddtrace_config_minit(int module_number);
 void ddtrace_config_first_rinit();
 
 extern bool runtime_config_first_init;

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -418,7 +418,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     REGISTER_INI_ENTRIES();
 
     // config initialization needs to be at the top
-    ddtrace_config_minit(module_number);
+    if (!ddtrace_config_minit(module_number)) {
+        return FAILURE;
+    }
     dd_disable_if_incompatible_sapi_detected();
     atomic_init(&ddtrace_warn_legacy_api, 1);
 

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -12,7 +12,7 @@
 // note: only call this if ddtrace_config_trace_enabled() returns true
 bool ddtrace_config_integration_enabled(ddtrace_integration_name integration_name);
 
-void ddtrace_config_minit(int module_number);
+bool ddtrace_config_minit(int module_number);
 void ddtrace_config_first_rinit();
 
 extern bool runtime_config_first_init;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -374,7 +374,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     REGISTER_INI_ENTRIES();
 
     // config initialization needs to be at the top
-    ddtrace_config_minit(module_number);
+    if (!ddtrace_config_minit(module_number)) {
+        return FAILURE;
+    }
     dd_disable_if_incompatible_sapi_detected();
     atomic_init(&ddtrace_warn_legacy_api, 1);
 

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -29,6 +29,11 @@ if (${BUILD_ZAI_ASAN})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
 endif()
 
+option(RUN_SHARED_EXTS_TESTS "Enable shared extension tests" OFF)
+if (${RUN_SHARED_EXTS_TESTS})
+  add_definitions(-DRUN_SHARED_EXTS_TESTS)
+endif()
+
 include(GNUInstallDirs)
 
 add_library(zai_zend_abstract_interface INTERFACE)

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -1,12 +1,11 @@
 #include "./config.h"
 
 #include <assert.h>
+#include <json/json.h>
 #include <main/php.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <json/json.h>
 
 #if PHP_VERSION_ID < 70000
 #define ZVAL_UNDEF(z)  \
@@ -121,12 +120,13 @@ static void zai_config_entries_init(zai_config_entry entries[], zai_config_id en
     }
 }
 
-void zai_config_minit(zai_config_entry entries[], size_t entries_count, zai_config_env_to_ini_name env_to_ini,
+bool zai_config_minit(zai_config_entry entries[], size_t entries_count, zai_config_env_to_ini_name env_to_ini,
                       int module_number) {
-    if (!entries || !entries_count) return;
-    zai_json_setup_bindings();
+    if (!entries || !entries_count) return false;
+    if (!zai_json_setup_bindings()) return false;
     zai_config_entries_init(entries, entries_count);
     zai_config_ini_minit(env_to_ini, module_number);
+    return true;
 }
 
 static void zai_config_dtor_memoized_zvals(void) {

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -68,7 +68,7 @@ struct zai_config_memoized_entry_s {
 // Memoizes config entries to default values
 // Adds INI defs
 // env_to_ini can be NULL to disable INI support
-void zai_config_minit(zai_config_entry entries[], size_t entries_count, zai_config_env_to_ini_name env_to_ini,
+bool zai_config_minit(zai_config_entry entries[], size_t entries_count, zai_config_env_to_ini_name env_to_ini,
                       int module_number);
 // dtors all pzvals and name maps
 // Caller must call UNREGISTER_INI_ENTRIES() after this if using env_to_ini

--- a/zend_abstract_interface/config/config_decode.c
+++ b/zend_abstract_interface/config/config_decode.c
@@ -342,7 +342,7 @@ static void zai_config_persist_zval(zval *in) {
 static bool zai_config_decode_json(zai_string_view value, zval *decoded_value, bool persistent) {
     ZAI_TSRMLS_FETCH();
 
-    zai_json_decode(decoded_value, (char *)value.ptr, (int)value.len, true, 20 ZAI_TSRMLS_CC);
+    zai_json_decode_assoc(decoded_value, (char *)value.ptr, (int)value.len, 20 ZAI_TSRMLS_CC);
 
     if (Z_TYPE_P(decoded_value) != IS_ARRAY) {
         zval_dtor(decoded_value);

--- a/zend_abstract_interface/config/tests/config.cc
+++ b/zend_abstract_interface/config/tests/config.cc
@@ -32,7 +32,9 @@ static PHP_MINIT_FUNCTION(zai_config_env) {
         EXT_CFG_ALIASED_ENTRY(BAR_ALIASED_INT, INT, "0", aliases_int),
         EXT_CFG_ENTRY(BAZ_MAP_EMPTY, MAP, ""),
     };
-    zai_config_minit(entries, (sizeof entries / sizeof entries[0]), NULL, 0);
+    if (!zai_config_minit(entries, (sizeof entries / sizeof entries[0]), NULL, 0)) {
+        return FAILURE;
+    }
     return SUCCESS;
 }
 

--- a/zend_abstract_interface/config/tests/config_decode.cc
+++ b/zend_abstract_interface/config/tests/config_decode.cc
@@ -268,7 +268,7 @@ TEST_CASE("decode set", "[zai_config_decode]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
-    zai_json_setup_bindings();
+    REQUIRE(zai_json_setup_bindings());
 
     zval value;
     bool ret;
@@ -331,7 +331,7 @@ TEST_CASE("decode json", "[zai_config_decode]") {
     REQUIRE(zai_sapi_spinup());
     ZAI_SAPI_TSRMLS_FETCH();
     ZAI_SAPI_ABORT_ON_BAILOUT_OPEN()
-    zai_json_setup_bindings();
+    REQUIRE(zai_json_setup_bindings());
 
     // ---
 

--- a/zend_abstract_interface/config/tests/config_ini.cc
+++ b/zend_abstract_interface/config/tests/config_ini.cc
@@ -40,7 +40,9 @@ static PHP_MINIT_FUNCTION(zai_config_ini) {
         EXT_CFG_ALIASED_ENTRY(INI_BAR_ALIASED_STRING, STRING, "0", aliases_string),
         EXT_CFG_ENTRY(INI_BAZ_MAP_EMPTY, MAP, ""),
     };
-    zai_config_minit(entries, (sizeof entries / sizeof entries[0]), ext_ini_env_to_ini_name, module_number);
+    if (!zai_config_minit(entries, (sizeof entries / sizeof entries[0]), ext_ini_env_to_ini_name, module_number)) {
+        return FAILURE;
+    }
     return SUCCESS;
 }
 

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -1,20 +1,43 @@
 #include "json.h"
 
-#if PHP_VERSION_ID < 70000
+#if PHP_VERSION_ID < 70100
 void (*zai_json_encode)(smart_str *buf, zval *val, int options TSRMLS_DC);
 void (*zai_json_decode_ex)(zval *return_value, char *str, int str_len, int options, long depth TSRMLS_DC);
+
+__attribute__((weak)) void php_json_encode(smart_str *buf, zval *val, int options TSRMLS_DC);
+__attribute__((weak)) void php_json_decode_ex(zval *return_value, char *str, int str_len, int options,
+                                              long depth TSRMLS_DC);
+#elif PHP_VERSION_ID < 80000
+int (*zai_json_encode)(smart_str *buf, zval *val, int options);
+int (*zai_json_decode_ex)(zval *return_value, char *str, size_t str_len, zend_long options, zend_long depth);
+
+__attribute__((weak)) int php_json_encode(smart_str *buf, zval *val, int options);
+__attribute__((weak)) int php_json_decode_ex(zval *return_value, char *str, size_t str_len, zend_long options,
+                                             zend_long depth);
 #else
 int (*zai_json_encode)(smart_str *buf, zval *val, int options);
 int (*zai_json_decode_ex)(zval *return_value, const char *str, size_t str_len, zend_long options, zend_long depth);
+
+__attribute__((weak)) int php_json_encode(smart_str *buf, zval *val, int options);
+__attribute__((weak)) int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options,
+                                             zend_long depth);
 #endif
 
-void zai_json_setup_bindings(void) {
-    zend_module_entry *json_me;
+bool zai_json_setup_bindings(void) {
+    if (php_json_encode && php_json_decode_ex) {
+        zai_json_encode = php_json_encode;
+        zai_json_decode_ex = php_json_decode_ex;
+        return true;
+    }
+
+    zend_module_entry *json_me = NULL;
 #if PHP_VERSION_ID < 70000
     zend_hash_find(&module_registry, ZEND_STRS("json"), (void **)&json_me);
 #else
     json_me = zend_hash_str_find_ptr(&module_registry, ZEND_STRL("json"));
 #endif
+
+    if (!json_me) return false;
 
     zai_json_encode = DL_FETCH_SYMBOL(json_me->handle, "php_json_encode");
     if (zai_json_encode == NULL) {
@@ -25,4 +48,6 @@ void zai_json_setup_bindings(void) {
     if (zai_json_decode_ex == NULL) {
         zai_json_decode_ex = DL_FETCH_SYMBOL(json_me->handle, "_php_json_decode_ex");
     }
+
+    return zai_json_encode && zai_json_decode_ex;
 }

--- a/zend_abstract_interface/json/json.h
+++ b/zend_abstract_interface/json/json.h
@@ -1,39 +1,58 @@
 #ifndef ZAI_JSON_H
 #define ZAI_JSON_H
 
+#include <stdbool.h>
+
 #include "php.h"
-
-#define PHP_JSON_OBJECT_AS_ARRAY (1 << 0)
-
-/**
- * This interface is 1:1 with ext/json, but with different names to avoid possible symbol clashes and confusion
- *
- * WARNING: php_json_encode will not null terminate buf; Always do smart_str_0 on buf or risk shenanigans
- **/
 
 #if PHP_VERSION_ID < 70000
 #include "ext/standard/php_smart_str.h"
+#else
+#include "zend_smart_str.h"
+#endif
 
+#define PHP_JSON_OBJECT_AS_ARRAY (1 << 0)
+
+/* The JSON extension is a required module and ZAI JSON must work under the
+ * following environments:
+ *
+ * 1. ext/json is built in tree (statically) with the json.h header installed
+ * 2. ext/json is built statically without the json.h header installed
+ * 3. ext/json is loaded as a shared library
+ *
+ * In order to accommodate all three of these scenarios, the symbol addresses
+ * need to be resolved to ZAI-flavored function pointers at runtime. The edge
+ * case where the symbol addresses cannot be resolved must be handled gracefully
+ * to avoid a crash.
+ *
+ * WARNING: php_json_encode will not null terminate buf; Always do smart_str_0
+ * on buf or risk shenanigans.
+ */
+
+#if PHP_VERSION_ID < 70100
 extern void (*zai_json_encode)(smart_str *buf, zval *val, int options TSRMLS_DC);
 extern void (*zai_json_decode_ex)(zval *return_value, char *str, int str_len, int options, long depth TSRMLS_DC);
 
-static inline void zai_json_decode(zval *return_value, char *str, int str_len, zend_bool assoc, long depth TSRMLS_DC) {
-    zai_json_decode_ex(return_value, str, str_len, assoc ? PHP_JSON_OBJECT_AS_ARRAY : 0, depth TSRMLS_CC);
+static inline void zai_json_decode_assoc(zval *return_value, const char *str, int str_len, long depth TSRMLS_DC) {
+    zai_json_decode_ex(return_value, (char *)str, str_len, PHP_JSON_OBJECT_AS_ARRAY, depth TSRMLS_CC);
+}
+#elif PHP_VERSION_ID < 80000
+extern int (*zai_json_encode)(smart_str *buf, zval *val, int options);
+extern int (*zai_json_decode_ex)(zval *return_value, char *str, size_t str_len, zend_long options, zend_long depth);
+
+static inline int zai_json_decode_assoc(zval *return_value, const char *str, int str_len, zend_long depth) {
+    return zai_json_decode_ex(return_value, (char *)str, str_len, PHP_JSON_OBJECT_AS_ARRAY, depth);
 }
 #else
-#include <stdbool.h>
-
-#include "zend_smart_str.h"
-
 extern int (*zai_json_encode)(smart_str *buf, zval *val, int options);
 extern int (*zai_json_decode_ex)(zval *return_value, const char *str, size_t str_len, zend_long options,
                                  zend_long depth);
 
-static inline int zai_json_decode(zval *return_value, const char *str, int str_len, bool assoc, zend_long depth) {
-    return zai_json_decode_ex(return_value, str, str_len, assoc ? PHP_JSON_OBJECT_AS_ARRAY : 0, depth);
+static inline int zai_json_decode_assoc(zval *return_value, const char *str, int str_len, zend_long depth) {
+    return zai_json_decode_ex(return_value, str, str_len, PHP_JSON_OBJECT_AS_ARRAY, depth);
 }
 #endif
 
-void zai_json_setup_bindings(void);
+bool zai_json_setup_bindings(void);
 
 #endif  // ZAI_JSON_H

--- a/zend_abstract_interface/json/tests/json.cc
+++ b/zend_abstract_interface/json/tests/json.cc
@@ -10,10 +10,16 @@ extern "C" {
 #include <cstdlib>
 #include <cstring>
 
+#ifndef RUN_SHARED_EXTS_TESTS
+#define SHARED_EXTS_ONLY "[.]"
+#else
+#define SHARED_EXTS_ONLY
+#endif
+
 #define TEST(name, code) TEST_CASE(name, "[zai_json]") { \
         REQUIRE(zai_sapi_sinit()); \
         REQUIRE(zai_sapi_minit()); \
-        zai_json_setup_bindings(); \
+        REQUIRE(zai_json_setup_bindings()); \
         REQUIRE(zai_sapi_rinit()); \
         ZAI_SAPI_TSRMLS_FETCH(); \
         ZAI_SAPI_ABORT_ON_BAILOUT_OPEN() \
@@ -48,10 +54,56 @@ TEST("decode", {
 
     ZVAL_NULL(&val);
 
-    zai_json_decode(&val, smart_str_value(&buf), smart_str_length(&buf), 0, 1 ZAI_TSRMLS_CC);
+    zai_json_decode_ex(&val, smart_str_value(&buf), smart_str_length(&buf), 0, 1 ZAI_TSRMLS_CC);
 
     REQUIRE(Z_TYPE(val) == IS_LONG);
     REQUIRE(Z_LVAL(val) == 42);
 
     smart_str_free(&buf);
 })
+
+// ext/json cannot be loaded as a shared extension on PHP 8
+#if PHP_VERSION_ID < 80000
+TEST_CASE("json bindings fail when no json extension loaded", "[zai_json]" SHARED_EXTS_ONLY) {
+    REQUIRE(zai_sapi_sinit());
+    // Disable all shared extensions
+    zai_module.php_ini_ignore = 1;
+    REQUIRE(zai_sapi_minit());
+
+    REQUIRE(zai_json_setup_bindings() == false);
+
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+
+/* A fake extension called "json" to simulate the condition where ext/json is
+ * loaded as a shared library but the symbol addresses did not resolve.
+ */
+// clang-format off
+static zend_module_entry fake_json_ext = {
+    STANDARD_MODULE_HEADER,
+    "json",
+    NULL,  // Functions
+    NULL,  // MINIT
+    NULL,  // MSHUTDOWN
+    NULL,  // RINIT
+    NULL,  // RSHUTDOWN
+    NULL,  // Info function
+    PHP_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+// clang-format on
+
+TEST_CASE("json bindings fail when no json symbols resolve", "[zai_json]" SHARED_EXTS_ONLY) {
+    REQUIRE(zai_sapi_sinit());
+    // Disable all shared extensions
+    zai_module.php_ini_ignore = 1;
+    REQUIRE(zai_sapi_minit());
+
+    REQUIRE(zend_startup_module(&fake_json_ext) == SUCCESS);
+    REQUIRE(zai_json_setup_bindings() == false);
+
+    zai_sapi_mshutdown();
+    zai_sapi_sshutdown();
+}
+#endif

--- a/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php5/zai_sapi.c
@@ -167,7 +167,7 @@ bool zai_sapi_sinit(void) {
      * This will prevent inadvertently loading any extensions that we did not
      * intend to. It also gives us a consistent clean slate of INI settings.
      */
-    zai_module.php_ini_ignore = 1;
+    zai_module.php_ini_ignore = zai_sapi_php_ini_ignore() ? 1 : 0;
 
     /* Show phpinfo()/module info as plain text. */
     zai_module.phpinfo_as_text = 1;

--- a/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php7/zai_sapi.c
@@ -174,7 +174,7 @@ bool zai_sapi_sinit(void) {
      * This will prevent inadvertently loading any extensions that we did not
      * intend to. It also gives us a consistent clean slate of INI settings.
      */
-    zai_module.php_ini_ignore = 1;
+    zai_module.php_ini_ignore = zai_sapi_php_ini_ignore() ? 1 : 0;
 
     /* Show phpinfo()/module info as plain text. */
     zai_module.phpinfo_as_text = 1;

--- a/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
+++ b/zend_abstract_interface/zai_sapi/php8/zai_sapi.c
@@ -147,7 +147,7 @@ bool zai_sapi_sinit(void) {
      * This will prevent inadvertently loading any extensions that we did not
      * intend to. It also gives us a consistent clean slate of INI settings.
      */
-    zai_module.php_ini_ignore = 1;
+    zai_module.php_ini_ignore = zai_sapi_php_ini_ignore() ? 1 : 0;
 
     /* Show phpinfo()/module info as plain text. */
     zai_module.phpinfo_as_text = 1;

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.c
@@ -44,3 +44,15 @@ ssize_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, 
 
     return (written_len != append_len) ? -1 : (ssize_t)(entries_len + append_len);
 }
+
+bool zai_sapi_php_ini_ignore(void) {
+    const char *env = getenv("ZAI_SAPI_PHP_INI_IGNORE");
+    if (env) {
+        size_t len = strlen(env);
+        if (len == 1) return *env != '0';
+        if (len == 2) return strcasecmp("no", env) != 0;
+        if (len == 3) return strcasecmp("off", env) != 0;
+        if (len == 4) return strcasecmp("false", env) != 0;
+    }
+    return true;
+}

--- a/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
+++ b/zend_abstract_interface/zai_sapi/zai_sapi_ini.h
@@ -27,4 +27,7 @@ void zai_sapi_ini_entries_free(char **entries);
  */
 ssize_t zai_sapi_ini_entries_realloc_append(char **entries, size_t entries_len, const char *key, const char *value);
 
+/* Will return false if ZAI_SAPI_PHP_INI_IGNORE env variable is a falsy value */
+bool zai_sapi_php_ini_ignore(void);
+
 #endif  // ZAI_SAPI_INI_H


### PR DESCRIPTION
### Description

This is a followup PR to address the [concerns raised](https://github.com/DataDog/dd-trace-php/pull/1366#discussion_r760421429) in #1366 with regard to resolving symbol addresses from ext/json. This technique implements weak symbols similar to how we resolved the same issue for ext/curl in #1181 & #1209 and gracefully handles the case where the symbol addresses could not resolve.

I also added a new shared-extension container for PHP 5.4 (`datadog/dd-trace-ci:php-5.4-shared-ext`) to test the edge cases.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
