### PR TITLE
Reduce memory footprint of strpprintf

### DIFF
--- a/ext/php8/compatibility.h
+++ b/ext/php8/compatibility.h
@@ -50,6 +50,27 @@
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
 
 #if PHP_VERSION_ID < 80200
+static inline zend_string *ddtrace_vstrpprintf(size_t max_len, const char *format, va_list ap)
+{
+    zend_string *str = zend_vstrpprintf(max_len, format, ap);
+    return zend_string_realloc(str, ZSTR_LEN(str), 0);
+}
+
+#define zend_vstrpprintf ddtrace_vstrpprintf
+
+static inline zend_string *ddtrace_strpprintf(size_t max_len, const char *format, ...)
+{
+    va_list arg;
+    zend_string *str;
+
+    va_start(arg, format);
+    str = zend_vstrpprintf(max_len, format, arg);
+    va_end(arg);
+    return str;
+}
+
+#define zend_strpprintf ddtrace_strpprintf
+
 #define zend_weakrefs_hash_add zend_weakrefs_hash_add_fallback
 #define zend_weakrefs_hash_del zend_weakrefs_hash_del_fallback
 #define zend_weakrefs_hash_add_ptr zend_weakrefs_hash_add_ptr_fallback


### PR DESCRIPTION
### Description

This generally cuts fresh span memory overhead by 40%:
strpprintf under the hood uses a smart_str. Smart strings always use at least 224 bytes of memory.
By default for each string we allocate a span_fci (256 bytes), empty metrics and meta arrays (each 64 bytes) - and two strings: the span id and the resource name. Which are ~20 + 50-100 bytes, but we alloc 448 bytes.

This improvement will be (see https://github.com/php/php-src/pull/8902) on php-src master, but we do it for versions older than PHP 8.2 as well.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
