### PR TITLE
Release 0.75.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.74.0/datadog-php-tracer_0.74.0_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/0a694950-082d-4a97-9ffb-97daf99f6828/artifacts/0/datadog-php-tracer_0.75.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.75.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,27 @@
         <api>stable</api>
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
-    <notes>${notes}</notes>
+    <notes>
+    ## Tracer
+    ### Added
+    - Add a new decision maker mechanism #1598
+    - Rename DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE to DD_TRACE_PROPAGATE_SERVICE #1612, #1613
+    - Add support for unix domain sockets #1601
+    - Add RedisCluster split by host #1602 (Thanks to @radykal-com)
+    - Add http.useragent to root span #1607
+
+    ### Fixed
+    - Fix #1582: *_id keys in meta and metrics are wrongly encoded #1599
+    - Fix dlerror logging format #1605
+    - Fix DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED accidentally guarding http.method and http.url as well #1608
+
+    ### Internal changes
+    - Fix downstream job trigger for deployments to rel-env #1597
+    - Update dd-trace-php link for reliability environment #1595
+    - Move request-replayer from our internal deprecated repository to dd-trace-php #1600
+    - Support restricting PHP versions while running randomized tests #1604
+    - Transition to non-legacy circleci images #1609
+    </notes>
     <contents>
         <dir name="/">
             <!-- code and test files -->${codefiles}

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.75.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
## Tracer
### Added
- Add a new decision maker mechanism #1598
  -  Rename DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE to DD_TRACE_PROPAGATE_SERVICE #1612
- Add support for unix domain sockets #1601
- Add RedisCluster split by host #1602 (Thanks to @radykal-com)
- Add http.useragent to root span #1607

### Fixed
- Fix #1582: *_id keys in meta and metrics are wrongly encoded #1599
- Fix dlerror logging format #1605
- Fix DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED accidentally guarding http.method and http.url as well #1608

### Internal changes
- Fix downstream job trigger for deployments to rel-env #1597
- Update dd-trace-php link for reliability environment #1595
- Move request-replayer from our internal deprecated repository to dd-trace-php #1600
- Support restricting PHP versions while running randomized tests #1604
