### PR TITLE
Fix compatibility with PHP 8.2 (master)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -246,8 +246,12 @@ if test "$PHP_DDTRACE" != "no"; then
       ext/php8/span.c \
       ext/php8/startup_logging.c \
       ext/php8/tracer_tag_propagation/tracer_tag_propagation.c \
-      ext/php8/weakrefs.c \
     "
+    if test $PHP_VERSION_ID -lt 80200; then
+      DD_TRACE_PHP_SOURCES="$DD_TRACE_PHP_SOURCES \
+        ext/php8/weakrefs.c \
+      "
+    fi
 
     ZAI_SOURCES="\
       zend_abstract_interface/config/config.c \

--- a/ext/php8/compatibility.h
+++ b/ext/php8/compatibility.h
@@ -49,6 +49,7 @@
 #define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval *)list)[arg_num]))
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
 
+#if PHP_VERSION_ID < 80200
 #define zend_weakrefs_hash_add zend_weakrefs_hash_add_fallback
 #define zend_weakrefs_hash_del zend_weakrefs_hash_del_fallback
 #define zend_weakrefs_hash_add_ptr zend_weakrefs_hash_add_ptr_fallback
@@ -65,5 +66,12 @@ static zend_always_inline void *zend_weakrefs_hash_add_ptr(HashTable *ht, zend_o
         return NULL;
     }
 }
+
+static zend_always_inline zend_ulong zend_object_to_weakref_key(const zend_object *object) { return (uintptr_t)object; }
+
+static zend_always_inline zend_object *zend_weakref_key_to_object(zend_ulong key) {
+    return (zend_object *)(uintptr_t)key;
+}
+#endif
 
 #endif  // DD_COMPATIBILITY_H

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -40,9 +40,13 @@ static int write_hash_table(mpack_writer_t *writer, HashTable *ht) {
     zend_long num_key;
     bool is_assoc = 0;
 
+#if PHP_VERSION_ID >= 80100
+    is_assoc = !zend_array_is_list(ht);
+#else
     Bucket *bucket;
     ZEND_HASH_FOREACH_BUCKET(ht, bucket) { is_assoc = is_assoc || bucket->key != NULL; }
     ZEND_HASH_FOREACH_END();
+#endif
 
     if (is_assoc) {
         mpack_start_map(writer, zend_hash_num_elements(ht));


### PR DESCRIPTION
### Description

Fixes a couple immediate segfaults / assertion failures when running ddtrace against php-src master.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
