### PR TITLE
Respect autofinish on flush(), add warnings in debug mode when having unbalanced spans

### DIFF
--- a/ext/php5/ddtrace.c
+++ b/ext/php5/ddtrace.c
@@ -1753,6 +1753,9 @@ static PHP_FUNCTION(close_span) {
 
 static PHP_FUNCTION(flush) {
     UNUSED(return_value_used, this_ptr, return_value_ptr, ht);
+    if (get_DD_AUTOFINISH_SPANS()) {
+        ddtrace_close_userland_spans_until(NULL TSRMLS_CC);
+    }
     if (!ddtrace_flush_tracer(TSRMLS_C)) {
         ddtrace_log_debug("Unable to flush the tracer");
     }

--- a/ext/php5/span.c
+++ b/ext/php5/span.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "auto_flush.h"
+#include "compat_string.h"
 #include "configuration.h"
 #include "ddtrace.h"
 #include "dispatch.h"
@@ -168,6 +169,11 @@ void ddtrace_close_userland_spans_until(ddtrace_span_fci *until TSRMLS_DC) {
         if (span_fci->execute_data) {
             ddtrace_log_err("Found internal span data while closing userland spans");
         }
+
+        zval name = zval_used_for_init;
+        ddtrace_convert_to_string(&name, ddtrace_spandata_property_name(&span_fci->span) TSRMLS_CC);
+        ddtrace_log_debugf("Found unfinished span while automatically closing spans with name '%s'", Z_STRVAL(name));
+        zval_dtor(&name);
 
         if (get_DD_AUTOFINISH_SPANS()) {
             dd_trace_stop_span_time(&span_fci->span);

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -181,6 +181,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_env_config, 0, 0, 1)
 ZEND_ARG_INFO(0, env_name)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_close_spans_until, 0, 0, 1)
+ZEND_ARG_INFO(0, until)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_set_trace_id, 0, 0, 1)
 ZEND_ARG_INFO(0, trace_id)
 ZEND_END_ARG_INFO()
@@ -1467,6 +1471,38 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
     }
 }
 
+/* {{{ proto int DDTrace\close_spans_until(DDTrace\SpanData) */
+static PHP_FUNCTION(close_spans_until) {
+    zval *untilzv = NULL;
+
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "O!", &untilzv, ddtrace_ce_span_data) ==
+        FAILURE) {
+        ddtrace_log_debug("DDTrace\\close_spans_until() expects null or a SpanData object");
+        RETURN_FALSE;
+    }
+
+    ddtrace_span_fci *until = untilzv ? (ddtrace_span_fci *)Z_OBJ_P(untilzv) : NULL, *span_fci;
+
+    if (until) {
+        span_fci = DDTRACE_G(open_spans_top);
+        while (span_fci && span_fci != until && span_fci->execute_data == NULL) {
+            span_fci = span_fci->next;
+        }
+        if (span_fci != until) {
+            RETURN_FALSE;
+        }
+    }
+
+    int closed_spans = 0;
+    while ((span_fci = DDTRACE_G(open_spans_top)) && span_fci != until && span_fci->execute_data == NULL) {
+        dd_trace_stop_span_time(&span_fci->span);
+        ddtrace_close_span(span_fci);
+        ++closed_spans;
+    }
+
+    RETURN_LONG(closed_spans);
+}
+
 /* {{{ proto string dd_trace_set_trace_id() */
 static PHP_FUNCTION(dd_trace_set_trace_id) {
     UNUSED(execute_data);
@@ -1817,6 +1853,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_internal_fn, arginfo_dd_trace_internal_fn),
     DDTRACE_FE(dd_trace_noop, arginfo_ddtrace_void),
     DDTRACE_NS_FE(flush, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(close_spans_until, arginfo_dd_trace_close_spans_until),
     DDTRACE_NS_FE(start_span, arginfo_dd_trace_start_span),
     DDTRACE_NS_FE(close_span, arginfo_dd_trace_close_span),
     DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -1643,6 +1643,9 @@ static PHP_FUNCTION(close_span) {
 
 static PHP_FUNCTION(flush) {
     UNUSED(execute_data);
+    if (get_DD_AUTOFINISH_SPANS()) {
+        ddtrace_close_userland_spans_until(NULL);
+    }
     if (ddtrace_flush_tracer() == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "auto_flush.h"
+#include "compat_string.h"
 #include "configuration.h"
 #include "ddtrace.h"
 #include "dispatch.h"
@@ -163,6 +164,10 @@ void ddtrace_close_userland_spans_until(ddtrace_span_fci *until) {
         if (span_fci->execute_data) {
             ddtrace_log_err("Found internal span data while closing userland spans");
         }
+
+        zend_string *name = ddtrace_convert_to_str(ddtrace_spandata_property_name(&span_fci->span));
+        ddtrace_log_debugf("Found unfinished span while automatically closing spans with name '%s'", ZSTR_VAL(name));
+        zend_string_release(name);
 
         if (get_DD_AUTOFINISH_SPANS()) {
             dd_trace_stop_span_time(&span_fci->span);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -1583,6 +1583,9 @@ static PHP_FUNCTION(close_span) {
 
 static PHP_FUNCTION(flush) {
     UNUSED(execute_data);
+    if (get_DD_AUTOFINISH_SPANS()) {
+        ddtrace_close_userland_spans_until(NULL);
+    }
     if (ddtrace_flush_tracer() == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -150,6 +150,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_env_config, 0, 0, 1)
 ZEND_ARG_INFO(0, env_name)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_close_spans_until, 0, 0, 1)
+ZEND_ARG_INFO(0, until)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dd_trace_set_trace_id, 0, 0, 1)
 ZEND_ARG_INFO(0, trace_id)
 ZEND_END_ARG_INFO()
@@ -1411,6 +1415,38 @@ static PHP_FUNCTION(dd_trace_internal_fn) {
     }
 }
 
+/* {{{ proto int DDTrace\close_spans_until(DDTrace\SpanData) */
+static PHP_FUNCTION(close_spans_until) {
+    zval *untilzv = NULL;
+
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "O!", &untilzv, ddtrace_ce_span_data) ==
+        FAILURE) {
+        ddtrace_log_debug("DDTrace\\close_spans_until() expects null or a SpanData object");
+        RETURN_FALSE;
+    }
+
+    ddtrace_span_fci *until = untilzv ? (ddtrace_span_fci *)Z_OBJ_P(untilzv) : NULL, *span_fci;
+
+    if (until) {
+        span_fci = DDTRACE_G(open_spans_top);
+        while (span_fci && span_fci != until && span_fci->execute_data == NULL) {
+            span_fci = span_fci->next;
+        }
+        if (span_fci != until) {
+            RETURN_FALSE;
+        }
+    }
+
+    int closed_spans = 0;
+    while ((span_fci = DDTRACE_G(open_spans_top)) && span_fci != until && span_fci->execute_data == NULL) {
+        dd_trace_stop_span_time(&span_fci->span);
+        ddtrace_close_span(span_fci);
+        ++closed_spans;
+    }
+
+    RETURN_LONG(closed_spans);
+}
+
 /* {{{ proto string dd_trace_set_trace_id() */
 static PHP_FUNCTION(dd_trace_set_trace_id) {
     UNUSED(execute_data);
@@ -1757,6 +1793,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(dd_trace_internal_fn, arginfo_dd_trace_internal_fn),
     DDTRACE_FE(dd_trace_noop, arginfo_ddtrace_void),
     DDTRACE_NS_FE(flush, arginfo_ddtrace_void),
+    DDTRACE_NS_FE(close_spans_until, arginfo_dd_trace_close_spans_until),
     DDTRACE_NS_FE(start_span, arginfo_dd_trace_start_span),
     DDTRACE_NS_FE(close_span, arginfo_dd_trace_close_span),
     DDTRACE_NS_FE(active_span, arginfo_ddtrace_void),

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "auto_flush.h"
+#include "compat_string.h"
 #include "configuration.h"
 #include "ddtrace.h"
 #include "dispatch.h"
@@ -162,6 +163,10 @@ void ddtrace_close_userland_spans_until(ddtrace_span_fci *until) {
         if (span_fci->execute_data) {
             ddtrace_log_err("Found internal span data while closing userland spans");
         }
+
+        zend_string *name = ddtrace_convert_to_str(ddtrace_spandata_property_name(&span_fci->span));
+        ddtrace_log_debugf("Found unfinished span while automatically closing spans with name '%s'", ZSTR_VAL(name));
+        zend_string_release(name);
 
         if (get_DD_AUTOFINISH_SPANS()) {
             dd_trace_stop_span_time(&span_fci->span);

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -110,7 +110,7 @@ final class Tracer implements TracerInterface
             }
         }
 
-        $this->reset();
+        $this->scopeManager = new ScopeManager($this->rootContext);
     }
 
     public function limited()
@@ -123,6 +123,11 @@ final class Tracer implements TracerInterface
      */
     public function reset()
     {
+        if (_ddtrace_config_bool(ini_get("datadog.tracer.enabled"), false)) {
+            // Do a full shutdown and re-startup of the tracer, which implies clearing the internal span stack
+            ini_set("datadog.tracer.enabled", 0);
+            ini_set("datadog.tracer.enabled", 1);
+        }
         $this->scopeManager = new ScopeManager($this->rootContext);
     }
 

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -384,6 +384,17 @@ final class TracerTest extends BaseTestCase
         self::assertSame('from-env', $span['meta']['version']);
     }
 
+    public function testTracerReset()
+    {
+        $traces = $this->isolateTracer(function (Tracer $tracer) {
+            $tracer->startRootSpan('custom.root');
+            $tracer->startActiveSpan('custom.internal');
+            $tracer->reset();
+        });
+
+        $this->assertEmpty($traces);
+    }
+
     public function testServiceMappingNoEnvMapping()
     {
         $traces = $this->isolateTracer(function (Tracer $tracer) {

--- a/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
@@ -29,5 +29,4 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     call_httpbin('user-agent');
     $scope->close();
     $tracer->flush();
-    $tracer->reset();
 }

--- a/tests/ext/close_spans_until.phpt
+++ b/tests/ext/close_spans_until.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test DDTrace\close_spans_until
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+function traced() {
+    DDTrace\start_span();
+    DDTrace\start_span();
+    var_dump(DDTrace\close_spans_until(DDTrace\root_span()));
+    var_dump(DDTrace\close_spans_until(null));
+
+    $start = DDTrace\start_span();
+    DDTrace\start_span();
+    DDTrace\start_span();
+    var_dump(DDTrace\close_spans_until($start));
+    DDTrace\close_span();
+}
+
+DDTrace\trace_function('traced', function() {});
+traced();
+var_dump(DDTrace\close_spans_until(null));
+var_dump(DDTrace\close_spans_until(null));
+
+?>
+--EXPECTF--
+bool(false)
+int(2)
+int(2)
+int(1)
+int(0)
+Successfully triggered flush with trace of size 7

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -24,6 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
+Found unfinished span while automatically closing spans with name 'my precious span'
 array(1) {
   [0]=>
   array(10) {

--- a/tests/ext/start_span_without_closing_autofinish.phpt
+++ b/tests/ext/start_span_without_closing_autofinish.phpt
@@ -24,6 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
+Found unfinished span while automatically closing spans with name 'my precious span'
 array(2) {
   [0]=>
   array(9) {


### PR DESCRIPTION
### Description

- Respect the autofinish setting on `DDTrace\flush()`.
  - Actually, I discovered that the original flush() implementation pre-internal spans did just that. So I restored that behaviour.
- Add `DDTrace\close_spans_until()`, a facility to close spans up to a current span, or up to the last internal (i.e. trace/hook) span.
  - `Span->finish` makes use of this new function, to ensure generally balanced spans.
- Warnings are emitted with `DD_TRACE_DEBUG=1` active, if spans are found to be unbalanced.
- `GlobalTracer->reset()` now does a hard-reset of the tracer.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
