### PR TITLE
Always separate meta and metrics arrays on access

### DIFF
--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -37,6 +37,7 @@ static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
         array_init(zv);
         zval_ptr_dtor(&garbage);
     }
+    SEPARATE_ARRAY(zv);
     return Z_ARR_P(zv);
 }
 static inline zval *ddtrace_spandata_property_meta_zval(ddtrace_span_t *span) {

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -37,6 +37,7 @@ static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
         array_init(zv);
         zval_ptr_dtor(&garbage);
     }
+    SEPARATE_ARRAY(zv);
     return Z_ARR_P(zv);
 }
 static inline zval *ddtrace_spandata_property_meta_zval(ddtrace_span_t *span) {


### PR DESCRIPTION
Prevent rc > 1 write access on meta and metrics by always separating these.