### PR TITLE
Use latest ubuntu images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -878,7 +878,7 @@ jobs:
         # Possible values: php_installer, native_package
         default: php_installer
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - run: mkdir -p test-results
@@ -954,7 +954,7 @@ jobs:
   installer_tests:
     working_directory: ~/datadog
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202111-02
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
@@ -969,7 +969,7 @@ jobs:
   randomized_tests:
     working_directory: ~/datadog
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202111-02
     resource_class: xlarge
     parameters:
       batch:


### PR DESCRIPTION
### Description

CircleCI is deprecating ubuntu 14.04 and 16.04 images, that we were using to verify centos 6 installs (14.04)
https://circleci.com/blog/ubuntu-14-16-image-deprecation

Moreover, this PR also updates ubuntu 20.04 images to the latest with the log4j vulnerability patched.
While we do not use Java, it is still preferrable to have a patched image.
https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
