### PR TITLE
Add g1a/composer-test-scenarios and symfony/flex to composer allow-plugin list

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_0/composer.json
@@ -37,7 +37,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_4_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_2/composer.json
@@ -38,7 +38,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_4_4/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_4/composer.json
@@ -53,7 +53,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_0/composer.json
@@ -52,7 +52,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_1/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_1/composer.json
@@ -54,7 +54,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -20,7 +20,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -12,6 +12,11 @@
         "symfony/process": "<5",
         "g1a/composer-test-scenarios": "~3.0"
     },
+    "config": {
+        "allow-plugins": {
+            "g1a/composer-test-scenarios": true
+        }
+    },
     "extra": {
         "scenarios": {
             "elasticsearch1": {

--- a/tests/ext/extract_server_values.phpt
+++ b/tests/ext/extract_server_values.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test invalid $_SERVER values are properly ignored
+--SKIPIF--
+<?php if (!extension_loaded('pcntl')) die('skip: pcntl extension required'); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_HEADER_TAGS=0


### PR DESCRIPTION
### Description

Whitelisting composer plugins has been required from this first of July, hence tests on runners using a recent composer are failing.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
