### PR TITLE
Pin composer on PHP 7 docker containers to version 2.2.

### DIFF
--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -86,7 +86,7 @@ RUN set -eux; \
     switch-php debug;
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/buster/php-7.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.1/Dockerfile
@@ -92,7 +92,7 @@ RUN set -eux; \
     switch-php debug;
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/buster/php-7.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.2/Dockerfile
@@ -92,7 +92,7 @@ RUN set -eux; \
     switch-php debug;
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/buster/php-7.3/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.3/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
     switch-php debug;
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 

--- a/dockerfiles/ci/buster/php-7.4/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.4/Dockerfile
@@ -91,7 +91,7 @@ RUN set -eux; \
     switch-php debug;
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 COPY welcome /etc/motd
 


### PR DESCRIPTION
### Description

Dependencies got updated in composer 2.3, using more restrictive types, which is incompatible with some older framework versions we are testing against.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
