### PR TITLE
(PHP 5) Remove empty multi_curl handles hashtables and track curl handle freeing

### DIFF
--- a/ext/php5/handlers_curl.c
+++ b/ext/php5/handlers_curl.c
@@ -241,6 +241,10 @@ static void dd_multi_remove_handle(zval *mh, zval *ch TSRMLS_DC) {
         dd_multi_update_cache(mh, handles TSRMLS_CC);
         if (handles) {
             zend_hash_index_del(handles, Z_RESVAL_P(ch));
+            if (zend_hash_num_elements(handles) == 0) {
+                zend_hash_index_del(DDTRACE_G(curl_multi_handles), Z_RESVAL_P(mh));
+                dd_multi_update_cache(mh, NULL TSRMLS_CC);
+            }
         }
     }
 }

--- a/ext/php5/handlers_internal.c
+++ b/ext/php5/handlers_internal.c
@@ -19,6 +19,7 @@ void dd_install_handler(dd_zif_handler handler TSRMLS_DC) {
 }
 
 void ddtrace_curl_handlers_startup(void);
+void ddtrace_curl_handlers_rinit(TSRMLS_D);
 void ddtrace_curl_handlers_rshutdown(TSRMLS_D);
 void ddtrace_pcntl_handlers_startup(void);
 void ddtrace_exception_handlers_startup(TSRMLS_D);
@@ -35,6 +36,9 @@ void ddtrace_internal_handlers_startup(TSRMLS_D) {
 
 void ddtrace_internal_handlers_shutdown(void) { ddtrace_exception_handlers_shutdown(); }
 
-void ddtrace_internal_handlers_rinit(TSRMLS_D) { ddtrace_exception_handlers_rinit(TSRMLS_C); }
+void ddtrace_internal_handlers_rinit(TSRMLS_D) {
+    ddtrace_curl_handlers_rinit(TSRMLS_C);
+    ddtrace_exception_handlers_rinit(TSRMLS_C);
+}
 
 void ddtrace_internal_handlers_rshutdown(TSRMLS_D) { ddtrace_curl_handlers_rshutdown(TSRMLS_C); }


### PR DESCRIPTION
### Description

Fixes a memory leak.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~ - Tets part of to be committed randomized suite

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
