### PR TITLE
Run Wordpress testsuite actually against PHP 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1679,11 +1679,11 @@ workflows:
           name: "PHPRedis 5 baseline testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
-          framework_target: wordpress
+          framework_target: wordpress_php5
           name: "WordPress testsuite"
       - framework_tests:
           requires: [ "Framework tests" ]
-          framework_target: wordpress_no_ddtrace
+          framework_target: wordpress_php5_no_ddtrace
           name: "WordPress baseline testsuite"
       - verify_alpine:
           requires: [ "package extension" ]

--- a/dockerfiles/frameworks/contrib/Dockerfile
+++ b/dockerfiles/frameworks/contrib/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe; \
         php${V}-dom \
         php${V}-gd \
         php${V}-iconv \
-        php${V}-imagick \
+        # php${V}-imagick \
         php${V}-json \
         php${V}-intl \
         php${V}-fileinfo\
@@ -52,7 +52,7 @@ RUN set -xe; \
 RUN set -xe; \
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');";\
     php -r "if (hash_file('sha384', 'composer-setup.php') === '$(curl -L -o - https://composer.github.io/installer.sig)') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"; \
-    php composer-setup.php; \
+    php composer-setup.php --2.2; \
     php -r "unlink('composer-setup.php');"; \
     mv composer.phar /usr/local/bin/composer;
 

--- a/dockerfiles/frameworks/contrib/Dockerfile
+++ b/dockerfiles/frameworks/contrib/Dockerfile
@@ -23,7 +23,6 @@ RUN set -xe; \
         php${V}-dom \
         php${V}-gd \
         php${V}-iconv \
-        # php${V}-imagick \
         php${V}-json \
         php${V}-intl \
         php${V}-fileinfo\

--- a/dockerfiles/frameworks/wordpress_php5.yml
+++ b/dockerfiles/frameworks/wordpress_php5.yml
@@ -1,9 +1,9 @@
 version: "3.6"
 
 services:
-  wordpress:
+  wordpress_php5:
     depends_on: ['mysql', 'nginx_file_server']
-    image: 'datadog/dd-trace-ci:php-framework-wordpress'
+    image: 'datadog/dd-trace-ci:php-framework-wordpress_php5'
     build:
       context: contrib
       target: wordpress


### PR DESCRIPTION
### Description

The wordpress container now runs PHP 7. Creating an extra _php5 variant for the PHP 5 testsuite.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
