### PR TITLE
Add system tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1575,6 +1575,48 @@ jobs:
     steps:
       - run: echo "."
 
+  system_tests:
+    machine:
+      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
+      image: ubuntu-2004:current
+    resource_class: large
+    working_directory: ~/datadog
+    steps:
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Install good version of docker-compose
+          command: |
+            sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+      - run:
+          name: versions
+          command: |
+            docker --version
+            docker-compose --version
+      - run:
+          name: Clone System Tests repo
+          command: git clone https://github.com/DataDog/system-tests.git
+      - run:
+          name: Copy .tar.gz file to system test binaries folder
+          command: |
+            ls -la build/packages
+            installable_bundle=$(find build/packages -maxdepth 1 -name 'datadog-php-tracer-*-nightly.x86_64.tar.gz')
+            echo using $installable_bundle
+            cp $installable_bundle system-tests/binaries/
+      - run:
+          name: Build
+          command: |
+            cd system-tests
+            ./build.sh php
+      - run:
+          name: Run
+          command: |
+            cd system-tests
+            DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh
+      - store_artifacts:
+          path: system-tests/logs
+          destination: system-tests.tar.gz
+
 workflows:
   version: 2
 
@@ -2069,6 +2111,10 @@ workflows:
             parameters:
               php_version:
                 - '8.0'
+
+      - system_tests:
+          requires: [ 'package extension' ]
+          name: "System tests"
 
   build:
     jobs:


### PR DESCRIPTION
### Description

Add [System tests](https://github.com/DataDog/system-tests) in CI ([doc](https://github.com/DataDog/system-tests/tree/main/docs)).

System tests is a functional test suite that performs end-to-end testing on our customer products. It spawns a tracer, an agent, some proxies to spy traffic between all components, run a typical scenario and checks that everything happen as expected.

#### Goals

* Having a unique tests suite for all tracers
* good to catch integration bugs and everything that happen in real life.
* fast (5 mn for build step, 2:30 minutes for test step), and adding new test case is almost free.
* free from flakiness, so you can rely on failure on test step. If you have any doubt, please reach us on slack channel `libraries-system-tests`.
* easy to run locally
 
#### Non-goals 

* provide a detailled explanation of issues : it's black box testing, so we'll describe what we expected and what we saw, but we don't have access to component's internals, so you'll need to investigate to understand the root cause.
* crawling a context matrix : as now we support `apache` and `php-fpm`. We can add other framework, or idiomatic versions. But it's not meant to do smoke test on all possible OS/framework versions (or at least, it'll ask you some effort, for probably a bad return on investment).
* performance testing

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
    -  **NA**
- [ ] Tests added for this feature/bug. **NA**
    -  **NA**

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
