### PR TITLE
Disable clang format check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,20 +295,6 @@ jobs:
           name: Running phpcs
           command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure
       - run:
-          name: Install Clang
-          command: |
-              codename=$(cat /etc/os-release | awk -F = '/UBUNTU_CODENAME/ { print $2 }')
-              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-              (
-                echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename} main"
-                echo "deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename} main"
-              ) | sudo tee /etc/apt/sources.list.d/llvm-toolchain.list
-              sudo apt-get update
-              sudo apt-get -y install clang-format
-      - run:
-          name: Run clang-format
-          command: make clang_format_check CLANG_FORMAT=clang-format
-      - run:
           name: Check linting failure
           command: test -e .failure && exit 1 || true
       - run:


### PR DESCRIPTION
### Description

This disables the clang format check for C source files while leaving the remaining tasks for the lint job unchanged.

Our very basic usage of clang format leads to frustration when opening PR's of any complexity. We could invest time in learning and configuring the software, however it would seem like a waste of time.

Bob and I both agree that our current usage is a hinderance rather than a help; We both agree that it's reasonable for us to just point out particularly jarring formatting during code review.
