### PR TITLE
ZAI Symbols Interface

### DIFF
--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -98,6 +98,7 @@ add_subdirectory(env)
 add_subdirectory(exceptions)
 add_subdirectory(config)
 add_subdirectory(json)
+add_subdirectory(symbols)
 if(PHP_VERSION_DIRECTORY STREQUAL "php5")
   # TODO Support PHP 7 & PHP 8
   add_subdirectory(methods)

--- a/zend_abstract_interface/symbols/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(zai_symbols lookup.c call.c)
+
+target_include_directories(
+  zai_symbols PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                    $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(zai_symbols PUBLIC "${PHP_LIB}" Zai::Sandbox)
+
+target_compile_features(zai_symbols PUBLIC c_std_99)
+
+set_target_properties(zai_symbols PROPERTIES EXPORT_NAME Symbols
+                                            VERSION ${PROJECT_VERSION})
+
+add_library(Zai::Symbols ALIAS zai_symbols)
+
+if(${BUILD_ZAI_TESTING})
+  add_subdirectory(tests)
+endif()
+
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/symbols.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/symbols/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_symbols)
+
+install(TARGETS zai_symbols EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/symbols/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/CMakeLists.txt
@@ -21,6 +21,10 @@ install(
   FILES ${CMAKE_CURRENT_SOURCE_DIR}/symbols.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/symbols/)
 
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api
+  DESTINATION ${CMAKE_INSTAL_INCLUDEDIR}/symbols/api)
+
 target_link_libraries(zai_zend_abstract_interface INTERFACE zai_symbols)
 
 install(TARGETS zai_symbols EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/symbols/api/README.md
+++ b/zend_abstract_interface/symbols/api/README.md
@@ -1,0 +1,1 @@
+Files in this folder define a thin API on top of an interface, or part of an interface (in the case of lookups)

--- a/zend_abstract_interface/symbols/api/call.h
+++ b/zend_abstract_interface/symbols/api/call.h
@@ -1,0 +1,143 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_CALL_H
+#define HAVE_ZAI_SYMBOLS_API_CALL_H
+// clang-format off
+static inline bool zai_symbol_call(
+                        zai_symbol_scope_t scope_type, void *scope, 
+                        zai_symbol_function_t function_type, void *function,
+                        zval **rv ZAI_TSRMLS_DC,
+                        uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result = zai_symbol_call_impl(scope_type, scope, function_type, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_known(
+                    zai_symbol_scope_t scope_type, void *scope,
+                    zend_function *function,
+                    zval **rv ZAI_TSRMLS_DC,
+                    uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(scope_type, scope, ZAI_SYMBOL_FUNCTION_KNOWN, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_named(
+                    zai_symbol_scope_t scope_type, void *scope, 
+                    zai_string_view *function,
+                    zval **rv ZAI_TSRMLS_DC,
+                    uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(scope_type, scope, ZAI_SYMBOL_FUNCTION_NAMED, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_static(zend_class_entry *scope, zai_string_view *function, zval **rv ZAI_TSRMLS_DC, uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_CLASS, scope, ZAI_SYMBOL_FUNCTION_NAMED, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_static_literal(zend_class_entry *scope,
+                                                  const char *fn, size_t fnl,
+                                                  zval **rv ZAI_TSRMLS_DC,
+                                                  uint32_t argc, ...) {
+    zai_string_view vfn =
+        (zai_string_view) {fnl, fn};
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_CLASS, scope, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_method(zval *zv, zai_string_view *function, zval **rv ZAI_TSRMLS_DC, uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_OBJECT, zv, ZAI_SYMBOL_FUNCTION_NAMED, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_method_literal(zval *zv, const char *fn, size_t fnl, zval **rv ZAI_TSRMLS_DC, uint32_t argc, ...) {
+    zai_string_view vfn =
+        (zai_string_view) {fnl, fn};
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_OBJECT, zv, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_literal(
+                    const char *fn, size_t fnl, 
+                    zval **rv ZAI_TSRMLS_DC,
+                    uint32_t argc, ...) {
+    zai_string_view vfn =
+        (zai_string_view) {fnl, fn};
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline bool zai_symbol_call_literal_ns(
+                    const char *ns, size_t nsl,
+                    const char *fn, size_t fnl, 
+                    zval **rv ZAI_TSRMLS_DC,
+                    uint32_t argc, ...) {
+    zai_string_view vns =
+        (zai_string_view) {nsl, ns};
+    zai_string_view vfn =
+        (zai_string_view) {fnl, fn};
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result =
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/api/call.h
+++ b/zend_abstract_interface/symbols/api/call.h
@@ -2,7 +2,7 @@
 #define HAVE_ZAI_SYMBOLS_API_CALL_H
 // clang-format off
 static inline bool zai_symbol_call(
-                        zai_symbol_scope_t scope_type, void *scope, 
+                        zai_symbol_scope_t scope_type, void *scope,
                         zai_symbol_function_t function_type, void *function,
                         zval **rv ZAI_TSRMLS_DC,
                         uint32_t argc, ...) {
@@ -33,7 +33,7 @@ static inline bool zai_symbol_call_known(
 }
 
 static inline bool zai_symbol_call_named(
-                    zai_symbol_scope_t scope_type, void *scope, 
+                    zai_symbol_scope_t scope_type, void *scope,
                     zai_string_view *function,
                     zval **rv ZAI_TSRMLS_DC,
                     uint32_t argc, ...) {
@@ -104,7 +104,7 @@ static inline bool zai_symbol_call_method_literal(zval *zv, const char *fn, size
 }
 
 static inline bool zai_symbol_call_literal(
-                    const char *fn, size_t fnl, 
+                    const char *fn, size_t fnl,
                     zval **rv ZAI_TSRMLS_DC,
                     uint32_t argc, ...) {
     zai_string_view vfn =
@@ -122,7 +122,7 @@ static inline bool zai_symbol_call_literal(
 
 static inline bool zai_symbol_call_literal_ns(
                     const char *ns, size_t nsl,
-                    const char *fn, size_t fnl, 
+                    const char *fn, size_t fnl,
                     zval **rv ZAI_TSRMLS_DC,
                     uint32_t argc, ...) {
     zai_string_view vns =

--- a/zend_abstract_interface/symbols/api/class.h
+++ b/zend_abstract_interface/symbols/api/class.h
@@ -1,0 +1,27 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_CLASS_H
+#define HAVE_ZAI_SYMBOLS_API_CLASS_H
+// clang-format off
+static inline zend_class_entry *zai_symbol_lookup_class(
+                                    zai_symbol_scope_t scope_type, void *scope,
+                                    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zend_class_entry *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zend_class_entry *zai_symbol_lookup_class_literal(const char *cn, size_t cnl ZAI_TSRMLS_DC) {
+    zai_string_view vcn =
+        (zai_string_view){cnl, cn};
+
+    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vcn ZAI_TSRMLS_CC);
+}
+
+static inline zend_class_entry *zai_symbol_lookup_class_literal_ns(const char *ns, size_t nsl,
+                                                                   const char *cn, size_t cnl ZAI_TSRMLS_DC) {
+    zai_string_view vns =
+        (zai_string_view){nsl, ns};
+    zai_string_view vcn =
+        (zai_string_view){cnl, cn};
+
+    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vcn ZAI_TSRMLS_CC);
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/api/constant.h
+++ b/zend_abstract_interface/symbols/api/constant.h
@@ -1,0 +1,27 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_CONSTANT_H
+#define HAVE_ZAI_SYMBOLS_API_CONSTANT_H
+// clang-format off
+static inline zval *zai_symbol_lookup_constant(
+                        zai_symbol_scope_t scope_type, void *scope,
+                        zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zval *zai_symbol_lookup_constant_literal(const char *cn, size_t cnl ZAI_TSRMLS_DC) {
+    zai_string_view vcn =
+        (zai_string_view){cnl, cn};
+
+    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vcn ZAI_TSRMLS_CC);
+}
+
+static inline zval *zai_symbol_lookup_constant_literal_ns(const char *ns, size_t nsl,
+                                                          const char *cn, size_t cnl ZAI_TSRMLS_DC) {
+    zai_string_view vns =
+        (zai_string_view){nsl, ns};
+    zai_string_view vcn =
+        (zai_string_view){cnl, cn};
+
+    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vcn ZAI_TSRMLS_CC);
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/api/function.h
+++ b/zend_abstract_interface/symbols/api/function.h
@@ -1,0 +1,27 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_FUNCTION_H
+#define HAVE_ZAI_SYMBOLS_API_FUNCTION_H
+// clang-format off
+static inline zend_function *zai_symbol_lookup_function(
+                                zai_symbol_scope_t scope_type, void *scope,
+                                zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zend_function *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zend_function *zai_symbol_lookup_function_literal(const char *fn, size_t fnl ZAI_TSRMLS_DC) {
+    zai_string_view vfn =
+        (zai_string_view){fnl, fn};
+
+    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vfn ZAI_TSRMLS_CC);
+}
+
+static inline zend_function *zai_symbol_lookup_function_literal_ns(const char *ns, size_t nsl,
+                                                                   const char *fn, size_t fnl ZAI_TSRMLS_DC) {
+    zai_string_view vns =
+        (zai_string_view){nsl, ns};
+    zai_string_view vfn =
+        (zai_string_view){fnl, fn};
+
+    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vfn ZAI_TSRMLS_CC);
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/api/local.h
+++ b/zend_abstract_interface/symbols/api/local.h
@@ -1,0 +1,10 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_LOCAL_H
+#define HAVE_ZAI_SYMBOLS_API_LOCAL_H
+// clang-format off
+static inline zval *zai_symbol_lookup_local(
+                        zai_symbol_scope_t scope_type, void *scope,
+                        zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, scope_type, scope, name ZAI_TSRMLS_CC);
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/api/property.h
+++ b/zend_abstract_interface/symbols/api/property.h
@@ -1,0 +1,16 @@
+#ifndef HAVE_ZAI_SYMBOLS_API_PROPERTY_H
+#define HAVE_ZAI_SYMBOLS_API_PROPERTY_H
+// clang-format off
+static inline zval *zai_symbol_lookup_property(
+                        zai_symbol_scope_t scope_type, void *scope,
+                        zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zval *zai_symbol_lookup_property_literal(zai_symbol_scope_t scope_type, void *scope, const char *pn, size_t pnl ZAI_TSRMLS_DC) {
+    zai_string_view vpn =
+        (zai_string_view) {pnl, pn};
+    return zai_symbol_lookup_property(scope_type, scope, &vpn ZAI_TSRMLS_CC);
+}
+// clang-format on
+#endif

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -1,0 +1,177 @@
+#include "symbols.h"
+
+#include <ctype.h>
+#include <sandbox/sandbox.h>
+#include <zai_assert/zai_assert.h>
+
+// clang-format off
+static bool zai_symbol_call_impl(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_symbol_function_t function_type, void *function,
+    zval **rv ZAI_TSRMLS_DC,
+    uint32_t argc, va_list *args);
+// clang-format on
+
+bool zai_symbol_call(zai_symbol_scope_t scope_type, void *scope, zai_symbol_function_t function_type, void *function,
+                     zval **rv ZAI_TSRMLS_DC, uint32_t argc, ...) {
+    bool result;
+
+    va_list args;
+    va_start(args, argc);
+    result = zai_symbol_call_impl(scope_type, scope, function_type, function, rv ZAI_TSRMLS_CC, argc, &args);
+    va_end(args);
+
+    return result;
+}
+
+static inline void zai_symbol_call_argv(zend_fcall_info *fci, uint32_t argc, va_list *args ZAI_TSRMLS_DC) {
+#if PHP_VERSION_ID < 70000
+    fci->params = emalloc(argc * sizeof(zval **));
+#else
+    fci->params = emalloc(argc * sizeof(zval));
+#endif
+    for (uint32_t arg = 0; arg < argc; arg++) {
+        zval **param = va_arg(*args, zval **);
+#if PHP_VERSION_ID < 70000
+        fci->params[arg] = param;
+#else
+        ZVAL_COPY_VALUE(&fci->params[arg], *param);
+#endif
+    }
+    fci->param_count = argc;
+}
+
+static bool zai_symbol_call_impl(
+    // clang-format off
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_symbol_function_t function_type, void *function,
+    zval **rv ZAI_TSRMLS_DC,
+    uint32_t argc, va_list *args
+    // clang-format on
+) {
+    zend_fcall_info fci = empty_fcall_info;
+    zend_fcall_info_cache fcc = empty_fcall_info_cache;
+
+    fci.size = sizeof(zend_fcall_info);
+#if PHP_VERSION_ID >= 70000
+    fci.retval = *rv;
+#if PHP_VERSION_ID < 70300
+    fcc.initialized = 1;
+#endif
+#else
+    fcc.initialized = 1;
+    fci.retval_ptr_ptr = rv;
+#endif
+
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_CLASS:
+            fcc.called_scope = (zend_class_entry *)scope;
+            break;
+
+        case ZAI_SYMBOL_SCOPE_OBJECT: {
+            fcc.called_scope = Z_OBJCE_P((zval *)scope);
+#if PHP_VERSION_ID >= 70000
+            fci.object = fcc.object = Z_OBJ_P((zval *)scope);
+#else
+            fci.object_ptr = fcc.object_ptr = (zval *)scope;
+#endif
+        } break;
+
+        case ZAI_SYMBOL_SCOPE_GLOBAL:
+            /* nothing to do */
+            break;
+
+        case ZAI_SYMBOL_SCOPE_NAMESPACE:
+            /* nothing to do yet */
+            break;
+    }
+
+    switch (function_type) {
+        case ZAI_SYMBOL_FUNCTION_KNOWN:
+            fcc.function_handler = (zend_function *)function;
+            break;
+
+        case ZAI_SYMBOL_FUNCTION_NAMED:
+            // clang-format off
+            fcc.function_handler =
+                zai_symbol_lookup(
+                    ZAI_SYMBOL_TYPE_FUNCTION,
+                    scope_type, scope,
+                    function ZAI_TSRMLS_CC);
+            // clang-format on
+            break;
+    }
+
+    if (!fcc.function_handler) {
+        return false;
+    }
+
+    if (fcc.function_handler->common.fn_flags & ZEND_ACC_ABSTRACT) {
+        return false;
+    }
+
+    if (scope_type == ZAI_SYMBOL_SCOPE_CLASS) {
+        if (!(fcc.function_handler->common.fn_flags & ZEND_ACC_STATIC)) {
+            return false;
+        }
+    }
+
+    volatile int zai_symbol_call_result = FAILURE;
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    if (argc) {
+        zai_symbol_call_argv(&fci, argc, args ZAI_TSRMLS_CC);
+    }
+
+    // clang-format off
+    zend_try {
+        zai_symbol_call_result =
+            zend_call_function(&fci, &fcc ZAI_TSRMLS_CC);
+    } zend_end_try();
+    // clang-format on
+
+    if (argc) {
+        efree(fci.params);
+    }
+
+    if ((zai_symbol_call_result == SUCCESS) && (NULL == EG(exception))) {
+        zai_sandbox_close(&sandbox);
+        return true;
+    }
+
+    zai_sandbox_close(&sandbox);
+    return false;
+}
+
+bool zai_symbol_new(zval *zv, zend_class_entry *ce ZAI_TSRMLS_DC, uint32_t argc, ...) {
+    bool result = true;
+
+    memset(zv, 0, sizeof(zv));
+
+    object_init_ex(zv, ce);
+
+    if (ce->constructor) {
+        va_list args;
+        va_start(args, argc);
+
+        zval rz, *rv = &rz;
+        // clang-format off
+        result = zai_symbol_call_impl(
+            ZAI_SYMBOL_SCOPE_OBJECT, zv,
+            ZAI_SYMBOL_FUNCTION_KNOWN, ce->constructor,
+            &rv ZAI_TSRMLS_CC,
+            argc, &args);
+        // clang-format on
+
+#if PHP_VERSION_ID < 70000
+        zval_ptr_dtor(&rv);
+#else
+        zval_ptr_dtor(rv);
+#endif
+        va_end(args);
+    }
+
+    return result;
+}

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -4,26 +4,6 @@
 #include <sandbox/sandbox.h>
 #include <zai_assert/zai_assert.h>
 
-// clang-format off
-static bool zai_symbol_call_impl(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_symbol_function_t function_type, void *function,
-    zval **rv ZAI_TSRMLS_DC,
-    uint32_t argc, va_list *args);
-// clang-format on
-
-bool zai_symbol_call(zai_symbol_scope_t scope_type, void *scope, zai_symbol_function_t function_type, void *function,
-                     zval **rv ZAI_TSRMLS_DC, uint32_t argc, ...) {
-    bool result;
-
-    va_list args;
-    va_start(args, argc);
-    result = zai_symbol_call_impl(scope_type, scope, function_type, function, rv ZAI_TSRMLS_CC, argc, &args);
-    va_end(args);
-
-    return result;
-}
-
 static inline void zai_symbol_call_argv(zend_fcall_info *fci, uint32_t argc, va_list *args ZAI_TSRMLS_DC) {
 #if PHP_VERSION_ID < 70000
     fci->params = emalloc(argc * sizeof(zval **));
@@ -41,7 +21,7 @@ static inline void zai_symbol_call_argv(zend_fcall_info *fci, uint32_t argc, va_
     fci->param_count = argc;
 }
 
-static bool zai_symbol_call_impl(
+bool zai_symbol_call_impl(
     // clang-format off
     zai_symbol_scope_t scope_type, void *scope,
     zai_symbol_function_t function_type, void *function,

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -1,0 +1,519 @@
+#include <sandbox/sandbox.h>
+#include "symbols.h"
+#include "zend_compile.h"
+
+// clang-format off
+static inline bool zai_symbol_update(zend_class_entry *ce ZAI_TSRMLS_DC) {
+    if (ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED) {
+        return true;
+    }
+
+    volatile bool zai_symbol_updated = true;
+
+    zai_sandbox sandbox;
+    zai_sandbox_open(&sandbox);
+
+    zend_try {
+#if PHP_VERSION_ID < 70000
+        zend_update_class_constants(ce ZAI_TSRMLS_CC);
+#else
+        if (zend_update_class_constants(ce) != SUCCESS) {
+            zai_symbol_updated = false;
+        }
+#endif
+    } zend_catch {
+        zai_symbol_updated = false;
+    } zend_end_try();
+
+    if (zai_symbol_updated && !EG(exception)) {
+        zai_sandbox_close(&sandbox);
+        return true;
+    }
+
+    zai_sandbox_close(&sandbox);
+    return false;
+}
+
+static inline void *zai_symbol_lookup_table(HashTable *table, const char *name, size_t length, bool ncase, bool pointer ZAI_TSRMLS_DC) {
+#if PHP_VERSION_ID >= 70000
+    zval *result = zend_hash_str_find(table, name, length);
+#else
+    void *result = NULL;
+
+    zend_hash_find(table, name, length + 1, (void **)&result);
+#endif
+
+    if (!result && ncase) {
+        char *ptr = (char *)pemalloc(length + 1, 1);
+
+        for (uint32_t c = 0; c < length; c++) {
+            ptr[c] = tolower(name[c]);
+        }
+
+        ptr[length] = 0;
+
+#if PHP_VERSION_ID >= 70000
+        result = zend_hash_str_find(table, ptr, length);
+#else
+        zend_hash_find(table, ptr, length + 1, (void **)&result);
+#endif
+
+        pefree(ptr, 1);
+    }
+
+#if PHP_VERSION_ID >= 70000
+    if (pointer && result) {
+        return Z_PTR_P(result);
+    } else {
+        return result;
+    }
+#endif
+    return result;
+}
+
+static inline size_t zai_symbol_lookup_lengthof(zai_string_view *view) {
+    if (!view->len) {
+        return 0;
+    }
+
+    if (memcmp(view->ptr, "\\", sizeof("\\")-1) == SUCCESS) {
+        return view->len - 1;
+    }
+
+    return view->len;
+}
+
+static inline const char* zai_symbol_lookup_startof(zai_string_view *view) {
+    if (!view->len) {
+        return NULL;
+    }
+
+    if (memcmp(view->ptr, "\\", sizeof("\\")-1) == SUCCESS) {
+        return view->ptr + 1;
+    }
+
+    return view->ptr;
+}
+
+static inline zai_string_view* zai_symbol_lookup_key(zai_string_view *namespace, zai_string_view *name, bool lower ZAI_TSRMLS_DC) {
+    zai_string_view *result = pemalloc(sizeof(zai_string_view), 1);
+
+    size_t namespace_length = zai_symbol_lookup_lengthof(namespace);
+    size_t name_length      = zai_symbol_lookup_lengthof(name);
+
+    const char* namespace_start   = zai_symbol_lookup_startof(namespace);
+    const char* name_start        = zai_symbol_lookup_startof(name);
+
+#define CHAR_AT(n) (((char*) result->ptr)[n])
+    if (namespace_length) {
+        result->len = namespace_length + name_length + sizeof("\\")-1;
+        result->ptr = pemalloc(result->len + 1, 2);
+
+        memcpy(&CHAR_AT(0), namespace_start, namespace_length);
+
+        for (uint32_t c = 0; c < namespace_length; c++) {
+            CHAR_AT(c) = tolower(CHAR_AT(c));
+        }
+
+        memcpy(&CHAR_AT(namespace_length), "\\", sizeof("\\")-1);
+        memcpy(&CHAR_AT(namespace_length + (sizeof("\\")-1)), name_start, name_length);
+    } else {
+        result->len = name_length;
+        result->ptr = pemalloc(result->len + 1, 1);
+
+        memcpy(&CHAR_AT(0), name_start, name_length);
+    }
+
+    if (lower) {
+        for (uint32_t c = namespace_length ? namespace_length + (sizeof("\\")-1) : 0;
+                      c < result->len;
+                      c++) {
+            CHAR_AT(c) = tolower(CHAR_AT(c));
+        }
+    }
+
+    CHAR_AT(result->len) = 0;
+#undef CHAR_AT
+
+    return result;
+}
+
+static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
+    void *result = NULL;
+
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_GLOBAL: {
+            result = zai_symbol_lookup_table(
+                EG(class_table),
+                zai_symbol_lookup_startof(name),
+                zai_symbol_lookup_lengthof(name),
+                true, true ZAI_TSRMLS_CC);
+        } break;
+
+        case ZAI_SYMBOL_SCOPE_NAMESPACE: {
+            zai_string_view *key = zai_symbol_lookup_key(scope, name, true ZAI_TSRMLS_CC);
+
+            if (key) {
+                result = zai_symbol_lookup_table(
+                    EG(class_table),
+                    key->ptr,
+                    key->len,
+                    false, true ZAI_TSRMLS_CC);
+
+                pefree((char*) key->ptr, 1);
+                pefree(key, 1);
+            }
+        } break;
+
+        default:
+            assert(0 && "class lookup may only be performed in global and namespace scopes");
+    }
+
+#if PHP_VERSION_ID >= 70000
+    return result;
+#else
+    return result ? *(void **)result : NULL;
+#endif
+}
+
+static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
+    zend_function *result;
+    HashTable *table = NULL;
+    zai_string_view *key = name;
+
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_CLASS:
+            table = &((zend_class_entry *)scope)->function_table;
+            break;
+
+        case ZAI_SYMBOL_SCOPE_OBJECT:
+            table = &Z_OBJCE_P((zval *)scope)->function_table;
+            break;
+
+        case ZAI_SYMBOL_SCOPE_NAMESPACE:
+            key = zai_symbol_lookup_key(scope, name, true ZAI_TSRMLS_CC);
+            /* intentional fall through */
+
+        case ZAI_SYMBOL_SCOPE_GLOBAL:
+            table = EG(function_table);
+            break;
+
+        default:
+            assert(0 && "function lookup may not be performed in static and frame scopes");
+            return NULL;
+    }
+
+    zend_function *function = zai_symbol_lookup_table(
+        table,
+        key == name ? zai_symbol_lookup_startof(key) : key->ptr,
+        key == name ? zai_symbol_lookup_lengthof(key) : key->len,
+        scope_type != ZAI_SYMBOL_SCOPE_NAMESPACE, true ZAI_TSRMLS_CC);
+
+    if (key != name) {
+        pefree((char*) key->ptr, 1);
+        pefree(key, 1);
+    }
+
+    return function;
+}
+
+static inline zval* zai_symbol_lookup_constant_global(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
+    zai_string_view *key = name;
+
+    if (scope_type == ZAI_SYMBOL_SCOPE_NAMESPACE) {
+        key = zai_symbol_lookup_key(scope, name, false ZAI_TSRMLS_CC);
+    }
+
+    zend_constant *constant = zai_symbol_lookup_table(
+        EG(zend_constants),
+        key == name ? zai_symbol_lookup_startof(key) : key->ptr,
+        key == name ? zai_symbol_lookup_lengthof(key) : key->len,
+        false, true ZAI_TSRMLS_CC);
+
+    if (key != name) {
+        pefree((char*) key->ptr, 1);
+        pefree(key, 1);
+    }
+
+    if (!constant) {
+        return NULL;
+    }
+
+    return &constant->value;
+}
+
+static inline zval* zai_symbol_lookup_constant_class(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
+    zend_class_entry *ce;
+
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_CLASS:
+            ce = (zend_class_entry*) scope;
+        break;
+
+        case ZAI_SYMBOL_SCOPE_OBJECT:
+            ce = Z_OBJCE_P((zval*) scope);
+        break;
+    }
+
+    if (!zai_symbol_update(ce ZAI_TSRMLS_CC)) {
+        return NULL;
+    }
+
+#if PHP_VERSION_ID >= 70100
+    zend_class_constant *constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, true ZAI_TSRMLS_CC);
+
+    if (!constant) {
+        return NULL;
+    }
+
+    return &constant->value;
+#elif PHP_VERSION_ID >= 70000
+    zval *constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+
+    if (!constant) {
+        return NULL;
+    }
+
+    return constant;
+#else
+    zval **constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+
+    if (!constant) {
+        return NULL;
+    }
+
+    return *constant;
+#endif
+}
+
+static inline zval* zai_symbol_lookup_constant_impl(
+        zai_symbol_scope_t scope_type, void *scope,
+        zai_string_view *name ZAI_TSRMLS_DC) {
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_GLOBAL:
+        case ZAI_SYMBOL_SCOPE_NAMESPACE:
+            return zai_symbol_lookup_constant_global(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_SCOPE_CLASS:
+        case ZAI_SYMBOL_SCOPE_OBJECT:
+            return zai_symbol_lookup_constant_class(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        default:
+            assert(0 && "constant lookup may not be performed in static and frame scopes");
+            return NULL;
+    }
+}
+
+static inline zval* zai_symbol_lookup_property_impl(
+        zai_symbol_scope_t scope_type, void *scope,
+        zai_string_view *name ZAI_TSRMLS_DC) {
+    zend_property_info *info = NULL;
+    zend_class_entry *ce = NULL;
+
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_OBJECT:
+            ce = Z_OBJCE_P((zval*) scope);
+        break;
+
+        case ZAI_SYMBOL_SCOPE_CLASS:
+            ce = (zend_class_entry*) scope;
+        break;
+
+        default:
+            assert(0 && "property lookup may only be performed in class and object scopes");
+            return NULL;
+    }
+
+    info = zai_symbol_lookup_table(&ce->properties_info, name->ptr, name->len, false, true ZAI_TSRMLS_CC);
+
+    if (!info) {
+        if (scope_type == ZAI_SYMBOL_SCOPE_OBJECT) {
+#if PHP_VERSION_ID < 70000
+            zend_object *obj = zend_object_store_get_object((zval*) scope ZAI_TSRMLS_CC);
+#else
+            zend_object *obj = Z_OBJ_P((zval*) scope);
+#endif
+
+            void *property = zai_symbol_lookup_table(
+                obj->properties,
+                name->ptr, name->len,
+                false, false ZAI_TSRMLS_CC);
+
+#if PHP_VERSION_ID < 70000
+            if (!property) {
+                return NULL;
+            }
+
+            return *(zval**) property;
+#else
+            return (zval*) property;
+#endif
+        }
+        return NULL;
+    }
+
+    if (scope_type == ZAI_SYMBOL_SCOPE_CLASS) {
+        if ( !(info->flags & ZEND_ACC_STATIC)) {
+            return NULL;
+        }
+
+        if (!zai_symbol_update(ce ZAI_TSRMLS_CC)) {
+            return NULL;
+        }
+
+#if PHP_VERSION_ID < 70000
+        if (!CE_STATIC_MEMBERS(ce)) {
+            return NULL;
+        }
+
+        return CE_STATIC_MEMBERS(ce)[info->offset];
+#else
+
+#if PHP_VERSION_ID >= 70300
+        if (CE_STATIC_MEMBERS(ce) == NULL) {
+            zend_class_init_statics(ce);
+        }
+#endif
+
+        zval *property = CE_STATIC_MEMBERS(ce) + info->offset;
+
+        while (Z_TYPE_P(property) == IS_INDIRECT) {
+            property = Z_INDIRECT_P(property);
+        }
+
+        return property;
+#endif
+    }
+
+#if PHP_VERSION_ID < 70000
+    zend_object *obj = zend_object_store_get_object((zval*) scope ZAI_TSRMLS_CC);
+
+    if (obj->properties) {
+        return *(zval **)obj->properties_table[info->offset];
+    } else {
+        return obj->properties_table[info->offset];
+    }
+#else
+    return OBJ_PROP(Z_OBJ_P((zval*)scope), info->offset);
+#endif
+}
+
+static inline zval* zai_symbol_lookup_local_frame(zend_execute_data *ex, zai_string_view *name ZAI_TSRMLS_DC) {
+#if PHP_VERSION_ID < 70000
+    zend_function *function = ex->function_state.function;
+#else
+    zend_function *function = ex->func;
+#endif
+
+    if (!function || function->type != ZEND_USER_FUNCTION) {
+        return NULL;
+    }
+
+#if PHP_VERSION_ID >= 70000
+    zval *local = NULL;
+    for (uint32_t var = 0; var < function->op_array.last_var; var++) {
+        zend_string *match = function->op_array.vars[var];
+
+        if ((name->len == ZSTR_LEN(match)) && (memcmp(name->ptr, ZSTR_VAL(match), name->len) == SUCCESS)) {
+            local = ZEND_CALL_VAR_NUM(ex, var);
+            break;
+        }
+    }
+
+    if (!local) {
+        return NULL;
+    }
+
+    ZVAL_DEREF(local);
+
+    return local;
+#else
+    zval **local = NULL;
+    zend_execute_data *frame = EG(current_execute_data);
+
+    for (int var = 0; var < function->op_array.last_var; var++) {
+        zend_compiled_variable *match = &function->op_array.vars[var];
+
+        if ((name->len == match->name_len) && (memcmp(name->ptr, match->name, name->len) == SUCCESS)) {
+#ifdef EX_CV_NUM
+            local = *EX_CV_NUM(frame, var);
+#else
+            local = frame->CVs[var];
+#endif
+            break;
+        }
+    }
+
+    if (!local) {
+        return NULL;
+    }
+
+    return *local;
+#endif
+}
+
+static inline zval* zai_symbol_lookup_local_static(zend_function *function, zai_string_view *name ZAI_TSRMLS_DC) {
+    if (function->type != ZEND_USER_FUNCTION || !function->op_array.static_variables) {
+        return NULL;
+    }
+
+#ifdef ZEND_MAP_PTR_GET
+    HashTable *table = ZEND_MAP_PTR_GET(function->op_array.static_variables_ptr);
+
+    if (!table) {
+        return NULL;
+    }
+#else
+    HashTable *table = function->op_array.static_variables;
+#endif
+
+    zval *var = (zval*) zai_symbol_lookup_table(table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+
+    if (!var) {
+        return NULL;
+    }
+
+#if PHP_VERSION_ID >= 70000
+    ZVAL_DEREF(var);
+
+    return var;
+#else
+    return *(zval**) var;
+#endif
+}
+
+static inline zval* zai_symbol_lookup_local_impl(
+        zai_symbol_scope_t scope_type, void *scope,
+        zai_string_view *name ZAI_TSRMLS_DC) {
+    switch (scope_type) {
+        case ZAI_SYMBOL_SCOPE_FRAME:
+            return zai_symbol_lookup_local_frame(scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_SCOPE_STATIC:
+            return zai_symbol_lookup_local_static(scope, name ZAI_TSRMLS_CC);
+
+        default:
+            assert(0 && "local lookup may only be performed in frame and static scopes");
+    }
+    return NULL;
+}
+
+void* zai_symbol_lookup(zai_symbol_type_t symbol_type, zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
+    switch (symbol_type) {
+        case ZAI_SYMBOL_TYPE_CLASS:
+            return zai_symbol_lookup_class_impl(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_TYPE_FUNCTION:
+            return zai_symbol_lookup_function_impl(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_TYPE_CONSTANT:
+            return zai_symbol_lookup_constant_impl(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_TYPE_PROPERTY:
+            return zai_symbol_lookup_property_impl(scope_type, scope, name ZAI_TSRMLS_CC);
+
+        case ZAI_SYMBOL_TYPE_LOCAL:
+            return zai_symbol_lookup_local_impl(scope_type, scope, name ZAI_TSRMLS_CC);
+    }
+}
+// clang-format on

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -95,7 +95,7 @@ static inline zai_string_view zai_symbol_lookup_key(zai_string_view *namespace, 
             CHAR_AT(c) = tolower(CHAR_AT(c));
         }
 
-        memcpy(&CHAR_AT(vns.len), "\\", 1);
+        CHAR_AT(vns.len) = '\\';
         memcpy(&CHAR_AT(vns.len + 1), vn.ptr, vn.len);
     } else {
         rv.len = vn.len;
@@ -306,7 +306,7 @@ static inline zval* zai_symbol_lookup_property_impl(
             zend_object *obj = Z_OBJ_P((zval*) scope);
 #endif
 
-            void *property = zai_symbol_lookup_table(obj->properties, *name, false, false ZAI_TSRMLS_CC);
+            zval *property = (zval*) zai_symbol_lookup_table(obj->properties, *name, false, false ZAI_TSRMLS_CC);
 
 #if PHP_VERSION_ID < 70000
             if (!property) {
@@ -317,7 +317,7 @@ static inline zval* zai_symbol_lookup_property_impl(
 #else
             ZVAL_DEREF(property);
 
-            return (zval*) property;
+            return property;
 #endif
         }
         return NULL;

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -308,11 +308,11 @@ static inline zval* zai_symbol_lookup_property_impl(
 
             zval *property = (zval*) zai_symbol_lookup_table(obj->properties, *name, false, false ZAI_TSRMLS_CC);
 
-#if PHP_VERSION_ID < 70000
             if (!property) {
                 return NULL;
             }
 
+#if PHP_VERSION_ID < 70000
             return *(zval**) property;
 #else
             ZVAL_DEREF(property);

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -34,28 +34,28 @@ static inline bool zai_symbol_update(zend_class_entry *ce ZAI_TSRMLS_DC) {
     return false;
 }
 
-static inline void *zai_symbol_lookup_table(HashTable *table, const char *name, size_t length, bool ncase, bool pointer ZAI_TSRMLS_DC) {
+static inline void *zai_symbol_lookup_table(HashTable *table, zai_string_view key, bool ncase, bool pointer ZAI_TSRMLS_DC) {
 #if PHP_VERSION_ID >= 70000
-    zval *result = zend_hash_str_find(table, name, length);
+    zval *result = zend_hash_str_find(table, key.ptr, key.len);
 #else
     void *result = NULL;
 
-    zend_hash_find(table, name, length + 1, (void **)&result);
+    zend_hash_find(table, key.ptr, key.len + 1, (void **)&result);
 #endif
 
     if (!result && ncase) {
-        char *ptr = (char *)pemalloc(length + 1, 1);
+        char *ptr = (char *)pemalloc(key.len + 1, 1);
 
-        for (uint32_t c = 0; c < length; c++) {
-            ptr[c] = tolower(name[c]);
+        for (uint32_t c = 0; c < key.len; c++) {
+            ptr[c] = tolower(key.ptr[c]);
         }
 
-        ptr[length] = 0;
+        ptr[key.len] = 0;
 
 #if PHP_VERSION_ID >= 70000
-        result = zend_hash_str_find(table, ptr, length);
+        result = zend_hash_str_find(table, ptr, key.len);
 #else
-        zend_hash_find(table, ptr, length + 1, (void **)&result);
+        zend_hash_find(table, ptr, key.len + 1, (void **)&result);
 #endif
 
         pefree(ptr, 1);
@@ -71,71 +71,52 @@ static inline void *zai_symbol_lookup_table(HashTable *table, const char *name, 
     return result;
 }
 
-static inline size_t zai_symbol_lookup_lengthof(zai_string_view *view) {
-    if (!view->len) {
-        return 0;
+static inline zai_string_view zai_symbol_lookup_clean(zai_string_view view) {
+    if (!view.len || *view.ptr != '\\') {
+        return view;
     }
-
-    if (memcmp(view->ptr, "\\", sizeof("\\")-1) == SUCCESS) {
-        return view->len - 1;
-    }
-
-    return view->len;
+    return (zai_string_view){ .ptr = view.ptr + 1, .len = view.len - 1 };
 }
 
-static inline const char* zai_symbol_lookup_startof(zai_string_view *view) {
-    if (!view->len) {
-        return NULL;
-    }
+static inline zai_string_view zai_symbol_lookup_key(zai_string_view *namespace, zai_string_view *name, bool lower ZAI_TSRMLS_DC) {
+    zai_string_view rv;
+    zai_string_view vns     = zai_symbol_lookup_clean(*namespace);
+    zai_string_view vn      = zai_symbol_lookup_clean(*name);
 
-    if (memcmp(view->ptr, "\\", sizeof("\\")-1) == SUCCESS) {
-        return view->ptr + 1;
-    }
+    char *result = NULL;
+#define CHAR_AT(n) (result[n])
+    if (vns.len) {
+        rv.len = vns.len + vn.len + 1;
+        result = pemalloc(rv.len + 1, 1);
 
-    return view->ptr;
-}
+        memcpy(&CHAR_AT(0), vns.ptr, vns.len);
 
-static inline zai_string_view* zai_symbol_lookup_key(zai_string_view *namespace, zai_string_view *name, bool lower ZAI_TSRMLS_DC) {
-    zai_string_view *result = pemalloc(sizeof(zai_string_view), 1);
-
-    size_t namespace_length = zai_symbol_lookup_lengthof(namespace);
-    size_t name_length      = zai_symbol_lookup_lengthof(name);
-
-    const char* namespace_start   = zai_symbol_lookup_startof(namespace);
-    const char* name_start        = zai_symbol_lookup_startof(name);
-
-#define CHAR_AT(n) (((char*) result->ptr)[n])
-    if (namespace_length) {
-        result->len = namespace_length + name_length + sizeof("\\")-1;
-        result->ptr = pemalloc(result->len + 1, 2);
-
-        memcpy(&CHAR_AT(0), namespace_start, namespace_length);
-
-        for (uint32_t c = 0; c < namespace_length; c++) {
+        for (uint32_t c = 0; c < vns.len; c++) {
             CHAR_AT(c) = tolower(CHAR_AT(c));
         }
 
-        memcpy(&CHAR_AT(namespace_length), "\\", sizeof("\\")-1);
-        memcpy(&CHAR_AT(namespace_length + (sizeof("\\")-1)), name_start, name_length);
+        memcpy(&CHAR_AT(vns.len), "\\", 1);
+        memcpy(&CHAR_AT(vns.len + 1), vn.ptr, vn.len);
     } else {
-        result->len = name_length;
-        result->ptr = pemalloc(result->len + 1, 1);
+        rv.len = vn.len;
+        result = pemalloc(rv.len + 1, 1);
 
-        memcpy(&CHAR_AT(0), name_start, name_length);
+        memcpy(&CHAR_AT(0), vn.ptr, vn.len);
     }
 
     if (lower) {
-        for (uint32_t c = namespace_length ? namespace_length + (sizeof("\\")-1) : 0;
-                      c < result->len;
+        for (uint32_t c = vns.len ? vns.len + 1 : 0;
+                      c < rv.len;
                       c++) {
             CHAR_AT(c) = tolower(CHAR_AT(c));
         }
     }
 
-    CHAR_AT(result->len) = 0;
+    CHAR_AT(rv.len) = 0;
 #undef CHAR_AT
+    rv.ptr = result;
 
-    return result;
+    return rv;
 }
 
 static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
@@ -145,23 +126,20 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
         case ZAI_SYMBOL_SCOPE_GLOBAL: {
             result = zai_symbol_lookup_table(
                 EG(class_table),
-                zai_symbol_lookup_startof(name),
-                zai_symbol_lookup_lengthof(name),
+                zai_symbol_lookup_clean(*name),
                 true, true ZAI_TSRMLS_CC);
         } break;
 
         case ZAI_SYMBOL_SCOPE_NAMESPACE: {
-            zai_string_view *key = zai_symbol_lookup_key(scope, name, true ZAI_TSRMLS_CC);
+            zai_string_view key = zai_symbol_lookup_key(scope, name, true ZAI_TSRMLS_CC);
 
-            if (key) {
+            if (key.ptr) {
                 result = zai_symbol_lookup_table(
                     EG(class_table),
-                    key->ptr,
-                    key->len,
+                    key,
                     false, true ZAI_TSRMLS_CC);
 
-                pefree((char*) key->ptr, 1);
-                pefree(key, 1);
+                pefree((char*) key.ptr, 1);
             }
         } break;
 
@@ -179,7 +157,7 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
 static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
     zend_function *result;
     HashTable *table = NULL;
-    zai_string_view *key = name;
+    zai_string_view key = *name;
 
     switch (scope_type) {
         case ZAI_SYMBOL_SCOPE_CLASS:
@@ -205,20 +183,18 @@ static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t 
 
     zend_function *function = zai_symbol_lookup_table(
         table,
-        key == name ? zai_symbol_lookup_startof(key) : key->ptr,
-        key == name ? zai_symbol_lookup_lengthof(key) : key->len,
+        key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         scope_type != ZAI_SYMBOL_SCOPE_NAMESPACE, true ZAI_TSRMLS_CC);
 
-    if (key != name) {
-        pefree((char*) key->ptr, 1);
-        pefree(key, 1);
+    if (key.ptr != name->ptr) {
+        pefree((char*) key.ptr, 1);
     }
 
     return function;
 }
 
 static inline zval* zai_symbol_lookup_constant_global(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name ZAI_TSRMLS_DC) {
-    zai_string_view *key = name;
+    zai_string_view key = *name;
 
     if (scope_type == ZAI_SYMBOL_SCOPE_NAMESPACE) {
         key = zai_symbol_lookup_key(scope, name, false ZAI_TSRMLS_CC);
@@ -226,13 +202,11 @@ static inline zval* zai_symbol_lookup_constant_global(zai_symbol_scope_t scope_t
 
     zend_constant *constant = zai_symbol_lookup_table(
         EG(zend_constants),
-        key == name ? zai_symbol_lookup_startof(key) : key->ptr,
-        key == name ? zai_symbol_lookup_lengthof(key) : key->len,
+        key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         false, true ZAI_TSRMLS_CC);
 
-    if (key != name) {
-        pefree((char*) key->ptr, 1);
-        pefree(key, 1);
+    if (key.ptr != name->ptr) {
+        pefree((char*) key.ptr, 1);
     }
 
     if (!constant) {
@@ -260,7 +234,7 @@ static inline zval* zai_symbol_lookup_constant_class(zai_symbol_scope_t scope_ty
     }
 
 #if PHP_VERSION_ID >= 70100
-    zend_class_constant *constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, true ZAI_TSRMLS_CC);
+    zend_class_constant *constant = zai_symbol_lookup_table(&ce->constants_table, *name, false, true ZAI_TSRMLS_CC);
 
     if (!constant) {
         return NULL;
@@ -268,7 +242,7 @@ static inline zval* zai_symbol_lookup_constant_class(zai_symbol_scope_t scope_ty
 
     return &constant->value;
 #elif PHP_VERSION_ID >= 70000
-    zval *constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+    zval *constant = zai_symbol_lookup_table(&ce->constants_table, *name, false, false ZAI_TSRMLS_CC);
 
     if (!constant) {
         return NULL;
@@ -276,7 +250,7 @@ static inline zval* zai_symbol_lookup_constant_class(zai_symbol_scope_t scope_ty
 
     return constant;
 #else
-    zval **constant = zai_symbol_lookup_table(&ce->constants_table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+    zval **constant = zai_symbol_lookup_table(&ce->constants_table, *name, false, false ZAI_TSRMLS_CC);
 
     if (!constant) {
         return NULL;
@@ -324,7 +298,7 @@ static inline zval* zai_symbol_lookup_property_impl(
             return NULL;
     }
 
-    info = zai_symbol_lookup_table(&ce->properties_info, name->ptr, name->len, false, true ZAI_TSRMLS_CC);
+    info = zai_symbol_lookup_table(&ce->properties_info, *name, false, true ZAI_TSRMLS_CC);
 
     if (!info) {
         if (scope_type == ZAI_SYMBOL_SCOPE_OBJECT) {
@@ -334,10 +308,7 @@ static inline zval* zai_symbol_lookup_property_impl(
             zend_object *obj = Z_OBJ_P((zval*) scope);
 #endif
 
-            void *property = zai_symbol_lookup_table(
-                obj->properties,
-                name->ptr, name->len,
-                false, false ZAI_TSRMLS_CC);
+            void *property = zai_symbol_lookup_table(obj->properties, *name, false, false ZAI_TSRMLS_CC);
 
 #if PHP_VERSION_ID < 70000
             if (!property) {
@@ -467,7 +438,7 @@ static inline zval* zai_symbol_lookup_local_static(zend_function *function, zai_
     HashTable *table = function->op_array.static_variables;
 #endif
 
-    zval *var = (zval*) zai_symbol_lookup_table(table, name->ptr, name->len, false, false ZAI_TSRMLS_CC);
+    zval *var = (zval*) zai_symbol_lookup_table(table, *name, false, false ZAI_TSRMLS_CC);
 
     if (!var) {
         return NULL;

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -105,9 +105,7 @@ static inline zai_string_view zai_symbol_lookup_key(zai_string_view *namespace, 
     }
 
     if (lower) {
-        for (uint32_t c = vns.len ? vns.len + 1 : 0;
-                      c < rv.len;
-                      c++) {
+        for (uint32_t c = vns.len; c < rv.len; c++) {
             CHAR_AT(c) = tolower(CHAR_AT(c));
         }
     }
@@ -317,6 +315,8 @@ static inline zval* zai_symbol_lookup_property_impl(
 
             return *(zval**) property;
 #else
+            ZVAL_DEREF(property);
+
             return (zval*) property;
 #endif
         }
@@ -352,6 +352,8 @@ static inline zval* zai_symbol_lookup_property_impl(
             property = Z_INDIRECT_P(property);
         }
 
+        ZVAL_DEREF(property);
+
         return property;
 #endif
     }
@@ -365,7 +367,11 @@ static inline zval* zai_symbol_lookup_property_impl(
         return obj->properties_table[info->offset];
     }
 #else
-    return OBJ_PROP(Z_OBJ_P((zval*)scope), info->offset);
+    zval *property = OBJ_PROP(Z_OBJ_P((zval*)scope), info->offset);
+
+    ZVAL_DEREF(property);
+
+    return property;
 #endif
 }
 

--- a/zend_abstract_interface/symbols/symbols.h
+++ b/zend_abstract_interface/symbols/symbols.h
@@ -1,0 +1,127 @@
+#ifndef ZAI_SYMBOLS_H
+#define ZAI_SYMBOLS_H
+/**
+ * zai_symbol_lookup is a single interface for access to Zend symbols:
+ *  - classes (global, namespace)
+ *  - functions (global, namespace, class, object)
+ *  - constants (global, namespace, class, object)
+ *  - properties (class, object)
+ *  - locals (function static, frame)
+ *
+ * for caller convenience (avoiding casts), the following helpers are provided:
+ *
+ *  - zai_symbol_lookup_class
+ *  - zai_symbol_lookup_function
+ *  - zai_symbol_lookup_constant
+ *  - zai_symbol_lookup_property
+ *  - zai_symbol_lookup_local
+
+ * zai_symbol_call is a single interface for invocation
+ *
+ * zai_symbol_new is a single interface for object construction
+ */
+#include "php.h"
+
+#include "../zai_string/string.h"
+#include "zai_compat.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// clang-format off
+typedef enum {
+    /* The return type is zend_class_entry* */
+    ZAI_SYMBOL_TYPE_CLASS,
+    /* The return type is zend_function* */
+    ZAI_SYMBOL_TYPE_FUNCTION,
+    /* The return type is zval* */
+    ZAI_SYMBOL_TYPE_CONSTANT,
+    /* The return type is zval* */
+    ZAI_SYMBOL_TYPE_PROPERTY,
+    /* The return type is zval* */
+    ZAI_SYMBOL_TYPE_LOCAL,
+} zai_symbol_type_t;
+
+typedef enum {
+    /* The next parameter is expected to be zend_class_entry* */
+    ZAI_SYMBOL_SCOPE_CLASS,
+    /* The next parameter is expected to be zval* and Z_TYPE_P is IS_OBJECT */
+    ZAI_SYMBOL_SCOPE_OBJECT,
+    /* The next parameter is expected to be null */
+    ZAI_SYMBOL_SCOPE_GLOBAL,
+    /* The next parameter is zai_string_view* */
+    ZAI_SYMBOL_SCOPE_NAMESPACE,
+    /* The next parameter is zend_execute_data* */
+    ZAI_SYMBOL_SCOPE_FRAME,
+    /* The next symbol is zend_function* with type == ZEND_USER_FUNCTION */
+    ZAI_SYMBOL_SCOPE_STATIC,
+} zai_symbol_scope_t;
+
+/* LOOKUP */
+void* zai_symbol_lookup(
+        zai_symbol_type_t symbol_type,
+        zai_symbol_scope_t scope_type, void *scope,
+        zai_string_view *name ZAI_TSRMLS_DC);
+
+static inline zend_class_entry* zai_symbol_lookup_class(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zend_class_entry*)
+        zai_symbol_lookup(
+            ZAI_SYMBOL_TYPE_CLASS,
+            scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zend_function* zai_symbol_lookup_function(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zend_function*)
+        zai_symbol_lookup(
+            ZAI_SYMBOL_TYPE_FUNCTION,
+            scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zval* zai_symbol_lookup_constant(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval*)
+        zai_symbol_lookup(
+            ZAI_SYMBOL_TYPE_CONSTANT,
+            scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zval* zai_symbol_lookup_property(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval*)
+        zai_symbol_lookup(
+            ZAI_SYMBOL_TYPE_PROPERTY,
+            scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+static inline zval* zai_symbol_lookup_local(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_string_view *name ZAI_TSRMLS_DC) {
+    return (zval*)
+        zai_symbol_lookup(
+            ZAI_SYMBOL_TYPE_LOCAL,
+            scope_type, scope, name ZAI_TSRMLS_CC);
+}
+
+/* CALL */
+typedef enum {
+    /* The function parameter is zend_function* */
+    ZAI_SYMBOL_FUNCTION_KNOWN,
+    /* The function parameter is zai_string_view* */
+    ZAI_SYMBOL_FUNCTION_NAMED,
+} zai_symbol_function_t;
+
+bool zai_symbol_call(
+    zai_symbol_scope_t scope_type, void *scope,
+    zai_symbol_function_t function_type, void *function,
+    zval **rv ZAI_TSRMLS_DC,
+    uint32_t argc, ...);
+
+bool zai_symbol_new(zval *zv, zend_class_entry *ce ZAI_TSRMLS_DC, uint32_t argc, ...);
+// clang-format on
+#endif  // ZAI_SYMBOLS_H

--- a/zend_abstract_interface/symbols/symbols.h
+++ b/zend_abstract_interface/symbols/symbols.h
@@ -8,14 +8,6 @@
  *  - properties (class, object)
  *  - locals (function static, frame)
  *
- * for caller convenience (avoiding casts), the following helpers are provided:
- *
- *  - zai_symbol_lookup_class
- *  - zai_symbol_lookup_function
- *  - zai_symbol_lookup_constant
- *  - zai_symbol_lookup_property
- *  - zai_symbol_lookup_local
-
  * zai_symbol_call is a single interface for invocation
  *
  * zai_symbol_new is a single interface for object construction
@@ -63,50 +55,11 @@ void* zai_symbol_lookup(
         zai_symbol_scope_t scope_type, void *scope,
         zai_string_view *name ZAI_TSRMLS_DC);
 
-static inline zend_class_entry* zai_symbol_lookup_class(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_string_view *name ZAI_TSRMLS_DC) {
-    return (zend_class_entry*)
-        zai_symbol_lookup(
-            ZAI_SYMBOL_TYPE_CLASS,
-            scope_type, scope, name ZAI_TSRMLS_CC);
-}
-
-static inline zend_function* zai_symbol_lookup_function(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_string_view *name ZAI_TSRMLS_DC) {
-    return (zend_function*)
-        zai_symbol_lookup(
-            ZAI_SYMBOL_TYPE_FUNCTION,
-            scope_type, scope, name ZAI_TSRMLS_CC);
-}
-
-static inline zval* zai_symbol_lookup_constant(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_string_view *name ZAI_TSRMLS_DC) {
-    return (zval*)
-        zai_symbol_lookup(
-            ZAI_SYMBOL_TYPE_CONSTANT,
-            scope_type, scope, name ZAI_TSRMLS_CC);
-}
-
-static inline zval* zai_symbol_lookup_property(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_string_view *name ZAI_TSRMLS_DC) {
-    return (zval*)
-        zai_symbol_lookup(
-            ZAI_SYMBOL_TYPE_PROPERTY,
-            scope_type, scope, name ZAI_TSRMLS_CC);
-}
-
-static inline zval* zai_symbol_lookup_local(
-    zai_symbol_scope_t scope_type, void *scope,
-    zai_string_view *name ZAI_TSRMLS_DC) {
-    return (zval*)
-        zai_symbol_lookup(
-            ZAI_SYMBOL_TYPE_LOCAL,
-            scope_type, scope, name ZAI_TSRMLS_CC);
-}
+#include "api/class.h"
+#include "api/function.h"
+#include "api/constant.h"
+#include "api/property.h"
+#include "api/local.h"
 
 /* CALL */
 typedef enum {
@@ -116,11 +69,13 @@ typedef enum {
     ZAI_SYMBOL_FUNCTION_NAMED,
 } zai_symbol_function_t;
 
-bool zai_symbol_call(
+bool zai_symbol_call_impl(
     zai_symbol_scope_t scope_type, void *scope,
     zai_symbol_function_t function_type, void *function,
     zval **rv ZAI_TSRMLS_DC,
-    uint32_t argc, ...);
+    uint32_t argc, va_list *args);
+
+#include "api/call.h"
 
 bool zai_symbol_new(zval *zv, zend_class_entry *ce ZAI_TSRMLS_DC, uint32_t argc, ...);
 // clang-format on

--- a/zend_abstract_interface/symbols/tests/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(symbols 
+    lookup/class.cc 
+    lookup/function.cc 
+    lookup/constant.cc 
+    lookup/property.cc 
+    lookup/local/static.cc 
+    lookup/local/frame.cc 
+    call/internal.cc 
+    call/user.cc)
+
+target_link_libraries(symbols PUBLIC catch2_main ZaiSapi::ZaiSapi Zai::Value Zai::Symbols)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+catch_discover_tests(symbols)

--- a/zend_abstract_interface/symbols/tests/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/tests/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_executable(symbols 
-    lookup/class.cc 
+    lookup/class.cc
     lookup/function.cc 
     lookup/constant.cc 
     lookup/property.cc 
     lookup/local/static.cc 
     lookup/local/frame.cc 
     call/internal.cc 
-    call/user.cc)
+    call/user.cc
+    api/class.cc
+    api/constant.cc
+    api/function.cc
+    api/property.cc
+    api/call.cc)
 
 target_link_libraries(symbols PUBLIC catch2_main ZaiSapi::ZaiSapi Zai::Value Zai::Symbols)
 

--- a/zend_abstract_interface/symbols/tests/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(symbols
     api/property.cc
     api/call.cc)
 
-target_link_libraries(symbols PUBLIC catch2_main ZaiSapi::ZaiSapi Zai::Value Zai::Symbols)
+target_link_libraries(symbols PUBLIC catch2_main Tea::Tea Zai::Value Zai::Symbols)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/stubs
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/zend_abstract_interface/symbols/tests/api/README.md
+++ b/zend_abstract_interface/symbols/tests/api/README.md
@@ -1,0 +1,1 @@
+Files in this folder should test API declared in api/*.h

--- a/zend_abstract_interface/symbols/tests/api/call.cc
+++ b/zend_abstract_interface/symbols/tests/api/call.cc
@@ -1,0 +1,52 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "value/value.h"
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+
+ZAI_SAPI_TEST_CASE("symbol/api/call", "literal", {
+    zval *result;
+
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call_literal(ZEND_STRL("phpversion"), &result ZAI_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "literal ns", "./stubs/call/user/Stub.php", {
+    zval *result;
+
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("noargs"), &result ZAI_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "static", "./stubs/call/user/Stub.php", {
+    zval *result;
+    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+    zai_string_view vfn = ZAI_STRL_VIEW("staticPublicFunction");
+
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call_static(ce, &vfn, &result ZAI_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "static literal", "./stubs/call/user/Stub.php", {
+    zval *result;
+    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call_static_literal(ce, ZEND_STRL("staticPublicFunction"), &result ZAI_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+})

--- a/zend_abstract_interface/symbols/tests/api/call.cc
+++ b/zend_abstract_interface/symbols/tests/api/call.cc
@@ -1,52 +1,51 @@
 extern "C" {
 #include "symbols/symbols.h"
 #include "value/value.h"
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 
-ZAI_SAPI_TEST_CASE("symbol/api/call", "literal", {
+TEA_TEST_CASE("symbol/api/call", "literal", {
     zval *result;
 
     ZAI_VALUE_INIT(result);
 
-    CHECK(zai_symbol_call_literal(ZEND_STRL("phpversion"), &result ZAI_TSRMLS_CC, 0));
+    CHECK(zai_symbol_call_literal(ZEND_STRL("phpversion"), &result TEA_TSRMLS_CC, 0));
 
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "literal ns", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/api/call", "literal ns", "./stubs/call/user/Stub.php", {
     zval *result;
 
     ZAI_VALUE_INIT(result);
 
-    CHECK(zai_symbol_call_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("noargs"), &result ZAI_TSRMLS_CC, 0));
+    CHECK(zai_symbol_call_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("noargs"), &result TEA_TSRMLS_CC, 0));
 
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "static", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/api/call", "static", "./stubs/call/user/Stub.php", {
     zval *result;
     zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") TEA_TSRMLS_CC);
     zai_string_view vfn = ZAI_STRL_VIEW("staticPublicFunction");
 
     ZAI_VALUE_INIT(result);
 
-    CHECK(zai_symbol_call_static(ce, &vfn, &result ZAI_TSRMLS_CC, 0));
+    CHECK(zai_symbol_call_static(ce, &vfn, &result TEA_TSRMLS_CC, 0));
 
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/call", "static literal", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/api/call", "static literal", "./stubs/call/user/Stub.php", {
     zval *result;
     zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") TEA_TSRMLS_CC);
 
     ZAI_VALUE_INIT(result);
 
-    CHECK(zai_symbol_call_static_literal(ce, ZEND_STRL("staticPublicFunction"), &result ZAI_TSRMLS_CC, 0));
+    CHECK(zai_symbol_call_static_literal(ce, ZEND_STRL("staticPublicFunction"), &result TEA_TSRMLS_CC, 0));
 
     ZAI_VALUE_DTOR(result);
 })

--- a/zend_abstract_interface/symbols/tests/api/class.cc
+++ b/zend_abstract_interface/symbols/tests/api/class.cc
@@ -1,0 +1,14 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal, exists", "./stubs/lookup/class/Stub.php", {
+    REQUIRE(zai_symbol_lookup_class_literal(ZEND_STRL("\\DDTraceTesting\\Stub") ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal ns, exists", "./stubs/lookup/class/Stub.php", {
+    REQUIRE(zai_symbol_lookup_class_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC));
+})      

--- a/zend_abstract_interface/symbols/tests/api/class.cc
+++ b/zend_abstract_interface/symbols/tests/api/class.cc
@@ -1,14 +1,13 @@
 extern "C" {
 #include "symbols/symbols.h"
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal, exists", "./stubs/lookup/class/Stub.php", {
-    REQUIRE(zai_symbol_lookup_class_literal(ZEND_STRL("\\DDTraceTesting\\Stub") ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_STUB("symbol/api/class", "literal, exists", "./stubs/lookup/class/Stub.php", {
+    REQUIRE(zai_symbol_lookup_class_literal(ZEND_STRL("\\DDTraceTesting\\Stub") TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal ns, exists", "./stubs/lookup/class/Stub.php", {
-    REQUIRE(zai_symbol_lookup_class_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_STUB("symbol/api/class", "literal ns, exists", "./stubs/lookup/class/Stub.php", {
+    REQUIRE(zai_symbol_lookup_class_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/api/class.cc
+++ b/zend_abstract_interface/symbols/tests/api/class.cc
@@ -11,4 +11,4 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal, exists", "./stubs/loo
 
 ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/class", "literal ns, exists", "./stubs/lookup/class/Stub.php", {
     REQUIRE(zai_symbol_lookup_class_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC));
-})      
+})

--- a/zend_abstract_interface/symbols/tests/api/constant.cc
+++ b/zend_abstract_interface/symbols/tests/api/constant.cc
@@ -11,4 +11,4 @@ ZAI_SAPI_TEST_CASE("symbol/api/constant", "literal, exists", {
 
 ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/constant", "literal ns, exists", "./stubs/lookup/constant/Stub.php", {
     REQUIRE(zai_symbol_lookup_constant_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("DD_TRACE_TESTING") ZAI_TSRMLS_CC));
-})      
+})

--- a/zend_abstract_interface/symbols/tests/api/constant.cc
+++ b/zend_abstract_interface/symbols/tests/api/constant.cc
@@ -1,14 +1,13 @@
 extern "C" {
 #include "symbols/symbols.h"
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 
-ZAI_SAPI_TEST_CASE("symbol/api/constant", "literal, exists", {
-    REQUIRE(zai_symbol_lookup_constant_literal(ZEND_STRL("PHP_VERSION") ZAI_TSRMLS_CC));
+TEA_TEST_CASE("symbol/api/constant", "literal, exists", {
+    REQUIRE(zai_symbol_lookup_constant_literal(ZEND_STRL("PHP_VERSION") TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/constant", "literal ns, exists", "./stubs/lookup/constant/Stub.php", {
-    REQUIRE(zai_symbol_lookup_constant_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("DD_TRACE_TESTING") ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_STUB("symbol/api/constant", "literal ns, exists", "./stubs/lookup/constant/Stub.php", {
+    REQUIRE(zai_symbol_lookup_constant_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("DD_TRACE_TESTING") TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/api/constant.cc
+++ b/zend_abstract_interface/symbols/tests/api/constant.cc
@@ -1,0 +1,14 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+
+ZAI_SAPI_TEST_CASE("symbol/api/constant", "literal, exists", {
+    REQUIRE(zai_symbol_lookup_constant_literal(ZEND_STRL("PHP_VERSION") ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/constant", "literal ns, exists", "./stubs/lookup/constant/Stub.php", {
+    REQUIRE(zai_symbol_lookup_constant_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("DD_TRACE_TESTING") ZAI_TSRMLS_CC));
+})      

--- a/zend_abstract_interface/symbols/tests/api/function.cc
+++ b/zend_abstract_interface/symbols/tests/api/function.cc
@@ -11,4 +11,4 @@ ZAI_SAPI_TEST_CASE("symbol/api/function", "literal, exists", {
 
 ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/function", "literal ns, exists", "./stubs/lookup/function/Stub.php", {
     REQUIRE(zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("StubFunction") ZAI_TSRMLS_CC));
-})      
+})

--- a/zend_abstract_interface/symbols/tests/api/function.cc
+++ b/zend_abstract_interface/symbols/tests/api/function.cc
@@ -1,0 +1,14 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+
+ZAI_SAPI_TEST_CASE("symbol/api/function", "literal, exists", {
+    REQUIRE(zai_symbol_lookup_function_literal(ZEND_STRL("strlen") ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/function", "literal ns, exists", "./stubs/lookup/function/Stub.php", {
+    REQUIRE(zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("StubFunction") ZAI_TSRMLS_CC));
+})      

--- a/zend_abstract_interface/symbols/tests/api/function.cc
+++ b/zend_abstract_interface/symbols/tests/api/function.cc
@@ -1,14 +1,13 @@
 extern "C" {
 #include "symbols/symbols.h"
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 
-ZAI_SAPI_TEST_CASE("symbol/api/function", "literal, exists", {
-    REQUIRE(zai_symbol_lookup_function_literal(ZEND_STRL("strlen") ZAI_TSRMLS_CC));
+TEA_TEST_CASE("symbol/api/function", "literal, exists", {
+    REQUIRE(zai_symbol_lookup_function_literal(ZEND_STRL("strlen") TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/function", "literal ns, exists", "./stubs/lookup/function/Stub.php", {
-    REQUIRE(zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("StubFunction") ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_STUB("symbol/api/function", "literal ns, exists", "./stubs/lookup/function/Stub.php", {
+    REQUIRE(zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("StubFunction") TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/api/property.cc
+++ b/zend_abstract_interface/symbols/tests/api/property.cc
@@ -1,0 +1,15 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/property", "literal", "./stubs/lookup/property/Stub.php", {
+    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    REQUIRE(zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_CLASS, ce, ZEND_STRL("publicStatic") ZAI_TSRMLS_CC));
+})

--- a/zend_abstract_interface/symbols/tests/api/property.cc
+++ b/zend_abstract_interface/symbols/tests/api/property.cc
@@ -1,15 +1,14 @@
 extern "C" {
 #include "symbols/symbols.h"
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/api/property", "literal", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/api/property", "literal", "./stubs/lookup/property/Stub.php", {
     zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") ZAI_TSRMLS_CC);
+        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub") TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
-    REQUIRE(zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_CLASS, ce, ZEND_STRL("publicStatic") ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_CLASS, ce, ZEND_STRL("publicStatic") TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/call/internal.cc
+++ b/zend_abstract_interface/symbols/tests/call/internal.cc
@@ -71,3 +71,48 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "empty ns", {
     ZAI_VALUE_DTOR(param);
     ZAI_VALUE_DTOR(result);
 })
+
+ZAI_SAPI_TEST_CASE("symbol/call/internal", "named (macro)", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view fn = ZAI_STRL_VIEW("strlen");
+
+    zai_symbol_call_named(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);   
+})
+
+ZAI_SAPI_TEST_CASE("symbol/call/internal", "known (macro)", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view fn = ZAI_STRL_VIEW("strlen");
+    zend_function *fe = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn ZAI_TSRMLS_CC);
+
+    REQUIRE(fe);
+
+    zai_symbol_call_known(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, fe, &result ZAI_TSRMLS_CC, 1, &param);
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);   
+})

--- a/zend_abstract_interface/symbols/tests/call/internal.cc
+++ b/zend_abstract_interface/symbols/tests/call/internal.cc
@@ -90,7 +90,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "named (macro)", {
     REQUIRE(Z_LVAL_P(result) == 6);
 
     ZAI_VALUE_DTOR(param);
-    ZAI_VALUE_DTOR(result);   
+    ZAI_VALUE_DTOR(result);
 })
 
 ZAI_SAPI_TEST_CASE("symbol/call/internal", "known (macro)", {
@@ -114,5 +114,5 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "known (macro)", {
     REQUIRE(Z_LVAL_P(result) == 6);
 
     ZAI_VALUE_DTOR(param);
-    ZAI_VALUE_DTOR(result);   
+    ZAI_VALUE_DTOR(result);
 })

--- a/zend_abstract_interface/symbols/tests/call/internal.cc
+++ b/zend_abstract_interface/symbols/tests/call/internal.cc
@@ -1,16 +1,13 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE("symbol/call/internal", "global", {
+TEA_TEST_CASE("symbol/call/internal", "global", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -21,7 +18,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "global", {
 
     zai_string_view fn = ZAI_STRL_VIEW("\\strlen");
 
-    zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 1, &param);
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -30,7 +27,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "global", {
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE("symbol/call/internal", "root ns", {
+TEA_TEST_CASE("symbol/call/internal", "root ns", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -42,7 +39,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "root ns", {
     zai_string_view ns = ZAI_STRL_VIEW("\\");
     zai_string_view fn = ZAI_STRL_VIEW("strlen");
 
-    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 1, &param);
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -51,7 +48,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "root ns", {
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE("symbol/call/internal", "empty ns", {
+TEA_TEST_CASE("symbol/call/internal", "empty ns", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -63,7 +60,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "empty ns", {
     zai_string_view ns = ZAI_STRL_VIEW("");
     zai_string_view fn = ZAI_STRL_VIEW("strlen");
 
-    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 1, &param);
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -72,7 +69,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "empty ns", {
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE("symbol/call/internal", "named (macro)", {
+TEA_TEST_CASE("symbol/call/internal", "named (macro)", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -84,7 +81,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "named (macro)", {
 
     zai_string_view fn = ZAI_STRL_VIEW("strlen");
 
-    zai_symbol_call_named(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+    zai_symbol_call_named(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn, &result TEA_TSRMLS_CC, 1, &param);
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -93,7 +90,7 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "named (macro)", {
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE("symbol/call/internal", "known (macro)", {
+TEA_TEST_CASE("symbol/call/internal", "known (macro)", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -104,11 +101,11 @@ ZAI_SAPI_TEST_CASE("symbol/call/internal", "known (macro)", {
     ZAI_VALUE_INIT(result);
 
     zai_string_view fn = ZAI_STRL_VIEW("strlen");
-    zend_function *fe = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn ZAI_TSRMLS_CC);
+    zend_function *fe = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &fn TEA_TSRMLS_CC);
 
     REQUIRE(fe);
 
-    zai_symbol_call_known(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, fe, &result ZAI_TSRMLS_CC, 1, &param);
+    zai_symbol_call_known(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, fe, &result TEA_TSRMLS_CC, 1, &param);
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);

--- a/zend_abstract_interface/symbols/tests/call/internal.cc
+++ b/zend_abstract_interface/symbols/tests/call/internal.cc
@@ -1,0 +1,73 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE("symbol/call/internal", "global", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view fn = ZAI_STRL_VIEW("\\strlen");
+
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE("symbol/call/internal", "root ns", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\");
+    zai_string_view fn = ZAI_STRL_VIEW("strlen");
+
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE("symbol/call/internal", "empty ns", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("");
+    zai_string_view fn = ZAI_STRL_VIEW("strlen");
+
+    zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param);
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);
+})

--- a/zend_abstract_interface/symbols/tests/call/user.cc
+++ b/zend_abstract_interface/symbols/tests/call/user.cc
@@ -1,16 +1,13 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "global function", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "global function", "./stubs/call/user/Stub.php", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -21,7 +18,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "global function", "./stubs/cal
 
     zai_string_view fn = ZAI_STRL_VIEW("\\stub");
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 1, &param));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -30,7 +27,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "global function", "./stubs/cal
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "ns function", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "ns function", "./stubs/call/user/Stub.php", {
     zval *param;
 
     ZAI_VALUE_MAKE(param);
@@ -42,7 +39,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "ns function", "./stubs/call/us
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view fn = ZAI_STRL_VIEW("stub");
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 1, &param));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 6);
@@ -51,7 +48,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "ns function", "./stubs/call/us
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static public", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "static public", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -59,9 +56,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static public", "./stubs/call/
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
     zai_string_view fn = ZAI_STRL_VIEW("staticPublicFunction");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -69,7 +66,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static public", "./stubs/call/
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static protected", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "static protected", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -77,9 +74,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static protected", "./stubs/ca
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
     zai_string_view fn = ZAI_STRL_VIEW("staticProtectedFunction");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -87,7 +84,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static protected", "./stubs/ca
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static private", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "static private", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -95,9 +92,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static private", "./stubs/call
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
     zai_string_view fn = ZAI_STRL_VIEW("staticPrivateFunction");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -105,7 +102,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static private", "./stubs/call
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance public", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "instance public", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -115,13 +112,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance public", "./stubs/cal
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view fn = ZAI_STRL_VIEW("publicFunction");
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -130,7 +127,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance public", "./stubs/cal
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance protected", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "instance protected", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -140,13 +137,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance protected", "./stubs/
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view fn = ZAI_STRL_VIEW("protectedFunction");
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -155,7 +152,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance protected", "./stubs/
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance private", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "instance private", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -165,13 +162,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance private", "./stubs/ca
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view fn = ZAI_STRL_VIEW("privateFunction");
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(result) == IS_LONG);
     REQUIRE(Z_LVAL_P(result) == 42);
@@ -180,7 +177,7 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance private", "./stubs/ca
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "no magic", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "no magic", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
@@ -190,55 +187,55 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "no magic", "./stubs/call/user/
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("NoMagicCall");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view fn = ZAI_STRL_VIEW("nonExistent");
 
-    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "no abstract", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "no abstract", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("NoAbstractCall");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     zai_string_view fn = ZAI_STRL_VIEW("abstractFunction");
 
-    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static mismatch", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "static mismatch", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("NoStaticMismatch");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     zai_string_view fn = ZAI_STRL_VIEW("nonStaticFunction");
 
-    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "exception", "./stubs/call/user/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/call/user", "exception", "./stubs/call/user/Stub.php", {
     zval *result;
     ZAI_VALUE_INIT(result);
 
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("NoExceptionLeakage");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     zai_string_view fn = ZAI_STRL_VIEW("throwsException");
 
-    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result TEA_TSRMLS_CC, 0));
 })

--- a/zend_abstract_interface/symbols/tests/call/user.cc
+++ b/zend_abstract_interface/symbols/tests/call/user.cc
@@ -1,0 +1,244 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "global function", "./stubs/call/user/Stub.php", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view fn = ZAI_STRL_VIEW("\\stub");
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "ns function", "./stubs/call/user/Stub.php", {
+    zval *param;
+
+    ZAI_VALUE_MAKE(param);
+    ZAI_VALUE_STRINGL(param, "string", sizeof("string")-1);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view fn = ZAI_STRL_VIEW("stub");
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 1, &param));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 6);
+
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static public", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+    zai_string_view fn = ZAI_STRL_VIEW("staticPublicFunction");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static protected", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+    zai_string_view fn = ZAI_STRL_VIEW("staticProtectedFunction");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static private", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+    zai_string_view fn = ZAI_STRL_VIEW("staticPrivateFunction");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance public", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view fn = ZAI_STRL_VIEW("publicFunction");
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance protected", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view fn = ZAI_STRL_VIEW("protectedFunction");
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "instance private", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view fn = ZAI_STRL_VIEW("privateFunction");
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(result) == IS_LONG);
+    REQUIRE(Z_LVAL_P(result) == 42);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "no magic", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("NoMagicCall");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view fn = ZAI_STRL_VIEW("nonExistent");
+
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_OBJECT, object, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "no abstract", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("NoAbstractCall");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_string_view fn = ZAI_STRL_VIEW("abstractFunction");
+
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "static mismatch", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("NoStaticMismatch");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_string_view fn = ZAI_STRL_VIEW("nonStaticFunction");
+
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/call/user", "exception", "./stubs/call/user/Stub.php", {
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("NoExceptionLeakage");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zai_string_view fn = ZAI_STRL_VIEW("throwsException");
+
+    REQUIRE(!zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &fn, &result ZAI_TSRMLS_CC, 0));
+})

--- a/zend_abstract_interface/symbols/tests/lookup/class.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/class.cc
@@ -1,79 +1,76 @@
 extern "C" {
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "global, exists", {
+TEA_TEST_CASE("symbol/lookup/class", "global, exists", {
     zai_string_view lower = ZAI_STRL_VIEW("stdclass");
     zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower TEA_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "global, does not exist", {
+TEA_TEST_CASE("symbol/lookup/class", "global, does not exist", {
     zai_string_view lower = ZAI_STRL_VIEW("nosuchclass");
     zai_string_view mixed = ZAI_STRL_VIEW("NoSuchClass");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "empty ns, exists", {
+TEA_TEST_CASE("symbol/lookup/class", "empty ns, exists", {
     zai_string_view ns   = ZAI_STRL_VIEW("");
     zai_string_view lower = ZAI_STRL_VIEW("stdclass");
     zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower TEA_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns, exists", {
+TEA_TEST_CASE("symbol/lookup/class", "root ns, exists", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view lower = ZAI_STRL_VIEW("stdclass");
     zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower TEA_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns fqcn, exists", {
+TEA_TEST_CASE("symbol/lookup/class", "root ns fqcn, exists", {
     zai_string_view name = ZAI_STRL_VIEW("\\stdClass");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns, does not exist", {
+TEA_TEST_CASE("symbol/lookup/class", "root ns, does not exist", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view lower = ZAI_STRL_VIEW("nosuchclass");
     zai_string_view mixed = ZAI_STRL_VIEW("NoSuchClass");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns, exists", "./stubs/lookup/class/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns, exists", "./stubs/lookup/class/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view name = ZAI_STRL_VIEW("Stub");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns fqcn, exists", "./stubs/lookup/class/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns fqcn, exists", "./stubs/lookup/class/Stub.php", {
     zai_string_view name = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/class", "incorrect API usage", "[use][.]", {
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_CLASS, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_OBJECT, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_TAGS("symbol/lookup/class", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_CLASS, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_OBJECT, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/lookup/class.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/class.cc
@@ -1,0 +1,79 @@
+extern "C" {
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "global, exists", {
+    zai_string_view lower = ZAI_STRL_VIEW("stdclass");
+    zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "global, does not exist", {
+    zai_string_view lower = ZAI_STRL_VIEW("nosuchclass");
+    zai_string_view mixed = ZAI_STRL_VIEW("NoSuchClass");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "empty ns, exists", {
+    zai_string_view ns   = ZAI_STRL_VIEW("");
+    zai_string_view lower = ZAI_STRL_VIEW("stdclass");
+    zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns, exists", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view lower = ZAI_STRL_VIEW("stdclass");
+    zai_string_view mixed = ZAI_STRL_VIEW("stdClass");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns fqcn, exists", {
+    zai_string_view name = ZAI_STRL_VIEW("\\stdClass");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/class", "root ns, does not exist", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view lower = ZAI_STRL_VIEW("nosuchclass");
+    zai_string_view mixed = ZAI_STRL_VIEW("NoSuchClass");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns, exists", "./stubs/lookup/class/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view name = ZAI_STRL_VIEW("Stub");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/class", "ns fqcn, exists", "./stubs/lookup/class/Stub.php", {
+    zai_string_view name = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/class", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_CLASS, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_OBJECT, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
+})

--- a/zend_abstract_interface/symbols/tests/lookup/constant.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/constant.cc
@@ -1,0 +1,136 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "global, exists", {
+    zai_string_view name = ZAI_STRL_VIEW("PHP_VERSION");
+    zai_string_view mixed = ZAI_STRL_VIEW("Php_Version");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "global, does not exist", {
+    zai_string_view name = ZAI_STRL_VIEW("NO_SUCH_CONSTANT");
+    zai_string_view mixed = ZAI_STRL_VIEW("No_Such_Constant");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns, exists", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view name = ZAI_STRL_VIEW("PHP_VERSION");
+    zai_string_view mixed = ZAI_STRL_VIEW("Php_Version");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns fqn, exists", {
+    zai_string_view name = ZAI_STRL_VIEW("\\PHP_VERSION");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns, does not exist", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view name  = ZAI_STRL_VIEW("NO_SUCH_CONSTANT");
+    zai_string_view mixed = ZAI_STRL_VIEW("No_Such_Constant");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, exists", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
+
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(constant);
+    REQUIRE(Z_TYPE_P(constant) == IS_LONG);
+    REQUIRE(Z_LVAL_P(constant) == 42);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, does not exists", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TEST_CONSTANT_DOES_NOT_EXIST");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, exists", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn   = ZAI_STRL_VIEW("Stub");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(constant);
+    REQUIRE(Z_TYPE_P(constant) == IS_LONG);
+    REQUIRE(Z_LVAL_P(constant) == 42);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, does not exist", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn   = ZAI_STRL_VIEW("Stub");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING_DOES_NOT_EXIST");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, exists", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn   = ZAI_STRL_VIEW("Stub");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(constant);
+    REQUIRE(Z_TYPE_P(constant) == IS_LONG);
+    REQUIRE(Z_LVAL_P(constant) == 42);
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, does not exist", "./stubs/lookup/constant/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn   = ZAI_STRL_VIEW("Stub");
+    zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING_DOES_NOT_EXIST");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/constant", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+})

--- a/zend_abstract_interface/symbols/tests/lookup/constant.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/constant.cc
@@ -1,110 +1,107 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "global, exists", {
+TEA_TEST_CASE("symbol/lookup/constant", "global, exists", {
     zai_string_view name = ZAI_STRL_VIEW("PHP_VERSION");
     zai_string_view mixed = ZAI_STRL_VIEW("Php_Version");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "global, does not exist", {
+TEA_TEST_CASE("symbol/lookup/constant", "global, does not exist", {
     zai_string_view name = ZAI_STRL_VIEW("NO_SUCH_CONSTANT");
     zai_string_view mixed = ZAI_STRL_VIEW("No_Such_Constant");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns, exists", {
+TEA_TEST_CASE("symbol/lookup/constant", "root ns, exists", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view name = ZAI_STRL_VIEW("PHP_VERSION");
     zai_string_view mixed = ZAI_STRL_VIEW("Php_Version");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns fqn, exists", {
+TEA_TEST_CASE("symbol/lookup/constant", "root ns fqn, exists", {
     zai_string_view name = ZAI_STRL_VIEW("\\PHP_VERSION");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/constant", "root ns, does not exist", {
+TEA_TEST_CASE("symbol/lookup/constant", "root ns, does not exist", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view name  = ZAI_STRL_VIEW("NO_SUCH_CONSTANT");
     zai_string_view mixed = ZAI_STRL_VIEW("No_Such_Constant");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, exists", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, exists", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
 
-    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC);
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC);
 
     REQUIRE(constant);
     REQUIRE(Z_TYPE_P(constant) == IS_LONG);
     REQUIRE(Z_LVAL_P(constant) == 42);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, does not exists", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "ns, does not exists", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view name = ZAI_STRL_VIEW("DD_TEST_CONSTANT_DOES_NOT_EXIST");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, exists", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, exists", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn   = ZAI_STRL_VIEW("Stub");
     zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
     REQUIRE(constant);
     REQUIRE(Z_TYPE_P(constant) == IS_LONG);
     REQUIRE(Z_LVAL_P(constant) == 42);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, does not exist", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "class, does not exist", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn   = ZAI_STRL_VIEW("Stub");
     zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING_DOES_NOT_EXIST");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, exists", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, exists", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn   = ZAI_STRL_VIEW("Stub");
     zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
-    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+    zval *constant = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC);
 
     REQUIRE(constant);
     REQUIRE(Z_TYPE_P(constant) == IS_LONG);
@@ -113,24 +110,24 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, exists", "./stub
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, does not exist", "./stubs/lookup/constant/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/constant", "object, does not exist", "./stubs/lookup/constant/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn   = ZAI_STRL_VIEW("Stub");
     zai_string_view name = ZAI_STRL_VIEW("DD_TRACE_TESTING_DOES_NOT_EXIST");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/constant", "incorrect API usage", "[use][.]", {
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_TAGS("symbol/lookup/constant", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/lookup/function.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/function.cc
@@ -1,144 +1,141 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/function", "global, exists", {
+TEA_TEST_CASE("symbol/lookup/function", "global, exists", {
     zai_string_view lower = ZAI_STRL_VIEW("strlen");
     zai_string_view mixed = ZAI_STRL_VIEW("strLen");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower TEA_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/function", "global, does not exist", {
+TEA_TEST_CASE("symbol/lookup/function", "global, does not exist", {
     zai_string_view lower = ZAI_STRL_VIEW("nosuchfunction");
     zai_string_view mixed = ZAI_STRL_VIEW("NoSuchFunction");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns, exists", {
+TEA_TEST_CASE("symbol/lookup/function", "root ns, exists", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view lower = ZAI_STRL_VIEW("strlen");
     zai_string_view mixed = ZAI_STRL_VIEW("strLen");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower TEA_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns fqcn, exists", {
+TEA_TEST_CASE("symbol/lookup/function", "root ns fqcn, exists", {
     zai_string_view name = ZAI_STRL_VIEW("\\strlen");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns, does not exist", {
+TEA_TEST_CASE("symbol/lookup/function", "root ns, does not exist", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\");
     zai_string_view lower = ZAI_STRL_VIEW("nosuchfunction");
     zai_string_view mixed = ZAI_STRL_VIEW("NoSuchFunction");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns, exists", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns, exists", "./stubs/lookup/function/Stub.php", {
     zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view name = ZAI_STRL_VIEW("StubFunction");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns fqcn, exists", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns fqcn, exists", "./stubs/lookup/function/Stub.php", {
     zai_string_view name = ZAI_STRL_VIEW("\\DDTraceTesting\\StubFunction");
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, public", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, public", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsPublic");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, protected", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, protected", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsProtected");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, private", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, private", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsPrivate");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, public", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, public", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsPublic");
 
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method TEA_TSRMLS_CC));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, protected", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, protected", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsProtected");
 
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method TEA_TSRMLS_CC));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, private", "./stubs/lookup/function/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, private", "./stubs/lookup/function/Stub.php", {
     zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
     zai_string_view method = ZAI_STRL_VIEW("existsPrivate");
 
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope TEA_TSRMLS_CC);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
-    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method TEA_TSRMLS_CC));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/function", "incorrect API usage", "[use][.]", {
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_TAGS("symbol/lookup/function", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/lookup/function.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/function.cc
@@ -1,0 +1,144 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/function", "global, exists", {
+    zai_string_view lower = ZAI_STRL_VIEW("strlen");
+    zai_string_view mixed = ZAI_STRL_VIEW("strLen");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/function", "global, does not exist", {
+    zai_string_view lower = ZAI_STRL_VIEW("nosuchfunction");
+    zai_string_view mixed = ZAI_STRL_VIEW("NoSuchFunction");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &lower ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns, exists", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view lower = ZAI_STRL_VIEW("strlen");
+    zai_string_view mixed = ZAI_STRL_VIEW("strLen");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns fqcn, exists", {
+    zai_string_view name = ZAI_STRL_VIEW("\\strlen");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE("symbol/lookup/function", "root ns, does not exist", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\");
+    zai_string_view lower = ZAI_STRL_VIEW("nosuchfunction");
+    zai_string_view mixed = ZAI_STRL_VIEW("NoSuchFunction");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &lower ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &mixed ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns, exists", "./stubs/lookup/function/Stub.php", {
+    zai_string_view ns   = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view name = ZAI_STRL_VIEW("StubFunction");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "ns fqcn, exists", "./stubs/lookup/function/Stub.php", {
+    zai_string_view name = ZAI_STRL_VIEW("\\DDTraceTesting\\StubFunction");
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, public", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsPublic");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, protected", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsProtected");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "class method exists, private", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsPrivate");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &method ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, public", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsPublic");
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, protected", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsProtected");
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/function", "object method exists, private", "./stubs/lookup/function/Stub.php", {
+    zai_string_view scope = ZAI_STRL_VIEW("\\DDTraceTesting\\Stub");
+    zai_string_view method = ZAI_STRL_VIEW("existsPrivate");
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &scope ZAI_TSRMLS_CC);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    REQUIRE(zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_OBJECT, object, &method ZAI_TSRMLS_CC));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/function", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+})

--- a/zend_abstract_interface/symbols/tests/lookup/local/frame.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/local/frame.cc
@@ -1,0 +1,188 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+#include "zai_sapi/zai_sapi_extension.h"
+
+#include "zai_compat.h"
+
+static zval* ddtrace_testing_frame_result;
+
+ZEND_BEGIN_ARG_INFO_EX(ddtrace_testing_frame_intercept_arginfo, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+// clang-format off
+static PHP_FUNCTION(ddtrace_testing_frame_intercept) {
+#if PHP_VERSION_ID >= 70000
+    zend_execute_data* frame = EX(prev_execute_data);
+#else
+    zend_execute_data* frame =
+        EG(current_execute_data)
+            ->prev_execute_data;
+#endif
+    zai_string_view name = ZAI_STRL_VIEW("var");
+
+    zval* result = (zval*) zai_symbol_lookup(
+        ZAI_SYMBOL_TYPE_LOCAL,
+        ZAI_SYMBOL_SCOPE_FRAME,
+        frame, &name ZAI_TSRMLS_CC);
+
+    ZAI_VALUE_COPY(ddtrace_testing_frame_result, result);
+
+    RETURN_NULL();
+}
+
+static zend_function_entry ddtrace_testing_frame_extension_functions[] = {
+    PHP_FE(ddtrace_testing_frame_intercept, ddtrace_testing_frame_intercept_arginfo)
+    PHP_FE_END
+};
+
+static zend_module_entry ddtrace_testing_frame_extension = {
+    STANDARD_MODULE_HEADER,
+    "DDTraceTestingSymbolsLocalFrame",
+    ddtrace_testing_frame_extension_functions,  // Functions
+    NULL,  // MINIT
+    NULL,  // MSHUTDOWN
+    NULL,  // RINIT
+    NULL,  // RSHUTDOWN
+    NULL,  // Info function
+    PHP_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+// clang-format on
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "scalar", "./stubs/lookup/local/frame/Stub.php", {
+    zai_module.php_ini_ignore = 1;
+    zai_sapi_extension = ddtrace_testing_frame_extension;
+},{
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    ZAI_VALUE_MAKE(ddtrace_testing_frame_result);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("scalar");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_LONG);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "refcounted", "./stubs/lookup/local/frame/Stub.php", {
+    zai_module.php_ini_ignore = 1;
+    zai_sapi_extension = ddtrace_testing_frame_extension;
+},{
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    ZAI_VALUE_MAKE(ddtrace_testing_frame_result);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("refcounted");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_OBJECT);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "reference", "./stubs/lookup/local/frame/Stub.php", {
+    zai_module.php_ini_ignore = 1;
+    zai_sapi_extension = ddtrace_testing_frame_extension;
+},{
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    ZAI_VALUE_MAKE(ddtrace_testing_frame_result);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("reference");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_OBJECT);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "param", "./stubs/lookup/local/frame/Stub.php", {
+    zai_module.php_ini_ignore = 1;
+    zai_sapi_extension = ddtrace_testing_frame_extension;
+},{
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    ZAI_VALUE_MAKE(ddtrace_testing_frame_result);
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zval *param;
+    ZAI_VALUE_MAKE(param);
+
+    ZVAL_LONG(param, 42);
+
+    zai_string_view name = ZAI_STRL_VIEW("param");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 1, &param));
+
+    REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_LONG);
+
+    ZAI_VALUE_DTOR(result);
+    ZAI_VALUE_DTOR(param);
+    ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
+})
+

--- a/zend_abstract_interface/symbols/tests/lookup/local/frame.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/local/frame.cc
@@ -1,10 +1,7 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-#include "zai_sapi/zai_sapi_extension.h"
-
-#include "zai_compat.h"
+#include "tea/extension.h"
 
 static zval* ddtrace_testing_frame_result;
 
@@ -25,7 +22,7 @@ static PHP_FUNCTION(ddtrace_testing_frame_intercept) {
     zval* result = (zval*) zai_symbol_lookup(
         ZAI_SYMBOL_TYPE_LOCAL,
         ZAI_SYMBOL_SCOPE_FRAME,
-        frame, &name ZAI_TSRMLS_CC);
+        frame, &name TEA_TSRMLS_CC);
 
     ZAI_VALUE_COPY(ddtrace_testing_frame_result, result);
 
@@ -36,34 +33,21 @@ static zend_function_entry ddtrace_testing_frame_extension_functions[] = {
     PHP_FE(ddtrace_testing_frame_intercept, ddtrace_testing_frame_intercept_arginfo)
     PHP_FE_END
 };
-
-static zend_module_entry ddtrace_testing_frame_extension = {
-    STANDARD_MODULE_HEADER,
-    "DDTraceTestingSymbolsLocalFrame",
-    ddtrace_testing_frame_extension_functions,  // Functions
-    NULL,  // MINIT
-    NULL,  // MSHUTDOWN
-    NULL,  // RINIT
-    NULL,  // RSHUTDOWN
-    NULL,  // Info function
-    PHP_VERSION,
-    STANDARD_MODULE_PROPERTIES
-};
 // clang-format on
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "scalar", "./stubs/lookup/local/frame/Stub.php", {
-    zai_module.php_ini_ignore = 1;
-    zai_sapi_extension = ddtrace_testing_frame_extension;
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "scalar", "./stubs/lookup/local/frame/Stub.php", {
+    tea_sapi_module.php_ini_ignore = 1;
+    tea_extension_functions(ddtrace_testing_frame_extension_functions);
 },{
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -77,9 +61,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "scalar"
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("scalar");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_LONG);
 
@@ -87,14 +71,14 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "scalar"
     ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "refcounted", "./stubs/lookup/local/frame/Stub.php", {
-    zai_module.php_ini_ignore = 1;
-    zai_sapi_extension = ddtrace_testing_frame_extension;
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "refcounted", "./stubs/lookup/local/frame/Stub.php", {
+    tea_sapi_module.php_ini_ignore = 1;
+    tea_extension_functions(ddtrace_testing_frame_extension_functions);
 },{
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -108,9 +92,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "refcoun
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("refcounted");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_OBJECT);
 
@@ -118,14 +102,14 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "refcoun
     ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "reference", "./stubs/lookup/local/frame/Stub.php", {
-    zai_module.php_ini_ignore = 1;
-    zai_sapi_extension = ddtrace_testing_frame_extension;
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "reference", "./stubs/lookup/local/frame/Stub.php", {
+    tea_sapi_module.php_ini_ignore = 1;
+    tea_extension_functions(ddtrace_testing_frame_extension_functions);
 },{
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -139,9 +123,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "referen
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("reference");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_OBJECT);
 
@@ -149,14 +133,14 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "referen
     ZAI_VALUE_DTOR(ddtrace_testing_frame_result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "param", "./stubs/lookup/local/frame/Stub.php", {
-    zai_module.php_ini_ignore = 1;
-    zai_sapi_extension = ddtrace_testing_frame_extension;
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "param", "./stubs/lookup/local/frame/Stub.php", {
+    tea_sapi_module.php_ini_ignore = 1;
+    tea_extension_functions(ddtrace_testing_frame_extension_functions);
 },{
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -175,9 +159,9 @@ ZAI_SAPI_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/lookup/local/frame", "param",
     ZVAL_LONG(param, 42);
 
     zai_string_view name = ZAI_STRL_VIEW("param");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 1, &param));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 1, &param));
 
     REQUIRE(Z_TYPE_P(ddtrace_testing_frame_result) == IS_LONG);
 

--- a/zend_abstract_interface/symbols/tests/lookup/local/static.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/local/static.cc
@@ -1,20 +1,17 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lookup/local/static/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lookup/local/static/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -26,13 +23,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lo
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("scalar");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     zai_string_view var = ZAI_STRL_VIEW("var");
 
-    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     REQUIRE(Z_TYPE_P(local) == IS_LONG);
@@ -41,11 +38,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lo
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stubs/lookup/local/static/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stubs/lookup/local/static/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -57,13 +54,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stub
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("refcounted");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     zai_string_view var = ZAI_STRL_VIEW("var");
 
-    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     REQUIRE(Z_TYPE_P(local) == IS_OBJECT);
@@ -71,11 +68,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stub
     ZAI_VALUE_DTOR(result);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs/lookup/local/static/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs/lookup/local/static/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -87,13 +84,13 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("reference");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
 
     zai_string_view var = ZAI_STRL_VIEW("var");
 
-    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     /* This may seem counter intuitive, this is how we expect zend (and so zai) to behave though ... */

--- a/zend_abstract_interface/symbols/tests/lookup/local/static.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/local/static.cc
@@ -1,0 +1,103 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lookup/local/static/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("scalar");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    zai_string_view var = ZAI_STRL_VIEW("var");
+
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+
+    REQUIRE(local);
+    REQUIRE(Z_TYPE_P(local) == IS_LONG);
+    REQUIRE(Z_LVAL_P(local) == 42);
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stubs/lookup/local/static/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("refcounted");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    zai_string_view var = ZAI_STRL_VIEW("var");
+
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+
+    REQUIRE(local);
+    REQUIRE(Z_TYPE_P(local) == IS_OBJECT);
+
+    ZAI_VALUE_DTOR(result);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs/lookup/local/static/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    zai_string_view name = ZAI_STRL_VIEW("reference");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result ZAI_TSRMLS_CC, 0));
+
+    zai_string_view var = ZAI_STRL_VIEW("var");
+
+    zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var ZAI_TSRMLS_CC);
+
+    REQUIRE(local);
+    /* This may seem counter intuitive, this is how we expect zend (and so zai) to behave though ... */
+    REQUIRE(Z_TYPE_P(local) == IS_NULL);
+
+    ZAI_VALUE_DTOR(result);
+})

--- a/zend_abstract_interface/symbols/tests/lookup/property.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/property.cc
@@ -1,20 +1,17 @@
 extern "C" {
 #include "value/value.h"
 #include "symbols/symbols.h"
-#include "zai_sapi/zai_sapi.h"
-
-#include "zai_compat.h"
 }
 
-#include "zai_sapi/testing/catch2.hpp"
+#include "tea/testing/catch2.hpp"
 #include <cstdlib>
 #include <cstring>
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public static", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "public static", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -24,18 +21,18 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public static", "./stubs
 
     zai_string_view name = ZAI_STRL_VIEW("publicStatic");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
     REQUIRE(Z_LVAL_P(property) == 42);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected static", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected static", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -45,18 +42,18 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected static", "./st
 
     zai_string_view name = ZAI_STRL_VIEW("protectedStatic");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
     REQUIRE(Z_LVAL_P(property) == 42);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private static", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "private static", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -66,18 +63,18 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private static", "./stub
 
     zai_string_view name = ZAI_STRL_VIEW("privateStatic");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
     REQUIRE(Z_LVAL_P(property) == 42);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "static access instance property", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "static access instance property", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -87,14 +84,14 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "static access instance p
 
     zai_string_view name = ZAI_STRL_VIEW("publicProperty");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared static", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared static", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -104,14 +101,14 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared static", "./s
 
     zai_string_view name = ZAI_STRL_VIEW("undeclaredStaticProperty");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC));
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "public", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -122,11 +119,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public", "./stubs/lookup
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view name = ZAI_STRL_VIEW("publicProperty");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
@@ -135,11 +132,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public", "./stubs/lookup
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -150,11 +147,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected", "./stubs/loo
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view name = ZAI_STRL_VIEW("protectedProperty");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
@@ -163,11 +160,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected", "./stubs/loo
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "private", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -178,11 +175,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private", "./stubs/looku
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view name = ZAI_STRL_VIEW("privateProperty");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
@@ -191,11 +188,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private", "./stubs/looku
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "dynamic", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "dynamic", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -206,11 +203,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "dynamic", "./stubs/looku
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view name = ZAI_STRL_VIEW("dynamicProperty");
 
-    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC);
 
     REQUIRE(property);
     REQUIRE(Z_TYPE_P(property) == IS_LONG);
@@ -219,11 +216,11 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "dynamic", "./stubs/looku
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared", "./stubs/lookup/property/Stub.php", {
+TEA_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared", "./stubs/lookup/property/Stub.php", {
     zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
     zai_string_view cn = ZAI_STRL_VIEW("Stub");
 
-    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn TEA_TSRMLS_CC);
 
     REQUIRE(ce);
 
@@ -234,18 +231,18 @@ ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared", "./stubs/lo
     zval *object;
     ZAI_VALUE_MAKE(object);
 
-    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+    zai_symbol_new(object, ce TEA_TSRMLS_CC, 0);
 
     zai_string_view name = ZAI_STRL_VIEW("undeclaredProperty");
 
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name TEA_TSRMLS_CC));
 
     ZAI_VALUE_DTOR(object);
 })
 
-ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/property", "incorrect API usage", "[use][.]", {
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_NAMESPACE, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
-    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+TEA_TEST_CASE_WITH_TAGS("symbol/lookup/property", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_NAMESPACE, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL TEA_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL TEA_TSRMLS_CC));
 })

--- a/zend_abstract_interface/symbols/tests/lookup/property.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/property.cc
@@ -1,0 +1,251 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "zai_sapi/zai_sapi.h"
+
+#include "zai_compat.h"
+}
+
+#include "zai_sapi/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public static", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zai_string_view name = ZAI_STRL_VIEW("publicStatic");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected static", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zai_string_view name = ZAI_STRL_VIEW("protectedStatic");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private static", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zai_string_view name = ZAI_STRL_VIEW("privateStatic");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "static access instance property", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zai_string_view name = ZAI_STRL_VIEW("publicProperty");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared static", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zai_string_view name = ZAI_STRL_VIEW("undeclaredStaticProperty");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_CLASS, ce, &name ZAI_TSRMLS_CC));
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "public", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view name = ZAI_STRL_VIEW("publicProperty");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "protected", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view name = ZAI_STRL_VIEW("protectedProperty");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "private", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view name = ZAI_STRL_VIEW("privateProperty");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "dynamic", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view name = ZAI_STRL_VIEW("dynamicProperty");
+
+    zval *property = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC);
+
+    REQUIRE(property);
+    REQUIRE(Z_TYPE_P(property) == IS_LONG);
+    REQUIRE(Z_LVAL_P(property) == 42);
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_STUB("symbol/lookup/property", "undeclared", "./stubs/lookup/property/Stub.php", {
+    zai_string_view ns = ZAI_STRL_VIEW("\\DDTraceTesting");
+    zai_string_view cn = ZAI_STRL_VIEW("Stub");
+
+    zend_class_entry *ce = (zend_class_entry*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, ZAI_SYMBOL_SCOPE_NAMESPACE, &ns, &cn ZAI_TSRMLS_CC);
+
+    REQUIRE(ce);
+
+    if (!ce) {
+        return;
+    }
+
+    zval *object;
+    ZAI_VALUE_MAKE(object);
+
+    zai_symbol_new(object, ce ZAI_TSRMLS_CC, 0);
+
+    zai_string_view name = ZAI_STRL_VIEW("undeclaredProperty");
+
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_OBJECT, object, &name ZAI_TSRMLS_CC));
+
+    ZAI_VALUE_DTOR(object);
+})
+
+ZAI_SAPI_TEST_CASE_WITH_TAGS("symbol/lookup/property", "incorrect API usage", "[use][.]", {
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_GLOBAL, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_NAMESPACE, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_STATIC, NULL, NULL ZAI_TSRMLS_CC));
+    REQUIRE(!zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, ZAI_SYMBOL_SCOPE_FRAME, NULL, NULL ZAI_TSRMLS_CC));
+})

--- a/zend_abstract_interface/symbols/tests/stubs/call/user/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/call/user/Stub.php
@@ -1,0 +1,86 @@
+<?php
+namespace DDTraceTesting {
+    class Base {
+        public static function staticPublicFunction() {
+            return 24;
+        }
+
+        protected static function staticProtectedFunction() {
+            return 24;
+        }
+
+        private static function staticPrivateFunction() {
+            return 24;
+        }
+
+        public function publicFunction() {
+            return 24;
+        }
+
+        public function protectedFunction() {
+            return 24;
+        }
+
+        public function privateFunction() {
+            return 24;
+        }
+    }
+
+    class Stub extends Base {
+        public static function staticPublicFunction() {
+            return 42;
+        }
+
+        protected static function staticProtectedFunction() {
+            return 42;
+        }
+
+        private static function staticPrivateFunction() {
+            return 42;
+        }
+
+        public function publicFunction() {
+            return 42;
+        }
+
+        public function protectedFunction() {
+            return 42;
+        }
+
+        public function privateFunction() {
+            return 42;
+        }
+    }
+
+    class NoMagicCall {
+        public function __call($name, $args) {
+            /* Will not be called for non-existent case */
+            return 42;
+        }
+    }
+
+    abstract class NoAbstractCall {
+        public abstract function abstractFunction();
+    }
+
+    class NoStaticMismatch {
+        public function nonStaticFunction() {}
+    }
+
+    class NoExceptionLeakage {
+        public static function throwsException() {
+            throw new RuntimeException();
+        }
+    }
+
+    function stub($param) {
+        return strlen($param);
+    }
+}
+
+namespace {
+    function stub($param) {
+        return \DDTraceTesting\stub($param);
+    }
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/call/user/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/call/user/Stub.php
@@ -76,6 +76,8 @@ namespace DDTraceTesting {
     function stub($param) {
         return strlen($param);
     }
+    
+    function noargs() {}
 }
 
 namespace {

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/class/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/class/Stub.php
@@ -1,0 +1,7 @@
+<?php
+namespace DDTraceTesting;
+
+class Stub {
+
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/constant/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/constant/Stub.php
@@ -1,0 +1,9 @@
+<?php
+namespace DDTraceTesting;
+
+const DD_TRACE_TESTING = 42;
+
+class Stub {
+    const DD_TRACE_TESTING = 42;
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/function/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/function/Stub.php
@@ -1,0 +1,11 @@
+<?php
+namespace DDTraceTesting;
+
+class Stub {
+    public function existsPublic() {}
+    protected function existsProtected() {}
+    private function existsPrivate() {}
+}
+
+function StubFunction() {}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/local/frame/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/local/frame/Stub.php
@@ -1,0 +1,30 @@
+<?php
+namespace DDTraceTesting;
+
+class Stub {
+
+    public static function scalar() {
+        $var = 42;
+
+        \ddtrace_testing_frame_intercept();
+    }
+
+    public static function refcounted() {
+        $var = new self();
+
+        \ddtrace_testing_frame_intercept();
+    }
+
+    public static function reference() {
+        $bar = new self();
+ 
+        $var =& $bar;
+
+        \ddtrace_testing_frame_intercept();
+    }
+
+    public static function param($var) {
+        \ddtrace_testing_frame_intercept();
+    }
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/local/static/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/local/static/Stub.php
@@ -1,0 +1,35 @@
+<?php
+namespace DDTraceTesting;
+
+class Stub {
+
+    public static function scalar() {
+        static $var;
+
+        if (!$var) {
+            $var = 42;
+        }
+    }
+
+    public static function refcounted() {
+        static $var;
+
+        if (!$var) {
+            $var = new self();
+        }
+    }
+
+    public static function reference() {
+        static $var, $bar;
+
+        if (!$bar) {
+            $bar = new self();
+        }
+ 
+        if (!$var) {
+            /* will not survive call boundary */
+            $var = &$bar;
+        }
+    }
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/property/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/property/Stub.php
@@ -1,0 +1,28 @@
+<?php
+namespace DDTraceTesting;
+
+class Base {
+    public static $publicStatic = 24;
+    protected static $protectedStatic = 24;
+    private static $privateStatic = 24;
+
+    public $publicProperty = 24;
+    protected $protectedProperty = 24;
+    private $privateProperty = 24;
+}
+
+class Stub extends Base {
+
+    public function __construct() {
+        $this->dynamicProperty = 42;
+    }
+
+    public static $publicStatic = 42;
+    protected static $protectedStatic = 42;
+    private static $privateStatic = 42;
+
+    public $publicProperty = 42;
+    protected $protectedProperty = 42;
+    private $privateProperty = 42;
+}
+?>


### PR DESCRIPTION
### Description

Accessing symbols will be an integral part of the new integrations we are working on migrating from PHP. We currently have multiple incomplete interfaces which ZAI Symbols replaces with access to all of the following via a single interface:

   - classes (global, namespace)
   - functions (global, namespace, class, object)
   - constants (global, namespace, class, object)
   - properties (class, object)
   - locals (function static, frame)

Symbols also contains a call interface and a `new` interface.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
