### PR TITLE
Disable flacky test on PHP 5.4

### DIFF
--- a/dockerfiles/ci/xfail_tests/5.4.list
+++ b/dockerfiles/ci/xfail_tests/5.4.list
@@ -227,6 +227,7 @@ ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/strval.phpt
 ext/standard/tests/general_functions/type.phpt
 ext/standard/tests/general_functions/var_dump_64bit.phpt
+ext/standard/tests/http/bug60570.phpt
 ext/standard/tests/php_ini_loaded_file.phpt
 ext/standard/tests/serialize/005.phpt
 ext/standard/tests/serialize/006.phpt


### PR DESCRIPTION
### Description

The test fails because `$b > $a` instead of the [expected](https://github.com/php/php-src/blob/PHP-5.4/ext/standard/tests/http/bug60570.phpt#L37) `$b == $a`, where `$b` is the previous output of `memory_get_usage()` and `$a` is the latest output of `memory_get_usage()`.

Actually what we are observing here is that the previous read is larger than the latest read, which means no leak at all. Specifically `$b = 257896` and `$a = 257880`.

My hypothesis is that incidentally a gc collection happens between the two latest iterations. This hypothesis seems confirmed by the fact that if we `gc_collect_cycles()` right before the [loop](https://github.com/php/php-src/blob/PHP-5.4/ext/standard/tests/http/bug60570.phpt#L25) now the test will pass - or `$b == $a` even when the tracer is installed.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
