### PR TITLE
(PHP 5) Remove service name propagation and filter x-datadog-tags for _dd.p. prefix

### DIFF
--- a/ext/php5/configuration.h
+++ b/ext/php5/configuration.h
@@ -92,7 +92,6 @@ extern bool runtime_config_first_init;
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                               \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                           \
     CONFIG(INT, DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "512")                                                    \
-    CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                         \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                       \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                            \
            .ini_change = zai_config_system_ini_change)                                                        \

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -358,10 +358,7 @@ final class SpanChecker
 
             $filtered = $out;
             $expectedTags = $exp->getExactTags();
-            // Ignore _dd.dm.service_hash and _dd.p.dm unless explicitly tested
-            if (!isset($expectedTags['_dd.dm.service_hash'])) {
-                unset($filtered['_dd.dm.service_hash']);
-            }
+            // Ignore _dd.p.dm unless explicitly tested
             if (!isset($expectedTags['_dd.p.dm'])) {
                 unset($filtered['_dd.p.dm']);
             }

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -5,7 +5,6 @@ HTTP_X_DATADOG_TRACE_ID=foo
 HTTP_X_DATADOG_PARENT_ID=bar
 HTTP_X_DATADOG_ORIGIN=datadog
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 
@@ -37,15 +36,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(4) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.origin"]=>
       string(7) "datadog"
       ["_dd.p.dm"]=>
-      string(12) "2f8110d3de-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2f8110d3de"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -5,7 +5,7 @@ HTTP_X_DATADOG_TRACE_ID=42
 HTTP_X_DATADOG_PARENT_ID=10
 HTTP_X_DATADOG_ORIGIN=datadog
 HTTP_X_DATADOG_SAMPLING_PRIORITY=3
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,dropped,other_tag=also,drop
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag=inherited,_dd.p.dropped,_dd.p.other_tag=also,_dd.p.drop
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
@@ -45,11 +45,11 @@ array(2) {
     string(3) "cli"
     ["meta"]=>
     array(5) {
-      ["custom_tag"]=>
+      ["_dd.p.custom_tag"]=>
       string(9) "inherited"
       ["_dd.propagation_error"]=>
       string(14) "decoding_error"
-      ["other_tag"]=>
+      ["_dd.p.other_tag"]=>
       string(4) "also"
       ["system.pid"]=>
       string(%d) "%d"

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite.phpt
@@ -4,7 +4,7 @@ Setting custom distributed header information
 HTTP_X_DATADOG_TRACE_ID=42
 HTTP_X_DATADOG_PARENT_ID=10
 HTTP_X_DATADOG_ORIGIN=datadog
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,second_tag=bar
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag=inherited,_dd.p.second_tag=bar
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
@@ -27,7 +27,7 @@ dump_context();
 trace_id: 42
 distributed_tracing_origin: datadog
 distributed_tracing_parent_id: 10
-distributed_tracing_propagated_tags: {"custom_tag":"inherited","second_tag":"bar"}
+distributed_tracing_propagated_tags: {"_dd.p.custom_tag":"inherited","_dd.p.second_tag":"bar"}
 trace_id: 123
 distributed_tracing_origin: foo
 distributed_tracing_parent_id: 321

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
@@ -18,7 +18,7 @@ DDTrace\close_span();
 DDTrace\close_span();
 
 foreach (dd_trace_serialize_closed_spans() as $span) {
-    unset($span["meta"]["system.pid"], $span["meta"]["_dd.p.dm"], $span["meta"]["_dd.dm.service_hash"]);
+    unset($span["meta"]["system.pid"], $span["meta"]["_dd.p.dm"]);
     echo "parent: {$span["parent_id"]}, trace: {$span["trace_id"]}, meta: " . json_encode($span["meta"]) . "\n";
 }
 

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -10,7 +10,7 @@ DD_TRACE_DEBUG=1
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH=25
 HTTP_X_DATADOG_ORIGIN=phpt-test
-HTTP_X_DATADOG_TAGS=very=looooooooooooooooooooooong
+HTTP_X_DATADOG_TAGS=_dd.p.very=looooooooooooooooong
 --FILE--
 <?php
 include 'curl_helper.inc';
@@ -43,7 +43,7 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-The to be propagated tag 'very=looooooooooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
+The to be propagated tag '_dd.p.very=looooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 bool(true)

--- a/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_propagate_tags.phpt
@@ -3,10 +3,9 @@ Distributed tracing header tags propagate with curl_exec()
 --SKIPIF--
 <?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
-<?php die('skip: disabled functionality'); ?>
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=curl_exec
-HTTP_X_DATADOG_TAGS=custom_tag=inherited,to_remove=,foo=bar,_dd.p.dm=abcdef|0|2|1.000
+HTTP_X_DATADOG_TAGS=custom_tag=inherited,to_remove=,_dd.p.foo=bar,_dd.p.dm=abcdef-2
 --FILE--
 <?php
 
@@ -30,10 +29,10 @@ $meta["foo"] = "buzz";
 $span = DDTrace\start_span();
 $span->service = "dd";
 
-DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_USER_REJECT);
+DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_USER_KEEP);
 
 dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-tags']);
 
 ?>
 --EXPECT--
-x-datadog-tags: custom_tag=inherited,foo=buzz,_dd.p.dm=abcdef|0|2|1.000;ZGQ|-1|4|
+x-datadog-tags: _dd.p.foo=bar,_dd.p.dm=abcdef-2

--- a/tests/ext/priority_sampling/001-default-sampling.phpt
+++ b/tests/ext/priority_sampling/001-default-sampling.phpt
@@ -2,7 +2,6 @@
 priority_sampling default sampling
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
@@ -37,4 +36,4 @@ echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 metrics[_sampling_priority_v1] OK
 metrics[_dd.rule_psr] OK
 \DDTrace\get_priority_sampling() OK
-_dd.p.dm = 4724d3a3a4-1
+_dd.p.dm = -1

--- a/tests/ext/priority_sampling/003-user-keep.phpt
+++ b/tests/ext/priority_sampling/003-user-keep.phpt
@@ -3,7 +3,6 @@ priority_sampling user keep
 --ENV--
 DD_TRACE_SAMPLE_RATE=1
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
@@ -38,4 +37,4 @@ echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 metrics[_sampling_priority_v1] OK
 metrics[_dd.rule_psr] OK
 \DDTrace\get_priority_sampling() OK
-_dd.p.dm = dd68494d3d-3
+_dd.p.dm = -3

--- a/tests/ext/priority_sampling/004-rule-basic.phpt
+++ b/tests/ext/priority_sampling/004-rule-basic.phpt
@@ -3,7 +3,6 @@ priority_sampling basic rule
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 $root = \DDTrace\root_span();
@@ -19,4 +18,4 @@ echo "_dd.p.dm = ", isset($root->meta["_dd.p.dm"]) ? $root->meta["_dd.p.dm"] : "
 ?>
 --EXPECTREGEX--
 Rule OK
-_dd.p.dm = (45664d1a27-3|-)
+_dd.p.dm = (-3|-)

--- a/tests/ext/priority_sampling/005-rule-name.phpt
+++ b/tests/ext/priority_sampling/005-rule-name.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with name match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.7, "name": "bar"},{"sample_rate": 0.3, "name": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 $root = \DDTrace\root_span();
@@ -20,4 +19,4 @@ echo "_dd.p.dm = ", isset($root->meta["_dd.p.dm"]) ? $root->meta["_dd.p.dm"] : "
 ?>
 --EXPECTREGEX--
 Rule OK
-_dd.p.dm = (d6ca629dc2-3|-)
+_dd.p.dm = (-3|-)

--- a/tests/ext/priority_sampling/006-rule-name-reject.phpt
+++ b/tests/ext/priority_sampling/006-rule-name-reject.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with name reject
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "name": "bar"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 $root = \DDTrace\root_span();
@@ -16,10 +15,8 @@ if ($root->metrics["_dd.rule_psr"] != 0.3) {
 } else {
     var_dump($root->metrics);
 }
-echo "_dd.dm.service_hash = {$root->meta["_dd.dm.service_hash"]}\n";
 echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 ?>
 --EXPECT--
 Rule OK
-_dd.dm.service_hash = 78d5c41f07
-_dd.p.dm = 78d5c41f07-1
+_dd.p.dm = -1

--- a/tests/ext/priority_sampling/007-rule-service.phpt
+++ b/tests/ext/priority_sampling/007-rule-service.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with service match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.7, "service": "bar"},{"sample_rate": 0.3, "service": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {
@@ -26,4 +25,4 @@ echo "_dd.p.dm = ", isset($root->meta["_dd.p.dm"]) ? $root->meta["_dd.p.dm"] : "
 ?>
 --EXPECTREGEX--
 Rule OK
-_dd.p.dm = (a31069e7b4-3|-)
+_dd.p.dm = (-3|-)

--- a/tests/ext/priority_sampling/008-rule-service-reject.phpt
+++ b/tests/ext/priority_sampling/008-rule-service-reject.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with service reject
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "service": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {
@@ -26,4 +25,4 @@ echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 ?>
 --EXPECT--
 Rule OK
-_dd.p.dm = df0d0df4cc-1
+_dd.p.dm = -1

--- a/tests/ext/priority_sampling/009-rule-name-service.phpt
+++ b/tests/ext/priority_sampling/009-rule-name-service.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with name and service match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "name": "fo.*ame", "service": "bar"}, {"sample_rate": 0.7}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 $root = \DDTrace\root_span();
@@ -21,4 +20,4 @@ echo "_dd.p.dm = ", isset($root->meta["_dd.p.dm"]) ? $root->meta["_dd.p.dm"] : "
 ?>
 --EXPECTREGEX--
 Rule OK
-_dd.p.dm = (df0d0df4cc-3|-)
+_dd.p.dm = (-3|-)

--- a/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
+++ b/tests/ext/priority_sampling/010-rule-name-service-reject.phpt
@@ -3,7 +3,6 @@ priority_sampling rule with name and service reject
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "name": "no.*match", "service": "no.*match"}, {"sample_rate": 0.7}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_PROPAGATE_SERVICE=1
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {
@@ -27,4 +26,4 @@ echo "_dd.p.dm = ", isset($root->meta["_dd.p.dm"]) ? $root->meta["_dd.p.dm"] : "
 ?>
 --EXPECTREGEX--
 Rule OK
-_dd.p.dm = (df0d0df4cc-3|-)
+_dd.p.dm = (-3|-)

--- a/tests/ext/root_span_add_tag.phpt
+++ b/tests/ext/root_span_add_tag.phpt
@@ -4,7 +4,6 @@ Test ddtrace_root_span_add_tag
 <?php if (PHP_VERSION_ID < 70000) die('skip: ddtrace_get_root_span only available on php 7 and 8'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 // Fail if root span not available
@@ -40,15 +39,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(4) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["after"]=>
       string(9) "root_span"
       ["_dd.p.dm"]=>
-      string(12) "f1999f9456-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "f1999f9456"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -4,7 +4,6 @@ root span with DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=1
-DD_TRACE_PROPAGATE_SERVICE=1
 DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED=""
 HTTPS=on
 SERVER_NAME=localhost:8888
@@ -23,7 +22,7 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(6) {
+array(5) {
   ["system.pid"]=>
   %s
   ["http.url"]=>
@@ -31,9 +30,7 @@ array(6) {
   ["http.method"]=>
   string(3) "GET"
   ["_dd.p.dm"]=>
-  string(12) "9753902159-1"
-  ["_dd.dm.service_hash"]=>
-  string(10) "9753902159"
+  string(2) "-1"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -4,7 +4,6 @@ root span with DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED (variant using SERVER_NAME
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED=1
-DD_TRACE_PROPAGATE_SERVICE=1
 SERVER_NAME=localhost:8888
 SCRIPT_NAME=/foo.php
 REQUEST_URI=/foo
@@ -19,7 +18,7 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(6) {
+array(5) {
   ["system.pid"]=>
   %s
   ["http.url"]=>
@@ -27,9 +26,7 @@ array(6) {
   ["http.method"]=>
   string(3) "GET"
   ["_dd.p.dm"]=>
-  string(12) "9753902159-1"
-  ["_dd.dm.service_hash"]=>
-  string(10) "9753902159"
+  string(2) "-1"
   ["http.status_code"]=>
   string(3) "200"
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -5,7 +5,6 @@
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -113,15 +112,13 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(4) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
       ["_dd.p.dm"]=>
-      string(12) "24565f64fe-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "24565f64fe"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(5) {
@@ -182,13 +179,11 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "afd2f82e39-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "afd2f82e39"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -2,7 +2,6 @@
 dd_trace_function() is aliased to DDTrace\trace_function()
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -27,6 +26,5 @@ bar(hello)
 spans(\DDTrace\SpanData) (1) {
   bar (alias, bar, cli)
     system.pid => %d
-    _dd.p.dm => 1a0a6a36ca-1
-    _dd.dm.service_hash => 1a0a6a36ca
+    _dd.p.dm => -1
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -3,7 +3,6 @@ DDTrace\trace_function() can trace with internal spans
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,mt_rand
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -112,7 +111,7 @@ array(5) {
     ["type"]=>
     string(7) "BarType"
     ["meta"]=>
-    array(7) {
+    array(6) {
       ["system.pid"]=>
       string(%d) "%d"
       ["args.0"]=>
@@ -124,9 +123,7 @@ array(5) {
       ["retval.rand"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "3f89c4ec87-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "3f89c4ec87"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(5) {
@@ -203,13 +200,11 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "2606321bce-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2606321bce"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {
@@ -240,13 +235,11 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "2606321bce-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "2606321bce"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -3,7 +3,6 @@ DDTrace\trace_function() can trace internal functions with internal spans
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -43,13 +42,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "e23c636b43-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "e23c636b43"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -3,7 +3,6 @@ DDTrace\trace_method() can trace with internal spans
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=mt_rand
-DD_TRACE_PROPAGATE_SERVICE=0
 --FILE--
 <?php
 use DDTrace\SpanData;

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -2,7 +2,6 @@
 dd_trace_method() is aliased to DDTrace\trace_method()
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -31,6 +30,5 @@ Foo::bar(hello)
 spans(\DDTrace\SpanData) (1) {
   Foo.bar (alias, Foo.bar, cli)
     system.pid => %d
-    _dd.p.dm => 1a0a6a36ca-1
-    _dd.dm.service_hash => 1a0a6a36ca
+    _dd.p.dm => -1
 }

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -3,7 +3,6 @@ Span properties defaults to values if not explicitly set (functions)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=array_sum,range
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -36,8 +35,7 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (5) {
   main (default_span_properties.php, main, cli)
     max => 6
-    _dd.p.dm => b43b371c6f-1
-    _dd.dm.service_hash => b43b371c6f
+    _dd.p.dm => -1
   array_sum (default_span_properties.php, array_sum, cli)
     retval => 28
   MyRange (default_span_properties.php, MyRange, cli)

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -3,7 +3,6 @@ Span properties defaults to values if not explicitly set (methods)
 --ENV--
 DD_TRACE_TRACED_INTERNAL_FUNCTIONS=DateTime::__construct,DateTime::format
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -43,8 +42,7 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (3) {
   Foo.main (default_span_properties_method.php, Foo.main, cli)
     year => 2020
-    _dd.p.dm => ac317c120d-1
-    _dd.dm.service_hash => ac317c120d
+    _dd.p.dm => -1
   MyDateTimeFormat (default_span_properties_method.php, MyDateTimeFormat, cli)
     format => m
   DateTime.__construct (default_span_properties_method.php, DateTime.__construct, cli)

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -2,7 +2,6 @@
 Errors from userland will be flagged on span
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -45,15 +44,13 @@ array(1) {
     ["error"]=>
     int(1)
     ["meta"]=>
-    array(4) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["error.msg"]=>
       string(9) "Foo error"
       ["_dd.p.dm"]=>
-      string(12) "ce20576ee7-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "ce20576ee7"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -2,7 +2,6 @@
 Clone DDTrace\SpanData
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 use DDTrace\SpanData;
@@ -83,13 +82,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "8cfa685fde-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "8cfa685fde"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -2,7 +2,6 @@
 Unset, nulled and generally invalid data in exception property is ignored
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 
@@ -62,13 +61,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "df6da0e28f-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {
@@ -101,13 +98,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "df6da0e28f-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {
@@ -140,13 +135,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "df6da0e28f-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "df6da0e28f"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -2,7 +2,6 @@
 Set DDTrace\start_span() properties
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 
@@ -74,13 +73,11 @@ array(2) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "a98551ac2e-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "a98551ac2e"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {
@@ -111,15 +108,13 @@ array(2) {
     ["type"]=>
     string(6) "runner"
     ["meta"]=>
-    array(4) {
+    array(3) {
       ["system.pid"]=>
       string(%d) "%d"
       ["aa"]=>
       string(2) "bb"
       ["_dd.p.dm"]=>
-      string(12) "9f86d08188-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "9f86d08188"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -3,7 +3,6 @@ Use DDTrace\close_span() on span started within internal span
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_GENERATE_ROOT_SPAN=0
-DD_TRACE_PROPAGATE_SERVICE=1
 --FILE--
 <?php
 
@@ -46,13 +45,11 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(2) {
       ["system.pid"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
-      string(12) "1b8a8775ac-1"
-      ["_dd.dm.service_hash"]=>
-      string(10) "1b8a8775ac"
+      string(2) "-1"
     }
     ["metrics"]=>
     array(3) {


### PR DESCRIPTION
### Description

Backport of #1635 and half of #1618. 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
