### PR TITLE
Fix test_web on PHP 8.0

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_4/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_4/composer.json
@@ -7,7 +7,7 @@
         "ext-iconv": "*",
         "composer/package-versions-deprecated": "^1.10",
         "doctrine/annotations": "^1.0",
-        "doctrine/doctrine-bundle": "^2.1",
+        "doctrine/doctrine-bundle": "^2.1,<2.7",
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "doctrine/orm": "^2.7",
         "phpdocumentor/reflection-docblock": "^5.1",


### PR DESCRIPTION
### Description

The doctrine/doctrine-bundle 2.7 is not compatible with doctrine/orm <2.11 (due to other dependencies, we're forced to a lower version).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
