### PR TITLE
Release 0.76.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://output.circle-artifacts.com/output/job/08fccc8e-417b-4892-9155-000bfe6b7871/artifacts/0/datadog-php-tracer_0.76.0_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/7b76f0d9-154c-4a15-9f17-5b739e5fa41e/artifacts/0/datadog-php-tracer_0.76.1_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.76.0"
+#define PHP_DDTRACE_VERSION "0.76.1"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -49,50 +49,14 @@
     </stability>
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
-    ### Added
-    - Add B3 headers injection and extraction #1629
-    - Collect http.client_ip #1621
-
-    ### Changed
-    - Filter x-datadog-tags for _dd.p. prefix and add DDTrace\add_distributed_tag #1618
-    - Rename query string obfuscation variable #1630
-    - Collect query string by default and obfuscate #1615
-    - Update regex to account for URL encoding #1622
-    - Update library versions used in tests + support plesk paths #1632
-    - Remove service name propagation #1635, #1636
-    - Add integration loaded output for deferred integrations on DD_TRACE_DEBUG=1 #1639
-    - Reduce memory footprint of strpprintf #1640
-    - New implementation for hooks #1617
-    - (PHP 5) Add g1a/composer-test-scenarios and symfony/flex to composer allow-plugin list #1647
-
     ### Fixed
-    - Fix crash with numerical value in $_SERVER array #1634
-    - Fix missing query string on http.url from integrations #1642
+
+    Bump PHP minimum version in PECL #1652
+    PHP 7.3+ Fix compatibility with opcache #1656
 
     ### Internal changes
-    - Add link to compatibility requirements in README.md #1610
-    - Manually build PHP for randomized tests images #1616
-    - Eliminate PHP 5 references from master #1626
-    - Remove PHP 5 from CI and fetch it instead from the latest PHP-5 branch build #1624
-    - Fix test_web on PHP 8.0 #1631
-    - Add g1a/composer-test-scenarios and symfony/flex to composer allow-plugin list #1637
-    - (PHP 5) Run Wordpress testsuite actually against PHP 5 #1638
-    - Test debian bullseye instead of stretch in CI #1644
-    - Update rel env to use 0.75.0 (#1620)
-    - Disable clang format check in CI #1619
-    - Add one more allow-plugins in root composer.json #1646
-    - (PHP 5) Add g1a/composer-test-scenarios and symfony/flex to composer allow-plugin list #1647
 
-    ## Profiling (v0.7.0)
-    # Changed
-    - Do not upload empty profiles. See DataDog/dd-prof-php@e03ff23e5216f863061285e13170d011d0c04bc8 for details.
-
-    # Fixed
-    - Fix a small memory leak with env var handling.
-
-    # Added
-    - Add SAPI as profile tag.
-    - Add support for `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED` env var. It previously supported this functionality under a different, undocumented name.
+    %d resource ids in language tests #1657
     </notes>
     <contents>
         <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -51,12 +51,12 @@
     <notes>
     ### Fixed
 
-    Bump PHP minimum version in PECL #1652
-    PHP 7.3+ Fix compatibility with opcache #1656
+    - Bump PHP minimum version in PECL #1652
+    - PHP 7.3+ Fix compatibility with opcache #1656
 
     ### Internal changes
 
-    %d resource ids in language tests #1657
+    - %d resource ids in language tests #1657
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.76.0';
+    const VERSION = '0.76.1';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Release 0.76.1

### Fixed

Bump PHP minimum version in PECL #1652
PHP 7.3+ Fix compatibility with opcache #1656

### Internal changes

%d resource ids in language tests #1657