### PR TITLE
Clear the root span when dropped

### DIFF
--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -211,6 +211,11 @@ void ddtrace_drop_top_open_span(TSRMLS_D) {
     DDTRACE_G(open_spans_top) = span_fci->next;
     // Sync with span ID stack
     ddtrace_pop_span_id(TSRMLS_C);
+
+    if (DDTRACE_G(open_spans_top) == NULL) {
+        DDTRACE_G(root_span) = NULL;
+    }
+
     zend_objects_store_del_ref_by_handle(span_fci->span.obj_value.handle TSRMLS_CC);
 }
 

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -207,6 +207,11 @@ void ddtrace_drop_top_open_span(void) {
     DDTRACE_G(open_spans_top) = span_fci->next;
     // Sync with span ID stack
     ddtrace_pop_span_id();
+
+    if (DDTRACE_G(open_spans_top) == NULL) {
+        DDTRACE_G(root_span) = NULL;
+    }
+
     OBJ_RELEASE(&span_fci->span.std);
 }
 

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -206,6 +206,11 @@ void ddtrace_drop_top_open_span(void) {
     DDTRACE_G(open_spans_top) = span_fci->next;
     // Sync with span ID stack
     ddtrace_pop_span_id();
+
+    if (DDTRACE_G(open_spans_top) == NULL) {
+        DDTRACE_G(root_span) = NULL;
+    }
+
     OBJ_RELEASE(&span_fci->span.std);
 }
 

--- a/tests/ext/disabling_root_span_generation_at_runtime.phpt
+++ b/tests/ext/disabling_root_span_generation_at_runtime.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Disabling root span removes the root span properly
+--FILE--
+<?php
+ini_set("datadog.trace.generate_root_span", false);
+var_dump(DDTrace\root_span());
+?>
+--EXPECT--
+NULL


### PR DESCRIPTION
### Description

Will segfault (or at least leak) when datadog.trace.generate_root_span is switched from true to false if only a root span is present.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
