### PR TITLE
Improve error detection for datadog-setup.php

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -444,6 +444,19 @@ function parse_validate_user_options()
     ];
     $options = getopt($shortOptions, $longOptions);
 
+    global $argc;
+    if ($options === false || (empty($options) && $argc > 1)) {
+        /* Note that the above conditions are not as robust as I'd like.
+         * Consider:
+         *   php datadog-setup.php --enable-profiling 0.69.0 --php-bin php
+         * getopt will stop at 0.69.0 as it doesn't recognize it, but it will
+         * return an array that only has enable-profiling in it.
+         * I don't see an obvious way out of this, but catching some failures
+         * here is better than not catching any.
+         */
+        print_error_and_exit("Failed to parse options", true);
+    }
+
     // Help and exit
     if (key_exists('h', $options) || key_exists(OPT_HELP, $options)) {
         print_help();


### PR DESCRIPTION
### Description

Fix #1488. It is not perfect, but it is better. It catches things like these:

    php datadog-setup.php --version 0.69.0 --enable-profiling
    php datadog-setup.php 0.69.0 --enable-profiling

But if the error happens after the first argument, then it won't catch it e.g.

    php datadog-setup.php --enable-profiling 0.69.0 --php-bin php-fpm

Will go into interactive mode because `getopt` stopped parsing at `0.69.0`.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
