### PR TITLE
Fix flaky curl tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,19 @@ aliases:
       name: Waiting for Dockerized request replayer
       command: dockerize -wait tcp://request-replayer:80/clear-dumped-data -timeout 2m
 
+  # Fix intermittent error: "Could not resolve host: httpbin_integration"
+  - &STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
+    run:
+      name: Resolving HTTPBIN_HOSTNAME to IP address
+      command: |
+        export HTTPBIN_HOSTNAME=$( \
+          curl --verbose "http://httpbin_integration:80/headers" 2>&1 | \
+          grep '* Connected to' | \
+          awk -F' ' '{print $5}' | \
+          sed 's/[()]//g' \
+        );
+        echo "Resolved httpbin_integration: HTTPBIN_HOSTNAME=${HTTPBIN_HOSTNAME}";
+
   - &STEP_PERSIST_TO_WORKSPACE
     persist_to_workspace:
       root: '.'
@@ -413,7 +426,6 @@ jobs:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
       DD_AGENT_HOST: 127.0.0.1
-      HTTPBIN_HOSTNAME: httpbin_integration
       DATADOG_HAVE_DEV_ENV: 1
     executor:
       name: with_httpbin_and_request_replayer
@@ -427,6 +439,7 @@ jobs:
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:
           name: Run tests
           command: |
@@ -457,7 +470,6 @@ jobs:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
       DD_AGENT_HOST: 127.0.0.1
-      HTTPBIN_HOSTNAME: httpbin_integration
       DATADOG_HAVE_DEV_ENV: 1
     executor:
       name: with_httpbin_and_request_replayer
@@ -468,6 +480,7 @@ jobs:
           php_version: << parameters.switch_php_version >>
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:
           name: Run tests
           command: |
@@ -680,7 +693,6 @@ jobs:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
       DD_AGENT_HOST: 127.0.0.1
-      HTTPBIN_HOSTNAME: httpbin_integration
       DATADOG_HAVE_DEV_ENV: 1
     executor:
       name: with_httpbin_and_request_replayer
@@ -692,6 +704,7 @@ jobs:
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:
           name: Ensure ext/<< parameters.ext_name >> is missing
           command: |
@@ -737,7 +750,6 @@ jobs:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
       DD_AGENT_HOST: 127.0.0.1
-      HTTPBIN_HOSTNAME: httpbin_integration
       DATADOG_HAVE_DEV_ENV: 1
     executor:
       name: with_httpbin_and_request_replayer
@@ -747,6 +759,7 @@ jobs:
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:
           name: Install .deb from artifacts
           command: |
@@ -1020,12 +1033,13 @@ jobs:
             echo "extension=ddtrace.so" | sudo tee $(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}')/ddtrace.ini
             php --ri=ddtrace
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:
           name: Run phpt tests with PECL
           command: |
             sudo \
             TERM=dumb \
-            HTTPBIN_HOSTNAME=httpbin_integration \
+            HTTPBIN_HOSTNAME=${HTTPBIN_HOSTNAME} \
             DATADOG_HAVE_DEV_ENV=1 \
             DD_TRACE_CLI_ENABLED=1 \
             pecl run-tests <<# parameters.showdiff >> --showdiff <</ parameters.showdiff >> --ini=" -d ddtrace.request_init_hook=" -p datadog_trace

--- a/tests/ext/integrations/curl/curl_helper.inc
+++ b/tests/ext/integrations/curl/curl_helper.inc
@@ -1,0 +1,17 @@
+<?php
+
+function show_curl_error_on_fail($ch)
+{
+    $error = curl_error($ch);
+    if ($error) {
+        echo 'curl error (' . curl_errno($ch) . '): ' . $error . PHP_EOL;
+        var_dump(curl_getinfo($ch));
+    }
+}
+
+function show_curl_multi_error_on_fail($status)
+{
+    if ($status != CURLM_OK) {
+        echo 'curl multi error (' . $status . '): ' . curl_multi_strerror($status) . PHP_EOL;
+    }
+}

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -11,6 +11,8 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
+
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
@@ -21,6 +23,7 @@ $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($ch);
+show_curl_error_on_fail($ch);
 curl_close($ch);
 
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -10,6 +10,8 @@ DD_TRACE_DEBUG=1
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 --FILE--
 <?php
+include 'curl_helper.inc';
+
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
@@ -28,17 +30,21 @@ curl_setopt_array($ch, [
 
 $responses = [];
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 
 $ch2 = curl_copy_handle($ch);
 
 $responses[] = curl_exec($ch2);
+show_curl_error_on_fail($ch2);
 
 curl_setopt($ch2, CURLOPT_HTTPHEADER, [
     'x-foo: after-the-copy',
     'x-bar: linguistics',
 ]);
 $responses[] = curl_exec($ch2);
+show_curl_error_on_fail($ch2);
 
 curl_close($ch);
 curl_close($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -11,6 +11,8 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
+
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
@@ -29,7 +31,9 @@ curl_setopt($ch, CURLOPT_HTTPHEADER, [
 
 $responses = [];
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 curl_close($ch);
 
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -11,6 +11,8 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
+
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
@@ -29,7 +31,9 @@ curl_setopt_array($ch, [
 
 $responses = [];
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 curl_close($ch);
 
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
@@ -17,6 +17,8 @@ DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
+
 DDTrace\trace_function('curl_exec', function (\DDTrace\SpanData $span) {
     $span->name = 'curl_exec';
 });
@@ -47,7 +49,9 @@ if (false === $res) {
 
 $responses = [];
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 $responses[] = curl_exec($ch);
+show_curl_error_on_fail($ch);
 curl_close($ch);
 
 include 'distributed_tracing.inc';

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -10,6 +10,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -41,9 +42,13 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch2);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -10,6 +10,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -42,9 +43,13 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch2);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -11,6 +11,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -53,9 +54,14 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch3);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
+    show_curl_error_on_fail($ch3);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle_bug_71523.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle_bug_71523.phpt
@@ -11,6 +11,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -53,9 +54,14 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch3);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
+    show_curl_error_on_fail($ch3);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_disable.phpt
@@ -10,6 +10,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -48,9 +49,13 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch2);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -10,6 +10,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -53,9 +54,13 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch2);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -10,6 +10,7 @@ DD_TRACE_DEBUG=1
 HTTP_X_DATADOG_ORIGIN=phpt-test
 --FILE--
 <?php
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 DDTrace\trace_function('doMulti', function (\DDTrace\SpanData $span) {
@@ -57,9 +58,13 @@ function doMulti($url)
     curl_multi_add_handle($mh, $ch2);
 
     do {
-        curl_multi_exec($mh, $active);
+        $status = curl_multi_exec($mh, $active);
         curl_multi_select($mh);
-    } while ($active > 0);
+    } while ($active > 0 && $status === CURLM_OK);
+
+    show_curl_multi_error_on_fail($status);
+    show_curl_error_on_fail($ch1);
+    show_curl_error_on_fail($ch2);
 
     dumpHeaders($ch1);
     dumpHeaders($ch2);

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
@@ -5,7 +5,7 @@ Distributed tracing headers propagate with curl_exec()
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
 --FILE--
 <?php
-
+include 'curl_helper.inc';
 include 'distributed_tracing.inc';
 
 function query_headers() {
@@ -15,6 +15,7 @@ function query_headers() {
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $response = curl_exec($ch);
+    show_curl_error_on_fail($ch);
     curl_close($ch);
     return dt_decode_headers_from_httpbin($response);
 }


### PR DESCRIPTION
### Description

This PR fixes the [flaky curl tests in CI](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/7110/workflows/402191ef-8b1c-41aa-9c85-7447903af20b/jobs/831899/artifacts). It also adds error info to the curl tests so that we can more easily debug issues like this in the future.

For this specific issue, the tests would fail intermittently with the following curl error:

```
Could not resolve host: httpbin_integration
```

Resolving the `httpbin_integration` hostname's IP address for `HTTPBIN_HOSTNAME` fixed the issue.