### PR TITLE
Adjust stack sample max stack depth

### DIFF
--- a/components/stack-sample/stack-sample.c
+++ b/components/stack-sample/stack-sample.c
@@ -4,8 +4,8 @@
 
 /* Done in the impl instead of the header because on CentOS 6 in gnu++11 mode
  * it fails in the header. The header gets included in C++ mode for testing. */
-_Static_assert(sizeof(struct datadog_php_stack_sample_s) <= 8192u,
-               "datadog_php_stack_sample should be less than or equal to 8KiB");
+_Static_assert(sizeof(struct datadog_php_stack_sample_s) < 8192u,
+               "size of datadog_php_stack_sample should be less than 8KiB");
 
 typedef datadog_php_stack_sample stack_sample_t;
 typedef datadog_php_stack_sample_frame stack_sample_frame_t;

--- a/components/stack-sample/stack-sample.h
+++ b/components/stack-sample/stack-sample.h
@@ -4,7 +4,7 @@
 #include <components/string_view/string_view.h>
 #include <stdint.h>
 
-#define DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH 101u
+#define DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH 99u
 static const uint16_t datadog_php_stack_sample_max_depth = DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH;
 
 /**


### PR DESCRIPTION
### Description

Adjust max stack depth so record_msg can fit in 8KiB (it was slightly
going over). The `record_msg` is part of the profiler that hasn't been
merged yet, so only the parts that have been merged have been sync'd.

This is part of a sync with the current dd-prof-php components.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
