### PR TITLE
Support restricting PHP versions while running randomized tests

### DIFF
--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -6,6 +6,7 @@ LIBRARY_DOWNLOAD_PATH := ./.library-versions
 CONCURRENT_JOBS := 5
 DURATION := 30s
 NUMBER_OF_SCENARIOS := 20
+VERSIONS := *
 
 build: build.centos7
 
@@ -69,7 +70,7 @@ library.version:
 	@echo "Done"
 
 generate: clean results_folder
-	@php generate-scenarios.php --seed=$(SEED) --number=$(NUMBER_OF_SCENARIOS)
+	@php generate-scenarios.php --seed=$(SEED) --number=$(NUMBER_OF_SCENARIOS) --versions=$(VERSIONS)
 	@cp -r $(LIBRARY_DOWNLOAD_PATH) $$(pwd)/$(TMP_SCENARIO_FOLDER)
 
 generate.%: clean results_folder

--- a/tests/randomized/generate-scenarios.php
+++ b/tests/randomized/generate-scenarios.php
@@ -39,10 +39,14 @@ function generate()
     } else {
         // If a scenario number has not been provided, we generate a number of different scenarios based on based
         // configuration
-        $options = getopt('', ['seed:', 'number:']);
+        $options = getopt('', ['seed:', 'number:', 'versions:']);
         $seed = isset($options['seed']) ? intval($options['seed']) : rand();
         srand($seed);
         echo "Using seed: $seed\n";
+        // Versions as a CSV, e.g. '7.4,8.0'
+        $restrictedPHPVersions = isset($options['versions'])
+            ? array_map('trim', explode(',', $options['versions']))
+            : null;
 
         if (empty($options['number'])) {
             echo "Error: --number option is required to set the number of scenarios to create.\n";
@@ -52,18 +56,21 @@ function generate()
 
         for ($iteration = 0; $iteration < $numberOfScenarios; $iteration++) {
             $scenarioSeed = rand();
-            $testIdentifiers[] = generateOne($scenarioSeed);
+            $testIdentifiers[] = generateOne($scenarioSeed, $restrictedPHPVersions);
         }
     }
 
     (new MakefileGenerator())->generate("$scenariosFolder/Makefile", $testIdentifiers);
 }
 
-function generateOne($scenarioSeed)
+function generateOne($scenarioSeed, array $restrictedPHPVersions)
 {
     srand($scenarioSeed);
     $selectedOs = array_rand(OS);
     $availablePHPVersions = OS[$selectedOs]['php'];
+    if ($restrictedPHPVersions && $restrictedPHPVersions[0] !== '*') {
+        $availablePHPVersions = array_intersect($availablePHPVersions, $restrictedPHPVersions);
+    }
     $selectedPhpVersion = $availablePHPVersions[array_rand($availablePHPVersions)];
     $selectedInstallationMethod = INSTALLATION[array_rand(INSTALLATION)];
 


### PR DESCRIPTION
### Description

For arm we will only support a limited number of versions.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
