### PR TITLE
Skip curl test if curl is not loaded

### DIFF
--- a/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
+++ b/tests/ext/integrations/curl/curl_release_on_shutdown.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Curl multi objects release order does not crash on shutdown
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
### Description

This test fails on [PHP 8.1 min tests run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/8601/workflows/cf8ca03f-0f22-4ecf-b137-77238cc17495/jobs/1314491). Not sure if this container _should_ have curl or not, but it's odd to have just one test in the curl suite avoid the skipif.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
