### PR TITLE
Release 0.71.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.70.1/datadog-php-tracer_0.70.1_amd64.deb"
+    value: "https://1105103-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.71.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
     value: "https://1105103-119990860-gh.circle-artifacts.com/0/datadog-php-tracer_0.71.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
-    value: "master"
+    value: "php/deployment-trigger"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.5.1/datadog-profiling.tar.gz
-APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.1/dd-appsec-php-0.2.1-amd64.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.2/dd-appsec-php-0.2.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.71.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,40 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ### Changed
+    - Do not disable tracing when ionCube loader is detected #1520
+
+    ### Added
+    - Added ES integration support for newer PHP and ES versions #1516
+    - Add support for wordpress on PHP 8 and use a different hook #1522
+    - Add Code Hotspots #1517
+    - Implement split by instance in PDO #1498
+
+    ### Fixed
+    - Trigger profiling interrupt function before internal observer_end #1499
+    - Fix compatibility with PHP 8.2 (master) #1521
+
+    ### Internal changes
+    - Clean up Tea SAPI and allow ddtrace to run there #1502
+    - Use a new curl session for each writer iteration and clear it after #1504
+    - Increase bgs backlog by 20% #1506
+    - Always include the Tea SAPI Catch2 test header #1507
+    - Add is_nil function to UUID component #1515
+    - Fix randomized testsuite memory limits and background sender curl handling #1525
+    - Run cmake-format on TEA's CMakeLists.txt #1527
+    - Simplify calls (zai symbols), add support for generators #1529
+    - Update profiling to v0.5.0 #1537
+    - Update profiling to v0.5.1 #1541
+    - Move from checking status code reported by vegeta to check error logs #1540
+    - Fix ZAI symbols on PHP 7.3+ (randomized tests failures) #1536
+    - ​​Add a test case for guzzle url no schema + split by domain #1534
+    - Point rel-env deployment to GH release 0.70.1 #1531
+    - Tea ZE Suppport #1526
+    - Show curl response status code in tests #1524
+    - Add long running script memory check to randomized tests #1356
+    - Add a test for sub path and wildcards normalization #1505
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.71.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Changed
- Do not disable tracing when ionCube loader is detected #1520

### Added
- Added ES integration support for newer PHP and ES versions #1516
- Add support for wordpress on PHP 8 and use a different hook #1522
- Add Code Hotspots #1517
- Implement split by instance in PDO #1498

### Fixed
- Trigger profiling interrupt function before internal observer_end #1499
- Fix compatibility with PHP 8.2 (master) #1521

### Internal changes
- Clean up Tea SAPI and allow ddtrace to run there #1502
- Use a new curl session for each writer iteration and clear it after #1504
- Increase bgs backlog by 20% #1506
- Always include the Tea SAPI Catch2 test header #1507
- Add is_nil function to UUID component #1515
- Fix randomized testsuite memory limits and background sender curl handling #1525
- Run cmake-format on TEA's CMakeLists.txt #1527
- Simplify calls (zai symbols), add support for generators #1529
- Update profiling to v0.5.0 #1537
- Update profiling to v0.5.1 #1541
- Move from checking status code reported by vegeta to check error logs #1540
- Fix ZAI symbols on PHP 7.3+ (randomized tests failures) #1536
- ​​Add a test case for guzzle url no schema + split by domain #1534
- Point rel-env deployment to GH release 0.70.1 #1531
- Tea ZE Suppport #1526
- Show curl response status code in tests #1524
- Add long running script memory check to randomized tests #1356
- Add a test for sub path and wildcards normalization #1505

