### PR TITLE
Add the scenario name to the randomized test docker name

### DIFF
--- a/tests/randomized/lib/templates/Makefile.scenario.template
+++ b/tests/randomized/lib/templates/Makefile.scenario.template
@@ -3,11 +3,11 @@ DURATION := 30s
 SCENARIO := {{scenario_name}}
 
 run: prepare_results_folders
-	@DURATION=$(DURATION) docker-compose up php-test
+	@DURATION=$(DURATION) docker-compose up php-test-$(SCENARIO)
 	@docker-compose down
 
 shell: prepare_results_folders
-	@docker-compose run --rm php-test bash
+	@docker-compose run --rm php-test-$(SCENARIO) bash
 	@docker-compose down
 
 prepare_results_folders:

--- a/tests/randomized/lib/templates/docker-compose.template.yml
+++ b/tests/randomized/lib/templates/docker-compose.template.yml
@@ -34,7 +34,7 @@ services:
       - MYSQL_USER=test
       - MYSQL_DATABASE=test
 
-  php-test:
+  php-test-{{identifier}}:
     image: {{image}}
     ulimits:
       core: 99999999999


### PR DESCRIPTION
### Description

The name ends up in logs e.g.

```
php-test-randomized-277800912-centos7-7.0_1  |   - Installing elasticsearch/elasticsearch (v6.7.2): Extracting archive
php-test-randomized-277800912-centos7-7.0_1  |   - Installing symfony/polyfill-php72 (v1.19.0): Extracting archive
php-test-randomized-277800912-centos7-7.0_1  |   - Installing paragonie/random_compat (v9.99.100): Extracting archive
```

Previously it would have looked more like this for every scenario, making it hard to know what scenario went wrong:

```
php-test_1       |   - Installing elasticsearch/elasticsearch (v6.7.2): Extracting archive
php-test_1       |   - Installing symfony/polyfill-php72 (v1.19.0): Extracting archive
php-test_1       |   - Installing paragonie/random_compat (v9.99.100): Extracting archive
```

Motivated by seeing this in the logs and was unable to track it back to a scenario:

```
php-test_1       | Failed loading datadog-profiling.so:  datadog-profiling.so: cannot open shared object file: No such file or directory
```

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ No, this _is_ tests.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
