### PR TITLE
Instrument pcntl_fork and reset tracing when it is called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini file
 RUN_TESTS_IS_PARALLEL := $(shell test $(shell php-config --vernum) -gt 70399 && echo 1 || echo 0)
 
 ifeq ($(RUN_TESTS_IS_PARALLEL), 1)
-RUN_TESTS_EXTRA_ARGS := -j$(shell expr $(shell nproc) \* 3)
+RUN_TESTS_EXTRA_ARGS := -j$(shell nproc)
 else
 RUN_TESTS_EXTRA_ARGS :=
 endif

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ INI_FILE := $(shell php -i | awk -F"=>" '/Scan this dir for additional .ini file
 RUN_TESTS_IS_PARALLEL := $(shell test $(shell php-config --vernum) -gt 70399 && echo 1 || echo 0)
 
 ifeq ($(RUN_TESTS_IS_PARALLEL), 1)
-RUN_TESTS_EXTRA_ARGS := -j$(shell nproc)
+RUN_TESTS_EXTRA_ARGS := -j$(shell expr $(shell nproc) \* 3)
 else
 RUN_TESTS_EXTRA_ARGS :=
 endif

--- a/bridge/_files_integrations.php
+++ b/bridge/_files_integrations.php
@@ -10,6 +10,7 @@ return [
     __DIR__ . '/../src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php',
     __DIR__ . '/../src/Integrations/Integrations/Web/WebIntegration.php',
     __DIR__ . '/../src/Integrations/Integrations/IntegrationsLoader.php',
+    __DIR__ . '/../src/Integrations/Integrations/Pcntl/PcntlIntegration.php',
     __DIR__ . '/../src/Integrations/Integrations/PDO/PDOIntegration.php',
     __DIR__ . '/../src/Integrations/Integrations/PHPRedis/PHPRedisIntegration.php',
     __DIR__ . '/../src/Integrations/Integrations/Predis/PredisIntegration.php',

--- a/ext/hook/uhook_legacy.c
+++ b/ext/hook/uhook_legacy.c
@@ -211,7 +211,7 @@ static void dd_uhook_generator_yield(zend_ulong invocation, zend_execute_data *e
             if (get_DD_TRACE_ENABLED()) {
                 ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync", ZSTR_VAL(EX(func)->common.function_name));
             }
-        } else {
+        } else if (dyn->span->span.duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
             zval *exception_zv = ddtrace_spandata_property_exception(&dyn->span->span);
             if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
                 ZVAL_OBJ_COPY(exception_zv, EG(exception));
@@ -247,7 +247,7 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
             if (get_DD_TRACE_ENABLED()) {
                 ddtrace_log_errf("Cannot run tracing closure for %s(); spans out of sync", ZSTR_VAL(EX(func)->common.function_name));
             }
-        } else {
+        } else if (dyn->span->span.duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
             zval *exception_zv = ddtrace_spandata_property_exception(&dyn->span->span);
             if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
                 ZVAL_OBJ_COPY(exception_zv, EG(exception));

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -314,7 +314,7 @@ struct _writer_thread_variables_t {
 
 struct _writer_loop_data_t {
     CURL *curl;
-    struct curl_slist *headers;
+    _Atomic(struct curl_slist *)headers;
     ddtrace_coms_stack_t *tmp_stack;
 
     struct _writer_thread_variables_t *thread;
@@ -786,6 +786,13 @@ static size_t _dd_dummy_write_callback(char *ptr, size_t size, size_t nmemb, voi
     return data_length;
 }
 
+static void _dd_curl_reset_headers(struct _writer_loop_data_t *writer) {
+    struct curl_slist *headers = atomic_exchange(&writer->headers, NULL);
+    if (headers) {
+        curl_slist_free_all(headers);
+    }
+}
+
 #define DD_TRACE_COUNT_HEADER "X-Datadog-Trace-Count: "
 
 static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trace_count) {
@@ -802,9 +809,7 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
         headers = curl_slist_append(headers, buffer);
     }
 
-    if (writer->headers) {
-        curl_slist_free_all(writer->headers);
-    }
+    _dd_curl_reset_headers(writer);
 
     curl_easy_setopt(writer->curl, CURLOPT_HTTPHEADER, headers);
     writer->headers = headers;
@@ -840,8 +845,7 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         }
 
         _dd_deinit_read_userdata(read_data);
-        curl_slist_free_all(writer->headers);
-        writer->headers = NULL;
+        _dd_curl_reset_headers(writer);
     }
 }
 static void _dd_signal_writer_started(struct _writer_loop_data_t *writer) {
@@ -976,7 +980,9 @@ static void *_dd_writer_loop(void *_) {
             *stack = _dd_coms_attempt_acquire_stack();
         }
 
-        curl_easy_cleanup(writer->curl);
+        CURL *curl = writer->curl;
+        writer->curl = NULL;
+        curl_easy_cleanup(curl);
 
         if (processed_stacks > 0) {
             atomic_fetch_add(&writer->flush_processed_stacks_total, processed_stacks);
@@ -987,8 +993,7 @@ static void *_dd_writer_loop(void *_) {
         _dd_signal_data_processed(writer);
     } while (running);
 
-    curl_slist_free_all(writer->headers);
-    writer->headers = NULL;
+    _dd_curl_reset_headers(writer);
 
     _dd_coms_stack_shutdown();
 
@@ -1070,6 +1075,18 @@ void ddtrace_coms_kill_background_sender(void) {
         free(writer->thread);
         writer->thread = NULL;
     }
+}
+
+void ddtrace_coms_clean_background_sender_after_fork(void) {
+    struct _writer_loop_data_t *writer = _dd_get_writer();
+    ddtrace_coms_kill_background_sender();
+    _dd_curl_reset_headers(writer);
+    curl_easy_cleanup(writer->curl);
+    writer->curl = NULL;
+    _dd_unsafe_cleanup_dirty_stack_area();
+    _dd_coms_stack_shutdown();
+    global_writer = (struct _writer_loop_data_t){0};
+    ddtrace_coms_minit();
 }
 
 bool ddtrace_coms_on_pid_change(void) {

--- a/ext/php7/coms.h
+++ b/ext/php7/coms.h
@@ -60,6 +60,7 @@ bool ddtrace_coms_on_pid_change(void);
 
 // Kills the background sender thread
 void ddtrace_coms_kill_background_sender(void);
+void ddtrace_coms_clean_background_sender_after_fork(void);
 
 /* exposed for testing {{{ */
 uint32_t ddtrace_coms_test_writers(void);

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -130,6 +130,7 @@ extern bool runtime_config_first_init;
     CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                  \
     CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \
+    CONFIG(BOOL, DD_TRACE_FORKED_PROCESS, "true")                                                              \
     DD_INTEGRATIONS
 
 #define CALIAS CONFIG

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -683,7 +683,7 @@ static void dd_clean_globals() {
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown();
 
-    ddtrace_free_span_stacks();
+    ddtrace_free_span_stacks(false);
     ddtrace_coms_rshutdown();
 
     if (ZSTR_LEN(get_DD_TRACE_REQUEST_INIT_HOOK())) {

--- a/ext/php7/handlers_pcntl.c
+++ b/ext/php7/handlers_pcntl.c
@@ -17,7 +17,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
         ddtrace_coms_kill_background_sender();
-        ddtrace_init_span_stacks();
+        ddtrace_free_span_stacks();
         ddtrace_seed_prng();
         if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
             ddtrace_push_root_span();

--- a/ext/php7/handlers_pcntl.c
+++ b/ext/php7/handlers_pcntl.c
@@ -24,7 +24,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
                 DDTRACE_G(distributed_parent_trace_id) = DDTRACE_G(open_spans_top)->span.span_id;
                 DDTRACE_G(trace_id) = DDTRACE_G(open_spans_top)->span.trace_id;
             }
-            ddtrace_free_span_stacks();
+            ddtrace_free_span_stacks(true);
             if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
                 ddtrace_push_root_span();
             }

--- a/ext/php7/handlers_pcntl.c
+++ b/ext/php7/handlers_pcntl.c
@@ -17,8 +17,13 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
         ddtrace_coms_kill_background_sender();
+        int parent_span_id = 0;
+        if (DDTRACE_G(open_spans_top) != NULL) {
+            parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;
+        }
         ddtrace_free_span_stacks();
         ddtrace_seed_prng();
+        DDTRACE_G(distributed_parent_trace_id) = parent_span_id;
         if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
             ddtrace_push_root_span();
         }

--- a/ext/php7/handlers_pcntl.c
+++ b/ext/php7/handlers_pcntl.c
@@ -16,17 +16,18 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     dd_pcntl_fork_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
-        ddtrace_coms_kill_background_sender();
+        ddtrace_coms_clean_background_sender_after_fork();
         ddtrace_coms_curl_shutdown();
-        int parent_span_id = 0;
-        if (DDTRACE_G(open_spans_top) != NULL) {
-            parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;
-        }
-        ddtrace_free_span_stacks();
         ddtrace_seed_prng();
-        DDTRACE_G(distributed_parent_trace_id) = parent_span_id;
-        if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
-            ddtrace_push_root_span();
+        if (get_DD_TRACE_ENABLED()) {
+            if (DDTRACE_G(open_spans_top) != NULL) {
+                DDTRACE_G(distributed_parent_trace_id) = DDTRACE_G(open_spans_top)->span.span_id;
+                DDTRACE_G(trace_id) = DDTRACE_G(open_spans_top)->span.trace_id;
+            }
+            ddtrace_free_span_stacks();
+            if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
+                ddtrace_push_root_span();
+            }
         }
         ddtrace_coms_init_and_start_writer();
     }

--- a/ext/php7/handlers_pcntl.c
+++ b/ext/php7/handlers_pcntl.c
@@ -17,6 +17,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
         ddtrace_coms_kill_background_sender();
+        ddtrace_coms_curl_shutdown();
         int parent_span_id = 0;
         if (DDTRACE_G(open_spans_top) != NULL) {
             parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;

--- a/ext/php7/integrations/integrations.h
+++ b/ext/php7/integrations/integrations.h
@@ -21,6 +21,7 @@
     INTEGRATION(MONGODB, "mongodb")             \
     INTEGRATION(MYSQLI, "mysqli")               \
     INTEGRATION(NETTE, "nette")                 \
+    INTEGRATION(PCNTL, "pcntl")                 \
     INTEGRATION(PDO, "pdo")                     \
     INTEGRATION(PHPREDIS, "phpredis")           \
     INTEGRATION(PREDIS, "predis")               \

--- a/ext/php7/span.h
+++ b/ext/php7/span.h
@@ -11,6 +11,7 @@
 #include "ddtrace_export.h"
 
 #define DDTRACE_DROPPED_SPAN (-1ull)
+#define DDTRACE_SILENTLY_DROPPED_SPAN (-2ull)
 
 // error.type, error.type, error.stack
 static const int ddtrace_num_error_tags = 3;
@@ -44,7 +45,7 @@ struct ddtrace_span_fci {
 typedef struct ddtrace_span_fci ddtrace_span_fci;
 
 void ddtrace_init_span_stacks(void);
-void ddtrace_free_span_stacks(void);
+void ddtrace_free_span_stacks(bool silent);
 
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
 ddtrace_span_fci *ddtrace_init_span(enum ddtrace_span_type type);

--- a/ext/php8/coms.h
+++ b/ext/php8/coms.h
@@ -59,6 +59,7 @@ bool ddtrace_coms_on_pid_change(void);
 
 // Kills the background sender thread
 void ddtrace_coms_kill_background_sender(void);
+void ddtrace_coms_clean_background_sender_after_fork(void);
 
 /* exposed for testing {{{ */
 uint32_t ddtrace_coms_test_writers(void);

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -130,6 +130,7 @@ extern bool runtime_config_first_init;
     CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_HEADER_DISABLED, "false")                                                  \
     CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \
+    CONFIG(BOOL, DD_TRACE_FORKED_PROCESS, "true")                                                              \
     DD_INTEGRATIONS
 
 #define CALIAS CONFIG

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -652,7 +652,7 @@ static void dd_clean_globals() {
     ddtrace_internal_handlers_rshutdown();
     ddtrace_dogstatsd_client_rshutdown();
 
-    ddtrace_free_span_stacks();
+    ddtrace_free_span_stacks(false);
     ddtrace_coms_rshutdown();
 
     if (ZSTR_LEN(get_DD_TRACE_REQUEST_INIT_HOOK())) {

--- a/ext/php8/handlers_pcntl.c
+++ b/ext/php8/handlers_pcntl.c
@@ -24,7 +24,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
                 DDTRACE_G(distributed_parent_trace_id) = DDTRACE_G(open_spans_top)->span.span_id;
                 DDTRACE_G(trace_id) = DDTRACE_G(open_spans_top)->span.trace_id;
             }
-            ddtrace_free_span_stacks();
+            ddtrace_free_span_stacks(true);
             if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
                 ddtrace_push_root_span();
             }

--- a/ext/php8/handlers_pcntl.c
+++ b/ext/php8/handlers_pcntl.c
@@ -17,8 +17,13 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
         ddtrace_coms_kill_background_sender();
-        ddtrace_init_span_stacks();
+        int parent_span_id = 0;
+        if (DDTRACE_G(open_spans_top) != NULL) {
+            parent_span_id = DDTRACE_G(open_spans_top)->span_id;
+        }
+        ddtrace_free_span_stacks();
         ddtrace_seed_prng();
+        DDTRACE_G(distributed_parent_trace_id) = parent_span_id;
         if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
             ddtrace_push_root_span();
         }

--- a/ext/php8/handlers_pcntl.c
+++ b/ext/php8/handlers_pcntl.c
@@ -19,7 +19,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
         ddtrace_coms_kill_background_sender();
         int parent_span_id = 0;
         if (DDTRACE_G(open_spans_top) != NULL) {
-            parent_span_id = DDTRACE_G(open_spans_top)->span_id;
+            parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;
         }
         ddtrace_free_span_stacks();
         ddtrace_seed_prng();

--- a/ext/php8/handlers_pcntl.c
+++ b/ext/php8/handlers_pcntl.c
@@ -16,17 +16,18 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     dd_pcntl_fork_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
-        ddtrace_coms_kill_background_sender();
+        ddtrace_coms_clean_background_sender_after_fork();
         ddtrace_coms_curl_shutdown();
-        int parent_span_id = 0;
-        if (DDTRACE_G(open_spans_top) != NULL) {
-            parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;
-        }
-        ddtrace_free_span_stacks();
         ddtrace_seed_prng();
-        DDTRACE_G(distributed_parent_trace_id) = parent_span_id;
-        if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
-            ddtrace_push_root_span();
+        if (get_DD_TRACE_ENABLED()) {
+            if (DDTRACE_G(open_spans_top) != NULL) {
+                DDTRACE_G(distributed_parent_trace_id) = DDTRACE_G(open_spans_top)->span.span_id;
+                DDTRACE_G(trace_id) = DDTRACE_G(open_spans_top)->span.trace_id;
+            }
+            ddtrace_free_span_stacks();
+            if (get_DD_TRACE_GENERATE_ROOT_SPAN()) {
+                ddtrace_push_root_span();
+            }
         }
         ddtrace_coms_init_and_start_writer();
     }

--- a/ext/php8/handlers_pcntl.c
+++ b/ext/php8/handlers_pcntl.c
@@ -17,6 +17,7 @@ ZEND_FUNCTION(ddtrace_pcntl_fork) {
     if (Z_LVAL_P(return_value) == 0) {
         // CHILD PROCESS
         ddtrace_coms_kill_background_sender();
+        ddtrace_coms_curl_shutdown();
         int parent_span_id = 0;
         if (DDTRACE_G(open_spans_top) != NULL) {
             parent_span_id = DDTRACE_G(open_spans_top)->span.span_id;

--- a/ext/php8/integrations/integrations.h
+++ b/ext/php8/integrations/integrations.h
@@ -21,6 +21,7 @@
     INTEGRATION(MONGODB, "mongodb")             \
     INTEGRATION(MYSQLI, "mysqli")               \
     INTEGRATION(NETTE, "nette")                 \
+    INTEGRATION(PCNTL, "pcntl")                 \
     INTEGRATION(PDO, "pdo")                     \
     INTEGRATION(PHPREDIS, "phpredis")           \
     INTEGRATION(PREDIS, "predis")               \

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -28,24 +28,24 @@ void ddtrace_init_span_stacks(void) {
     DDTRACE_G(closed_spans_count) = 0;
 }
 
-static void dd_drop_span(ddtrace_span_fci *span) {
-    span->span.duration = DDTRACE_DROPPED_SPAN;
+static void dd_drop_span(ddtrace_span_fci *span, bool silent) {
+    span->span.duration = silent ? DDTRACE_SILENTLY_DROPPED_SPAN : DDTRACE_DROPPED_SPAN;
     span->next = NULL;
     OBJ_RELEASE(&span->span.std);
 }
 
-static void _free_span_stack(ddtrace_span_fci *span_fci) {
+static void _free_span_stack(ddtrace_span_fci *span_fci, bool silent) {
     while (span_fci != NULL) {
         ddtrace_span_fci *tmp = span_fci;
         span_fci = tmp->next;
-        dd_drop_span(tmp);
+        dd_drop_span(tmp, silent);
     }
 }
 
-void ddtrace_free_span_stacks(void) {
-    _free_span_stack(DDTRACE_G(open_spans_top));
+void ddtrace_free_span_stacks(bool silent) {
+    _free_span_stack(DDTRACE_G(open_spans_top), silent);
     DDTRACE_G(open_spans_top) = NULL;
-    _free_span_stack(DDTRACE_G(closed_spans_top));
+    _free_span_stack(DDTRACE_G(closed_spans_top), silent);
     DDTRACE_G(closed_spans_top) = NULL;
     DDTRACE_G(open_spans_count) = 0;
     DDTRACE_G(dropped_spans_count) = 0;
@@ -131,7 +131,7 @@ void ddtrace_clear_execute_data_span(zend_ulong index, bool keep) {
     zval *span_zv = zend_hash_index_find(&DDTRACE_G(traced_spans), index);
     if (--Z_TYPE_INFO_P(span_zv) == 1) {
         ddtrace_span_fci *span_fci = Z_PTR_P(span_zv);
-        if (span_fci->span.duration != DDTRACE_DROPPED_SPAN) {
+        if (span_fci->span.duration != DDTRACE_DROPPED_SPAN && span_fci->span.duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
             if (keep) {
                 ddtrace_close_span(span_fci);
             } else {
@@ -274,12 +274,12 @@ void ddtrace_drop_top_open_span(void) {
     ++DDTRACE_G(dropped_spans_count);
     --DDTRACE_G(open_spans_count);
 
-    dd_drop_span(span_fci);
+    dd_drop_span(span_fci, false);
 }
 
 void ddtrace_serialize_closed_spans(zval *serialized) {
     // The tracer supports only one trace per request so free any remaining open spans
-    _free_span_stack(DDTRACE_G(open_spans_top));
+    _free_span_stack(DDTRACE_G(open_spans_top), false);
     DDTRACE_G(open_spans_top) = NULL;
     DDTRACE_G(open_spans_count) = 0;
     DDTRACE_G(dropped_spans_count) = 0;

--- a/ext/php8/span.h
+++ b/ext/php8/span.h
@@ -11,6 +11,7 @@
 #include "ddtrace_export.h"
 
 #define DDTRACE_DROPPED_SPAN (-1ull)
+#define DDTRACE_SILENTLY_DROPPED_SPAN (-2ull)
 
 // error.type, error.type, error.stack
 static const int ddtrace_num_error_tags = 3;
@@ -44,7 +45,7 @@ struct ddtrace_span_fci {
 typedef struct ddtrace_span_fci ddtrace_span_fci;
 
 void ddtrace_init_span_stacks(void);
-void ddtrace_free_span_stacks(void);
+void ddtrace_free_span_stacks(bool silent);
 
 void ddtrace_open_span(ddtrace_span_fci *span_fci);
 ddtrace_span_fci *ddtrace_init_span(enum ddtrace_span_type type);

--- a/src/Integrations/Integrations/IntegrationsLoader.php
+++ b/src/Integrations/Integrations/IntegrationsLoader.php
@@ -14,6 +14,7 @@ use DDTrace\Integrations\Memcached\MemcachedIntegration;
 use DDTrace\Integrations\Mongo\MongoIntegration;
 use DDTrace\Integrations\Mysqli\MysqliIntegration;
 use DDTrace\Integrations\Nette\NetteIntegration;
+use DDTrace\Integrations\Pcntl\PcntlIntegration;
 use DDTrace\Integrations\PDO\PDOIntegration;
 use DDTrace\Integrations\Predis\PredisIntegration;
 use DDTrace\Integrations\Slim\SlimIntegration;
@@ -60,17 +61,9 @@ class IntegrationsLoader
     {
         $this->integrations = $integrations;
 
-        // Add integrations as they support PHP 8
-        if (\PHP_MAJOR_VERSION >= 8) {
-            $this->integrations[CurlIntegration::NAME] =
-                '\DDTrace\Integrations\Curl\CurlIntegration';
-            $this->integrations[GuzzleIntegration::NAME] =
-                '\DDTrace\Integrations\Guzzle\GuzzleIntegration';
-            $this->integrations[LaravelIntegration::NAME] =
-                '\DDTrace\Integrations\Laravel\LaravelIntegration';
-            $this->integrations[MysqliIntegration::NAME] =
-                '\DDTrace\Integrations\Mysqli\MysqliIntegration';
-            return;
+        if (\PHP_MAJOR_VERSION >= 7) {
+            $this->integrations[PcntlIntegration::NAME] =
+                '\DDTrace\Integrations\Pcntl\PcntlIntegration';
         }
 
         $this->integrations[CurlIntegration::NAME] =
@@ -79,10 +72,16 @@ class IntegrationsLoader
             '\DDTrace\Integrations\Guzzle\GuzzleIntegration';
         $this->integrations[LaravelIntegration::NAME] =
             '\DDTrace\Integrations\Laravel\LaravelIntegration';
-        $this->integrations[MongoIntegration::NAME] =
-            '\DDTrace\Integrations\Mongo\MongoIntegration';
         $this->integrations[MysqliIntegration::NAME] =
             '\DDTrace\Integrations\Mysqli\MysqliIntegration';
+
+        // Add integrations as they support PHP 8
+        if (\PHP_MAJOR_VERSION >= 8) {
+            return;
+        }
+
+        $this->integrations[MongoIntegration::NAME] =
+            '\DDTrace\Integrations\Mongo\MongoIntegration';
         $this->integrations[ZendFrameworkIntegration::NAME] =
             '\DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration';
 

--- a/src/Integrations/Integrations/Pcntl/PcntlIntegration.php
+++ b/src/Integrations/Integrations/Pcntl/PcntlIntegration.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DDTrace\Integrations\Pcntl;
+
+use DDTrace\Integrations\Integration;
+use DDTrace\SpanData;
+
+class PcntlIntegration extends Integration
+{
+    const NAME = 'pcntl';
+
+    /**
+     * @return string The integration name.
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * Add instrumentation to forking
+     */
+    public function init()
+    {
+        if (!extension_loaded('pcntl')) {
+            // pcntl is provided through an extension and not through a class loader.
+            return Integration::NOT_AVAILABLE;
+        }
+
+        $trace_fork = function (SpanData $span, $args, $retval) {
+            $span->name = $span->resource = 'pcntl_fork';
+            if ($retval > 0) {
+                $span->meta["fork.pid"] = $retval;
+            } else {
+                $span->meta["fork.errno"] = $errno = pcntl_get_last_error();
+                $span->meta["fork.error"] = pcntl_strerror($errno);
+            }
+        };
+        \DDTrace\trace_function('pcntl_fork', $trace_fork);
+        \DDTrace\trace_function('pcntl_rfork', $trace_fork); // PHP 8.1+
+        \DDTrace\trace_function('pcntl_forkx', $trace_fork); // PHP 8.2+
+
+        return Integration::LOADED;
+    }
+}

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -5,7 +5,7 @@ namespace DDTrace\Tests\Integrations\PCNTL;
 use DDTrace\Tests\Common\IntegrationTestCase;
 use DDTrace\Tests\Common\SpanAssertion;
 
-const ACCEPTABLE_TEST_EXECTION_TIME_S = 0.4;
+const ACCEPTABLE_TEST_EXECTION_TIME_S = 1.2;
 
 final class PCNTLTest extends IntegrationTestCase
 {
@@ -69,17 +69,26 @@ final class PCNTLTest extends IntegrationTestCase
 
     public function testCliShortRunningTracingWhenEnabled()
     {
-        list($traces) = $this->inCli(
+        $this->executeCli(
             __DIR__ . '/scripts/synthetic.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
             ]
         );
+        $requests = $this->parseMultipleRequestsFromDumpedData();
 
-        $this->assertFlameGraph($traces, [
-            SpanAssertion::exists('synthetic.php'),
-        ]);
+        $this->assertCount(2, $requests);
+        foreach ($requests as $traces) {
+            $this->assertFlameGraph($traces, [
+                SpanAssertion::exists('synthetic.php'),
+            ]);
+        }
+
+        $childSpan = $requests[0][0][0];
+        $parentSpan = $requests[1][0][0];
+        $this->assertSame($childSpan["trace_id"], $parentSpan["trace_id"]);
+        $this->assertSame($childSpan["parent_id"], $parentSpan["span_id"]);
     }
 
     public function testAccessingTracerAfterForkIsUnproblematic()
@@ -106,15 +115,23 @@ final class PCNTLTest extends IntegrationTestCase
 
     public function testCliShortRunningMainSpanAreGenerateBeforeAndAfter()
     {
-        list($traces) = $this->inCli(
+        $this->executeCli(
             __DIR__ . '/scripts/short-running.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
             ]
         );
+        $requests = $this->parseMultipleRequestsFromDumpedData();
 
-        $this->assertFlameGraph($traces, [
+        $this->assertCount(2, $requests);
+        $this->assertFlameGraph($requests[0], [ // child
+            SpanAssertion::exists('short-running.php')->withChildren([
+                SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
+                SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+            ]),
+        ]);
+        $this->assertFlameGraph($requests[1], [
             SpanAssertion::exists('short-running.php')->withChildren([
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
@@ -125,15 +142,18 @@ final class PCNTLTest extends IntegrationTestCase
 
     public function testCliShortRunningMultipleForks()
     {
-        list($traces) = $this->inCli(
+        $this->executeCli(
             __DIR__ . '/scripts/short-running-multiple.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
             ]
         );
+        $requests = $this->parseMultipleRequestsFromDumpedData();
 
-        $this->assertFlameGraph($traces, [
+        $this->assertCount(6, $requests);
+
+        $this->assertFlameGraph(array_pop($requests), [ // main trace
             SpanAssertion::exists('short-running-multiple.php')->withChildren([
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
@@ -144,34 +164,47 @@ final class PCNTLTest extends IntegrationTestCase
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
             ]),
         ]);
+
+        foreach ($requests as $traces) {
+            $this->assertFlameGraph($traces, [
+                SpanAssertion::exists('short-running-multiple.php')->withChildren([
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+                ]),
+            ]);
+        }
     }
 
     public function testCliShortRunningMultipleNestedForks()
     {
-        list($traces) = $this->inCli(
+        $this->executeCli(
             __DIR__ . '/scripts/short-running-multiple-nested.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
             ]
         );
+        $requests = $this->parseMultipleRequestsFromDumpedData();
 
-        $this->assertFlameGraph($traces, [
+        $this->assertFlameGraph(array_pop($requests), [ // main trace
             SpanAssertion::exists('short-running-multiple-nested.php')->withChildren([
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
             ]),
         ]);
+
+        foreach ($requests as $traces) {
+            $this->assertFlameGraph($traces, [
+                SpanAssertion::exists('short-running-multiple-nested.php')->withChildren([
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
+                ]),
+            ]);
+        }
     }
 
     public function testCliLongRunningMultipleForksAutoFlush()
     {
-        if ($this->matchesPhpVersion('5')) {
-            $this->markTestSkipped('autoflushing is not implemented on 5');
-            return;
-        }
-
         $this->executeCli(
             __DIR__ . '/scripts/long-running-autoflush.php',
             [
@@ -183,14 +216,17 @@ final class PCNTLTest extends IntegrationTestCase
             ]
         );
         $requests = $this->parseMultipleRequestsFromDumpedData();
-        $this->assertCount(2, $requests);
+        $this->assertCount(4, $requests);
 
-        // Both requests have 1 trace each
-        $this->assertCount(1, $requests[0]);
-        $this->assertCount(1, $requests[1]);
+        for ($i = 0; $i < 4; $i += 2) {
+            $this->assertCount(1, $requests[$i]);
+            $this->assertCount(1, $requests[$i + 1]);
 
-        foreach ($requests as $traces) {
-            $this->assertFlameGraph($traces, [
+            $this->assertFlameGraph($requests[$i], [
+                SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+            ]);
+
+            $this->assertFlameGraph($requests[$i + 1], [
                 SpanAssertion::exists('long_running_entry_point')->withChildren([
                     SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                     SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
@@ -212,9 +248,24 @@ final class PCNTLTest extends IntegrationTestCase
             ]
         );
         $requests = $this->parseMultipleRequestsFromDumpedData();
-        $this->assertCount(1, $requests, 'Traces are buffered into one request');
+        $this->assertCount(4, $requests);
 
         $this->assertFlameGraph($requests[0], [
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
+        ]);
+
+        $this->assertFlameGraph($requests[1], [
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
+        ]);
+
+        $this->assertFlameGraph($requests[2], [
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+            SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
+        ]);
+
+        $this->assertFlameGraph($requests[3], [
             SpanAssertion::exists('manual_tracing')->withChildren([
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
                 SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),

--- a/tests/Integrations/PCNTL/scripts/long-running-autoflush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-autoflush.php
@@ -31,4 +31,5 @@ function long_running_entry_point()
         exit(-1);
     }
     call_httpbin('user-agent');
+    pcntl_waitpid($forkPid, $childStatus);
 }

--- a/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
@@ -19,6 +19,7 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     if ($forkPid > 0) {
         // Main
         call_httpbin('headers');
+        pcntl_waitpid($forkPid, $childStatus);
     } else if ($forkPid === 0) {
         // Child
         call_httpbin('ip');

--- a/tests/Integrations/PCNTL/scripts/short-running-multiple.php
+++ b/tests/Integrations/PCNTL/scripts/short-running-multiple.php
@@ -13,6 +13,7 @@ while ($currentIteration !== NUMBER_OF_CHILDREN) {
     if ($forkPid > 0) {
         // Main
         call_httpbin('headers');
+        pcntl_waitpid($forkPid, $childStatus);
     } else if ($forkPid === 0) {
         // Child
         call_httpbin('ip');
@@ -23,7 +24,5 @@ while ($currentIteration !== NUMBER_OF_CHILDREN) {
 
     $currentIteration++;
 }
-
-pcntl_wait($childStatus);
 
 call_httpbin('user-agent');

--- a/tests/ext/pcntl/functions.inc
+++ b/tests/ext/pcntl/functions.inc
@@ -1,10 +1,11 @@
 <?php
 
+\DDTrace\trace_function('call_httpbin', function ($span) {
+    $span->type = 'custom';
+    $span->service = 'pcntl-testing-service';
+});
+
 function call_httpbin()
 {
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, "httpbin_integration/get");
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_exec($ch);
-    curl_close($ch);
+    usleep(10000);
 }

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -38,14 +38,11 @@ function long_running_entry_point()
 
     $forkPid = pcntl_fork();
 
-    //ob_start();
-
     if ($forkPid > 0) {
         // Main
         if (ddtrace_config_trace_enabled()) {
             echo "parent is enabled\n";
         }
-        call_httpbin();
     } else if ($forkPid === 0) {
         // Child
         usleep(100000);
@@ -64,13 +61,15 @@ function long_running_entry_point()
 ?>
 --EXPECTF--
 parent is enabled
-Successfully triggered flush with trace of size 4
+Successfully triggered flush with trace of size 3
 child is enabled
 Successfully triggered flush with trace of size 1
+Cannot run tracing closure for long_running_entry_point(); spans out of sync
 No finished traces to be sent to the agent
 parent is enabled
-Successfully triggered flush with trace of size 4
+Successfully triggered flush with trace of size 3
 child is enabled
 Successfully triggered flush with trace of size 1
+Cannot run tracing closure for long_running_entry_point(); spans out of sync
 No finished traces to be sent to the agent
 No finished traces to be sent to the agent

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -4,7 +4,6 @@ Long running autoflush
 <?php
 include __DIR__ . '/../includes/skipif_no_dev_env.inc';
 if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
 ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=false
@@ -22,14 +21,16 @@ const ITERATIONS = 2;
     $span->service = 'pcntl-testing-service';
 });
 
-\DDTrace\trace_function('call_httpbin', function ($span) {
+function test() {}
+
+\DDTrace\trace_function('test', function ($span) {
     $span->type = 'custom';
     $span->service = 'pcntl-testing-service';
 });
 
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     long_running_entry_point();
-    usleep(200000);
+    usleep(300000);
 }
 
 function long_running_entry_point()
@@ -45,29 +46,29 @@ function long_running_entry_point()
         }
     } else if ($forkPid === 0) {
         // Child
-        usleep(100000);
+        usleep(200000);
         if (ddtrace_config_trace_enabled()) {
             echo "child is enabled\n";
         }
-        call_httpbin();
+        test();
         exit(0);
     } else {
         error_log('Error');
         exit(-1);
     }
-    call_httpbin();
+    test();
 }
 
 ?>
 --EXPECTF--
 parent is enabled
-Successfully triggered flush with trace of size 3
+Successfully triggered flush with trace of size 2
 child is enabled
 Successfully triggered flush with trace of size 1
 Cannot run tracing closure for long_running_entry_point(); spans out of sync
 No finished traces to be sent to the agent
 parent is enabled
-Successfully triggered flush with trace of size 3
+Successfully triggered flush with trace of size 2
 child is enabled
 Successfully triggered flush with trace of size 1
 Cannot run tracing closure for long_running_entry_point(); spans out of sync

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -1,10 +1,7 @@
 --TEST--
 Long running autoflush
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=false
 DD_TRACE_AUTO_FLUSH_ENABLED=true
@@ -21,16 +18,9 @@ const ITERATIONS = 2;
     $span->service = 'pcntl-testing-service';
 });
 
-function test() {}
-
-\DDTrace\trace_function('test', function ($span) {
-    $span->type = 'custom';
-    $span->service = 'pcntl-testing-service';
-});
-
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     long_running_entry_point();
-    usleep(300000);
+    usleep(400000);
 }
 
 function long_running_entry_point()
@@ -46,31 +36,29 @@ function long_running_entry_point()
         }
     } else if ($forkPid === 0) {
         // Child
-        usleep(200000);
+        usleep(300000);
         if (ddtrace_config_trace_enabled()) {
             echo "child is enabled\n";
         }
-        test();
+        call_httpbin();
         exit(0);
     } else {
         error_log('Error');
         exit(-1);
     }
-    test();
+    call_httpbin();
 }
 
 ?>
 --EXPECTF--
 parent is enabled
-Successfully triggered flush with trace of size 2
+Successfully triggered flush with trace of size 3
 child is enabled
 Successfully triggered flush with trace of size 1
-Cannot run tracing closure for long_running_entry_point(); spans out of sync
 No finished traces to be sent to the agent
 parent is enabled
-Successfully triggered flush with trace of size 2
+Successfully triggered flush with trace of size 3
 child is enabled
 Successfully triggered flush with trace of size 1
-Cannot run tracing closure for long_running_entry_point(); spans out of sync
 No finished traces to be sent to the agent
 No finished traces to be sent to the agent

--- a/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
@@ -1,11 +1,7 @@
 --TEST--
 Long running manual flush
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --ENV--
 DD_TRACE_CLI_ENABLED=true
 DD_TRACE_GENERATE_ROOT_SPAN=false

--- a/tests/ext/pcntl/pcntl_fork_reseed_span_id.phpt
+++ b/tests/ext/pcntl/pcntl_fork_reseed_span_id.phpt
@@ -1,15 +1,11 @@
 --TEST--
 Short running multiple forks
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=false
 DD_TRACE_DEBUG=false
-DD_TRACE_DEBUG_PRNG_SEED=1
+DD_TRACE_DEBUG_PRNG_SEED=100
 --FILE--
 <?php
 
@@ -21,10 +17,11 @@ call_httpbin();
 DDTrace\start_span();
 echo DDTrace\active_span()->id . ' - parent' . PHP_EOL;
 
-$currentIteration = 0;
-while ($currentIteration !== NUMBER_OF_CHILDREN) {
+$currentIteration = 1;
+while ($currentIteration <= NUMBER_OF_CHILDREN) {
     DDTrace\start_span();
     echo DDTrace\active_span()->id . ' - parent' . PHP_EOL;
+    ini_set("datadog.trace.debug_prng_seed", $currentIteration);
     $forkPid = pcntl_fork();
     if ($forkPid > 0) {
         // Main
@@ -52,20 +49,20 @@ call_httpbin();
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECTF--
-2469588189546311528 - parent
-2516265689700432462 - parent
+5969071622678286091 - parent
+17952737041105130042 - parent
 2469588189546311528 - child
 Done.
-387828560950575246 - parent
-2469588189546311528 - child
+16631841681740081638 - parent
+16668552215174154828 - child
 Done.
-6472927700900931384 - parent
-2469588189546311528 - child
+17628273237363548829 - parent
+10307413207671831467 - child
 Done.
-16811588669333006409 - parent
-2469588189546311528 - child
+15745505721093787712 - parent
+14490808261858112199 - child
 Done.
-8683844110200328628 - parent
-2469588189546311528 - child
+18026061444052040848 - parent
+12415856028556828342 - child
 Done.
 Done.

--- a/tests/ext/pcntl/pcntl_fork_reseed_span_id.phpt
+++ b/tests/ext/pcntl/pcntl_fork_reseed_span_id.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Short running multiple forks
+--SKIPIF--
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
+if (!extension_loaded('curl')) die('skip: curl extension required');
+?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=false
+DD_TRACE_DEBUG=false
+DD_TRACE_DEBUG_PRNG_SEED=1
+--FILE--
+<?php
+
+require 'functions.inc';
+
+const NUMBER_OF_CHILDREN = 5;
+
+call_httpbin();
+DDTrace\start_span();
+echo DDTrace\active_span()->id . ' - parent' . PHP_EOL;
+
+$currentIteration = 0;
+while ($currentIteration !== NUMBER_OF_CHILDREN) {
+    DDTrace\start_span();
+    echo DDTrace\active_span()->id . ' - parent' . PHP_EOL;
+    $forkPid = pcntl_fork();
+    if ($forkPid > 0) {
+        // Main
+        call_httpbin();
+    } else if ($forkPid === 0) {
+        // Child
+        DDTrace\start_span();
+        echo DDTrace\active_span()->id . ' - child' . PHP_EOL;
+        call_httpbin();
+        DDTrace\close_span();
+        echo 'Done.' . PHP_EOL;
+        exit(0);
+    } else {
+        exit(-1);
+    }
+    pcntl_wait($childStatus);
+    $currentIteration++;
+    DDTrace\close_span();
+}
+
+pcntl_wait($childStatus);
+DDTrace\close_span();
+
+call_httpbin();
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+2469588189546311528 - parent
+2516265689700432462 - parent
+2469588189546311528 - child
+Done.
+387828560950575246 - parent
+2469588189546311528 - child
+Done.
+6472927700900931384 - parent
+2469588189546311528 - child
+Done.
+16811588669333006409 - parent
+2469588189546311528 - child
+Done.
+8683844110200328628 - parent
+2469588189546311528 - child
+Done.
+Done.

--- a/tests/ext/pcntl/pcntl_fork_short_running_multiple.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_multiple.phpt
@@ -1,11 +1,7 @@
 --TEST--
 Short running multiple forks
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/pcntl/pcntl_fork_short_running_nested.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_nested.phpt
@@ -1,11 +1,7 @@
 --TEST--
 Short running nested forks
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --FILE--
 <?php
 

--- a/tests/ext/pcntl/pcntl_fork_short_running_single.phpt
+++ b/tests/ext/pcntl/pcntl_fork_short_running_single.phpt
@@ -1,11 +1,7 @@
 --TEST--
 Short running single fork
 --SKIPIF--
-<?php
-include __DIR__ . '/../includes/skipif_no_dev_env.inc';
-if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
-if (!extension_loaded('curl')) die('skip: curl extension required');
-?>
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
This will do 4 things:
- reset the open, closed, root and dropped spans globals
- reseed the random number generator used to assign span ids
- generate a root span if configured to do so
- turn background sending off and then on again, to remove timeouts when communicating with the agent
