### PR TITLE
Add support for unix domain sockets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ x-aliases:
         - .:/home/circleci/app
         - .composer:/home/circleci/.composer
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
+        - agent-socket:/var/run/datadog
       tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec', '/home/circleci/app/tests/vendor:uid=3434,gid=3434,exec' ]
       depends_on:
         - agent
@@ -141,10 +142,12 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - agent-socket:/var/run/datadog
     environment:
       - DD_API_KEY=${DATADOG_API_KEY}
       - DD_APM_ENABLED=true
       - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
+      - DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
     ports:
       - "8126:8126"
 
@@ -153,3 +156,6 @@ services:
     working_dir: /app
     volumes:
       - .:/app
+
+volumes:
+  agent-socket:

--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -718,6 +718,10 @@ char *ddtrace_agent_url(void) {
     }
 
     zai_string_view hostname = get_global_DD_AGENT_HOST();
+    if (hostname.len > 7 && strncmp(hostname.ptr, "unix://", 7) == 0) {
+        return zend_strndup(hostname.ptr, hostname.len);
+    }
+
     if (hostname.len > 0) {
         int64_t port = get_global_DD_TRACE_AGENT_PORT();
         if (port <= 0 || port > 65535) {

--- a/ext/php5/coms.c
+++ b/ext/php5/coms.c
@@ -653,6 +653,7 @@ static ddtrace_coms_stack_t *_dd_coms_attempt_acquire_stack(void) {
 
 #define TRACE_PATH_STR "/v0.4/traces"
 #define HOST_FORMAT_STR "http://%s:%u"
+#define DEFAULT_UDS_PATH "/var/run/datadog/apm.socket"
 
 static struct curl_slist *dd_agent_curl_headers = NULL;
 
@@ -727,15 +728,30 @@ char *ddtrace_agent_url(void) {
         return formatted_url;
     }
 
-    return zend_strndup(ZEND_STRL("http://localhost:8126"));
+    if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+        return zend_strndup(ZEND_STRL("unix://" DEFAULT_UDS_PATH));
+    }
+
+    int64_t port = get_global_DD_TRACE_AGENT_PORT();
+    if (port <= 0 || port > 65535) {
+        port = 8126;
+    }
+    char *formatted_url;
+    asprintf(&formatted_url, HOST_FORMAT_STR, "localhost", (uint32_t)port);
+    return formatted_url;
 }
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
     if (url && url[0]) {
-        size_t agent_url_len = strlen(url) + sizeof(TRACE_PATH_STR);
+        char *http_url = url;
+        if (strlen(url) > 7 && strncmp(url, "unix://", 7) == 0) {
+            curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, url + 7);
+            http_url = "http://localhost";
+        }
+        size_t agent_url_len = strlen(http_url) + sizeof(TRACE_PATH_STR);
         char *agent_url = malloc(agent_url_len);
-        sprintf(agent_url, "%s%s", url, TRACE_PATH_STR);
+        sprintf(agent_url, "%s%s", http_url, TRACE_PATH_STR);
         curl_easy_setopt(curl, CURLOPT_URL, agent_url);
         free(agent_url);
     }

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -57,7 +57,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
-    CONFIG(STRING, DD_AGENT_HOST, "localhost", .ini_change = zai_config_system_ini_change)                    \
+    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -58,6 +58,7 @@ extern bool runtime_config_first_init;
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
+    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                      \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -58,9 +58,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
     dogstatsd_client dogstatsd_client;
-    char *dogstatsd_host;
-    char *dogstatsd_port;
-    char *dogstatsd_buffer;
 
     // Distributed tracing & curl
     HashTable *curl_headers;

--- a/ext/php5/dogstatsd_client.c
+++ b/ext/php5/dogstatsd_client.c
@@ -63,7 +63,8 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
 
         client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
-            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "", port ? port : "");
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "",
+                               port ? port : "");
             break;
         }
 

--- a/ext/php5/dogstatsd_client.c
+++ b/ext/php5/dogstatsd_client.c
@@ -35,23 +35,58 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
 
     while (health_metrics_enabled) {
         struct addrinfo *addrs;
-        const char *host = get_DD_AGENT_HOST().ptr;
-        const char *port = get_DD_DOGSTATSD_PORT().ptr;
-        if (!*host) {
-            if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
-                addrs = dd_alloc_unix_addr(DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
-                host = "unix://" DEFAULT_UDS_PATH;
-                port = NULL;
-            } else {
-                host = "localhost";
-            }
-        }
+        const char *url = get_DD_DOGSTATSD_URL().ptr;
+        const char *host, *port;
+        if (*url) {
+            if (strlen(url) > 7 && strncmp("unix://", url, 7) == 0) {
+                addrs = dd_alloc_unix_addr(url + 7, strlen(url) - 7);
+            } else if (strlen(url) > 6 && strncmp("udp://", url, 6) == 0) {
+                char *colon = strchr(url + 6, ':');
+                if (!colon) {
+                    ddtrace_log_debugf(
+                        "Dogstatsd client encountered an invalid udp:// DD_DOGSTATSD_URL: %s, missing a colon followed by a port",
+                        url);
+                    break;
+                }
 
-        if (port) {
+                char *hostname = estrndup(url + 6, colon - url - 6);
+
+                port = colon + 1;
+                int err;
+                if ((err = dogstatsd_client_getaddrinfo(&addrs, hostname, port))) {
+                    ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", hostname, port,
+                                       (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                    efree(hostname);
+                    break;
+                }
+                efree(hostname);
+            } else {
+                ddtrace_log_debugf(
+                    "Dogstatsd client encountered an invalid DD_DOGSTATSD_URL: %s, expecting url starting with unix:// or udp://",
+                    url);
+                break;
+            }
+
+            host = url;
+            port = NULL;
+        } else {
+            host = get_DD_AGENT_HOST().ptr;
+            port = get_DD_DOGSTATSD_PORT().ptr;
+
+            if (!*host) {
+                if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+                    addrs = dd_alloc_unix_addr(DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                    host = "unix://" DEFAULT_UDS_PATH;
+                    port = NULL;
+                } else {
+                    host = "localhost";
+                }
+            }
+
             if (strlen(host) > 7 && strncmp("unix://", host, 7) == 0) {
                 addrs = dd_alloc_unix_addr(host + 7, strlen(host) - 7);
                 port = NULL;
-            } else {
+            } else if (port) {
                 int err;
                 if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
                     ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,

--- a/ext/php5/dogstatsd_client.c
+++ b/ext/php5/dogstatsd_client.c
@@ -9,38 +9,47 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 #define METRICS_CONST_TAGS "lang:php,lang_version:" PHP_VERSION ",tracer_version:" PHP_DDTRACE_VERSION
+#define DEFAULT_UDS_PATH "/var/run/datadog/dsd.socket"
 
 void ddtrace_dogstatsd_client_minit(TSRMLS_D) { DDTRACE_G(dogstatsd_client) = dogstatsd_client_default_ctor(); }
 
-static void _set_dogstatsd_client_globals(dogstatsd_client client, char *host, char *port, char *buffer TSRMLS_DC) {
-    DDTRACE_G(dogstatsd_client) = client;
-    DDTRACE_G(dogstatsd_host) = host;
-    DDTRACE_G(dogstatsd_port) = port;
-    DDTRACE_G(dogstatsd_buffer) = buffer;
-}
+static void _set_dogstatsd_client_globals(dogstatsd_client client TSRMLS_DC) { DDTRACE_G(dogstatsd_client) = client; }
 
 void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
     bool health_metrics_enabled = get_DD_TRACE_HEALTH_METRICS_ENABLED();
     dogstatsd_client client = dogstatsd_client_default_ctor();
-    const char *host = NULL;
-    const char *port = NULL;
-    char *buffer = NULL;
 
     while (health_metrics_enabled) {
-        host = get_DD_AGENT_HOST().ptr;
-        port = get_DD_DOGSTATSD_PORT().ptr;
-        buffer = malloc(DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE);
-        size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
-
         struct addrinfo *addrs;
-        int err;
-        if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
-            ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
-                               (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-            break;
+        const char *host = get_DD_AGENT_HOST().ptr;
+        if (!*host) {
+            if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+                addrs = malloc(sizeof(*addrs));
+                addrs->ai_next = NULL;
+                addrs->ai_family = PF_UNIX;
+                addrs->ai_protocol = 0;
+                addrs->ai_socktype = SOCK_STREAM;
+                struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
+                addrs->ai_addr = (struct sockaddr *)unixaddr;
+                memcpy(unixaddr->sun_path, DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                unixaddr->sun_family = AF_UNIX;
+                host = NULL;
+            } else {
+                host = "localhost";
+            }
         }
 
-        client = dogstatsd_client_ctor(addrs, buffer, len, METRICS_CONST_TAGS);
+        const char *port = get_DD_DOGSTATSD_PORT().ptr;
+        if (host) {
+            int err;
+            if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
+                ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
+                                   (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                break;
+            }
+        }
+
+        client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
             ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
             break;
@@ -55,18 +64,13 @@ void ddtrace_dogstatsd_client_rinit(TSRMLS_D) {
             ddtrace_log_errf("Health metric '%s' failed to send: %s", metric, status_str);
         }
 
-        host = zend_strndup(host, strlen(host));
-        port = zend_strndup(port, strlen(port));
         break;
     }
-    _set_dogstatsd_client_globals(client, (char *)host, (char *)port, buffer TSRMLS_CC);
+    _set_dogstatsd_client_globals(client TSRMLS_CC);
 }
 
 void ddtrace_dogstatsd_client_rshutdown(TSRMLS_D) {
     dogstatsd_client_dtor(&DDTRACE_G(dogstatsd_client));
-    free(DDTRACE_G(dogstatsd_host));
-    free(DDTRACE_G(dogstatsd_port));
-    free(DDTRACE_G(dogstatsd_buffer));
 
-    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor(), NULL, NULL, NULL TSRMLS_CC);
+    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor() TSRMLS_CC);
 }

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -653,6 +653,7 @@ static ddtrace_coms_stack_t *_dd_coms_attempt_acquire_stack(void) {
 
 #define TRACE_PATH_STR "/v0.4/traces"
 #define HOST_FORMAT_STR "http://%s:%u"
+#define DEFAULT_UDS_PATH "/var/run/datadog/apm.socket"
 
 static struct curl_slist *dd_agent_curl_headers = NULL;
 
@@ -727,15 +728,30 @@ char *ddtrace_agent_url(void) {
         return formatted_url;
     }
 
-    return zend_strndup(ZEND_STRL("http://localhost:8126"));
+    if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+        return zend_strndup(ZEND_STRL("unix://" DEFAULT_UDS_PATH));
+    }
+
+    int64_t port = get_global_DD_TRACE_AGENT_PORT();
+    if (port <= 0 || port > 65535) {
+        port = 8126;
+    }
+    char *formatted_url;
+    asprintf(&formatted_url, HOST_FORMAT_STR, "localhost", (uint32_t)port);
+    return formatted_url;
 }
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
     if (url && url[0]) {
-        size_t agent_url_len = strlen(url) + sizeof(TRACE_PATH_STR);
+        char *http_url = url;
+        if (strlen(url) > 7 && strncmp(url, "unix://", 7) == 0) {
+            curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, url + 7);
+            http_url = "http://localhost";
+        }
+        size_t agent_url_len = strlen(http_url) + sizeof(TRACE_PATH_STR);
         char *agent_url = malloc(agent_url_len);
-        sprintf(agent_url, "%s%s", url, TRACE_PATH_STR);
+        sprintf(agent_url, "%s%s", http_url, TRACE_PATH_STR);
         curl_easy_setopt(curl, CURLOPT_URL, agent_url);
         free(agent_url);
     }

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -718,6 +718,10 @@ char *ddtrace_agent_url(void) {
     }
 
     zend_string *hostname = get_global_DD_AGENT_HOST();
+    if (ZSTR_LEN(hostname) > 7 && strncmp(ZSTR_VAL(hostname), "unix://", 7) == 0) {
+        return zend_strndup(ZSTR_VAL(hostname), ZSTR_LEN(hostname));
+    }
+
     if (ZSTR_LEN(hostname) > 0) {
         int64_t port = get_global_DD_TRACE_AGENT_PORT();
         if (port <= 0 || port > 65535) {

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -57,7 +57,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
-    CONFIG(STRING, DD_AGENT_HOST, "localhost", .ini_change = zai_config_system_ini_change)                    \
+    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -58,6 +58,7 @@ extern bool runtime_config_first_init;
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
+    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                      \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -89,9 +89,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
     dogstatsd_client dogstatsd_client;
-    char *dogstatsd_host;
-    char *dogstatsd_port;
-    char *dogstatsd_buffer;
 
     uint64_t trace_id;
     zend_long default_priority_sampling;

--- a/ext/php7/dogstatsd_client.c
+++ b/ext/php7/dogstatsd_client.c
@@ -63,7 +63,8 @@ void ddtrace_dogstatsd_client_rinit(void) {
 
         client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
-            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "", port ? port : "");
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "",
+                               port ? port : "");
             break;
         }
 

--- a/ext/php7/dogstatsd_client.c
+++ b/ext/php7/dogstatsd_client.c
@@ -9,38 +9,47 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 #define METRICS_CONST_TAGS "lang:php,lang_version:" PHP_VERSION ",tracer_version:" PHP_DDTRACE_VERSION
+#define DEFAULT_UDS_PATH "/var/run/datadog/dsd.socket"
 
 void ddtrace_dogstatsd_client_minit(void) { DDTRACE_G(dogstatsd_client) = dogstatsd_client_default_ctor(); }
 
-static void _set_dogstatsd_client_globals(dogstatsd_client client, char *host, char *port, char *buffer) {
-    DDTRACE_G(dogstatsd_client) = client;
-    DDTRACE_G(dogstatsd_host) = host;
-    DDTRACE_G(dogstatsd_port) = port;
-    DDTRACE_G(dogstatsd_buffer) = buffer;
-}
+static void _set_dogstatsd_client_globals(dogstatsd_client client) { DDTRACE_G(dogstatsd_client) = client; }
 
 void ddtrace_dogstatsd_client_rinit(void) {
     bool health_metrics_enabled = get_DD_TRACE_HEALTH_METRICS_ENABLED();
     dogstatsd_client client = dogstatsd_client_default_ctor();
-    char *host = NULL;
-    char *port = NULL;
-    char *buffer = NULL;
 
     while (health_metrics_enabled) {
-        host = ZSTR_VAL(get_DD_AGENT_HOST());
-        port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
-        buffer = malloc(DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE);
-        size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
-
         struct addrinfo *addrs;
-        int err;
-        if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
-            ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
-                               (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-            break;
+        char *host = ZSTR_VAL(get_DD_AGENT_HOST());
+        if (!*host) {
+            if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+                addrs = malloc(sizeof(*addrs));
+                addrs->ai_next = NULL;
+                addrs->ai_family = PF_UNIX;
+                addrs->ai_protocol = 0;
+                addrs->ai_socktype = SOCK_STREAM;
+                struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
+                addrs->ai_addr = (struct sockaddr *)unixaddr;
+                memcpy(unixaddr->sun_path, DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                unixaddr->sun_family = AF_UNIX;
+                host = NULL;
+            } else {
+                host = "localhost";
+            }
         }
 
-        client = dogstatsd_client_ctor(addrs, buffer, len, METRICS_CONST_TAGS);
+        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
+        if (host) {
+            int err;
+            if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
+                ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
+                                   (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                break;
+            }
+        }
+
+        client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
             ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
             break;
@@ -55,18 +64,13 @@ void ddtrace_dogstatsd_client_rinit(void) {
             ddtrace_log_errf("Health metric '%s' failed to send: %s", metric, status_str);
         }
 
-        host = zend_strndup(host, strlen(host));
-        port = zend_strndup(port, strlen(port));
         break;
     }
-    _set_dogstatsd_client_globals(client, host, port, buffer);
+    _set_dogstatsd_client_globals(client);
 }
 
 void ddtrace_dogstatsd_client_rshutdown(void) {
     dogstatsd_client_dtor(&DDTRACE_G(dogstatsd_client));
-    free(DDTRACE_G(dogstatsd_host));
-    free(DDTRACE_G(dogstatsd_port));
-    free(DDTRACE_G(dogstatsd_buffer));
 
-    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor(), NULL, NULL, NULL);
+    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor());
 }

--- a/ext/php7/dogstatsd_client.c
+++ b/ext/php7/dogstatsd_client.c
@@ -15,6 +15,20 @@ void ddtrace_dogstatsd_client_minit(void) { DDTRACE_G(dogstatsd_client) = dogsta
 
 static void _set_dogstatsd_client_globals(dogstatsd_client client) { DDTRACE_G(dogstatsd_client) = client; }
 
+static struct addrinfo *dd_alloc_unix_addr(const char *path, size_t len) {
+    struct addrinfo *addrs = malloc(sizeof(*addrs));
+    addrs->ai_next = NULL;
+    addrs->ai_family = PF_UNIX;
+    addrs->ai_protocol = 0;
+    addrs->ai_socktype = SOCK_STREAM;
+    addrs->ai_addrlen = sizeof(struct sockaddr_un);
+    struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
+    addrs->ai_addr = (struct sockaddr *)unixaddr;
+    memcpy(unixaddr->sun_path, path, len);
+    unixaddr->sun_family = AF_UNIX;
+    return addrs;
+}
+
 void ddtrace_dogstatsd_client_rinit(void) {
     bool health_metrics_enabled = get_DD_TRACE_HEALTH_METRICS_ENABLED();
     dogstatsd_client client = dogstatsd_client_default_ctor();
@@ -22,36 +36,34 @@ void ddtrace_dogstatsd_client_rinit(void) {
     while (health_metrics_enabled) {
         struct addrinfo *addrs;
         char *host = ZSTR_VAL(get_DD_AGENT_HOST());
+        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
         if (!*host) {
             if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
-                addrs = malloc(sizeof(*addrs));
-                addrs->ai_next = NULL;
-                addrs->ai_family = PF_UNIX;
-                addrs->ai_protocol = 0;
-                addrs->ai_socktype = SOCK_STREAM;
-                struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
-                addrs->ai_addr = (struct sockaddr *)unixaddr;
-                memcpy(unixaddr->sun_path, DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
-                unixaddr->sun_family = AF_UNIX;
-                host = NULL;
+                addrs = dd_alloc_unix_addr(DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                host = "unix://" DEFAULT_UDS_PATH;
+                port = NULL;
             } else {
                 host = "localhost";
             }
         }
 
-        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
-        if (host) {
-            int err;
-            if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
-                ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
-                                   (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-                break;
+        if (port) {
+            if (strlen(host) > 7 && strncmp("unix://", host, 7) == 0) {
+                addrs = dd_alloc_unix_addr(host + 7, strlen(host) - 7);
+                port = NULL;
+            } else {
+                int err;
+                if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
+                    ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
+                                       (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                    break;
+                }
             }
         }
 
         client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
-            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "", port ? port : "");
             break;
         }
 

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -711,6 +711,10 @@ char *ddtrace_agent_url(void) {
     }
 
     zend_string *hostname = get_global_DD_AGENT_HOST();
+    if (ZSTR_LEN(hostname) > 7 && strncmp(ZSTR_VAL(hostname), "unix://", 7) == 0) {
+        return zend_strndup(ZSTR_VAL(hostname), ZSTR_LEN(hostname));
+    }
+
     if (ZSTR_LEN(hostname) > 0) {
         int64_t port = get_global_DD_TRACE_AGENT_PORT();
         if (port <= 0 || port > 65535) {

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -646,6 +646,7 @@ static ddtrace_coms_stack_t *_dd_coms_attempt_acquire_stack(void) {
 
 #define TRACE_PATH_STR "/v0.4/traces"
 #define HOST_FORMAT_STR "http://%s:%u"
+#define DEFAULT_UDS_PATH "/var/run/datadog/apm.socket"
 
 static struct curl_slist *dd_agent_curl_headers = NULL;
 
@@ -720,15 +721,30 @@ char *ddtrace_agent_url(void) {
         return formatted_url;
     }
 
-    return zend_strndup(ZEND_STRL("http://localhost:8126"));
+    if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+        return zend_strndup(ZEND_STRL("unix://" DEFAULT_UDS_PATH));
+    }
+
+    int64_t port = get_global_DD_TRACE_AGENT_PORT();
+    if (port <= 0 || port > 65535) {
+        port = 8126;
+    }
+    char *formatted_url;
+    asprintf(&formatted_url, HOST_FORMAT_STR, "localhost", (uint32_t)port);
+    return formatted_url;
 }
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
     if (url && url[0]) {
-        size_t agent_url_len = strlen(url) + sizeof(TRACE_PATH_STR);
+        char *http_url = url;
+        if (strlen(url) > 7 && strncmp(url, "unix://", 7) == 0) {
+            curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, url + 7);
+            http_url = "http://localhost";
+        }
+        size_t agent_url_len = strlen(http_url) + sizeof(TRACE_PATH_STR);
         char *agent_url = malloc(agent_url_len);
-        sprintf(agent_url, "%s%s", url, TRACE_PATH_STR);
+        sprintf(agent_url, "%s%s", http_url, TRACE_PATH_STR);
         curl_easy_setopt(curl, CURLOPT_URL, agent_url);
         free(agent_url);
     }

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -57,7 +57,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
-    CONFIG(STRING, DD_AGENT_HOST, "localhost", .ini_change = zai_config_system_ini_change)                    \
+    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -58,6 +58,7 @@ extern bool runtime_config_first_init;
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
+    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                      \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
     CONFIG(STRING, DD_ENV, "")                                                                                \

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -89,9 +89,6 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     zend_bool backtrace_handler_already_run;
     ddtrace_error_data active_error;
     dogstatsd_client dogstatsd_client;
-    char *dogstatsd_host;
-    char *dogstatsd_port;
-    char *dogstatsd_buffer;
 
     uint64_t trace_id;
     zend_long default_priority_sampling;

--- a/ext/php8/dogstatsd_client.c
+++ b/ext/php8/dogstatsd_client.c
@@ -63,7 +63,8 @@ void ddtrace_dogstatsd_client_rinit(void) {
 
         client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
-            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "", port ? port : "");
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "",
+                               port ? port : "");
             break;
         }
 

--- a/ext/php8/dogstatsd_client.c
+++ b/ext/php8/dogstatsd_client.c
@@ -9,38 +9,47 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 #define METRICS_CONST_TAGS "lang:php,lang_version:" PHP_VERSION ",tracer_version:" PHP_DDTRACE_VERSION
+#define DEFAULT_UDS_PATH "/var/run/datadog/dsd.socket"
 
 void ddtrace_dogstatsd_client_minit(void) { DDTRACE_G(dogstatsd_client) = dogstatsd_client_default_ctor(); }
 
-static void _set_dogstatsd_client_globals(dogstatsd_client client, char *host, char *port, char *buffer) {
-    DDTRACE_G(dogstatsd_client) = client;
-    DDTRACE_G(dogstatsd_host) = host;
-    DDTRACE_G(dogstatsd_port) = port;
-    DDTRACE_G(dogstatsd_buffer) = buffer;
-}
+static void _set_dogstatsd_client_globals(dogstatsd_client client) { DDTRACE_G(dogstatsd_client) = client; }
 
 void ddtrace_dogstatsd_client_rinit(void) {
     bool health_metrics_enabled = get_DD_TRACE_HEALTH_METRICS_ENABLED();
     dogstatsd_client client = dogstatsd_client_default_ctor();
-    char *host = NULL;
-    char *port = NULL;
-    char *buffer = NULL;
 
     while (health_metrics_enabled) {
-        host = ZSTR_VAL(get_DD_AGENT_HOST());
-        port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
-        buffer = malloc(DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE);
-        size_t len = DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE;
-
         struct addrinfo *addrs;
-        int err;
-        if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
-            ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
-                               (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-            break;
+        char *host = ZSTR_VAL(get_DD_AGENT_HOST());
+        if (!*host) {
+            if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
+                addrs = malloc(sizeof(*addrs));
+                addrs->ai_next = NULL;
+                addrs->ai_family = PF_UNIX;
+                addrs->ai_protocol = 0;
+                addrs->ai_socktype = SOCK_STREAM;
+                struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
+                addrs->ai_addr = (struct sockaddr *)unixaddr;
+                memcpy(unixaddr->sun_path, DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                unixaddr->sun_family = AF_UNIX;
+                host = NULL;
+            } else {
+                host = "localhost";
+            }
         }
 
-        client = dogstatsd_client_ctor(addrs, buffer, len, METRICS_CONST_TAGS);
+        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
+        if (host) {
+            int err;
+            if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
+                ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
+                                   (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                break;
+            }
+        }
+
+        client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
             ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
             break;
@@ -55,18 +64,13 @@ void ddtrace_dogstatsd_client_rinit(void) {
             ddtrace_log_errf("Health metric '%s' failed to send: %s", metric, status_str);
         }
 
-        host = zend_strndup(host, strlen(host));
-        port = zend_strndup(port, strlen(port));
         break;
     }
-    _set_dogstatsd_client_globals(client, host, port, buffer);
+    _set_dogstatsd_client_globals(client);
 }
 
 void ddtrace_dogstatsd_client_rshutdown(void) {
     dogstatsd_client_dtor(&DDTRACE_G(dogstatsd_client));
-    free(DDTRACE_G(dogstatsd_host));
-    free(DDTRACE_G(dogstatsd_port));
-    free(DDTRACE_G(dogstatsd_buffer));
 
-    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor(), NULL, NULL, NULL);
+    _set_dogstatsd_client_globals(dogstatsd_client_default_ctor());
 }

--- a/ext/php8/dogstatsd_client.c
+++ b/ext/php8/dogstatsd_client.c
@@ -15,6 +15,20 @@ void ddtrace_dogstatsd_client_minit(void) { DDTRACE_G(dogstatsd_client) = dogsta
 
 static void _set_dogstatsd_client_globals(dogstatsd_client client) { DDTRACE_G(dogstatsd_client) = client; }
 
+static struct addrinfo *dd_alloc_unix_addr(const char *path, size_t len) {
+    struct addrinfo *addrs = malloc(sizeof(*addrs));
+    addrs->ai_next = NULL;
+    addrs->ai_family = PF_UNIX;
+    addrs->ai_protocol = 0;
+    addrs->ai_socktype = SOCK_STREAM;
+    addrs->ai_addrlen = sizeof(struct sockaddr_un);
+    struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
+    addrs->ai_addr = (struct sockaddr *)unixaddr;
+    memcpy(unixaddr->sun_path, path, len);
+    unixaddr->sun_family = AF_UNIX;
+    return addrs;
+}
+
 void ddtrace_dogstatsd_client_rinit(void) {
     bool health_metrics_enabled = get_DD_TRACE_HEALTH_METRICS_ENABLED();
     dogstatsd_client client = dogstatsd_client_default_ctor();
@@ -22,36 +36,34 @@ void ddtrace_dogstatsd_client_rinit(void) {
     while (health_metrics_enabled) {
         struct addrinfo *addrs;
         char *host = ZSTR_VAL(get_DD_AGENT_HOST());
+        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
         if (!*host) {
             if (access(DEFAULT_UDS_PATH, F_OK) == SUCCESS) {
-                addrs = malloc(sizeof(*addrs));
-                addrs->ai_next = NULL;
-                addrs->ai_family = PF_UNIX;
-                addrs->ai_protocol = 0;
-                addrs->ai_socktype = SOCK_STREAM;
-                struct sockaddr_un *unixaddr = calloc(1, sizeof(struct sockaddr_un));
-                addrs->ai_addr = (struct sockaddr *)unixaddr;
-                memcpy(unixaddr->sun_path, DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
-                unixaddr->sun_family = AF_UNIX;
-                host = NULL;
+                addrs = dd_alloc_unix_addr(DEFAULT_UDS_PATH, sizeof(DEFAULT_UDS_PATH));
+                host = "unix://" DEFAULT_UDS_PATH;
+                port = NULL;
             } else {
                 host = "localhost";
             }
         }
 
-        char *port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
-        if (host) {
-            int err;
-            if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
-                ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
-                                   (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
-                break;
+        if (port) {
+            if (strlen(host) > 7 && strncmp("unix://", host, 7) == 0) {
+                addrs = dd_alloc_unix_addr(host + 7, strlen(host) - 7);
+                port = NULL;
+            } else {
+                int err;
+                if ((err = dogstatsd_client_getaddrinfo(&addrs, host, port))) {
+                    ddtrace_log_debugf("Dogstatsd client failed looking up %s:%s: %s", host, port,
+                                       (err == EAI_SYSTEM) ? strerror(errno) : gai_strerror(err));
+                    break;
+                }
             }
         }
 
         client = dogstatsd_client_ctor(addrs, DOGSTATSD_CLIENT_RECOMMENDED_MAX_MESSAGE_SIZE, METRICS_CONST_TAGS);
         if (dogstatsd_client_is_default_client(client)) {
-            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s:%s", host, port);
+            ddtrace_log_debugf("Dogstatsd client failed opening socket to %s%s%s", host, port ? ":" : "", port ? port : "");
             break;
         }
 

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -1,6 +1,7 @@
 #include "dogstatsd_client/client.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -38,8 +39,8 @@ int dogstatsd_client_getaddrinfo(struct addrinfo **result, const char *host,
   return getaddrinfo(host, port, &hints, result);
 }
 
-dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
-                                       int buffer_len, const char *const_tags) {
+dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, int buffer_len,
+                                       const char *const_tags) {
   dogstatsd_client client = dogstatsd_client_default_ctor();
 
   if (!addrs) {
@@ -48,7 +49,7 @@ dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
   client.addresslist = addrs;
 
   struct addrinfo *addr = NULL;
-  if (!buffer || buffer_len < 0) {
+  if (buffer_len < 0) {
     return client;
   }
 
@@ -60,6 +61,14 @@ dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
     }
   }
 
+  if (addr->ai_family == PF_UNIX) {
+    if (!bind(client.socket, addr->ai_addr, addr->ai_addrlen)) {
+      close(client.socket);
+      client.socket = -1;
+      return client;
+    }
+  }
+
   if (!const_tags) {
     const_tags = "";
   }
@@ -67,7 +76,7 @@ dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
   client.const_tags = const_tags;
   client.const_tags_len = strlen(const_tags);
   client.address = addr;
-  client.msg_buffer = buffer;
+  client.msg_buffer = malloc(buffer_len);
   client.msg_buffer_len = buffer_len;
 
   return client;
@@ -77,12 +86,20 @@ void dogstatsd_client_dtor(dogstatsd_client *client) {
   if (!client) {
     return;
   }
+  if (client->msg_buffer) {
+    free(client->msg_buffer);
+  }
   if (client->socket != -1) {
     close(client->socket);
     client->socket = -1;
   }
   if (client->addresslist) {
-    freeaddrinfo(client->addresslist);
+    if (client->address->ai_family == PF_UNIX) {
+      free(client->address->ai_addr);
+      free(client->addresslist);
+    } else {
+      freeaddrinfo(client->addresslist);
+    }
     client->addresslist = NULL;
   }
 }

--- a/src/dogstatsd/client.c
+++ b/src/dogstatsd/client.c
@@ -62,7 +62,10 @@ dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, int buffer_len,
   }
 
   if (addr->ai_family == PF_UNIX) {
-    if (!bind(client.socket, addr->ai_addr, addr->ai_addrlen)) {
+    if (!connect(client.socket, addr->ai_addr, addr->ai_addrlen)) {
+      free(addr->ai_addr);
+      free(client.addresslist);
+      client.addresslist = NULL;
       close(client.socket);
       client.socket = -1;
       return client;

--- a/src/dogstatsd/dogstatsd_client/client.h
+++ b/src/dogstatsd/dogstatsd_client/client.h
@@ -4,6 +4,7 @@
 #include <netdb.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/un.h>
 
 /* This describes a simple interface to communicate with dogstatsd. It only
  * implements the portions of the interface that the PHP tracer needs. If it
@@ -117,8 +118,8 @@ int dogstatsd_client_getaddrinfo(struct addrinfo **result, const char *host,
                                  const char *port);
 
 /* If the client fails to open a socket, it will create a default client. */
-dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, char *buffer,
-                                       int buffer_len, const char *const_tags);
+dogstatsd_client dogstatsd_client_ctor(struct addrinfo *addrs, int buffer_len,
+                                       const char *const_tags);
 
 /* Most generic way to send a metric. If the input is malformed the metric will
  * not be sent, and an error code will be returned.

--- a/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
+++ b/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
@@ -12,10 +12,7 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
 
-$socketPath = getenv("DD_TRACE_AGENT_URL");
-@unlink($socketPath);
-$p = popen(PHP_BINARY . ' -r \'$s=stream_socket_server("' . $socketPath . '");print 1;$c=stream_socket_accept($s);$t=stream_socket_client("request-replayer:80");$a=$r=[$c,$t];foreach($r as $f)stream_set_blocking($f, false);while(stream_select($r,$w,$e,null)){$d=fread($f=reset($r),4096);if($d=="")exit;fwrite($f==$t?$c:$t,$d);$r=$a;}\'', 'r');
-fread($p, 1); // ready
+RequestReplayer::launchUnixProxy(str_replace("unix://", "", getenv("DD_TRACE_AGENT_URL")));
 
 // payload = [[]]
 $payload = "\x91\x90";

--- a/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
+++ b/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
@@ -1,0 +1,58 @@
+--TEST--
+HTTP headers are sent to the Agent from the background sender over an unix domain socket
+--SKIPIF--
+<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+--ENV--
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_URL=unix:///tmp/ddtrace-agent-test.socket
+DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS=1
+DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+include __DIR__ . '/../includes/request_replayer.inc';
+
+$socketPath = getenv("DD_TRACE_AGENT_URL");
+@unlink($socketPath);
+$p = popen(PHP_BINARY . ' -r \'$s=stream_socket_server("' . $socketPath . '");print 1;$c=stream_socket_accept($s);$t=stream_socket_client("request-replayer:80");$a=$r=[$c,$t];foreach($r as $f)stream_set_blocking($f, false);while(stream_select($r,$w,$e,null)){$d=fread($f=reset($r),4096);if($d=="")exit;fwrite($f==$t?$c:$t,$d);$r=$a;}\'', 'r');
+fread($p, 1); // ready
+
+// payload = [[]]
+$payload = "\x91\x90";
+var_dump(dd_trace_send_traces_via_thread(1, [], $payload));
+
+$rr = new RequestReplayer();
+$rr->waitForFlush();
+
+echo PHP_EOL;
+$headers = $rr->replayHeaders([
+    'Content-Type',
+    'Datadog-Meta-Lang',
+    'Datadog-Meta-Lang-Interpreter',
+    'Datadog-Meta-Lang-Version',
+    'Datadog-Meta-Tracer-Version',
+    'X-Datadog-Trace-Count',
+]);
+foreach ($headers as $name => $value) {
+    echo $name . ': ' . $value . PHP_EOL;
+}
+echo PHP_EOL;
+
+echo 'Done.' . PHP_EOL;
+
+?>
+--CLEAN--
+<?php
+@unlink("/tmp/ddtrace-agent-test.socket");
+?>
+--EXPECTF--
+bool(true)
+
+Content-Type: application/msgpack
+Datadog-Meta-Lang: php
+Datadog-Meta-Lang-Interpreter: cli
+Datadog-Meta-Lang-Version: %d.%d.%s
+Datadog-Meta-Tracer-Version: %s
+X-Datadog-Trace-Count: 1
+
+Done.

--- a/tests/ext/background-sender/default_unix_domain_socket_agent.phpt
+++ b/tests/ext/background-sender/default_unix_domain_socket_agent.phpt
@@ -13,9 +13,7 @@ include __DIR__ . '/../includes/request_replayer.inc';
 include_once __DIR__ . '/../startup_logging.inc';
 
 if (!file_exists("/var/run/datadog/apm.socket")) {
-    @unlink("/var/run/datadog/apm.socket");
-    $p = popen(PHP_BINARY . ' -r \'$s=stream_socket_server("unix:///var/run/datadog/apm.socket");print 1;$c=stream_socket_accept($s);$t=stream_socket_client("request-replayer:80");$a=$r=[$c,$t];foreach($r as $f)stream_set_blocking($f, false);while(stream_select($r,$w,$e,null)){$d=fread($f=reset($r),4096);if($d=="")exit;fwrite($f==$t?$c:$t,$d);$r=$a;}\'', 'r');
-    fread($p, 1); // ready
+    RequestReplayer::launchUnixProxy("/var/run/datadog/apm.socket");
 }
 
 $logs = dd_get_startup_logs([], ['DD_TRACE_DEBUG=1']);

--- a/tests/ext/background-sender/default_unix_domain_socket_agent.phpt
+++ b/tests/ext/background-sender/default_unix_domain_socket_agent.phpt
@@ -1,0 +1,33 @@
+--TEST--
+If an agent unix domain socket exists it will try to connect to it
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: run-tests crashes with shell commands on PHP 5'); ?>
+<?php include __DIR__ . '/../startup_logging_skipif.inc'; ?>
+<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php @mkdir("/var/run/datadog"); if (!is_dir("/var/run/datadog")) { `sudo mkdir /var/run/datadog <&-; sudo chown $(id -u) /var/run/datadog`; } if (!is_file("/var/run/datadog/apm.socket") && !is_writable("/var/run/datadog")) die("skip: no permissions to create a /var/run/datadog/apm.socket"); ?>
+--ENV--
+DD_AGENT_HOST=
+--FILE--
+<?php
+include __DIR__ . '/../includes/request_replayer.inc';
+include_once __DIR__ . '/../startup_logging.inc';
+
+if (!file_exists("/var/run/datadog/apm.socket")) {
+    @unlink("/var/run/datadog/apm.socket");
+    $p = popen(PHP_BINARY . ' -r \'$s=stream_socket_server("unix:///var/run/datadog/apm.socket");print 1;$c=stream_socket_accept($s);$t=stream_socket_client("request-replayer:80");$a=$r=[$c,$t];foreach($r as $f)stream_set_blocking($f, false);while(stream_select($r,$w,$e,null)){$d=fread($f=reset($r),4096);if($d=="")exit;fwrite($f==$t?$c:$t,$d);$r=$a;}\'', 'r');
+    fread($p, 1); // ready
+}
+
+$logs = dd_get_startup_logs([], ['DD_TRACE_DEBUG=1']);
+
+dd_dump_startup_logs($logs, [
+    'agent_error', // should be absent
+    'agent_url',
+]);
+?>
+--CLEAN--
+<?php
+if (!@stream_socket_client("/var/run/datadog/apm.socket")) @unlink("/var/run/datadog/apm.socket");
+?>
+--EXPECT--
+agent_url: "unix:///var/run/datadog/apm.socket"

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -60,4 +60,28 @@ class RequestReplayer
         }
         return $headers;
     }
+
+    public static function launchUnixProxy($socketPath) {
+        @unlink($socketPath);
+        $code = str_replace("\n", "", '
+$server = stream_socket_server("unix://' . $socketPath . '");
+print "1\n"; /* ready marker */
+$client = stream_socket_accept($server);
+$replayer = stream_socket_client("request-replayer:80");
+$all = $read = [$client, $replayer];
+foreach ($read as $fp) stream_set_blocking($fp, false);
+while (stream_select($read, $w, $e, null)) {
+    $data = fread($fp = reset($read), 4096);
+    if ($data == "") {
+        exit;
+    }
+    fwrite($fp == $replayer ? $client : $replayer, $data);
+    $read = $all;
+}
+');
+
+        static $unix_proxy_process_reference;
+        $unix_proxy_process_reference = popen(PHP_BINARY . " -r '$code'", 'r');
+        fread($unix_proxy_process_reference, 1); // ready
+    }
 }


### PR DESCRIPTION
Including:
- default unix socket for dogstatsd
- default unix socket for background sender

Manually tested dogstatsd by creating a dummy socket `socat UNIX-LISTEN:/var/run/datadog/dsd.socket -` - not sure how to test that automatically, or against the real stats receiver.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
