### PR TITLE
Use a new curl session for each writer iteration and clear it after

### DIFF
--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -52,6 +52,10 @@ static bool _dd_is_memory_pressure_high(void) {
     }
 }
 
+/* Is called internally in the context of the PHP thread and actually attempts at storing the payload to send. If
+ * there is not enough memory left in the currently active stack, it does not attempt to generate a new stack, instead
+ * it returns a `ENOMEM` code that should be read by the invoker that can manually decide to ask for a larger stack.
+ */
 static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size) {
     ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_globals.current_stack);
     if (stack == NULL) {
@@ -83,6 +87,12 @@ static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size
     return 0;
 }
 
+/* Allocates a new stack of the minimum possible size. Only if `min_size` (which is the size required by the user to
+ * fit in a given payload) is larger than the currently active stack size, then new sizes are attempted attemptiong
+ * to double at each iteration, up to `DDTRACE_COMS_STACK_MAX_SIZE`.
+ * The rationale behind this is that once we know that at least one single trace can be larger than X bytes, then
+ * all the subsequent stacks are allocated at least as large as that size.
+ */
 static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
     size_t initial_size = atomic_load(&ddtrace_coms_globals.stack_size);
     size_t size = initial_size;
@@ -202,6 +212,17 @@ static void _dd_unsafe_cleanup_dirty_stack_area(void) {
     ddtrace_coms_globals.tmp_stack = NULL;
 }
 
+/* Stores the global current stack (if any) into the global `stacks` array. The writer will pick from this array when
+ * sending payloads to the backend. This function is invoked when a global current stack is "filled enough" to be sent
+ * to the backend.
+ * This function has a side effect: it tries to save memory by using as the "next" global current stack one of the
+ * stacks in the global `stack` array mentioned above. This is possible if a payload contained in one of the elements of
+ * the array has already been sent to the backend and, as a consequence, that element is ready for reuse. Keep in mind
+ * that in order to be ready for reuse it has to be at least of size `min_size`.
+ * It is possible that the global current stack is set to `NULL` by this function. In this case it means that there were
+ * no available existing stacks that could store `min_size` bytes and it is the invoker's own responsibility to allocate
+ * a new stack of the desired size and assign it to the global current stack.
+ */
 static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) {
     _dd_unsafe_cleanup_dirty_stack_area();
 
@@ -248,16 +269,23 @@ static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_si
     *current_stack = NULL;
 }
 
-static bool _dd_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool _dd_coms_unsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     _dd_unsafe_store_or_swap_current_stack_for_empty_stack(min_size);
 
     ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
 
+    /* In this case we are reusing a stack (from the global `stacks` array) that has been already sent and was
+     * recycled, and `current_stack` is just a pointer to one of `<global>.stacks[i]`.
+     */
     if (current_stack && current_stack->size >= min_size && ddtrace_coms_is_stack_free(current_stack)) {
         return true;
     }
 
-    // old current stack was stored so set a new stack
+    /* In this case it wasn't possible to reuse an existing stack, for one of two reasons:
+     *   1. All the N currently allocated stacks (with N <= `DDTRACE_COMS_STACKS_BACKLOG_SIZE`) are filled and waiting
+     *      to be sent by the writer; or
+     *   2. None of the available stacks in the global `stacks` array that could be reused has size >= `min_size`.
+     */
     if (!current_stack) {
         if (attempt_allocate_new) {
             ddtrace_coms_stack_t **next_stack = &ddtrace_coms_globals.tmp_stack;
@@ -307,12 +335,12 @@ static struct _writer_loop_data_t global_writer = {.thread = NULL,
 
 static struct _writer_loop_data_t *_dd_get_writer() { return &global_writer; }
 
-bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     struct _writer_loop_data_t *writer = _dd_get_writer();
     bool rv = false;
     if (writer->thread) {
         pthread_mutex_lock(&writer->thread->stack_rotation_mutex);
-        rv = _dd_coms_rotate_stack(attempt_allocate_new, min_size);
+        rv = _dd_coms_unsafe_rotate_stack(attempt_allocate_new, min_size);
         pthread_mutex_unlock(&writer->thread->stack_rotation_mutex);
     }
     return rv;
@@ -760,9 +788,7 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
 
 static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms_stack_t *stack) {
     if (!writer->curl) {
-        writer->curl = curl_easy_init();
-        curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
-        curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+        ddtrace_bgs_logf("[bgs] no curl session - dropping the current stack.\n", NULL);
     }
 
     if (writer->curl) {
@@ -777,7 +803,6 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
-        curl_easy_setopt(writer->curl, CURLOPT_INFILESIZE, 10);
         curl_easy_setopt(writer->curl, CURLOPT_VERBOSE, get_global_DD_TRACE_AGENT_DEBUG_VERBOSE_CURL());
 
         res = curl_easy_perform(writer->curl);
@@ -902,6 +927,12 @@ static void *_dd_writer_loop(void *_) {
         if (!*stack) {
             *stack = _dd_coms_attempt_acquire_stack();
         }
+
+        // initializing a curl client only for this iteration
+        writer->curl = curl_easy_init();
+        curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
+        curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+
         while (*stack) {
             processed_stacks++;
             if (atomic_load(&writer->sending)) {
@@ -916,6 +947,8 @@ static void *_dd_writer_loop(void *_) {
 
             *stack = _dd_coms_attempt_acquire_stack();
         }
+
+        curl_easy_cleanup(writer->curl);
 
         if (processed_stacks > 0) {
             atomic_fetch_add(&writer->flush_processed_stacks_total, processed_stacks);
@@ -1194,7 +1227,7 @@ uint32_t ddtrace_coms_test_writers(void) {
 }
 
 uint32_t ddtrace_coms_test_consumer(void) {
-    if (!_dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
+    if (!_dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
         printf("error rotating stacks");
     }
 
@@ -1248,7 +1281,7 @@ uint32_t ddtrace_coms_test_consumer(void) {
     } while (0)
 
 uint32_t ddtrace_coms_test_msgpack_consumer(void) {
-    _dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
+    _dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
 
     ddtrace_coms_stack_t *stack = _dd_coms_attempt_acquire_stack();
     if (!stack) {

--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -962,7 +962,6 @@ static void *_dd_writer_loop(void *_) {
     curl_slist_free_all(writer->headers);
     writer->headers = NULL;
 
-    curl_easy_cleanup(writer->curl);
     _dd_coms_stack_shutdown();
 
     pthread_cleanup_pop(1);

--- a/ext/php5/coms.h
+++ b/ext/php5/coms.h
@@ -20,10 +20,18 @@ typedef struct ddtrace_coms_stack_t {
 } ddtrace_coms_stack_t;
 
 typedef struct ddtrace_coms_state_t {
+    // This is the current stack where new incoming payloads are written to.
     _Atomic(ddtrace_coms_stack_t *) current_stack;
     ddtrace_coms_stack_t *tmp_stack;
+    /* An array of `DDTRACE_COMS_STACKS_BACKLOG_SIZE` stacks. Different stacks can have different size.
+     * Stacks that are accessed through this array are not for write. They are either empty, if their content has been
+     * sent and the stack is ready to be reused, or filled with data ready to be sent at the next writer iteration.
+     */
     ddtrace_coms_stack_t **stacks;
     _Atomic(uint32_t) next_group_id;
+    /* The size of the `current_stack`. Note that `current_stack` and `stack_size` are not changed in a 'transaction',
+     * so, with the current implementation, they have to be manually kept in sync.
+     */
     atomic_size_t stack_size;
 } ddtrace_coms_state_t;
 
@@ -33,6 +41,8 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
     return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
+/* Is called by the PHP thread to buffer a payload in order to send it. It is non-blocking on the request to the agent.
+ */
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
 bool ddtrace_coms_minit(void);
 void ddtrace_coms_mshutdown(void);

--- a/ext/php7/comms_php.c
+++ b/ext/php7/comms_php.c
@@ -40,7 +40,6 @@ bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t pay
 
         if (ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), data, data_len)) {
             sent_to_background_sender = true;
-            ddtrace_log_debugf("Sent a trace to the BGS (group id: %u)", DDTRACE_G(traces_group_id));
         } else {
             ddtrace_log_debug("Unable to send payload to background sender's buffer");
         }

--- a/ext/php7/comms_php.c
+++ b/ext/php7/comms_php.c
@@ -40,6 +40,7 @@ bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t pay
 
         if (ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), data, data_len)) {
             sent_to_background_sender = true;
+            ddtrace_log_debugf("Sent a trace to the BGS (group id: %u)", DDTRACE_G(traces_group_id));
         } else {
             ddtrace_log_debug("Unable to send payload to background sender's buffer");
         }

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -52,6 +52,10 @@ static bool _dd_is_memory_pressure_high(void) {
     }
 }
 
+/* Is called internally in the context of the PHP thread and actually attempts at storing the payload to send. If
+ * there is not enough memory left in the currently active stack, it does not attempt to generate a new stack, instead
+ * it returns a `ENOMEM` code that should be read by the invoker that can manually decide to ask for a larger stack.
+ */
 static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size) {
     ddtrace_log_debugf("Storing group: %u, size: %u)", group_id, size);
     ddtrace_coms_stack_t *stack = atomic_load(&ddtrace_coms_globals.current_stack);
@@ -88,6 +92,13 @@ static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size
     return 0;
 }
 
+/*
+ * Allocates a new stack of the minimum possible size. Only if `min_size` (which is the size required by the user to
+ * fit in a given payload) is larger than the currently active stack size, then new sizes are attempted attemptiong
+ * to double at each iteration, up to `DDTRACE_COMS_STACK_MAX_SIZE`.
+ * The rationale behind this is that once we know that at least one single payload can be larger than X bytes, then
+ * all the subsequent stacks are allocated larger than that size.
+ */
 static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
     size_t initial_size = atomic_load(&ddtrace_coms_globals.stack_size);
     size_t size = initial_size;
@@ -207,6 +218,17 @@ static void _dd_unsafe_cleanup_dirty_stack_area(void) {
     ddtrace_coms_globals.tmp_stack = NULL;
 }
 
+/* Stores the global current stack (if any) into the global `stacks` array. The writer will pick from this array when
+ * sending payloads to the backend. This function is invoked when a global current stack is "filled enough" to be sent
+ * to the backend.
+ * This function has a side effect: it tries to save memory by using as the "next" global current stack one of the
+ * stacks in the global `stack` array mentioned above. This is possible if a payload contained in one of the elements of
+ * the array has already been sent to the backend and, as a consequence, that element is ready for reuse. Keep in mind
+ * that in order to be ready for reuse it has to be at list of size `min_size`.
+ * It is possible that the global current stack is set to `NULL` by this function. In this case it means that there were
+ * no available existing stacks that could store `min_size` bytes and it is the invoker's own responsibility to allocate
+ * a new stack of the desired size and assign it to the global current stack.
+ */
 static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) {
     _dd_unsafe_cleanup_dirty_stack_area();
 
@@ -253,16 +275,23 @@ static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_si
     *current_stack = NULL;
 }
 
-static bool _dd_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool _dd_coms_unsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     _dd_unsafe_store_or_swap_current_stack_for_empty_stack(min_size);
 
     ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
 
+    /* In this case we are reusing a stack (from the global `stacks` array) that has been already sent and was
+     * recycled, and `current_stack` is just a pointer to one of `<global>.stacks[i]`.
+     */
     if (current_stack && current_stack->size >= min_size && ddtrace_coms_is_stack_free(current_stack)) {
         return true;
     }
 
-    // old current stack was stored so set a new stack
+    /* In this case it wasn't possible to reuse an existing stack, for one of two reasons:
+     *   1. All the N currently allocated stacks (with N <= `DDTRACE_COMS_STACKS_BACKLOG_SIZE`) are filled and waiting
+     *      to be sent by the writer; or
+     *   2. None of the available stacks in the global `stacks` array that could be reused has size >= `min_size`.
+     */
     if (!current_stack) {
         if (attempt_allocate_new) {
             ddtrace_coms_stack_t **next_stack = &ddtrace_coms_globals.tmp_stack;
@@ -312,12 +341,12 @@ static struct _writer_loop_data_t global_writer = {.thread = NULL,
 
 static struct _writer_loop_data_t *_dd_get_writer() { return &global_writer; }
 
-bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     struct _writer_loop_data_t *writer = _dd_get_writer();
     bool rv = false;
     if (writer->thread) {
         pthread_mutex_lock(&writer->thread->stack_rotation_mutex);
-        rv = _dd_coms_rotate_stack(attempt_allocate_new, min_size);
+        rv = _dd_coms_unsafe_rotate_stack(attempt_allocate_new, min_size);
         pthread_mutex_unlock(&writer->thread->stack_rotation_mutex);
     }
     return rv;
@@ -1199,7 +1228,7 @@ uint32_t ddtrace_coms_test_writers(void) {
 }
 
 uint32_t ddtrace_coms_test_consumer(void) {
-    if (!_dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
+    if (!_dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
         printf("error rotating stacks");
     }
 
@@ -1253,7 +1282,7 @@ uint32_t ddtrace_coms_test_consumer(void) {
     } while (0)
 
 uint32_t ddtrace_coms_test_msgpack_consumer(void) {
-    _dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
+    _dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
 
     ddtrace_coms_stack_t *stack = _dd_coms_attempt_acquire_stack();
     if (!stack) {

--- a/ext/php7/coms.h
+++ b/ext/php7/coms.h
@@ -20,10 +20,18 @@ typedef struct ddtrace_coms_stack_t {
 } ddtrace_coms_stack_t;
 
 typedef struct ddtrace_coms_state_t {
+    // This is the current stack where new incoming payloads are written to.
     _Atomic(ddtrace_coms_stack_t *) current_stack;
     ddtrace_coms_stack_t *tmp_stack;
+    /* An array of `DDTRACE_COMS_STACKS_BACKLOG_SIZE` stacks. Different stacks can have different size.
+     * Stacks that are accessed through this array are not for write. They are either empty, if their content has been
+     * sent and the stack is ready to be reused, or filled with data ready to be sent at the next writer iteration.
+     */
     ddtrace_coms_stack_t **stacks;
     _Atomic(uint32_t) next_group_id;
+    /* The size of the `current_stack`. Note that `current_stack` and `stack_size` are not changed in a 'transaction',
+     * so, with the current implementation, they have to be manually kept in sync.
+     */
     atomic_size_t stack_size;
 } ddtrace_coms_state_t;
 
@@ -33,7 +41,11 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
     return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
+/* Is called by the PHP thread to buffer a payload in order to send it. It is non-blocking on the request to the agent.
+ * TBD: why `group_id` is necessary???
+ */
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
+
 bool ddtrace_coms_minit(void);
 void ddtrace_coms_mshutdown(void);
 void ddtrace_coms_curl_shutdown(void);

--- a/ext/php7/coms.h
+++ b/ext/php7/coms.h
@@ -42,7 +42,6 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
 }
 
 /* Is called by the PHP thread to buffer a payload in order to send it. It is non-blocking on the request to the agent.
- * TBD: why `group_id` is necessary???
  */
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
 

--- a/ext/php7/coms.h
+++ b/ext/php7/coms.h
@@ -44,7 +44,6 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
 /* Is called by the PHP thread to buffer a payload in order to send it. It is non-blocking on the request to the agent.
  */
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
-
 bool ddtrace_coms_minit(void);
 void ddtrace_coms_mshutdown(void);
 void ddtrace_coms_curl_shutdown(void);

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -83,7 +83,13 @@ static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size
     return 0;
 }
 
-static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
+/* Allocates a new stack of the minimum possible size. Only if `min_size` (which is the size required by the user to
+ * fit in a given payload) is larger than the currently active stack size, then new sizes are attempted attemptiong
+ * to double at each iteration, up to `DDTRACE_COMS_STACK_MAX_SIZE`.
+ * The rationale behind this is that once we know that at least one single trace can be larger than X bytes, then
+ * all the subsequent stacks are allocated at least as large as that size.
+ */
+ static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
     size_t initial_size = atomic_load(&ddtrace_coms_globals.stack_size);
     size_t size = initial_size;
     while (min_size > size && size <= DDTRACE_COMS_STACK_HALF_MAX_SIZE) {
@@ -202,6 +208,17 @@ static void _dd_unsafe_cleanup_dirty_stack_area(void) {
     ddtrace_coms_globals.tmp_stack = NULL;
 }
 
+/* Stores the global current stack (if any) into the global `stacks` array. The writer will pick from this array when
+ * sending payloads to the backend. This function is invoked when a global current stack is "filled enough" to be sent
+ * to the backend.
+ * This function has a side effect: it tries to save memory by using as the "next" global current stack one of the
+ * stacks in the global `stack` array mentioned above. This is possible if a payload contained in one of the elements of
+ * the array has already been sent to the backend and, as a consequence, that element is ready for reuse. Keep in mind
+ * that in order to be ready for reuse it has to be at least of size `min_size`.
+ * It is possible that the global current stack is set to `NULL` by this function. In this case it means that there were
+ * no available existing stacks that could store `min_size` bytes and it is the invoker's own responsibility to allocate
+ * a new stack of the desired size and assign it to the global current stack.
+ */
 static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_size) {
     _dd_unsafe_cleanup_dirty_stack_area();
 
@@ -248,7 +265,7 @@ static void _dd_unsafe_store_or_swap_current_stack_for_empty_stack(size_t min_si
     *current_stack = NULL;
 }
 
-static bool _dd_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool _dd_coms_unsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     _dd_unsafe_store_or_swap_current_stack_for_empty_stack(min_size);
 
     ddtrace_coms_stack_t *current_stack = atomic_load(&ddtrace_coms_globals.current_stack);
@@ -257,7 +274,11 @@ static bool _dd_coms_rotate_stack(bool attempt_allocate_new, size_t min_size) {
         return true;
     }
 
-    // old current stack was stored so set a new stack
+    /* In this case it wasn't possible to reuse an existing stack, for one of two reasons:
+     *   1. All the N currently allocated stacks (with N <= `DDTRACE_COMS_STACKS_BACKLOG_SIZE`) are filled and waiting
+     *      to be sent by the writer; or
+     *   2. None of the available stacks in the global `stacks` array that could be reused has size >= `min_size`.
+     */
     if (!current_stack) {
         if (attempt_allocate_new) {
             ddtrace_coms_stack_t **next_stack = &ddtrace_coms_globals.tmp_stack;
@@ -307,12 +328,12 @@ static struct _writer_loop_data_t global_writer = {.thread = NULL,
 
 static struct _writer_loop_data_t *_dd_get_writer() { return &global_writer; }
 
-bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
+static bool ddtrace_coms_threadsafe_rotate_stack(bool attempt_allocate_new, size_t min_size) {
     struct _writer_loop_data_t *writer = _dd_get_writer();
     bool rv = false;
     if (writer->thread) {
         pthread_mutex_lock(&writer->thread->stack_rotation_mutex);
-        rv = _dd_coms_rotate_stack(attempt_allocate_new, min_size);
+        rv = _dd_coms_unsafe_rotate_stack(attempt_allocate_new, min_size);
         pthread_mutex_unlock(&writer->thread->stack_rotation_mutex);
     }
     return rv;
@@ -760,9 +781,7 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
 
 static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms_stack_t *stack) {
     if (!writer->curl) {
-        writer->curl = curl_easy_init();
-        curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
-        curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+        ddtrace_bgs_logf("[bgs] no curl session - dropping the current stack.\n", NULL);
     }
 
     if (writer->curl) {
@@ -777,7 +796,6 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
-        curl_easy_setopt(writer->curl, CURLOPT_INFILESIZE, 10);
         curl_easy_setopt(writer->curl, CURLOPT_VERBOSE, get_global_DD_TRACE_AGENT_DEBUG_VERBOSE_CURL());
 
         res = curl_easy_perform(writer->curl);
@@ -903,6 +921,12 @@ static void *_dd_writer_loop(void *_) {
         if (!*stack) {
             *stack = _dd_coms_attempt_acquire_stack();
         }
+
+        // initializing a curl client only for this iteration
+        writer->curl = curl_easy_init();
+        curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
+        curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+
         while (*stack) {
             processed_stacks++;
             if (atomic_load(&writer->sending)) {
@@ -917,6 +941,8 @@ static void *_dd_writer_loop(void *_) {
 
             *stack = _dd_coms_attempt_acquire_stack();
         }
+
+        curl_easy_cleanup(writer->curl);
 
         if (processed_stacks > 0) {
             atomic_fetch_add(&writer->flush_processed_stacks_total, processed_stacks);
@@ -1195,7 +1221,7 @@ uint32_t ddtrace_coms_test_writers(void) {
 }
 
 uint32_t ddtrace_coms_test_consumer(void) {
-    if (!_dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
+    if (!_dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size))) {
         printf("error rotating stacks");
     }
 
@@ -1249,7 +1275,7 @@ uint32_t ddtrace_coms_test_consumer(void) {
     } while (0)
 
 uint32_t ddtrace_coms_test_msgpack_consumer(void) {
-    _dd_coms_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
+    _dd_coms_unsafe_rotate_stack(true, atomic_load(&ddtrace_coms_globals.stack_size));
 
     ddtrace_coms_stack_t *stack = _dd_coms_attempt_acquire_stack();
     if (!stack) {

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -956,7 +956,6 @@ static void *_dd_writer_loop(void *_) {
     curl_slist_free_all(writer->headers);
     writer->headers = NULL;
 
-    curl_easy_cleanup(writer->curl);
     _dd_coms_stack_shutdown();
 
     pthread_cleanup_pop(1);

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -89,7 +89,7 @@ static uint32_t _dd_store_data(group_id_t group_id, const char *src, size_t size
  * The rationale behind this is that once we know that at least one single trace can be larger than X bytes, then
  * all the subsequent stacks are allocated at least as large as that size.
  */
- static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
+static ddtrace_coms_stack_t *_dd_new_stack(size_t min_size) {
     size_t initial_size = atomic_load(&ddtrace_coms_globals.stack_size);
     size_t size = initial_size;
     while (min_size > size && size <= DDTRACE_COMS_STACK_HALF_MAX_SIZE) {

--- a/ext/php8/coms.h
+++ b/ext/php8/coms.h
@@ -22,8 +22,15 @@ typedef struct ddtrace_coms_stack_t {
 typedef struct ddtrace_coms_state_t {
     _Atomic(ddtrace_coms_stack_t *) current_stack;
     ddtrace_coms_stack_t *tmp_stack;
+    /* An array of `DDTRACE_COMS_STACKS_BACKLOG_SIZE` stacks. Different stacks can have different size.
+     * Stacks that are accessed through this array are not for write. They are either empty, if their content has been
+     * sent and the stack is ready to be reused, or filled with data ready to be sent at the next writer iteration.
+     */
     ddtrace_coms_stack_t **stacks;
     _Atomic(uint32_t) next_group_id;
+    /* The size of the `current_stack`. Note that `current_stack` and `stack_size` are not changed in a 'transaction',
+     * so, with the current implementation, they have to be manually kept in sync.
+     */
     atomic_size_t stack_size;
 } ddtrace_coms_state_t;
 
@@ -33,6 +40,8 @@ inline bool ddtrace_coms_is_stack_free(ddtrace_coms_stack_t *stack) {
     return ddtrace_coms_is_stack_unused(stack) && atomic_load(&stack->bytes_written) == 0;
 }
 
+/* Is called by the PHP thread to buffer a payload in order to send it. It is non-blocking on the request to the agent.
+ */
 bool ddtrace_coms_buffer_data(uint32_t group_id, const char *data, size_t size);
 bool ddtrace_coms_minit(void);
 void ddtrace_coms_mshutdown(void);


### PR DESCRIPTION
### Description

Before this PR, we initialized a curl session at the first iteration (with loop time of 5 seconds) and then we used it until the process got killed. This means, potentially, that the same curl session could be alive for days.

This resulted in some cycles to be lost because the trace agent closed the connection (RST flag verified through tcpdump) at random intervals.

This PR changes this behavior in two ways:
1. it instantiates a new session at each writer iteration (5 seconds by default) and clears it after the transmission of the payloads that can be sent is completed.
2. increases the total usable number of buffers by 20% (from 10 to 12). This in order to account for possible delays due to slower connection operations during each cycle.

Note that this is only a first optimization, as a better approach, that can be explored as part of a refactoring that we have scheduled soon, could be to keep a session for more than one iteration, but attempting a new send in case of a network error to avoid loosing a payload.


### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~ I extensively tested it manually, but in order to add proper testing we will have to wait for the componentization of the BGS, that might be scheduled soon.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
