### PR TITLE
Update flex to v1.18.5 in composer.lock files for Symfony 4.0 and 5.0

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_0/composer.lock
+++ b/tests/Frameworks/Symfony/Version_4_0/composer.lock
@@ -3019,16 +3019,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.9.10",
+            "version": "v1.18.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "7335ec033995aa34133e621627333368f260b626"
+                "reference": "22c14c5e4bce8e9087975b34738827c0e01d6460"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/7335ec033995aa34133e621627333368f260b626",
-                "reference": "7335ec033995aa34133e621627333368f260b626",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/22c14c5e4bce8e9087975b34738827c0e01d6460",
+                "reference": "22c14c5e4bce8e9087975b34738827c0e01d6460",
                 "shasum": ""
             },
             "require": {
@@ -3044,7 +3044,7 @@
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.9-dev"
+                    "dev-main": "1.18-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -3066,7 +3066,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.9.10"
+                "source": "https://github.com/symfony/flex/tree/v1.18.5"
             },
             "funding": [
                 {
@@ -3082,7 +3082,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-14T17:41:54+00:00"
+            "time": "2022-04-05T13:31:54+00:00"
         },
         {
             "name": "symfony/form",

--- a/tests/Frameworks/Symfony/Version_5_0/composer.lock
+++ b/tests/Frameworks/Symfony/Version_5_0/composer.lock
@@ -3467,16 +3467,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.12.2",
+            "version": "v1.18.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "e472606b4b3173564f0edbca8f5d32b52fc4f2c9"
+                "reference": "22c14c5e4bce8e9087975b34738827c0e01d6460"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/e472606b4b3173564f0edbca8f5d32b52fc4f2c9",
-                "reference": "e472606b4b3173564f0edbca8f5d32b52fc4f2c9",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/22c14c5e4bce8e9087975b34738827c0e01d6460",
+                "reference": "22c14c5e4bce8e9087975b34738827c0e01d6460",
                 "shasum": ""
             },
             "require": {
@@ -3486,14 +3486,13 @@
             "require-dev": {
                 "composer/composer": "^1.0.2|^2.0",
                 "symfony/dotenv": "^4.4|^5.0",
-                "symfony/filesystem": "^4.4|^5.0",
                 "symfony/phpunit-bridge": "^4.4|^5.0",
                 "symfony/process": "^3.4|^4.4|^5.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.12-dev"
+                    "dev-main": "1.18-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -3515,7 +3514,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.12.2"
+                "source": "https://github.com/symfony/flex/tree/v1.18.5"
             },
             "funding": [
                 {
@@ -3531,7 +3530,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-16T14:05:05+00:00"
+            "time": "2022-04-05T13:31:54+00:00"
         },
         {
             "name": "symfony/form",


### PR DESCRIPTION
### Description

The newer flex version check against the existence of the manifest key instead of failing outright when it is missing.

This fixes our test_web_symfony runners.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
