### PR TITLE
Explicitly depend on ext/standard and fix in-tree builds

### DIFF
--- a/components/container_id/container_id.h
+++ b/components/container_id/container_id.h
@@ -1,6 +1,9 @@
 #ifndef DATADOG_PHP_CONTAINER_ID_H
 #define DATADOG_PHP_CONTAINER_ID_H
 
+#include <stddef.h>
+#include <sys/types.h>
+// comment to ensure both defs are before regex.h
 #include <regex.h>
 #include <stdbool.h>
 

--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -503,11 +503,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * hooks too, but not loadable as zend_extension=ddtrace.so.
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
-    Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
+#ifdef COMPILE_DL_DDTRACE
+    Dl_info infos;
     // The symbol used needs to be public on Alpine.
     dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
+#endif
     /* }}} */
 
     if (DDTRACE_G(disable)) {
@@ -1970,7 +1972,8 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_SUB_NS_FE("Testing\\", trigger_error, arginfo_ddtrace_testing_trigger_error),
     DDTRACE_FE_END};
 
-static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_END};
+static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_REQUIRED("standard")
+                                                          ZEND_MOD_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           ddtrace_module_deps,       PHP_DDTRACE_EXTNAME,

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -445,11 +445,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * hooks too, but not loadable as zend_extension=ddtrace.so.
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
-    Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
+#ifdef COMPILE_DL_DDTRACE
+    Dl_info infos;
     // The symbol used needs to be public on Alpine.
     dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
+#endif
     /* }}} */
 
     if (DDTRACE_G(disable)) {
@@ -1855,7 +1857,8 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_SUB_NS_FE("Testing\\", trigger_error, arginfo_ddtrace_testing_trigger_error),
     DDTRACE_FE_END};
 
-static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_END};
+static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_REQUIRED("standard")
+                                                          ZEND_MOD_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           ddtrace_module_deps,       PHP_DDTRACE_EXTNAME,

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -400,11 +400,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * hooks too, but not loadable as zend_extension=ddtrace.so.
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
-    Dl_info infos;
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
+#ifdef COMPILE_DL_DDTRACE
+    Dl_info infos;
     // The symbol used needs to be public on Alpine.
     dladdr(get_module, &infos);
     dlopen(infos.dli_fname, RTLD_LAZY);
+#endif
     /* }}} */
 
     if (DDTRACE_G(disable)) {
@@ -1795,7 +1797,8 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_SUB_NS_FE("Testing\\", trigger_error, arginfo_ddtrace_testing_trigger_error),
     DDTRACE_FE_END};
 
-static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_END};
+static const zend_module_dep ddtrace_module_deps[] = {ZEND_MOD_REQUIRED("json") ZEND_MOD_REQUIRED("standard")
+                                                          ZEND_MOD_END};
 
 zend_module_entry ddtrace_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,
                                           ddtrace_module_deps,       PHP_DDTRACE_EXTNAME,


### PR DESCRIPTION
### Description

get_module is only declared when building as a shared object
And fix build on mac: without stddef.h and sys/types.h container component lacks off_t and size_t

We need to ensure ext/standard RINIT is executed before ours (can only happen with in-tree builds).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
