### PR TITLE
Test debian bullseye instead of stretch in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1899,7 +1899,7 @@ workflows:
                 - sury
               docker_image:
                 - debian:buster
-                - debian:stretch
+                - debian:bullseye
               configuration:
                 - PHP_VERSION=7.0
                 - PHP_VERSION=7.1


### PR DESCRIPTION
### Description

Debian stretch repos are no longer available, testing bullseye instead (in addition to the already tested buster).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
