### PR TITLE
Add integration loaded output for deferred integrations on DD_TRACE_DEBUG=1

### DIFF
--- a/src/Integrations/Integrations/Integration.php
+++ b/src/Integrations/Integrations/Integration.php
@@ -157,13 +157,14 @@ abstract class Integration
 
 function load_deferred_integration($integrationName)
 {
-    // it should have already been loaded (in current architecture)
+    // it should have already been autoloaded (in current architecture)
     if (
         \class_exists($integrationName, $autoload = false)
         && \is_subclass_of($integrationName, 'DDTrace\\Integrations\\Integration')
     ) {
         /** @var Integration $integration */
         $integration = new $integrationName();
-        $integration->init();
+        $result = $integration->init();
+        IntegrationsLoader::logResult($integrationName, $result);
     }
 }

--- a/src/Integrations/Integrations/IntegrationsLoader.php
+++ b/src/Integrations/Integrations/IntegrationsLoader.php
@@ -154,7 +154,7 @@ class IntegrationsLoader
             return;
         }
 
-        self::logDebug('Attempting integrations load');
+        self::logDebug('Attempting integrations load; note: some integrations are only loaded on first usage');
 
         foreach ($this->integrations as $name => $class) {
             if (!\ddtrace_config_integration_enabled($name)) {
@@ -177,7 +177,7 @@ class IntegrationsLoader
 
             $integration = new $class();
             $this->loadings[$name] = $integration->init();
-            $this->logResult($name, $this->loadings[$name]);
+            self::logResult($name, $this->loadings[$name]);
         }
     }
 
@@ -187,7 +187,7 @@ class IntegrationsLoader
      * @param string $name
      * @param int $result
      */
-    private function logResult($name, $result)
+    public static function logResult($name, $result)
     {
         if ($result === Integration::LOADED) {
             self::logDebug('Loaded integration {name}', ['name' => $name]);


### PR DESCRIPTION
### Description

Showing there only always loaded integrations might be confusing when debugging which integrations are supposed to be loaded.

Fixes #1592.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
