### PR TITLE
Fix installer setting check for extensions

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -899,10 +899,16 @@ function add_missing_ini_settings($iniFilePath, $settings)
     $formattedMissingProperties = '';
 
     foreach ($settings as $setting) {
-        $settingMightExist = 1 === preg_match(
-            '/' . str_replace('.', '\.', $setting['name']) . '\s?=\s?/',
-            $iniFileContent
-        );
+        // The extension setting is not unique, so make sure we check that the
+        // right extension setting is available.
+        $settingRegex = '/' . str_replace('.', '\.', $setting['name']) . '\s?=\s?';
+        if ($setting['name'] === 'extension' || $setting['name'] == 'zend_extension') {
+            $settingRegex .= str_replace('.', '\.', $setting['default']);
+        }
+        $settingRegex .= '/';
+
+        $settingMightExist = 1 === preg_match($settingRegex, $iniFileContent);
+
         if ($settingMightExist) {
             continue;
         }


### PR DESCRIPTION
### Description

Currently the installer checks if a setting was already available before adding it to the `.ini` file, however since the extension setting is not unique, on existing installations performed with a different installation method, `extension = ddappsec.so` is not added.

This fix just makes sure we verify that the correct extensions and zend extensions are loaded by checking not only the setting but also the value.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
