### PR TITLE
Fix run_time_cache initialization for closure calls with foreign scope on PHP 7.4-8.1

### DIFF
--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -191,8 +191,15 @@ bool zai_symbol_call_impl(
                 op_array->fn_flags &= ~ZEND_ACC_CLOSURE;
 #if PHP_VERSION_ID >= 70400
                 op_array->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
+#if PHP_VERSION_ID >= 80200
                 void *ptr = emalloc(op_array->cache_size);
                 ZEND_MAP_PTR_INIT(op_array->run_time_cache, ptr);
+#else
+                void *ptr = emalloc(op_array->cache_size + sizeof(void *));
+                ZEND_MAP_PTR_INIT(op_array->run_time_cache, ptr);
+                ptr = (char*)ptr + sizeof(void*);
+                ZEND_MAP_PTR_SET(op_array->run_time_cache, ptr);
+#endif
                 memset(ptr, 0, op_array->cache_size);
 #elif PHP_VERSION_ID >= 70000
                 op_array->run_time_cache = ecalloc(1, op_array->cache_size);


### PR DESCRIPTION
### Description

The handling of MAP_PTR_INIT changes with PHP 8.2, and the old code had 8.2+ handling only.
On PHP 7.4 - 8.1 run_time_cache needs to be allocated 8 bytes bigger.

This might be a possible sources of crashes.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.
  - It's an actual failure, but somehow asan does not see it, only valgrind...

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
