### PR TITLE
Make consistent (working) ASAN builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,10 @@ build_zai_asan:
 	CMAKE_PREFIX_PATH=/opt/catch2 \
 	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
 	cmake \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -DBUILD_ZAI_TESTING=ON \
-        -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
-        -DPHP_CONFIG=$(shell which php-config) \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DBUILD_ZAI_TESTING=ON \
+		-DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
+		-DPHP_CONFIG=$(shell which php-config) \
 	$(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) clean $(MAKEFLAGS); \
 	$(MAKE) $(MAKEFLAGS); \

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ clean_components:
 	rm -rf $(COMPONENTS_BUILD_DIR)
 
 dist_clean:
-	rm -rf $(BUILD_DIR) $(ZAI_BUILD_DIR) $(COMPONENTS_BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(ZAI_SAPI_BUILD_DIR) $(ZAI_BUILD_DIR) $(COMPONENTS_BUILD_DIR)
 
 clean:
 	if [[ -f "$(BUILD_DIR)/Makefile" ]]; then $(MAKE) -C $(BUILD_DIR) clean; fi

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build_zai_sapi_asan:
 		-DCMAKE_INSTALL_PREFIX=$(ZAI_SAPI_INSTALL_DIR) \
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DBUILD_ZAI_SAPI_TESTING=$(ZAI_SAPI_BUILD_TESTS) \
-		-DBUILD_ZAI_SAPI_ASAN=ON \
+		-DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
 		-DPHP_CONFIG=$(shell which php-config) \
 	$(PROJECT_ROOT)/zai_sapi; \
 	$(MAKE) $(MAKEFLAGS); \
@@ -210,7 +210,12 @@ build_zai_asan:
 	cd $(ZAI_BUILD_DIR); \
 	CMAKE_PREFIX_PATH=/opt/catch2 \
 	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
-	cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_ZAI_TESTING=ON -DBUILD_ZAI_ASAN=ON -DPHP_CONFIG=$(shell which php-config) $(PROJECT_ROOT)/zend_abstract_interface; \
+	cmake \
+	    -DCMAKE_BUILD_TYPE=Debug \
+	    -DBUILD_ZAI_TESTING=ON \
+	    -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
+	    -DPHP_CONFIG=$(shell which php-config) \
+	$(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) clean $(MAKEFLAGS); \
 	$(MAKE) $(MAKEFLAGS); \
 	)

--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,10 @@ build_zai_asan:
 	CMAKE_PREFIX_PATH=/opt/catch2 \
 	ZaiSapi_ROOT=$(ZAI_SAPI_INSTALL_DIR) \
 	cmake \
-	    -DCMAKE_BUILD_TYPE=Debug \
-	    -DBUILD_ZAI_TESTING=ON \
-	    -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
-	    -DPHP_CONFIG=$(shell which php-config) \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DBUILD_ZAI_TESTING=ON \
+        -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/cmake/asan.cmake \
+        -DPHP_CONFIG=$(shell which php-config) \
 	$(PROJECT_ROOT)/zend_abstract_interface; \
 	$(MAKE) clean $(MAKEFLAGS); \
 	$(MAKE) $(MAKEFLAGS); \

--- a/zai_sapi/CMakeLists.txt
+++ b/zai_sapi/CMakeLists.txt
@@ -73,14 +73,6 @@ set_target_properties(ZaiSapi PROPERTIES VERSION ${PROJECT_VERSION})
 
 add_library(ZaiSapi::ZaiSapi ALIAS ZaiSapi)
 
-option(BUILD_ZAI_SAPI_ASAN "Enable ASAN" OFF)
-if(${BUILD_ZAI_ASAN})
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-endif()
-
 option(BUILD_ZAI_SAPI_TESTING "Enable ZAI SAPI tests" OFF)
 if(${BUILD_ZAI_SAPI_TESTING})
 

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -26,14 +26,6 @@ if(${BUILD_ZAI_TESTING})
   enable_testing()
 endif()
 
-option(BUILD_ZAI_ASAN "Enable ASAN" OFF)
-if(${BUILD_ZAI_ASAN})
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-endif()
-
 option(RUN_SHARED_EXTS_TESTS "Enable shared extension tests" OFF)
 if(${RUN_SHARED_EXTS_TESTS})
   add_definitions(-DRUN_SHARED_EXTS_TESTS)


### PR DESCRIPTION
### Description

CI and makefile builds were configured differently causing local asan builds to fail.

This change uses the toolchain file for both makefile and CI builds for ZAI SAPI and ZAI.

It drops the option from both ZAI and ZAI SAPI in favour of the working, more precise toolchain file that was already present.

Also fix dist_clean (another cause of build failures)