### PR TITLE
Fix DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED accidentally guarding http.method and http.url as well

### DIFF
--- a/ext/php5/serializer.c
+++ b/ext/php5/serializer.c
@@ -510,15 +510,17 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span TSRMLS_DC) {
 
     add_assoc_long(meta, "system.pid", (long)getpid());
 
+    smart_str http_url = dd_build_req_url(TSRMLS_C);
+    if (http_url.c) {
+        add_assoc_string(meta, "http.url", http_url.c, 0);
+    }
+
     const char *method = SG(request_info).request_method;
-    if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED() && method) {
+    if (method) {
         add_assoc_string(meta, "http.method", (char *)method, 1);
+    }
 
-        smart_str http_url = dd_build_req_url(TSRMLS_C);
-        if (http_url.c) {
-            add_assoc_string(meta, "http.url", http_url.c, 0);
-        }
-
+    if (method && get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED()) {
         const char *uri = dd_get_req_uri(TSRMLS_C);
         zval **prop_resource = ddtrace_spandata_property_resource_write(span);
         MAKE_STD_ZVAL(*prop_resource);

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -532,38 +532,41 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         zend_hash_str_add_new(meta, "runtime-id", sizeof("runtime-id") - 1, &zv);
     }
 
+    zval http_url;
+    ZVAL_STR(&http_url, dd_build_req_url());
+    if (Z_STRLEN(http_url)) {
+        zend_hash_str_add_new(meta, "http.url", sizeof("http.url") - 1, &http_url);
+    }
+
     const char *method = SG(request_info).request_method;
-    if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED() && method) {
+    if (method) {
         zval http_method;
         ZVAL_STR(&http_method, zend_string_init(method, strlen(method), 0));
         zend_hash_str_add_new(meta, "http.method", sizeof("http.method") - 1, &http_method);
 
-        zval http_url;
-        ZVAL_STR(&http_url, dd_build_req_url());
-        if (Z_STRLEN(http_url)) {
-            zend_hash_str_add_new(meta, "http.url", sizeof("http.url") - 1, &http_url);
-        }
+        if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED()) {
+            const char *uri = dd_get_req_uri();
+            zval *prop_resource = ddtrace_spandata_property_resource(span);
+            if (uri) {
+                zend_string *path = zend_string_init(uri, strlen(uri), 0);
+                zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
+                zend_string *query_string = ZSTR_EMPTY_ALLOC();
+                const char *query_str = dd_get_query_string();
+                if (query_str) {
+                    query_string =
+                        zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
+                                                get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED());
+                }
 
-        const char *uri = dd_get_req_uri();
-        zval *prop_resource = ddtrace_spandata_property_resource(span);
-        if (uri) {
-            zend_string *path = zend_string_init(uri, strlen(uri), 0);
-            zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
-            zend_string *query_string = ZSTR_EMPTY_ALLOC();
-            const char *query_str = dd_get_query_string();
-            if (query_str) {
-                query_string = zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
-                                                       get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED());
+                ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),
+                                                        ZSTR_LEN(query_string) ? "?" : "", (int)ZSTR_LEN(query_string),
+                                                        ZSTR_VAL(query_string)));
+                zend_string_release(query_string);
+                zend_string_release(normalized);
+                zend_string_release(path);
+            } else {
+                ZVAL_COPY(prop_resource, &http_method);
             }
-
-            ZVAL_STR(prop_resource,
-                     zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized), ZSTR_LEN(query_string) ? "?" : "",
-                                     (int)ZSTR_LEN(query_string), ZSTR_VAL(query_string)));
-            zend_string_release(query_string);
-            zend_string_release(normalized);
-            zend_string_release(path);
-        } else {
-            ZVAL_COPY(prop_resource, &http_method);
         }
     }
 

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -24,10 +24,10 @@ var_dump($spans[0]['meta']);
 array(6) {
   ["system.pid"]=>
   %s
-  ["http.method"]=>
-  string(3) "GET"
   ["http.url"]=>
   string(26) "https://localhost:9999/foo"
+  ["http.method"]=>
+  string(3) "GET"
   ["_dd.dm.service_hash"]=>
   string(10) "9753902159"
   ["_dd.p.dm"]=>

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -21,10 +21,10 @@ var_dump($spans[0]['meta']);
 array(6) {
   ["system.pid"]=>
   %s
-  ["http.method"]=>
-  string(3) "GET"
   ["http.url"]=>
   string(25) "http://localhost:8888/foo"
+  ["http.method"]=>
+  string(3) "GET"
   ["_dd.dm.service_hash"]=>
   string(10) "9753902159"
   ["_dd.p.dm"]=>

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -195,7 +195,11 @@ inline void zai_sandbox_close(zai_sandbox *sandbox) {
 }
 
 inline bool zai_sandbox_timed_out(void) {
+#if PHP_VERSION_ID >= 80200
+    if (zend_atomic_bool_load(&EG(timed_out))) {
+#else
     if (EG(timed_out)) {
+#endif
         return true;
     }
 


### PR DESCRIPTION
### Description

This was an oversight and unrelated. It should never have guarded that option.

Also fix compilation on master (PHP 8.2)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~
  - meaningless - the features are not related at all

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
