### PR TITLE
Add configurations for retaining select query string parameters in resources and http.url

### DIFF
--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -85,6 +85,8 @@ extern bool runtime_config_first_init;
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                   \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                   \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                              \
+    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "")                                                  \
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -85,6 +85,8 @@ extern bool runtime_config_first_init;
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                   \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                   \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                              \
+    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "")                                                  \
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -85,6 +85,8 @@ extern bool runtime_config_first_init;
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                   \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                   \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                              \
+    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "")                                                  \
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -439,19 +439,28 @@ static const char *dd_get_req_uri() {
     return uri;
 }
 
+static const char *dd_get_query_string() {
+    const char *query_string = NULL;
+    zval *_server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (Z_TYPE_P(_server) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+        zval *query_str = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("QUERY_STRING"));
+        if (query_str && Z_TYPE_P(query_str) == IS_STRING) {
+            query_string = Z_STRVAL_P(query_str);
+        }
+    }
+
+    if (!query_string) {
+        query_string = SG(request_info).query_string;
+    }
+
+    return query_string;
+}
+
 static zend_string *dd_build_req_url() {
     zval *_server = &PG(http_globals)[TRACK_VARS_SERVER];
     const char *uri = dd_get_req_uri();
     if (!uri) {
         return ZSTR_EMPTY_ALLOC();
-    }
-
-    int uri_len;
-    char *question_mark = strchr(uri, '?');
-    if (question_mark) {
-        uri_len = question_mark - uri;
-    } else {
-        uri_len = strlen(uri);
     }
 
     zend_bool is_https = zend_hash_str_exists(Z_ARRVAL_P(_server), ZEND_STRL("HTTPS"));
@@ -463,7 +472,25 @@ static zend_string *dd_build_req_url() {
         return ZSTR_EMPTY_ALLOC();
     }
 
-    return zend_strpprintf(0, "http%s://%s%.*s", is_https ? "s" : "", Z_STRVAL_P(host_zv), uri_len, uri);
+    int uri_len;
+    char *question_mark = strchr(uri, '?');
+    zend_string *query_string = zend_empty_string;
+    if (question_mark) {
+        uri_len = question_mark - uri;
+        query_string =
+            zai_filter_query_string((zai_string_view){.len = strlen(uri) - uri_len - 1, .ptr = question_mark + 1},
+                                    get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED());
+    } else {
+        uri_len = strlen(uri);
+    }
+
+    zend_string *url =
+        zend_strpprintf(0, "http%s://%s%.*s%s%.*s", is_https ? "s" : "", Z_STRVAL_P(host_zv), uri_len, uri,
+                        ZSTR_LEN(query_string) ? "?" : "", (int)ZSTR_LEN(query_string), ZSTR_VAL(query_string));
+
+    zend_string_release(query_string);
+
+    return url;
 }
 
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
@@ -509,7 +536,17 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         if (uri) {
             zend_string *path = zend_string_init(uri, strlen(uri), 0);
             zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
-            ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s", method, ZSTR_VAL(normalized)));
+            zend_string *query_string = zend_empty_string;
+            const char *query_str = dd_get_query_string();
+            if (query_str) {
+                query_string = zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
+                                                       get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED());
+            }
+
+            ZVAL_STR(prop_resource,
+                     zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized), ZSTR_LEN(query_string) ? "?" : "",
+                                     (int)ZSTR_LEN(query_string), ZSTR_VAL(query_string)));
+            zend_string_release(query_string);
             zend_string_release(normalized);
             zend_string_release(path);
         } else {

--- a/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
@@ -7,6 +7,7 @@ use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
+use DDTrace\Util\Normalizer;
 use Router;
 
 class CakePHPIntegration extends Integration
@@ -71,7 +72,8 @@ class CakePHPIntegration extends Integration
 
                     $integration->rootSpan->resource =
                         $_SERVER['REQUEST_METHOD'] . ' ' . $this->name . 'Controller@' . $request->params['action'];
-                    $integration->rootSpan->meta[Tag::HTTP_URL] = Router::url($request->here, true);
+                    $integration->rootSpan->meta[Tag::HTTP_URL] = Router::url($request->here, true)
+                        . Normalizer::sanitizedQueryString();
                     $integration->rootSpan->meta['cakephp.route.controller'] = $request->params['controller'];
                     $integration->rootSpan->meta['cakephp.route.action'] = $request->params['action'];
                     if (isset($request->params['plugin'])) {

--- a/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -6,6 +6,7 @@ use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
+use DDTrace\Util\Normalizer;
 
 class CodeIgniterIntegration extends Integration
 {
@@ -79,7 +80,8 @@ class CodeIgniterIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(base_url(uri_string()));
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(base_url(uri_string()))
+                    . Normalizer::sanitizedQueryString();
                 $rootSpan->meta['app.endpoint'] = "{$class}::{$method}";
             }
         );
@@ -103,7 +105,8 @@ class CodeIgniterIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $this->load->helper('url');
-                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(base_url(uri_string()));
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(base_url(uri_string()))
+                    . Normalizer::sanitizedQueryString();
                 $rootSpan->meta['app.endpoint'] = "{$class}::_remap";
             }
         );

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -82,6 +82,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
+                /** @var \Illuminate\Http\Request $request */
                 list($request) = $args;
 
                 // Overwriting the default web integration
@@ -92,7 +93,7 @@ class LaravelIntegration extends Integration
 
                 $rootSpan->meta['laravel.route.name'] = $routeName;
                 $rootSpan->meta['laravel.route.action'] = $route->getActionName();
-                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize($request->url());
+                $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize($request->fullUrl());
                 $rootSpan->meta[Tag::HTTP_METHOD] = $request->method();
             }
         );

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -6,6 +6,7 @@ use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
+use DDTrace\Util\Normalizer;
 use DDTrace\Util\Versions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -156,9 +157,7 @@ class SymfonyIntegration extends Integration
                 $span->type = Type::WEB_SERVLET;
 
                 $integration->symfonyRequestSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
-                $integration->symfonyRequestSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(
-                    $request->getUriForPath($request->getPathInfo())
-                );
+                $integration->symfonyRequestSpan->meta[Tag::HTTP_URL] = Normalizer::urlSanitize($request->getUri());
                 if (isset($response)) {
                     $integration->symfonyRequestSpan->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
                 }

--- a/src/Integrations/Util/Normalizer.php
+++ b/src/Integrations/Util/Normalizer.php
@@ -185,6 +185,14 @@ class Normalizer
             . ($trimQueryString ? "" : self::cleanQueryString($url, "datadog.trace.http_url_query_param_allowed"));
     }
 
+    public static function sanitizedQueryString()
+    {
+        return self::cleanQueryString(
+            isset($_SERVER["QUERY_STRING"]) ? $_SERVER["QUERY_STRING"] : "",
+            "datadog.trace.http_url_query_param_allowed"
+        );
+    }
+
     private static function cleanQueryString($queryString, $allowedSetting)
     {
         if (!preg_match('(\?(?!:\??@)\K.*)', $queryString, $m)) {

--- a/tests/Unit/Util/Normalizer/UriTest.php
+++ b/tests/Unit/Util/Normalizer/UriTest.php
@@ -13,6 +13,7 @@ class UriTest extends BaseTestCase
             'DD_TRACE_RESOURCE_URI_MAPPING_INCOMING',
             'DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING',
             'DD_TRACE_RESOURCE_URI_MAPPING',
+            'DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED',
         ]);
         parent::ddSetUp();
     }
@@ -25,6 +26,7 @@ class UriTest extends BaseTestCase
             'DD_TRACE_RESOURCE_URI_MAPPING_INCOMING',
             'DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING',
             'DD_TRACE_RESOURCE_URI_MAPPING',
+            'DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED',
         ]);
     }
 
@@ -517,6 +519,38 @@ class UriTest extends BaseTestCase
         $this->assertSame(
             '/int/?/nested/some',
             \DDTrace\Util\Normalizer::uriNormalizeOutgoingPath('/int/123/nested/some?key=value')
+        );
+    }
+
+    public function testQueryParamPreserve()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED=foo,bar',
+        ]);
+
+        $this->assertSame(
+            '/int/??foo=page&bar=other',
+            \DDTrace\Util\Normalizer::uriNormalizeIncomingPath('/int/123?foo=page&bar=other&baz=removed')
+        );
+        $this->assertSame(
+            '/int/??foo=page&bar=other',
+            \DDTrace\Util\Normalizer::uriNormalizeOutgoingPath('/int/123?foo=page&&bar=other&baz=removed')
+        );
+    }
+
+    public function testQueryParamPreserveWildcard()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED=*',
+        ]);
+
+        $this->assertSame(
+            '/?foo=page&bar=other',
+            \DDTrace\Util\Normalizer::uriNormalizeIncomingPath('?foo=page&bar=other')
+        );
+        $this->assertSame(
+            '/?foo=page&bar=other',
+            \DDTrace\Util\Normalizer::uriNormalizeOutgoingPath('?foo=page&bar=other')
         );
     }
 

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -9,6 +9,7 @@ SERVER_NAME=localhost:8888
 HTTP_HOST=localhost:9999
 SCRIPT_NAME=/foo.php
 REQUEST_URI=/foo?with_to_be_stripped?query_string
+QUERY_STRING=with_to_be_stripped?query_string
 METHOD=GET
 --GET--
 foo=bar

--- a/tests/ext/root_span_url_with_query_params_whitelist.phpt
+++ b/tests/ext/root_span_url_with_query_params_whitelist.phpt
@@ -1,0 +1,28 @@
+--TEST--
+root span with DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED
+--SKIPIF--
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=1
+DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED=param
+DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED=*
+HTTPS=off
+SERVER_NAME=localhost:8888
+HTTP_HOST=localhost:9999
+SCRIPT_NAME=/foo.php
+REQUEST_URI=/foo?some=query&param&eters
+QUERY_STRING=some=query&param&eters
+METHOD=GET
+--GET--
+some=query&param&eters
+--FILE--
+<?php
+DDTrace\start_span();
+DDTrace\close_span();
+$spans = dd_trace_serialize_closed_spans();
+var_dump($spans[0]['resource']);
+var_dump($spans[0]['meta']["http.url"]);
+?>
+--EXPECT--
+string(14) "GET /foo?param"
+string(49) "https://localhost:9999/foo?some=query&param&eters"

--- a/zend_abstract_interface/uri_normalization/uri_normalization.h
+++ b/zend_abstract_interface/uri_normalization/uri_normalization.h
@@ -11,7 +11,9 @@
  */
 #if PHP_VERSION_ID < 70000
 zai_string_view zai_uri_normalize_path(zai_string_view path, HashTable *fragmentRegex, HashTable *mapping);
+zai_string_view zai_filter_query_string(zai_string_view queryString, HashTable *whitelist);
 #else
 zend_string *zai_uri_normalize_path(zend_string *path, zend_array *fragmentRegex, zend_array *mapping);
+zend_string *zai_filter_query_string(zai_string_view queryString, zend_array *whitelist);
 #endif
 #endif  // ZAI_URI_NORMALIZATION_H


### PR DESCRIPTION
### Description

This restores the possibility to fully send the request URL as http.url. (Which was previously disabled to prevent accidental PII leaks.)
Additionally query parameters in resources are now supported.

This is configurable via `datadog.trace.http_url_query_param_whitelist` (for http.url) and `datadog.trace.resource_uri_query_param_whitelist` (for resources).

Fixes #1270, #1033, #1117.

On top of that, I'm ensuring integrations pass full normalized URLs to http.url tag, including sanitized query string, fixing #1577.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
