### PR TITLE
Filter x-datadog-tags for _dd.p. prefix and add DDTrace\add_distributed_tag

### DIFF
--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -987,6 +987,37 @@ static PHP_FUNCTION(add_global_tag) {
     RETURN_NULL();
 }
 
+/* {{{ proto string DDTrace\add_distributed_tag(string $key, string $value) */
+static PHP_FUNCTION(add_distributed_tag) {
+    UNUSED(execute_data);
+
+    zend_string *key, *val;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &key, &val) == FAILURE) {
+        ddtrace_log_debug(
+            "Unable to parse parameters for DDTrace\\add_distributed_tag; expected (string $key, string $value)");
+        RETURN_NULL();
+    }
+
+    if (!get_DD_TRACE_ENABLED()) {
+        RETURN_NULL();
+    }
+
+    zend_string *prefixed_key = zend_strpprintf(0, "_dd.p.%s", ZSTR_VAL(key));
+
+    zend_array *target_table = DDTRACE_G(root_span) ? ddtrace_spandata_property_meta(&DDTRACE_G(root_span)->span)
+                                                    : &DDTRACE_G(root_span_tags_preset);
+
+    zval value_zv;
+    ZVAL_STR_COPY(&value_zv, val);
+    zend_hash_update(target_table, prefixed_key, &value_zv);
+
+    zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), prefixed_key);
+
+    zend_string_release(prefixed_key);
+
+    RETURN_NULL();
+}
+
 static PHP_FUNCTION(trace_function) {
     zval *function = NULL;
     zval *tracing_closure = NULL;
@@ -1874,6 +1905,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FE(ddtrace_config_trace_enabled, arginfo_ddtrace_void),
     DDTRACE_FE(ddtrace_init, arginfo_ddtrace_init),
     DDTRACE_NS_FE(add_global_tag, arginfo_ddtrace_add_global_tag),
+    DDTRACE_NS_FE(add_distributed_tag, arginfo_ddtrace_add_global_tag),
     DDTRACE_NS_FE(additional_trace_meta, arginfo_ddtrace_void),
     DDTRACE_NS_FE(trace_function, arginfo_ddtrace_trace_function),
     DDTRACE_FALIAS(dd_trace_function, trace_function, arginfo_ddtrace_trace_function),

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -5,7 +5,7 @@ HTTP_X_DATADOG_TRACE_ID=42
 HTTP_X_DATADOG_PARENT_ID=10
 HTTP_X_DATADOG_ORIGIN=datadog
 HTTP_X_DATADOG_SAMPLING_PRIORITY=3
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,dropped,other_tag=also,drop
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag=inherited,_dd.p.dropped,_dd.p.other_tag=also,_dd.p.drop
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
@@ -45,11 +45,11 @@ array(2) {
     string(3) "cli"
     ["meta"]=>
     array(5) {
-      ["custom_tag"]=>
+      ["_dd.p.custom_tag"]=>
       string(9) "inherited"
       ["_dd.propagation_error"]=>
       string(14) "decoding_error"
-      ["other_tag"]=>
+      ["_dd.p.other_tag"]=>
       string(4) "also"
       ["system.pid"]=>
       string(%d) "%d"

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
@@ -4,7 +4,7 @@ Setting custom distributed header information
 HTTP_X_DATADOG_TRACE_ID=42
 HTTP_X_DATADOG_PARENT_ID=10
 HTTP_X_DATADOG_ORIGIN=datadog
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,second_tag=bar
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag=inherited,_dd.p.second_tag=bar
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
@@ -27,7 +27,7 @@ dump_context();
 trace_id: 42
 distributed_tracing_origin: datadog
 distributed_tracing_parent_id: 10
-distributed_tracing_propagated_tags: {"custom_tag":"inherited","second_tag":"bar"}
+distributed_tracing_propagated_tags: {"_dd.p.custom_tag":"inherited","_dd.p.second_tag":"bar"}
 trace_id: 123
 distributed_tracing_origin: foo
 distributed_tracing_parent_id: 321

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -10,7 +10,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH=25
 HTTP_X_DATADOG_ORIGIN=phpt-test
-HTTP_X_DATADOG_TAGS=very=looooooooooooooooooooooong
+HTTP_X_DATADOG_TAGS=_dd.p.very=looooooooooooooooong
 --FILE--
 <?php
 include 'curl_helper.inc';
@@ -43,7 +43,7 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-The to be propagated tag 'very=looooooooooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
+The to be propagated tag '_dd.p.very=looooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)

--- a/tests/ext/integrations/curl/distributed_tracing_curl_propagate_custom_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_propagate_custom_tags.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Distributed tracing header tags propagate with curl_exec()
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--ENV--
+DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
+--FILE--
+<?php
+
+include 'distributed_tracing.inc';
+
+function query_headers() {
+    $port = getenv('HTTPBIN_PORT') ?: '80';
+    $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return dt_decode_headers_from_httpbin($response);
+}
+
+DDTrace\add_distributed_tag("usr.id", "1234");
+$meta = DDTrace\root_span()->meta;
+var_dump($meta["_dd.p.usr.id"]);
+
+dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-tags']);
+
+?>
+--EXPECT--
+string(4) "1234"
+x-datadog-tags: _dd.p.usr.id=1234,_dd.p.dm=-1

--- a/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
@@ -3,10 +3,9 @@ Distributed tracing header tags propagate with curl_exec()
 --SKIPIF--
 <?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
-<?php die('skip: disabled functionality'); ?>
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,to_remove=,foo=bar,_dd.p.dm=abcdef|0|2|1.000
+HTTP_X_DATADOG_TAGS=custom_tag=inherited,to_remove=,_dd.p.foo=bar,_dd.p.dm=abcdef-2
 --FILE--
 <?php
 
@@ -30,10 +29,10 @@ $meta["foo"] = "buzz";
 $span = DDTrace\start_span();
 $span->service = "dd";
 
-DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_USER_REJECT);
+DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_USER_KEEP);
 
 dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-tags']);
 
 ?>
 --EXPECT--
-x-datadog-tags: custom_tag=inherited,foo=buzz,_dd.p.dm=abcdef|0|2|1.000;ZGQ|-1|4|
+x-datadog-tags: _dd.p.foo=bar,_dd.p.dm=abcdef-2


### PR DESCRIPTION
### Description

We only want tags starting with _dd.p. prefix to avoid arbitrary tag injection...

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
