### PR TITLE
Replace direct access of meta/metrics zvals by safe array access in most places

### DIFF
--- a/ext/php5/ddshared.c
+++ b/ext/php5/ddshared.c
@@ -1,6 +1,7 @@
 #include "ddshared.h"
 
 #include <components/container_id/container_id.h>
+
 #include "ddtrace.h"
 #include "logging.h"
 

--- a/ext/php5/startup_logging.c
+++ b/ext/php5/startup_logging.c
@@ -3,11 +3,11 @@
 #include <SAPI.h>
 #include <Zend/zend_API.h>
 #include <curl/curl.h>
+#include <json/json.h>
 #include <php.h>
 #include <stdbool.h>
 #include <time.h>
 
-#include <json/json.h>
 #include <ext/standard/info.h>
 
 #include "coms.h"

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -276,8 +276,8 @@ static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
     ddtrace_span_fci *span_fci = ecalloc(1, sizeof(*span_fci));
     zend_object_std_init(&span_fci->span.std, class_type);
     span_fci->span.std.handlers = &ddtrace_span_data_handlers;
-    array_init(ddtrace_spandata_property_meta(&span_fci->span));
-    array_init(ddtrace_spandata_property_metrics(&span_fci->span));
+    array_init(ddtrace_spandata_property_meta_zval(&span_fci->span));
+    array_init(ddtrace_spandata_property_metrics_zval(&span_fci->span));
     return &span_fci->span.std;
 }
 

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -31,8 +31,7 @@ static inline zval *ddtrace_spandata_property_type(ddtrace_span_t *span) {
 }
 static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
     ZVAL_DEREF(zv);
-    if (Z_TYPE_P(zv) != IS_ARRAY)
-    {
+    if (Z_TYPE_P(zv) != IS_ARRAY) {
         zval garbage;
         ZVAL_COPY_VALUE(&garbage, zv);
         array_init(zv);

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -29,11 +29,28 @@ static inline zval *ddtrace_spandata_property_service(ddtrace_span_t *span) {
 static inline zval *ddtrace_spandata_property_type(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 3);
 }
-static inline zval *ddtrace_spandata_property_meta(ddtrace_span_t *span) {
+static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
+    ZVAL_DEREF(zv);
+    if (Z_TYPE_P(zv) != IS_ARRAY)
+    {
+        zval garbage;
+        ZVAL_COPY_VALUE(&garbage, zv);
+        array_init(zv);
+        zval_ptr_dtor(&garbage);
+    }
+    return Z_ARR_P(zv);
+}
+static inline zval *ddtrace_spandata_property_meta_zval(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 4);
 }
-static inline zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) {
+static inline zend_array *ddtrace_spandata_property_meta(ddtrace_span_t *span) {
+    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_meta_zval(span));
+}
+static inline zval *ddtrace_spandata_property_metrics_zval(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 5);
+}
+static inline zend_array *ddtrace_spandata_property_metrics(ddtrace_span_t *span) {
+    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_metrics_zval(span));
 }
 static inline zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 6);

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -59,7 +59,9 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
         }
         ZEND_HASH_FOREACH_END();
 
-        add_assoc_double_ex(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_dd.rule_psr"), sample_rate);
+        zval sample_rate_zv;
+        ZVAL_DOUBLE(&sample_rate_zv, sample_rate);
+        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_dd.rule_psr", sizeof("_dd.rule_psr") - 1, &sample_rate_zv);
 
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
@@ -69,7 +71,10 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
             priority = sampling ? PRIORITY_SAMPLING_AUTO_KEEP : PRIORITY_SAMPLING_AUTO_REJECT;
         }
     }
-    add_assoc_long_ex(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"), priority);
+
+    zval priority_zv;
+    ZVAL_LONG(&priority_zv, priority);
+    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_sampling_priority_v1", sizeof("_sampling_priority_v1") - 1, &priority_zv);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {
@@ -83,20 +88,14 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
         return DDTRACE_G(default_priority_sampling);
     }
 
-    zval *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
-    ZVAL_DEREF(root_metrics);
-    if (Z_TYPE_P(root_metrics) != IS_ARRAY) {
-        zval_ptr_dtor(root_metrics);
-        array_init(root_metrics);
-    }
-
-    if (!(priority_zv = zend_hash_str_find(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1")))) {
+    zend_array *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
+    if (!(priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1")))) {
         if (DDTRACE_G(default_priority_sampling) == DDTRACE_PRIORITY_SAMPLING_UNSET) {
             return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
         }
 
         dd_decide_on_sampling(root_span);
-        priority_zv = zend_hash_str_find(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1"));
+        priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     }
 
     return zval_get_long(priority_zv);
@@ -109,18 +108,12 @@ void ddtrace_set_prioritySampling_on_root(zend_long priority) {
         return;
     }
 
-    zval *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
-    ZVAL_DEREF(root_metrics);
-    if (Z_TYPE_P(root_metrics) != IS_ARRAY) {
-        zval_ptr_dtor(root_metrics);
-        array_init(root_metrics);
-    }
-
+    zend_array *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
     if (priority == DDTRACE_PRIORITY_SAMPLING_UNKNOWN || priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-        zend_hash_str_del(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1"));
+        zend_hash_str_del(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     } else {
         zval zv;
         ZVAL_LONG(&zv, priority);
-        zend_hash_str_update(Z_ARR_P(root_metrics), "_sampling_priority_v1", sizeof("_sampling_priority_v1") - 1, &zv);
+        zend_hash_str_update(root_metrics, "_sampling_priority_v1", sizeof("_sampling_priority_v1") - 1, &zv);
     }
 }

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -61,7 +61,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
 
         zval sample_rate_zv;
         ZVAL_DOUBLE(&sample_rate_zv, sample_rate);
-        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_dd.rule_psr", sizeof("_dd.rule_psr") - 1, &sample_rate_zv);
+        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_dd.rule_psr", sizeof("_dd.rule_psr") - 1,
+                             &sample_rate_zv);
 
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
@@ -74,7 +75,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
 
     zval priority_zv;
     ZVAL_LONG(&priority_zv, priority);
-    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_sampling_priority_v1", sizeof("_sampling_priority_v1") - 1, &priority_zv);
+    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), "_sampling_priority_v1",
+                         sizeof("_sampling_priority_v1") - 1, &priority_zv);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -102,12 +102,7 @@ DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
         return false;
     }
 
-    zval *meta = ddtrace_spandata_property_meta(&root->span);
-    if (Z_TYPE_P(meta) != IS_ARRAY) {
-        return false;
-    }
-
-    return zend_hash_add(Z_ARR_P(meta), tag, value) != NULL;
+    return zend_hash_add(ddtrace_spandata_property_meta(&root->span), tag, value) != NULL;
 }
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -4,11 +4,11 @@
 #include <Zend/zend_API.h>
 #include <Zend/zend_smart_str.h>
 #include <curl/curl.h>
+#include <json/json.h>
 #include <php.h>
 #include <stdbool.h>
 #include <time.h>
 
-#include <json/json.h>
 #include <ext/standard/info.h>
 
 #include "coms.h"

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -245,8 +245,8 @@ static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
     ddtrace_span_fci *span_fci = ecalloc(1, sizeof(*span_fci));
     zend_object_std_init(&span_fci->span.std, class_type);
     span_fci->span.std.handlers = &ddtrace_span_data_handlers;
-    array_init(ddtrace_spandata_property_meta(&span_fci->span));
-    array_init(ddtrace_spandata_property_metrics(&span_fci->span));
+    array_init(ddtrace_spandata_property_meta_zval(&span_fci->span));
+    array_init(ddtrace_spandata_property_metrics_zval(&span_fci->span));
     return &span_fci->span.std;
 }
 

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -31,8 +31,7 @@ static inline zval *ddtrace_spandata_property_type(ddtrace_span_t *span) {
 }
 static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
     ZVAL_DEREF(zv);
-    if (Z_TYPE_P(zv) != IS_ARRAY)
-    {
+    if (Z_TYPE_P(zv) != IS_ARRAY) {
         zval garbage;
         ZVAL_COPY_VALUE(&garbage, zv);
         array_init(zv);

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -29,11 +29,28 @@ static inline zval *ddtrace_spandata_property_service(ddtrace_span_t *span) {
 static inline zval *ddtrace_spandata_property_type(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 3);
 }
-static inline zval *ddtrace_spandata_property_meta(ddtrace_span_t *span) {
+static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
+    ZVAL_DEREF(zv);
+    if (Z_TYPE_P(zv) != IS_ARRAY)
+    {
+        zval garbage;
+        ZVAL_COPY_VALUE(&garbage, zv);
+        array_init(zv);
+        zval_ptr_dtor(&garbage);
+    }
+    return Z_ARR_P(zv);
+}
+static inline zval *ddtrace_spandata_property_meta_zval(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 4);
 }
-static inline zval *ddtrace_spandata_property_metrics(ddtrace_span_t *span) {
+static inline zend_array *ddtrace_spandata_property_meta(ddtrace_span_t *span) {
+    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_meta_zval(span));
+}
+static inline zval *ddtrace_spandata_property_metrics_zval(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 5);
+}
+static inline zend_array *ddtrace_spandata_property_metrics(ddtrace_span_t *span) {
+    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_metrics_zval(span));
 }
 static inline zval *ddtrace_spandata_property_exception(ddtrace_span_t *span) {
     return OBJ_PROP_NUM((zend_object *)span, 6);

--- a/ext/php8/priority_sampling/priority_sampling.c
+++ b/ext/php8/priority_sampling/priority_sampling.c
@@ -57,7 +57,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
 
         zval sample_rate_zv;
         ZVAL_DOUBLE(&sample_rate_zv, sample_rate);
-        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_dd.rule_psr"), &sample_rate_zv);
+        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_dd.rule_psr"),
+                             &sample_rate_zv);
 
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
@@ -70,7 +71,8 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
 
     zval priority_zv;
     ZVAL_LONG(&priority_zv, priority);
-    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"), &priority_zv);
+    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"),
+                         &priority_zv);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {

--- a/ext/php8/priority_sampling/priority_sampling.c
+++ b/ext/php8/priority_sampling/priority_sampling.c
@@ -55,7 +55,9 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
         }
         ZEND_HASH_FOREACH_END();
 
-        add_assoc_double_ex(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_dd.rule_psr"), sample_rate);
+        zval sample_rate_zv;
+        ZVAL_DOUBLE(&sample_rate_zv, sample_rate);
+        zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_dd.rule_psr"), &sample_rate_zv);
 
         bool sampling = (double)genrand64_int64() < sample_rate * (double)~0ULL;
 
@@ -65,7 +67,10 @@ static void dd_decide_on_sampling(ddtrace_span_fci *span) {
             priority = sampling ? PRIORITY_SAMPLING_AUTO_KEEP : PRIORITY_SAMPLING_AUTO_REJECT;
         }
     }
-    add_assoc_long_ex(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"), priority);
+
+    zval priority_zv;
+    ZVAL_LONG(&priority_zv, priority);
+    zend_hash_str_update(ddtrace_spandata_property_metrics(&span->span), ZEND_STRL("_sampling_priority_v1"), &priority_zv);
 }
 
 zend_long ddtrace_fetch_prioritySampling_from_root(void) {
@@ -76,14 +81,8 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
         return DDTRACE_G(default_priority_sampling);
     }
 
-    zval *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
-    ZVAL_DEREF(root_metrics);
-    if (Z_TYPE_P(root_metrics) != IS_ARRAY) {
-        zval_ptr_dtor(root_metrics);
-        array_init(root_metrics);
-    }
-
-    if (!(priority_zv = zend_hash_str_find(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1")))) {
+    zend_array *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
+    if (!(priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1")))) {
         if (DDTRACE_G(default_priority_sampling) == DDTRACE_PRIORITY_SAMPLING_UNSET) {
             if (DDTRACE_G(default_priority_sampling) == DDTRACE_PRIORITY_SAMPLING_UNSET) {
                 return DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
@@ -92,7 +91,7 @@ zend_long ddtrace_fetch_prioritySampling_from_root(void) {
         }
 
         dd_decide_on_sampling(root_span);
-        priority_zv = zend_hash_str_find(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1"));
+        priority_zv = zend_hash_str_find(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     }
 
     return zval_get_long(priority_zv);
@@ -105,18 +104,12 @@ void ddtrace_set_prioritySampling_on_root(zend_long priority) {
         return;
     }
 
-    zval *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
-    ZVAL_DEREF(root_metrics);
-    if (Z_TYPE_P(root_metrics) != IS_ARRAY) {
-        zval_ptr_dtor(root_metrics);
-        array_init(root_metrics);
-    }
-
+    zend_array *root_metrics = ddtrace_spandata_property_metrics(&root_span->span);
     if (priority == DDTRACE_PRIORITY_SAMPLING_UNKNOWN || priority == DDTRACE_PRIORITY_SAMPLING_UNSET) {
-        zend_hash_str_del(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1"));
+        zend_hash_str_del(root_metrics, ZEND_STRL("_sampling_priority_v1"));
     } else {
         zval zv;
         ZVAL_LONG(&zv, priority);
-        zend_hash_str_update(Z_ARR_P(root_metrics), ZEND_STRL("_sampling_priority_v1"), &zv);
+        zend_hash_str_update(root_metrics, ZEND_STRL("_sampling_priority_v1"), &zv);
     }
 }

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -331,22 +331,20 @@ static zend_string *dd_fatal_error_stack(void) {
     return error_stack;
 }
 
-static int dd_fatal_error_to_meta(zval *meta, dd_error_info error) {
-    HashTable *ht = Z_ARR_P(meta);
-
+static int dd_fatal_error_to_meta(zend_array *meta, dd_error_info error) {
     if (error.type) {
         zval tmp = ddtrace_zval_zstr(zend_string_copy(error.type));
-        zend_symtable_str_update(ht, ZEND_STRL("error.type"), &tmp);
+        zend_symtable_str_update(meta, ZEND_STRL("error.type"), &tmp);
     }
 
     if (error.msg) {
         zval tmp = ddtrace_zval_zstr(zend_string_copy(error.msg));
-        zend_symtable_str_update(ht, ZEND_STRL("error.msg"), &tmp);
+        zend_symtable_str_update(meta, ZEND_STRL("error.msg"), &tmp);
     }
 
     if (error.stack) {
         zval tmp = ddtrace_zval_zstr(zend_string_copy(error.stack));
-        zend_symtable_str_update(ht, ZEND_STRL("error.stack"), &tmp);
+        zend_symtable_str_update(meta, ZEND_STRL("error.stack"), &tmp);
     }
 
     return error.type && error.msg ? SUCCESS : FAILURE;
@@ -377,27 +375,31 @@ static void dd_add_header_to_meta(zend_array *meta, const char *type, zend_strin
 }
 
 void ddtrace_set_global_span_properties(ddtrace_span_t *span) {
-    zval *meta = ddtrace_spandata_property_meta(span);
+    zend_array *meta = ddtrace_spandata_property_meta(span);
+    zval value;
 
     zend_string *version = get_DD_VERSION();
     if (ZSTR_LEN(version) > 0) {  // non-empty
-        add_assoc_str(meta, "version", zend_string_copy(version));
+        ZVAL_STR_COPY(&value, version);
+        zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
     }
 
     zend_string *env = get_DD_ENV();
     if (ZSTR_LEN(env) > 0) {  // non-empty
-        add_assoc_str(meta, "env", zend_string_copy(env));
+        ZVAL_STR_COPY(&value, env);
+        zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
     }
 
     if (DDTRACE_G(dd_origin)) {
-        add_assoc_str(meta, "_dd.origin", zend_string_copy(DDTRACE_G(dd_origin)));
+        ZVAL_STR_COPY(&value, DDTRACE_G(dd_origin));
+        zend_hash_str_add_new(meta, ZEND_STRL("_dd.origin"), &value);
     }
 
     zend_array *global_tags = get_DD_TAGS();
     zend_string *global_key;
     zval *global_val;
     ZEND_HASH_FOREACH_STR_KEY_VAL(global_tags, global_key, global_val) {
-        if (zend_hash_add(Z_ARR_P(meta), global_key, global_val)) {
+        if (zend_hash_add(meta, global_key, global_val)) {
             Z_TRY_ADDREF_P(global_val);
         }
     }
@@ -406,7 +408,7 @@ void ddtrace_set_global_span_properties(ddtrace_span_t *span) {
     zend_string *tag_key;
     zval *tag_value;
     ZEND_HASH_FOREACH_STR_KEY_VAL(DDTRACE_G(additional_global_tags), tag_key, tag_value) {
-        if (zend_hash_add(Z_ARR_P(meta), tag_key, tag_value)) {
+        if (zend_hash_add(meta, tag_key, tag_value)) {
             Z_TRY_ADDREF_P(tag_value);
         }
     }
@@ -447,19 +449,22 @@ static zend_string *dd_build_req_url() {
 }
 
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
-    zval *meta = ddtrace_spandata_property_meta(span);
+    zend_array *meta = ddtrace_spandata_property_meta(span);
 
-    add_assoc_long(meta, "system.pid", (long)getpid());
+    zval pid;
+    ZVAL_LONG(&pid, (long)getpid());
+    zend_hash_str_add_new(meta, ZEND_STRL("system.pid"), &pid);
 
     const char *method = SG(request_info).request_method;
     if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED() && method) {
         zval http_method;
         ZVAL_STR(&http_method, zend_string_init(method, strlen(method), 0));
-        zend_hash_str_add_new(Z_ARR_P(meta), ZEND_STRL("http.method"), &http_method);
+        zend_hash_str_add_new(meta, ZEND_STRL("http.method"), &http_method);
 
-        zend_string *http_url = dd_build_req_url();
-        if (ZSTR_LEN(http_url)) {
-            add_assoc_str(meta, "http.url", http_url);
+        zval http_url;
+        ZVAL_STR(&http_url, dd_build_req_url());
+        if (Z_STRLEN(http_url)) {
+            zend_hash_str_add_new(meta, ZEND_STRL("http.url"), &http_url);
         }
 
         const char *uri = SG(request_info).request_uri;
@@ -506,7 +511,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                     }
                 }
 
-                dd_add_header_to_meta(Z_ARR_P(meta), "request", lowerheader, Z_STR_P(headerval));
+                dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));
                 zend_string_release(lowerheader);
             }
         }
@@ -523,7 +528,9 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
             zend_string_release(hostname);
         } else {
             hostname = zend_string_truncate(hostname, strlen(ZSTR_VAL(hostname)), 0);
-            add_assoc_str(meta, "_dd.hostname", hostname);
+            zval hostname_zv;
+            ZVAL_STR(&hostname_zv, hostname);
+            zend_hash_str_add_new(meta, ZEND_STRL("_dd.hostname"), &hostname_zv);
         }
     }
 }
@@ -531,11 +538,11 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
 static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
     ddtrace_span_t *span = &span_fci->span;
     bool top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
-    zval meta_zv, *meta = ddtrace_spandata_property_meta(span);
+    zval meta_zv, *meta = ddtrace_spandata_property_meta_zval(span);
 
     array_init(&meta_zv);
     ZVAL_DEREF(meta);
-    if (meta && Z_TYPE_P(meta) == IS_ARRAY) {
+    if (Z_TYPE_P(meta) == IS_ARRAY) {
         zend_string *str_key;
         zval *orig_val, val_as_string;
         ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARRVAL_P(meta), str_key, orig_val) {
@@ -694,7 +701,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
 
     _serialize_meta(el, span_fci);
 
-    zval *metrics = ddtrace_spandata_property_metrics(span);
+    zval *metrics = ddtrace_spandata_property_metrics_zval(span);
     ZVAL_DEREF(metrics);
     if (Z_TYPE_P(metrics) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(metrics))) {
         zval metrics_zv;
@@ -754,12 +761,7 @@ void ddtrace_save_active_error_to_metadata(void) {
             continue;
         }
 
-        zval *meta = ddtrace_spandata_property_meta(&span->span);
-        if (Z_TYPE_P(meta) != IS_ARRAY) {
-            zval_ptr_dtor(meta);
-            array_init_size(meta, ddtrace_num_error_tags);
-        }
-        dd_fatal_error_to_meta(meta, error);
+        dd_fatal_error_to_meta(ddtrace_spandata_property_meta(&span->span), error);
     }
     zend_string_release(error.type);
     zend_string_release(error.msg);
@@ -789,19 +791,14 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
                 .msg = dd_truncate_uncaught_exception(message),
                 .stack = dd_fatal_error_stack(),
             };
-            dd_fatal_error_to_meta(&DDTRACE_G(additional_trace_meta), error);
+            dd_fatal_error_to_meta(Z_ARR(DDTRACE_G(additional_trace_meta)), error);
             ddtrace_span_fci *span;
             for (span = DDTRACE_G(open_spans_top); span; span = span->next) {
                 if (Z_TYPE_P(ddtrace_spandata_property_exception(&span->span)) > IS_FALSE) {
                     continue;
                 }
 
-                zval *meta = ddtrace_spandata_property_meta(&span->span);
-                if (Z_TYPE_P(meta) != IS_ARRAY) {
-                    zval_ptr_dtor(meta);
-                    array_init_size(meta, ddtrace_num_error_tags);
-                }
-                dd_fatal_error_to_meta(meta, error);
+                dd_fatal_error_to_meta(ddtrace_spandata_property_meta(&span->span), error);
             }
             zend_string_release(error.type);
             zend_string_release(error.msg);

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -101,12 +101,7 @@ DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
         return false;
     }
 
-    zval *meta = ddtrace_spandata_property_meta(&root->span);
-    if (Z_TYPE_P(meta) != IS_ARRAY) {
-        return false;
-    }
-
-    return zend_hash_add(Z_ARR_P(meta), tag, value) != NULL;
+    return zend_hash_add(ddtrace_spandata_property_meta(&root->span), tag, value) != NULL;
 }
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -4,11 +4,11 @@
 #include <Zend/zend_API.h>
 #include <Zend/zend_smart_str.h>
 #include <curl/curl.h>
+#include <json/json.h>
 #include <php.h>
 #include <stdbool.h>
 #include <time.h>
 
-#include <json/json.h>
 #include <ext/standard/info.h>
 
 #include "coms.h"


### PR DESCRIPTION
Fixing #1439 by eliminating a class of errors regarding missing derefs/type checks on meta and metrics.