### PR TITLE
Patch zend_alloc.c to not crash in CI for PHP 7.0 to 7.2

### DIFF
--- a/dockerfiles/ci/buster/php-7.0/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
+++ b/dockerfiles/ci/buster/php-7.0/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
@@ -1,0 +1,24 @@
+From 45b4368d5c2354781a7b2f1cad86402658868e1d Mon Sep 17 00:00:00 2001
+From: Dmitry Stogov <dmitry@zend.com>
+Date: Thu, 27 Feb 2020 12:27:22 +0300
+Subject: [PATCH] Fixed incorrect behavior of internal memory debugger
+
+---
+ Zend/zend_alloc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index 0ccc004e14..25216898ed 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -2103,6 +2103,7 @@ static zend_long zend_mm_find_leaks(zend_mm_heap *heap, zend_mm_chunk *p, uint32
+ 			}
+ 		}
+ 		p = p->next;
++		i = ZEND_MM_FIRST_PAGE;
+ 	} while (p != heap->main_chunk);
+ 	return count;
+ }
+-- 
+2.32.0 (Apple Git-132)
+

--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -9,13 +9,15 @@ ENV PHP_VERSION=${phpVersion}
 FROM base as build
 ARG phpTarGzUrl
 ARG phpSha256Hash
+COPY 0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch /home/circleci
 RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
     (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz; \
     cd ${PHP_SRC_DIR}; \
-    ./buildconf --force;
+    ./buildconf --force; \
+    patch Zend/zend_alloc.c /home/circleci/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch;
 COPY configure.sh /home/circleci
 
 FROM build as php-debug-zts

--- a/dockerfiles/ci/buster/php-7.1/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
+++ b/dockerfiles/ci/buster/php-7.1/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
@@ -1,0 +1,24 @@
+From 45b4368d5c2354781a7b2f1cad86402658868e1d Mon Sep 17 00:00:00 2001
+From: Dmitry Stogov <dmitry@zend.com>
+Date: Thu, 27 Feb 2020 12:27:22 +0300
+Subject: [PATCH] Fixed incorrect behavior of internal memory debugger
+
+---
+ Zend/zend_alloc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index 0ccc004e14..25216898ed 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -2103,6 +2103,7 @@ static zend_long zend_mm_find_leaks(zend_mm_heap *heap, zend_mm_chunk *p, uint32
+ 			}
+ 		}
+ 		p = p->next;
++		i = ZEND_MM_FIRST_PAGE;
+ 	} while (p != heap->main_chunk);
+ 	return count;
+ }
+-- 
+2.32.0 (Apple Git-132)
+

--- a/dockerfiles/ci/buster/php-7.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.1/Dockerfile
@@ -9,13 +9,15 @@ ENV PHP_VERSION=${phpVersion}
 FROM base as build
 ARG phpTarGzUrl
 ARG phpSha256Hash
+COPY 0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch /home/circleci
 RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
     (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz; \
     cd ${PHP_SRC_DIR}; \
-    ./buildconf --force;
+    ./buildconf --force; \
+    patch Zend/zend_alloc.c /home/circleci/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch;
 COPY configure.sh /home/circleci
 
 FROM build as php-debug-zts
@@ -72,7 +74,7 @@ RUN set -eux; \
         pecl install mcrypt-1.0.0; echo "extension=mcrypt.so" >> ${iniDir}/mcrypt.ini; \
         pecl install ast; echo "extension=ast.so" >> ${iniDir}/ast.ini; \
         yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini; \
-        pecl install mongodb; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
+        pecl install mongodb-1.11.1; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini; \
         pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini; \
         # Xdebug is disabled by default
         # 2.9.2

--- a/dockerfiles/ci/buster/php-7.2/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
+++ b/dockerfiles/ci/buster/php-7.2/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch
@@ -1,0 +1,24 @@
+From 45b4368d5c2354781a7b2f1cad86402658868e1d Mon Sep 17 00:00:00 2001
+From: Dmitry Stogov <dmitry@zend.com>
+Date: Thu, 27 Feb 2020 12:27:22 +0300
+Subject: [PATCH] Fixed incorrect behavior of internal memory debugger
+
+---
+ Zend/zend_alloc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Zend/zend_alloc.c b/Zend/zend_alloc.c
+index 0ccc004e14..25216898ed 100644
+--- a/Zend/zend_alloc.c
++++ b/Zend/zend_alloc.c
+@@ -2103,6 +2103,7 @@ static zend_long zend_mm_find_leaks(zend_mm_heap *heap, zend_mm_chunk *p, uint32
+ 			}
+ 		}
+ 		p = p->next;
++		i = ZEND_MM_FIRST_PAGE;
+ 	} while (p != heap->main_chunk);
+ 	return count;
+ }
+-- 
+2.32.0 (Apple Git-132)
+

--- a/dockerfiles/ci/buster/php-7.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.2/Dockerfile
@@ -9,13 +9,15 @@ ENV PHP_VERSION=${phpVersion}
 FROM base as build
 ARG phpTarGzUrl
 ARG phpSha256Hash
+COPY 0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch /home/circleci
 RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
     (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz; \
     cd ${PHP_SRC_DIR}; \
-    ./buildconf --force;
+    ./buildconf --force; \
+    patch Zend/zend_alloc.c /home/circleci/0001-Fixed-incorrect-behavior-of-internal-memory-debugger.patch;
 COPY configure.sh /home/circleci
 
 FROM build as php-debug-zts


### PR DESCRIPTION
Makes CI green again.