### PR TITLE
Bump profiling to v0.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PHP_EXTENSION_DIR=$(shell php -r 'print ini_get("extension_dir");')
 PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
-PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.6.0/datadog-profiling.tar.gz
+PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.6.1/datadog-profiling.tar.gz
 APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.3.2/dd-appsec-php-0.3.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini


### PR DESCRIPTION
### Description

This re-initialize statics variables on startup/minit. This should help
prevent crashes on Apache reloads, but I couldn't get it to crash
before these changes, so I'm not sure what I am doing wrong in my
tests, or if it's completely fixed.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
