### PR TITLE
Update AppSec to v0.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.6.0/datadog-profiling.tar.gz
-APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.3.1/dd-appsec-php-0.3.1-amd64.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.3.2/dd-appsec-php-0.3.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/tests/randomized/README.md
+++ b/tests/randomized/README.md
@@ -27,7 +27,7 @@ Download the tracer version you intend to test.
 make tracer.local
 
 # Download from a url
-make tracer.download TRACER_TEST_URL=<link to the .tar.gz>
+make library.download LIBRARY_TEST_URL=<link to the .tar.gz>
 ```
 
 Generate scenarios, i.e. all the possible configuration we are testing.


### PR DESCRIPTION
### Description

Update AppSec to v0.3.2 which contains a fix for the randomized test crashes.

Also updated the randomized tests README.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
