### PR TITLE
Ensure a proper sampling decision is also evaluated when distributed tracing is used

### DIFF
--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -189,7 +189,7 @@ void ddtrace_close_span(ddtrace_span_fci *span_fci TSRMLS_DC) {
         span_fci->dispatch = NULL;
     }
 
-    if (DDTRACE_G(span_ids_top) == NULL) {
+    if (DDTRACE_G(open_spans_top) == NULL) {
         // Enforce a sampling decision here
         ddtrace_fetch_prioritySampling_from_root(TSRMLS_C);
 

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -185,7 +185,7 @@ void ddtrace_close_span(ddtrace_span_fci *span_fci) {
         span_fci->dispatch = NULL;
     }
 
-    if (DDTRACE_G(span_ids_top) == NULL) {
+    if (DDTRACE_G(open_spans_top) == NULL) {
         // Enforce a sampling decision here
         ddtrace_fetch_prioritySampling_from_root();
 

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -184,7 +184,7 @@ void ddtrace_close_span(ddtrace_span_fci *span_fci) {
         span_fci->dispatch = NULL;
     }
 
-    if (DDTRACE_G(span_ids_top) == NULL) {
+    if (DDTRACE_G(open_spans_top) == NULL) {
         // Enforce a sampling decision here
         ddtrace_fetch_prioritySampling_from_root();
 

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -49,7 +49,11 @@ array(2) {
       string(7) "datadog"
     }
     ["metrics"]=>
-    array(1) {
+    array(3) {
+      ["_dd.rule_psr"]=>
+      float(1)
+      ["_sampling_priority_v1"]=>
+      float(1)
       ["php.compilation.total_time_ms"]=>
       float(%f)
     }

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -15,13 +15,11 @@ DDTrace\trace_function('array_sum', function (SpanData $span, $args, $retval) {
 });
 
 function main($max) {
-    // Emulate opening a userland span
-    dd_trace_push_span_id();
+    DDTrace\start_span();
     echo array_sum(range(0, $max)) . PHP_EOL;
     echo array_sum(range(0, $max + 1)) . PHP_EOL;
     echo 'Has not flushed yet.' . PHP_EOL;
-    // Emulate closing a userland span
-    dd_trace_pop_span_id();
+    DDTrace\close_span();
 }
 
 main(2);
@@ -35,16 +33,16 @@ echo PHP_EOL;
 3
 6
 Has not flushed yet.
-Successfully triggered flush with trace of size 2
+Successfully triggered flush with trace of size 3
 
 10
 15
 Has not flushed yet.
-Successfully triggered flush with trace of size 2
+Successfully triggered flush with trace of size 3
 
 21
 28
 Has not flushed yet.
-Successfully triggered flush with trace of size 2
+Successfully triggered flush with trace of size 3
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/dd_trace_set_trace_id.phpt
+++ b/tests/ext/sandbox/dd_trace_set_trace_id.phpt
@@ -44,6 +44,6 @@ Parent ID: 100
 *Flushed spans*
 int(2)
 Name: array_sum
-Span ID: 11788048577503494824
-Trace ID: 11788048577503494824
+Span ID: 13874630024467741450
+Trace ID: 13874630024467741450
 Parent ID: (empty)


### PR DESCRIPTION
### Description

This has no impact if the request_init_hook is used, because the PHP code will enforce a sampling decision. However it was not happening in the internal code directly.
This is especially necessary as we try to decouple our code from the userland code.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
