### PR TITLE
Always include the Tea SAPI Catch2 test header

### DIFF
--- a/tea/CMakeLists.txt
+++ b/tea/CMakeLists.txt
@@ -83,10 +83,6 @@ if(${BUILD_TEA_TESTING})
 
   enable_testing()
   add_subdirectory(tests)
-
-  install(
-    FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/testing/catch2.hpp
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tea/testing)
 endif()
 
 # Copy the include files on install
@@ -98,6 +94,9 @@ install(
         ${CMAKE_CURRENT_SOURCE_DIR}/include/exceptions.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/sapi.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tea)
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/testing/catch2.hpp
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tea/testing)
 # Copy the static library on install
 install(
   TARGETS Tea tea-libphp


### PR DESCRIPTION
### Description

I originally recommended only installing the Catch2 test header when `BUILD_TEA_TESTING=ON` but since Tea SAPI is built and installed separately as a static object, it doesn't always need to have the tests enabled. This PR makes the `tea/testing/catch2.hpp` header available all the time; even when `BUILD_TEA_TESTING=OFF`.

```
$ tree /opt/tea/include/tea
/opt/tea/include/tea
├── common.h
├── error.h
├── exceptions.h
├── extension.h
├── frame.h
├── sapi.h
└── testing
    └── catch2.hpp
```

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
