### PR TITLE
Add appsec library to the release bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,7 +877,7 @@ jobs:
       - run: mkdir -p test-results
       - run:
           name: Test installing packages on target systems
-          command: make -f dockerfiles/verify_packages/Makefile INSTALL_TYPE=<< parameters.install_type >> docker_compose_pull verify_centos_6
+          command: make -f dockerfiles/verify_packages/Makefile INSTALL_TYPE=<< parameters.install_type >> verify_centos_6
       - store_test_results:
           path: test-results
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0/datadog-profiling.tar.gz
+APPSEC_RELEASE_NONDEBUG_URL := https://github.com/labbati/test-actions/releases/download/appsec/dd-appsec-php-0.1.0-amd64.tar.gz
+APPSEC_RELEASE_DEBUG_URL := https://github.com/labbati/test-actions/releases/download/appsec/dd-appsec-php-0.1.0-amd64-debug.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
@@ -386,7 +388,9 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 	bash ./tooling/bin/generate-final-artifact.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR) \
-		$(PROFILING_RELEASE_URL)
+		$(PROFILING_RELEASE_URL) \
+		$(APPSEC_RELEASE_NONDEBUG_URL) \
+		$(APPSEC_RELEASE_DEBUG_URL)
 	bash ./tooling/bin/generate-installers.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0/datadog-profiling.tar.gz
-APPSEC_RELEASE_NONDEBUG_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.0/dd-appsec-php-0.2.0-amd64.tar.gz
-APPSEC_RELEASE_DEBUG_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.0/dd-appsec-php-0.2.0-amd64-debug.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.0/dd-appsec-php-0.2.0-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 
@@ -389,8 +388,7 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR) \
 		$(PROFILING_RELEASE_URL) \
-		$(APPSEC_RELEASE_NONDEBUG_URL) \
-		$(APPSEC_RELEASE_DEBUG_URL)
+		$(APPSEC_RELEASE_URL)
 	bash ./tooling/bin/generate-installers.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.3.0/datadog-profiling.tar.gz
-APPSEC_RELEASE_NONDEBUG_URL := https://github.com/labbati/test-actions/releases/download/appsec/dd-appsec-php-0.1.0-amd64.tar.gz
-APPSEC_RELEASE_DEBUG_URL := https://github.com/labbati/test-actions/releases/download/appsec/dd-appsec-php-0.1.0-amd64-debug.tar.gz
+APPSEC_RELEASE_NONDEBUG_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.0/dd-appsec-php-0.2.0-amd64.tar.gz
+APPSEC_RELEASE_DEBUG_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.0/dd-appsec-php-0.2.0-amd64-debug.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -95,7 +95,9 @@ function install($options)
         $tmpDirTarGz = $options[OPT_FILE];
     } else {
         $version = RELEASE_VERSION;
-        $url = "https://github.com/DataDog/dd-trace-php/releases/download/{$version}/dd-library-php-{$platform}.tar.gz";
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $url = "https://github.com/DataDog/dd-trace-php/releases/download/{$version}/dd-library-php-{$version}-{$platform}.tar.gz";
+        // phpcs:enable Generic.Files.LineLength.TooLong
         download($url, $tmpDirTarGz);
         unset($version);
     }

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -3,9 +3,6 @@ CENTOS6_PHP_VERSIONS:=5.4.centos6 5.5.centos6 5.6.centos6 7.0.centos6 7.1.centos
 
 .PHONY: $(CENTOS6_PHP_VERSIONS)
 
-docker_compose_pull:
-	@docker-compose -f $(ROOT_DIR)/docker-compose.yml pull --parallel
-
 $(CENTOS6_PHP_VERSIONS): %.centos6:
 	@echo Verifying Centos 6 - PHP $*
 	@docker-compose \
@@ -15,7 +12,7 @@ $(CENTOS6_PHP_VERSIONS): %.centos6:
 		-T \
 		--rm \
 		${*}-centos6 \
-		sh /build_src/dockerfiles/verify_packages/verify_rpm_centos6.sh
+		sh dockerfiles/verify_packages/verify_rpm_centos6.sh
 
 # The list of validated alpine images are in CI config. In case a package has to be validated locally, you can:
 #  1. copy the .apk|.deb|.rpm into '<root>/build/packages'

--- a/dockerfiles/verify_packages/alpine/install.sh
+++ b/dockerfiles/verify_packages/alpine/install.sh
@@ -31,7 +31,7 @@ else
     echo "Installing dd-trace-php using the new PHP installer"
     apk add --no-cache libexecinfo
     installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-musl.tar.gz')
-    $PHP_BIN datadog-setup.php --file "$installable_bundle"
+    $PHP_BIN datadog-setup.php --file "$installable_bundle" --php-bin all
 fi
 
 # Preparing NGINX

--- a/dockerfiles/verify_packages/alpine/install.sh
+++ b/dockerfiles/verify_packages/alpine/install.sh
@@ -30,7 +30,8 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
 else
     echo "Installing dd-trace-php using the new PHP installer"
     apk add --no-cache libexecinfo
-    $PHP_BIN datadog-setup.php --file $(pwd)/build/packages/dd-library-php-x86_64-linux-musl.tar.gz --php-bin all
+    installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-musl.tar.gz')
+    $PHP_BIN datadog-setup.php --file "$installable_bundle"
 fi
 
 # Preparing NGINX

--- a/dockerfiles/verify_packages/centos/install.sh
+++ b/dockerfiles/verify_packages/centos/install.sh
@@ -44,7 +44,8 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
     rpm -ivh $(pwd)/build/packages/*.rpm
 else
     echo "Installing dd-trace-php using the new PHP installer"
-    php datadog-setup.php --file $(pwd)/build/packages/dd-library-php-x86_64-linux-gnu.tar.gz --php-bin all
+    installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
+    php datadog-setup.php --file "$installable_bundle"
 fi
 
 # Starting services

--- a/dockerfiles/verify_packages/centos/install.sh
+++ b/dockerfiles/verify_packages/centos/install.sh
@@ -45,7 +45,7 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
 else
     echo "Installing dd-trace-php using the new PHP installer"
     installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
-    php datadog-setup.php --file "$installable_bundle"
+    php datadog-setup.php --file "$installable_bundle" --php-bin all
 fi
 
 # Starting services

--- a/dockerfiles/verify_packages/debian/install.sh
+++ b/dockerfiles/verify_packages/debian/install.sh
@@ -52,7 +52,8 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
     dpkg -i $(pwd)/build/packages/*.deb
 else
     echo "Installing dd-trace-php using the new PHP installer"
-    ${PHP_BIN} datadog-setup.php --file $(pwd)/build/packages/dd-library-php-x86_64-linux-gnu.tar.gz --php-bin all
+    installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
+    ${PHP_BIN} datadog-setup.php --file "$installable_bundle"
 fi
 
 # PHP-FPM setup

--- a/dockerfiles/verify_packages/debian/install.sh
+++ b/dockerfiles/verify_packages/debian/install.sh
@@ -53,7 +53,7 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
 else
     echo "Installing dd-trace-php using the new PHP installer"
     installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
-    ${PHP_BIN} datadog-setup.php --file "$installable_bundle"
+    ${PHP_BIN} datadog-setup.php --file "$installable_bundle" --php-bin all
 fi
 
 # PHP-FPM setup

--- a/dockerfiles/verify_packages/docker-compose.yml
+++ b/dockerfiles/verify_packages/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     ulimits: { core: 99999999999 }
     stdin_open: true
     tty: true
-    volumes: [ '../../:/build_src' ]
+    working_dir: /datadog
+    volumes: [ '../../:/datadog' ]
     cap_add: [ SYS_PTRACE ]
     image: 'datadog/dd-trace-ci:php-5.4_centos-6'
   '5.5-centos6': { <<: *base_image, image: 'datadog/dd-trace-ci:php-5.5_centos-6' }

--- a/dockerfiles/verify_packages/verify_rpm_centos6.sh
+++ b/dockerfiles/verify_packages/verify_rpm_centos6.sh
@@ -15,7 +15,7 @@ for phpVer in $(ls ${PHP_INSTALL_DIR}); do
     INSTALL_TYPE="${INSTALL_TYPE:-php_installer}"
     if [ "$INSTALL_TYPE" = "native_package" ]; then
         echo "Installing dd-trace-php using the OS-specific package installer"
-        rpm -Uvh /build_src/build/packages/*.rpm
+        rpm -Uvh build/packages/*.rpm
         php --ri=ddtrace
 
         # Uninstall the tracer
@@ -23,7 +23,7 @@ for phpVer in $(ls ${PHP_INSTALL_DIR}); do
         rm -f /opt/datadog-php/etc/ddtrace.ini
     else
         echo "Installing dd-trace-php using the new PHP installer"
-        installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
+        installable_bundle=$(find "build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
         php datadog-setup.php --file "$installable_bundle" --php-bin all
     fi
 done

--- a/dockerfiles/verify_packages/verify_rpm_centos6.sh
+++ b/dockerfiles/verify_packages/verify_rpm_centos6.sh
@@ -23,6 +23,7 @@ for phpVer in $(ls ${PHP_INSTALL_DIR}); do
         rm -f /opt/datadog-php/etc/ddtrace.ini
     else
         echo "Installing dd-trace-php using the new PHP installer"
-        php /build_src/datadog-setup.php --file /build_src/build/packages/dd-library-php-x86_64-linux-musl.tar.gz --php-bin all
+        installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
+        php datadog-setup.php --file "$installable_bundle"
     fi
 done

--- a/dockerfiles/verify_packages/verify_rpm_centos6.sh
+++ b/dockerfiles/verify_packages/verify_rpm_centos6.sh
@@ -24,6 +24,6 @@ for phpVer in $(ls ${PHP_INSTALL_DIR}); do
     else
         echo "Installing dd-trace-php using the new PHP installer"
         installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz')
-        php datadog-setup.php --file "$installable_bundle"
+        php datadog-setup.php --file "$installable_bundle" --php-bin all
     fi
 done

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -6,6 +6,8 @@ IFS=$'\n\t'
 release_version=$1
 packages_build_dir=$2
 profiling_url=$3
+appsec_url_nondebug=$4
+appsec_url_debug=$5
 
 tmp_folder=/tmp/bundle
 tmp_folder_final=$tmp_folder/final
@@ -72,6 +74,58 @@ cp -v \
     $tmp_folder_profiling/datadog-profiling/x86_64-alpine-linux-musl/LICENSE* \
     $tmp_folder_profiling/datadog-profiling/x86_64-alpine-linux-musl/NOTICE* \
     $tmp_folder_final_musl/dd-library-php/profiling/
+
+########################
+# AppSec
+########################
+tmp_folder_appsec="$tmp_folder/appsec"
+tmp_folder_appsec_nondebug="$tmp_folder_appsec/nondebug"
+tmp_folder_appsec_debug="$tmp_folder_appsec/debug"
+rm -rf "$tmp_folder_appsec"
+mkdir -p "$tmp_folder_appsec_debug" "$tmp_folder_appsec_nondebug"
+tmp_folder_final_gnu_appsec=$tmp_folder_final_gnu/dd-library-php/appsec
+tmp_folder_final_musl_appsec=$tmp_folder_final_musl/dd-library-php/appsec
+
+# Non debug
+tmp_folder_appsec_archive_nondebug="$tmp_folder/appsec/nondebug.tar.gz"
+curl -L --output "$tmp_folder_appsec_archive_nondebug" "$appsec_url_nondebug"
+tar -xf "$tmp_folder_appsec_archive_nondebug" -C $tmp_folder_appsec_nondebug
+
+# Debug
+tmp_folder_appsec_archive_debug="$tmp_folder/appsec/debug.tar.gz"
+curl -L --output "$tmp_folder_appsec_archive_debug" "$appsec_url_debug"
+tar -xf "$tmp_folder_appsec_archive_debug" -C $tmp_folder_appsec_debug
+
+php_apis=(20151012 20160303 20170718 20180731 20190902 20200930 20210902);
+for php_api in "${php_apis[@]}"; do
+    mkdir -p \
+        ${tmp_folder_final_gnu_appsec}/ext/$php_api \
+        ${tmp_folder_final_musl_appsec}/ext/$php_api
+
+    # Appsec does not differentiate between gnu and musl
+    #    non-zts
+    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec.so"
+    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec.so"
+    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-debug.so"
+    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-debug.so"
+    #    zts
+    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts.so"
+    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts.so"
+    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts-debug.so"
+    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts-debug.so"
+done
+
+# Helper
+mkdir -p "${tmp_folder_final_gnu_appsec}/bin" "${tmp_folder_final_musl_appsec}/bin"
+cp "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper"
+cp "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper"
+cp "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper.debug"
+cp "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper.debug"
+
+# Recommended rules
+mkdir -p "${tmp_folder_final_gnu_appsec}/etc" "${tmp_folder_final_musl_appsec}/etc"
+cp "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" "${tmp_folder_final_gnu_appsec}/etc/recommended.json"
+cp "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" "${tmp_folder_final_musl_appsec}/etc/recommended.json"
 
 ########################
 # Final archives

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -81,21 +81,24 @@ cp -v \
 tmp_folder_appsec="$tmp_folder/appsec"
 tmp_folder_appsec_nondebug="$tmp_folder_appsec/nondebug"
 tmp_folder_appsec_debug="$tmp_folder_appsec/debug"
-rm -rf "$tmp_folder_appsec"
-mkdir -p "$tmp_folder_appsec_debug" "$tmp_folder_appsec_nondebug"
 tmp_folder_final_gnu_appsec=$tmp_folder_final_gnu/dd-library-php/appsec
 tmp_folder_final_musl_appsec=$tmp_folder_final_musl/dd-library-php/appsec
 
-# Non debug
+# Starting from a clean directory
+rm -rf "$tmp_folder_appsec"
+mkdir -p "$tmp_folder_appsec_debug" "$tmp_folder_appsec_nondebug"
+
+# Downloading Non debug archive
 tmp_folder_appsec_archive_nondebug="$tmp_folder/appsec/nondebug.tar.gz"
 curl -L --output "$tmp_folder_appsec_archive_nondebug" "$appsec_url_nondebug"
 tar -xf "$tmp_folder_appsec_archive_nondebug" -C $tmp_folder_appsec_nondebug
 
-# Debug
+# Downloading Debug archive
 tmp_folder_appsec_archive_debug="$tmp_folder/appsec/debug.tar.gz"
 curl -L --output "$tmp_folder_appsec_archive_debug" "$appsec_url_debug"
 tar -xf "$tmp_folder_appsec_archive_debug" -C $tmp_folder_appsec_debug
 
+# Extensions
 php_apis=(20151012 20160303 20170718 20180731 20190902 20200930 20210902);
 for php_api in "${php_apis[@]}"; do
     mkdir -p \
@@ -104,28 +107,56 @@ for php_api in "${php_apis[@]}"; do
 
     # Appsec does not differentiate between gnu and musl
     #    non-zts
-    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec.so"
-    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec.so"
-    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-debug.so"
-    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-debug.so"
+    cp \
+        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
+        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec.so"
+    cp \
+        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
+        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec.so"
+    cp \
+        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" \
+        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-debug.so"
+    cp \
+        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" \
+        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-debug.so"
     #    zts
-    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts.so"
-    cp "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts.so"
-    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts-debug.so"
-    cp "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts-debug.so"
+    cp \
+        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
+        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts.so"
+    cp \
+        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
+        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts.so"
+    cp \
+        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" \
+        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts-debug.so"
+    cp \
+        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" \
+        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts-debug.so"
 done
 
 # Helper
 mkdir -p "${tmp_folder_final_gnu_appsec}/bin" "${tmp_folder_final_musl_appsec}/bin"
-cp "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper"
-cp "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper"
-cp "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper.debug"
-cp "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper.debug"
+cp \
+    "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" \
+    "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper"
+cp \
+    "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" \
+    "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper"
+cp \
+    "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" \
+    "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper.debug"
+cp \
+    "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" \
+    "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper.debug"
 
 # Recommended rules
 mkdir -p "${tmp_folder_final_gnu_appsec}/etc" "${tmp_folder_final_musl_appsec}/etc"
-cp "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" "${tmp_folder_final_gnu_appsec}/etc/recommended.json"
-cp "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" "${tmp_folder_final_musl_appsec}/etc/recommended.json"
+cp \
+    "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" \
+    "${tmp_folder_final_gnu_appsec}/etc/recommended.json"
+cp \
+    "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" \
+    "${tmp_folder_final_musl_appsec}/etc/recommended.json"
 
 ########################
 # Final archives

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -6,8 +6,7 @@ IFS=$'\n\t'
 release_version=$1
 packages_build_dir=$2
 profiling_url=$3
-appsec_url_nondebug=$4
-appsec_url_debug=$5
+appsec_url=$4
 
 tmp_folder=/tmp/bundle
 tmp_folder_final=$tmp_folder/final
@@ -79,24 +78,17 @@ cp -v \
 # AppSec
 ########################
 tmp_folder_appsec="$tmp_folder/appsec"
-tmp_folder_appsec_nondebug="$tmp_folder_appsec/nondebug"
-tmp_folder_appsec_debug="$tmp_folder_appsec/debug"
 tmp_folder_final_gnu_appsec=$tmp_folder_final_gnu/dd-library-php/appsec
 tmp_folder_final_musl_appsec=$tmp_folder_final_musl/dd-library-php/appsec
 
 # Starting from a clean directory
 rm -rf "$tmp_folder_appsec"
-mkdir -p "$tmp_folder_appsec_debug" "$tmp_folder_appsec_nondebug"
+mkdir -p "$tmp_folder_appsec"
 
-# Downloading Non debug archive
-tmp_folder_appsec_archive_nondebug="$tmp_folder/appsec/nondebug.tar.gz"
-curl -L --output "$tmp_folder_appsec_archive_nondebug" "$appsec_url_nondebug"
-tar -xf "$tmp_folder_appsec_archive_nondebug" -C $tmp_folder_appsec_nondebug
-
-# Downloading Debug archive
-tmp_folder_appsec_archive_debug="$tmp_folder/appsec/debug.tar.gz"
-curl -L --output "$tmp_folder_appsec_archive_debug" "$appsec_url_debug"
-tar -xf "$tmp_folder_appsec_archive_debug" -C $tmp_folder_appsec_debug
+# Downloading archive
+tmp_folder_appsec_archive="$tmp_folder/ddappsec.tar.gz"
+curl -L --output "$tmp_folder_appsec_archive" "$appsec_url"
+tar -xf "$tmp_folder_appsec_archive" -C $tmp_folder_appsec
 
 # Extensions
 php_apis=(20151012 20160303 20170718 20180731 20190902 20200930 20210902);
@@ -108,54 +100,36 @@ for php_api in "${php_apis[@]}"; do
     # Appsec does not differentiate between gnu and musl
     #    non-zts
     cp \
-        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
+        "$tmp_folder_appsec/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
         "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec.so"
     cp \
-        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
+        "$tmp_folder_appsec/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so" \
         "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec.so"
-    cp \
-        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" \
-        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-debug.so"
-    cp \
-        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-non-zts-$php_api/ddappsec.so.debug" \
-        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-debug.so"
     #    zts
     cp \
-        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
+        "$tmp_folder_appsec/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
         "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts.so"
     cp \
-        "$tmp_folder_appsec_nondebug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
+        "$tmp_folder_appsec/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so" \
         "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts.so"
-    cp \
-        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" \
-        "${tmp_folder_final_gnu_appsec}/ext/$php_api/ddappsec-zts-debug.so"
-    cp \
-        "$tmp_folder_appsec_debug/dd-appsec-php/lib/php/no-debug-zts-$php_api/ddappsec.so.debug" \
-        "${tmp_folder_final_musl_appsec}/ext/$php_api/ddappsec-zts-debug.so"
 done
 
 # Helper
 mkdir -p "${tmp_folder_final_gnu_appsec}/bin" "${tmp_folder_final_musl_appsec}/bin"
 cp \
-    "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" \
+    "$tmp_folder_appsec/dd-appsec-php/bin/ddappsec-helper" \
     "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper"
 cp \
-    "$tmp_folder_appsec_nondebug/dd-appsec-php/bin/ddappsec-helper" \
+    "$tmp_folder_appsec/dd-appsec-php/bin/ddappsec-helper" \
     "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper"
-cp \
-    "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" \
-    "${tmp_folder_final_gnu_appsec}/bin/ddappsec-helper.debug"
-cp \
-    "$tmp_folder_appsec_debug/dd-appsec-php/bin/ddappsec-helper.debug" \
-    "${tmp_folder_final_musl_appsec}/bin/ddappsec-helper.debug"
 
 # Recommended rules
 mkdir -p "${tmp_folder_final_gnu_appsec}/etc" "${tmp_folder_final_musl_appsec}/etc"
 cp \
-    "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" \
+    "$tmp_folder_appsec/dd-appsec-php/etc/dd-appsec/recommended.json" \
     "${tmp_folder_final_gnu_appsec}/etc/recommended.json"
 cp \
-    "$tmp_folder_appsec_nondebug/dd-appsec-php/etc/dd-appsec/recommended.json" \
+    "$tmp_folder_appsec/dd-appsec-php/etc/dd-appsec/recommended.json" \
     "${tmp_folder_final_musl_appsec}/etc/recommended.json"
 
 ########################

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -163,10 +163,10 @@ cp \
 ########################
 echo "$release_version" > ${tmp_folder_final_gnu}/dd-library-php/VERSION
 tar -czv \
-    -f ${packages_build_dir}/dd-library-php-x86_64-linux-gnu.tar.gz \
+    -f ${packages_build_dir}/dd-library-php-${release_version}-x86_64-linux-gnu.tar.gz \
     -C ${tmp_folder_final_gnu} .
 
 echo "$release_version" > ${tmp_folder_final_musl}/dd-library-php/VERSION
 tar -czv \
-    -f ${packages_build_dir}/dd-library-php-x86_64-linux-musl.tar.gz \
+    -f ${packages_build_dir}/dd-library-php-${release_version}-x86_64-linux-musl.tar.gz \
     -C ${tmp_folder_final_musl} .


### PR DESCRIPTION
### Description

Based on the latest agreements, this PR:

1. adds `appsec` to the release bundle (actually installing `appsec` will come with a separate PR #1470)
2. renames bundles adding the version number.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
