### PR TITLE
Fix typo in ini name in GlobalTracer->reset()

### DIFF
--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -123,10 +123,10 @@ final class Tracer implements TracerInterface
      */
     public function reset()
     {
-        if (_ddtrace_config_bool(ini_get("datadog.tracer.enabled"), false)) {
+        if (_ddtrace_config_bool(ini_get("datadog.trace.enabled"), false)) {
             // Do a full shutdown and re-startup of the tracer, which implies clearing the internal span stack
-            ini_set("datadog.tracer.enabled", 0);
-            ini_set("datadog.tracer.enabled", 1);
+            ini_set("datadog.trace.enabled", 0);
+            ini_set("datadog.trace.enabled", 1);
         }
         $this->scopeManager = new ScopeManager($this->rootContext);
     }

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -387,9 +387,10 @@ final class TracerTest extends BaseTestCase
     public function testTracerReset()
     {
         $traces = $this->isolateTracer(function (Tracer $tracer) {
-            $tracer->startRootSpan('custom.root');
+            $root = $tracer->startRootSpan('custom.root');
             $tracer->startActiveSpan('custom.internal');
             $tracer->reset();
+            $root->close();
         });
 
         $this->assertEmpty($traces);


### PR DESCRIPTION
### Description

Fixing (unreleased) bug introduced in #1564. (Thanks @olsavmic for the hint!)
Also fix the test to actually test something. (Now it fails, without the fix.)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
