### PR TITLE
Implement split by instance in PDO

### DIFF
--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -77,6 +77,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)              \
     CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)        \
     CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                    \
+    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -77,6 +77,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)              \
     CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)        \
     CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                    \
+    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -77,6 +77,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)              \
     CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)        \
     CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                    \
+    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
     CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -185,19 +185,17 @@ class PDOIntegration extends Integration
     }
 
     /**
-     * @param PDO|PDOStatement|array $pdoOrStmt
+     * @param PDO|PDOStatement|array $source
      * @param DDTrace\SpanData $span
      */
     public static function setCommonSpanInfo($source, SpanData $span)
     {
         if (\is_array($source)) {
             $storedConnectionInfo = $source;
-        } elseif (
-            \is_object($source)
-            && (\is_a($source, 'PDO') || \is_a($source, 'PDOStatement'))
-        ) {
-            $storedConnectionInfo = ObjectKVStore::get($source, PDOIntegration::CONNECTION_TAGS_KEY, []);
         } else {
+            $storedConnectionInfo = ObjectKVStore::get($source, PDOIntegration::CONNECTION_TAGS_KEY, []);
+        }
+        if (!\is_array($storedConnectionInfo)) {
             $storedConnectionInfo = [];
         }
 

--- a/tests/randomized/config/envs.php
+++ b/tests/randomized/config/envs.php
@@ -23,6 +23,7 @@ const ENVS = [
     'DD_TRACE_AGENT_TIMEOUT' => ['1'],
     'DD_TRACE_AUTO_FLUSH_ENABLED' => ['true'],
     'DD_TAGS' => ['tag_1:hi,tag_2:hello'],
+    'DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE' => ['true'],
     'DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN' => ['true'],
     'DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST' => ['true'],
     'DD_TRACE_MEASURE_COMPILE_TIME' => ['false'],


### PR DESCRIPTION
### Description

This feature implements split by instance for PDO spans, allowing to differentiate between different host/servers based on service name.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
