### PR TITLE
Run randomized internal API stress testing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2062,6 +2062,7 @@ workflows:
                 - test_api_unit
                 - test_c2php
                 - test_c_disabled
+                - test_internal_api_randomized
       - coverage:
           requires: [ 'Prepare Code' ]
           matrix:
@@ -2092,6 +2093,7 @@ workflows:
               make_target:
                 - test_c_asan
                 - test_with_init_hook_asan
+                - test_internal_api_randomized
 
       - integration:
           requires: [ 'Prepare Code' ]

--- a/Makefile
+++ b/Makefile
@@ -918,6 +918,10 @@ API_TESTS_ROOT := ./tests/api
 test_api_unit: composer.lock global_test_run_dependencies
 	$(ENV_OVERRIDE) php $(REQUEST_INIT_HOOK) vendor/bin/phpunit --config=phpunit.xml $(API_TESTS_ROOT)/Unit $(TESTS)
 
+# Just test it does not crash, i.e. the exit code
+test_internal_api_randomized: $(SO_FILE)
+	php -ddatadog.trace.cli_enabled=1 -d extension=$(SO_FILE) tests/internal-api-stress-test.php 2>/dev/null
+
 composer.lock: composer.json
 	$(Q) composer update
 

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -50,6 +50,7 @@
 #include "startup_logging.h"
 
 bool ddtrace_has_excluded_module;
+static zend_module_entry *ddtrace_module;
 
 atomic_int ddtrace_warn_legacy_api;
 
@@ -417,6 +418,11 @@ static PHP_MINIT_FUNCTION(ddtrace) {
                            CONST_CS | CONST_PERSISTENT);
     REGISTER_INI_ENTRIES();
 
+    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
+    if (ddtrace_module_zv) {
+        ddtrace_module = Z_PTR_P(ddtrace_module_zv);
+    }
+
     // config initialization needs to be at the top
     if (!ddtrace_config_minit(module_number)) {
         return FAILURE;
@@ -460,6 +466,11 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
     UNREGISTER_INI_ENTRIES();
+
+    /* prevent unloading ddtrace, extension shutdown is called later */
+    if (ddtrace_module) {
+        ddtrace_module->handle = NULL;
+    }
 
     if (DDTRACE_G(disable) == 1) {
         zai_config_mshutdown();

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -288,7 +288,7 @@ static ZEND_RESULT_CODE ddtrace_exception_to_meta(zend_object *exception, void *
 
     previous = ZAI_EXCEPTION_PROPERTY(exception_root, ZEND_STR_PREVIOUS);
     while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous) &&
-            instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
+           instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
         Z_UNPROTECT_RECURSION_P(previous);
         previous = ZAI_EXCEPTION_PROPERTY(Z_OBJ_P(previous), ZEND_STR_PREVIOUS);
     }

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -287,7 +287,8 @@ static ZEND_RESULT_CODE ddtrace_exception_to_meta(zend_object *exception, void *
     }
 
     previous = ZAI_EXCEPTION_PROPERTY(exception_root, ZEND_STR_PREVIOUS);
-    while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous)) {
+    while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous) &&
+            instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
         Z_UNPROTECT_RECURSION_P(previous);
         previous = ZAI_EXCEPTION_PROPERTY(Z_OBJ_P(previous), ZEND_STR_PREVIOUS);
     }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -417,6 +417,13 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
 
     UNREGISTER_INI_ENTRIES();
 
+    /* prevent unloading ddtrace, extension shutdown is called later */
+    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
+    if (ddtrace_module_zv) {
+        zend_module_entry *ddtrace_module = Z_PTR_P(ddtrace_module_zv);
+        ddtrace_module->handle = NULL;
+    }
+
     if (DDTRACE_G(disable) == 1) {
         zai_config_mshutdown();
         return SUCCESS;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -50,6 +50,7 @@
 #include "startup_logging.h"
 
 bool ddtrace_has_excluded_module;
+static zend_module_entry *ddtrace_module;
 
 atomic_int ddtrace_warn_legacy_api;
 
@@ -373,6 +374,11 @@ static PHP_MINIT_FUNCTION(ddtrace) {
                            CONST_CS | CONST_PERSISTENT);
     REGISTER_INI_ENTRIES();
 
+    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
+    if (ddtrace_module_zv) {
+        ddtrace_module = Z_PTR_P(ddtrace_module_zv);
+    }
+
     // config initialization needs to be at the top
     if (!ddtrace_config_minit(module_number)) {
         return FAILURE;
@@ -418,9 +424,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     UNREGISTER_INI_ENTRIES();
 
     /* prevent unloading ddtrace, extension shutdown is called later */
-    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
-    if (ddtrace_module_zv) {
-        zend_module_entry *ddtrace_module = Z_PTR_P(ddtrace_module_zv);
+    if (ddtrace_module) {
         ddtrace_module->handle = NULL;
     }
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -279,7 +279,8 @@ static zend_result ddtrace_exception_to_meta(zend_object *exception, void *conte
     }
 
     previous = ZAI_EXCEPTION_PROPERTY(exception_root, ZEND_STR_PREVIOUS);
-    while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous)) {
+    while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous) &&
+            instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
         Z_UNPROTECT_RECURSION_P(previous);
         previous = ZAI_EXCEPTION_PROPERTY(Z_OBJ_P(previous), ZEND_STR_PREVIOUS);
     }

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -280,7 +280,7 @@ static zend_result ddtrace_exception_to_meta(zend_object *exception, void *conte
 
     previous = ZAI_EXCEPTION_PROPERTY(exception_root, ZEND_STR_PREVIOUS);
     while (Z_TYPE_P(previous) == IS_OBJECT && !Z_IS_RECURSIVE_P(previous) &&
-            instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
+           instanceof_function(Z_OBJCE_P(previous), zend_ce_throwable)) {
         Z_UNPROTECT_RECURSION_P(previous);
         previous = ZAI_EXCEPTION_PROPERTY(Z_OBJ_P(previous), ZEND_STR_PREVIOUS);
     }

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -23,6 +23,7 @@ function generate_garbage()
         "DDTrace\hook_method",
         "call_function",
         [],
+        ["nonempty" => new stdClass()],
         new stdClass(),
         function () {
             ob_start();
@@ -84,7 +85,8 @@ function runOneIteration()
             return DDTrace\active_span();
         },
     ];
-    $props = (new ReflectionClass('DDTrace\SpanData'))->getProperties();
+    $props = array_filter((new ReflectionClass('DDTrace\SpanData'))->getProperties(),
+        function($p) { return $p->name != "parent"; });
 
     shuffle($functions);
     foreach ($functions as $function) {

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -91,16 +91,16 @@ function runOneIteration()
     shuffle($functions);
     foreach ($functions as $function) {
         $garbages = generate_garbage();
-        $e = new Exception("");
-        $exceptionClass = new ReflectionClass("Exception");
+        $ex = new Exception("");
+        $exceptionClass = new ReflectionClass($ex);
         foreach ($exceptionClass->getProperties() as $prop) {
             $prop->setAccessible(true);
             try {
-                $prop->setValue($e, rand(1, 5) == 1 ? $e : $garbages[array_rand($garbages)]);
+                $prop->setValue($ex, rand(1, 5) == 1 ? $ex : $garbages[array_rand($garbages)]);
             } catch (TypeError $e) {
             }
         }
-        $garbages[] = $e;
+        $garbages[] = $ex;
         foreach (array_slice($return_span, 0, rand(0, count($return_span))) as $spanreturner) {
             $span = $spanreturner();
             foreach ($props as $prop) {


### PR DESCRIPTION
### Description

This testsuite also would have caught #1439.

Additionally fixing:
- extension shutdown being called after module unload - seems to not have real impact in practice, but breaks with ASAN enabled.
- Fixing a crash when the previous exception is not an exception object.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
