### PR TITLE
Strip query string from http.url

### DIFF
--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -435,6 +435,11 @@ static smart_str dd_build_req_url(TSRMLS_D) {
         return url_str;
     }
 
+    char *question_mark = strchr(uri, '?');
+    if (question_mark) {
+        uri_len = question_mark - uri;
+    }
+
     zend_bool is_https = zend_hash_exists(Z_ARRVAL_P(_server), ZEND_STRS("HTTPS"));
 
     zval **host_zv;

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -441,6 +441,11 @@ static zend_string *dd_build_req_url() {
         }
     }
 
+    char *question_mark = strchr(uri, '?');
+    if (question_mark) {
+        uri_len = question_mark - uri;
+    }
+
     zend_bool is_https = zend_hash_str_exists(Z_ARRVAL_P(_server), ZEND_STRL("HTTPS"));
 
     zval *host_zv;

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -436,6 +436,11 @@ static zend_string *dd_build_req_url() {
         }
     }
 
+    char *question_mark = strchr(uri, '?');
+    if (question_mark) {
+        uri_len = question_mark - uri;
+    }
+
     zend_bool is_https = zend_hash_str_exists(Z_ARRVAL_P(_server), ZEND_STRL("HTTPS"));
 
     zval *host_zv;

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -8,7 +8,7 @@ HTTPS=on
 SERVER_NAME=localhost:8888
 HTTP_HOST=localhost:9999
 SCRIPT_NAME=/foo.php
-REQUEST_URI=/foo
+REQUEST_URI=/foo?with_to_be_stripped?query_string
 METHOD=GET
 --GET--
 foo=bar


### PR DESCRIPTION
### Description

Strips everything including and after the ? from an url.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
