### PR TITLE
Trigger profiling interrupt function before internal observer_end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1280,18 +1280,6 @@ jobs:
       - run:
           name: Extension Tea Tests
           command: |
-            case << parameters.php_version >> in
-              "5.4")
-                exit 0
-                ;;
-              "5.5")
-                exit 0
-                ;;
-              "5.6")
-                exit 0
-                ;;
-            esac
-
             for phpBuild in $(ls /opt/php)
             do
               switch-php ${phpBuild}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,6 +1303,7 @@ jobs:
 
               # build ddtrace.so
               cd ~/datadog
+              make clean
               make install
 
               # Build ext Tea tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1280,6 +1280,18 @@ jobs:
       - run:
           name: Extension Tea Tests
           command: |
+            case << parameters.php_version >> in
+              "5.4")
+                exit 0
+                ;;
+              "5.5")
+                exit 0
+                ;;
+              "5.6")
+                exit 0
+                ;;
+            esac
+
             for phpBuild in $(ls /opt/php)
             do
               switch-php ${phpBuild}
@@ -1300,8 +1312,8 @@ jobs:
               export CMAKE_PREFIX_PATH=/opt/catch2
               export Tea_ROOT=/opt/tea/${phpBuild}
               cmake ${toolchain} -DCMAKE_BUILD_TYPE=Debug -S ~/datadog/tests/tea
-              make -j all
-              make test
+              cmake --build . --parallel
+              ctest --output-on-failure
               grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1278,6 +1278,34 @@ jobs:
             grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
 
       - run:
+          name: Extension Tea Tests
+          command: |
+            for phpBuild in $(ls /opt/php)
+            do
+              switch-php ${phpBuild}
+              toolchain=""
+              if [ "${phpBuild}" = "debug-zts-asan" ]
+              then
+                toolchain="-DCMAKE_TOOLCHAIN_FILE=~/datadog/cmake/asan.cmake"
+              fi
+
+              # build ddtrace.so
+              cd ~/datadog
+              make install
+
+              # Build ext Tea tests
+              builddir="/tmp/build/ext-tea-${phpBuild}"
+              mkdir -p "${builddir}"
+              cd "${builddir}"
+              export CMAKE_PREFIX_PATH=/opt/catch2
+              export Tea_ROOT=/opt/tea/${phpBuild}
+              cmake ${toolchain} -DCMAKE_BUILD_TYPE=Debug -S ~/datadog/tests/tea
+              make -j all
+              make test
+              grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
+            done
+
+      - run:
           command: |
             mkdir -p /tmp/artifacts
             cp --parents /tmp/build/zai-*/Testing/Temporary/LastTest.log /tmp/artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1313,7 +1313,7 @@ jobs:
               export Tea_ROOT=/opt/tea/${phpBuild}
               cmake ${toolchain} -DCMAKE_BUILD_TYPE=Debug -S ~/datadog/tests/tea
               cmake --build . --parallel
-              ctest --output-on-failure
+              make test ARGS="--output-on-failure"
               grep -e "=== Total [0-9]+ memory leaks detected ===" Testing/Temporary/LastTest.log && exit 1 || true
             done
 

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -95,7 +95,7 @@ static void ddtrace_sort_modules(void *base, size_t count, size_t siz, compare_f
 }
 #endif
 
-static int ddtrace_startup(struct _zend_extension *extension) {
+static int ddtrace_startup(zend_extension *extension) {
 #if PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 70400
     // Turns out with zai config we have dynamically allocated INI entries. This does not play well with PHP 7.3
     // As of PHP 7.3 opcache stores INI entry values in SHM. However, only as of PHP 7.4 opcache delays detaching SHM.
@@ -113,7 +113,7 @@ static int ddtrace_startup(struct _zend_extension *extension) {
     // We deliberately leave handler replacement during startup, even though this uses some config
     // This touches global state, which, while unlikely, may play badly when interacting with other extensions, if done
     // post-startup
-    ddtrace_internal_handlers_startup();
+    ddtrace_internal_handlers_startup(extension);
     return SUCCESS;
 }
 
@@ -135,7 +135,7 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   ddtrace_shutdown,
                                                   ddtrace_activate,
                                                   ddtrace_deactivate,
-                                                  NULL,
+                                                  ddtrace_message_handler,
                                                   NULL,
                                                   NULL,
                                                   NULL,

--- a/ext/php7/engine_hooks.h
+++ b/ext/php7/engine_hooks.h
@@ -20,6 +20,7 @@ extern int ddtrace_op_array_extension;
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
+void ddtrace_message_handler(int message, void *arg);
 void ddtrace_engine_hooks_mshutdown(void);
 
 void ddtrace_compile_time_reset(void);

--- a/ext/php7/handlers_internal.h
+++ b/ext/php7/handlers_internal.h
@@ -1,6 +1,7 @@
 #ifndef DDTRACE_HANDLERS_INTERNAL_H
 #define DDTRACE_HANDLERS_INTERNAL_H
 
+#include <Zend/zend_extensions.h>
 #include <php.h>
 
 #include "ddtrace_string.h"
@@ -20,7 +21,7 @@ void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, 
 
 void ddtrace_free_unregistered_class(zend_class_entry *ce);
 
-void ddtrace_internal_handlers_startup(void);
+void ddtrace_internal_handlers_startup(zend_extension *ddtrace_extension);
 void ddtrace_internal_handlers_shutdown(void);
 void ddtrace_internal_handlers_rinit(void);
 void ddtrace_internal_handlers_rshutdown(void);

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -3,7 +3,9 @@
 #include <Zend/zend_closures.h>
 #include <Zend/zend_compile.h>
 #include <Zend/zend_exceptions.h>
+#include <Zend/zend_extensions.h>
 #include <Zend/zend_interfaces.h>
+#include <Zend/zend_portability.h>
 #include <exceptions/exceptions.h>
 #include <stdbool.h>
 #include <symbols/symbols.h>
@@ -1060,10 +1062,29 @@ void ddtrace_opcode_mshutdown(void) {
 void ddtrace_execute_internal_minit(void) {}
 void ddtrace_execute_internal_mshutdown(void) {}
 
-/* If the profiler is loaded, then this weak symbol will be overwritten by the
- * strong symbol provided by profiler.
+static void (*profiling_interrupt_function)(zend_execute_data *) = NULL;
+
+/**
+ * The message handler is used to determine if the profiler is loaded, and if
+ * so it will locate certain symbols so cross-product features can be enabled.
  */
-__attribute__((weak)) extern void datadog_profiling_interrupt_function(zend_execute_data *execute_data);
+void ddtrace_message_handler(int message, void *arg) {
+    if (UNEXPECTED(message != ZEND_EXTMSG_NEW_EXTENSION)) {
+        // There are currently no other defined messages.
+        return;
+    }
+
+    zend_extension *extension = (zend_extension *)arg;
+    if (extension->name && strcmp(extension->name, "datadog-profiling") == 0) {
+        DL_HANDLE handle = extension->handle;
+
+        profiling_interrupt_function = DL_FETCH_SYMBOL(handle, "datadog_profiling_interrupt_function");
+        if (UNEXPECTED(!profiling_interrupt_function)) {
+            ddtrace_log_debugf("[Datadog Trace] Profiling was detected, but locating symbol %s failed: %s\n",
+                               "datadog_profiling_interrupt_function", DL_ERROR());
+        }
+    }
+}
 
 PHP_FUNCTION(ddtrace_internal_function_handler) {
     ddtrace_dispatch_t *dispatch;
@@ -1084,8 +1105,8 @@ PHP_FUNCTION(ddtrace_internal_function_handler) {
          * give the profiler an opportunity to take a sample before calling the
          * tracing funcation.
          */
-        if (datadog_profiling_interrupt_function) {
-            datadog_profiling_interrupt_function(execute_data);
+        if (profiling_interrupt_function) {
+            profiling_interrupt_function(execute_data);
         }
         dd_observer_end(EX(func), span_fci, return_value);
     }

--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -1063,7 +1063,7 @@ void ddtrace_execute_internal_mshutdown(void) {}
 /* If the profiler is loaded, then this weak symbol will be overwritten by the
  * strong symbol provided by profiler.
  */
-extern void datadog_profiling_interrupt_function(zend_execute_data *execute_data) __attribute__((weak));
+__attribute__((weak)) extern void datadog_profiling_interrupt_function(zend_execute_data *execute_data);
 
 PHP_FUNCTION(ddtrace_internal_function_handler) {
     ddtrace_dispatch_t *dispatch;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -73,7 +73,7 @@ STD_PHP_INI_ENTRY("ddtrace.cgroup_file", "/proc/self/cgroup", PHP_INI_SYSTEM, On
                   zend_ddtrace_globals, ddtrace_globals)
 PHP_INI_END()
 
-static int ddtrace_startup(struct _zend_extension *extension) {
+static int ddtrace_startup(zend_extension *extension) {
     UNUSED(extension);
     ddtrace_resource = zend_get_resource_handle(PHP_DDTRACE_EXTNAME);
     ddtrace_op_array_extension = zend_get_op_array_extension_handle(PHP_DDTRACE_EXTNAME);
@@ -82,7 +82,7 @@ static int ddtrace_startup(struct _zend_extension *extension) {
     // We deliberately leave handler replacement during startup, even though this uses some config
     // This touches global state, which, while unlikely, may play badly when interacting with other extensions, if done
     // post-startup
-    ddtrace_internal_handlers_startup();
+    ddtrace_internal_handlers_startup(extension);
     return SUCCESS;
 }
 
@@ -104,7 +104,7 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   ddtrace_shutdown,
                                                   ddtrace_activate,
                                                   ddtrace_deactivate,
-                                                  NULL,
+                                                  ddtrace_message_handler,
                                                   NULL,
                                                   NULL,
                                                   NULL,

--- a/ext/php8/engine_hooks.h
+++ b/ext/php8/engine_hooks.h
@@ -18,6 +18,7 @@ extern int ddtrace_op_array_extension;
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
+void ddtrace_message_handler(int message, void *arg);
 void ddtrace_engine_hooks_mshutdown(void);
 
 void ddtrace_compile_time_reset(void);

--- a/ext/php8/handlers_internal.c
+++ b/ext/php8/handlers_internal.c
@@ -119,8 +119,21 @@ void ddtrace_exception_handlers_rinit(void);
 
 void ddtrace_curl_handlers_rshutdown(void);
 
+static void dd_message_dispatcher(const zend_extension *extension, const zend_extension *ddtrace) {
+    if (ddtrace != extension) {
+        ddtrace_message_handler(ZEND_EXTMSG_NEW_EXTENSION, (void *)extension);
+    }
+}
+
 // Internal handlers use ddtrace_resource and only implement the sandbox API.
-void ddtrace_internal_handlers_startup(void) {
+void ddtrace_internal_handlers_startup(zend_extension *ext) {
+    /* The zend_extension message_handler is used to detect if profiling is
+     * loaded, but it will not trigger for already loaded zend_extensions, so
+     * loop over existing zend_extensions to see if it's already there.
+     */
+    llist_apply_with_arg_func_t func = (llist_apply_with_arg_func_t)dd_message_dispatcher;
+    zend_llist_apply_with_argument(&zend_extensions, func, ext);
+
     // curl is different; it has pieces that always run.
     ddtrace_curl_handlers_startup();
     // pcntl handlers have to run even if tracing of pcntl extension is not enabled.

--- a/ext/php8/handlers_internal.h
+++ b/ext/php8/handlers_internal.h
@@ -1,6 +1,7 @@
 #ifndef DDTRACE_HANDLERS_INTERNAL_H
 #define DDTRACE_HANDLERS_INTERNAL_H
 
+#include <Zend/zend_extensions.h>
 #include <php.h>
 
 #include "ddtrace_string.h"
@@ -20,7 +21,7 @@ void ddtrace_replace_internal_methods(ddtrace_string Class, size_t methods_len, 
 
 void ddtrace_free_unregistered_class(zend_class_entry *ce);
 
-void ddtrace_internal_handlers_startup(void);
+void ddtrace_internal_handlers_startup(zend_extension *ddtrace_extension);
 void ddtrace_internal_handlers_shutdown(void);
 void ddtrace_internal_handlers_rinit(void);
 void ddtrace_internal_handlers_rshutdown(void);

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -761,7 +761,7 @@ zend_observer_fcall_handlers ddtrace_observer_fcall_init(zend_execute_data *exec
 /* If the profiler is loaded, then this weak symbol will be overwritten by the
  * strong symbol provided by profiler.
  */
-extern void datadog_profiling_interrupt_function(zend_execute_data *execute_data) __attribute__((weak));
+__attribute__((weak)) extern void datadog_profiling_interrupt_function(zend_execute_data *execute_data);
 
 PHP_FUNCTION(ddtrace_internal_function_handler) {
     ddtrace_dispatch_t *dispatch;

--- a/tests/tea/CMakeLists.txt
+++ b/tests/tea/CMakeLists.txt
@@ -39,4 +39,8 @@ target_link_libraries(ext-tea-tests INTERFACE Catch2::Catch2WithMain Tea::Tea)
 # Need components, for example stack-sample.
 add_subdirectory(../../components ${CMAKE_CURRENT_BINARY_DIR}/components)
 
-add_subdirectory(profiling)
+# Profiling doesn't support PHP 5, so there haven't been any changes to the
+# tracer on those versions to support it.
+if(PHP_VERSION_ID GREATER_EQUAL "70000")
+  add_subdirectory(profiling)
+endif()

--- a/tests/tea/CMakeLists.txt
+++ b/tests/tea/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(Catch2 2.4 REQUIRED)
 
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_POSITION_INDEPENDENT_CODE on)
 
 #[[ This file takes a while to build, so we do it once here and every test
 executable can link to it to save time.

--- a/tests/tea/CMakeLists.txt
+++ b/tests/tea/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.19)
+project(ExtTeaTests LANGUAGES C CXX)
+
+# The Catch2::Catch2 target has been available since 2.1.2 We are unsure of the
+# true minimum, but have tested 2.4
+find_package(Catch2 2.4 REQUIRED)
+
+set(CMAKE_C_VISIBILITY_PRESET "hidden")
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+
+#[[ This file takes a while to build, so we do it once here and every test
+executable can link to it to save time.
+]]
+if(NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
+  #[[ The build of catch2 we are using wasn't configured with
+      `CATCH_BUILD_STATIC_LIBRARY`; let's polyfill it.
+  ]]
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc
+       "#define CATCH_CONFIG_MAIN\n" "#include <catch2/catch.hpp>\n")
+
+  add_library(Catch2WithMain ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc)
+  target_compile_features(Catch2WithMain INTERFACE cxx_std_11)
+  target_link_libraries(Catch2WithMain PUBLIC Catch2::Catch2)
+  add_library(Catch2::Catch2WithMain ALIAS Catch2WithMain)
+endif()
+
+include(Catch)
+enable_testing()
+
+find_package(Tea 0.1.0 REQUIRED)
+if(NOT TARGET Tea::Tea)
+  message(FATAL_ERROR "TEA is required but not found")
+endif()
+
+add_library(ext-tea-tests INTERFACE)
+target_link_libraries(ext-tea-tests INTERFACE Catch2::Catch2WithMain Tea::Tea)
+
+# Need components, for example stack-sample.
+add_subdirectory(../../components ${CMAKE_CURRENT_BINARY_DIR}/components)
+
+add_subdirectory(profiling)

--- a/tests/tea/profiling/CMakeLists.txt
+++ b/tests/tea/profiling/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(tea-profiling SHARED profiling.cc profiling.h)
+set_target_properties(tea-profiling PROPERTIES PREFIX "")
+target_link_libraries(tea-profiling PUBLIC Tea::PHP datadog-php-stack-sample
+                                           datadog_php_string_view)
+
+add_executable(tea-profiling-interrupt-test
+               interrupt.cc ${CMAKE_CURRENT_BINARY_DIR}/sleep.php)
+
+target_link_libraries(
+  tea-profiling-interrupt-test
+  PUBLIC ext-tea-tests tea-profiling datadog-php-stack-sample
+         datadog_php_string_view)
+
+catch_discover_tests(tea-profiling-interrupt-test)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sleep.php
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/sleep.php
+          ${CMAKE_CURRENT_BINARY_DIR}/sleep.php
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/sleep.php)

--- a/tests/tea/profiling/interrupt.cc
+++ b/tests/tea/profiling/interrupt.cc
@@ -1,0 +1,55 @@
+extern "C" {
+#include "tea/common.h"
+#include "tea/extension.h"
+#include "tea/sapi.h"
+}
+
+#include <Zend/zend_API.h>
+#include <php_config.h>
+#include <unistd.h>
+
+#include <tea/testing/catch2.hpp>
+
+#include "profiling.h"
+
+#if PHP_VERSION_ID >= 70000
+
+TEA_TEST_CASE_WITH_PROLOGUE(
+    "profiling", "profiling interrupt function is called before internal function's post-hook",
+    {
+        char buffer[1024];
+        const char *pwd = getcwd(buffer, sizeof buffer);
+        REQUIRE(pwd);
+
+        char fqn[1024];
+        int result = snprintf(fqn, sizeof fqn, "%s/tea-profiling.so", pwd);
+        REQUIRE(result > 0);
+        REQUIRE(result < sizeof buffer);
+
+        REQUIRE(tea_sapi_append_system_ini_entry("extension", "ddtrace.so"));
+        REQUIRE(tea_sapi_append_system_ini_entry("zend_extension", fqn));
+        REQUIRE(tea_sapi_append_system_ini_entry("datadog.trace.debug", "true"));
+        REQUIRE(tea_sapi_append_system_ini_entry("datadog.trace.traced_internal_functions", "sleep"));
+    },
+    {
+        REQUIRE(tea_execute_script("sleep.php"));
+
+        datadog_php_stack_sample sample = tea_get_last_stack_sample();
+
+        /* sample should look something like:
+         *   <php>
+         *   main
+         *   sleep
+         */
+        REQUIRE(datadog_php_stack_sample_depth(&sample) == 3);
+
+        datadog_php_stack_sample_iterator iter = datadog_php_stack_sample_iterator_ctor(&sample);
+        REQUIRE(datadog_php_stack_sample_iterator_valid(&iter));
+
+        // top frame should be sleep, not the ddtrace closure
+        auto frame = datadog_php_stack_sample_iterator_frame(&iter);
+        auto expected = datadog_php_string_view_from_cstr("sleep");
+        REQUIRE(datadog_php_string_view_equal(frame.function, expected));
+    })
+
+#endif

--- a/tests/tea/profiling/interrupt.cc
+++ b/tests/tea/profiling/interrupt.cc
@@ -12,8 +12,6 @@ extern "C" {
 
 #include "profiling.h"
 
-#if PHP_VERSION_ID >= 70000
-
 TEA_TEST_CASE_WITH_PROLOGUE(
     "profiling", "profiling interrupt function is called before internal function's post-hook",
     {
@@ -51,5 +49,3 @@ TEA_TEST_CASE_WITH_PROLOGUE(
         auto expected = datadog_php_string_view_from_cstr("sleep");
         REQUIRE(datadog_php_string_view_equal(frame.function, expected));
     })
-
-#endif

--- a/tests/tea/profiling/profiling.cc
+++ b/tests/tea/profiling/profiling.cc
@@ -9,19 +9,19 @@ ZEND_TLS datadog_php_stack_sample last_stack_sample;
 
 ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void) { return last_stack_sample; }
 
-extern "C" {
 ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_data) {
     datadog_php_stack_sample_ctor(&last_stack_sample);
-    // don't try to re-implement everything
 
+    /* Don't try to re-implement everything. Remember, the tracer is being
+     * tested here, not the profiler!
+     */
     while (execute_data) {
         datadog_php_stack_sample_frame frame = {DATADOG_PHP_STRING_VIEW_INIT, DATADOG_PHP_STRING_VIEW_INIT, 0};
+
         if (execute_data->func && execute_data->func->common.function_name) {
             frame.function.ptr = ZSTR_VAL(execute_data->func->common.function_name);
             frame.function.len = ZSTR_LEN(execute_data->func->common.function_name);
-        }
-
-        if (!frame.function.len) {
+        } else {
             frame.function.ptr = "<php>";
             frame.function.len = sizeof("<php>") - 1;
         }
@@ -32,7 +32,6 @@ ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_da
 
         execute_data = execute_data->prev_execute_data;
     }
-}
 }
 
 ZEND_API zend_extension_version_info extension_version_info = {

--- a/tests/tea/profiling/profiling.cc
+++ b/tests/tea/profiling/profiling.cc
@@ -1,0 +1,70 @@
+#include "profiling.h"
+
+#include <Zend/zend_extensions.h>
+#include <php_config.h>
+
+#include <cstdio>
+
+ZEND_TLS datadog_php_stack_sample last_stack_sample;
+
+ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void) { return last_stack_sample; }
+
+extern "C" {
+ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_data) {
+    datadog_php_stack_sample_ctor(&last_stack_sample);
+    // don't try to re-implement everything
+
+    while (execute_data) {
+        datadog_php_stack_sample_frame frame = {DATADOG_PHP_STRING_VIEW_INIT, DATADOG_PHP_STRING_VIEW_INIT, 0};
+        if (execute_data->func && execute_data->func->common.function_name) {
+            frame.function.ptr = ZSTR_VAL(execute_data->func->common.function_name);
+            frame.function.len = ZSTR_LEN(execute_data->func->common.function_name);
+        }
+
+        if (!frame.function.len) {
+            frame.function.ptr = "<php>";
+            frame.function.len = sizeof("<php>") - 1;
+        }
+
+        if (!datadog_php_stack_sample_try_add(&last_stack_sample, frame)) {
+            break;
+        }
+
+        execute_data = execute_data->prev_execute_data;
+    }
+}
+}
+
+ZEND_API zend_extension_version_info extension_version_info = {
+    ZEND_EXTENSION_API_NO,
+    ZEND_EXTENSION_BUILD_ID,
+};
+
+static void profiling_activate(void) { datadog_php_stack_sample_ctor(&last_stack_sample); }
+
+static void profiling_deactivate(void) { datadog_php_stack_sample_dtor(&last_stack_sample); }
+
+static void profiling_message_handler(int code, void *ext) {
+    zend_extension *extension = static_cast<zend_extension *>(ext);
+    fprintf(stderr, "Tea profiling message_handler(%d, %p) (name: %s)\n", code, ext, extension->name);
+}
+
+ZEND_API zend_extension zend_extension_entry = {
+    "datadog-profiling",
+    NULL, /* is version allowed to be null? */
+    "Datadog",
+    "https://github.com/Datadog/dd-trace-php",
+    "Datadog",
+    NULL,
+    NULL,
+    profiling_activate,
+    profiling_deactivate,
+    profiling_message_handler,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    STANDARD_ZEND_EXTENSION_PROPERTIES,
+};

--- a/tests/tea/profiling/profiling.h
+++ b/tests/tea/profiling/profiling.h
@@ -2,12 +2,14 @@
 #define TEA_EXT_PROFILING_H
 
 #include <Zend/zend_portability.h>
+#include <Zend/zend_types.h>
 #include <stdint.h>
 
 BEGIN_EXTERN_C()
 #include <components/stack-sample/stack-sample.h>
 
 ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void);
+ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_data);
 END_EXTERN_C()
 
 #endif

--- a/tests/tea/profiling/profiling.h
+++ b/tests/tea/profiling/profiling.h
@@ -1,0 +1,13 @@
+#ifndef TEA_EXT_PROFILING_H
+#define TEA_EXT_PROFILING_H
+
+#include <Zend/zend_portability.h>
+#include <stdint.h>
+
+BEGIN_EXTERN_C()
+#include <components/stack-sample/stack-sample.h>
+
+ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void);
+END_EXTERN_C()
+
+#endif

--- a/tests/tea/profiling/sleep.php
+++ b/tests/tea/profiling/sleep.php
@@ -14,7 +14,8 @@ namespace {
         );
     }
 
-    function main() {
+    function main()
+    {
         sleep(1);
         echo "Done.\n";
     }

--- a/tests/tea/profiling/sleep.php
+++ b/tests/tea/profiling/sleep.php
@@ -1,24 +1,23 @@
 <?php
 
 namespace {
-  if (function_exists('DDTrace\\trace_function')) {
+    if (function_exists('DDTrace\\trace_function')) {
+        DDTrace\trace_function(
+            'sleep',
+            function ($span, $args) {
+                $span->name = 'sleep';
+                if (!empty($args[0])) {
+                    $span->resource = (string)$args[0];
+                }
+                $span->type = 'custom';
+            }
+        );
+    }
 
-    DDTrace\trace_function(
-      'sleep',
-      function ($span, $args) {
-        $span->name = 'sleep';
-        if (!empty($args[0])) {
-          $span->resource = (string)$args[0];
-        }
-        $span->type = 'custom';
-      }
-    );
-  }
+    function main() {
+        sleep(1);
+        echo "Done.\n";
+    }
 
-  function main() {
-    sleep(1);
-    echo "Done.\n";
-  }
-
-  main();
+    main();
 }

--- a/tests/tea/profiling/sleep.php
+++ b/tests/tea/profiling/sleep.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace {
+  if (function_exists('DDTrace\\trace_function')) {
+
+    DDTrace\trace_function(
+      'sleep',
+      function ($span, $args) {
+        $span->name = 'sleep';
+        if (!empty($args[0])) {
+          $span->resource = (string)$args[0];
+        }
+        $span->type = 'custom';
+      }
+    );
+  }
+
+  function main() {
+    sleep(1);
+    echo "Done.\n";
+  }
+
+  main();
+}


### PR DESCRIPTION
### Description

If the observer_end is called before the profiler processes an
interrupt, then the profiler mis-attributes time taken to the tracing
function, instead of the real leaf function. This change pairs with one
in the profiler that exposes `datadog_profiling_interrupt_function`.

Here's the profiling function which ends up being called by
 `datadog_profiling_interrupt_function`:
[datadog_php_stack_collector_interrupt_function](https://github.com/DataDog/dd-prof-php/blob/ed9b20cd4bf15e7dad0438cd9341d6c96d576123/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c#L306). It is safe to call this
function even when the profiler is disabled.

I wrote a simple "sleep" app + integration to demonstrate the bug:

```php
<?php

if (function_exists('DDTrace\trace_function')) {
  DDTrace\trace_function(
    'sleep',
    function ($span, $args) {
      $span->name = 'sleep';
      if (!empty($args[0])) {
        $span->resource = (string)$args[0];
      }
      $span->type = 'custom';
    }
  );
}

function main() {
  sleep(1);
}
main();
```

Before the change:
![app datadoghq com_profiling_search_query=service%3Aunnamed-service agg_m=%40prof_php_wall_time agg_q=service agg_t=avg event=AQAAAX7GZy6wthM-QAAAAABBWDdHWnpIOUFBQi1yYkZiRlZWZThnQUE profileId=AX7GZzH9AAB-rbFbFVVe8gAA start=1644004621742  (2)](https://user-images.githubusercontent.com/253316/152603139-12714c2f-a712-48d4-84f4-f6904d0d79d0.png)

As you can see, the time of the sleep is mis-attributed to the closure.
After the change:
![app datadoghq com_profiling_search_query=service%3Aunnamed-service agg_m=%40prof_php_wall_time agg_q=service agg_t=avg event=AQAAAX7GZy6wthM-QAAAAABBWDdHWnpIOUFBQi1yYkZiRlZWZThnQUE profileId=AX7GZzH9AAB-rbFbFVVe8gAA start=1644004621742  (3)](https://user-images.githubusercontent.com/253316/152603152-af96e526-f90a-434b-98ad-543c92915eef.png)

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
