### PR TITLE
Revert "remove embed sapi (#1195)"

### DIFF
--- a/dockerfiles/ci/alpine/php-8.0/configure.sh
+++ b/dockerfiles/ci/alpine/php-8.0/configure.sh
@@ -7,6 +7,7 @@ ${PHP_SRC_DIR}/configure \
     --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.4/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.4/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.5/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.5/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-5.6/configure.sh
+++ b/dockerfiles/ci/centos/6/php-5.6/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.0/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.0/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.1/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.1/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.2/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.2/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.3/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.3/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-7.4/configure.sh
+++ b/dockerfiles/ci/centos/6/php-7.4/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \

--- a/dockerfiles/ci/centos/6/php-8.0/configure.sh
+++ b/dockerfiles/ci/centos/6/php-8.0/configure.sh
@@ -6,6 +6,7 @@ fi
 ${PHP_SRC_DIR}/configure \
     --enable-option-checking=fatal \
     --enable-cgi \
+    --enable-embed \
     --enable-fpm \
     --enable-ftp \
     --enable-mbstring \


### PR DESCRIPTION
### Description

This reverts commit c2bbaad6469c0db1264eecf9434082350bb5543c. I believe #1195 was merged in error.

```bash
$ ll /opt/php/8.0/lib/
total 43512
-rwxr-xr-x  1 root root 44551144 Oct  2 00:21 libphp.so
drwxr-xr-x 15 root root     4096 Oct  2 00:22 php
```

The containers still have `libphp` (which is good) so they do not appear to have been rebuilt based on this change.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
