### PR TITLE
Restore support for manual distributed tracing

### DIFF
--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -163,6 +163,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_close_span, 0, 0, 0)
 ZEND_ARG_INFO(0, finish_time)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_set_distributed_tracing_context, 0, 0, 2)
+ZEND_ARG_INFO(0, trace_id)
+ZEND_ARG_INFO(0, parent_id)
+ZEND_ARG_INFO(0, origin)
+ZEND_ARG_INFO(0, tags)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_add_global_tag, 0, 0, 2)
 ZEND_ARG_INFO(0, key)
 ZEND_ARG_INFO(0, value)
@@ -1751,6 +1758,77 @@ static PHP_FUNCTION(current_context) {
         spprintf(&parent_id, DD_TRACE_MAX_ID_LEN, "%" PRIu64, DDTRACE_G(distributed_parent_trace_id));
         add_assoc_string_ex(return_value, ZEND_STRS("distributed_tracing_parent_id"), parent_id, 0);
     }
+
+    zval *tags = ddtrace_get_propagated_tags(TSRMLS_C);
+    add_assoc_zval_ex(return_value, ZEND_STRS("distributed_tracing_propagated_tags"), tags);
+}
+
+/* {{{ proto bool set_distributed_tracing_context() */
+static PHP_FUNCTION(set_distributed_tracing_context) {
+    UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+
+    char *trace_id_str, *parent_id_str, *origin = NULL;
+    int trace_id_len, parent_id_len, origin_len;
+    zval *tags = NULL;
+
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS() TSRMLS_CC, "ss|s!z!", &trace_id_str,
+                                 &trace_id_len, &parent_id_str, &parent_id_len, &origin, &origin_len,
+                                 &tags) != SUCCESS ||
+        (tags && Z_TYPE_P(tags) != IS_BOOL && Z_TYPE_P(tags) != IS_NULL && Z_TYPE_P(tags) != IS_ARRAY &&
+         Z_TYPE_P(tags) != IS_STRING)) {
+        ddtrace_log_debug(
+            "unexpected parameter. expecting string trace id and string parent id and possibly string origin and string or array propagated tags");
+        RETURN_FALSE;
+    }
+
+    if (!get_DD_TRACE_ENABLED()) {
+        RETURN_FALSE;
+    }
+
+    if (DDTRACE_G(open_spans_top)) {
+        ddtrace_log_debug("Cannot set the distributed tracing context when there are active spans");
+        RETURN_FALSE;
+    }
+
+    uint64_t old_trace_id = DDTRACE_G(trace_id);
+    zval trace_zv;
+    ZVAL_STRINGL(&trace_zv, trace_id_str, trace_id_len, 0);
+    if (trace_id_len == 1 && trace_id_str[0] == '0') {
+        DDTRACE_G(trace_id) = 0;
+    } else if (!ddtrace_set_userland_trace_id(&trace_zv TSRMLS_CC)) {
+        RETURN_FALSE;
+    }
+
+    zval parent_zv;
+    ZVAL_STRINGL(&parent_zv, parent_id_str, parent_id_len, 0);
+    uint64_t last_id = ddtrace_pop_span_id(TSRMLS_C);
+    if (parent_id_len == 1 && parent_id_str[0] == '0') {
+        DDTRACE_G(distributed_parent_trace_id) = 0;
+    } else if (ddtrace_push_userland_span_id(&parent_zv TSRMLS_CC)) {
+        DDTRACE_G(distributed_parent_trace_id) = ddtrace_peek_span_id(TSRMLS_C);
+    } else {
+        ddtrace_push_span_id(last_id TSRMLS_CC);
+        DDTRACE_G(trace_id) = old_trace_id;
+        RETURN_FALSE;
+    }
+
+    if (origin) {
+        if (DDTRACE_G(dd_origin)) {
+            efree(DDTRACE_G(dd_origin));
+        }
+        DDTRACE_G(dd_origin) = origin_len ? estrndup(origin, origin_len) : NULL;
+    }
+
+    if (tags) {
+        if (Z_TYPE_P(tags) == IS_STRING) {
+            ddtrace_add_tracer_tags_from_header(
+                (zai_string_view){.len = Z_STRLEN_P(tags), .ptr = Z_STRVAL_P(tags)} TSRMLS_CC);
+        } else if (Z_TYPE_P(tags) == IS_ARRAY) {
+            ddtrace_add_tracer_tags_from_array(Z_ARRVAL_P(tags) TSRMLS_CC);
+        }
+    }
+
+    RETURN_TRUE;
 }
 
 /* {{{ proto string dd_trace_closed_spans_count() */
@@ -1849,6 +1927,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_NS_FE(trace_id, arginfo_ddtrace_void),
     DDTRACE_NS_FE(current_context, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(set_distributed_tracing_context, arginfo_dd_trace_set_distributed_tracing_context),
     DDTRACE_FE(dd_trace_reset, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_send_traces_via_thread, arginfo_dd_trace_send_traces_via_thread),
     DDTRACE_FE(dd_trace_serialize_closed_spans, arginfo_ddtrace_void),
@@ -1935,6 +2014,6 @@ void dd_read_distributed_tracing_ids(TSRMLS_D) {
     }
 
     if (zai_read_header_literal("X_DATADOG_TAGS", &propagated_tags) == ZAI_HEADER_SUCCESS) {
-        ddtrace_add_tracer_tags_from_header(&propagated_tags TSRMLS_CC);
+        ddtrace_add_tracer_tags_from_header(propagated_tags TSRMLS_CC);
     }
 }

--- a/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php5/tracer_tag_propagation/tracer_tag_propagation.h
@@ -4,7 +4,10 @@
 #include <php.h>
 #include <zai_string/string.h>
 
-void ddtrace_add_tracer_tags_from_header(zai_string_view *headerstr TSRMLS_DC);
+void ddtrace_add_tracer_tags_from_header(zai_string_view headerstr TSRMLS_DC);
+void ddtrace_add_tracer_tags_from_array(HashTable *array TSRMLS_DC);
+
+zval *ddtrace_get_propagated_tags(TSRMLS_D);
 zai_string_view ddtrace_format_propagated_tags(TSRMLS_D);
 
 #endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/ext/php7/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php7/tracer_tag_propagation/tracer_tag_propagation.h
@@ -4,6 +4,9 @@
 #include <php.h>
 
 void ddtrace_add_tracer_tags_from_header(zend_string *headerstr);
+void ddtrace_add_tracer_tags_from_array(zend_array *array);
+
+zval ddtrace_get_propagated_tags(void);
 zend_string *ddtrace_format_propagated_tags(void);
 
 #endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -165,6 +165,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_close_span, 0, 0, 0)
 ZEND_ARG_INFO(0, finish_time)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_set_distributed_tracing_context, 0, 0, 2)
+ZEND_ARG_INFO(0, trace_id)
+ZEND_ARG_INFO(0, parent_id)
+ZEND_ARG_INFO(0, origin)
+ZEND_ARG_INFO(0, tags)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_add_global_tag, 0, 0, 2)
 ZEND_ARG_INFO(0, key)
 ZEND_ARG_INFO(0, value)
@@ -1576,6 +1583,68 @@ static PHP_FUNCTION(current_context) {
         add_assoc_str_ex(return_value, ZEND_STRL("distributed_tracing_parent_id"),
                          zend_strpprintf(DD_TRACE_MAX_ID_LEN, "%" PRIu64, DDTRACE_G(distributed_parent_trace_id)));
     }
+
+    zval tags = ddtrace_get_propagated_tags();
+    add_assoc_zval_ex(return_value, ZEND_STRL("distributed_tracing_propagated_tags"), &tags);
+}
+
+/* {{{ proto bool set_distributed_tracing_context() */
+static PHP_FUNCTION(set_distributed_tracing_context) {
+    zend_string *trace_id_str, *parent_id_str, *origin = NULL;
+    zval *tags = NULL;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|S!z!", &trace_id_str, &parent_id_str, &origin, &tags) != SUCCESS || (tags && Z_TYPE_P(tags) > IS_FALSE && Z_TYPE_P(tags) != IS_ARRAY && Z_TYPE_P(tags) != IS_STRING)) {
+        ddtrace_log_debug("unexpected parameter. expecting string trace id and string parent id and possibly string origin and string or array propagated tags");
+        RETURN_FALSE;
+    }
+
+    if (DDTRACE_G(open_spans_top)) {
+        ddtrace_log_debug("Cannot set the distributed tracing context when there are active spans");
+        RETURN_FALSE;
+    }
+
+    uint64_t old_trace_id = DDTRACE_G(trace_id);
+    if (trace_id_str) {
+        zval trace_zv;
+        ZVAL_STR(&trace_zv, trace_id_str);
+        if (ZSTR_LEN(trace_id_str) == 1 && ZSTR_VAL(trace_id_str)[0] == '0') {
+            DDTRACE_G(trace_id) = 0;
+        } else if (!ddtrace_set_userland_trace_id(&trace_zv)) {
+            RETURN_FALSE;
+        }
+    }
+
+    if (parent_id_str) {
+        zval parent_zv;
+        ZVAL_STR(&parent_zv, parent_id_str);
+        uint64_t last_id = ddtrace_pop_span_id();
+        if (ZSTR_LEN(parent_id_str) == 1 && ZSTR_VAL(parent_id_str)[0] == '0') {
+            DDTRACE_G(distributed_parent_trace_id) = 0;
+        } else if (ddtrace_push_userland_span_id(&parent_zv)) {
+            DDTRACE_G(distributed_parent_trace_id) = ddtrace_peek_span_id();
+        } else {
+            ddtrace_push_span_id(last_id);
+            DDTRACE_G(trace_id) = old_trace_id;
+            RETURN_FALSE;
+        }
+    }
+
+    if (origin) {
+        if (DDTRACE_G(dd_origin)) {
+            zend_string_release(DDTRACE_G(dd_origin));
+        }
+        DDTRACE_G(dd_origin) = ZSTR_LEN(origin) ? zend_string_copy(origin) : NULL;
+    }
+
+    if (tags) {
+        if (Z_TYPE_P(tags) == IS_STRING) {
+            ddtrace_add_tracer_tags_from_header(Z_STR_P(tags));
+        } else if (Z_TYPE_P(tags) == IS_ARRAY) {
+            ddtrace_add_tracer_tags_from_array(Z_ARR_P(tags));
+        }
+    }
+
+    RETURN_TRUE;
 }
 
 /* {{{ proto string dd_trace_closed_spans_count() */
@@ -1670,6 +1739,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_push_span_id, arginfo_dd_trace_push_span_id),
     DDTRACE_NS_FE(trace_id, arginfo_ddtrace_void),
     DDTRACE_NS_FE(current_context, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(set_distributed_tracing_context, arginfo_dd_trace_set_distributed_tracing_context),
     DDTRACE_FE(dd_trace_reset, arginfo_ddtrace_void),
     DDTRACE_FE(dd_trace_send_traces_via_thread, arginfo_dd_trace_send_traces_via_thread),
     DDTRACE_FE(dd_trace_serialize_closed_spans, arginfo_ddtrace_void),

--- a/ext/php8/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/php8/tracer_tag_propagation/tracer_tag_propagation.h
@@ -4,6 +4,9 @@
 #include <php.h>
 
 void ddtrace_add_tracer_tags_from_header(zend_string *headerstr);
+void ddtrace_add_tracer_tags_from_array(zend_array *array);
+
+zval ddtrace_get_propagated_tags(void);
 zend_string *ddtrace_format_propagated_tags(void);
 
 #endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -9,7 +9,6 @@ use DDTrace\Contracts\SpanContext as SpanContextInterface;
 use DDTrace\Contracts\Tracer;
 use DDTrace\SpanContext;
 
-/** @deprecated Obsoleted by moving related code to internal. */
 final class TextMap implements Propagator
 {
     use LoggingTrait;
@@ -74,39 +73,10 @@ final class TextMap implements Propagator
             return null;
         }
 
-        if (!$this->setDistributedTraceTraceId($traceId)) {
-            return null;
-        }
-
         $spanContext = new SpanContext($traceId, $spanId ?: '', null, $baggageItems, true);
         $this->extractPrioritySampling($spanContext, $carrier);
         $this->extractOrigin($spanContext, $carrier);
         return $spanContext;
-    }
-
-    /**
-     * Set the distributed trace's trace ID for internal spans
-     *
-     * @param string $traceId
-     * @return bool
-     */
-    private function setDistributedTraceTraceId($traceId)
-    {
-        if (!$traceId) {
-            return false;
-        }
-        if (\dd_trace_set_trace_id($traceId)) {
-            return true;
-        }
-        if (\ddtrace_config_debug_enabled()) {
-            self::logDebug(
-                'Error parsing distributed trace trace ID: {id}; ignoring.',
-                [
-                    'id' => $traceId,
-                ]
-            );
-        }
-        return false;
     }
 
     /**

--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -24,13 +24,15 @@ final class SpanContext extends SpanContextData
 
     public static function createAsChild(SpanContextInterface $parentContext = null, $startTime = null)
     {
-        $origin = property_exists($parentContext, 'origin') ? $parentContext->origin : null;
+        // @phpstan-ignore-next-line
+        $origin = \property_exists($parentContext, 'origin') ? $parentContext->origin : null;
         if (!$parentContext->isDistributedTracingActivationContext() || !active_span()) {
             if ($parentContext->isDistributedTracingActivationContext()) {
                 set_distributed_tracing_context(
                     $parentContext->getTraceId(),
                     $parentContext->getSpanId(),
-                    $origin);
+                    $origin
+                );
             }
             if ($startTime) {
                 start_span($startTime);

--- a/src/DDTrace/SpanContext.php
+++ b/src/DDTrace/SpanContext.php
@@ -24,7 +24,14 @@ final class SpanContext extends SpanContextData
 
     public static function createAsChild(SpanContextInterface $parentContext = null, $startTime = null)
     {
+        $origin = property_exists($parentContext, 'origin') ? $parentContext->origin : null;
         if (!$parentContext->isDistributedTracingActivationContext() || !active_span()) {
+            if ($parentContext->isDistributedTracingActivationContext()) {
+                set_distributed_tracing_context(
+                    $parentContext->getTraceId(),
+                    $parentContext->getSpanId(),
+                    $origin);
+            }
             if ($startTime) {
                 start_span($startTime);
             } else {
@@ -40,11 +47,8 @@ final class SpanContext extends SpanContextData
         );
         $instance->parentContext = $parentContext;
         $instance->setPropagatedPrioritySampling($parentContext->getPropagatedPrioritySampling());
-        if (
-            property_exists($instance, 'origin')
-            && !empty($parentContext->origin)
-        ) {
-            $instance->origin = $parentContext->origin;
+        if ($origin) {
+            $instance->origin = $origin;
         }
         return $instance;
     }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -8,6 +8,7 @@ use DDTrace\Contracts\Tracer as TracerInterface;
 use DDTrace\Exceptions\UnsupportedFormat;
 use DDTrace\Log\LoggingTrait;
 use DDTrace\Propagators\Noop as NoopPropagator;
+use DDTrace\Propagators\TextMap;
 use DDTrace\Transport\Internal;
 use DDTrace\Transport\Noop;
 use DDTrace\Transport\Noop as NoopTransport;
@@ -88,10 +89,10 @@ final class Tracer implements TracerInterface
     public function __construct(Transport $transport = null, array $propagators = null, array $config = [])
     {
         $this->transport = $transport ?: new Internal();
-        $noopPropagator = new NoopPropagator();
+        $textMapPropagator = new TextMap($this);
         $this->propagators = $propagators ?: [
-            Format::TEXT_MAP => $noopPropagator,
-            Format::HTTP_HEADERS => $noopPropagator,
+            Format::TEXT_MAP => $textMapPropagator,
+            Format::HTTP_HEADERS => $textMapPropagator,
         ];
         $this->config = array_merge($this->config, $config);
         foreach ($this->config['global_tags'] as $key => $val) {

--- a/tests/OpenTracer1Unit/TracerTest.php
+++ b/tests/OpenTracer1Unit/TracerTest.php
@@ -198,8 +198,6 @@ final class TracerTest extends BaseTestCase
 
     public function testOTSpanContextAsParent()
     {
-        $this->markTestIncomplete("We currently do not support setting trace id from custom distributed tracing");
-
         GlobalTracer::set(Tracer::make());
 
         $tracer = GlobalTracer::get();

--- a/tests/OpenTracerUnit/TracerTest.php
+++ b/tests/OpenTracerUnit/TracerTest.php
@@ -203,8 +203,6 @@ final class TracerTest extends BaseTestCase
 
     public function testOTSpanContextAsParent()
     {
-        $this->markTestIncomplete("We currently do not support setting trace id from custom distributed tracing");
-
         GlobalTracer::set(Tracer::make());
 
         $tracer = GlobalTracer::get();

--- a/tests/ext/dd_trace_current_context.phpt
+++ b/tests/ext/dd_trace_current_context.phpt
@@ -26,7 +26,7 @@ if (strcmp($context['env'], getenv("DD_ENV")) !== 0) {
 
 ?>
 --EXPECTF--
-array(4) {
+array(5) {
   ["trace_id"]=>
   string(%d) "%d"
   ["span_id"]=>
@@ -35,4 +35,7 @@ array(4) {
   string(5) "1.2.3"
   ["env"]=>
   string(13) "dd-trace-test"
+  ["distributed_tracing_propagated_tags"]=>
+  array(0) {
+  }
 }

--- a/tests/ext/dd_trace_current_context_noenv.phpt
+++ b/tests/ext/dd_trace_current_context_noenv.phpt
@@ -15,7 +15,7 @@ if (strcmp($context['span_id'], strval(\dd_trace_peek_span_id())) !== 0) {
 
 ?>
 --EXPECTF--
-array(4) {
+array(5) {
   ["trace_id"]=>
   string(%d) "%d"
   ["span_id"]=>
@@ -24,4 +24,7 @@ array(4) {
   NULL
   ["env"]=>
   NULL
+  ["distributed_tracing_propagated_tags"]=>
+  array(0) {
+  }
 }

--- a/tests/ext/distributed_tracing/distributed_trace_no_overwrite_with_active_span.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_no_overwrite_with_active_span.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Do not update distributed tracing context if a span is already active
+--FILE--
+<?php
+
+DDTrace\start_span();
+$oldContext = DDTrace\current_context();
+var_dump(DDTrace\set_distributed_tracing_context("123", "321", "foo", ["a" => "b"]));
+var_dump($oldContext == DDtrace\current_context());
+
+?>
+--EXPECT--
+bool(false)
+bool(true)

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Setting custom distributed header information
+--ENV--
+HTTP_X_DATADOG_TRACE_ID=42
+HTTP_X_DATADOG_PARENT_ID=10
+HTTP_X_DATADOG_ORIGIN=datadog
+HTTP_X_DATADOG_TAGS=custom_tag=inherited,second_tag=bar
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function dump_context() {
+    $context = DDTrace\current_context();
+    echo "trace_id: {$context["trace_id"]}\n";
+    echo "distributed_tracing_origin: " . (isset($context["distributed_tracing_parent_id"]) ? $context["distributed_tracing_origin"] : "<none>") . "\n";
+    echo "distributed_tracing_parent_id: " . (isset($context["distributed_tracing_parent_id"]) ? $context["distributed_tracing_parent_id"] : "<none>") . "\n";
+    echo "distributed_tracing_propagated_tags: " . json_encode($context["distributed_tracing_propagated_tags"]) . "\n";
+}
+dump_context();
+DDTrace\set_distributed_tracing_context("123", "321", "foo", ["a" => "b"]);
+dump_context();
+DDTrace\set_distributed_tracing_context("0", "0", "", [1 => "c"]);
+dump_context();
+
+?>
+--EXPECT--
+trace_id: 42
+distributed_tracing_origin: datadog
+distributed_tracing_parent_id: 10
+distributed_tracing_propagated_tags: {"custom_tag":"inherited","second_tag":"bar"}
+trace_id: 321
+distributed_tracing_origin: foo
+distributed_tracing_parent_id: 321
+distributed_tracing_propagated_tags: {"a":"b"}
+trace_id: 0
+distributed_tracing_origin: <none>
+distributed_tracing_parent_id: <none>
+distributed_tracing_propagated_tags: []


### PR DESCRIPTION
### Description

We broke the manual distributed tracing handling when moving the distributed tracing to internal.

Fixes #1292.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
