### PR TITLE
Do not mess with the span duration in curl integration

### DIFF
--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -80,10 +80,6 @@ final class CurlIntegration extends Integration
 
                 addSpanDataTagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
 
-                // Datadog sets durations in nanoseconds - convert from seconds
-                $span->meta['duration'] = $info['total_time'] * 1000000000;
-                unset($info['duration']);
-
                 addSpanDataTagFromCurlInfo($span, $info, 'network.client.ip', 'local_ip');
                 addSpanDataTagFromCurlInfo($span, $info, 'network.client.port', 'local_port');
 

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -57,7 +57,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
     private static function commonCurlInfoTags()
     {
         $tags = [
-            'duration',
+            'curl.total_time',
             'network.bytes_read',
             'network.bytes_written',
         ];


### PR DESCRIPTION
### Description

Keep a distinction between the native span duration and the measured curl duration.

This also prevents type confusion in the APM itself.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
