### PR TITLE
Fix ObjectKVStore compatibility with throwing autoloaders

### DIFF
--- a/src/DDTrace/Util/ObjectKVStore.php
+++ b/src/DDTrace/Util/ObjectKVStore.php
@@ -123,7 +123,7 @@ class ObjectKVStore
             return;
         }
 
-        if (\class_exists("WeakMap")) {
+        if (\class_exists("WeakMap", $autoload = false)) {
             if (!self::$weakmap) {
                 self::$weakmap = new \WeakMap();
             }
@@ -155,7 +155,7 @@ class ObjectKVStore
             return $default;
         }
 
-        if (\class_exists("WeakMap")) {
+        if (\class_exists("WeakMap", $autoload = false)) {
             if (!self::$weakmap || !isset(self::$weakmap[$instance])) {
                 return $default;
             }

--- a/tests/Unit/Util/ObjectKVStoreTest.php
+++ b/tests/Unit/Util/ObjectKVStoreTest.php
@@ -4,9 +4,28 @@ namespace DDTrace\Tests\Unit\Util;
 
 use DDTrace\Tests\Common\BaseTestCase;
 use DDTrace\Util\ObjectKVStore;
+use Exception;
+
+function throwing_autoloader($class)
+{
+    throw new Exception('This autoloader should never be triggered');
+}
 
 final class ObjectKVStoreTest extends BaseTestCase
 {
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        // Required to test compatibility with autoloaders that throw, since ObjectKVStore uses class_exists().
+        \spl_autoload_register('DDTrace\Tests\Unit\Util\throwing_autoloader');
+    }
+
+    protected function ddTearDown()
+    {
+        parent::ddTearDown();
+        \spl_autoload_unregister('DDTrace\Tests\Unit\Util\throwing_autoloader');
+    }
+
     public function testPutGet()
     {
         $instance = new \stdClass();


### PR DESCRIPTION
### Description

Some frameworks can use autoloaders that are not lenient, meaning that when they are asked to load a class, they either load it or generate a fatal (e.g. because the file is not found), rather than just returning `false` - example [`Varien_Autoload`](https://github.com/engineyard/magento-ce-1.9/blob/170c1a51387428fb56f3ada2504d52a2b130360a/lib/Varien/Autoload.php#L81-L93).

Since we use `class_exists('WeakMap')` in our `ObjectKVStore` ([usage 1](https://github.com/DataDog/dd-trace-php/blob/29b1106cbaaf6d7a8cca259600d493ad349bdae9/src/DDTrace/Util/ObjectKVStore.php#L126) and [usage 2](https://github.com/DataDog/dd-trace-php/blob/29b1106cbaaf6d7a8cca259600d493ad349bdae9/src/DDTrace/Util/ObjectKVStore.php#L158)) and `class_exists()` triggers the autoloading mechanism by default, then the error occurs on PHP < 8 which does not define `WeakMap`.

The consequence is poor or missing spans when the callback uses `ObjectKVStore` and it never results in an application crash thanks to callbacks sandboxing.

As part of this investigation, I also confirmed that we have not other 'loading' usages of `class_exists()` in our code base.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
