### PR TITLE
Remove Symfony 4.2 from PHP 7.4 web tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -747,7 +747,6 @@ TEST_WEB_74 := \
 	test_web_slim_4 \
 	test_web_symfony_34 \
 	test_web_symfony_40 \
-	test_web_symfony_42 \
 	test_web_symfony_44 \
 	test_web_symfony_50 \
 	test_web_symfony_51 \


### PR DESCRIPTION
### Description

Symfony 4.2 did not resolve to a properly installable set of packages when using symfony/flex, which was fixed with https://github.com/symfony/flex/commit/e74319d17ed4edc5f27b9d24757e172930a7ebc4.
This incidentally made the composer run as a whole not fail. Now that this is working now, a zend-code compatibility layer seems to be missing.

Given that we anyway test 4.0 on 7.4 too, and 4.2 is tested on all other PHP 7 versions, I guess we're fine dropping it for 7.4.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
