### PR TITLE
Bump profiling to v0.3.0-rc.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 	bash ./tooling/bin/generate-final-artifact.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR) \
-		https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0-rc.4/datadog-profiling.tar.gz
+		https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0-rc.6/datadog-profiling.tar.gz
 
 build_pecl_package:
 	BUILD_DIR='$(BUILD_DIR)/'; \

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -54,23 +54,23 @@ do
         $tmp_folder_final/x86_64-linux-musl/dd-library-php/profiling/ext/$version
 
     cp -v \
-        $tmp_folder_profiling/datadog-profiling/x86_64-linux-gnu/lib/php/$version/datadog-profiling.so \
+        $tmp_folder_profiling/datadog-profiling/x86_64-unknown-linux-gnu/lib/php/$version/datadog-profiling.so \
         $tmp_folder_final/x86_64-linux-gnu/dd-library-php/profiling/ext/$version/datadog-profiling.so
 
     cp -v \
-        $tmp_folder_profiling/datadog-profiling/x86_64-linux-musl/lib/php/$version/datadog-profiling.so \
+        $tmp_folder_profiling/datadog-profiling/x86_64-alpine-linux-musl/lib/php/$version/datadog-profiling.so \
         $tmp_folder_final/x86_64-linux-musl/dd-library-php/profiling/ext/$version/datadog-profiling.so
 done
 
 # Licenses
 cp -v \
-    $tmp_folder_profiling/datadog-profiling/x86_64-linux-gnu/LICENSE* \
-    $tmp_folder_profiling/datadog-profiling/x86_64-linux-gnu/NOTICE* \
+    $tmp_folder_profiling/datadog-profiling/x86_64-unknown-linux-gnu/LICENSE* \
+    $tmp_folder_profiling/datadog-profiling/x86_64-unknown-linux-gnu/NOTICE* \
     $tmp_folder_final_gnu/dd-library-php/profiling/
 
 cp -v \
-    $tmp_folder_profiling/datadog-profiling/x86_64-linux-musl/LICENSE* \
-    $tmp_folder_profiling/datadog-profiling/x86_64-linux-musl/NOTICE* \
+    $tmp_folder_profiling/datadog-profiling/x86_64-alpine-linux-musl/LICENSE* \
+    $tmp_folder_profiling/datadog-profiling/x86_64-alpine-linux-musl/NOTICE* \
     $tmp_folder_final_musl/dd-library-php/profiling/
 
 ########################


### PR DESCRIPTION
### Description

This is a stacked PR based on #1442.

This bumps the profiling product to v0.3.0-rc.6, which fixes some bugs
around over- and under-linking.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ No new tests; existing tests should be sufficient for this refactor.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
