### PR TITLE
Bump PHP minimal version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -80,7 +80,7 @@
     <dependencies>
         <required>
             <php>
-                <min>5.4</min>
+                <min>7.0</min>
                 <max>8.1.99</max>
             </php>
             <pearinstaller>


### PR DESCRIPTION
As this branch doesn't support PHP 5 anymore

> PHP 5 is not supported on this branch. Use the PHP-5 branch to build PHP 5.

so the package.xml should be consistent.