### PR TITLE
fix dd_update_upstream_services on php5

### DIFF
--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -50,8 +50,8 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     ddtrace_convert_to_string(&service_string, service TSRMLS_CC);
 
     int b64_servicename_length = 0;
-    unsigned char *b64_servicename = php_base64_encode((unsigned char *)Z_STRVAL(service_string),
-                                                       Z_STRLEN(service_string), &b64_servicename_length);
+    unsigned char *b64_servicename =
+        php_base64_encode((unsigned char *)Z_STRVAL(service_string), Z_STRLEN(service_string), &b64_servicename_length);
     while (b64_servicename_length > 0 && b64_servicename[b64_servicename_length - 1] == '=') {
         b64_servicename[--b64_servicename_length] = 0;  // remove padding
     }

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -51,8 +51,8 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
     ddtrace_convert_to_string(service_string, service TSRMLS_CC);
 
     int b64_servicename_length = 0;
-    unsigned char *b64_servicename =
-        php_base64_encode((unsigned char *)Z_STRVAL_P(service_string), Z_STRLEN_P(service_string), &b64_servicename_length);
+    unsigned char *b64_servicename = php_base64_encode((unsigned char *)Z_STRVAL_P(service_string),
+                                                       Z_STRLEN_P(service_string), &b64_servicename_length);
     while (b64_servicename_length > 0 && b64_servicename[b64_servicename_length - 1] == '=') {
         b64_servicename[--b64_servicename_length] = 0;  // remove padding
     }

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -5,6 +5,7 @@
 #include <ext/pcre/php_pcre.h>
 #include <ext/standard/base64.h>
 
+#include "../compat_string.h"
 #include "../configuration.h"
 #include "../span.h"
 
@@ -45,12 +46,18 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
 
     zval *service = ddtrace_spandata_property_service(&deciding_span->span);
 
+    zval *service_string;
+    ALLOC_INIT_ZVAL(service_string);
+    ddtrace_convert_to_string(service_string, service TSRMLS_CC);
+
     int b64_servicename_length = 0;
     unsigned char *b64_servicename =
-        php_base64_encode((unsigned char *)Z_STRVAL_P(service), Z_STRLEN_P(service), &b64_servicename_length);
+        php_base64_encode((unsigned char *)Z_STRVAL_P(service_string), Z_STRLEN_P(service_string), &b64_servicename_length);
     while (b64_servicename_length > 0 && b64_servicename[b64_servicename_length - 1] == '=') {
         b64_servicename[--b64_servicename_length] = 0;  // remove padding
     }
+
+    zval_ptr_dtor(&service_string);
 
     char sampling_rate[7] = {0};
     zval *metrics = ddtrace_spandata_property_metrics(&span->span), **sample_rate;

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -46,18 +46,17 @@ static void dd_update_upstream_services(ddtrace_span_fci *span, ddtrace_span_fci
 
     zval *service = ddtrace_spandata_property_service(&deciding_span->span);
 
-    zval *service_string;
-    ALLOC_INIT_ZVAL(service_string);
-    ddtrace_convert_to_string(service_string, service TSRMLS_CC);
+    zval service_string;
+    ddtrace_convert_to_string(&service_string, service TSRMLS_CC);
 
     int b64_servicename_length = 0;
-    unsigned char *b64_servicename = php_base64_encode((unsigned char *)Z_STRVAL_P(service_string),
-                                                       Z_STRLEN_P(service_string), &b64_servicename_length);
+    unsigned char *b64_servicename = php_base64_encode((unsigned char *)Z_STRVAL(service_string),
+                                                       Z_STRLEN(service_string), &b64_servicename_length);
     while (b64_servicename_length > 0 && b64_servicename[b64_servicename_length - 1] == '=') {
         b64_servicename[--b64_servicename_length] = 0;  // remove padding
     }
 
-    zval_ptr_dtor(&service_string);
+    zval_dtor(&service_string);
 
     char sampling_rate[7] = {0};
     zval *metrics = ddtrace_spandata_property_metrics(&span->span), **sample_rate;


### PR DESCRIPTION
### Description

PHP5 was not handling null services property like 7/8, causing possible faults, found under stress testing just merged.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
