### PR TITLE
Fix dlerror logging format

### DIFF
--- a/ext/php7/php7/engine_hooks.c
+++ b/ext/php7/php7/engine_hooks.c
@@ -1085,7 +1085,7 @@ void ddtrace_message_handler(int message, void *arg) {
 
         profiling_interrupt_function = DL_FETCH_SYMBOL(handle, "datadog_profiling_interrupt_function");
         if (UNEXPECTED(!profiling_interrupt_function)) {
-            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: \n",
+            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: %s\n",
                                extension->version, DL_ERROR());
         }
 
@@ -1093,7 +1093,7 @@ void ddtrace_message_handler(int message, void *arg) {
         if (EXPECTED(runtime_id)) {
             ddtrace_profiling_runtime_id = runtime_id;
         } else {
-            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: \n",
+            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: %s\n",
                                extension->version, DL_ERROR());
         }
     }

--- a/ext/php8/php8/engine_hooks.c
+++ b/ext/php8/php8/engine_hooks.c
@@ -783,7 +783,7 @@ void ddtrace_message_handler(int message, void *arg) {
 
         profiling_interrupt_function = DL_FETCH_SYMBOL(handle, "datadog_profiling_interrupt_function");
         if (UNEXPECTED(!profiling_interrupt_function)) {
-            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: \n",
+            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: %s\n",
                                extension->version, DL_ERROR());
         }
 
@@ -791,7 +791,7 @@ void ddtrace_message_handler(int message, void *arg) {
         if (EXPECTED(runtime_id)) {
             ddtrace_profiling_runtime_id = runtime_id;
         } else {
-            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: \n",
+            ddtrace_log_debugf("[Datadog Trace] Profiling v%s was detected, but locating symbol failed: %s\n",
                                extension->version, DL_ERROR());
         }
     }


### PR DESCRIPTION
### Description

I noticed the `DL_ERROR()` message wasn't showing up when I was
re-implementing the profiler in Rust.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
