### PR TITLE
Release 0.68.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://809973-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_1.0.0-nightly_amd64.deb"
+    value: "https://838393-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.68.1_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.68.0"
+#define PHP_DDTRACE_VERSION "0.68.1"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -49,35 +49,11 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-    ### Added
-    - Bring priority sampling to internal #1366
-    - SpanData::$parent property #1369
-    - Add queue and channel components #1388
-    - Add log component #1390
-    - Add arena component #1391
-    - Add stack sample component #1392
-    - Add uuid component #1393
-    - Add time component #1394, #1408
-    - Add profiler installation #1422
-    - Zai/json #1378, #1397
-    - Add Code Coverage #1389
-
-    ### Changed
-    - (PHP 8) Migrate ObjectKVStore to WeakMap internally #1362
-    - Adjust components #1387
-    - Export only specific symbols #1407
-    - Sanitize user information from urls #1396
-    - Split INI setting in installer so they can be added separately when missing #1415
-    - Use the new targz bundle format with the new PHP installer #1421
-    - Have both legacy and new installer to fail when json PHP extension is not enabled #1410
-
     ### Fixed
-    - Fix Laravel unnamed route with caching and domain specification #1364
-    - Fix http.url of internal root span #1360
-    - Add small framework to stress test our internal API with bogus inputs #1365
-    - PDOIntegration::parseDSN fails to parse some DSN #1373
-    - Fix constructor of OpenTracing wrapper when no Datadog tracer is provided #1406 - thanks @OGKevin for the reproduction case
-    - Fix parsing of urls without schema into host name #1385
+    - Do not diagnostics when ddtrace is disabled #1434
+    - Fix json symbol address resolving logic #1432
+    - Disable tracing when PHP is executed during RINIT #1429
+    - Change Predis integration type to "redis" #1427
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -25,7 +25,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.68.0';
+    const VERSION = '0.68.1';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Fixed
- Do not diagnostics when ddtrace is disabled #1434
- Fix json symbol address resolving logic #1432
- Disable tracing when PHP is executed during RINIT #1429
- Change Predis integration type to "redis" #1427