### PR TITLE
Update dd-trace-php link for reliability environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.71.1/datadog-php-tracer_0.71.1_amd64.deb"
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.74.0/datadog-php-tracer_0.74.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"


### PR DESCRIPTION
### Description

Updates the url of the binary installed on the reliability environment to the latest version

### Readiness checklist
- ~[ ] (only for Members) Changelog has been added to the release document.~
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
