### PR TITLE
Update regex to account for URL encoding

### DIFF
--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -54,7 +54,7 @@ extern bool runtime_config_first_init;
            CALIASES(DD_CFG_STR(DD_##id##_ANALYTICS_SAMPLE_RATE), DD_CFG_STR(DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE)))
 
 #define DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
-    "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\\s*=[^&]+|\"\\s*:\\s*\"[^\"]+\")|bearer\\s+[a-z0-9\\._\\-]|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(?:\\.[\\w.+\\/=-]+)?|[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*[a-z0-9\\/\\.+]{100,}"
+    "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}"
 
 #define DD_CONFIGURATION                                                                                      \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -54,7 +54,7 @@ extern bool runtime_config_first_init;
            CALIASES(DD_CFG_STR(DD_##id##_ANALYTICS_SAMPLE_RATE), DD_CFG_STR(DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE)))
 
 #define DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
-    "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\\s*=[^&]+|\"\\s*:\\s*\"[^\"]+\")|bearer\\s+[a-z0-9\\._\\-]|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(?:\\.[\\w.+\\/=-]+)?|[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*[a-z0-9\\/\\.+]{100,}"
+    "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}"
 
 #define DD_CONFIGURATION                                                                                      \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \

--- a/tests/ext/root_span_url_with_query_params_obfuscation.phpt
+++ b/tests/ext/root_span_url_with_query_params_obfuscation.phpt
@@ -9,11 +9,11 @@ DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED=*
 HTTPS=off
 HTTP_HOST=localhost:9999
 SCRIPT_NAME=/foo.php
-REQUEST_URI=/foo?key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
-QUERY_STRING=key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
+REQUEST_URI=/foo?key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D&other=value
+QUERY_STRING=key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D&other=value
 METHOD=GET
 --GET--
-key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
+key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D&other=value
 --FILE--
 <?php
 DDTrace\start_span();
@@ -22,4 +22,4 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']["http.url"]);
 ?>
 --EXPECT--
-string(87) "https://localhost:9999/foo?key1=val1&<redacted>&key2=val2&<redacted>&key={ "<redacted>}"
+string(107) "https://localhost:9999/foo?key1=val1&<redacted>&key2=val2&<redacted>&key=%7B%20%22<redacted>%7D&other=value"

--- a/tests/ext/root_span_url_with_query_params_obfuscation.phpt
+++ b/tests/ext/root_span_url_with_query_params_obfuscation.phpt
@@ -9,11 +9,11 @@ DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED=*
 HTTPS=off
 HTTP_HOST=localhost:9999
 SCRIPT_NAME=/foo.php
-REQUEST_URI=/foo?key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something
-QUERY_STRING=key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something
+REQUEST_URI=/foo?key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
+QUERY_STRING=key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
 METHOD=GET
 --GET--
-key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something
+key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&password=something&key=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D
 --FILE--
 <?php
 DDTrace\start_span();
@@ -22,4 +22,4 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']["http.url"]);
 ?>
 --EXPECT--
-string(68) "https://localhost:9999/foo?key1=val1&<redacted>&key2=val2&<redacted>"
+string(87) "https://localhost:9999/foo?key1=val1&<redacted>&key2=val2&<redacted>&key={ "<redacted>}"

--- a/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
+++ b/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
@@ -5,6 +5,7 @@
 
 #include <ext/pcre/php_pcre.h>
 #include <ext/standard/php_string.h>
+#include <ext/standard/url.h>
 
 #if PHP_VERSION_ID < 70200
 #define zend_strpprintf strpprintf
@@ -151,8 +152,9 @@ zend_string *zai_filter_query_string(zai_string_view queryString, zend_array *wh
                 zend_string *replacement = zend_string_init(ZEND_STRL("<redacted>"), 0);
                 zend_string *regex = zend_strpprintf(0, "(%.*s)", (int)ZSTR_LEN(pattern), ZSTR_VAL(pattern));
 
+                size_t decoded_len = php_raw_url_decode(ZSTR_VAL(qs), ZSTR_LEN(qs));
                 zend_string *redacted_qs =
-                    php_pcre_replace(regex, qs, ZSTR_VAL(qs), ZSTR_LEN(qs), replacement, -1, NULL);
+                    php_pcre_replace(regex, qs, ZSTR_VAL(qs), decoded_len, replacement, -1, NULL);
 
                 zend_string_release(regex);
                 zend_string_release(replacement);

--- a/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
+++ b/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
@@ -152,9 +152,8 @@ zend_string *zai_filter_query_string(zai_string_view queryString, zend_array *wh
                 zend_string *replacement = zend_string_init(ZEND_STRL("<redacted>"), 0);
                 zend_string *regex = zend_strpprintf(0, "(%.*s)", (int)ZSTR_LEN(pattern), ZSTR_VAL(pattern));
 
-                size_t decoded_len = php_raw_url_decode(ZSTR_VAL(qs), ZSTR_LEN(qs));
                 zend_string *redacted_qs =
-                    php_pcre_replace(regex, qs, ZSTR_VAL(qs), decoded_len, replacement, -1, NULL);
+                    php_pcre_replace(regex, qs, ZSTR_VAL(qs), ZSTR_LEN(qs), replacement, -1, NULL);
 
                 zend_string_release(regex);
                 zend_string_release(replacement);

--- a/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
+++ b/zend_abstract_interface/uri_normalization/php7-8/uri_normalization.c
@@ -5,7 +5,6 @@
 
 #include <ext/pcre/php_pcre.h>
 #include <ext/standard/php_string.h>
-#include <ext/standard/url.h>
 
 #if PHP_VERSION_ID < 70200
 #define zend_strpprintf strpprintf


### PR DESCRIPTION
### Description

The query string obfuscation currently doesn't work on encoded URLs, so this change simply decodes the URL (specifically the query string portion) before obfuscation.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
