### PR TITLE
Inline queue function pointers

### DIFF
--- a/components/channel/channel.c
+++ b/components/channel/channel.c
@@ -41,7 +41,7 @@ static bool receiver_recv(struct datadog_php_receiver_s *receiver, void **data, 
     datadog_php_channel_impl *channel = receiver->channel;
     uv_mutex_lock(&channel->mutex);
     datadog_php_queue *queue = &channel->queue;
-    bool succeeded = queue->try_pop(queue, data);
+    bool succeeded = datadog_php_queue_try_pop(queue, data);
 
     // If there wasn't an item but there are known producers, wait and try again
     if (!succeeded && channel->sender_count && timeout_nanos) {
@@ -53,7 +53,7 @@ static bool receiver_recv(struct datadog_php_receiver_s *receiver, void **data, 
              * the mutex will be re-acquired when resuming.
              */
             (void)uv_cond_timedwait(&channel->condvar, &channel->mutex, timeout_target - now);
-            succeeded = queue->try_pop(queue, data);
+            succeeded = datadog_php_queue_try_pop(queue, data);
             if (succeeded) {
                 break;
             }
@@ -90,7 +90,7 @@ static bool sender_send(struct datadog_php_sender_s *sender, void *data) {
     datadog_php_channel_impl *channel = sender->channel;
     uv_mutex_lock(&channel->mutex);
     datadog_php_queue *queue = &channel->queue;
-    bool sent = queue->try_push(queue, data);
+    bool sent = datadog_php_queue_try_push(queue, data);
     if (sent) {
         uv_cond_signal(&channel->condvar);
     }

--- a/components/channel/tests/channel.cc
+++ b/components/channel/tests/channel.cc
@@ -192,7 +192,7 @@ TEST_CASE("channel multiple producers easy", "[channel]") {
     int sum = 0;
     for (int i = 0; i < capacity; ++i) {
         int *item = nullptr;
-        CHECK(receiver->recv(receiver, (void**)&item, TIMEOUT));
+        CHECK(receiver->recv(receiver, (void **)&item, TIMEOUT));
         sum += *item;
     }
 

--- a/components/queue/queue.c
+++ b/components/queue/queue.c
@@ -1,6 +1,6 @@
 #include "queue.h"
 
-static bool queue_try_push(struct datadog_php_queue_s *queue, void *item) {
+bool datadog_php_queue_try_push(datadog_php_queue *queue, void *item) {
     if (queue->size == queue->capacity) {
         return false;
     }
@@ -10,7 +10,7 @@ static bool queue_try_push(struct datadog_php_queue_s *queue, void *item) {
     return true;
 }
 
-static bool queue_try_pop(struct datadog_php_queue_s *queue, void **item_ref) {
+bool datadog_php_queue_try_pop(datadog_php_queue *queue, void **item_ref) {
     bool has_item = queue->size;
     if (has_item) {
         *item_ref = queue->buffer[queue->tail];
@@ -20,7 +20,7 @@ static bool queue_try_pop(struct datadog_php_queue_s *queue, void **item_ref) {
     return has_item;
 }
 
-bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[]) {
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[static capacity]) {
     if (!queue || (capacity && !buffer)) {
         return false;
     }
@@ -31,8 +31,6 @@ bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *b
         .head = 0,
         .tail = 0,
         .buffer = buffer,
-        .try_push = queue_try_push,
-        .try_pop = queue_try_pop,
     };
     *queue = q;
     return true;

--- a/components/queue/queue.h
+++ b/components/queue/queue.h
@@ -4,6 +4,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
 /**
  * A bounded, NOT thread-safe queue.
  * If you are interested in thread-safety, look at datadog_php_channel.
@@ -19,11 +25,13 @@ typedef struct datadog_php_queue_s {
     uint16_t size, capacity;
     uint16_t head, tail;
     void **buffer;  // borrowed, not owned
-
-    bool (*try_push)(struct datadog_php_queue_s *queue, void *item);
-    bool (*try_pop)(struct datadog_php_queue_s *queue, void **item_ref);
 } datadog_php_queue;
 
-bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[]);
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity, void *buffer[C_STATIC(capacity)]);
+
+bool datadog_php_queue_try_pop(datadog_php_queue *queue, void **item_ref);
+bool datadog_php_queue_try_push(datadog_php_queue *queue, void *item);
+
+#undef C_STATIC
 
 #endif  // DATADOG_PHP_QUEUE_H

--- a/components/queue/tests/queue.cc
+++ b/components/queue/tests/queue.cc
@@ -9,8 +9,8 @@ TEST_CASE("empty queue operations", "[queue]") {
     REQUIRE(datadog_php_queue_ctor(&queue, 0, nullptr));
 
     void *item = nullptr;
-    REQUIRE(!queue.try_push(&queue, item));
-    REQUIRE(!queue.try_pop(&queue, &item));
+    REQUIRE(!datadog_php_queue_try_push(&queue, item));
+    REQUIRE(!datadog_php_queue_try_pop(&queue, &item));
 }
 
 TEST_CASE("basic queue operations", "[queue]") {
@@ -25,21 +25,21 @@ TEST_CASE("basic queue operations", "[queue]") {
 
     // by iterating a few times, we may have wrapped (depending on impl)
     for (unsigned i = 0; i != n; ++i) {
-        REQUIRE(queue.try_push(&queue, items + 0));
-        REQUIRE(queue.try_push(&queue, items + 1));
-        REQUIRE(queue.try_push(&queue, items + 2));
-        REQUIRE(queue.try_push(&queue, items + 3));
+        REQUIRE(datadog_php_queue_try_push(&queue, items + 0));
+        REQUIRE(datadog_php_queue_try_push(&queue, items + 1));
+        REQUIRE(datadog_php_queue_try_push(&queue, items + 2));
+        REQUIRE(datadog_php_queue_try_push(&queue, items + 3));
 
-        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(datadog_php_queue_try_pop(&queue, &item));
         REQUIRE(item == items + 0);
 
-        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(datadog_php_queue_try_pop(&queue, &item));
         REQUIRE(item == items + 1);
 
-        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(datadog_php_queue_try_pop(&queue, &item));
         REQUIRE(item == items + 2);
 
-        REQUIRE(queue.try_pop(&queue, &item));
+        REQUIRE(datadog_php_queue_try_pop(&queue, &item));
         REQUIRE(item == items + 3);
     }
 }
@@ -52,6 +52,6 @@ TEST_CASE("full queue push", "[queue]") {
 
     void *items[n];
 
-    REQUIRE(queue.try_push(&queue, items + 0));
-    REQUIRE(!queue.try_push(&queue, items + 0));
+    REQUIRE(datadog_php_queue_try_push(&queue, items + 0));
+    REQUIRE(!datadog_php_queue_try_push(&queue, items + 0));
 }


### PR DESCRIPTION
### Description

These were showing up in dtrace. It's obvious that some of them were
not inlined even with LTO because they were across a function pointer
boundary.

This is part of a sync with the current dd-prof-php components.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
