### PR TITLE
datadog-setup: allow profiling for PHP 8.1

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -176,7 +176,7 @@ function install($options)
 
         // Profiling
         $shouldInstallProfiling =
-            in_array($phpMajorMinor, ['7.1', '7.2', '7.3', '7.4', '8.0'])
+            in_array($phpMajorMinor, ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1'])
             && !is_truthy($phpProperties[THREAD_SAFETY])
             && !is_truthy($phpProperties[IS_DEBUG]);
 

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -47,7 +47,7 @@ curl -L -o $tmp_folder_profiling_archive $profiling_url
 tar -xf $tmp_folder_profiling_archive -C $tmp_folder_profiling
 
 # Extension
-php_apis=(20160303 20170718 20180731 20190902 20200930)
+php_apis=(20160303 20170718 20180731 20190902 20200930 20210902)
 for version in "${php_apis[@]}"
 do
     mkdir -v -p \


### PR DESCRIPTION
### Description

As a follow-up to #1573 which adds support in profiling for PHP 8.1, we
also need to allow it in the installer.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
