### PR TITLE
Move request-replayer from our internal deprecated repository to dd-trace-php

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ aliases:
       - MONGO_INITDB_ROOT_PASSWORD=test
 
   - &IMAGE_DOCKER_REQUEST_REPLAYER
-    image: datadog/dd-trace-ci:php-request-replayer-1.0
+    image: datadog/dd-trace-ci:php-request-replayer-2.0
     name: request-replayer
     environment:
       DD_REQUEST_DUMPER_FILE: dump.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - DD_API_KEY=invalid_key_but_its_ok
 
   request-replayer:
-    image: datadog/dd-trace-ci:php-request-replayer-1.0
+    image: datadog/dd-trace-ci:php-request-replayer-2.0
     ports:
       - "8766:80"
 

--- a/dockerfiles/services/Makefile
+++ b/dockerfiles/services/Makefile
@@ -6,3 +6,7 @@ redis_build:
 
 redis_publish: redis_build
 	$(Q) docker push $(REDIS_IMAGE)
+
+# It requires buildx to be able to build cross-architecture images
+request-replayer_push:
+	docker buildx build --platform=linux/arm64,linux/amd64 -t datadog/dd-trace-ci:php-request-replayer-2.0 ./request-replayer --push

--- a/dockerfiles/services/request-replayer/Dockerfile
+++ b/dockerfiles/services/request-replayer/Dockerfile
@@ -1,0 +1,21 @@
+FROM composer:2
+
+# RUN apt-get update \
+#   && apt-get install -y git unzip \
+#   && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www
+
+# RUN set -eux; \
+#   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"; \
+#   php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"; \
+#   php composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
+#   php -r "unlink('composer-setup.php');"
+
+COPY src /var/www
+
+EXPOSE 80
+
+RUN composer install
+
+CMD [ "php", "-S", "0.0.0.0:80", "index.php" ]

--- a/dockerfiles/services/request-replayer/Dockerfile
+++ b/dockerfiles/services/request-replayer/Dockerfile
@@ -1,16 +1,10 @@
 FROM composer:2
 
-# RUN apt-get update \
-#   && apt-get install -y git unzip \
-#   && rm -rf /var/lib/apt/lists/*
+# php-gmp is required to handle intermediate values for 64bit ids
+# while unpacking msgpack payloads.
+RUN install-php-extensions gmp
 
 WORKDIR /var/www
-
-# RUN set -eux; \
-#   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"; \
-#   php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"; \
-#   php composer-setup.php --install-dir=/usr/local/bin --filename=composer; \
-#   php -r "unlink('composer-setup.php');"
 
 COPY src /var/www
 

--- a/dockerfiles/services/request-replayer/src/composer.json
+++ b/dockerfiles/services/request-replayer/src/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "root/request_replayer",
+    "require": {
+        "rybakit/msgpack": "0.9.*"
+    }
+}

--- a/dockerfiles/services/request-replayer/src/index.php
+++ b/dockerfiles/services/request-replayer/src/index.php
@@ -1,0 +1,78 @@
+<?php
+
+include __DIR__ . '/vendor/autoload.php';
+
+use MessagePack\MessagePack;
+
+if ('cli-server' !== PHP_SAPI) {
+    echo "For use via the CLI SAPI's built-in web server only.\n";
+    exit;
+}
+
+define('REQUEST_LATEST_DUMP_FILE', getenv('REQUEST_LATEST_DUMP_FILE') ?: (sys_get_temp_dir() . '/dump.json'));
+define('REQUEST_LOG_FILE', getenv('REQUEST_LOG_FILE') ?: (sys_get_temp_dir() . '/requests-log.txt'));
+
+function logRequest($message, $data = '')
+{
+    if (!empty($data)) {
+        $message .= ":\n" . $data;
+    }
+    error_log(
+        sprintf('[%s | %s] %s', $_SERVER['REQUEST_URI'], REQUEST_LATEST_DUMP_FILE, $message)
+    );
+}
+
+switch ($_SERVER['REQUEST_URI']) {
+    case '/replay':
+        if (!file_exists(REQUEST_LATEST_DUMP_FILE)) {
+            logRequest('Cannot replay last request; request log does not exist');
+            break;
+        }
+        $request = file_get_contents(REQUEST_LATEST_DUMP_FILE);
+        echo $request;
+        unlink(REQUEST_LATEST_DUMP_FILE);
+        unlink(REQUEST_LOG_FILE);
+        logRequest('Returned last request and deleted request log', $request);
+        break;
+    case '/clear-dumped-data':
+        if (!file_exists(REQUEST_LATEST_DUMP_FILE)) {
+            logRequest('Cannot delete request log; request log does not exist');
+            break;
+        }
+        unlink(REQUEST_LATEST_DUMP_FILE);
+        unlink(REQUEST_LOG_FILE);
+        logRequest('Deleted request log');
+        break;
+    default:
+        $headers = getallheaders();
+        if (isset($headers['X-Datadog-Diagnostic-Check'])) {
+            logRequest('Received diagnostic check; ignoring');
+            break;
+        }
+
+        $raw = file_get_contents('php://input');
+        if (isset($headers['Content-Type']) && $headers['Content-Type'] === 'application/msgpack') {
+            $body = json_encode(MessagePack::unpack($raw));
+        } else {
+            $body = $raw;
+        }
+        if (file_exists(REQUEST_LATEST_DUMP_FILE)) {
+            $tracesStack = json_decode(file_get_contents(REQUEST_LATEST_DUMP_FILE), true);
+        } else {
+            $tracesStack = [];
+        }
+
+        $newIncomingRequest = [
+            'uri' => $_SERVER['REQUEST_URI'],
+            'headers' => $headers,
+            'body' => $body,
+        ];
+
+        $tracesStack[] = $newIncomingRequest;
+        $newIncomingRequestJson = json_encode($newIncomingRequest);
+
+        file_put_contents(REQUEST_LATEST_DUMP_FILE, json_encode($tracesStack));
+        file_put_contents(REQUEST_LOG_FILE, $newIncomingRequestJson . "\n", FILE_APPEND);
+        logRequest('Logged new request', $newIncomingRequestJson);
+        break;
+}

--- a/dockerfiles/services/request-replayer/src/test_send_msgpack.php
+++ b/dockerfiles/services/request-replayer/src/test_send_msgpack.php
@@ -1,0 +1,28 @@
+<?php
+
+include __DIR__ . '/vendor/autoload.php';
+
+use MessagePack\MessagePack;
+
+$msgpack = MessagePack::pack([
+    "sample" => "value",
+]);
+
+$ch = curl_init();
+
+curl_setopt($ch, CURLOPT_URL,"localhost");
+curl_setopt($ch, CURLOPT_PORT, 80);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $msgpack);
+
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Content-Type: application/msgpack',
+]);
+
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+$server_output = curl_exec($ch);
+
+curl_close ($ch);
+
+print_r($server_output);


### PR DESCRIPTION
Note: the `index.php` file has been modified compared to what's in our internal repo based on the file found in `/var/www/index.php` of image `datadog/dd-trace-ci:php-request-replayer-1.0`. The commit that applied those changes was lost.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
