### PR TITLE
Transition to non-legacy circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
   "Lint files":
     working_directory: ~/datadog
     docker:
-      - image: circleci/php:7.2-cli-node-browsers
+      - image: cimg/php:8.1-node
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - lib_curl_workaround:
@@ -801,7 +801,7 @@ jobs:
         default: all
     executor:
       name: with_agent
-      docker_image: circleci/php:7.3
+      docker_image: cimg/php:7.3
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_remote_docker
@@ -1506,7 +1506,7 @@ jobs:
 
   "Prepare Code":
     working_directory: ~/datadog
-    docker: [ image: 'circleci/php:7.3-cli' ]
+    docker: [ image: 'cimg/php:7.3' ]
     steps:
       - restore_cache:
           keys:
@@ -2391,7 +2391,7 @@ workflows:
       - static_analysis:
           requires: [ 'Prepare Code' ]
           name: "Static Analysis 71"
-          docker_image: circleci/php:7.1
+          docker_image: cimg/php:7.1
           scenario: opentracing_beta6
       - static_analysis:
           requires: [ 'Prepare Code' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,10 +297,11 @@ jobs:
       - run:
           name: Install Clang
           command: |
+              codename=$(cat /etc/os-release | awk -F = '/UBUNTU_CODENAME/ { print $2 }')
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
               (
-                echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main"
-                echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main"
+                echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename} main"
+                echo "deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename} main"
               ) | sudo tee /etc/apt/sources.list.d/llvm-toolchain.list
               sudo apt-get update
               sudo apt-get -y install clang-format

--- a/ext/php5/ddtrace.h
+++ b/ext/php5/ddtrace.h
@@ -114,8 +114,10 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
  */
 #define DDTRACE_ARG_INFO_SIZE(arg_info) ((zend_uint)(sizeof(arg_info) / sizeof(struct _zend_arg_info) - 1))
 
-#define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
-    { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
+#define DDTRACE_FENTRY(zend_name, name, arg_info, flags)                   \
+    {                                                                      \
+#zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags \
+    }
 #define DDTRACE_RAW_FENTRY(zend_name, name, arg_info, flags) \
     { zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
 

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -127,8 +127,10 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
  */
 #define DDTRACE_ARG_INFO_SIZE(arg_info) ((uint32_t)(sizeof(arg_info) / sizeof(struct _zend_internal_arg_info) - 1))
 
-#define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
-    { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
+#define DDTRACE_FENTRY(zend_name, name, arg_info, flags)                   \
+    {                                                                      \
+#zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags \
+    }
 #define DDTRACE_RAW_FENTRY(zend_name, name, arg_info, flags) \
     { zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
 

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -127,8 +127,10 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
  */
 #define DDTRACE_ARG_INFO_SIZE(arg_info) ((uint32_t)(sizeof(arg_info) / sizeof(struct _zend_internal_arg_info) - 1))
 
-#define DDTRACE_FENTRY(zend_name, name, arg_info, flags) \
-    { #zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
+#define DDTRACE_FENTRY(zend_name, name, arg_info, flags)                   \
+    {                                                                      \
+#zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags \
+    }
 #define DDTRACE_RAW_FENTRY(zend_name, name, arg_info, flags) \
     { zend_name, name, arg_info, DDTRACE_ARG_INFO_SIZE(arg_info), flags }
 

--- a/tea/include/exceptions.h
+++ b/tea/include/exceptions.h
@@ -1,10 +1,10 @@
 #ifndef TEA_EXCEPTIONS_H
 #define TEA_EXCEPTIONS_H
 
+#include "common.h"
+// common must come first.
 #include <Zend/zend_exceptions.h>
 #include <main/php_variables.h>
-
-#include "common.h"
 
 /* Throws an exception using the default exception class entry and sets the
  * 'Exception::$message' string to 'message'. Returns the class entry used for

--- a/tea/include/exceptions.h
+++ b/tea/include/exceptions.h
@@ -1,10 +1,10 @@
 #ifndef TEA_EXCEPTIONS_H
 #define TEA_EXCEPTIONS_H
 
-#include "common.h"
-
 #include <Zend/zend_exceptions.h>
 #include <main/php_variables.h>
+
+#include "common.h"
 
 /* Throws an exception using the default exception class entry and sets the
  * 'Exception::$message' string to 'message'. Returns the class entry used for

--- a/tea/include/sapi.h
+++ b/tea/include/sapi.h
@@ -8,9 +8,9 @@
 #ifndef TEA_SAPI_H
 #define TEA_SAPI_H
 
-#include <main/SAPI.h>
-
 #include "common.h"
+// common must come first
+#include <main/SAPI.h>
 
 /*
  * TODO reset 'tea_sapi_module' every SINIT to make sure no state lingers from

--- a/tea/include/sapi.h
+++ b/tea/include/sapi.h
@@ -8,9 +8,9 @@
 #ifndef TEA_SAPI_H
 #define TEA_SAPI_H
 
-#include "common.h"
-
 #include <main/SAPI.h>
+
+#include "common.h"
 
 /*
  * TODO reset 'tea_sapi_module' every SINIT to make sure no state lingers from

--- a/tea/src/sapi.c
+++ b/tea/src/sapi.c
@@ -1,8 +1,6 @@
 #include <include/sapi.h>
-
 #include <main/php_main.h>
 #include <main/php_variables.h>
-
 #include <private/error.h>
 #include <private/extension.h>
 #include <private/frame.h>

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -4,10 +4,9 @@
 #include <Zend/zend_observer.h>
 #endif
 
+#include <Zend/zend_closures.h>
 #include <ctype.h>
 #include <sandbox/sandbox.h>
-
-#include <Zend/zend_closures.h>
 
 #if PHP_VERSION_ID >= 70000 && PHP_VERSION_ID <= 70200
 #define ZEND_ACC_FAKE_CLOSURE ZEND_ACC_INTERFACE

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -1,4 +1,5 @@
 #include <sandbox/sandbox.h>
+
 #include "symbols.h"
 #include "zend_compile.h"
 

--- a/zend_abstract_interface/symbols/symbols.h
+++ b/zend_abstract_interface/symbols/symbols.h
@@ -12,13 +12,12 @@
  *
  * zai_symbol_new is a single interface for object construction
  */
-#include "php.h"
-
-#include "../zai_string/string.h"
-#include "zai_compat.h"
-
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "../zai_string/string.h"
+#include "php.h"
+#include "zai_compat.h"
 
 // clang-format off
 typedef enum {

--- a/zend_abstract_interface/symbols/symbols.h
+++ b/zend_abstract_interface/symbols/symbols.h
@@ -12,11 +12,11 @@
  *
  * zai_symbol_new is a single interface for object construction
  */
+#include <php.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "../zai_string/string.h"
-#include "php.h"
 #include "zai_compat.h"
 
 // clang-format off

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -2,6 +2,7 @@
 #define ZAI_STRING_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct zai_string_view_s {
     size_t len;


### PR DESCRIPTION
### Description

Transition to non-legacy circleci images. I'm not sure this is all of them, but it's at least a good chunk. A job will have a notice like this if it's a deprecated image:

![You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.](https://user-images.githubusercontent.com/253316/172701120-28724bb4-80f9-4c68-a624-60f363d1e41a.png)

This also means a newer clang-format is used, so had to fixup a few of those changes.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
