### PR TITLE
Fix randomized testsuite memory limits and background sender curl handling

### DIFF
--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -155,6 +155,10 @@ bool ddtrace_coms_minit(void) {
     _dd_ptr_at_exit_callback = _dd_at_exit_callback;
     atexit(_dd_at_exit_hook);
 
+    if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
+        return false;
+    }
+
     return true;
 }
 
@@ -932,6 +936,10 @@ static void *_dd_writer_loop(void *_) {
         writer->curl = curl_easy_init();
         curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
         curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+        // as per https://curl.se/libcurl/c/threadsafe.html
+        // Also note that the docs mention potential SIGPIPEs, which may occur with OpenSSL:
+        // We can ignore that for now as we don't do TLS traffic to the agent currently
+        curl_easy_setopt(writer->curl, CURLOPT_NOSIGNAL, 1);
 
         while (*stack) {
             processed_stacks++;

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -155,6 +155,10 @@ bool ddtrace_coms_minit(void) {
     _dd_ptr_at_exit_callback = _dd_at_exit_callback;
     atexit(_dd_at_exit_hook);
 
+    if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
+        return false;
+    }
+
     return true;
 }
 
@@ -932,6 +936,10 @@ static void *_dd_writer_loop(void *_) {
         writer->curl = curl_easy_init();
         curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
         curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+        // as per https://curl.se/libcurl/c/threadsafe.html
+        // Also note that the docs mention potential SIGPIPEs, which may occur with OpenSSL:
+        // We can ignore that for now as we don't do TLS traffic to the agent currently
+        curl_easy_setopt(writer->curl, CURLOPT_NOSIGNAL, 1);
 
         while (*stack) {
             processed_stacks++;

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -151,6 +151,10 @@ bool ddtrace_coms_minit(void) {
     _dd_ptr_at_exit_callback = _dd_at_exit_callback;
     atexit(_dd_at_exit_hook);
 
+    if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
+        return false;
+    }
+
     return true;
 }
 
@@ -926,6 +930,10 @@ static void *_dd_writer_loop(void *_) {
         writer->curl = curl_easy_init();
         curl_easy_setopt(writer->curl, CURLOPT_READFUNCTION, _dd_coms_read_callback);
         curl_easy_setopt(writer->curl, CURLOPT_WRITEFUNCTION, _dd_dummy_write_callback);
+        // as per https://curl.se/libcurl/c/threadsafe.html
+        // Also note that the docs mention potential SIGPIPEs, which may occur with OpenSSL:
+        // We can ignore that for now as we don't do TLS traffic to the agent currently
+        curl_easy_setopt(writer->curl, CURLOPT_NOSIGNAL, 1);
 
         while (*stack) {
             processed_stacks++;

--- a/tests/randomized/analyze-results.php
+++ b/tests/randomized/analyze-results.php
@@ -109,7 +109,7 @@ function analyze_cli($tmpScenariosFolder)
 
         list($slope, $intercept) = calculate_trend_line($values);
 
-        if ($intercept > 5 * 1000 * 1000) {
+        if ($intercept > 6 * 1000 * 1000) {
             // Heuristic 5MB limit. It might have to be increased as we add integrations
             $largeInterceptResults[] = $identifier;
             continue;


### PR DESCRIPTION
### Description

With the new ES integration we consume a little more memory. Adjusting the limit.

Additionally adding CURLOPT_NOSIGNAL to prevent spurious issues upon reconnects in background sender.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
