### PR TITLE
Ensure dropped spans are distinguishable from unfinished spans

### DIFF
--- a/ext/php5/php5_4/engine_hooks.c
+++ b/ext/php5/php5_4/engine_hooks.c
@@ -327,7 +327,7 @@ static void dd_execute_tracing_posthook(zend_op_array *op_array TSRMLS_DC) {
 
     if (ddtrace_has_top_internal_span(span_fci TSRMLS_CC)) {
         dd_tracing_posthook_impl(fbc, span_fci, actual_retval TSRMLS_CC);
-    } else if (get_DD_TRACE_DEBUG() && !span_fci->span.duration) {
+    } else if (get_DD_TRACE_DEBUG() && (span_fci->span.duration == 0 || span_fci->span.duration == -1ull)) {
         // todo: update to Classname::Methodname format
         const char *fname = Z_STRVAL(dispatch->function_name);
         ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync", fname);
@@ -589,7 +589,7 @@ static void dd_internal_tracing_posthook(zend_execute_data *execute_data, int re
 
     if (ddtrace_has_top_internal_span(span_fci TSRMLS_CC)) {
         dd_tracing_posthook_impl(fbc, span_fci, return_value TSRMLS_CC);
-    } else if (get_DD_TRACE_DEBUG() && !span_fci->span.duration) {
+    } else if (get_DD_TRACE_DEBUG() && (span_fci->span.duration == 0 || span_fci->span.duration == -1ull)) {
         // todo: update to Classname::Methodname format
         const char *fname = Z_STRVAL(dispatch->function_name);
         ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync", fname);

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -27,12 +27,17 @@ void ddtrace_init_span_stacks(void) {
     DDTRACE_G(closed_spans_count) = 0;
 }
 
+static void dd_drop_span(ddtrace_span_fci *span) {
+    span->span.duration = -1ull;
+    span->next = NULL;
+    OBJ_RELEASE(&span->span.std);
+}
+
 static void _free_span_stack(ddtrace_span_fci *span_fci) {
     while (span_fci != NULL) {
         ddtrace_span_fci *tmp = span_fci;
         span_fci = tmp->next;
-        tmp->next = NULL;
-        OBJ_RELEASE(&tmp->span.std);
+        dd_drop_span(tmp);
     }
 }
 
@@ -212,7 +217,7 @@ void ddtrace_drop_top_open_span(void) {
         DDTRACE_G(root_span) = NULL;
     }
 
-    OBJ_RELEASE(&span_fci->span.std);
+    dd_drop_span(span_fci);
 }
 
 void ddtrace_serialize_closed_spans(zval *serialized) {

--- a/tests/ext/dropped_spans_have_negative_duration.phpt
+++ b/tests/ext/dropped_spans_have_negative_duration.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Negative duration for dropped spans
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+$outerSpan = DDTrace\start_span();
+
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\flush();
+
+var_dump($outerSpan->getDuration());
+
+?>
+--EXPECT--
+Successfully triggered flush with trace of size 1
+int(-1)
+No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

This ensures that the DDTrace\Span::isFinished() check with which we guard closing spans in the manual tracing API returns true when a span is dropped.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
