### PR TITLE
Release 0.72.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.71.1/datadog-php-tracer_0.71.1_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/f18bab38-1de5-4358-8558-6b6cd592e5a8/artifacts/0/datadog-php-tracer_0.72.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.5.1/datadog-profiling.tar.gz
-APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.1/dd-appsec-php-0.2.1-amd64.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.2.2/dd-appsec-php-0.2.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.72.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,21 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ### Added
+    - Add support for memcached on PHP 8 #1558
+
+    ### Fixed
+    - Fix #1544: Handle hook dummy span hack when assigning parent #1557
+
+    ### Internal changes
+    - Add gdbinit files for php 8.0 and 8.1 #1556
+    - Add system tests in CI #1552
+    - Use latest 8.0.17 in buster images #1559
+    - Update flex to v1.18.5 in composer.lock files for Symfony 4.0 and 5.0 #1560
+    - Add a single test to xfail after upgrade of docker image to 8.0.18 #1561
+    - Update link to download 0.71.1 in the reliability environment #1555
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.72.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Added
- Add support for memcached on PHP 8 #1558

### Fixed
- Fix #1544: Handle hook dummy span hack when assigning parent #1557

### Internal changes
- Add gdbinit files for php 8.0 and 8.1 #1556
- Add system tests in CI #1552
- Use latest 8.0.17 in buster images #1559
- Update flex to v1.18.5 in composer.lock files for Symfony 4.0 and 5.0 #1560
- Add a single test to xfail after upgrade of docker image to 8.0.18 #1561
- Update link to download 0.71.1 in the reliability environment #1555