### PR TITLE
Fix #1510 post-install not detecting required extension

### DIFF
--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -192,7 +192,6 @@ println
 invoke_php -i > "$EXTENSION_LOGS_DIR/php-info.log"
 
 PHP_VERSION=$(invoke_php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $NF }')
-PHP_MAJOR_MINOR=$(invoke_php -r 'echo PHP_MAJOR_VERSION;').$(invoke_php -r 'echo PHP_MINOR_VERSION;')
 PHP_CFG_DIR=$(invoke_php -i | grep 'Scan this dir for additional .ini files =>' | sed -e 's/Scan this dir for additional .ini files =>//g' | head -n 1 | awk '{print $1}')
 
 PHP_THREAD_SAFETY=$(invoke_php -i | grep 'Thread Safety' | awk '{print $NF}' | grep -i enabled)

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -159,7 +159,7 @@ function fail_print_and_exit() {
 }
 
 function verify_installation() {
-    invoke_php -m | grep ddtrace && \
+    invoke_php -m | grep -e "^ddtrace$" && \
         println "Extension enabled successfully" || \
         fail_print_and_exit
 }
@@ -167,7 +167,7 @@ function verify_installation() {
 function verify_required_ext() {
     ext_name="$1"
     printf "Checking for extension: ${ext_name}\n"
-    output=$(invoke_php -m | grep "${ext_name}" || true)
+    output=$(invoke_php -m | grep -e "^${ext_name}$" || true)
 
     if [ "${output}" == "${ext_name}" ]; then
         printf "Extension '${ext_name}' was found.\n"


### PR DESCRIPTION
### Description

Fixes post install script.

The functions verify_installation and verify_required_ext were using matching that was not precise enough.

We are looking for an exact match; We don't want to match "could not load ddtrace because of something" or any other similar output when checking a required ext with -m, we want precisely the extension name on a newline.

It would have been better to use reflection to make this check, but fpm doesn't support executing code on the command line.

I found an unused var that used php -r, so dropped that too.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
