### PR TITLE
Fix too aggressive symbol exporting

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -281,13 +281,15 @@ if test "$PHP_DDTRACE" != "no"; then
 
   AC_CHECK_HEADER(time.h, [], [AC_MSG_ERROR([Cannot find or include time.h])])
 
-  dnl Only export symbols defined in ddtrace.sym, which should all be marked as
-  dnl DDTRACE_PUBLIC in their source files as well.
-  EXTRA_CFLAGS="$EXTRA_CFLAGS -fvisibility=hidden"
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -export-symbols $ext_srcdir/ddtrace.sym"
+  if test "$ext_shared" = "yes"; then
+    dnl Only export symbols defined in ddtrace.sym, which should all be marked as
+    dnl DDTRACE_PUBLIC in their source files as well.
+    EXTRA_CFLAGS="$EXTRA_CFLAGS -fvisibility=hidden"
+    EXTRA_LDFLAGS="$EXTRA_LDFLAGS -export-symbols $ext_srcdir/ddtrace.sym"
 
-  PHP_SUBST(EXTRA_CFLAGS)
-  PHP_SUBST(EXTRA_LDFLAGS)
+    PHP_SUBST(EXTRA_CFLAGS)
+    PHP_SUBST(EXTRA_LDFLAGS)
+  fi
 
   PHP_ADD_INCLUDE([$ext_srcdir])
   PHP_ADD_INCLUDE([$ext_srcdir/ext])


### PR DESCRIPTION
### Description

EXTRA_CFLAGS encompasses all of PHP, when not constrained to shared builds only.

This just made my in-tree opcache build export no symbols, not even zend_extension_entry...

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
