### PR TITLE
Add is_nil function to UUID component

### DIFF
--- a/components/uuid/tests/uuid.cc
+++ b/components/uuid/tests/uuid.cc
@@ -5,6 +5,23 @@ extern "C" {
 #include <catch2/catch.hpp>
 #include <cstring>
 
+TEST_CASE("uuid nil", "[uuid]") {
+    datadog_php_uuid uuid1;
+    datadog_php_uuid_default_ctor(&uuid1);
+
+    datadog_php_uuid uuid2 = DATADOG_PHP_UUID_INIT;
+
+    CHECK(datadog_php_uuid_is_nil(uuid1));
+    CHECK(datadog_php_uuid_is_nil(uuid2));
+}
+
+TEST_CASE("uuidv4 isn't nil", "[uuid]") {
+    datadog_php_uuid uuid;
+    const uint8_t src[16] = {0};
+    datadog_php_uuidv4_bytes_ctor(&uuid, src);
+    REQUIRE(!datadog_php_uuid_is_nil(uuid));
+}
+
 TEST_CASE("uuid encode32 nil", "[uuid]") {
     datadog_php_uuid uuid;
     datadog_php_uuid_default_ctor(&uuid);
@@ -20,6 +37,7 @@ TEST_CASE("uuid encode32", "[uuid]") {
     datadog_php_uuid uuid = {
         {29, 202, 33, 60, 217, 201, 77, 49, 162, 30, 13, 192, 25, 215, 90, 236},
     };
+    CHECK(!datadog_php_uuid_is_nil(uuid));
 
     alignas(32) char dest[32];
     datadog_php_uuid_encode32(uuid, dest);
@@ -32,6 +50,7 @@ TEST_CASE("uuid encode36", "[uuid]") {
     datadog_php_uuid uuid = {
         {190, 40, 194, 233, 78, 82, 76, 113, 164, 20, 69, 167, 221, 234, 5, 240},
     };
+    CHECK(!datadog_php_uuid_is_nil(uuid));
 
     alignas(32) char dest[36];
     datadog_php_uuid_encode36(uuid, dest);
@@ -65,6 +84,7 @@ TEST_CASE("uuidv4 encode36 bytes 6", "[uuid]") {
      */
     alignas(16) uint8_t bytes[16] = {190, 40, 194, 233, 78, 82, 191, 113, 164, 20, 69, 167, 221, 234, 5, 240};
     datadog_php_uuidv4_bytes_ctor(&uuidv4, bytes);
+    CHECK(!datadog_php_uuid_is_nil(uuidv4));
 
     alignas(32) char dest[36];
     datadog_php_uuid_encode36(uuidv4, dest);

--- a/components/uuid/uuid.c
+++ b/components/uuid/uuid.c
@@ -100,3 +100,5 @@ void datadog_php_uuid_encode36(datadog_php_uuid uuid, char dest[static 36]) {
         dest[dest_offset] = src[src_offset];
     }
 }
+
+extern bool datadog_php_uuid_is_nil(datadog_php_uuid uuid);

--- a/components/uuid/uuid.h
+++ b/components/uuid/uuid.h
@@ -2,6 +2,7 @@
 #define DATADOG_PHP_UUID
 
 #include <stdalign.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #if __cplusplus
@@ -61,6 +62,16 @@ void datadog_php_uuid_encode32(datadog_php_uuid uuid, char dest[C_STATIC(32)]);
  * @param dest A char buffer at least 36 chars in length.
  */
 void datadog_php_uuid_encode36(datadog_php_uuid uuid, char dest[C_STATIC(36)]);
+
+inline bool datadog_php_uuid_is_nil(datadog_php_uuid uuid) {
+    // Avoid string.h header for memcmp just for this
+    // Also avoid loops because GCC tends to miss the obvious optimizations:
+    // https://godbolt.org/z/jPYxcWrjd
+    return uuid.data[0] == 0 && uuid.data[1] == 0 && uuid.data[2] == 0 && uuid.data[3] == 0 && uuid.data[4] == 0 &&
+           uuid.data[5] == 0 && uuid.data[6] == 0 && uuid.data[7] == 0 && uuid.data[8] == 0 && uuid.data[9] == 0 &&
+           uuid.data[10] == 0 && uuid.data[11] == 0 && uuid.data[12] == 0 && uuid.data[13] == 0 && uuid.data[14] == 0 &&
+           uuid.data[15] == 0;
+}
 
 #undef C_STATIC
 


### PR DESCRIPTION
### Description

Add `datadog_php_uuid_is_nil` function to UUID component.

This is used by a work-in-progress implementation of Code Hotspots.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
