### PR TITLE
Rename query string obfuscation variable

### DIFF
--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -53,79 +53,79 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE, DD_CFG_EXPSTR(DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT), \
            CALIASES(DD_CFG_STR(DD_##id##_ANALYTICS_SAMPLE_RATE), DD_CFG_STR(DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE)))
 
-#define DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
+#define DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
     "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}"
 
-#define DD_CONFIGURATION                                                                                      \
-    CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \
-           CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
-    CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
-    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
-    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                      \
-    CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
-    CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
-    CONFIG(STRING, DD_ENV, "")                                                                                \
-    CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                \
-    CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                              \
-    CONFIG(SET, DD_INTEGRATIONS_DISABLED, "default")                                                          \
-    CONFIG(BOOL, DD_PRIORITY_SAMPLING, "true")                                                                \
-    CALIAS(STRING, DD_SERVICE, "", CALIASES("DD_SERVICE_NAME"))                                               \
-    CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                       \
-    CALIAS(MAP, DD_TAGS, "", CALIASES("DD_TRACE_GLOBAL_TAGS"))                                                \
-    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126", .ini_change = zai_config_system_ini_change)                      \
-    CONFIG(BOOL, DD_TRACE_ANALYTICS_ENABLED, "false")                                                         \
-    CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                        \
-    CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                               \
-    CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                       \
-    CONFIG(BOOL, DD_TRACE_DEBUG, "false")                                                                     \
-    CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)              \
-    CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)        \
-    CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                    \
-    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
-    CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
-    CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
-    CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \
-    CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                           \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                   \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                   \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                                \
-    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "*")                                                   \
-    CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
-    CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
-    CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                         \
-    CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
-    CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),            \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1")                                                               \
-    CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                   \
-    CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)      \
-    CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                 \
-    CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                      \
-           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                          \
-    CONFIG(INT, DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC,                                                       \
-           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC))                                   \
-    CONFIG(INT, DD_TRACE_BGS_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_CONNECT_TIMEOUT_VAL),                \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_BGS_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_TIMEOUT_VAL),                                \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_AGENT_FLUSH_INTERVAL, "5000", .ini_change = zai_config_system_ini_change)            \
-    CONFIG(INT, DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS, "10")                                                  \
-    CONFIG(INT, DD_TRACE_SHUTDOWN_TIMEOUT, "5000", .ini_change = zai_config_system_ini_change)                \
-    CONFIG(BOOL, DD_TRACE_STARTUP_LOGS, "true")                                                               \
-    CONFIG(BOOL, DD_TRACE_AGENT_DEBUG_VERBOSE_CURL, "false", .ini_change = zai_config_system_ini_change)      \
-    CONFIG(BOOL, DD_TRACE_DEBUG_CURL_OUTPUT, "false", .ini_change = zai_config_system_ini_change)             \
-    CONFIG(INT, DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT, "80", .ini_change = zai_config_system_ini_change) \
-    CONFIG(BOOL, DD_TRACE_WARN_LEGACY_DD_TRACE, "true")                                                       \
-    CONFIG(BOOL, DD_TRACE_RETAIN_THREAD_CAPABILITIES, "false", .ini_change = zai_config_system_ini_change)    \
-    CONFIG(STRING, DD_VERSION, "")                                                                            \
-    CONFIG(STRING, DD_OBFUSCATION_QUERY_STRING_REGEXP, DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT)            \
-    CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                 \
-    CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                             \
+#define DD_CONFIGURATION                                                                                       \
+    CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
+           CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
+    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
+    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \
+    CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                               \
+    CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                  \
+    CONFIG(STRING, DD_ENV, "")                                                                                 \
+    CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                 \
+    CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                               \
+    CONFIG(SET, DD_INTEGRATIONS_DISABLED, "default")                                                           \
+    CONFIG(BOOL, DD_PRIORITY_SAMPLING, "true")                                                                 \
+    CALIAS(STRING, DD_SERVICE, "", CALIASES("DD_SERVICE_NAME"))                                                \
+    CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                        \
+    CALIAS(MAP, DD_TAGS, "", CALIASES("DD_TRACE_GLOBAL_TAGS"))                                                 \
+    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126", .ini_change = zai_config_system_ini_change)                       \
+    CONFIG(BOOL, DD_TRACE_ANALYTICS_ENABLED, "false")                                                          \
+    CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                         \
+    CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                                \
+    CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                        \
+    CONFIG(BOOL, DD_TRACE_DEBUG, "false")                                                                      \
+    CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)               \
+    CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)         \
+    CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                     \
+    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                 \
+    CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
+    CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                    \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                                 \
+    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "*")                                                    \
+    CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                    \
+    CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                                \
+    CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                            \
+    CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                     \
+    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                          \
+    CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                        \
+    CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                             \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),             \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1")                                                                \
+    CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                    \
+    CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
+    CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \
+    CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                       \
+           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                           \
+    CONFIG(INT, DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC,                                                        \
+           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC))                                    \
+    CONFIG(INT, DD_TRACE_BGS_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_CONNECT_TIMEOUT_VAL),                 \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_BGS_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_TIMEOUT_VAL),                                 \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_AGENT_FLUSH_INTERVAL, "5000", .ini_change = zai_config_system_ini_change)             \
+    CONFIG(INT, DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS, "10")                                                   \
+    CONFIG(INT, DD_TRACE_SHUTDOWN_TIMEOUT, "5000", .ini_change = zai_config_system_ini_change)                 \
+    CONFIG(BOOL, DD_TRACE_STARTUP_LOGS, "true")                                                                \
+    CONFIG(BOOL, DD_TRACE_AGENT_DEBUG_VERBOSE_CURL, "false", .ini_change = zai_config_system_ini_change)       \
+    CONFIG(BOOL, DD_TRACE_DEBUG_CURL_OUTPUT, "false", .ini_change = zai_config_system_ini_change)              \
+    CONFIG(INT, DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT, "80", .ini_change = zai_config_system_ini_change)  \
+    CONFIG(BOOL, DD_TRACE_WARN_LEGACY_DD_TRACE, "true")                                                        \
+    CONFIG(BOOL, DD_TRACE_RETAIN_THREAD_CAPABILITIES, "false", .ini_change = zai_config_system_ini_change)     \
+    CONFIG(STRING, DD_VERSION, "")                                                                             \
+    CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
+    CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                  \
+    CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \
     DD_INTEGRATIONS
 
 #define CALIAS CONFIG

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -482,7 +482,7 @@ static zend_string *dd_build_req_url() {
         uri_len = question_mark - uri;
         query_string = zai_filter_query_string(
             (zai_string_view){.len = strlen(uri) - uri_len - 1, .ptr = question_mark + 1},
-            get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_OBFUSCATION_QUERY_STRING_REGEXP());
+            get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
     } else {
         uri_len = strlen(uri);
     }
@@ -554,9 +554,10 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                 zend_string *query_string = ZSTR_EMPTY_ALLOC();
                 const char *query_str = dd_get_query_string();
                 if (query_str) {
-                    query_string = zai_filter_query_string(
-                        (zai_string_view){.len = strlen(query_str), .ptr = query_str},
-                        get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(), get_DD_OBFUSCATION_QUERY_STRING_REGEXP());
+                    query_string =
+                        zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
+                                                get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
+                                                get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                 }
 
                 ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -53,79 +53,79 @@ extern bool runtime_config_first_init;
     CALIAS(DOUBLE, DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE, DD_CFG_EXPSTR(DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT), \
            CALIASES(DD_CFG_STR(DD_##id##_ANALYTICS_SAMPLE_RATE), DD_CFG_STR(DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE)))
 
-#define DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
+#define DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT \
     "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}"
 
-#define DD_CONFIGURATION                                                                                      \
-    CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                             \
-           CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                 \
-    CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                        \
-    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                             \
-    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                      \
-    CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                              \
-    CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                 \
-    CONFIG(STRING, DD_ENV, "")                                                                                \
-    CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                \
-    CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                              \
-    CONFIG(SET, DD_INTEGRATIONS_DISABLED, "default")                                                          \
-    CONFIG(BOOL, DD_PRIORITY_SAMPLING, "true")                                                                \
-    CALIAS(STRING, DD_SERVICE, "", CALIASES("DD_SERVICE_NAME"))                                               \
-    CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                       \
-    CALIAS(MAP, DD_TAGS, "", CALIASES("DD_TRACE_GLOBAL_TAGS"))                                                \
-    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126", .ini_change = zai_config_system_ini_change)                      \
-    CONFIG(BOOL, DD_TRACE_ANALYTICS_ENABLED, "false")                                                         \
-    CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                        \
-    CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                               \
-    CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                       \
-    CONFIG(BOOL, DD_TRACE_DEBUG, "false")                                                                     \
-    CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)              \
-    CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)        \
-    CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                    \
-    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                               \
-    CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                               \
-    CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                \
-    CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                 \
-    CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                           \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                     \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                   \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                   \
-    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                                \
-    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "*")                                                   \
-    CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                   \
-    CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
-    CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
-    CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                         \
-    CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
-    CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),            \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1")                                                               \
-    CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                   \
-    CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)      \
-    CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                 \
-    CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                      \
-           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                          \
-    CONFIG(INT, DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC,                                                       \
-           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC))                                   \
-    CONFIG(INT, DD_TRACE_BGS_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_CONNECT_TIMEOUT_VAL),                \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_BGS_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_TIMEOUT_VAL),                                \
-           .ini_change = zai_config_system_ini_change)                                                        \
-    CONFIG(INT, DD_TRACE_AGENT_FLUSH_INTERVAL, "5000", .ini_change = zai_config_system_ini_change)            \
-    CONFIG(INT, DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS, "10")                                                  \
-    CONFIG(INT, DD_TRACE_SHUTDOWN_TIMEOUT, "5000", .ini_change = zai_config_system_ini_change)                \
-    CONFIG(BOOL, DD_TRACE_STARTUP_LOGS, "true")                                                               \
-    CONFIG(BOOL, DD_TRACE_AGENT_DEBUG_VERBOSE_CURL, "false", .ini_change = zai_config_system_ini_change)      \
-    CONFIG(BOOL, DD_TRACE_DEBUG_CURL_OUTPUT, "false", .ini_change = zai_config_system_ini_change)             \
-    CONFIG(INT, DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT, "80", .ini_change = zai_config_system_ini_change) \
-    CONFIG(BOOL, DD_TRACE_WARN_LEGACY_DD_TRACE, "true")                                                       \
-    CONFIG(BOOL, DD_TRACE_RETAIN_THREAD_CAPABILITIES, "false", .ini_change = zai_config_system_ini_change)    \
-    CONFIG(STRING, DD_VERSION, "")                                                                            \
-    CONFIG(STRING, DD_OBFUSCATION_QUERY_STRING_REGEXP, DD_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT)            \
-    CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                 \
-    CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                             \
+#define DD_CONFIGURATION                                                                                       \
+    CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
+           CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
+    CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
+    CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \
+    CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                               \
+    CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                  \
+    CONFIG(STRING, DD_ENV, "")                                                                                 \
+    CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                 \
+    CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                               \
+    CONFIG(SET, DD_INTEGRATIONS_DISABLED, "default")                                                           \
+    CONFIG(BOOL, DD_PRIORITY_SAMPLING, "true")                                                                 \
+    CALIAS(STRING, DD_SERVICE, "", CALIASES("DD_SERVICE_NAME"))                                                \
+    CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                        \
+    CALIAS(MAP, DD_TAGS, "", CALIASES("DD_TRACE_GLOBAL_TAGS"))                                                 \
+    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126", .ini_change = zai_config_system_ini_change)                       \
+    CONFIG(BOOL, DD_TRACE_ANALYTICS_ENABLED, "false")                                                          \
+    CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                         \
+    CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                                \
+    CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                        \
+    CONFIG(BOOL, DD_TRACE_DEBUG, "false")                                                                      \
+    CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)               \
+    CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)         \
+    CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                     \
+    CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_HTTP_CLIENT_SPLIT_BY_DOMAIN, "false")                                                \
+    CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                 \
+    CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
+    CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                    \
+    CONFIG(SET, DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED, "")                                                 \
+    CONFIG(SET, DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED, "*")                                                    \
+    CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "1", CALIASES("DD_SAMPLING_RATE"))                                    \
+    CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                                \
+    CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                            \
+    CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                     \
+    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                          \
+    CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                        \
+    CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                             \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),             \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1")                                                                \
+    CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                    \
+    CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
+    CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \
+    CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                       \
+           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                           \
+    CONFIG(INT, DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC,                                                        \
+           DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_RETRY_TIME_MSEC))                                    \
+    CONFIG(INT, DD_TRACE_BGS_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_CONNECT_TIMEOUT_VAL),                 \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_BGS_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_BGS_TIMEOUT_VAL),                                 \
+           .ini_change = zai_config_system_ini_change)                                                         \
+    CONFIG(INT, DD_TRACE_AGENT_FLUSH_INTERVAL, "5000", .ini_change = zai_config_system_ini_change)             \
+    CONFIG(INT, DD_TRACE_AGENT_FLUSH_AFTER_N_REQUESTS, "10")                                                   \
+    CONFIG(INT, DD_TRACE_SHUTDOWN_TIMEOUT, "5000", .ini_change = zai_config_system_ini_change)                 \
+    CONFIG(BOOL, DD_TRACE_STARTUP_LOGS, "true")                                                                \
+    CONFIG(BOOL, DD_TRACE_AGENT_DEBUG_VERBOSE_CURL, "false", .ini_change = zai_config_system_ini_change)       \
+    CONFIG(BOOL, DD_TRACE_DEBUG_CURL_OUTPUT, "false", .ini_change = zai_config_system_ini_change)              \
+    CONFIG(INT, DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT, "80", .ini_change = zai_config_system_ini_change)  \
+    CONFIG(BOOL, DD_TRACE_WARN_LEGACY_DD_TRACE, "true")                                                        \
+    CONFIG(BOOL, DD_TRACE_RETAIN_THREAD_CAPABILITIES, "false", .ini_change = zai_config_system_ini_change)     \
+    CONFIG(STRING, DD_VERSION, "")                                                                             \
+    CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
+    CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                  \
+    CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \
     DD_INTEGRATIONS
 
 #define CALIAS CONFIG

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -481,7 +481,7 @@ static zend_string *dd_build_req_url() {
         uri_len = question_mark - uri;
         query_string = zai_filter_query_string(
             (zai_string_view){.len = strlen(uri) - uri_len - 1, .ptr = question_mark + 1},
-            get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_OBFUSCATION_QUERY_STRING_REGEXP());
+            get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
     } else {
         uri_len = strlen(uri);
     }
@@ -553,9 +553,10 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
                 zend_string *query_string = zend_empty_string;
                 const char *query_str = dd_get_query_string();
                 if (query_str) {
-                    query_string = zai_filter_query_string(
-                        (zai_string_view){.len = strlen(query_str), .ptr = query_str},
-                        get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(), get_DD_OBFUSCATION_QUERY_STRING_REGEXP());
+                    query_string =
+                        zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
+                                                get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
+                                                get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                 }
 
                 ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),


### PR DESCRIPTION
### Description
Rename `DD_OBFUSCATION_QUERY_STRING_REGEXP` variable to `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
