### PR TITLE
Update profiling to v0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PHP_EXTENSION_DIR=$(shell php -r 'print ini_get("extension_dir");')
 PHP_MAJOR_MINOR:=$(shell php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
-PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.6.1/datadog-profiling.tar.gz
+PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.7.0/datadog-profiling.tar.gz
 APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.3.2/dd-appsec-php-0.3.2-amd64.tar.gz
 
 INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini


### PR DESCRIPTION
### Changed
- Do not upload empty profiles. See DataDog/dd-prof-php@e03ff23e5216f863061285e13170d011d0c04bc8 for details.

### Fixed
- Fix a small memory leak with env var handling.

### Added
- Add SAPI as profile tag.
- Add support for `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED` env var. It previously supported this functionality under a different, undocumented name.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
