### PR TITLE
Release 0.74.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.71.1/datadog-php-tracer_0.71.1_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/75750403-c87c-415b-b3d8-a37e3188dddc/artifacts/0/datadog-php-tracer_0.74.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.74.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,39 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ## Tracer
+    ### Added
+    - Add configurations for retaining select query string parameters in resources and http.url #1566
+
+    ### Changed
+    - Respect autofinish on flush(), add warnings in debug mode when having unbalanced spans #1564, #1569
+    - Loose restrictions around distributed tracing context setting #1571
+
+    ### Fixed
+    - Fix dispatch resetting #1570
+    - Fix run_time_cache initialization for closure calls with foreign scope on PHP 7.4-8.1 #1578
+    - Eliminate the separate span id stack, fix distributed tracing trace_id #1586
+    - Fix handling of INI and ENV changes post minit, pre runtime #1593
+    - Fix inconsistent module load and unload sequence #1585
+    - Fix installer setting check for extensions #1584
+
+    ### Internal changes
+    - Pin composer on PHP 7 docker containers to version 2.2 #1565
+    - Disable flaky test on PHP 5.4 #1583
+    - Remove Symfony 4.2 from PHP 7.4 web tests #1587
+    - Add the scenario name to the randomized test docker name #1590
+    - Fix ownership of files within release artifact tars #1591
+
+    ## Profiling (v0.6.1)
+    ### Fixed
+    - Bump profiling to v0.6.1 #1588. This re-initializes static variables on startup/minit which may help prevent Apache reload from crashing.
+    - Enable profiling installation on PHP 8.1 #1576
+
+    ## Application Security Monitoring (v0.3.2)
+    ### Fixed
+    - Fix hybrid extension initialisation [#92](https://github.com/DataDog/dd-appsec-php/pull/92)
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.74.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
## Tracer
### Added
- Add configurations for retaining select query string parameters in resources and http.url #1566

### Changed
- Respect autofinish on flush(), add warnings in debug mode when having unbalanced spans #1564, #1569
- Loose restrictions around distributed tracing context setting #1571

### Fixed
- Fix dispatch resetting #1570
- Fix run_time_cache initialization for closure calls with foreign scope on PHP 7.4-8.1 #1578
- Eliminate the separate span id stack, fix distributed tracing trace_id #1586
- Fix handling of INI and ENV changes post minit, pre runtime #1593
- Fix inconsistent module load and unload sequence #1585
- Fix installer setting check for extensions #1584

### Internal changes
- Pin composer on PHP 7 docker containers to version 2.2 #1565
- Disable flaky test on PHP 5.4 #1583
- Remove Symfony 4.2 from PHP 7.4 web tests #1587
- Add the scenario name to the randomized test docker name #1590
- Fix ownership of files within release artifact tars #1591

## Profiling (v0.6.1)
### Fixed
- Bump profiling to v0.6.1 #1588. This re-initializes static variables on startup/minit which may help prevent Apache reload from crashing.
- Enable profiling installation on PHP 8.1 #1576

## Application Security Monitoring (v0.3.2)
### Fixed
- Fix hybrid extension initialisation [#92](https://github.com/DataDog/dd-appsec-php/pull/92)
