### PR TITLE
Fix #1544: Handle hook dummy span hack when assigning parent

### DIFF
--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -82,11 +82,15 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
         DDTRACE_G(root_span) = span_fci;
         ddtrace_set_root_span_properties(&span_fci->span);
     } else {
+        ddtrace_span_fci *next_span = span_fci->next;
+        while (next_span->span.start == 0 && next_span->next) {  // skip placeholder span from dd_create_duplicate_span
+            next_span = next_span->next;
+        }
+
         ZVAL_COPY(ddtrace_spandata_property_service(&span_fci->span),
-                  ddtrace_spandata_property_service(&span_fci->next->span));
-        ZVAL_COPY(ddtrace_spandata_property_type(&span_fci->span),
-                  ddtrace_spandata_property_type(&span_fci->next->span));
-        ZVAL_OBJ(ddtrace_spandata_property_parent(&span_fci->span), &span_fci->next->span.std);
+                  ddtrace_spandata_property_service(&next_span->span));
+        ZVAL_COPY(ddtrace_spandata_property_type(&span_fci->span), ddtrace_spandata_property_type(&next_span->span));
+        ZVAL_OBJ(ddtrace_spandata_property_parent(&span_fci->span), &next_span->span.std);
         Z_ADDREF_P(ddtrace_spandata_property_parent(&span_fci->span));
     }
     ddtrace_set_global_span_properties(&span_fci->span);


### PR DESCRIPTION
### Description

Fixes #1544. The dummy span hack of hooks strikes again.

To expand on that: in our current implementation of hook_function we install a dummy span. This dummy span must never be exposed to userland. This fixes this span being exposed via the parent property.

Once we merge our new hooks implementation no such span will exist anymore and this hack of skipping that span can be removed.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.
  - Intentionally skipped it this time, it's a hack and obsolete once the new hooks land.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
