### PR TITLE
Disable diagnostics when the tracer is disabled

### DIFF
--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -809,7 +809,9 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     _dd_info_tracer_config();
     php_info_print_table_end();
 
-    _dd_info_diagnostics_table(TSRMLS_C);
+    if (!DDTRACE_G(disable)) {
+        _dd_info_diagnostics_table(TSRMLS_C);
+    }
 
     DISPLAY_INI_ENTRIES();
 }

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -733,7 +733,9 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     _dd_info_tracer_config();
     php_info_print_table_end();
 
-    _dd_info_diagnostics_table();
+    if (!DDTRACE_G(disable)) {
+        _dd_info_diagnostics_table();
+    }
 
     DISPLAY_INI_ENTRIES();
 }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -683,7 +683,9 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     _dd_info_tracer_config();
     php_info_print_table_end();
 
-    _dd_info_diagnostics_table();
+    if (!DDTRACE_G(disable)) {
+        _dd_info_diagnostics_table();
+    }
 
     DISPLAY_INI_ENTRIES();
 }


### PR DESCRIPTION
### Description

When ddtrace is disabled by configuration, we need not run or display diagnostics

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
