### PR TITLE
Release 0.71.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.70.1/datadog-php-tracer_0.70.1_amd64.deb"
+    value: "https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/7931/workflows/1e27f305-4a3a-43e0-85aa-13446542fa21/jobs/1122057/artifacts#:~:text=datadog%2Dphp%2Dtracer_0.71.1_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/7931/workflows/1e27f305-4a3a-43e0-85aa-13446542fa21/jobs/1122057/artifacts#:~:text=datadog%2Dphp%2Dtracer_0.71.1_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/318505e8-096c-4334-9d6a-914b83e0c0e0/artifacts/0/datadog-php-tracer_0.71.1_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.5.1/datadog-profiling.tar.gz
-APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.1/dd-appsec-php-0.2.1-amd64.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.2/dd-appsec-php-0.2.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.71.1"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,18 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ### Fixed
+
+    - Use -1 as uninitialized op_array_extension marker #1550
+
+    ### Internal changes
+
+    - Use latest ubuntu images in CI #1543
+    - Use 8.1.4 in development buster images #1553
+    - Add randomized tests for PHP 8.1 and make buster containers arm64 ready #1551
+    - Remove regressions from randomized tests #1547
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.71.1';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Fixed

- Use -1 as uninitialized op_array_extension marker #1550

### Internal changes

- Use latest ubuntu images in CI #1543
- Use 8.1.4 in development buster images #1553
- Add randomized tests for PHP 8.1 and make buster containers arm64 ready #1551
- Remove regressions from randomized tests #1547