### PR TITLE
fix symbols build and call issues

### DIFF
--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -2,24 +2,247 @@
 
 #include <ctype.h>
 #include <sandbox/sandbox.h>
-#include <zai_assert/zai_assert.h>
 
-static inline void zai_symbol_call_argv(zend_fcall_info *fci, uint32_t argc, va_list *args ZAI_TSRMLS_DC) {
-#if PHP_VERSION_ID < 70000
-    fci->params = emalloc(argc * sizeof(zval **));
-#else
-    fci->params = emalloc(argc * sizeof(zval));
+#include <Zend/zend_closures.h>
+
+/*
+ * This interface is focused on making calls as an observer, it tries to avoid visible side effects
+ *
+ * Calls are executed with functions, runtime caches, and arguments allocated with a single emalloc
+ *
+ * When a user function is called that has not yet been initialized it is the callers
+ * responsibility to initialize the function. Which means allocating a run time cache, sometimes copying the function.
+ *
+ * Some versions of PHP export some API, which has visible side effecfs, such as allocating on the compilers
+ * arena, or setting map pointers, or otherwise mutating the runtime.
+ *
+ * Trying to decide how to use the API, on which versions of PHP, leads to difficult to read and understand code
+ *
+ * The requirements of a call are simple to model, and in taking care of every detail, consistently across versions
+ * of PHP, we produce an interface that is much easier to debug, and achieves the goal of avoiding visible side effects
+ *
+ */
+
+#if PHP_VERSION_ID >= 50400
+#define ZAI_SYMBOL_CALL_ZE2
 #endif
+
+#if PHP_VERSION_ID >= 70000
+#define ZAI_SYMBOL_CALL_ZE3
+#endif
+
+#if PHP_VERSION_ID >= 80000
+#define ZAI_SYMBOL_CALL_ZE4
+#endif
+
+#if defined(ZEND_MAP_PTR_INIT)
+#define ZAI_SYMBOL_CALL_MAP
+#endif
+
+#if PHP_VERSION_ID < 70300
+#define ZAI_SYMBOL_CALL_FCC_INITIALIZE
+#endif
+
+/* {{{ private arena code */
+typedef struct {
+    char *base;
+    char *ptr;
+    size_t used;
+    size_t size;
+} zai_symbol_call_arena_t;
+
+static inline void zai_symbol_call_arena_create(zai_symbol_call_arena_t *arena, zend_fcall_info_cache *fcc,
+                                                uint32_t argc) {
+    zend_function *fbc = fcc->function_handler;
+
+    size_t zai_symbol_call_arena_size = 0;
+
+    if (fbc->type == ZEND_USER_FUNCTION) {
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(sizeof(zend_op_array));
+
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(fbc->op_array.cache_size);
+#elif defined(ZAI_SYMBOL_CALL_ZE2)
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(fbc->op_array.last_cache_slot * sizeof(void *));
+#endif
+
+#if defined(ZAI_SYMBOL_CALL_MAP)
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(sizeof(void *));
+#endif
+    } else {
+        if (fbc->common.scope != fcc->called_scope) {
+            zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(sizeof(zend_internal_function));
+        }
+    }
+
+    if (argc) {
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(sizeof(zval) * argc);
+#else
+        zai_symbol_call_arena_size += ZEND_MM_ALIGNED_SIZE(sizeof(zval **) * argc);
+#endif
+    }
+
+    if (!zai_symbol_call_arena_size) {
+        memset(arena, 0, sizeof(zai_symbol_call_arena_t));
+        return;
+    }
+
+    arena->base = emalloc(zai_symbol_call_arena_size);
+
+    memset(arena->base, 0, zai_symbol_call_arena_size);
+
+    arena->ptr = arena->base;
+    arena->size = zai_symbol_call_arena_size;
+    arena->used = 0;
+}
+
+static inline void *zai_symbol_call_arena_alloc(zai_symbol_call_arena_t *arena, size_t size) {
+    size = ZEND_MM_ALIGNED_SIZE(size);
+
+    if ((arena->used + size) > arena->size) {
+        return NULL;
+    }
+
+    char *ptr = arena->ptr;
+
+    arena->ptr = ptr + size;
+    arena->used += size;
+
+    return ptr;
+}
+
+static inline void zai_symbol_call_arena_release(zai_symbol_call_arena_t *arena) {
+    if (!arena->size) {
+        return;
+    }
+
+    efree(arena->base);
+} /* }}} */
+
+/* {{{ private call code */
+static inline void zai_symbol_call_argv(zai_symbol_call_arena_t *arena, zend_fcall_info *fci, uint32_t argc,
+                                        va_list *args) {
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+    size_t zai_symbol_call_argv_size = sizeof(zval) * argc;
+#else
+    size_t zai_symbol_call_argv_size = sizeof(zval **) * argc;
+#endif
+
+    fci->params = zai_symbol_call_arena_alloc(arena, zai_symbol_call_argv_size);
+
     for (uint32_t arg = 0; arg < argc; arg++) {
         zval **param = va_arg(*args, zval **);
-#if PHP_VERSION_ID < 70000
-        fci->params[arg] = param;
-#else
+
+#if defined(ZAI_SYMBOL_CALL_ZE3)
         ZVAL_COPY_VALUE(&fci->params[arg], *param);
+#else
+        fci->params[arg] = param;
 #endif
     }
     fci->param_count = argc;
 }
+
+static inline zend_function *zai_symbol_call_init_internal(zai_symbol_call_arena_t *arena,
+                                                           zend_internal_function *function, zend_class_entry *scope) {
+    /* we only need to copy internal functions if we are mutating */
+    if (function->scope == scope) {
+        return (zend_function *)function;
+    }
+
+    zend_internal_function *allocated = zai_symbol_call_arena_alloc(arena, sizeof(zend_internal_function));
+
+    memcpy(allocated, function, sizeof(zend_internal_function));
+
+#if defined(ZEND_ACC_NEVER_CACHE)
+    /* should this function ever find it's way to an
+        INIT, it would be terrible if it were cached */
+    allocated->fn_flags |= ZEND_ACC_NEVER_CACHE;
+#endif
+
+    /* scope this copied function */
+    allocated->scope = scope;
+
+    return (zend_function *)allocated;
+}
+
+static inline zend_function *zai_symbol_call_init_user(zai_symbol_call_arena_t *arena, zend_op_array *ops,
+                                                       zend_class_entry *scope) {
+    size_t zai_symbol_call_init_size = sizeof(zend_op_array);
+
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+    zai_symbol_call_init_size += ops->cache_size;
+#elif defined(ZAI_SYMBOL_CALL_ZE2)
+    zai_symbol_call_init_size += ops->last_cache_slot * sizeof(void *);
+#endif
+
+#if defined(ZAI_SYMBOL_CALL_MAP)
+    zai_symbol_call_init_size += sizeof(void *);
+#endif
+
+    zend_op_array *allocated = zai_symbol_call_arena_alloc(arena, zai_symbol_call_init_size);
+
+    memcpy(allocated, ops, sizeof(zend_op_array));
+
+#if defined(ZAI_SYMBOL_CALL_ZE2)
+    /* get run time cache address */
+    void *rtc = (void **)(allocated + 1);
+
+#if defined(ZAI_SYMBOL_CALL_MAP)
+    /* initialize cache address ptr, uses sizeof(void*) */
+    ZEND_MAP_PTR_INIT(allocated->run_time_cache, rtc);
+
+    /* get actual runtime cache address, after map pointer */
+    rtc = (char *)rtc + sizeof(void *);
+
+    /* map cache address */
+    ZEND_MAP_PTR_SET(allocated->run_time_cache, rtc);
+#else
+    /* set cache address */
+    allocated->run_time_cache = rtc;
+#endif
+
+    /* zero run time cache */
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+    memset(rtc, 0, allocated->cache_size);
+#else
+    memset(rtc, 0, allocated->last_cache_slot * sizeof(void *));
+#endif
+
+#endif /* if defined(ZAI_SYMBOL_CALL_ZE2) */
+
+    /* the cache is on the heap, however, we are going to free it */
+#if defined(ZEND_ACC_HEAP_RT_CACHE)
+    allocated->fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
+#endif
+
+#if defined(ZEND_ACC_IMMUTABLE)
+    allocated->fn_flags &= ~ZEND_ACC_IMMUTABLE;
+#endif
+
+    /* no longer a real closure object */
+    allocated->fn_flags &= ~ZEND_ACC_CLOSURE;
+
+#if defined(ZEND_ACC_NEVER_CACHE)
+    /* should this function ever find it's way to an
+        INIT, it would be terrible if it were cached */
+    allocated->fn_flags |= ZEND_ACC_NEVER_CACHE;
+#endif
+
+    /* scope this copied function */
+    allocated->scope = scope;
+
+    return (zend_function *)allocated;
+}
+
+static inline zend_function *zai_symbol_call_init(zai_symbol_call_arena_t *arena, zend_fcall_info_cache *fcc) {
+    zend_function *fbc = fcc->function_handler;
+
+    if (fbc->type == ZEND_USER_FUNCTION) {
+        return zai_symbol_call_init_user(arena, (zend_op_array *)fbc, fcc->called_scope);
+    }
+    return zai_symbol_call_init_internal(arena, (zend_internal_function *)fbc, fcc->called_scope);
+} /* }}} */
 
 bool zai_symbol_call_impl(
     // clang-format off
@@ -33,14 +256,14 @@ bool zai_symbol_call_impl(
     zend_fcall_info_cache fcc = empty_fcall_info_cache;
 
     fci.size = sizeof(zend_fcall_info);
-#if PHP_VERSION_ID >= 70000
+#if defined(ZAI_SYMBOL_CALL_ZE3)
     fci.retval = *rv;
-#if PHP_VERSION_ID < 70300
-    fcc.initialized = 1;
-#endif
 #else
-    fcc.initialized = 1;
     fci.retval_ptr_ptr = rv;
+#endif
+
+#if defined(ZAI_SYMBOL_CALL_FCC_INITIALIZE)
+    fcc.initialized = 1;
 #endif
 
     switch (scope_type) {
@@ -50,7 +273,7 @@ bool zai_symbol_call_impl(
 
         case ZAI_SYMBOL_SCOPE_OBJECT: {
             fcc.called_scope = Z_OBJCE_P((zval *)scope);
-#if PHP_VERSION_ID >= 70000
+#if defined(ZAI_SYMBOL_CALL_ZE3)
             fci.object = fcc.object = Z_OBJ_P((zval *)scope);
 #else
             fci.object_ptr = fcc.object_ptr = (zval *)scope;
@@ -58,29 +281,51 @@ bool zai_symbol_call_impl(
         } break;
 
         case ZAI_SYMBOL_SCOPE_GLOBAL:
+        case ZAI_SYMBOL_SCOPE_NAMESPACE:
             /* nothing to do */
             break;
 
-        case ZAI_SYMBOL_SCOPE_NAMESPACE:
-            /* nothing to do yet */
-            break;
+        default:
+            assert(0 && "call may not be performed in frame and static scopes");
+            return NULL;
     }
 
+    // clang-format off
     switch (function_type) {
         case ZAI_SYMBOL_FUNCTION_KNOWN:
             fcc.function_handler = (zend_function *)function;
             break;
 
         case ZAI_SYMBOL_FUNCTION_NAMED:
-            // clang-format off
             fcc.function_handler =
                 zai_symbol_lookup(
                     ZAI_SYMBOL_TYPE_FUNCTION,
                     scope_type, scope,
                     function ZAI_TSRMLS_CC);
-            // clang-format on
+            break;
+
+        case ZAI_SYMBOL_FUNCTION_CLOSURE:
+#if defined(ZAI_SYMBOL_CALL_ZE4)
+            fcc.function_handler = (zend_function *)zend_get_closure_method_def(Z_OBJ_P((zval *)function));
+#else
+            fcc.function_handler = (zend_function *)zend_get_closure_method_def((zval *)function ZAI_TSRMLS_CC);
+#endif
+            if ((scope_type != ZAI_SYMBOL_SCOPE_CLASS) &&
+                (scope_type != ZAI_SYMBOL_SCOPE_OBJECT)) {
+                zval *object = zend_get_closure_this_ptr((zval*) function ZAI_TSRMLS_CC);
+
+                if (object && Z_TYPE_P(object) == IS_OBJECT) {
+                    fcc.called_scope = Z_OBJCE_P(object);
+#if defined(ZAI_SYMBOL_CALL_ZE3)
+                    fci.object = fcc.object = Z_OBJ_P(object);
+#else
+                    fci.object_ptr = fcc.object_ptr = object;
+#endif
+                }
+            }
             break;
     }
+    // clang-format on
 
     if (!fcc.function_handler) {
         return false;
@@ -96,39 +341,60 @@ bool zai_symbol_call_impl(
         }
     }
 
-    volatile int zai_symbol_call_result = FAILURE;
+    // clang-format off
+    volatile int  zai_symbol_call_result    = FAILURE;
+    volatile bool zai_symbol_call_exception = false;
+    volatile bool zai_symbol_call_bailed    = false;
 
     zai_sandbox sandbox;
     zai_sandbox_open(&sandbox);
 
-    if (argc) {
-        zai_symbol_call_argv(&fci, argc, args ZAI_TSRMLS_CC);
+    zai_symbol_call_arena_t arena;
+    zend_try {
+        zai_symbol_call_arena_create(&arena, &fcc, argc);
+    } zend_catch {
+        zai_symbol_call_bailed = true;
+    } zend_end_try();
+
+    if (zai_symbol_call_bailed) {
+        zai_sandbox_bailout(&sandbox);
+        zai_sandbox_close(&sandbox);
+        return false;
     }
 
-    // clang-format off
+    fcc.function_handler = zai_symbol_call_init(&arena, &fcc);
+
+    if (argc) {
+        zai_symbol_call_argv(&arena, &fci, argc, args);
+    }
+
     zend_try {
         zai_symbol_call_result =
             zend_call_function(&fci, &fcc ZAI_TSRMLS_CC);
+    } zend_catch {
+        zai_symbol_call_bailed = true;
     } zend_end_try();
     // clang-format on
 
-    if (argc) {
-        efree(fci.params);
+    zai_symbol_call_arena_release(&arena);
+
+    if (zai_symbol_call_bailed) {
+        zai_sandbox_bailout(&sandbox);
     }
 
-    if ((zai_symbol_call_result == SUCCESS) && (NULL == EG(exception))) {
-        zai_sandbox_close(&sandbox);
-        return true;
-    }
+    zai_symbol_call_exception = EG(exception) != NULL;
 
     zai_sandbox_close(&sandbox);
+
+    if (zai_symbol_call_result == SUCCESS) {
+        return !zai_symbol_call_exception;
+    }
+
     return false;
 }
 
 bool zai_symbol_new(zval *zv, zend_class_entry *ce ZAI_TSRMLS_DC, uint32_t argc, ...) {
     bool result = true;
-
-    memset(zv, 0, sizeof(zv));
 
     object_init_ex(zv, ce);
 
@@ -145,11 +411,12 @@ bool zai_symbol_new(zval *zv, zend_class_entry *ce ZAI_TSRMLS_DC, uint32_t argc,
             argc, &args);
         // clang-format on
 
-#if PHP_VERSION_ID < 70000
-        zval_ptr_dtor(&rv);
-#else
+#if defined(ZAI_SYMBOL_CALL_ZE3)
         zval_ptr_dtor(rv);
+#else
+        zval_ptr_dtor(&rv);
 #endif
+
         va_end(args);
     }
 

--- a/zend_abstract_interface/symbols/symbols.h
+++ b/zend_abstract_interface/symbols/symbols.h
@@ -67,6 +67,8 @@ typedef enum {
     ZAI_SYMBOL_FUNCTION_KNOWN,
     /* The function parameter is zai_string_view* */
     ZAI_SYMBOL_FUNCTION_NAMED,
+    /* The function parameter is zval* Z_TYPE_P IS_OBJECT, instanceof zend_ce_closure */
+    ZAI_SYMBOL_FUNCTION_CLOSURE,
 } zai_symbol_function_t;
 
 bool zai_symbol_call_impl(

--- a/zend_abstract_interface/symbols/tests/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(symbols
     lookup/local/frame.cc 
     call/internal.cc 
     call/user.cc
+    call/closure.cc
     api/class.cc
     api/constant.cc
     api/function.cc

--- a/zend_abstract_interface/symbols/tests/call/closure.cc
+++ b/zend_abstract_interface/symbols/tests/call/closure.cc
@@ -1,0 +1,99 @@
+extern "C" {
+#include "value/value.h"
+#include "symbols/symbols.h"
+#include "tea/extension.h"
+
+static zval* ddtrace_testing_closure_object;
+static zval* ddtrace_testing_closure_value;
+
+PHP_FUNCTION(ddtrace_testing_closure_intercept) {
+    zval *object, *value;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TEA_TSRMLS_CC, "zz", &object, &value) != SUCCESS) {
+        return;
+    }
+
+    ZAI_VALUE_COPY(ddtrace_testing_closure_object, object);
+    ZAI_VALUE_COPY(ddtrace_testing_closure_value, value);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(ddtrace_testing_closure_arginfo, 0, 0, 2)
+    ZEND_ARG_INFO(0, object)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+const zend_function_entry ddtrace_testing_closure_functions[] = {
+    PHP_FE(ddtrace_testing_closure_intercept, ddtrace_testing_closure_arginfo)
+    PHP_FE_END
+};
+
+}
+
+#include "tea/testing/catch2.hpp"
+#include <cstdlib>
+#include <cstring>
+
+static bool zai_symbol_call_closure_test(const char *fn, size_t fnl ZAI_TSRMLS_DC) {
+    zend_function *function = zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), fn, fnl TEA_TSRMLS_CC);
+
+    if (!function) {
+        return false;
+    }
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    if (zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, ZAI_SYMBOL_FUNCTION_KNOWN, function, &result TEA_TSRMLS_CC, 0)) {
+        ZAI_VALUE_DTOR(result);
+        return true;
+    }
+
+    ZAI_VALUE_DTOR(result);
+    return false;
+}
+
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/call/closure", "closure bound", "./stubs/call/closure/Stub.php", {
+    tea_extension_functions(ddtrace_testing_closure_functions);
+},{
+    ZAI_VALUE_MAKE(ddtrace_testing_closure_object);
+    ZAI_VALUE_MAKE(ddtrace_testing_closure_value);
+
+    REQUIRE(zai_symbol_call_closure_test(ZEND_STRL("closureTestBinding") TEA_TSRMLS_CC));
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call(
+            ZAI_SYMBOL_SCOPE_GLOBAL, NULL,
+            ZAI_SYMBOL_FUNCTION_CLOSURE, ddtrace_testing_closure_value,
+            &result TEA_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+
+    ZAI_VALUE_DTOR(ddtrace_testing_closure_object);
+    ZAI_VALUE_DTOR(ddtrace_testing_closure_value);
+})
+
+TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/call/closure", "closure rebound", "./stubs/call/closure/Stub.php", {
+    tea_extension_functions(ddtrace_testing_closure_functions);
+},{
+    ZAI_VALUE_MAKE(ddtrace_testing_closure_object);
+    ZAI_VALUE_MAKE(ddtrace_testing_closure_value);
+
+    REQUIRE(zai_symbol_call_closure_test(ZEND_STRL("closureTestRebinding") TEA_TSRMLS_CC));
+
+    zval *result;
+    ZAI_VALUE_INIT(result);
+
+    CHECK(zai_symbol_call(
+            ZAI_SYMBOL_SCOPE_OBJECT, ddtrace_testing_closure_object,
+            ZAI_SYMBOL_FUNCTION_CLOSURE, ddtrace_testing_closure_value,
+            &result TEA_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
+
+    ZAI_VALUE_DTOR(ddtrace_testing_closure_object);
+    ZAI_VALUE_DTOR(ddtrace_testing_closure_value);
+})
+
+

--- a/zend_abstract_interface/symbols/tests/lookup/local/static.cc
+++ b/zend_abstract_interface/symbols/tests/lookup/local/static.cc
@@ -23,19 +23,20 @@ TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "scalar", "./stubs/lookup/
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("scalar");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &name, &result TEA_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
 
     zai_string_view var = ZAI_STRL_VIEW("var");
+    zai_string_view target = ZAI_STRL_VIEW("target");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &target TEA_TSRMLS_CC);
 
     zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     REQUIRE(Z_TYPE_P(local) == IS_LONG);
     REQUIRE(Z_LVAL_P(local) == 42);
-
-    ZAI_VALUE_DTOR(result);
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stubs/lookup/local/static/Stub.php", {
@@ -54,18 +55,19 @@ TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "refcounted", "./stubs/loo
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("refcounted");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &name, &result TEA_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
 
     zai_string_view var = ZAI_STRL_VIEW("var");
+    zai_string_view target = ZAI_STRL_VIEW("target");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &target TEA_TSRMLS_CC);
 
     zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     REQUIRE(Z_TYPE_P(local) == IS_OBJECT);
-
-    ZAI_VALUE_DTOR(result);
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs/lookup/local/static/Stub.php", {
@@ -84,17 +86,18 @@ TEA_TEST_CASE_WITH_STUB("symbol/lookup/local/static", "reference", "./stubs/look
     ZAI_VALUE_INIT(result);
 
     zai_string_view name = ZAI_STRL_VIEW("reference");
-    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &name TEA_TSRMLS_CC);
 
-    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_KNOWN, method, &result TEA_TSRMLS_CC, 0));
+    REQUIRE(zai_symbol_call(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_SYMBOL_FUNCTION_NAMED, &name, &result TEA_TSRMLS_CC, 0));
+
+    ZAI_VALUE_DTOR(result);
 
     zai_string_view var = ZAI_STRL_VIEW("var");
+    zai_string_view target = ZAI_STRL_VIEW("targetWithReference");
+    zend_function* method = (zend_function*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, ZAI_SYMBOL_SCOPE_CLASS, ce, &target TEA_TSRMLS_CC);
 
     zval *local = (zval*) zai_symbol_lookup(ZAI_SYMBOL_TYPE_LOCAL, ZAI_SYMBOL_SCOPE_STATIC, method, &var TEA_TSRMLS_CC);
 
     REQUIRE(local);
     /* This may seem counter intuitive, this is how we expect zend (and so zai) to behave though ... */
     REQUIRE(Z_TYPE_P(local) == IS_NULL);
-
-    ZAI_VALUE_DTOR(result);
 })

--- a/zend_abstract_interface/symbols/tests/stubs/call/closure/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/call/closure/Stub.php
@@ -1,0 +1,46 @@
+<?php
+namespace DDTraceTesting {
+
+    class Stub {
+        public static $self;
+
+        public function testRebinding() {
+            return function() {
+                if (!$this instanceof Rebind) {
+                    throw new \RuntimeException();
+                }
+
+                if ($this == Stub::$self) {
+                    throw new \RuntimeException();
+                }
+            };
+        }
+
+        public function testBinding() {
+            return function() {
+                if (!$this instanceof Stub) {
+                    throw new \RuntimeException();
+                }
+
+                if ($this != Stub::$self) {
+                    throw new \RuntimeException();
+                }
+            };
+        }
+    }
+
+    class Rebind extends Stub {}
+
+    function closureTestRebinding() {
+        Stub::$self = new Stub;
+
+        \ddtrace_testing_closure_intercept(new Rebind, Stub::$self->testRebinding());
+    }
+
+    function closureTestBinding() {
+        Stub::$self = new Stub;
+
+        \ddtrace_testing_closure_intercept(null, Stub::$self->testBinding());
+    }
+}
+?>

--- a/zend_abstract_interface/symbols/tests/stubs/lookup/local/static/Stub.php
+++ b/zend_abstract_interface/symbols/tests/stubs/lookup/local/static/Stub.php
@@ -4,32 +4,31 @@ namespace DDTraceTesting;
 class Stub {
 
     public static function scalar() {
-        static $var;
-
-        if (!$var) {
-            $var = 42;
-        }
+        self::target(42);
     }
 
     public static function refcounted() {
-        static $var;
-
-        if (!$var) {
-            $var = new self();
-        }
+        self::target(new self());
     }
 
     public static function reference() {
-        static $var, $bar;
+        static $var;
 
-        if (!$bar) {
-            $bar = new self();
-        }
- 
-        if (!$var) {
-            /* will not survive call boundary */
-            $var = &$bar;
-        }
+        $var = new self();
+
+        self::targetWithReference($var);
+    }
+
+    public static function target($value) {
+        static $var;
+
+        $var = $value;
+    }
+
+    public static function targetWithReference(&$value) {
+        static $var;
+
+        $var = &$value;
     }
 }
 ?>


### PR DESCRIPTION
### Description

When I tried to move usage of ZAI Symbols into the extension, it uncovered many build errors because the ext built has stricter Wflags.

In addition, the randomized testing framework uncovered a flaw in the logic of the call interface.

Doesn't need to go into release doc, follow up to #1452, depends on #1473