### PR TITLE
Add http.useragent to root span

### DIFF
--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -590,7 +590,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                 if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
                     memcmp(ZSTR_VAL(lowerheader), "user-agent", sizeof("user-agent") - 1) == 0) {
                     zval http_useragent;
-                    ZVAL_STR(&http_useragent, Z_STR_P(headerval));
+                    ZVAL_STR_COPY(&http_useragent, Z_STR_P(headerval));
                     zend_hash_str_add_new(meta, "http.useragent", sizeof("http.useragent") - 1, &http_useragent);
                 }
 

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -495,6 +495,17 @@ static zend_string *dd_build_req_url() {
     return url;
 }
 
+static zend_string *dd_get_user_agent() {
+    zval *_server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (Z_TYPE_P(_server) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+        zval *user_agent = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("HTTP_USER_AGENT"));
+        if (user_agent && Z_TYPE_P(user_agent) == IS_STRING) {
+            return Z_STR_P(user_agent);
+        }
+    }
+    return ZSTR_EMPTY_ALLOC();
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -555,6 +566,14 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
             ZVAL_COPY(prop_resource, &http_method);
         }
     }
+
+    zend_string *user_agent = dd_get_user_agent();
+    if (user_agent && ZSTR_LEN(user_agent) > 0) {
+        zval http_useragent;
+        ZVAL_STR_COPY(&http_useragent, user_agent);
+        zend_hash_str_add_new(meta, "http.useragent", sizeof("http.useragent") - 1, &http_useragent);
+    }
+
     zval *prop_type = ddtrace_spandata_property_type(span);
     zval *prop_name = ddtrace_spandata_property_name(span);
     if (strcmp(sapi_module.name, "cli") == 0) {
@@ -585,13 +604,6 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                     } else if (*ptr == '_') {
                         *ptr = '-';
                     }
-                }
-
-                if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
-                    memcmp(ZSTR_VAL(lowerheader), "user-agent", sizeof("user-agent") - 1) == 0) {
-                    zval http_useragent;
-                    ZVAL_STR_COPY(&http_useragent, Z_STR_P(headerval));
-                    zend_hash_str_add_new(meta, "http.useragent", sizeof("http.useragent") - 1, &http_useragent);
                 }
 
                 dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -587,6 +587,13 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                     }
                 }
 
+                if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
+                    memcmp(ZSTR_VAL(lowerheader), ZEND_STRL("user-agent")) == 0) {
+                    zval http_useragent;
+                    ZVAL_STR(&http_useragent, Z_STR_P(headerval));
+                    zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
+                }
+
                 dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));
                 zend_string_release(lowerheader);
             }

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -588,10 +588,10 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                 }
 
                 if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
-                    memcmp(ZSTR_VAL(lowerheader), ZEND_STRL("user-agent")) == 0) {
+                    memcmp(ZSTR_VAL(lowerheader), "user-agent", sizeof("user-agent") - 1) == 0) {
                     zval http_useragent;
                     ZVAL_STR(&http_useragent, Z_STR_P(headerval));
-                    zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
+                    zend_hash_str_add_new(meta, "http.useragent", sizeof("http.useragent") - 1, &http_useragent);
                 }
 
                 dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -589,7 +589,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                 if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
                     memcmp(ZSTR_VAL(lowerheader), ZEND_STRL("user-agent")) == 0) {
                     zval http_useragent;
-                    ZVAL_STR(&http_useragent, Z_STR_P(headerval));
+                    ZVAL_STR_COPY(&http_useragent, Z_STR_P(headerval));
                     zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
                 }
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -494,6 +494,17 @@ static zend_string *dd_build_req_url() {
     return url;
 }
 
+static zend_string *dd_get_user_agent() {
+    zval *_server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (Z_TYPE_P(_server) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+        zval *user_agent = zend_hash_str_find(Z_ARRVAL_P(_server), ZEND_STRL("HTTP_USER_AGENT"));
+        if (user_agent && Z_TYPE_P(user_agent) == IS_STRING) {
+            return Z_STR_P(user_agent);
+        }
+    }
+    return zend_empty_string;
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -554,6 +565,14 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
             ZVAL_COPY(prop_resource, &http_method);
         }
     }
+
+    zend_string *user_agent = dd_get_user_agent();
+    if (user_agent && ZSTR_LEN(user_agent) > 0) {
+        zval http_useragent;
+        ZVAL_STR_COPY(&http_useragent, user_agent);
+        zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
+    }
+
     zval *prop_type = ddtrace_spandata_property_type(span);
     zval *prop_name = ddtrace_spandata_property_name(span);
     if (strcmp(sapi_module.name, "cli") == 0) {
@@ -584,13 +603,6 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                     } else if (*ptr == '_') {
                         *ptr = '-';
                     }
-                }
-
-                if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
-                    memcmp(ZSTR_VAL(lowerheader), ZEND_STRL("user-agent")) == 0) {
-                    zval http_useragent;
-                    ZVAL_STR_COPY(&http_useragent, Z_STR_P(headerval));
-                    zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
                 }
 
                 dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -586,6 +586,13 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                     }
                 }
 
+                if (ZSTR_LEN(lowerheader) == (sizeof("user-agent") - 1) &&
+                    memcmp(ZSTR_VAL(lowerheader), ZEND_STRL("user-agent")) == 0) {
+                    zval http_useragent;
+                    ZVAL_STR(&http_useragent, Z_STR_P(headerval));
+                    zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
+                }
+
                 dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));
                 zend_string_release(lowerheader);
             }

--- a/tests/ext/root_span_http_useragent.phpt
+++ b/tests/ext/root_span_http_useragent.phpt
@@ -9,47 +9,8 @@ HTTP_USER_AGENT=dd_trace_user_agent
 <?php
 DDTrace\start_span();
 DDTrace\close_span(0);
-var_dump(dd_trace_serialize_closed_spans());
+$span = dd_trace_serialize_closed_spans();
+var_dump($span[0]["meta"]["http.useragent"]);
 ?>
 --EXPECTF--
-array(1) {
-  [0]=>
-  array(10) {
-    ["trace_id"]=>
-    string(%d) "%d"
-    ["span_id"]=>
-    string(%d) "%d"
-    ["start"]=>
-    int(%d)
-    ["duration"]=>
-    int(%d)
-    ["name"]=>
-    string(28) "root_span_http_useragent.php"
-    ["resource"]=>
-    string(28) "root_span_http_useragent.php"
-    ["service"]=>
-    string(28) "root_span_http_useragent.php"
-    ["type"]=>
-    string(3) "cli"
-    ["meta"]=>
-    array(4) {
-      ["system.pid"]=>
-      string(%d) "%d"
-      ["http.useragent"]=>
-      string(19) "dd_trace_user_agent"
-      ["_dd.dm.service_hash"]=>
-      string(%d) %s
-      ["_dd.p.dm"]=>
-      string(%d) %s
-    }
-    ["metrics"]=>
-    array(3) {
-      ["_dd.rule_psr"]=>
-      float(1)
-      ["_sampling_priority_v1"]=>
-      float(1)
-      ["php.compilation.total_time_ms"]=>
-      float(%s)
-    }
-  }
-}
+string(19) "dd_trace_user_agent"

--- a/tests/ext/root_span_http_useragent.phpt
+++ b/tests/ext/root_span_http_useragent.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Verify the user agent is added to the root span on serialization.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('skip: http.useragent only available on php 7 and 8'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+HTTP_USER_AGENT=dd_trace_user_agent
+--FILE--
+<?php
+DDTrace\start_span();
+DDTrace\close_span(0);
+var_dump(dd_trace_serialize_closed_spans());
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(28) "root_span_http_useragent.php"
+    ["resource"]=>
+    string(28) "root_span_http_useragent.php"
+    ["service"]=>
+    string(28) "root_span_http_useragent.php"
+    ["type"]=>
+    string(3) "cli"
+    ["meta"]=>
+    array(4) {
+      ["system.pid"]=>
+      string(%d) "%d"
+      ["http.useragent"]=>
+      string(19) "dd_trace_user_agent"
+      ["_dd.dm.service_hash"]=>
+      string(%d) %s
+      ["_dd.p.dm"]=>
+      string(%d) %s
+    }
+    ["metrics"]=>
+    array(3) {
+      ["_dd.rule_psr"]=>
+      float(1)
+      ["_sampling_priority_v1"]=>
+      float(1)
+      ["php.compilation.total_time_ms"]=>
+      float(%s)
+    }
+  }
+}


### PR DESCRIPTION
### Description

This PR introduces a change to include the `http.useragent` tag to the root span on PHP 7 and 8.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
