### PR TITLE
Fix ZaiSapi_ROOT path in Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1227,7 +1227,6 @@ jobs:
               echo 'catch2 already installed'
               exit 0
             fi
-            export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
             cd /tmp
             curl -OL https://github.com/catchorg/Catch2/archive/v<< parameters.catch2_version >>.tar.gz
             mkdir catch2

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,9 @@ build_zai:
 	( \
 	mkdir -p "$(ZAI_BUILD_DIR)"; \
 	cd $(ZAI_BUILD_DIR); \
-	CMAKE_PREFIX_PATH=/opt/catch2 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
+	CMAKE_PREFIX_PATH=/opt/catch2 \
+	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
+	cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) $(MAKEFLAGS); \
 	)
 
@@ -182,7 +184,9 @@ build_zai_asan:
 	( \
 	mkdir -p "$(ZAI_BUILD_DIR)"; \
 	cd $(ZAI_BUILD_DIR); \
-	CMAKE_PREFIX_PATH=/opt/catch2 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DBUILD_ZAI_ASAN=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
+	CMAKE_PREFIX_PATH=/opt/catch2 \
+	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
+	cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DBUILD_ZAI_ASAN=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) clean $(MAKEFLAGS); \
 	$(MAKE) $(MAKEFLAGS); \
 	)
@@ -195,7 +199,7 @@ build_zai_coverage: install_zai_sapi
 	mkdir -p "$(ZAI_BUILD_DIR)"; \
 	cd $(ZAI_BUILD_DIR); \
 	CMAKE_PREFIX_PATH=/opt/catch2 \
-	ZaiSapi_ROOT=$(ZAI_SAPI_BUILD_DIR)/opt \
+	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
 	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 --coverage" -DBUILD_ZAI_TESTING=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) $(MAKEFLAGS); \
 	)


### PR DESCRIPTION
### Description

A quick follow up to #1411 that fixes `ZaiSapi_ROOT` references in the Makefile. Also removes a redundant PATH modification in CI config.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
