### PR TITLE
Release 0.73.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://output.circle-artifacts.com/output/job/f18bab38-1de5-4358-8558-6b6cd592e5a8/artifacts/0/datadog-php-tracer_0.72.0_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/8169f281-e76d-4a28-b883-9c06fa375829/artifacts/0/datadog-php-tracer_0.73.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.72.0"
+#define PHP_DDTRACE_VERSION "0.73.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -49,19 +49,32 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-    ### Added
-    - Add support for memcached on PHP 8 #1558
+    ## Application Security Monitoring
+    ### v0.3.1
+    #### Fixes
+    - Fix relative module order with ddtrace on PHP 7.3 issue [#88](https://github.com/DataDog/dd-appsec-php/issues/88) -  [#86](https://github.com/DataDog/dd-appsec-php/pull/86)
 
-    ### Fixed
-    - Fix #1544: Handle hook dummy span hack when assigning parent #1557
+    ### v0.3.0
+    #### Breaking Changes
+    - Rename ini settings from `datadog.appsec.rules_path` to `datadog.appsec.rules` [#74](https://github.com/DataDog/dd-appsec-php/pull/74)
+    - Interpret `datadog.appsec.waf_timeout` as microseconds rather than milliseconds [#74](https://github.com/DataDog/dd-appsec-php/pull/74)
 
-    ### Internal changes
-    - Add gdbinit files for php 8.0 and 8.1 #1556
-    - Add system tests in CI #1552
-    - Use latest 8.0.17 in buster images #1559
-    - Update flex to v1.18.5 in composer.lock files for Symfony 4.0 and 5.0 #1560
-    - Add a single test to xfail after upgrade of docker image to 8.0.18 #1561
-    - Update link to download 0.71.1 in the reliability environment #1555
+    ### Fixes
+    - Add obfuscator strings when initialising WAF from client settings [#83](https://github.com/DataDog/dd-appsec-php/pull/83)
+
+    #### Additions
+    - Add WAF metrics and errors to traces [#79](https://github.com/DataDog/dd-appsec-php/pull/79)
+    - Actor IP resolution from request headers [#80](https://github.com/DataDog/dd-appsec-php/pull/80)
+    - Add support for WAF event obfuscator [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
+    - Add obfuscator regex for values [#84](https://github.com/DataDog/dd-appsec-php/pull/84)
+
+    #### Miscellaneous Changes
+    - Update installer links in documentation and tests [#76](https://github.com/DataDog/dd-appsec-php/pull/76)
+    - Add `parameter_view` for non-ownership of WAF parameters [#78](https://github.com/DataDog/dd-appsec-php/pull/78)
+    - Accept IP list on `X-Cluster-Client-IP` header [#81](https://github.com/DataDog/dd-appsec-php/pull/81)
+    - Update ruleset to v1.3.1 [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
+    - libddwaf upgraded to v1.3.0 [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
+    - Update installation instructions [#84](https://github.com/DataDog/dd-appsec-php/pull/84)
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.72.0';
+    const VERSION = '0.73.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
## Application Security Monitoring

#### Breaking Changes
- Rename ini settings from `datadog.appsec.rules_path` to `datadog.appsec.rules` [#74](https://github.com/DataDog/dd-appsec-php/pull/74)
- Interpret `datadog.appsec.waf_timeout` as microseconds rather than milliseconds [#74](https://github.com/DataDog/dd-appsec-php/pull/74)

### Fixes
- Add obfuscator strings when initialising WAF from client settings [#83](https://github.com/DataDog/dd-appsec-php/pull/83)
- Fix relative module order with ddtrace on PHP 7.3 issue [#88](https://github.com/DataDog/dd-appsec-php/issues/88) -  [#86](https://github.com/DataDog/dd-appsec-php/pull/86)

#### Additions
- Add WAF metrics and errors to traces [#79](https://github.com/DataDog/dd-appsec-php/pull/79)
- Actor IP resolution from request headers [#80](https://github.com/DataDog/dd-appsec-php/pull/80)
- Add support for WAF event obfuscator [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
- Add obfuscator regex for values [#84](https://github.com/DataDog/dd-appsec-php/pull/84)

#### Miscellaneous Changes
- Update installer links in documentation and tests [#76](https://github.com/DataDog/dd-appsec-php/pull/76)
- Add `parameter_view` for non-ownership of WAF parameters [#78](https://github.com/DataDog/dd-appsec-php/pull/78)
- Accept IP list on `X-Cluster-Client-IP` header [#81](https://github.com/DataDog/dd-appsec-php/pull/81)
- Update ruleset to v1.3.1 [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
- libddwaf upgraded to v1.3.0 [#82](https://github.com/DataDog/dd-appsec-php/pull/82)
- Update installation instructions [#84](https://github.com/DataDog/dd-appsec-php/pull/84)
