### PR TITLE
Unmark PDO reconnect spans as an error if the (same) connection is immediately restarted afterwards

### DIFF
--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -80,6 +80,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_DATABASE_NO_ERROR_ON_CONNECTION_RETRY_SUCCESS, "true")                              \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                           \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \

--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -675,7 +675,7 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci TSRMLS_DC) {
 
     zend_bool error = zend_hash_exists(Z_ARRVAL_P(meta), "error.msg", sizeof("error.msg")) ||
                       zend_hash_exists(Z_ARRVAL_P(meta), "error.type", sizeof("error.type"));
-    if (error) {
+    if (error && !zend_hash_exists(Z_ARRVAL_P(meta), ZEND_STRS("error"))) {
         add_assoc_long(el, "error", 1);
     }
 

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -80,6 +80,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_DATABASE_NO_ERROR_ON_CONNECTION_RETRY_SUCCESS, "true")                              \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                           \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -661,7 +661,7 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
 
     zend_bool error = ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.msg")) ||
                       ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.type"));
-    if (error) {
+    if (error && !zend_hash_str_exists(Z_ARR_P(meta), ZEND_STRL("error"))) {
         add_assoc_long(el, "error", 1);
     }
 

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -80,6 +80,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_DATABASE_NO_ERROR_ON_CONNECTION_RETRY_SUCCESS, "true")                              \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                           \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -660,7 +660,7 @@ static void _serialize_meta(zval *el, ddtrace_span_fci *span_fci) {
 
     zend_bool error = ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.msg")) ||
                       ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.type"));
-    if (error) {
+    if (error && !zend_hash_str_exists(Z_ARR_P(meta), ZEND_STRL("error"))) {
         add_assoc_long(el, "error", 1);
     }
 

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -19,7 +19,7 @@ typedef uint16_t zai_config_id;
 
 #define ZAI_CONFIG_ENTRIES_COUNT_MAX 128
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
-#define ZAI_CONFIG_NAME_BUFSIZ 60
+#define ZAI_CONFIG_NAME_BUFSIZ 70
 
 #define ZAI_CONFIG_ENTRY(_id, _name, _type, default, ...)                          \
     {                                                                              \


### PR DESCRIPTION
### Description

I'm not sure whether that's the correct fix, or whether we should fix this at the eloquent level only. But given that Eloquent (or more precisely the laravel database backend) supports reconnecting natively, it should not register an error if it reconnects afterwards.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug. - No idea how to emulate a connection goes away...? Testing locally I killed the docker container with mysql inside...

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
