### PR TITLE
Update library versions used in tests + support plesk paths

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -104,7 +104,7 @@ function install($options)
         // For testing purposes, we need an alternate repo where we can push bundles that includes changes that we are
         // trying to test, as the previously released versions would not have those changes.
         $url = (getenv('DD_TEST_INSTALLER_REPO') ?: "https://github.com/DataDog/dd-trace-php")
-                . "/releases/download/${version}/dd-library-php-${version}-${platform}.tar.gz";
+            . "/releases/download/${version}/dd-library-php-${version}-${platform}.tar.gz";
         // phpcs:enable Generic.Files.LineLength.TooLong
         download($url, $tmpDirTarGz);
         unset($version);
@@ -170,7 +170,7 @@ function install($options)
         }
 
         // Trace
-        $extensionRealPath = "$tmpArchiveTraceRoot/ext/$extensionVersion/ddtrace$extensionSuffix.so" ;
+        $extensionRealPath = "$tmpArchiveTraceRoot/ext/$extensionVersion/ddtrace$extensionSuffix.so";
         $extensionDestination = $phpProperties[EXTENSION_DIR] . '/ddtrace.so';
         safe_copy_extension($extensionRealPath, $extensionDestination);
 
@@ -285,11 +285,11 @@ function install($options)
                 );
 
                 if (is_truthy($options[OPT_ENABLE_APPSEC])) {
-                        execute_or_exit(
-                            'Impossible to update the INI settings file.',
-                            "sed -i 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
-                                . escapeshellarg($iniFilePath)
-                        );
+                    execute_or_exit(
+                        'Impossible to update the INI settings file.',
+                        "sed -i 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
+                            . escapeshellarg($iniFilePath)
+                    );
                 } else {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
@@ -813,6 +813,7 @@ function search_php_binaries($prefix = '')
         $prefix . '/usr/local/bin',
         $prefix . '/usr/local/sbin',
     ];
+
     $remiSafePaths = array_map(function ($phpVersion) use ($prefix) {
         list($major, $minor) = explode('.', $phpVersion);
         /* php is installed to /usr/bin/php${major}${minor} so we do not need to do anything special, while php-fpm
@@ -821,7 +822,16 @@ function search_php_binaries($prefix = '')
          */
         return "${prefix}/opt/remi/php${major}${minor}/root/usr/sbin";
     }, get_supported_php_versions());
-    $escapedSearchLocations =  implode(' ', array_map('escapeshellarg', $standardPaths + $remiSafePaths));
+
+    $pleskPaths = array_map(function ($phpVersion) use ($prefix) {
+        return "/opt/plesk/php/$phpVersion/bin";
+        return "/opt/plesk/php/$phpVersion/sbin";
+    }, get_supported_php_versions());
+
+    $escapedSearchLocations = implode(
+        ' ',
+        array_map('escapeshellarg', array_merge($standardPaths, $remiSafePaths, $pleskPaths))
+    );
     $escapedCommandNamesForFind = implode(
         ' -o ',
         array_map(
@@ -916,16 +926,16 @@ function add_missing_ini_settings($iniFilePath, $settings)
         // Formatting the setting to be added.
         $description =
             is_string($setting['description'])
-                ? '; ' . $setting['description']
-                : implode(
-                    "\n",
-                    array_map(
-                        function ($line) {
-                            return '; ' . $line;
-                        },
-                        $setting['description']
-                    )
-                );
+            ? '; ' . $setting['description']
+            : implode(
+                "\n",
+                array_map(
+                    function ($line) {
+                        return '; ' . $line;
+                    },
+                    $setting['description']
+                )
+            );
         $setting = ($setting['commented'] ? ';' : '') . $setting['name'] . ' = ' . $setting['default'];
         $formattedMissingProperties .= "\n$description\n$setting\n";
     }

--- a/dockerfiles/verify_packages/.env
+++ b/dockerfiles/verify_packages/.env
@@ -1,1 +1,1 @@
-DD_TEST_INSTALLER_REPO=https://github.com/labbati/test-actions
+DD_TEST_INSTALLER_REPO=https://github.com/Datadog/dd-trace-php

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -84,24 +84,29 @@ test_uninstall.sh \
 test_upgrade_from_legacy.sh \
 test_upgrade_from_php_installer.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.4-cli sh dockerfiles/verify_packages/installer/$(@)
 
 test_first_install_php_debug.sh \
 test_first_install_php_debugzts.sh \
 test_profiler_install_unsupported_debug.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app datadog/dd-trace-ci:php-7.4_buster sh dockerfiles/verify_packages/installer/$(@)
 
 test_first_install_php_zts.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.4-zts-buster sh dockerfiles/verify_packages/installer/$(@)
 
 test_fpm.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.4-fpm sh dockerfiles/verify_packages/installer/$(@)
 
 test_profiler_install_unsupported.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.0-cli sh dockerfiles/verify_packages/installer/$(@)
 
 test_alpine_no_ext_json.sh \
@@ -110,7 +115,13 @@ test_first_install_alpine.sh \
 test_alpine_install_no_ext_curl_no_curl_cli.sh \
 test_alpine_install_no_ext_curl_yes_curl_cli.sh \
 	:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app alpine:3.12 sh dockerfiles/verify_packages/installer/$(@)
 
 test_alpine_no_libexecinfo.sh:
+	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.4-cli-alpine sh dockerfiles/verify_packages/installer/$(@)
+
+test_install_on_plesk.sh:
+	@echo "################### $(@) ###################"
+	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app plesk/plesk:18.0 sh dockerfiles/verify_packages/installer/$(@)

--- a/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_no_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_no_curl_cli.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo php7-openssl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_yes_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_yes_curl_cli.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo curl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
@@ -10,7 +10,7 @@ apk add php7 curl libexecinfo
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_alpine_no_libcurl.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_libcurl.sh
@@ -10,7 +10,7 @@ apk add php7
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_alpine_no_libexecinfo.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_libexecinfo.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
@@ -13,7 +13,7 @@ generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 
 assert_ddtrace_version "${new_version}"
-assert_appsec_version 0.2.0
+assert_appsec_version 0.3.2
 assert_appsec_disabled
 
 assert_file_exists "$(get_php_extension_dir)"/ddappsec.so

--- a/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
@@ -12,7 +12,7 @@ new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --enable-appsec
 assert_ddtrace_version "${new_version}"
-assert_appsec_version 0.2.0
+assert_appsec_version 0.3.2
 assert_appsec_enabled
 
 assert_file_exists "$(get_php_extension_dir)"/ddappsec.so

--- a/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --enable-appsec
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_alpine.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_alpine.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo curl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_php_debug.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_debug.sh
@@ -13,7 +13,7 @@ sudo chmod a+w ./build/packages/*
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_php_debugzts.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_debugzts.sh
@@ -13,7 +13,7 @@ switch-php debug-zts-asan
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_first_install_php_zts.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_zts.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_fpm.sh
+++ b/dockerfiles/verify_packages/installer/test_fpm.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-fpm
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_install_add_missing_ini_settings.sh
+++ b/dockerfiles/verify_packages/installer/test_install_add_missing_ini_settings.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_install_custom_installation_directory.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_installation_directory.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --install-dir /custom/dd
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_install_custom_installation_root.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_installation_root.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 # Verify that wrong installation dir (e.g. /) does not delete all files in root

--- a/dockerfiles/verify_packages/installer/test_install_non_root_user.sh
+++ b/dockerfiles/verify_packages/installer/test_install_non_root_user.sh
@@ -10,7 +10,7 @@ assert_no_ddtrace
 useradd -m datadog -p datadog
 usermod -a -G datadog datadog
 
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
+++ b/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Install using the php installer
+new_version="0.75.0"
+generate_installers "${new_version}"
+/opt/plesk/php/7.4/bin/php ./build/packages/datadog-setup.php --php-bin=all
+
+assert_ddtrace_version "${new_version}" /opt/plesk/php/7.4/bin/php
+assert_ddtrace_version "${new_version}" /opt/plesk/php/7.4/sbin/php-fpm
+assert_ddtrace_version "${new_version}" /opt/plesk/php/8.0/bin/php
+assert_ddtrace_version "${new_version}" /opt/plesk/php/8.0/sbin/php-fpm

--- a/dockerfiles/verify_packages/installer/test_install_subdir_from_file.sh
+++ b/dockerfiles/verify_packages/installer/test_install_subdir_from_file.sh
@@ -12,7 +12,7 @@ if [ "$CIRCLECI" = "true" ]; then
     exit 0
 fi
 
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 repo_url=${DD_TEST_INSTALLER_REPO:-"https://github.com/DataDog/dd-trace-php"}
 curl -L -o /tmp/downloaded.tar.gz "${repo_url}/releases/download/${new_version}/dd-library-php-${new_version}-x86_64-linux-gnu.tar.gz"

--- a/dockerfiles/verify_packages/installer/test_install_subdir_from_version.sh
+++ b/dockerfiles/verify_packages/installer/test_install_subdir_from_version.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
@@ -22,7 +22,7 @@ assert_no_appsec
 assert_no_profiler
 
 php ./build/packages/datadog-setup.php --enable-appsec --php-bin php
-assert_appsec_version 0.2.0
+assert_appsec_version 0.3.2
 assert_appsec_enabled
 
 # Appsec requires ddtrace to be enabled, otherwise it crashes with missing symbols.

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 
@@ -23,8 +23,8 @@ assert_no_profiler
 
 php ./build/packages/datadog-setup.php --enable-profiling --php-bin php
 
-assert_ddtrace_version 0.68.2
-assert_profiler_version 0.3.0
+assert_ddtrace_version 0.75.0
+assert_profiler_version 0.6.1
 
 extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 if [ -f "${extension_dir}/ddtrace.so" ]; then

--- a/dockerfiles/verify_packages/installer/test_profiler_install_disabled.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_disabled.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
@@ -8,11 +8,11 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --enable-profiling
 assert_ddtrace_version "${new_version}"
 
 assert_file_exists "$(get_php_extension_dir)"/datadog-profiling.so
 
-assert_profiler_version 0.3.0
+assert_profiler_version 0.6.1

--- a/dockerfiles/verify_packages/installer/test_profiler_install_unsupported.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_unsupported.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.69.0"
+new_version="0.75.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_uninstall.sh
+++ b/dockerfiles/verify_packages/installer/test_uninstall.sh
@@ -11,12 +11,12 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --enable-profiling --enable-appsec
 assert_ddtrace_version "${new_version}"
-assert_appsec_version "0.2.0"
-assert_profiler_version "0.3.0"
+assert_appsec_version "0.3.2"
+assert_profiler_version "0.6.1"
 
 # Uninstall
 php ./build/packages/datadog-setup.php --php-bin php --uninstall

--- a/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
+++ b/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
@@ -13,7 +13,7 @@ install_legacy_ddtrace "${old_version}"
 assert_ddtrace_version "${old_version}"
 
 # Upgrade using the php installer
-new_version="0.68.0"
+new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_upgrade_from_php_installer.sh
+++ b/dockerfiles/verify_packages/installer/test_upgrade_from_php_installer.sh
@@ -8,13 +8,13 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-old_version="0.68.0"
+old_version="0.74.0"
 generate_installers "${old_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${old_version}"
 
 # Upgrade using the php installer
-new_version="0.68.2"
+new_version="0.75.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -41,11 +41,13 @@ assert_no_profiler() {
 }
 
 assert_ddtrace_version() {
-    output="$(php -v)"
-    if [ -z "${output##*ddtrace v${1}*}" ]; then
-        echo "---\nOk: ddtrace version '${1}' is correctly installed\n---\n${output}\n---\n"
+    expected_version=${1}
+    php_bin=${2:-php}
+    output="$($php_bin -v)"
+    if [ -z "${output##*ddtrace v${expected_version}*}" ]; then
+        echo "---\nOk: ddtrace version '${expected_version}' is correctly installed\n---\n${output}\n---\n"
     else
-        echo "---\nError: Wrong ddtrace version. Expected: ${1}\n---\n${output}\n---\n"
+        echo "---\nError: Wrong ddtrace version. Expected: ${expected_version}\n---\n${output}\n---\n"
         exit 1
     fi
 }


### PR DESCRIPTION
### Description

- Use more recent libraries to test the installer
- Download them from the official repo rather than a dummy repo with ad-hoc versions
- Support and test plesk installation paths

Fixes #1625 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
