### PR TITLE
(PHP 7) Fix curl wrapper use after free

### DIFF
--- a/ext/php7/handlers_curl.c
+++ b/ext/php7/handlers_curl.c
@@ -612,7 +612,10 @@ static void dd_curl_wrap_dtor_obj(zend_object *obj) {
     if (dd_headers) {
         zend_hash_index_del(dd_headers, wrapper->res_handle);
     }
+}
 
+static void dd_curl_wrap_free_obj(zend_object *obj) {
+    struct dd_curl_wrapper *wrapper = (struct dd_curl_wrapper *)obj;
     zend_hash_destroy(&wrapper->multi);
 }
 
@@ -644,6 +647,7 @@ void ddtrace_curl_handlers_startup(void) {
     memcpy(&dd_curl_wrap_handler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
     dd_curl_wrap_handler_handlers.get_closure = dd_curl_wrap_get_closure;
     dd_curl_wrap_handler_handlers.dtor_obj = dd_curl_wrap_dtor_obj;
+    dd_curl_wrap_handler_handlers.free_obj = dd_curl_wrap_free_obj;
 
     // if we cannot find ext/curl then do not instrument it
     zend_string *curl = zend_string_init(ZEND_STRL("curl"), 1);

--- a/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
+++ b/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Curl multi objects release order does not crash on shutdown
+--FILE--
+<?php
+
+$ch = curl_init();
+$mh = curl_multi_init();
+curl_multi_add_handle($mh, $ch);
+
+class A {
+    public static $a;
+    public $ch;
+    public $mh;
+
+    function __destruct() {
+        curl_multi_remove_handle($this->mh, $this->ch);
+        echo "DONE\n";
+    }
+}
+
+A::$a = new A;
+A::$a->ch = $ch;
+A::$a->mh = $mh;
+
+?>
+--EXPECT--
+DONE

--- a/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
+++ b/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
@@ -8,7 +8,7 @@ $mh = curl_multi_init();
 curl_multi_add_handle($mh, $ch);
 
 class A {
-    public static $a;
+    public static $a; // static var to ensure delaying destruction until all object destructors are collectively called
     public $ch;
     public $mh;
 


### PR DESCRIPTION
### Description

The internal object could be destroyed before the curl handles were all properly destroyed. Ensure the curl wrapper multi-array is not destroyed early.

Fixes a bug reported in #1633.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
