### PR TITLE
(PHP 5) Add g1a/composer-test-scenarios and symfony/flex to composer allow-plugin list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
         "symfony/process": "<5"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "g1a/composer-test-scenarios": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_4_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_0/composer.json
@@ -37,7 +37,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_4_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_2/composer.json
@@ -38,7 +38,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_4_4/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_4/composer.json
@@ -53,7 +53,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_0/composer.json
@@ -52,7 +52,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_1/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_1/composer.json
@@ -54,7 +54,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -20,7 +20,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -12,6 +12,11 @@
         "symfony/process": "<5",
         "g1a/composer-test-scenarios": "~3.0"
     },
+    "config": {
+        "allow-plugins": {
+            "g1a/composer-test-scenarios": true
+        }
+    },
     "extra": {
         "scenarios": {
             "elasticsearch1": {


### PR DESCRIPTION
### Description

Backport from master: cherry picked from commits 5c93191a30046eeb72f7dfd58174a47ec30fb56b, 70b131cd839d079767f19479449aebabbc1993fe

Fixing CI.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
