### PR TITLE
Fix crash with numerical value in $_SERVER array

### DIFF
--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -606,7 +606,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         zval *headerval;
         ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), headername, headerval) {
             ZVAL_DEREF(headerval);
-            if (Z_TYPE_P(headerval) == IS_STRING && ZSTR_LEN(headername) > 5 &&
+            if (Z_TYPE_P(headerval) == IS_STRING && headername && ZSTR_LEN(headername) > 5 &&
                 memcmp(ZSTR_VAL(headername), "HTTP_", 5) == 0) {
                 zend_string *lowerheader = zend_string_init(ZSTR_VAL(headername) + 5, ZSTR_LEN(headername) - 5, 0);
                 for (char *ptr = ZSTR_VAL(lowerheader); *ptr; ++ptr) {

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -605,7 +605,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         zval *headerval;
         ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), headername, headerval) {
             ZVAL_DEREF(headerval);
-            if (Z_TYPE_P(headerval) == IS_STRING && ZSTR_LEN(headername) > 5 &&
+            if (Z_TYPE_P(headerval) == IS_STRING && headername && ZSTR_LEN(headername) > 5 &&
                 memcmp(ZSTR_VAL(headername), "HTTP_", 5) == 0) {
                 zend_string *lowerheader = zend_string_init(ZSTR_VAL(headername) + 5, ZSTR_LEN(headername) - 5, 0);
                 for (char *ptr = ZSTR_VAL(lowerheader); *ptr; ++ptr) {

--- a/tests/ext/extract_server_values.phpt
+++ b/tests/ext/extract_server_values.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test invalid $_SERVER values are properly ignored
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_HEADER_TAGS=0
+HTTP_0=http_zero_header
+--FILE--
+<?php
+
+// hack to squeeze a numerical env var into PHP
+if (!isset($_SERVER[0])) {
+    putenv("0=garbage");
+    $cmdAndArgs = explode("\0", file_get_contents("/proc/" . getmypid() . "/cmdline"));
+    pcntl_exec(array_shift($cmdAndArgs), $cmdAndArgs);
+}
+
+DDTrace\start_span();
+DDTrace\close_span();
+var_dump(dd_trace_serialize_closed_spans()[0]["meta"]);
+
+?>
+--EXPECTF--
+array(3) {
+  ["system.pid"]=>
+  string(%d) "%d"
+  ["http.request.headers.0"]=>
+  string(16) "http_zero_header"
+  ["_dd.p.dm"]=>
+  string(2) "-1"
+}


### PR DESCRIPTION
### Description

Apparently some supervisor processes can add a "0" env var, which was not properly handled in our code.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
