### PR TITLE
Fix inconsistent module load and unload sequence

### DIFF
--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -450,15 +450,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-#ifdef COMPILE_DL_DDTRACE
     zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
         PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
         return FAILURE;
     }
-    mod_ptr = NULL;
-#endif
+    mod_ptr->handle = NULL;
     /* }}} */
 
     if (DDTRACE_G(disable)) {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -450,8 +450,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-    zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
-        PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
+    zend_module_entry *mod_ptr =
+        zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
         return FAILURE;

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -450,6 +450,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
+    // The original entry is copied into the module registry when the module is
+    // registered, so we search the module registry to find the right
+    // zend_module_entry to modify.
     zend_module_entry *mod_ptr =
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -487,11 +487,6 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
 
     UNREGISTER_INI_ENTRIES();
 
-    /* prevent unloading ddtrace, extension shutdown is called later */
-    if (ddtrace_module) {
-        ddtrace_module->handle = NULL;
-    }
-
     if (DDTRACE_G(disable) == 1) {
         zai_config_mshutdown();
         return SUCCESS;

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -451,10 +451,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
 #ifdef COMPILE_DL_DDTRACE
-    Dl_info infos;
-    // The symbol used needs to be public on Alpine.
-    dladdr(get_module, &infos);
-    dlopen(infos.dli_fname, RTLD_LAZY);
+    zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
+        PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
+    if (mod_ptr == NULL) {
+        // This shouldn't happen, possibly a bug if it does.
+        return FAILURE;
+    }
+    mod_ptr = NULL;
 #endif
     /* }}} */
 

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -454,6 +454,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
+        zend_error(E_CORE_WARNING,
+                   "Failed to find ddtrace extension in "
+                   "registered modules. Please open a bug report.");
         return FAILURE;
     }
     mod_ptr->handle = NULL;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -405,15 +405,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-#ifdef COMPILE_DL_DDTRACE
     zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
         PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
         return FAILURE;
     }
-    mod_ptr = NULL;
-#endif
+    mod_ptr->handle = NULL;
     /* }}} */
 
     if (DDTRACE_G(disable)) {

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -409,6 +409,10 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
+        zend_error(E_CORE_WARNING,
+                   "Failed to find ddtrace extension in "
+                   "registered modules. Please open a bug report.");
+
         return FAILURE;
     }
     mod_ptr->handle = NULL;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -406,10 +406,13 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
 #ifdef COMPILE_DL_DDTRACE
-    Dl_info infos;
-    // The symbol used needs to be public on Alpine.
-    dladdr(get_module, &infos);
-    dlopen(infos.dli_fname, RTLD_LAZY);
+    zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
+        PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
+    if (mod_ptr == NULL) {
+        // This shouldn't happen, possibly a bug if it does.
+        return FAILURE;
+    }
+    mod_ptr = NULL;
 #endif
     /* }}} */
 
@@ -438,11 +441,6 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
     UNREGISTER_INI_ENTRIES();
-
-    /* prevent unloading ddtrace, extension shutdown is called later */
-    if (ddtrace_module) {
-        ddtrace_module->handle = NULL;
-    }
 
     if (DDTRACE_G(disable) == 1) {
         zai_config_mshutdown();

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -405,8 +405,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
-    zend_module_entry *mod_ptr = zend_hash_str_find_ptr(&module_registry,
-        PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) -1);
+    zend_module_entry *mod_ptr =
+        zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
         return FAILURE;

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -405,6 +405,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
      * See http://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions
      * {{{ */
     zend_register_extension(&_dd_zend_extension_entry, ddtrace_module_entry.handle);
+    // The original entry is copied into the module registry when the module is
+    // registered, so we search the module registry to find the right
+    // zend_module_entry to modify.
     zend_module_entry *mod_ptr =
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {


### PR DESCRIPTION
### Description

Currently the tracer calls `dlload` on itself on `MINIT` to ensure the reference count is consistent with the number of times `dlclose` should, in theory, be called against it, due to it being both a module and a zend extension. However during `MSHUTDOWN` the tracer also sets the module handle to `NULL`, thus preventing one of the two calls to `dlclose` on its handle and leaking resources.

This change consolidates the current behaviour during `MINIT` by setting the module handle to `NULL` and removing any extra calls to `dlload`.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
