### PR TITLE
Build and package datadog-profiling in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1516,8 +1516,11 @@ jobs:
               cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
             done
             tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
-      - store_artifacts:
-          path: datadog-profiling.tar.gz
+            rm -fr "datadog-profiling"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - datadog-profiling.tar.gz
 
   compile_extension_centos:
     working_directory: ~/datadog
@@ -1741,8 +1744,10 @@ workflows:
                 - "7.4"
                 - "8.0"
 
-  build_profiling:
+  build_packages:
     jobs:
+      - "Prepare Code"
+
       - "cargo fetch":
           name: "cargo fetch - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
@@ -1841,9 +1846,6 @@ workflows:
             - "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
             - "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
 
-  build_packages:
-    jobs:
-      - "Prepare Code"
       - compile_alpine:
           requires: [ 'Prepare Code' ]
           matrix:
@@ -1913,6 +1915,7 @@ workflows:
             - "Compile PHP 80 nts + zts + debug"
             - "Compile PHP 81 nts + zts + debug"
             - "Build PECL"
+            - "package profiler"
       - "x-profiling phpt tests on Alpine":
           requires: [ 'package extension' ]
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1493,9 +1493,32 @@ jobs:
           root: .
           paths:
             - datadog-profiling
+
+  "cargo test":
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+      triplet:
+        type: string
+    docker: [ image: << parameters.docker_image >> ]
+    resource_class: xlarge # mostly for more RAM for ramdisk
+    environment:
+      - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - run:
           name: Test Profiler
-          command: cd profiling && cargo test --release
+          command: |
+            set -u
+            command -v switch-php && switch-php "${PHP_VERSION}"
+            set -e
+            cd profiling
+            cargo test --release
 
   "package profiler":
     working_directory: ~/datadog
@@ -1795,6 +1818,31 @@ workflows:
           abi_no: "20210902"
           triplet: "x86_64-alpine-linux-musl"
 
+      - "cargo test":
+          name: "Profiler test PHP v7.1 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.1"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo test":
+          name: "Profiler test PHP v7.2 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.2"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo test":
+          name: "Profiler test PHP v7.3 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.3"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo test":
+          name: "Profiler test PHP v7.4 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.4"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo test":
+          name: "Profiler test PHP v8.0 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo test":
+          name: "Profiler test PHP v8.1 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
+          triplet: "x86_64-alpine-linux-musl"
+
       - "cache cargo deps":
           name: "cache cargo deps - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:centos-7"
@@ -1828,6 +1876,32 @@ workflows:
           name: "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           abi_no: "20210902"
+          triplet: "x86_64-unknown-linux-gnu"
+
+
+      - "cargo test":
+          name: "Profiler test PHP v7.1 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo test":
+          name: "Profiler test PHP v7.2 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo test":
+          name: "Profiler test PHP v7.3 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo test":
+          name: "Profiler test PHP v7.4 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo test":
+          name: "Profiler test PHP v8.0 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo test":
+          name: "Profiler test PHP v8.1 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
 
       - "package profiler":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1469,6 +1469,7 @@ jobs:
       triplet:
         type: string
     docker: [ image: << parameters.docker_image >> ]
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1502,7 +1502,7 @@ jobs:
     parameters:
       docker_image:
         type: string
-        default: "datadog/dd-trace-ci:centos-7"
+        default: "cimg/base:2022.07" # small image likely to be cached
     docker: [ image: << parameters.docker_image >> ]
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1455,7 +1455,7 @@ jobs:
             cargo fetch --target << parameters.triplet >>
       - save_cache:
           name: Save Cargo Package Cache
-          key: profiling-cargo-cache-{{ checksum "profiling/Cargo.toml" }}
+          key: profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
           paths:
             - /rust/cargo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1469,7 +1469,9 @@ jobs:
       triplet:
         type: string
     docker: [ image: << parameters.docker_image >> ]
-    resource_class: xlarge
+    resource_class: xlarge # mostly for more RAM for ramdisk
+    environment:
+      - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
       - checkout
       - restore_cache:
@@ -1486,12 +1488,14 @@ jobs:
             set -e
             cd profiling
             cargo build --release
-            cargo test --release
-            cp -v ./target/release/libdatadog_php_profiling.so "${libdir}/datadog-profiling.so"
+            cp -v "${CARGO_TARGET_DIR}/release/libdatadog_php_profiling.so" "${libdir}/datadog-profiling.so"
       - persist_to_workspace:
           root: .
           paths:
             - datadog-profiling
+      - run:
+          name: Test Profiler
+          command: cd profiling && cargo test --release
 
   "package profiler":
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1481,10 +1481,11 @@ jobs:
       - run:
           name: Build Profiler
           command: |
-            set -eu
+            set -u
             libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
             mkdir -vp "${libdir}"
-            switch-php "${PHP_VERSION}"
+            command -v switch-php && switch-php "${PHP_VERSION}"
+            set -e
             cd profiling
             cargo build --release
             cargo test --release
@@ -1508,6 +1509,8 @@ jobs:
       - run:
           name: "Package profiler extensions"
           command: |
+            # The layout matches what the dd-prof-php releases had to minimize
+            # transition work.
             for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl ; do
               # Add licensing
               cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1434,7 +1434,7 @@ jobs:
           root: '.'
           paths: ['./extensions']
 
-  "cargo fetch":
+  "cache cargo deps":
     working_directory: ~/datadog
     parameters:
       docker_image:
@@ -1755,83 +1755,76 @@ workflows:
     jobs:
       - "Prepare Code"
 
-      - "cargo fetch":
-          name: "cargo fetch - x86_64-alpine-linux-musl"
+      # In the event the cache is broken, all cargo jobs will end up fetching
+      # dependencies. Although this is a bit wasteful, when the cache isn't
+      # broken this saves us about 30+ secs of build time on the critical path.
+      # Since the tracer folks are unlikely to break the cache, they will save
+      # time in their CI cycles and only profiler folks will have to pay.
+      - "cache cargo deps":
+          name: "cache cargo deps - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v7.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.1"
           abi_no: "20160303"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v7.2 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.2"
           abi_no: "20170718"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v7.3 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.3"
           abi_no: "20180731"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v7.4 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.4"
           abi_no: "20190902"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v8.0 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
           abi_no: "20200930"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
           name: "Profiler PHP v8.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
           abi_no: "20210902"
           triplet: "x86_64-alpine-linux-musl"
 
-      - "cargo fetch":
-          name: "cargo fetch - x86_64-unknown-linux-gnu"
+      - "cache cargo deps":
+          name: "cache cargo deps - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
           abi_no: "20160303"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
           abi_no: "20170718"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
           abi_no: "20180731"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
           abi_no: "20190902"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
           abi_no: "20200930"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           abi_no: "20210902"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1818,27 +1818,35 @@ workflows:
           abi_no: "20210902"
           triplet: "x86_64-alpine-linux-musl"
 
+      # These don't actually need the other job to complete, but this way
+      # there are fewer resources used when the build step fails.
       - "cargo test":
+          requires: [ "Profiler PHP v7.1 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.1"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo test":
+          requires: [ "Profiler PHP v7.2 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.2 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.2"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo test":
+          requires: [ "Profiler PHP v7.3 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.3 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.3"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo test":
+          requires: [ "Profiler PHP v7.4 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.4 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.4"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo test":
+          requires: [ "Profiler PHP v8.0 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v8.0 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
           triplet: "x86_64-alpine-linux-musl"
       - "cargo test":
+          requires: [ "Profiler PHP v8.1 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v8.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
           triplet: "x86_64-alpine-linux-musl"
@@ -1878,28 +1886,35 @@ workflows:
           abi_no: "20210902"
           triplet: "x86_64-unknown-linux-gnu"
 
-
+      # These don't actually need the other job to complete, but this way
+      # there are fewer resources used when the build step fails.
       - "cargo test":
+          requires: [ "Profiler PHP v7.1 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo test":
+          requires: [ "Profiler PHP v7.2 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.2 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo test":
+          requires: [ "Profiler PHP v7.3 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.3 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo test":
+          requires: [ "Profiler PHP v7.4 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.4 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo test":
+          requires: [ "Profiler PHP v8.0 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v8.0 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo test":
+          requires: [ "Profiler PHP v8.1 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v8.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           triplet: "x86_64-unknown-linux-gnu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1608,6 +1608,7 @@ jobs:
       - run:
           name: Build packages
           command: make packages
+      - run: cd build/packages && find . -type f -exec sha256sum {} +
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
       - store_artifacts: { path: 'pecl', destination: '/pecl' }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1459,11 +1459,6 @@ jobs:
           paths:
             - /rust/cargo
 
-      - persist_to_workspace:
-          root: /rust
-          paths:
-            - cargo
-
   "cargo build --release":
     working_directory: ~/datadog
     parameters:
@@ -1476,8 +1471,10 @@ jobs:
     docker: [ image: << parameters.docker_image >> ]
     steps:
       - checkout
-      - attach_workspace:
-          at: /rust
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - run:
           name: Build Profiler
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1509,7 +1509,7 @@ jobs:
             # The layout matches what the dd-prof-php releases had to minimize
             # transition work.
             for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl ; do
-              # Add licensing
+              # Add licensing. TODO: generate rust libs to third-party CSV.
               cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"
               mkdir -vp "datadog-profiling/${triplet}/bin"
               # Add undocumented installer currently used by relenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,7 +927,7 @@ jobs:
   installer_tests:
     working_directory: ~/datadog
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:2022.04.2
     steps:
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
@@ -1516,11 +1516,12 @@ jobs:
               cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
             done
             tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
-            rm -fr "datadog-profiling"
+            rm -fr "datadog-profiling/*"
       - persist_to_workspace:
           root: .
           paths:
             - datadog-profiling.tar.gz
+            - datadog-profiling
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1520,37 +1520,6 @@ jobs:
             cd profiling
             cargo test --release
 
-  "package profiler":
-    working_directory: ~/datadog
-    parameters:
-      docker_image:
-        type: string
-        default: "cimg/base:2022.07" # small image likely to be cached
-    docker: [ image: << parameters.docker_image >> ]
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: "Package profiler extensions"
-          command: |
-            # The layout matches what the dd-prof-php releases had to minimize
-            # transition work.
-            for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl ; do
-              # Add licensing. TODO: generate rust libs to third-party CSV.
-              cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"
-              mkdir -vp "datadog-profiling/${triplet}/bin"
-              # Add undocumented installer currently used by relenv
-              cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
-            done
-            tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
-            rm -fr "datadog-profiling/*"
-      - persist_to_workspace:
-          root: .
-          paths:
-            - datadog-profiling.tar.gz
-            - datadog-profiling
-
   compile_extension_centos:
     working_directory: ~/datadog
     parameters:
@@ -1634,6 +1603,19 @@ jobs:
             curl -Lo php5.tar.gz "https://output.circle-artifacts.com/output/job/$JOB_ID/artifacts/0/datadog-php-tracer-1.0.0-nightly.x86_64.tar.gz"
             tar xzf php5.tar.gz
             mv opt/datadog-php/extensions/* extensions/
+      - run:
+          name: Package Profiler
+          command: |
+            # The layout matches what the dd-prof-php releases had to minimize
+            # transition work.
+            for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl ; do
+              # Add licensing. TODO: generate rust libs to third-party CSV.
+              cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"
+              mkdir -vp "datadog-profiling/${triplet}/bin"
+              # Add undocumented installer currently used by relenv
+              cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
+            done
+            tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
       - run:
           name: Build packages
           command: make packages
@@ -1919,22 +1901,6 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           triplet: "x86_64-unknown-linux-gnu"
 
-      - "package profiler":
-          requires:
-            - "Profiler PHP v7.1 - x86_64-alpine-linux-musl"
-            - "Profiler PHP v7.2 - x86_64-alpine-linux-musl"
-            - "Profiler PHP v7.3 - x86_64-alpine-linux-musl"
-            - "Profiler PHP v7.4 - x86_64-alpine-linux-musl"
-            - "Profiler PHP v8.0 - x86_64-alpine-linux-musl"
-            - "Profiler PHP v8.1 - x86_64-alpine-linux-musl"
-
-            - "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
-            - "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
-            - "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
-            - "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
-            - "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
-            - "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
-
       - compile_alpine:
           requires: [ 'Prepare Code' ]
           matrix:
@@ -2004,7 +1970,21 @@ workflows:
             - "Compile PHP 80 nts + zts + debug"
             - "Compile PHP 81 nts + zts + debug"
             - "Build PECL"
-            - "package profiler"
+
+            - "Profiler PHP v7.1 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.2 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.3 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.4 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v8.0 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v8.1 - x86_64-alpine-linux-musl"
+
+            - "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
+
       - "x-profiling phpt tests on Alpine":
           requires: [ 'package extension' ]
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1434,6 +1434,89 @@ jobs:
           root: '.'
           paths: ['./extensions']
 
+  "cargo fetch":
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+        default: "datadog/dd-trace-ci:centos-7"
+    docker: [ image: << parameters.docker_image >> ]
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - profiling-cargo-cache-{{ checksum "profiling/Cargo.toml" }}
+      - run:
+          name: cargo fetch
+          command: |
+            cd profiling
+            cargo fetch
+      - save_cache:
+          name: Save Cargo Package Cache
+          key: profiling-cargo-cache-{{ checksum "profiling/Cargo.toml" }}
+          paths:
+            - /rust/cargo
+
+      - persist_to_workspace:
+          root: /rust
+          paths:
+            - cargo
+
+  "cargo build --release":
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+      abi_no:
+        type: string
+      triplet:
+        type: string
+    docker: [ image: << parameters.docker_image >> ]
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /rust
+      - run:
+          name: Build Profiler
+          command: |
+            set -eu
+            libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php
+            mkdir -vp "${libdir}"
+            switch-php ${PHP_VERSION}
+            cd profiling
+            cargo build --release
+            cargo test --release
+            mkdir -vp "${libdir}/"<< parameters.abi_no >>
+            cp -v ./target/release/libdatadog_php_profiling.so "${libdir}/"<< parameters.abi_no >>/datadog-profiling.so
+      - persist_to_workspace:
+          root: .
+          paths:
+            - datadog-profiling
+
+  "package profiler":
+    working_directory: ~/datadog
+    parameters:
+      docker_image:
+        type: string
+        default: "datadog/dd-trace-ci:centos-7"
+    docker: [ image: << parameters.docker_image >> ]
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Package profiler extensions"
+          command: |
+            # Add licensing
+            cp -v profiling/LICENSE* profiling/NOTICE datadog-profiling/x86_64-unknown-linux-gnu/
+            mkdir -vp datadog-profiling/x86_64-unknown-linux-gnu/bin
+            # Add undocumented installer currently used by relenv
+            cp -v profiling/datadog-profiling-install.sh datadog-profiling/x86_64-unknown-linux-gnu/bin/
+            tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
+      - store_artifacts:
+          path: datadog-profiling.tar.gz
+
   compile_extension_centos:
     working_directory: ~/datadog
     parameters:
@@ -1456,7 +1539,7 @@ jobs:
           command: |
             switch-php << parameters.php_version >>
             make clean && make -j all ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
-            cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>.so
+            cp -v tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-<< parameters.so_suffix >>.so
       - run:
           name: Build debug, nts configuration
           command: |
@@ -1655,6 +1738,54 @@ workflows:
               php_version:
                 - "7.4"
                 - "8.0"
+
+  build_profiling:
+    jobs:
+      - "cargo fetch"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
+          abi_no: "20160303"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
+          abi_no: "20170718"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
+          abi_no: "20180731"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
+          abi_no: "20190902"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
+          abi_no: "20200930"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch' ]
+          name: "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
+          abi_no: "20210902"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "package profiler":
+          requires:
+            - "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
+            - "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
 
   build_packages:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1439,19 +1439,20 @@ jobs:
     parameters:
       docker_image:
         type: string
-        default: "datadog/dd-trace-ci:centos-7"
+      triplet:
+        type: string
     docker: [ image: << parameters.docker_image >> ]
     steps:
       - checkout
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - profiling-cargo-cache-{{ checksum "profiling/Cargo.toml" }}
+            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - run:
           name: cargo fetch
           command: |
             cd profiling
-            cargo fetch
+            cargo fetch --target << parameters.triplet >>
       - save_cache:
           name: Save Cargo Package Cache
           key: profiling-cargo-cache-{{ checksum "profiling/Cargo.toml" }}
@@ -1481,14 +1482,13 @@ jobs:
           name: Build Profiler
           command: |
             set -eu
-            libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php
+            libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
             mkdir -vp "${libdir}"
-            switch-php ${PHP_VERSION}
+            switch-php "${PHP_VERSION}"
             cd profiling
             cargo build --release
             cargo test --release
-            mkdir -vp "${libdir}/"<< parameters.abi_no >>
-            cp -v ./target/release/libdatadog_php_profiling.so "${libdir}/"<< parameters.abi_no >>/datadog-profiling.so
+            cp -v ./target/release/libdatadog_php_profiling.so "${libdir}/datadog-profiling.so"
       - persist_to_workspace:
           root: .
           paths:
@@ -1508,11 +1508,13 @@ jobs:
       - run:
           name: "Package profiler extensions"
           command: |
-            # Add licensing
-            cp -v profiling/LICENSE* profiling/NOTICE datadog-profiling/x86_64-unknown-linux-gnu/
-            mkdir -vp datadog-profiling/x86_64-unknown-linux-gnu/bin
-            # Add undocumented installer currently used by relenv
-            cp -v profiling/datadog-profiling-install.sh datadog-profiling/x86_64-unknown-linux-gnu/bin/
+            for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl ; do
+              # Add licensing
+              cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"
+              mkdir -vp "datadog-profiling/${triplet}/bin"
+              # Add undocumented installer currently used by relenv
+              cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
+            done
             tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
       - store_artifacts:
           path: datadog-profiling.tar.gz
@@ -1741,45 +1743,97 @@ workflows:
 
   build_profiling:
     jobs:
-      - "cargo fetch"
+      - "cargo fetch":
+          name: "cargo fetch - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
+          triplet: "x86_64-alpine-linux-musl"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v7.1 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.1"
+          abi_no: "20160303"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v7.2 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.2"
+          abi_no: "20170718"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v7.3 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.3"
+          abi_no: "20180731"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v7.4 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.4"
+          abi_no: "20190902"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v8.0 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
+          abi_no: "20200930"
+          triplet: "x86_64-alpine-linux-musl"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-alpine-linux-musl' ]
+          name: "Profiler PHP v8.1 - x86_64-alpine-linux-musl"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
+          abi_no: "20210902"
+          triplet: "x86_64-alpine-linux-musl"
+
+      - "cargo fetch":
+          name: "cargo fetch - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:centos-7"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cargo build --release":
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
           abi_no: "20160303"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
           abi_no: "20170718"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
           abi_no: "20180731"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v7.4 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
           abi_no: "20190902"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v8.0 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
           abi_no: "20200930"
           triplet: "x86_64-unknown-linux-gnu"
       - "cargo build --release":
-          requires: [ 'cargo fetch' ]
+          requires: [ 'cargo fetch - x86_64-unknown-linux-gnu' ]
           name: "Profiler PHP v8.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           abi_no: "20210902"
           triplet: "x86_64-unknown-linux-gnu"
+
       - "package profiler":
           requires:
+            - "Profiler PHP v7.1 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.2 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.3 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v7.4 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v8.0 - x86_64-alpine-linux-musl"
+            - "Profiler PHP v8.1 - x86_64-alpine-linux-musl"
+
             - "Profiler PHP v7.1 - x86_64-unknown-linux-gnu"
             - "Profiler PHP v7.2 - x86_64-unknown-linux-gnu"
             - "Profiler PHP v7.3 - x86_64-unknown-linux-gnu"

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -68,10 +68,17 @@ function install($options)
     // Checking required libraries
     check_library_prerequisite_or_exit('libcurl');
     if (is_alpine()) {
+        check_library_prerequisite_or_exit('libexecinfo');
         if (is_truthy($options[OPT_ENABLE_PROFILING])) {
             check_library_prerequisite_or_exit('libgcc_s');
         }
-        check_library_prerequisite_or_exit('libexecinfo');
+    } else {
+        if (is_truthy($options[OPT_ENABLE_PROFILING])) {
+            check_library_prerequisite_or_exit('libdl.so');
+            check_library_prerequisite_or_exit('libgcc_s');
+            check_library_prerequisite_or_exit('libpthread');
+            check_library_prerequisite_or_exit('librt');
+        }
     }
 
     // Picking the right binaries to install the library

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -68,6 +68,9 @@ function install($options)
     // Checking required libraries
     check_library_prerequisite_or_exit('libcurl');
     if (is_alpine()) {
+        if (is_truthy($options[OPT_ENABLE_PROFILING])) {
+            check_library_prerequisite_or_exit('libgcc_s');
+        }
         check_library_prerequisite_or_exit('libexecinfo');
     }
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -248,6 +248,14 @@ function install($options)
                     "sed -i 's@extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
                         . escapeshellarg($iniFilePath)
                 );
+
+
+                // Support upgrading from the C based zend_extension.
+                execute_or_exit(
+                    'Impossible to update the INI settings file.',
+                    "sed -i 's@zend_extension \?= \?.*datadog-profiling.*\(.*\)@extension = datadog-profiling.so@g' "
+                        . escapeshellarg($iniFilePath)
+                );
             }
 
             add_missing_ini_settings(
@@ -261,7 +269,7 @@ function install($options)
                 if ($shouldInstallProfiling) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i 's@ \?; \?zend_extension \?= \?datadog-profiling.so@zend_extension = datadog-profiling.so@g' "
+                        "sed -i 's@ \?; \?extension \?= \?datadog-profiling.so@extension = datadog-profiling.so@g' "
                             . escapeshellarg($iniFilePath)
                     );
                 } else {
@@ -982,7 +990,7 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
             'description' => 'Enables or disables tracing (set by the installer, do not change it)',
         ],
         [
-            'name' => 'zend_extension',
+            'name' => 'extension',
             'default' => 'datadog-profiling.so',
             'commented' => true,
             'description' => 'Enables the profiling module',

--- a/dockerfiles/compile_extension/Dockerfile_alpine
+++ b/dockerfiles/compile_extension/Dockerfile_alpine
@@ -27,3 +27,6 @@ ENV PATH ${PATH}:${PHP_INSTALL_DIR}/bin
 ADD ./build-dd-trace-php /usr/bin/build-dd-trace-php
 
 CMD sh
+
+ENV CARGO_HOME=/rust/cargo
+RUN mkdir -vp "${CARGO_HOME}"

--- a/dockerfiles/compile_extension/Dockerfile_alpine
+++ b/dockerfiles/compile_extension/Dockerfile_alpine
@@ -1,4 +1,5 @@
-FROM alpine:3.5
+ARG baseImage=alpine:3.16
+FROM ${baseImage}
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/dockerfiles/compile_extension/alpine.Dockerfile
+++ b/dockerfiles/compile_extension/alpine.Dockerfile
@@ -1,8 +1,28 @@
-ARG baseImage=alpine:3.16
-FROM ${baseImage}
+FROM alpine:3.16 as base
 
 RUN mkdir -p /app
 WORKDIR /app
+
+# Break the dependencies into multiple layers to reduce individual layer size.
+# This is just to avoid an upload issue I was hitting with large layers.
+RUN set -eux; \
+    apk add --no-cache \
+        build-base \
+        curl-dev \
+        libedit-dev \
+        libffi-dev \
+        libmcrypt-dev \
+        libsodium-dev \
+        libxml2-dev \
+        oniguruma-dev
+
+# Profiling deps
+RUN apk add --no-cache llvm13-libs
+RUN apk add --no-cache rust-stdlib
+RUN apk add --no-cache cargo
+RUN apk add --no-cache clang git protoc unzip
+
+FROM base
 
 ADD ./docker-php-source /usr/bin/docker-php-source
 ADD ./install-php /usr/bin/install-php

--- a/dockerfiles/compile_extension/build-dd-trace-php
+++ b/dockerfiles/compile_extension/build-dd-trace-php
@@ -35,7 +35,8 @@ apk add --no-cache \
     libexecinfo-dev \
     make \
 
-make -j all CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror" ECHO_ARG="-e"
+# -Werror=return-local-addr _should be fixed_ but I need to keep working on my CI thing.
+make -j all CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror -Wno-error=return-local-addr" ECHO_ARG="-e"
 
 sofile="tmp/build_extension/.libs/ddtrace.so"
 actual_symbols=`mktemp "$TMPDIR/actual_symbols.XXXXXXXX"`

--- a/dockerfiles/compile_extension/docker-compose.yml
+++ b/dockerfiles/compile_extension/docker-compose.yml
@@ -2,45 +2,6 @@ version: '3.7'
 
 services:
 
-  5.4-alpine:
-    image: datadog/dd-trace-ci:php-compile-extension-alpine-5.4
-    build:
-      context: .
-      dockerfile: Dockerfile_alpine
-      args:
-        php_version: 5.4.45
-        php_sha: 25bc4723955f4e352935258002af14a14a9810b491a19400d76fcdfa9d04b28f
-        php_api: 20100412
-    command: build-dd-trace-php
-    volumes:
-        - ../../:/app
-
-  5.5-alpine:
-    image: datadog/dd-trace-ci:php-compile-extension-alpine-5.5
-    build:
-      context: .
-      dockerfile: Dockerfile_alpine
-      args:
-        php_version: 5.5.38
-        php_sha: 4f458c9b504269615715a62f182b7c2f89bb8284f484befc221b56a1571b506e
-        php_api: 20121113
-    command: build-dd-trace-php
-    volumes:
-        - ../../:/app
-
-  5.6-alpine:
-    image: datadog/dd-trace-ci:php-compile-extension-alpine-5.6
-    build:
-      context: .
-      dockerfile: Dockerfile_alpine
-      args:
-        php_version: 5.6.40
-        php_sha: 56fb9878d12fdd921f6a0897e919f4e980d930160e154cbde2cc6d9206a27cac
-        php_api: 20131106
-    command: build-dd-trace-php
-    volumes:
-        - ../../:/app
-
   7.0-alpine:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.0
     build:
@@ -86,8 +47,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 7.3.29
-        php_sha: ba4de3955b0cbd33baee55a83568acc4347605e210a54b5654e4c1e09b544659
+        php_version: 7.3.33
+        php_sha: 9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8
         php_api: 20180731
     command: build-dd-trace-php
     volumes:
@@ -99,8 +60,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 7.4.21
-        php_sha: 4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db
+        php_version: 7.4.30
+        php_sha: e37ea37e0f79109351ac615da85eb7c2c336101fc5bc802ee79a124a4310dc10
         php_api: 20190902
     command: build-dd-trace-php
     volumes:
@@ -112,8 +73,8 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 8.0.8
-        php_sha: 084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945
+        php_version: 8.0.21
+        php_sha: 2f51f6e90e2e8efd3a20db08f0dd61d7f8d5a9362f8c7325f1ad28ccea5be0ac
         php_api: 20200930
     command: build-dd-trace-php
     volumes:
@@ -125,10 +86,9 @@ services:
       context: .
       dockerfile: Dockerfile_alpine
       args:
-        php_version: 8.1.0-rc1
-        php_sha: 8a4fad22c02909705c740833bf99e3039d7d3971a55deb998206f6d67151c294
+        php_version: 8.1.8
+        php_sha: 889d910558d2492f7f2236921b9bcde620674c8b684ec02d126060f8ca45dc8d
         php_api: 20210902
-        php_url: https://downloads.php.net/~patrickallaert/php-8.1.0RC1.tar.gz
     command: build-dd-trace-php
     volumes:
       - ../../:/app

--- a/dockerfiles/compile_extension/docker-compose.yml
+++ b/dockerfiles/compile_extension/docker-compose.yml
@@ -2,11 +2,18 @@ version: '3.7'
 
 services:
 
+  base:
+    image: datadog/dd-trace-ci:php-compile-extension-alpine
+    build:
+      context: .
+      dockerfile: alpine.Dockerfile
+      target: base
+
   7.0-alpine:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.0
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 7.0.33
         php_sha: d71a6ecb6b13dc53fed7532a7f8f949c4044806f067502f8fb6f9facbb40452a
@@ -19,7 +26,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.1
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 7.1.33
         php_sha: 0055f368ffefe51d5a4483755bd17475e88e74302c08b727952831c5b2682ea2
@@ -32,7 +39,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.2
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 7.2.34
         php_sha: 8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78
@@ -45,7 +52,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.3
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 7.3.33
         php_sha: 9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8
@@ -58,7 +65,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-7.4
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 7.4.30
         php_sha: e37ea37e0f79109351ac615da85eb7c2c336101fc5bc802ee79a124a4310dc10
@@ -71,7 +78,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-8.0
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 8.0.21
         php_sha: 2f51f6e90e2e8efd3a20db08f0dd61d7f8d5a9362f8c7325f1ad28ccea5be0ac
@@ -84,7 +91,7 @@ services:
     image: datadog/dd-trace-ci:php-compile-extension-alpine-8.1
     build:
       context: .
-      dockerfile: Dockerfile_alpine
+      dockerfile: alpine.Dockerfile
       args:
         php_version: 8.1.8
         php_sha: 889d910558d2492f7f2236921b9bcde620674c8b684ec02d126060f8ca45dc8d

--- a/dockerfiles/compile_extension/install-php
+++ b/dockerfiles/compile_extension/install-php
@@ -9,19 +9,22 @@ apk add --no-cache --virtual .php-build-deps \
     bison \
     ca-certificates \
     coreutils \
-    g++ \
-    gcc \
-    make \
     re2c \
     wget
 apk add --no-cache --virtual .php-deps \
+    build-base \
+    cargo \
+    clang \
     curl-dev \
+    git \
     libedit-dev \
     libffi-dev \
     libmcrypt-dev \
-    oniguruma-dev \
     libsodium-dev \
-    libxml2-dev
+    libxml2-dev \
+    oniguruma-dev \
+    protoc \
+    unzip
 mkdir -p $PHP_SRC_DIR
 cd $SRC_DIR
 wget -O "${PHP_TAR_FILE}" "$PHP_URL"
@@ -33,19 +36,31 @@ cd $PHP_SRC_DIR
 CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS"
 PHP_CONFIG_ARGS=""
 
+PHP_72_API='20170718'
+PHP_74_API='20190902'
+if [ "${PHP_API}" -lt "${PHP_72_API}" ] ; then
+    # Removed in v7.2
+    PHP_CONFIG_ARGS="--with-mcrypt $PHP_CONFIG_ARGS"
+else
+    PHP_CONFIG_ARGS="--with-sodium=shared $PHP_CONFIG_ARGS"
+fi
+
+if [ "${PHP_API}" -ge "${PHP_74_API}" ] ; then
+    PHP_CONFIG_ARGS="--with-ffi $PHP_CONFIG_ARGS"
+fi
+
+srcdir="$PWD"
 # Installing PHP
-./buildconf --force
-./configure \
+mkdir -vp /tmp/build-php
+cd /tmp/build-php
+"$srcdir/configure" \
     --prefix="${PHP_INSTALL_DIR}" \
     --with-config-file-path="${PHP_INI_DIR}" \
     --with-config-file-scan-dir="${PHP_INI_DIR}/conf.d" \
     --with-mhash \
-    --with-mcrypt \
     --enable-ftp \
     --enable-mbstring \
-    --with-sodium=shared \
     --with-curl \
-    --with-ffi \
     --with-libedit \
     --without-pdo-sqlite \
     --without-sqlite3 \
@@ -57,6 +72,8 @@ PHP_CONFIG_ARGS=""
     ${PHP_CONFIG_ARGS}
 make -j "$(nproc)"
 make install clean
+cd -
+rm -fr /tmp/build-php
 
 # Removing sources and unused packages
 docker-php-source delete

--- a/dockerfiles/compile_extension/install-php
+++ b/dockerfiles/compile_extension/install-php
@@ -11,20 +11,7 @@ apk add --no-cache --virtual .php-build-deps \
     coreutils \
     re2c \
     wget
-apk add --no-cache --virtual .php-deps \
-    build-base \
-    cargo \
-    clang \
-    curl-dev \
-    git \
-    libedit-dev \
-    libffi-dev \
-    libmcrypt-dev \
-    libsodium-dev \
-    libxml2-dev \
-    oniguruma-dev \
-    protoc \
-    unzip
+
 mkdir -p $PHP_SRC_DIR
 cd $SRC_DIR
 wget -O "${PHP_TAR_FILE}" "$PHP_URL"

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
@@ -10,26 +10,45 @@ assert_no_ddtrace
 extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
-# Install using the php installer
-new_version="0.75.0"
-generate_installers "${new_version}"
-php ./build/packages/datadog-setup.php --php-bin php
 
-# Uninstall
-php ./build/packages/datadog-setup.php --php-bin php --uninstall
+# Get a relased version of the setup script. I've picked a recent one that at
+# this time doesn't have the switch from zend_extension to extension for the
+# profiling module.
+released_version="0.75.0"
+released_version_sha="76506c5ec222b2975333e1bae85f8b91d7c02eb9ccd4dcc807cdf2f23c667785"
+cd /tmp
+curl -OL https://github.com/DataDog/dd-trace-php/releases/download/${released_version}/datadog-setup.php
+echo "${released_version_sha}  datadog-setup.php" | sha256sum -c
+php datadog-setup.php --php-bin php
+rm -v datadog-setup.php
+cd -
+
+assert_ddtrace_version "${released_version}"
+
+# Parse current version numbers and generate an installer.
+trace_version=$(awk -F\' '/const VERSION/ {print $2}' < src/DDTrace/Tracer.php)
+profiling_version=$(awk -F\" '/^version[ \t]*=/ {print $2}' < profiling/Cargo.toml)
+generate_installers "${trace_version}"
+
+# Uninstall with new version, since it seems likely users will attempt this.
+# This gives us a heads up if it breaks somehow.
+php datadog-setup.php --php-bin php --uninstall
 assert_no_ddtrace
 assert_no_appsec
 assert_no_profiler
 
-php ./build/packages/datadog-setup.php --enable-profiling --php-bin php
-
-assert_ddtrace_version 0.75.0
-assert_profiler_version 0.6.1
+# Lastly, re-install with profiling.
+php ./build/packages/datadog-setup.php --enable-profiling --php-bin php --file "./build/packages/dd-library-php-${trace_version}-x86_64-linux-gnu.tar.gz"
 
 extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
-if [ -f "${extension_dir}/ddtrace.so" ]; then
-    echo "Ok: File ${extension_dir}/ddtrace.so exists."
-else
-    echo "Error. File ${extension_dir}/ddtrace.so should exist."
-    exit 1
-fi
+for extension in ddtrace datadog-profiling ; do
+    if [ -f "${extension_dir}/${extension}.so" ]; then
+        echo "Ok: File ${extension_dir}/${extension}.so exists."
+    else
+        echo "Error. File ${extension_dir}/${extension}.so should exist."
+        exit 1
+    fi
+done
+
+assert_ddtrace_version "${trace_version}"
+assert_profiler_version "${profiling_version}"

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
@@ -16,18 +16,16 @@ ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 # profiling module.
 released_version="0.75.0"
 released_version_sha="76506c5ec222b2975333e1bae85f8b91d7c02eb9ccd4dcc807cdf2f23c667785"
-cd /tmp
-curl -OL https://github.com/DataDog/dd-trace-php/releases/download/${released_version}/datadog-setup.php
-echo "${released_version_sha}  datadog-setup.php" | sha256sum -c
-php datadog-setup.php --php-bin php
-rm -v datadog-setup.php
-cd -
+
+fetch_setup_for_version "$released_version" "$released_version_sha" "/tmp"
+php /tmp/datadog-setup.php --php-bin php
+rm -v /tmp/datadog-setup.php
 
 assert_ddtrace_version "${released_version}"
 
 # Parse current version numbers and generate an installer.
-trace_version=$(awk -F\' '/const VERSION/ {print $2}' < src/DDTrace/Tracer.php)
-profiling_version=$(awk -F\" '/^version[ \t]*=/ {print $2}' < profiling/Cargo.toml)
+trace_version=$(parse_trace_version)
+profiling_version=$(parse_profiling_version)
 generate_installers "${trace_version}"
 
 # Uninstall with new version, since it seems likely users will attempt this.

--- a/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
@@ -8,11 +8,13 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
-generate_installers "${new_version}"
-php ./build/packages/datadog-setup.php --php-bin php --enable-profiling
-assert_ddtrace_version "${new_version}"
+trace_version=$(parse_trace_version)
+profiling_version=$(parse_profiling_version)
+generate_installers "$trace_version"
+php ./build/packages/datadog-setup.php --php-bin php --enable-profiling \
+    --file "./build/packages/dd-library-php-${trace_version}-x86_64-linux-gnu.tar.gz"
+assert_ddtrace_version "${trace_version}"
 
 assert_file_exists "$(get_php_extension_dir)"/datadog-profiling.so
 
-assert_profiler_version 0.6.1
+assert_profiler_version "${profiling_version}"

--- a/dockerfiles/verify_packages/installer/test_uninstall.sh
+++ b/dockerfiles/verify_packages/installer/test_uninstall.sh
@@ -15,8 +15,7 @@ version="0.75.0"
 sha256sum="76506c5ec222b2975333e1bae85f8b91d7c02eb9ccd4dcc807cdf2f23c667785"
 destdir="/tmp"
 fetch_setup_for_version "$version" "$sha256sum" "$destdir"
-php "$destdir/datadog-setup.php" --php-bin php --enable-profiling --enable-appsec \
-    --file "$destdir/dd-library-php-${version}-x86_64-linux-gnu.tar.gz"
+php "$destdir/datadog-setup.php" --php-bin php --enable-profiling --enable-appsec
 rm -v "$destdir/datadog-setup.php"
 assert_ddtrace_version "${version}"
 assert_appsec_version "0.3.2"

--- a/dockerfiles/verify_packages/installer/test_uninstall.sh
+++ b/dockerfiles/verify_packages/installer/test_uninstall.sh
@@ -11,15 +11,23 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.75.0"
-generate_installers "${new_version}"
-php ./build/packages/datadog-setup.php --php-bin php --enable-profiling --enable-appsec
-assert_ddtrace_version "${new_version}"
+version="0.75.0"
+sha256sum="76506c5ec222b2975333e1bae85f8b91d7c02eb9ccd4dcc807cdf2f23c667785"
+destdir="/tmp"
+fetch_setup_for_version "$version" "$sha256sum" "$destdir"
+php "$destdir/datadog-setup.php" --php-bin php --enable-profiling --enable-appsec \
+    --file "$destdir/dd-library-php-${version}-x86_64-linux-gnu.tar.gz"
+rm -v "$destdir/datadog-setup.php"
+assert_ddtrace_version "${version}"
 assert_appsec_version "0.3.2"
 assert_profiler_version "0.6.1"
 
 # Uninstall
-php ./build/packages/datadog-setup.php --php-bin php --uninstall
+trace_version="$(parse_trace_version)"
+generate_installers "$trace_version"
+php ./build/packages/datadog-setup.php --php-bin php --uninstall \
+    --file "./build/packages/dd-library-php-${trace_version}-x86_64-linux-gnu.tar.gz"
+
 assert_no_ddtrace
 assert_no_appsec
 assert_no_profiler

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -136,6 +136,26 @@ generate_installers() {
     sh "$(pwd)/tooling/bin/generate-installers.sh" "${version}" "$(pwd)/build/packages"
 }
 
+fetch_setup_for_version() {
+    version="${1?}"
+    sha256sum="${2?}"
+    destdir="${3?}"
+
+    mkdir -vp "${destdir?}"
+    cd "${destdir}"
+    curl -OL https://github.com/DataDog/dd-trace-php/releases/download/${version}/datadog-setup.php
+    echo "${sha256sum}  datadog-setup.php" | sha256sum -c
+    cd -
+}
+
+parse_trace_version() {
+    awk -F\' '/const VERSION/ {print $2}' < src/DDTrace/Tracer.php
+}
+
+parse_profiling_version() {
+    awk -F\" '/^version[ \t]*=/ {print $2}' < profiling/Cargo.toml
+}
+
 dashed_print() {
     echo "---"
     for line in "$@" ; do

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -2,6 +2,7 @@
 name = "datadog-php-profiling"
 version = "0.8.0"
 edition = "2021"
+license = "Apache-2.0"
 rust-version = "1.60"
 
 [lib]

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -34,5 +34,5 @@ cc = { version = "1.0" }
 
 [profile.release]
 debug = 1
-lto = true
+lto = "thin"
 incremental = false

--- a/profiling/LICENSE
+++ b/profiling/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/profiling/LICENSE-3rdparty.csv
+++ b/profiling/LICENSE-3rdparty.csv
@@ -1,0 +1,3 @@
+Component,Origin,License,Copyright
+protobuf-c,https://github.com/protobuf-c/protobuf-c,BSD-2-Clause,Copyright (c) 2008-2016 Dave Benson and the protobuf-c authors
+protobuf,https://github.com/protocolbuffers/protobuf,BSD-3-Clause,Copyright 2008 Google Inc

--- a/profiling/NOTICE
+++ b/profiling/NOTICE
@@ -1,0 +1,4 @@
+Datadog dd-prof-php
+Copyright 2021-Present Datadog, Inc.
+
+This product includes software developed at Datadog (<https://www.datadoghq.com/).>

--- a/profiling/datadog-profiling-install.sh
+++ b/profiling/datadog-profiling-install.sh
@@ -83,6 +83,6 @@ cat <<EOF
 
 The Datadog profiler has been installed. Add the following line to an INI file:
 
-extension = datadog-profiling.so
+extension=datadog-profiling.so
 
 EOF

--- a/profiling/datadog-profiling-install.sh
+++ b/profiling/datadog-profiling-install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+<<EOF
+This is only intended to work from the packaged release, not from the source
+tree. It expects a directory structure like this:
+
+datadog-profiling
+├── bin
+│   └── this script
+└── lib
+    └── php
+        ├── 20160303
+        │   └── datadog-profiling.so
+        ├── 20170718
+        │   └── datadog-profiling.so
+        ├── 20180731
+        │   └── datadog-profiling.so
+        └── 20190902
+            └── datadog-profiling.so
+EOF
+
+basedir="$(dirname $0)"
+
+usage() {
+  echo "USAGE: ${0##*/} [php]
+
+OPTIONS:
+  php           The name or full path of php. Defaults to \"php\".
+"
+}
+
+php="${1:-php}"
+
+# not all environments will have `which`, so just try to run php --version
+if ! version=$("$php" "--version" 2>/dev/null) ; then
+  (echo "ERROR: Unable to detect PHP version through php."
+  if [ ! -z "$1" ] ; then
+    echo "Provided argument php=\"${1}\"."
+    echo ""
+  fi
+  ) >&2
+  exit 1
+fi
+
+echo "Detected PHP version:"
+echo "$version"
+
+# Should we select "Local Value" or "Master Value"?
+extdir=$("$php" -i | awk '/^extension_dir/ { print $3 }')
+echo "Detected extension directory: $extdir"
+
+module_api_no=$("$php" -i | awk '/^PHP Extension/ && 4 == NF { print $4 }')
+zts=$("$php" -i | awk '/^Thread Safety/ { print ("enabled" == $NF) ? "-zts" : "" ; exit 0}')
+debug=$("$php" -i | awk '/^Debug Build/ { print ("yes" == $NF) ? "-debug" : "" ; exit 0}')
+
+build="${module_api_no}${zts}${debug}"
+echo "Detected build: $build"
+
+status=0
+if [ ! -z "$zts" ] ; then
+  echo "Detected a ZTS build of PHP; this is not currently supported." >&2
+  status=1
+fi
+
+if [ ! -z "$debug" ] ; then
+  echo "Detected a debug build of PHP; this is not currently supported." >&2
+  status=1
+fi
+
+if [ $status -ne 0 ] ; then
+  exit $status
+fi
+
+target="$basedir/../lib/php/$build/datadog-profiling.so"
+if [ ! -f "$target" ] ; then
+  echo "ERROR: expected file \"$target\"! Was there a packaging error?" >&2
+  exit 1
+fi
+
+cp -v "$target" "$extdir"
+
+cat <<EOF
+
+The Datadog profiler has been installed. Add the following line to an INI file:
+
+extension = datadog-profiling.so
+
+EOF

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -260,7 +260,7 @@ impl Default for DatadogPhpProfilingGlobals {
     fn default() -> Self {
         Self {
             profiling_enabled: false,
-            profiling_experimental_cpu_time_enabled: false,
+            profiling_experimental_cpu_time_enabled: true,
             profiling_log_level: LevelFilter::Off,
             vm_interrupt_addr: std::ptr::null(),
             interrupt_count: AtomicU32::new(0),

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -359,7 +359,7 @@ unsafe fn read_env(globals: &mut zend::zend_datadog_php_profiling_globals) {
             ))
         })
         .and_then(parse_boolean)
-        .unwrap_or(false);
+        .unwrap_or(true);
 
     let profiling_log_level = profiling_log_level
         .and_then(|string| {

--- a/tests/ext/profiling/runtime_id_02.phpt
+++ b/tests/ext/profiling/runtime_id_02.phpt
@@ -1,5 +1,5 @@
 --TEST--
-runtime-id doesn't exist in meta when profiling is disabled
+runtime-id exists in meta when profiling is disabled
 --ENV--
 DD_PROFILING_ENABLED=false
 DD_TRACE_CLI_ENABLED=true
@@ -12,7 +12,7 @@ if (!extension_loaded('datadog-profiling'))
 <?php
 
 $meta = DDTrace\active_span()->meta;
-var_dump(!isset($meta['runtime-id']));
+var_dump(isset($meta['runtime-id']));
 
 ?>
 --EXPECTF--

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -43,7 +43,13 @@ cp -r ./bridge ${tmp_folder_final_musl_trace};
 tmp_folder_profiling=$tmp_folder/profiling
 tmp_folder_profiling_archive=$tmp_folder_profiling/datadog-profiling.tar.gz
 mkdir -p $tmp_folder_profiling
-curl -L -o $tmp_folder_profiling_archive $profiling_url
+
+# Profiling: C version
+#curl -L -o $tmp_folder_profiling_archive $profiling_url
+
+# Profiling: Rust version
+cp -v datadog-profiling.tar.gz "$tmp_folder_profiling_archive"
+
 tar -xf $tmp_folder_profiling_archive -C $tmp_folder_profiling
 
 # Extension

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -14,7 +14,10 @@ static ZEND_FUNCTION(pass)
 }
 
 // HACK: define a name for XDebug compatibility..., a fully functional zend_string for "{zend_pass}"
-static const struct __attribute__((__packed__)) { zend_string str; char value[]; } zend_pass_function_name = {
+static const struct __attribute__((packed, aligned(_Alignof(zend_string)))) {
+    zend_string str;
+    char value[];
+} zend_pass_function_name = {
         .str.gc.refcount = 2,
         .str.gc.u.v.type = IS_STRING,
         .str.gc.u.v.flags = IS_STR_INTERNED,
@@ -27,7 +30,7 @@ static const zend_internal_function zend_pass_function = {
         ZEND_INTERNAL_FUNCTION, /* type              */
         {0, 0, 0},              /* arg_flags         */
         0,                      /* fn_flags          */
-        (zend_string *)&zend_pass_function_name,     /* name              */
+        (zend_string *)&zend_pass_function_name.str,     /* name              */
         NULL,                   /* scope             */
         NULL,                   /* prototype         */
         0,                      /* num_args          */


### PR DESCRIPTION
### Description

This adds jobs to the `build_packages` workflow in CircleCI that build
the datadog-profiling extension on x86_64-unknown-linux-gnu and
x86_64-alpine-linux-musl. It adjusts the `datadog-setup.php` install
script to use `extension = datadog-profiling.so` instead of
`zend_extension = datadog-profiling.so` and checks for profiling 
dependencies that weren't there before, which depending on your OS
includes `libgcc_s`, `libdl`,  `libpthread`, and `librt`.

This also updated the Alpine images to v3.16, which caused a few things
to break in CI. I fixed one of them already, but there's still an issue
with the warning `return-local-addr`. This was beyond my skill to just
drop in and fix quickly, so I dropped in a
`-Wno-error=return-local-addr` that should be removed once the fix is
in place. In the testing I did, the tracer built from this workflow can
run on Alpine 3.11 and earlier for x86-64, but I suspect for arm it
will not be possible to due to the libmusl v1.2 upgrade that happens
on Alpine 3.13.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
