### PR TITLE
Remove ioncube loader disabling

### DIFF
--- a/ext/php5/excluded_modules.c
+++ b/ext/php5/excluded_modules.c
@@ -3,12 +3,6 @@
 #include "logging.h"
 
 bool ddtrace_is_excluded_module(zend_module_entry *module, char *error) {
-    if (strcmp("ionCube Loader", module->name) == 0 || strcmp("newrelic", module->name) == 0 ||
-        strcmp("Zend Guard Loader", module->name) == 0) {
-        snprintf(error, DDTRACE_EXCLUDED_MODULES_ERROR_MAX_LEN,
-                 "Found incompatible module: %s, disabling conflicting functionality", module->name);
-        return true;
-    }
     return false;
 }
 

--- a/ext/php7/excluded_modules.c
+++ b/ext/php7/excluded_modules.c
@@ -8,11 +8,6 @@
 #include "logging.h"
 
 bool ddtrace_is_excluded_module(zend_module_entry *module, char *error) {
-    if (strcmp("ionCube Loader", module->name) == 0) {
-        snprintf(error, DDTRACE_EXCLUDED_MODULES_ERROR_MAX_LEN,
-                 "Found incompatible module: %s, disabling conflicting functionality", module->name);
-        return true;
-    }
     if (strcmp("xdebug", module->name) == 0) {
         /*
         PHP 7.0 was only supported from Xdebug 2.4 through 2.7

--- a/ext/php8/excluded_modules.c
+++ b/ext/php8/excluded_modules.c
@@ -8,11 +8,6 @@
 #include "logging.h"
 
 bool ddtrace_is_excluded_module(zend_module_entry *module, char *error) {
-    if (strcmp("ionCube Loader", module->name) == 0) {
-        snprintf(error, DDTRACE_EXCLUDED_MODULES_ERROR_MAX_LEN,
-                 "Found incompatible module: %s, disabling conflicting functionality", module->name);
-        return true;
-    }
     if (strcmp("xdebug", module->name) == 0) {
         /*
         Xdebug versions < 2.9.3 did not call neighboring extension's opcode handlers.


### PR DESCRIPTION
### Description

Compatibility with ionCube loader has been manually verified in our nice neighbor framework. Now tracing will work in presence of ionCube Loader.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
