### PR TITLE
Clean up Tea SAPI and allow ddtrace to run there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1163,7 +1163,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
-  Zai:
+  Tea:
     working_directory: ~/datadog
     parameters:
       os:
@@ -1542,7 +1542,7 @@ workflows:
   zend_abstract_interface:
     jobs:
       - "Prepare Code"
-      - Zai:
+      - Tea:
           requires: [ 'Prepare Code' ]
           matrix:
             parameters:

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -22,6 +22,7 @@ sapi_t datadog_php_sapi_from_name(string_view_t module) {
         {SV("fpm-fcgi"), DATADOG_PHP_SAPI_FPM_FCGI},
         {SV("litespeed"), DATADOG_PHP_SAPI_LITESPEED},
         {SV("phpdbg"), DATADOG_PHP_SAPI_PHPDBG},
+        {SV("tea"), DATADOG_PHP_SAPI_TEA},
     };
 
     unsigned n_sapis = sizeof sapis / sizeof *sapis;

--- a/components/sapi/sapi.h
+++ b/components/sapi/sapi.h
@@ -13,6 +13,7 @@ typedef enum {
     DATADOG_PHP_SAPI_LITESPEED,
     DATADOG_PHP_SAPI_FPM_FCGI,
     DATADOG_PHP_SAPI_PHPDBG,
+    DATADOG_PHP_SAPI_TEA,
 } datadog_php_sapi;
 
 datadog_php_sapi datadog_php_sapi_from_name(datadog_php_string_view module);

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -18,6 +18,7 @@ TEST_CASE("recognize real sapis", "[sapi]") {
         {"fpm-fcgi", DATADOG_PHP_SAPI_FPM_FCGI},
         {"litespeed", DATADOG_PHP_SAPI_LITESPEED},
         {"phpdbg", DATADOG_PHP_SAPI_PHPDBG},
+        {"tea", DATADOG_PHP_SAPI_TEA},
     };
 
     for (auto server : servers) {

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -457,6 +457,7 @@ static bool dd_is_compatible_sapi(datadog_php_string_view module_name) {
         case DATADOG_PHP_SAPI_CLI:
         case DATADOG_PHP_SAPI_CLI_SERVER:
         case DATADOG_PHP_SAPI_FPM_FCGI:
+        case DATADOG_PHP_SAPI_TEA:
             return true;
 
         default:

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -394,6 +394,7 @@ static bool dd_is_compatible_sapi(datadog_php_string_view module_name) {
         case DATADOG_PHP_SAPI_CLI:
         case DATADOG_PHP_SAPI_CLI_SERVER:
         case DATADOG_PHP_SAPI_FPM_FCGI:
+        case DATADOG_PHP_SAPI_TEA:
             return true;
 
         default:

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -349,6 +349,7 @@ static bool dd_is_compatible_sapi(datadog_php_string_view module_name) {
         case DATADOG_PHP_SAPI_CLI:
         case DATADOG_PHP_SAPI_CLI_SERVER:
         case DATADOG_PHP_SAPI_FPM_FCGI:
+        case DATADOG_PHP_SAPI_TEA:
             return true;
 
         default:

--- a/tea/CMakeLists.txt
+++ b/tea/CMakeLists.txt
@@ -30,10 +30,12 @@ find_library(
   # 'REQUIRED' added in cmake v3.18
   REQUIRED)
 
-include_directories(
-  "${PHP_PREFIX_PATH}/include/php/" "${PHP_PREFIX_PATH}/include/php/TSRM"
-  "${PHP_PREFIX_PATH}/include/php/Zend" "${PHP_PREFIX_PATH}/include/php/ext"
-  "${PHP_PREFIX_PATH}/include/php/main")
+add_library(tea-libphp INTERFACE)
+set_target_properties(tea-libphp PROPERTIES EXPORT_NAME PHP)
+target_link_libraries(tea-libphp INTERFACE "${PHP_LIB}")
+target_include_directories(tea-libphp INTERFACE
+  "${PHP_PREFIX_PATH}/include/php" "${PHP_PREFIX_PATH}/include/php/TSRM"
+  "${PHP_PREFIX_PATH}/include/php/Zend" "${PHP_PREFIX_PATH}/include/php/main")
 
 add_library(Tea src/extension.c src/error.c src/frame.c src/exceptions.c src/ini.c src/io.c src/sapi.c)
 
@@ -44,7 +46,7 @@ target_include_directories(
 
 target_compile_features(Tea PUBLIC c_std_99)
 
-target_link_libraries(Tea PUBLIC "${PHP_LIB}")
+target_link_libraries(Tea PUBLIC tea-libphp)
 
 set_target_properties(Tea PROPERTIES VERSION ${PROJECT_VERSION})
 
@@ -98,12 +100,12 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tea)
 # Copy the static library on install
 install(
-  TARGETS Tea
+  TARGETS Tea tea-libphp
   EXPORT TeaTargets
   ARCHIVE)
 # Copy the .cmake files on install
 export(
-  TARGETS Tea
+  TARGETS Tea tea-libphp
   NAMESPACE Tea::
   FILE ${CMAKE_CURRENT_BINARY_DIR}/TeaTargets.cmake)
 install(


### PR DESCRIPTION
### Description

The extension maintains a list of recognized SAPIs. If an unknown SAPI
is detected, then tracing is disabled. This PR adds the Tea SAPI to
this list so tracing can happen in the Tea SAPI.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
