### PR TITLE
Fix dispatch resetting

### DIFF
--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -544,11 +544,6 @@ static void dd_initialize_request() {
 
     ddtrace_internal_handlers_rinit();
     ddtrace_bgs_log_rinit(PG(error_log));
-    ddtrace_dispatch_init();
-
-    // This allows us to hook the ZEND_HANDLE_EXCEPTION pseudo opcode
-    ZEND_VM_SET_OPCODE_HANDLER(EG(exception_op));
-    EG(exception_op)->opcode = ZEND_HANDLE_EXCEPTION;
 
     ddtrace_dogstatsd_client_rinit();
 
@@ -556,9 +551,6 @@ static void dd_initialize_request() {
     ddtrace_init_span_id_stack();
     ddtrace_init_span_stacks();
     ddtrace_coms_on_pid_change();
-
-    // Initialize C integrations and deferred loading
-    ddtrace_integrations_rinit();
 
     // Reset compile time after request init hook has compiled
     ddtrace_compile_time_reset();
@@ -593,6 +585,14 @@ static PHP_RINIT_FUNCTION(ddtrace) {
 
     DDTRACE_G(request_init_hook_loaded) = 0;
 
+    // This allows us to hook the ZEND_HANDLE_EXCEPTION pseudo opcode
+    ZEND_VM_SET_OPCODE_HANDLER(EG(exception_op));
+    EG(exception_op)->opcode = ZEND_HANDLE_EXCEPTION;
+
+    ddtrace_dispatch_init();
+    // Initialize C integrations and deferred loading
+    ddtrace_integrations_rinit();
+
     if (!get_DD_TRACE_ENABLED()) {
         return SUCCESS;
     }
@@ -616,7 +616,6 @@ static void dd_clean_globals() {
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown();
 
-    ddtrace_dispatch_destroy();
     ddtrace_free_span_stacks();
     ddtrace_coms_rshutdown();
 
@@ -629,6 +628,7 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
     if (!get_DD_TRACE_ENABLED()) {
+        ddtrace_dispatch_destroy();
         ddtrace_free_span_id_stack();
         return SUCCESS;
     }
@@ -643,7 +643,11 @@ static PHP_RSHUTDOWN_FUNCTION(ddtrace) {
         ddtrace_log_debug("Unable to flush the tracer");
     }
 
-    dd_clean_globals();
+    // we here need to disable the tracer, so that further dispatches do not trigger
+    ddtrace_disable_tracing_in_current_request();  // implicitly calling dd_clean_globals
+
+    // The dispatches shall not be reset, just disabled at runtime.
+    ddtrace_dispatch_destroy();
     ddtrace_free_span_id_stack();
 
     return SUCCESS;

--- a/tests/Integration/TracerTest.php
+++ b/tests/Integration/TracerTest.php
@@ -396,6 +396,28 @@ final class TracerTest extends BaseTestCase
         $this->assertEmpty($traces);
     }
 
+    private function preservedHook()
+    {
+    }
+
+    public function testTracerResetPreservesHooks()
+    {
+        $traces = $this->isolateTracer(function (Tracer $tracer) {
+            \DDTrace\trace_method('DDTrace\Tests\Integration\TracerTest', 'preservedHook', function () use (&$called) {
+                ++$called;
+            });
+            $this->preservedHook();
+            self::assertSame(1, $called);
+            $tracer->reset();
+            $this->preservedHook();
+            self::assertSame(2, $called);
+        });
+
+        // exactly one preserved_hook
+        self::assertSame(1, \count($traces));
+        self::assertSame(1, \count($traces[0]));
+    }
+
     public function testServiceMappingNoEnvMapping()
     {
         $traces = $this->isolateTracer(function (Tracer $tracer) {


### PR DESCRIPTION
### Description

On PHP 8 we cache our dispatches directly with the op_arrays. We thus must not free the dispatches before we are certain that we won't use them anymore. As an additional safeguard the tracer disables itself in RSHUTDOWN.

Given that on PHP 5 we also preserve dispatches across tracer disabling, we bring this behaviour in line for all versions and just keep the dispatches when disabling (or re-enabling) the tracer.

Fixes a crash reported in #1545.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
