### PR TITLE
Update profiling to v0.5.0 from v0.5.0-rc.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PHP_EXTENSION_DIR=$(shell php -r 'print ini_get("extension_dir");')
 PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
-PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.5.0-rc.2/datadog-profiling.tar.gz
+PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.5.0/datadog-profiling.tar.gz
 APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.1/dd-appsec-php-0.2.1-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini


### PR DESCRIPTION
### Description

Update profiling to v0.5.0 from v0.5.0-rc.2. The new version has been
running on the relenv for a few hours and given that there weren't any
changes between v0.5.0-rc.2 and v0.5.0 except the version bump, I am
confident in making this change.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
