### PR TITLE
Rename DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE to DD_TRACE_PROPAGATE_SERVICE

### DIFF
--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -92,7 +92,7 @@ extern bool runtime_config_first_init;
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
     CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE, "true")                                           \
+    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "true")                                                          \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php5/priority_sampling/priority_sampling.c
+++ b/ext/php5/priority_sampling/priority_sampling.c
@@ -52,13 +52,16 @@ static void dd_update_decision_maker_tag(ddtrace_span_fci *span, ddtrace_span_fc
 
             zval *dm_service;
             MAKE_STD_ZVAL(dm_service);
-            ZVAL_STRINGL(dm_service, service_hexsha256,
-                         get_DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE() ? hexshadigits : 0, 1);
-            zend_hash_update(Z_ARRVAL_P(meta), "_dd.dm.service_hash", sizeof("_dd.dm.service_hash"), &dm_service,
-                             sizeof(zval *), NULL);
+            ZVAL_STRINGL(dm_service, service_hexsha256, get_DD_TRACE_PROPAGATE_SERVICE() ? hexshadigits : 0, 1);
             char *dm_service_str;
             spprintf(&dm_service_str, 0, "%s-%d", Z_STRVAL_P(dm_service), mechanism);
             add_assoc_string(meta, "_dd.p.dm", dm_service_str, 0);
+            if (get_DD_TRACE_PROPAGATE_SERVICE()) {
+                zend_hash_update(Z_ARRVAL_P(meta), "_dd.dm.service_hash", sizeof("_dd.dm.service_hash"), &dm_service,
+                                 sizeof(zval *), NULL);
+            } else {
+                zval_ptr_dtor(&dm_service);
+            }
         }
     } else {
         zend_hash_del(Z_ARRVAL_P(meta), "_dd.p.dm", sizeof("_dd.p.dm"));

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -92,7 +92,7 @@ extern bool runtime_config_first_init;
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
     CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE, "true")                                           \
+    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "true")                                                          \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php7/priority_sampling/priority_sampling.c
+++ b/ext/php7/priority_sampling/priority_sampling.c
@@ -46,11 +46,14 @@ static void dd_update_decision_maker_tag(ddtrace_span_fci *span, ddtrace_span_fc
 
             zval dm, dm_service;
             ZVAL_STR(&dm_service,
-                     zend_string_init(service_hexsha256,
-                                      get_DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE() ? hexshadigits : 0, 0));
-            zend_hash_str_update(meta, "_dd.dm.service_hash", sizeof("_dd.dm.service_hash") - 1, &dm_service);
+                     zend_string_init(service_hexsha256, get_DD_TRACE_PROPAGATE_SERVICE() ? hexshadigits : 0, 0));
             ZVAL_STR(&dm, zend_strpprintf(0, "%s-%d", Z_STRVAL(dm_service), mechanism));
             zend_hash_str_add_new(meta, "_dd.p.dm", sizeof("_dd.p.dm") - 1, &dm);
+            if (get_DD_TRACE_PROPAGATE_SERVICE()) {
+                zend_hash_str_update(meta, "_dd.dm.service_hash", sizeof("_dd.dm.service_hash") - 1, &dm_service);
+            } else {
+                zend_string_release(Z_STR(dm_service));
+            }
         }
     } else {
         zend_hash_str_del(meta, "_dd.p.dm", sizeof("_dd.p.dm") - 1);

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -92,7 +92,7 @@ extern bool runtime_config_first_init;
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
     CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE, "true")                                           \
+    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "true")                                                          \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/ext/php8/priority_sampling/priority_sampling.c
+++ b/ext/php8/priority_sampling/priority_sampling.c
@@ -46,11 +46,14 @@ static void dd_update_decision_maker_tag(ddtrace_span_fci *span, ddtrace_span_fc
 
             zval dm, dm_service;
             ZVAL_STR(&dm_service,
-                     zend_string_init(service_hexsha256,
-                                      get_DD_TRACE_X_DATADOG_TAGS_PROPAGATE_SERVICE() ? hexshadigits : 0, 0));
-            zend_hash_str_update(meta, "_dd.dm.service_hash", sizeof("_dd.dm.service_hash") - 1, &dm_service);
+                     zend_string_init(service_hexsha256, get_DD_TRACE_PROPAGATE_SERVICE() ? hexshadigits : 0, 0));
             ZVAL_STR(&dm, zend_strpprintf(0, "%s-%d", Z_STRVAL(dm_service), mechanism));
             zend_hash_str_add_new(meta, "_dd.p.dm", sizeof("_dd.p.dm") - 1, &dm);
+            if (get_DD_TRACE_PROPAGATE_SERVICE()) {
+                zend_hash_str_update(meta, "_dd.dm.service_hash", sizeof("_dd.dm.service_hash") - 1, &dm_service);
+            } else {
+                zend_string_release(Z_STR(dm_service));
+            }
         }
     } else {
         zend_hash_str_del(meta, "_dd.p.dm", sizeof("_dd.p.dm") - 1);

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -41,10 +41,10 @@ array(1) {
       string(%d) "%d"
       ["_dd.origin"]=>
       string(7) "datadog"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2f8110d3de"
       ["_dd.p.dm"]=>
       string(12) "2f8110d3de-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "2f8110d3de"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/root_span_add_tag.phpt
+++ b/tests/ext/root_span_add_tag.phpt
@@ -44,10 +44,10 @@ array(1) {
       string(%d) "%d"
       ["after"]=>
       string(9) "root_span"
-      ["_dd.dm.service_hash"]=>
-      string(10) "f1999f9456"
       ["_dd.p.dm"]=>
       string(12) "f1999f9456-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "f1999f9456"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -28,10 +28,10 @@ array(6) {
   string(26) "https://localhost:9999/foo"
   ["http.method"]=>
   string(3) "GET"
-  ["_dd.dm.service_hash"]=>
-  string(10) "9753902159"
   ["_dd.p.dm"]=>
   string(12) "9753902159-1"
+  ["_dd.dm.service_hash"]=>
+  string(10) "9753902159"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -25,10 +25,10 @@ array(6) {
   string(25) "http://localhost:8888/foo"
   ["http.method"]=>
   string(3) "GET"
-  ["_dd.dm.service_hash"]=>
-  string(10) "9753902159"
   ["_dd.p.dm"]=>
   string(12) "9753902159-1"
+  ["_dd.dm.service_hash"]=>
+  string(10) "9753902159"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -117,10 +117,10 @@ array(3) {
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
-      ["_dd.dm.service_hash"]=>
-      string(10) "24565f64fe"
       ["_dd.p.dm"]=>
       string(12) "24565f64fe-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "24565f64fe"
     }
     ["metrics"]=>
     array(5) {
@@ -184,10 +184,10 @@ array(3) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "afd2f82e39"
       ["_dd.p.dm"]=>
       string(12) "afd2f82e39-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "afd2f82e39"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -26,6 +26,6 @@ bar(hello)
 spans(\DDTrace\SpanData) (1) {
   bar (alias, bar, cli)
     system.pid => %d
-    _dd.dm.service_hash => 1a0a6a36ca
     _dd.p.dm => 1a0a6a36ca-1
+    _dd.dm.service_hash => 1a0a6a36ca
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -122,10 +122,10 @@ array(5) {
       string(5) "first"
       ["retval.rand"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "3f89c4ec87"
       ["_dd.p.dm"]=>
       string(12) "3f89c4ec87-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "3f89c4ec87"
     }
     ["metrics"]=>
     array(5) {
@@ -205,10 +205,10 @@ array(5) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2606321bce"
       ["_dd.p.dm"]=>
       string(12) "2606321bce-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "2606321bce"
     }
     ["metrics"]=>
     array(3) {
@@ -242,10 +242,10 @@ array(5) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2606321bce"
       ["_dd.p.dm"]=>
       string(12) "2606321bce-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "2606321bce"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -45,10 +45,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "e23c636b43"
       ["_dd.p.dm"]=>
       string(12) "e23c636b43-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "e23c636b43"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -3,6 +3,7 @@ DDTrace\trace_method() can trace with internal spans
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
+DD_TRACE_PROPAGATE_SERVICE=0
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -119,7 +120,7 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(7) {
+    array(6) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
@@ -130,10 +131,8 @@ array(3) {
       string(5) "first"
       ["retval.rand"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "24565f64fe"
       ["_dd.p.dm"]=>
-      string(12) "24565f64fe-1"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(5) {
@@ -196,13 +195,11 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "afd2f82e39"
       ["_dd.p.dm"]=>
-      string(12) "afd2f82e39-1"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -30,6 +30,6 @@ Foo::bar(hello)
 spans(\DDTrace\SpanData) (1) {
   Foo.bar (alias, Foo.bar, cli)
     system.pid => %d
-    _dd.dm.service_hash => 1a0a6a36ca
     _dd.p.dm => 1a0a6a36ca-1
+    _dd.dm.service_hash => 1a0a6a36ca
 }

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -35,8 +35,8 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (5) {
   main (default_span_properties.php, main, cli)
     max => 6
-    _dd.dm.service_hash => b43b371c6f
     _dd.p.dm => b43b371c6f-1
+    _dd.dm.service_hash => b43b371c6f
   array_sum (default_span_properties.php, array_sum, cli)
     retval => 28
   MyRange (default_span_properties.php, MyRange, cli)

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -42,8 +42,8 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (3) {
   Foo.main (default_span_properties_method.php, Foo.main, cli)
     year => 2020
-    _dd.dm.service_hash => ac317c120d
     _dd.p.dm => ac317c120d-1
+    _dd.dm.service_hash => ac317c120d
   MyDateTimeFormat (default_span_properties_method.php, MyDateTimeFormat, cli)
     format => m
   DateTime.__construct (default_span_properties_method.php, DateTime.__construct, cli)

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -49,10 +49,10 @@ array(1) {
       string(%d) "%d"
       ["error.msg"]=>
       string(9) "Foo error"
-      ["_dd.dm.service_hash"]=>
-      string(10) "ce20576ee7"
       ["_dd.p.dm"]=>
       string(12) "ce20576ee7-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "ce20576ee7"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -85,10 +85,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "8cfa685fde"
       ["_dd.p.dm"]=>
       string(12) "8cfa685fde-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "8cfa685fde"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -64,10 +64,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
       ["_dd.p.dm"]=>
       string(12) "df6da0e28f-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "df6da0e28f"
     }
     ["metrics"]=>
     array(3) {
@@ -103,10 +103,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
       ["_dd.p.dm"]=>
       string(12) "df6da0e28f-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "df6da0e28f"
     }
     ["metrics"]=>
     array(3) {
@@ -142,10 +142,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
       ["_dd.p.dm"]=>
       string(12) "df6da0e28f-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "df6da0e28f"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -76,10 +76,10 @@ array(2) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "a98551ac2e"
       ["_dd.p.dm"]=>
       string(12) "a98551ac2e-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "a98551ac2e"
     }
     ["metrics"]=>
     array(3) {
@@ -115,10 +115,10 @@ array(2) {
       string(%d) "%d"
       ["aa"]=>
       string(2) "bb"
-      ["_dd.dm.service_hash"]=>
-      string(10) "9f86d08188"
       ["_dd.p.dm"]=>
       string(12) "9f86d08188-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "9f86d08188"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -48,10 +48,10 @@ array(1) {
     array(3) {
       ["system.pid"]=>
       string(%d) "%d"
-      ["_dd.dm.service_hash"]=>
-      string(10) "1b8a8775ac"
       ["_dd.p.dm"]=>
       string(12) "1b8a8775ac-1"
+      ["_dd.dm.service_hash"]=>
+      string(10) "1b8a8775ac"
     }
     ["metrics"]=>
     array(3) {


### PR DESCRIPTION
### Description

We decided to simplify the name.

Also omitting _dd.dm.service_hash if unused. (This caused me to have to change all the tests again...)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
