### PR TITLE
Manually build PHP for randomized tests images

### DIFF
--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -9,7 +9,6 @@ DURATION := 30s
 NUMBER_OF_SCENARIOS := 20
 VERSIONS := *
 
-PHP_DOWNLOAD_URL_7.4=https://www.php.net/distributions/php-7.4.30.tar.gz
 
 build: build.centos7
 
@@ -17,63 +16,53 @@ publish: publish.centos7
 
 pull: pull.centos7
 
-A_1 := a_1
-A_2 := a_2
-VARIANT := 2
-
-aaa:
-	echo $(A_$(VARIANT))
-
-build.centos7:
-	@docker build --build-arg PHP_MAJOR=8 --build-arg PHP_MINOR=1 -t $(DOCKER_IMAGE_PREFIX)centos7-8.1-$(DOCKER_IMAGE_VERSION) ./docker
-	@docker build --build-arg PHP_MAJOR=8 --build-arg PHP_MINOR=0 -t $(DOCKER_IMAGE_PREFIX)centos7-8.0 ./docker
-	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=4 -t $(DOCKER_IMAGE_PREFIX)centos7-7.4 ./docker
-	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=3 -t $(DOCKER_IMAGE_PREFIX)centos7-7.3 ./docker
-	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=2 -t $(DOCKER_IMAGE_PREFIX)centos7-7.2 ./docker
-	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=1 -t $(DOCKER_IMAGE_PREFIX)centos7-7.1 ./docker
-	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=0 -t $(DOCKER_IMAGE_PREFIX)centos7-7.0 ./docker
-	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=6 -t $(DOCKER_IMAGE_PREFIX)centos7-5.6 ./docker
-	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=5 -t $(DOCKER_IMAGE_PREFIX)centos7-5.5 ./docker
-	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=4 -t $(DOCKER_IMAGE_PREFIX)centos7-5.4 ./docker
+build.centos7: \
+	build.centos7.5.4 \
+	build.centos7.5.5 \
+	build.centos7.5.6 \
+	build.centos7.7.0 \
+	build.centos7.7.1 \
+	build.centos7.7.2 \
+	build.centos7.7.3 \
+	build.centos7.7.4 \
+	build.centos7.8.0 \
+	build.centos7.8.1
 
 build.centos7.%:
 	docker build \
-		--build-arg PHP_DOWNLOAD_URL="$(PHP_DOWNLOAD_URL_$(*))" \
+		--build-arg PHP_MAJOR_MINOR="$(*)" \
 		-t $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION) \
 		./docker
-# build.centos7.%:
-# 	docker build \
-# 		--build-arg PHP_MAJOR="$(firstword $(subst ., ,$(*)))" \
-# 		--build-arg PHP_MINOR="$(lastword $(subst ., ,$(*)))" \
-# 		-t $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION) \
-# 		./docker
+
+publish.centos7: \
+	publish.centos7.5.4 \
+	publish.centos7.5.5 \
+	publish.centos7.5.6 \
+	publish.centos7.7.0 \
+	publish.centos7.7.1 \
+	publish.centos7.7.2 \
+	publish.centos7.7.3 \
+	publish.centos7.7.4 \
+	publish.centos7.8.0 \
+	publish.centos7.8.1
 
 publish.centos7.%: build.centos7.%
-	docker push $(DOCKER_IMAGE_PREFIX)centos7-$(*)
+	docker push $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION)
 
-publish.centos7: build.centos7
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-8.1
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-8.0
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-7.4
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-7.3
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-7.2
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-7.1
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-7.0
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-5.6
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-5.5
-	@docker push $(DOCKER_IMAGE_PREFIX)centos7-5.4
+pull.centos7: \
+	pull.centos7.5.4 \
+	pull.centos7.5.5 \
+	pull.centos7.5.6 \
+	pull.centos7.7.0 \
+	pull.centos7.7.1 \
+	pull.centos7.7.2 \
+	pull.centos7.7.3 \
+	pull.centos7.7.4 \
+	pull.centos7.8.0 \
+	pull.centos7.8.1
 
-pull.centos7:
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-8.1
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-8.0
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-7.4
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-7.3
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-7.2
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-7.1
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-7.0
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-5.6
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-5.5
-	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-5.4
+pull.centos7.%:
+	@docker pull $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION)
 
 library.local:
 	@mkdir -p $(LIBRARY_DOWNLOAD_PATH)

--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -109,3 +109,5 @@ clean:
 
 clean_results:
 	@rm -rf $(TMP_RESULTS_FOLDER)
+
+.PHONY: build.centos7 publish.centos7 pull.centos7

--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -1,12 +1,15 @@
 TMP_SCENARIO_FOLDER := ./.tmp.scenarios
 TMP_RESULTS_FOLDER := $(TMP_SCENARIO_FOLDER)/.results
 DOCKER_COMPOSE_FILE := $(TMP_SCENARIO_FOLDER)/docker-compose.yml
-DOCKER_IMAGE_PREFIX := datadog/dd-trace-ci:php-randomizedtests-dev-
+DOCKER_IMAGE_PREFIX := datadog/dd-trace-ci:php-randomizedtests-
+DOCKER_IMAGE_VERSION := 1
 LIBRARY_DOWNLOAD_PATH := ./.library-versions
 CONCURRENT_JOBS := 5
 DURATION := 30s
 NUMBER_OF_SCENARIOS := 20
 VERSIONS := *
+
+PHP_DOWNLOAD_URL_7.4=https://www.php.net/distributions/php-7.4.30.tar.gz
 
 build: build.centos7
 
@@ -14,8 +17,15 @@ publish: publish.centos7
 
 pull: pull.centos7
 
+A_1 := a_1
+A_2 := a_2
+VARIANT := 2
+
+aaa:
+	echo $(A_$(VARIANT))
+
 build.centos7:
-	@docker build --build-arg PHP_MAJOR=8 --build-arg PHP_MINOR=1 -t $(DOCKER_IMAGE_PREFIX)centos7-8.1 ./docker
+	@docker build --build-arg PHP_MAJOR=8 --build-arg PHP_MINOR=1 -t $(DOCKER_IMAGE_PREFIX)centos7-8.1-$(DOCKER_IMAGE_VERSION) ./docker
 	@docker build --build-arg PHP_MAJOR=8 --build-arg PHP_MINOR=0 -t $(DOCKER_IMAGE_PREFIX)centos7-8.0 ./docker
 	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=4 -t $(DOCKER_IMAGE_PREFIX)centos7-7.4 ./docker
 	@docker build --build-arg PHP_MAJOR=7 --build-arg PHP_MINOR=3 -t $(DOCKER_IMAGE_PREFIX)centos7-7.3 ./docker
@@ -25,6 +35,21 @@ build.centos7:
 	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=6 -t $(DOCKER_IMAGE_PREFIX)centos7-5.6 ./docker
 	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=5 -t $(DOCKER_IMAGE_PREFIX)centos7-5.5 ./docker
 	@docker build --build-arg PHP_MAJOR=5 --build-arg PHP_MINOR=4 -t $(DOCKER_IMAGE_PREFIX)centos7-5.4 ./docker
+
+build.centos7.%:
+	docker build \
+		--build-arg PHP_DOWNLOAD_URL="$(PHP_DOWNLOAD_URL_$(*))" \
+		-t $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION) \
+		./docker
+# build.centos7.%:
+# 	docker build \
+# 		--build-arg PHP_MAJOR="$(firstword $(subst ., ,$(*)))" \
+# 		--build-arg PHP_MINOR="$(lastword $(subst ., ,$(*)))" \
+# 		-t $(DOCKER_IMAGE_PREFIX)centos7-$(*)-$(DOCKER_IMAGE_VERSION) \
+# 		./docker
+
+publish.centos7.%: build.centos7.%
+	docker push $(DOCKER_IMAGE_PREFIX)centos7-$(*)
 
 publish.centos7: build.centos7
 	@docker push $(DOCKER_IMAGE_PREFIX)centos7-8.1

--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -9,7 +9,6 @@ DURATION := 30s
 NUMBER_OF_SCENARIOS := 20
 VERSIONS := *
 
-
 build: build.centos7
 
 publish: publish.centos7

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -145,6 +145,7 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx.site.conf /etc/nginx/conf.d/default.conf
 
 # Preparing HTTPD
+ADD apache.php.conf /etc/httpd/conf.d/php.conf
 RUN sed -i 's/Listen 80/Listen 81/' /etc/httpd/conf/httpd.conf
 RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/httpd/conf/httpd.conf
 

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN echo $'[nginx]\nname=nginx repo\nbaseurl=https://nginx.org/packages/mainline
 RUN \
     rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
     && yum install -y \
+        autoconf \
         bzip2-devel \
         elinks \
         gcc \
@@ -16,6 +17,7 @@ RUN \
         git \
         httpd \
         libcurl-devel \
+        libmemcached-devel \
         libsodium-devel \
         libsqlite3x-devel \
         libxml2-devel \
@@ -78,6 +80,7 @@ RUN set -eux; \
         --with-config-file-scan-dir=/etc/php.d \
         --enable-calendar \
         --enable-exif \
+        --enable-fpm \
         --enable-ftp \
         --enable-mysqlnd \
         --enable-pcntl \
@@ -88,10 +91,13 @@ RUN set -eux; \
         --enable-sysvshm \
         --with-bz2 \
         --with-curl \
+        --with-fpm-group=www-data \
+        --with-fpm-user=www-data \
         --with-gettext \
         --with-mysqli \
         --with-openssl \
         --with-pdo-mysql \
+        --with-pear \
         --with-readline \
         --with-sodium \
         --with-xsl \
@@ -100,40 +106,57 @@ RUN set -eux; \
     make -j "$((`nproc`+1))"; \
     make install
 
-CMD bash
-# # Installing vegeta
-# RUN curl -L -o /tmp/vegeta.tar.gz https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
-#     && tar -C /usr/bin -zxvf /tmp/vegeta.tar.gz vegeta \
-#     && rm /tmp/vegeta.tar.gz
+# Enabling Opcache, which is disabled by default
+RUN echo "zend_extension=opcache.so" > /etc/php.d/opache.ini
 
-# # Installing composer
-# RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# Igbinary
+RUN set -eux; \
+    pecl install igbinary; \
+    echo "extension=igbinary.so" > /etc/php.d/igbinary.ini
 
-# # Preparing PHP
-# RUN echo "date.timezone = UTC" > "/etc/php.d/00-adjust-timezones.ini"
+# Memached
+RUN set -eux; \
+    printf 'yes' | pecl install memcached; \
+    echo "extension=memcached.so" > /etc/php.d/memcached.ini
 
-# # Preparing PHP-FPM
-# RUN mkdir -p /run/php-fpm
-# RUN sed -i 's/^listen = .*$/listen = 9000/g' /etc/php-fpm.d/www.conf
+# Memached
+RUN set -eux; \
+    printf 'yes' | pecl install redis; \
+    echo "extension=redis.so" > /etc/php.d/redis.ini
 
-# # Preparing NGINX
-# RUN groupadd www-data
-# RUN adduser -M --system -g www-data www-data
-# ADD nginx.conf /etc/nginx/nginx.conf
-# ADD nginx.site.conf /etc/nginx/conf.d/default.conf
+# Installing vegeta
+RUN curl -L -o /tmp/vegeta.tar.gz https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
+    && tar -C /usr/bin -zxvf /tmp/vegeta.tar.gz vegeta \
+    && rm /tmp/vegeta.tar.gz
 
-# # Preparing HTTPD
-# RUN sed -i 's/Listen 80/Listen 81/' /etc/httpd/conf/httpd.conf
-# RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/httpd/conf/httpd.conf
+# Installing composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# ADD run.sh /scripts/run.sh
-# ADD prepare.sh /scripts/prepare.sh
+# Preparing PHP
+RUN echo "date.timezone = UTC" > "/etc/php.d/00-adjust-timezones.ini"
 
-# WORKDIR /var/www/html
+# Preparing PHP-FPM
+RUN mkdir -p /run/php-fpm
+RUN sed -i 's/^listen = .*$/listen = 9000/g' /etc/php-fpm.d/www.conf
 
-# ENV COMPOSER_CACHE_DIR /composer-cache
-# RUN mkdir -p ${COMPOSER_CACHE_DIR}
-# ENV COMPOSER_VENDOR_DIR /composer-vendor
-# RUN mkdir -p ${COMPOSER_VENDOR_DIR}
+# Preparing NGINX
+RUN groupadd www-data
+RUN adduser -M --system -g www-data www-data
+ADD nginx.conf /etc/nginx/nginx.conf
+ADD nginx.site.conf /etc/nginx/conf.d/default.conf
 
-# CMD [ "bash", "/scripts/run.sh" ]
+# Preparing HTTPD
+RUN sed -i 's/Listen 80/Listen 81/' /etc/httpd/conf/httpd.conf
+RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/httpd/conf/httpd.conf
+
+ADD run.sh /scripts/run.sh
+ADD prepare.sh /scripts/prepare.sh
+
+WORKDIR /var/www/html
+
+ENV COMPOSER_CACHE_DIR /composer-cache
+RUN mkdir -p ${COMPOSER_CACHE_DIR}
+ENV COMPOSER_VENDOR_DIR /composer-vendor
+RUN mkdir -p ${COMPOSER_VENDOR_DIR}
+
+CMD [ "bash", "/scripts/run.sh" ]

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM centos:7
 
-# ARG PHP_MAJOR
-# ARG PHP_MINOR
+ARG PHP_MAJOR_MINOR
 
 # Getting the latest nginx
 RUN echo $'[nginx]\nname=nginx repo\nbaseurl=https://nginx.org/packages/mainline/centos/7/$basearch/\ngpgcheck=0\nenabled=1' >> /etc/yum.repos.d/nginx.repo
@@ -33,40 +32,15 @@ RUN \
     && yum clean all \
     && rm -rf /var/cache/yum
 
-    # && rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm \
-    # && yum --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} install -y \
-    #         php-cli \
-    #         php-curl \
-    #         php-fpm \
-    #         php-memcached \
-    #         php-opcache \
-    #         php-pdo_mysql \
-    #         php-pear \
-    #         php-pecl-redis \
-    #         mod_php \
-    # && debuginfo-install --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} -y php-fpm \
-
-# Create coredumps folder
-# If not generated, see: https://fromdual.com/hunting-the-core
-RUN mkdir -p /tmp/corefiles
-RUN chmod -R a+w /tmp/corefiles
-ADD enable-coredump.sh /scripts/enable-coredump.sh
-
-# Add the wait script to the image: note SHA 672a28f0509433e3b4b9bcd4d9cd7668cea7e31a has been reviewed and should not
-# be changed without an appropriate code review.
-ADD https://raw.githubusercontent.com/eficode/wait-for/672a28f0509433e3b4b9bcd4d9cd7668cea7e31a/wait-for /scripts/wait-for.sh
-RUN chmod +x /scripts/wait-for.sh
-
-ARG PHP_DOWNLOAD_URL
-
-RUN echo ${PHP_DOWNLOAD_URL}
+ADD envs /envs
 
 # Downloading / Extracting PHP
 RUN set -eux; \
-        curl -L --output php.tar.gz ${PHP_DOWNLOAD_URL}; \
-        tar -xvf php.tar.gz -C /usr/local/src/; \
-        mv /usr/local/src/php-* /usr/local/src/php; \
-        rm php.tar.gz
+    source /envs/${PHP_MAJOR_MINOR}.env; \
+    curl -L --output php.tar.gz ${PHP_DOWNLOAD_URL}; \
+    tar -xvf php.tar.gz -C /usr/local/src/; \
+    mv /usr/local/src/php-* /usr/local/src/php; \
+    rm php.tar.gz
 
 WORKDIR /usr/local/src/php
 
@@ -110,18 +84,35 @@ RUN echo "zend_extension=opcache.so" > /etc/php.d/opache.ini
 
 # Igbinary
 RUN set -eux; \
-    pecl install igbinary; \
+    source /envs/${PHP_MAJOR_MINOR}.env; \
+    if [[ -z "${IGBINARY_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${IGBINARY_VERSION:-}"; fi; \
+    pecl install "igbinary${PECL_SUFFIX}"; \
     echo "extension=igbinary.so" > /etc/php.d/igbinary.ini
 
 # Memached
 RUN set -eux; \
-    printf 'yes' | pecl install memcached; \
+    source /envs/${PHP_MAJOR_MINOR}.env; \
+    if [[ -z "${MEMCACHED_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${MEMCACHED_VERSION:-}"; fi; \
+    printf 'yes' | pecl install "memcached${PECL_SUFFIX}"; \
     echo "extension=memcached.so" > /etc/php.d/memcached.ini
 
-# Memached
+# Redis
 RUN set -eux; \
-    printf 'yes' | pecl install redis; \
+    source /envs/${PHP_MAJOR_MINOR}.env; \
+    if [[ -z "${REDIS_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${REDIS_VERSION:-}"; fi; \
+    printf 'yes' | pecl install "redis${PECL_SUFFIX}"; \
     echo "extension=redis.so" > /etc/php.d/redis.ini
+
+# Create coredumps folder
+# If not generated, see: https://fromdual.com/hunting-the-core
+RUN mkdir -p /tmp/corefiles
+RUN chmod -R a+w /tmp/corefiles
+ADD enable-coredump.sh /scripts/enable-coredump.sh
+
+# Add the wait script to the image: note SHA 672a28f0509433e3b4b9bcd4d9cd7668cea7e31a has been reviewed and should not
+# be changed without an appropriate code review.
+ADD https://raw.githubusercontent.com/eficode/wait-for/672a28f0509433e3b4b9bcd4d9cd7668cea7e31a/wait-for /scripts/wait-for.sh
+RUN chmod +x /scripts/wait-for.sh
 
 # Installing vegeta
 RUN curl -L -o /tmp/vegeta.tar.gz https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -1,37 +1,48 @@
 FROM centos:7
 
-ARG PHP_MAJOR
-ARG PHP_MINOR
+# ARG PHP_MAJOR
+# ARG PHP_MINOR
 
 # Getting the latest nginx
 RUN echo $'[nginx]\nname=nginx repo\nbaseurl=https://nginx.org/packages/mainline/centos/7/$basearch/\ngpgcheck=0\nenabled=1' >> /etc/yum.repos.d/nginx.repo
 
 RUN \
     rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && yum install -y elinks wget nginx httpd unzip gdb git nc \
-    && rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm \
-    && yum --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} install -y \
-            php-cli \
-            php-curl \
-            php-fpm \
-            php-memcached \
-            php-opcache \
-            php-pdo_mysql \
-            php-pear \
-            php-pecl-redis \
-            mod_php \
-    && debuginfo-install --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} -y php-fpm \
+    && yum install -y \
+        bzip2-devel \
+        elinks \
+        gcc \
+        gdb \
+        git \
+        httpd \
+        libcurl-devel \
+        libsodium-devel \
+        libsqlite3x-devel \
+        libxml2-devel \
+        libxslt-devel \
+        nc \
+        nginx \
+        openssl-devel \
+        readline-devel \
+        unzip \
+        vim \
+        wget \
     && debuginfo-install -y httpd \
     && yum clean all \
     && rm -rf /var/cache/yum
 
-# Installing vegeta
-RUN curl -L -o /tmp/vegeta.tar.gz https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
-    && tar -C /usr/bin -zxvf /tmp/vegeta.tar.gz vegeta \
-    && rm /tmp/vegeta.tar.gz
-
-# Installing composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+    # && rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm \
+    # && yum --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} install -y \
+    #         php-cli \
+    #         php-curl \
+    #         php-fpm \
+    #         php-memcached \
+    #         php-opcache \
+    #         php-pdo_mysql \
+    #         php-pear \
+    #         php-pecl-redis \
+    #         mod_php \
+    # && debuginfo-install --enablerepo=remi-php${PHP_MAJOR}${PHP_MINOR} -y php-fpm \
 
 # Create coredumps folder
 # If not generated, see: https://fromdual.com/hunting-the-core
@@ -39,36 +50,90 @@ RUN mkdir -p /tmp/corefiles
 RUN chmod -R a+w /tmp/corefiles
 ADD enable-coredump.sh /scripts/enable-coredump.sh
 
-# Preparing PHP
-RUN echo "date.timezone = UTC" > "/etc/php.d/00-adjust-timezones.ini"
-
 # Add the wait script to the image: note SHA 672a28f0509433e3b4b9bcd4d9cd7668cea7e31a has been reviewed and should not
 # be changed without an appropriate code review.
 ADD https://raw.githubusercontent.com/eficode/wait-for/672a28f0509433e3b4b9bcd4d9cd7668cea7e31a/wait-for /scripts/wait-for.sh
 RUN chmod +x /scripts/wait-for.sh
 
-# Preparing PHP-FPM
-RUN mkdir -p /run/php-fpm
-RUN sed -i 's/^listen = .*$/listen = 9000/g' /etc/php-fpm.d/www.conf
+ARG PHP_DOWNLOAD_URL
 
-# Preparing NGINX
-RUN groupadd www-data
-RUN adduser -M --system -g www-data www-data
-ADD nginx.conf /etc/nginx/nginx.conf
-ADD nginx.site.conf /etc/nginx/conf.d/default.conf
+RUN echo ${PHP_DOWNLOAD_URL}
 
-# Preparing HTTPD
-RUN sed -i 's/Listen 80/Listen 81/' /etc/httpd/conf/httpd.conf
-RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/httpd/conf/httpd.conf
+# Downloading / Extracting PHP
+RUN set -eux; \
+        curl -L --output php.tar.gz ${PHP_DOWNLOAD_URL}; \
+        tar -xvf php.tar.gz -C /usr/local/src/; \
+        mv /usr/local/src/php-* /usr/local/src/php; \
+        rm php.tar.gz
 
-ADD run.sh /scripts/run.sh
-ADD prepare.sh /scripts/prepare.sh
+WORKDIR /usr/local/src/php
 
-WORKDIR /var/www/html
+# ENV EPREFIX /usr/local
 
-ENV COMPOSER_CACHE_DIR /composer-cache
-RUN mkdir -p ${COMPOSER_CACHE_DIR}
-ENV COMPOSER_VENDOR_DIR /composer-vendor
-RUN mkdir -p ${COMPOSER_VENDOR_DIR}
+RUN set -eux; \
+    mkdir -p /etc/php.d; \
+    ./configure \
+        --prefix=/usr/local \
+        --with-config-file-path=/etc \
+        --with-config-file-scan-dir=/etc/php.d \
+        --enable-calendar \
+        --enable-exif \
+        --enable-ftp \
+        --enable-mysqlnd \
+        --enable-pcntl \
+        --enable-shmop \
+        --enable-sockets \
+        --enable-sysvmsg \
+        --enable-sysvsem \
+        --enable-sysvshm \
+        --with-bz2 \
+        --with-curl \
+        --with-gettext \
+        --with-mysqli \
+        --with-openssl \
+        --with-pdo-mysql \
+        --with-readline \
+        --with-sodium \
+        --with-xsl \
+        --with-zlib \
+    ; \
+    make -j "$((`nproc`+1))"; \
+    make install
 
-CMD [ "bash", "/scripts/run.sh" ]
+CMD bash
+# # Installing vegeta
+# RUN curl -L -o /tmp/vegeta.tar.gz https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
+#     && tar -C /usr/bin -zxvf /tmp/vegeta.tar.gz vegeta \
+#     && rm /tmp/vegeta.tar.gz
+
+# # Installing composer
+# RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# # Preparing PHP
+# RUN echo "date.timezone = UTC" > "/etc/php.d/00-adjust-timezones.ini"
+
+# # Preparing PHP-FPM
+# RUN mkdir -p /run/php-fpm
+# RUN sed -i 's/^listen = .*$/listen = 9000/g' /etc/php-fpm.d/www.conf
+
+# # Preparing NGINX
+# RUN groupadd www-data
+# RUN adduser -M --system -g www-data www-data
+# ADD nginx.conf /etc/nginx/nginx.conf
+# ADD nginx.site.conf /etc/nginx/conf.d/default.conf
+
+# # Preparing HTTPD
+# RUN sed -i 's/Listen 80/Listen 81/' /etc/httpd/conf/httpd.conf
+# RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/httpd/conf/httpd.conf
+
+# ADD run.sh /scripts/run.sh
+# ADD prepare.sh /scripts/prepare.sh
+
+# WORKDIR /var/www/html
+
+# ENV COMPOSER_CACHE_DIR /composer-cache
+# RUN mkdir -p ${COMPOSER_CACHE_DIR}
+# ENV COMPOSER_VENDOR_DIR /composer-vendor
+# RUN mkdir -p ${COMPOSER_VENDOR_DIR}
+
+# CMD [ "bash", "/scripts/run.sh" ]

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -85,21 +85,21 @@ RUN echo "zend_extension=opcache.so" > /etc/php.d/opache.ini
 # Igbinary
 RUN set -eux; \
     source /envs/${PHP_MAJOR_MINOR}.env; \
-    if [[ -z "${IGBINARY_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${IGBINARY_VERSION:-}"; fi; \
+    if [[ -z "${IGBINARY_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${IGBINARY_VERSION}"; fi; \
     pecl install "igbinary${PECL_SUFFIX}"; \
     echo "extension=igbinary.so" > /etc/php.d/igbinary.ini
 
 # Memached
 RUN set -eux; \
     source /envs/${PHP_MAJOR_MINOR}.env; \
-    if [[ -z "${MEMCACHED_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${MEMCACHED_VERSION:-}"; fi; \
+    if [[ -z "${MEMCACHED_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${MEMCACHED_VERSION}"; fi; \
     printf 'yes' | pecl install "memcached${PECL_SUFFIX}"; \
     echo "extension=memcached.so" > /etc/php.d/memcached.ini
 
 # Redis
 RUN set -eux; \
     source /envs/${PHP_MAJOR_MINOR}.env; \
-    if [[ -z "${REDIS_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${REDIS_VERSION:-}"; fi; \
+    if [[ -z "${REDIS_VERSION:-}" ]]; then PECL_SUFFIX=""; else PECL_SUFFIX="-${REDIS_VERSION}"; fi; \
     printf 'yes' | pecl install "redis${PECL_SUFFIX}"; \
     echo "extension=redis.so" > /etc/php.d/redis.ini
 

--- a/tests/randomized/docker/Dockerfile
+++ b/tests/randomized/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN \
         gcc \
         gdb \
         git \
-        httpd \
+        httpd-devel \
         libcurl-devel \
         libmemcached-devel \
         libsodium-devel \
@@ -70,8 +70,6 @@ RUN set -eux; \
 
 WORKDIR /usr/local/src/php
 
-# ENV EPREFIX /usr/local
-
 RUN set -eux; \
     mkdir -p /etc/php.d; \
     ./configure \
@@ -89,6 +87,7 @@ RUN set -eux; \
         --enable-sysvmsg \
         --enable-sysvsem \
         --enable-sysvshm \
+        --with-apxs2 \
         --with-bz2 \
         --with-curl \
         --with-fpm-group=www-data \
@@ -136,8 +135,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN echo "date.timezone = UTC" > "/etc/php.d/00-adjust-timezones.ini"
 
 # Preparing PHP-FPM
-RUN mkdir -p /run/php-fpm
-RUN sed -i 's/^listen = .*$/listen = 9000/g' /etc/php-fpm.d/www.conf
+RUN mkdir -p /usr/local/etc/php-fpm.d
+ADD php-fpm.conf /usr/local/etc/php-fpm.conf
 
 # Preparing NGINX
 RUN groupadd www-data

--- a/tests/randomized/docker/apache.php.conf
+++ b/tests/randomized/docker/apache.php.conf
@@ -1,4 +1,4 @@
-<IfModule  mod_php7.c>
+<IfModule php7_module>
     #
     # Cause the PHP interpreter to handle files with a .php extension.
     #
@@ -7,12 +7,21 @@
     </FilesMatch>
 
     #
-    # Uncomment the following lines to allow PHP to pretty-print .phps
-    # files as PHP source code:
+    # Apache specific PHP configuration options
+    # those can be override in each configured vhost
     #
-    #<FilesMatch \.phps$>
-    #    SetHandler application/x-httpd-php-source
-    #</FilesMatch>
+    php_value session.save_handler "files"
+    php_value session.save_path    "/var/lib/php/session"
+    php_value soap.wsdl_cache_dir  "/var/lib/php/wsdlcache"
+</IfModule>
+
+<IfModule php_module>
+    #
+    # Cause the PHP interpreter to handle files with a .php extension.
+    #
+    <FilesMatch \.(php|phar)$>
+        SetHandler application/x-httpd-php
+    </FilesMatch>
 
     #
     # Apache specific PHP configuration options
@@ -21,6 +30,4 @@
     php_value session.save_handler "files"
     php_value session.save_path    "/var/lib/php/session"
     php_value soap.wsdl_cache_dir  "/var/lib/php/wsdlcache"
-
-    #php_value opcache.file_cache   "/var/lib/php/opcache"
 </IfModule>

--- a/tests/randomized/docker/apache.php.conf
+++ b/tests/randomized/docker/apache.php.conf
@@ -1,0 +1,26 @@
+<IfModule  mod_php7.c>
+    #
+    # Cause the PHP interpreter to handle files with a .php extension.
+    #
+    <FilesMatch \.(php|phar)$>
+        SetHandler application/x-httpd-php
+    </FilesMatch>
+
+    #
+    # Uncomment the following lines to allow PHP to pretty-print .phps
+    # files as PHP source code:
+    #
+    #<FilesMatch \.phps$>
+    #    SetHandler application/x-httpd-php-source
+    #</FilesMatch>
+
+    #
+    # Apache specific PHP configuration options
+    # those can be override in each configured vhost
+    #
+    php_value session.save_handler "files"
+    php_value session.save_path    "/var/lib/php/session"
+    php_value soap.wsdl_cache_dir  "/var/lib/php/wsdlcache"
+
+    #php_value opcache.file_cache   "/var/lib/php/opcache"
+</IfModule>

--- a/tests/randomized/docker/envs/5.4.env
+++ b/tests/randomized/docker/envs/5.4.env
@@ -1,0 +1,4 @@
+IGBINARY_VERSION=2.0.8
+MEMCACHED_VERSION=2.2.0
+REDIS_VERSION=2.2.8
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-5.4.45.tar.gz

--- a/tests/randomized/docker/envs/5.5.env
+++ b/tests/randomized/docker/envs/5.5.env
@@ -1,0 +1,4 @@
+IGBINARY_VERSION=2.0.8
+MEMCACHED_VERSION=2.2.0
+REDIS_VERSION=2.2.8
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-5.5.38.tar.gz

--- a/tests/randomized/docker/envs/5.6.env
+++ b/tests/randomized/docker/envs/5.6.env
@@ -1,0 +1,4 @@
+IGBINARY_VERSION=2.0.8
+MEMCACHED_VERSION=2.2.0
+REDIS_VERSION=2.2.8
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-5.6.40.tar.gz

--- a/tests/randomized/docker/envs/7.0.env
+++ b/tests/randomized/docker/envs/7.0.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-7.0.33.tar.gz

--- a/tests/randomized/docker/envs/7.1.env
+++ b/tests/randomized/docker/envs/7.1.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-7.1.33.tar.gz

--- a/tests/randomized/docker/envs/7.2.env
+++ b/tests/randomized/docker/envs/7.2.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-7.2.34.tar.gz

--- a/tests/randomized/docker/envs/7.3.env
+++ b/tests/randomized/docker/envs/7.3.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-7.3.33.tar.gz

--- a/tests/randomized/docker/envs/7.4.env
+++ b/tests/randomized/docker/envs/7.4.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-7.4.30.tar.gz

--- a/tests/randomized/docker/envs/8.0.env
+++ b/tests/randomized/docker/envs/8.0.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-8.0.20.tar.gz

--- a/tests/randomized/docker/envs/8.1.env
+++ b/tests/randomized/docker/envs/8.1.env
@@ -1,0 +1,1 @@
+PHP_DOWNLOAD_URL=https://www.php.net/distributions/php-8.1.7.tar.gz

--- a/tests/randomized/docker/php-fpm.conf
+++ b/tests/randomized/docker/php-fpm.conf
@@ -1,0 +1,2 @@
+[global]
+include=etc/php-fpm.d/*.conf

--- a/tests/randomized/docker/php-fpm.conf
+++ b/tests/randomized/docker/php-fpm.conf
@@ -1,2 +1,3 @@
 [global]
+error_log=/var/log/php-fpm/error.log
 include=etc/php-fpm.d/*.conf

--- a/tests/randomized/generate-scenarios.php
+++ b/tests/randomized/generate-scenarios.php
@@ -115,7 +115,7 @@ function generateOne($scenarioSeed, array $restrictedPHPVersions)
         [
             'identifier' => $identifier,
             'scenario_folder' => $scenarioFolder,
-            'image' => "datadog/dd-trace-ci:php-randomizedtests-dev-$selectedOs-$selectedPhpVersion",
+            'image' => "datadog/dd-trace-ci:php-randomizedtests-$selectedOs-$selectedPhpVersion-1",
             'installation_method' => $selectedInstallationMethod,
             'project_root' => '../../../../',
         ]

--- a/tests/randomized/lib/templates/apache.template.conf
+++ b/tests/randomized/lib/templates/apache.template.conf
@@ -1,6 +1,7 @@
 <VirtualHost *:81>
     DocumentRoot "/var/www/html/public"
     ServerName randomized_tests
+    DirectoryIndex index.php index.html
 {{envs}}
 {{inis}}
 </VirtualHost>

--- a/tests/randomized/lib/templates/docker-compose.template.yml
+++ b/tests/randomized/lib/templates/docker-compose.template.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - {{project_root}}:/dd-trace-php
       - ./app:/var/www/html
-      - ./www.php-fpm.conf:/etc/php-fpm.d/www.conf
+      - ./www.php-fpm.conf:/usr/local/etc/php-fpm.d/www.conf
       - ./www.apache.conf:/etc/httpd/conf.d/www.conf
       - ./vegeta-request-targets.txt:/vegeta-request-targets.txt
       - ./cli-runner.sh:/cli-runner.sh

--- a/tests/randomized/lib/templates/php-fpm.template.conf
+++ b/tests/randomized/lib/templates/php-fpm.template.conf
@@ -5,6 +5,8 @@ listen = 9000
 user = www-data
 group = www-data
 
+access.log = /var/log/php-fpm/www.access.log
+
 pm = dynamic
 pm.max_children = 20
 pm.start_servers = 5


### PR DESCRIPTION
### Description

Since Remi's repo does not  provide arm64 binaries, we have moved to manually build our version of PHP which required quite a few changes  at our makefile to support different versions.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
