### PR TITLE
BGS shutdown/flush

### DIFF
--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -829,14 +829,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #endif
 
 static void _dd_writer_loop_cleanup(void *ctx) {
-    struct _writer_loop_data_t *writer = (struct _writer_loop_data_t *)ctx;
-
-    curl_slist_free_all(writer->headers);
-    writer->headers = NULL;
-
-    curl_easy_cleanup(writer->curl);
-    _dd_coms_stack_shutdown();
-    _dd_signal_writer_finished(writer);
+    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
 }
 
 static void *_dd_writer_loop(void *_) {
@@ -934,6 +927,12 @@ static void *_dd_writer_loop(void *_) {
 
         _dd_signal_data_processed(writer);
     } while (running);
+
+    curl_slist_free_all(writer->headers);
+    writer->headers = NULL;
+
+    curl_easy_cleanup(writer->curl);
+    _dd_coms_stack_shutdown();
 
     pthread_cleanup_pop(1);
 

--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -828,9 +828,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #define TIMEOUT_SIG SIGPROF
 #endif
 
-static void _dd_writer_loop_cleanup(void *ctx) {
-    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
-}
+static void _dd_writer_loop_cleanup(void *ctx) { _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx); }
 
 static void *_dd_writer_loop(void *_) {
     UNUSED(_);

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -829,14 +829,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #endif
 
 static void _dd_writer_loop_cleanup(void *ctx) {
-    struct _writer_loop_data_t *writer = (struct _writer_loop_data_t *)ctx;
-
-    curl_slist_free_all(writer->headers);
-    writer->headers = NULL;
-
-    curl_easy_cleanup(writer->curl);
-    _dd_coms_stack_shutdown();
-    _dd_signal_writer_finished(writer);
+    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
 }
 
 static void *_dd_writer_loop(void *_) {
@@ -934,6 +927,12 @@ static void *_dd_writer_loop(void *_) {
 
         _dd_signal_data_processed(writer);
     } while (running);
+
+    curl_slist_free_all(writer->headers);
+    writer->headers = NULL;
+
+    curl_easy_cleanup(writer->curl);
+    _dd_coms_stack_shutdown();
 
     pthread_cleanup_pop(1);
 

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -828,9 +828,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #define TIMEOUT_SIG SIGPROF
 #endif
 
-static void _dd_writer_loop_cleanup(void *ctx) {
-    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
-}
+static void _dd_writer_loop_cleanup(void *ctx) { _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx); }
 
 static void *_dd_writer_loop(void *_) {
     UNUSED(_);

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -828,6 +828,17 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #define TIMEOUT_SIG SIGPROF
 #endif
 
+static void _dd_writer_loop_cleanup(void *ctx) {
+    struct _writer_loop_data_t *writer = (struct _writer_loop_data_t *)ctx;
+
+    curl_slist_free_all(writer->headers);
+    writer->headers = NULL;
+
+    curl_easy_cleanup(writer->curl);
+    _dd_coms_stack_shutdown();
+    _dd_signal_writer_finished(writer);
+}
+
 static void *_dd_writer_loop(void *_) {
     UNUSED(_);
     /* This thread must not handle signals intended for the PHP threads.
@@ -869,6 +880,8 @@ static void *_dd_writer_loop(void *_) {
     }
 #endif
 
+    pthread_cleanup_push(_dd_writer_loop_cleanup, writer);
+
     bool running = true;
     _dd_signal_writer_started(writer);
     do {
@@ -888,6 +901,7 @@ static void *_dd_writer_loop(void *_) {
         if (atomic_load(&writer->suspended)) {
             continue;
         }
+
         atomic_store(&writer->requests_since_last_flush, 0);
 
         ddtrace_coms_stack_t **stack = &writer->tmp_stack;
@@ -922,12 +936,8 @@ static void *_dd_writer_loop(void *_) {
         _dd_signal_data_processed(writer);
     } while (running);
 
-    curl_slist_free_all(writer->headers);
-    writer->headers = NULL;
+    pthread_cleanup_pop(1);
 
-    curl_easy_cleanup(writer->curl);
-    _dd_coms_stack_shutdown();
-    _dd_signal_writer_finished(writer);
     return NULL;
 }
 
@@ -1077,7 +1087,13 @@ bool ddtrace_coms_flush_shutdown_writer_synchronous(void) {
 
         int rv = pthread_cond_timedwait(&writer->thread->writer_shutdown_signal_condition,
                                         &writer->thread->writer_shutdown_signal_mutex, &deadline);
-        if (rv == 0) {
+        if (rv == SUCCESS || rv == ETIMEDOUT) {
+            /* if this is not a fork, and timeout has been reached,
+                the thread needs to be cancelled and joined as this
+                is the last opportunity to join */
+            if (rv == ETIMEDOUT && !_dd_has_pid_changed()) {
+                pthread_cancel(writer->thread->self);
+            }
             should_join = true;
         }
     } else {

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -829,14 +829,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #endif
 
 static void _dd_writer_loop_cleanup(void *ctx) {
-    struct _writer_loop_data_t *writer = (struct _writer_loop_data_t *)ctx;
-
-    curl_slist_free_all(writer->headers);
-    writer->headers = NULL;
-
-    curl_easy_cleanup(writer->curl);
-    _dd_coms_stack_shutdown();
-    _dd_signal_writer_finished(writer);
+    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
 }
 
 static void *_dd_writer_loop(void *_) {
@@ -935,6 +928,12 @@ static void *_dd_writer_loop(void *_) {
 
         _dd_signal_data_processed(writer);
     } while (running);
+
+    curl_slist_free_all(writer->headers);
+    writer->headers = NULL;
+
+    curl_easy_cleanup(writer->curl);
+    _dd_coms_stack_shutdown();
 
     pthread_cleanup_pop(1);
 

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -828,9 +828,7 @@ static void _dd_signal_data_processed(struct _writer_loop_data_t *writer) {
 #define TIMEOUT_SIG SIGPROF
 #endif
 
-static void _dd_writer_loop_cleanup(void *ctx) {
-    _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx);
-}
+static void _dd_writer_loop_cleanup(void *ctx) { _dd_signal_writer_finished((struct _writer_loop_data_t *)ctx); }
 
 static void *_dd_writer_loop(void *_) {
     UNUSED(_);

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -1088,13 +1088,19 @@ bool ddtrace_coms_flush_shutdown_writer_synchronous(void) {
         int rv = pthread_cond_timedwait(&writer->thread->writer_shutdown_signal_condition,
                                         &writer->thread->writer_shutdown_signal_mutex, &deadline);
         if (rv == SUCCESS || rv == ETIMEDOUT) {
-            /* if this is not a fork, and timeout has been reached,
-                the thread needs to be cancelled and joined as this
-                is the last opportunity to join */
-            if (rv == ETIMEDOUT && !_dd_has_pid_changed()) {
-                pthread_cancel(writer->thread->self);
+            if (rv == SUCCESS) {
+                /* signalled, the writer thread finished */
+                should_join = true;
+            } else if (rv == ETIMEDOUT) {
+                /* if this is not a fork, and timeout has been reached,
+                    the thread needs to be cancelled and joined as this
+                    is the last opportunity to join */
+                if (!_dd_has_pid_changed()) {
+                    pthread_cancel(writer->thread->self);
+
+                    should_join = true;
+                }
             }
-            should_join = true;
         }
     } else {
         should_join = true;


### PR DESCRIPTION
### Description

The background sender is configured with a shutdown timeout, which defines the maximum amount of time the shutdown routine will wait for the writer thread before the routine ignores the request to join.

This is not safe, threads must be joined for predictable behaviour.

In the case where the timeout is reached, the shutdown routine needs to cancel the writer thread and then join with it at the last opportunity.

Failing to fulfil the contract of the function at the last opportunity leads to surprising behaviour, like the background sender trying to read from memory that was freed at mshutdown stage.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
