### PR TITLE
Add opcode shutdown handlers, fix integrations after repeated minit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1945,6 +1945,13 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 72 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.2_buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 72 web tests with nginx + FastCGI"
           resource_class: medium+
           sapi: cgi-fcgi
@@ -1959,6 +1966,13 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 74 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 74 web tests with nginx + FastCGI"
           resource_class: medium+
           sapi: cgi-fcgi
@@ -1966,11 +1980,25 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
+          name: "PHP 80 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.0_buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
           name: "PHP 80 web tests with nginx + FastCGI"
           resource_class: medium+
           sapi: cgi-fcgi
           integration_testsuite: "test_web"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
+      - integration_tests:
+          requires: [ 'Prepare Code' ]
+          name: "PHP 81 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.1_buster"
       - integration_tests:
           requires: [ 'Prepare Code' ]
           name: "PHP 81 web tests with nginx + FastCGI"

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -158,10 +158,12 @@ RUN set -eux; \
 # delete the "index.html" that installing Apache drops in here
     rm -rvf /var/www/html/*; \
     \
+# disable config depending on env var
+    a2disconf other-vhosts-access-log.conf; \
+    \
 # logs should go to stdout / stderr
     ln -sfT /dev/stderr "$APACHE_LOG_DIR/error.log"; \
     ln -sfT /dev/stdout "$APACHE_LOG_DIR/access.log"; \
-    ln -sfT /dev/stdout "$APACHE_LOG_DIR/other_vhosts_access.log"; \
     chown -R --no-dereference "$APACHE_RUN_USER:$APACHE_RUN_GROUP" "$APACHE_LOG_DIR"; \
     \
 # Apache + PHP requires preforking Apache for best results
@@ -180,7 +182,9 @@ RUN set -eux; \
         echo '\tAllowOverride All'; \
         echo '</Directory>'; \
     } | tee "$APACHE_CONFDIR/conf-available/docker-php.conf" \
-    && a2enconf docker-php;
+    && a2enconf docker-php; \
+# We want to use mod_rewrite
+    a2enmod rewrite
 
 RUN set -eux; \
 # Share welcome message with the world

--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -94,6 +94,7 @@ RUN set -eux; \
         pecl install xdebug-2.7.2; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-2.7.2.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-7.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.0/Dockerfile
@@ -31,6 +31,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_ZTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d;
 
 FROM build as php-debug
@@ -43,6 +48,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -54,6 +64,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -82,7 +97,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php7_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-7.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.1/Dockerfile
@@ -31,6 +31,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_ZTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d;
 
 FROM build as php-debug
@@ -43,6 +48,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -54,6 +64,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -88,7 +103,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php7_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-7.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.1/Dockerfile
@@ -100,6 +100,7 @@ RUN set -eux; \
         pecl install xdebug-2.9.5; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-2.9.5.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-7.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.2/Dockerfile
@@ -31,6 +31,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_ZTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d;
 
 FROM build as php-debug
@@ -43,6 +48,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -54,6 +64,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -88,7 +103,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php7_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-7.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.2/Dockerfile
@@ -100,6 +100,7 @@ RUN set -eux; \
         pecl install xdebug-2.9.5; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-2.9.5.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-7.3/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.3/Dockerfile
@@ -29,6 +29,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_ZTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_ZTS}/conf.d;
 
 FROM build as php-debug
@@ -41,6 +46,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -52,6 +62,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -85,7 +100,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php7_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-7.3/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.3/Dockerfile
@@ -97,6 +97,7 @@ RUN set -eux; \
         pecl install xdebug-2.9.5; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-2.9.5.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-7.4/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.4/Dockerfile
@@ -94,6 +94,7 @@ RUN set -eux; \
         pecl install xdebug-2.9.5; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-2.9.5.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-7.4/Dockerfile
+++ b/dockerfiles/ci/buster/php-7.4/Dockerfile
@@ -43,6 +43,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -54,6 +59,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp7.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -87,7 +97,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php7_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile
@@ -43,6 +43,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -54,6 +59,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM base as final
@@ -79,10 +89,13 @@ RUN set -eux; \
         pecl install xdebug-3.0.0; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-3.0.0.so; \
+        if [[ ${phpVer} != *asan* ]]; then echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; fi; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version \
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux; \
         pecl install xdebug-3.0.0; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-3.0.0.so; \
-        if [[ ${phpVer} != *asan* ]]; then echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; fi; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/php-8.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.1/Dockerfile
@@ -44,6 +44,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp.so ${PHP_INSTALL_DIR_DEBUG_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_DEBUG_NTS}/conf.d;
 
 FROM build as php-nts
@@ -55,6 +60,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_NTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp.so ${PHP_INSTALL_DIR_NTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_NTS}/conf.d;
 
 FROM build as php-zts
@@ -67,6 +77,11 @@ RUN set -eux; \
         --with-config-file-scan-dir=${PHP_INSTALL_DIR_ZTS}/conf.d; \
     make -j "$((`nproc`+1))"; \
     make install; \
+    # In two steps, because: You've configured multiple SAPIs to be built. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time. \
+    sed -i 's/--enable-embed/--with-apxs2=\/usr\/bin\/apxs2/' config.nice; \
+    ./config.nice; \
+    make -j "$((`nproc`+1))"; \
+    cp .libs/libphp.so ${PHP_INSTALL_DIR_ZTS}/lib/apache2handler-libphp.so; \
     mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d;
 
 FROM base as final
@@ -96,7 +111,9 @@ RUN set -eux; \
     done;
 
 RUN set -eux; \
-# Set the default PHP version
+    # Enable the apache config \
+    echo 'LoadModule php_module /usr/lib/apache2/modules/libphp.so' | sudo tee /etc/apache2/mods-enabled/php.load; \
+    # Set the default PHP version
     switch-php debug;
 
 # Install Composer

--- a/dockerfiles/ci/buster/php-8.1/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.1/Dockerfile
@@ -108,6 +108,7 @@ RUN set -eux; \
         pecl install xdebug-3.1.2; \
         cd $(php-config --extension-dir); \
         mv xdebug.so xdebug-3.1.2.so; \
+        echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini; \
     done;
 
 RUN set -eux; \

--- a/dockerfiles/ci/buster/switch-php
+++ b/dockerfiles/ci/buster/switch-php
@@ -18,3 +18,6 @@ sudo ln -sf /opt/php/${phpVersion}/bin/php-config /usr/local/bin/php-config
 sudo ln -sf /opt/php/${phpVersion}/bin/phpdbg /usr/local/bin/phpdbg
 sudo ln -sf /opt/php/${phpVersion}/bin/phpize /usr/local/bin/phpize
 sudo ln -sf /opt/php/${phpVersion}/sbin/php-fpm /usr/local/bin/php-fpm
+if [ "${phpVersion}" != *asan* ]; then
+    sudo ln -sf /opt/php/${phpVersion}/lib/apache2handler-libphp.so /usr/lib/apache2/modules/libphp.so
+fi

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -123,6 +123,7 @@ static void ddtrace_shutdown(struct _zend_extension *extension) {
     UNUSED(extension);
 
     ddtrace_internal_handlers_shutdown();
+    zai_interceptor_shutdown();
 }
 
 static void ddtrace_activate(void) {}

--- a/ext/php7/integrations/integrations.c
+++ b/ext/php7/integrations/integrations.c
@@ -135,6 +135,7 @@ void ddtrace_integrations_minit(void) {
     zend_hash_init(&_dd_string_to_integration_name_map, ddtrace_integrations_len, NULL, NULL, 1);
 
     for (size_t i = 0; i < ddtrace_integrations_len; ++i) {
+        memset(ddtrace_integrations[i].aux, 0, sizeof(ddtrace_integrations[i].aux));
         char *name = ddtrace_integrations[i].name_lcase;
         size_t name_len = ddtrace_integrations[i].name_len;
         _dd_add_integration_to_map(name, name_len, &ddtrace_integrations[i]);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -100,6 +100,8 @@ static void ddtrace_shutdown(struct _zend_extension *extension) {
     UNUSED(extension);
 
     ddtrace_internal_handlers_shutdown();
+
+    zai_interceptor_shutdown();
 }
 
 static void ddtrace_activate(void) {}

--- a/ext/php8/integrations/integrations.c
+++ b/ext/php8/integrations/integrations.c
@@ -135,6 +135,7 @@ void ddtrace_integrations_minit(void) {
     zend_hash_init(&_dd_string_to_integration_name_map, ddtrace_integrations_len, NULL, NULL, 1);
 
     for (size_t i = 0; i < ddtrace_integrations_len; ++i) {
+        memset(ddtrace_integrations[i].aux, 0, sizeof(ddtrace_integrations[i].aux));
         char *name = ddtrace_integrations[i].name_lcase;
         size_t name_len = ddtrace_integrations[i].name_len;
         _dd_add_integration_to_map(name, name_len, &ddtrace_integrations[i]);

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -362,6 +362,10 @@ final class SpanChecker
             if (!isset($expectedTags['_dd.p.dm'])) {
                 unset($filtered['_dd.p.dm']);
             }
+            // http.client_ip is present depending on target SAPI and not helpful here to test
+            if (!isset($expectedTags['http.client_ip'])) {
+                unset($filtered['http.client_ip']);
+            }
             foreach ($expectedTags as $tagName => $tagValue) {
                 TestCase::assertArrayHasKey(
                     $tagName,

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -151,6 +151,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             if ($headers) {
                 curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             }

--- a/tests/Frameworks/Laravel/Version_4_2/composer.json
+++ b/tests/Frameworks/Laravel/Version_4_2/composer.json
@@ -34,7 +34,10 @@
 		"test": "phpunit --colors=always"
 	},
 	"config": {
-		"preferred-install": "dist"
+		"preferred-install": "dist",
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
 	},
 	"minimum-stability": "stable"
 }

--- a/tests/Frameworks/Laravel/Version_5_7/composer.json
+++ b/tests/Frameworks/Laravel/Version_5_7/composer.json
@@ -49,7 +49,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/tests/Frameworks/Laravel/Version_5_8/composer.json
+++ b/tests/Frameworks/Laravel/Version_5_8/composer.json
@@ -24,7 +24,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     },
     "extra": {
         "laravel": {

--- a/tests/Frameworks/Lumen/Version_5_2/composer.json
+++ b/tests/Frameworks/Lumen/Version_5_2/composer.json
@@ -23,5 +23,10 @@
             "tests/",
             "database/"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     }
 }

--- a/tests/Frameworks/Lumen/Version_5_6/composer.json
+++ b/tests/Frameworks/Lumen/Version_5_6/composer.json
@@ -33,6 +33,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     }
 }

--- a/tests/Frameworks/Symfony/Version_2_3/app/SymfonyRequirements.php
+++ b/tests/Frameworks/Symfony/Version_2_3/app/SymfonyRequirements.php
@@ -41,25 +41,25 @@ class Requirement
     /**
      * Constructor that initializes the requirement.
      *
-     * @param Boolean     $fulfilled   Whether the requirement is fulfilled
+     * @param bool        $fulfilled   Whether the requirement is fulfilled
      * @param string      $testMessage The message for testing the requirement
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
-     * @param Boolean     $optional    Whether this is only an optional recommendation not a mandatory requirement
+     * @param bool        $optional    Whether this is only an optional recommendation not a mandatory requirement
      */
     public function __construct($fulfilled, $testMessage, $helpHtml, $helpText = null, $optional = false)
     {
-        $this->fulfilled = (Boolean) $fulfilled;
+        $this->fulfilled = (bool) $fulfilled;
         $this->testMessage = (string) $testMessage;
         $this->helpHtml = (string) $helpHtml;
         $this->helpText = null === $helpText ? strip_tags($this->helpHtml) : (string) $helpText;
-        $this->optional = (Boolean) $optional;
+        $this->optional = (bool) $optional;
     }
 
     /**
      * Returns whether the requirement is fulfilled.
      *
-     * @return Boolean true if fulfilled, otherwise false
+     * @return bool true if fulfilled, otherwise false
      */
     public function isFulfilled()
     {
@@ -99,7 +99,7 @@ class Requirement
     /**
      * Returns whether this is only an optional recommendation and not a mandatory requirement.
      *
-     * @return Boolean true if optional, false if mandatory
+     * @return bool true if optional, false if mandatory
      */
     public function isOptional()
     {
@@ -117,16 +117,16 @@ class PhpIniRequirement extends Requirement
     /**
      * Constructor that initializes the requirement.
      *
-     * @param string           $cfgName    The configuration name used for ini_get()
-     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
-     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string|null $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
-     * @param string|null $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
-     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
-     * @param Boolean     $optional        Whether this is only an optional recommendation not a mandatory requirement
+     * @param string        $cfgName           The configuration name used for ini_get()
+     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
+     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string|null   $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
+     * @param string|null   $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
+     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param bool          $optional          Whether this is only an optional recommendation not a mandatory requirement
      */
     public function __construct($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null, $optional = false)
     {
@@ -193,7 +193,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds a mandatory requirement.
      *
-     * @param Boolean     $fulfilled   Whether the requirement is fulfilled
+     * @param bool        $fulfilled   Whether the requirement is fulfilled
      * @param string      $testMessage The message for testing the requirement
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -206,7 +206,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds an optional recommendation.
      *
-     * @param Boolean     $fulfilled   Whether the recommendation is fulfilled
+     * @param bool        $fulfilled   Whether the recommendation is fulfilled
      * @param string      $testMessage The message for testing the recommendation
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -219,15 +219,15 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds a mandatory requirement in form of a php.ini configuration.
      *
-     * @param string           $cfgName    The configuration name used for ini_get()
-     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
-     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string      $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
-     * @param string      $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
-     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param string        $cfgName           The configuration name used for ini_get()
+     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
+     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
+     * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
+     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
     public function addPhpIniRequirement($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
@@ -237,15 +237,15 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds an optional recommendation in form of a php.ini configuration.
      *
-     * @param string           $cfgName    The configuration name used for ini_get()
-     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
-     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string      $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
-     * @param string      $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
-     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param string        $cfgName           The configuration name used for ini_get()
+     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
+     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
+     * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
+     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
     public function addPhpIniRecommendation($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
@@ -343,7 +343,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Returns whether a php.ini configuration is not correct.
      *
-     * @return Boolean php.ini configuration problem?
+     * @return bool php.ini configuration problem?
      */
     public function hasPhpIniConfigIssue()
     {
@@ -405,22 +405,24 @@ class SymfonyRequirements extends RequirementCollection
         $this->addRequirement(
             is_dir(__DIR__.'/../vendor/composer'),
             'Vendor libraries must be installed',
-            'Vendor libraries are missing. Install composer following instructions from <a href="http://getcomposer.org/">http://getcomposer.org/</a>. ' .
+            'Vendor libraries are missing. Install composer following instructions from <a href="http://getcomposer.org/">http://getcomposer.org/</a>. '.
                 'Then run "<strong>php composer.phar install</strong>" to install them.'
         );
 
-        $baseDir = basename(__DIR__);
+        $cacheDir = is_dir(__DIR__.'/../var/cache') ? __DIR__.'/../var/cache' : __DIR__.'/cache';
 
         $this->addRequirement(
-            is_writable(__DIR__.'/cache'),
-            "$baseDir/cache/ directory must be writable",
-            "Change the permissions of the \"<strong>$baseDir/cache/</strong>\" directory so that the web server can write into it."
+            is_writable($cacheDir),
+            'app/cache/ or var/cache/ directory must be writable',
+            'Change the permissions of either "<strong>app/cache/</strong>" or  "<strong>var/cache/</strong>" directory so that the web server can write into it.'
         );
 
+        $logsDir = is_dir(__DIR__.'/../var/logs') ? __DIR__.'/../var/logs' : __DIR__.'/logs';
+
         $this->addRequirement(
-            is_writable(__DIR__.'/logs'),
-            "$baseDir/logs/ directory must be writable",
-            "Change the permissions of the \"<strong>$baseDir/logs/</strong>\" directory so that the web server can write into it."
+            is_writable($logsDir),
+            'app/logs/ or var/logs/ directory must be writable',
+            'Change the permissions of either "<strong>app/logs/</strong>" or  "<strong>var/logs/</strong>" directory so that the web server can write into it.'
         );
 
         $this->addPhpIniRequirement(
@@ -438,11 +440,17 @@ class SymfonyRequirements extends RequirementCollection
             }
 
             $this->addRequirement(
-                isset($timezones[date_default_timezone_get()]),
-                sprintf('Configured default timezone "%s" must be supported by your installation of PHP', date_default_timezone_get()),
+                isset($timezones[@date_default_timezone_get()]),
+                sprintf('Configured default timezone "%s" must be supported by your installation of PHP', @date_default_timezone_get()),
                 'Your default timezone is not supported by PHP. Check for typos in your <strong>php.ini</strong> file and have a look at the list of deprecated timezones at <a href="http://php.net/manual/en/timezones.others.php">http://php.net/manual/en/timezones.others.php</a>.'
             );
         }
+
+        $this->addRequirement(
+            function_exists('iconv'),
+            'iconv() must be available',
+            'Install and enable the <strong>iconv</strong> extension.'
+        );
 
         $this->addRequirement(
             function_exists('json_encode'),
@@ -528,16 +536,26 @@ class SymfonyRequirements extends RequirementCollection
             'Install the <strong>PCRE</strong> extension (version 8.0+).'
         );
 
+        if (extension_loaded('mbstring')) {
+            $this->addPhpIniRequirement(
+                'mbstring.func_overload',
+                create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
+                true,
+                'string functions should not be overloaded',
+                'Set "<strong>mbstring.func_overload</strong>" to <strong>0</strong> in php.ini<a href="#phpini">*</a> to disable function overloading by the mbstring extension.'
+            );
+        }
+
         /* optional recommendations follow */
 
         if (file_exists(__DIR__.'/../vendor/composer')) {
             require_once __DIR__.'/../vendor/autoload.php';
 
             try {
-                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+                $r = new ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
 
                 $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
-            } catch (\ReflectionException $e) {
+            } catch (ReflectionException $e) {
                 $contents = '';
             }
             $this->addRecommendation(
@@ -611,6 +629,12 @@ class SymfonyRequirements extends RequirementCollection
             'Install and enable the <strong>XML</strong> extension.'
         );
 
+        $this->addRecommendation(
+            function_exists('filter_var'),
+            'filter_var() should be available',
+            'Install and enable the <strong>filter</strong> extension.'
+        );
+
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->addRecommendation(
                 function_exists('posix_isatty'),
@@ -620,7 +644,7 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRecommendation(
-            class_exists('Locale'),
+            extension_loaded('intl'),
             'intl extension should be available',
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );
@@ -667,6 +691,8 @@ class SymfonyRequirements extends RequirementCollection
             ||
             (extension_loaded('apc') && ini_get('apc.enabled'))
             ||
+            (extension_loaded('Zend Optimizer+') && ini_get('zend_optimizerplus.enable'))
+            ||
             (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
             ||
             (extension_loaded('xcache') && ini_get('xcache.cacher'))
@@ -677,8 +703,16 @@ class SymfonyRequirements extends RequirementCollection
         $this->addRecommendation(
             $accelerator,
             'a PHP accelerator should be installed',
-            'Install and enable a <strong>PHP accelerator</strong> like APC (highly recommended).'
+            'Install and/or enable a <strong>PHP accelerator</strong> (highly recommended).'
         );
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->addRecommendation(
+                $this->getRealpathCacheSize() > 1000,
+                'realpath_cache_size should be above 1024 in php.ini',
+                'Set "<strong>realpath_cache_size</strong>" to e.g. "<strong>1024</strong>" in php.ini<a href="#phpini">*</a> to improve performance on windows.'
+            );
+        }
 
         $this->addPhpIniRecommendation('short_open_tag', false);
 
@@ -697,10 +731,34 @@ class SymfonyRequirements extends RequirementCollection
         if (class_exists('PDO')) {
             $drivers = PDO::getAvailableDrivers();
             $this->addRecommendation(
-                count($drivers),
+                count($drivers) > 0,
                 sprintf('PDO should have some drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
                 'Install <strong>PDO drivers</strong> (mandatory for Doctrine).'
             );
+        }
+    }
+
+    /**
+     * Loads realpath_cache_size from php.ini and converts it to int.
+     *
+     * (e.g. 16k is converted to 16384 int)
+     *
+     * @return int
+     */
+    protected function getRealpathCacheSize()
+    {
+        $size = ini_get('realpath_cache_size');
+        $size = trim($size);
+        $unit = strtolower(substr($size, -1, 1));
+        switch ($unit) {
+            case 'g':
+                return $size * 1024 * 1024 * 1024;
+            case 'm':
+                return $size * 1024 * 1024;
+            case 'k':
+                return $size * 1024;
+            default:
+                return (int) $size;
         }
     }
 }

--- a/tests/Frameworks/Symfony/Version_2_3/app/SymfonyRequirements.php
+++ b/tests/Frameworks/Symfony/Version_2_3/app/SymfonyRequirements.php
@@ -41,25 +41,25 @@ class Requirement
     /**
      * Constructor that initializes the requirement.
      *
-     * @param bool        $fulfilled   Whether the requirement is fulfilled
+     * @param Boolean     $fulfilled   Whether the requirement is fulfilled
      * @param string      $testMessage The message for testing the requirement
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
-     * @param bool        $optional    Whether this is only an optional recommendation not a mandatory requirement
+     * @param Boolean     $optional    Whether this is only an optional recommendation not a mandatory requirement
      */
     public function __construct($fulfilled, $testMessage, $helpHtml, $helpText = null, $optional = false)
     {
-        $this->fulfilled = (bool) $fulfilled;
+        $this->fulfilled = (Boolean) $fulfilled;
         $this->testMessage = (string) $testMessage;
         $this->helpHtml = (string) $helpHtml;
         $this->helpText = null === $helpText ? strip_tags($this->helpHtml) : (string) $helpText;
-        $this->optional = (bool) $optional;
+        $this->optional = (Boolean) $optional;
     }
 
     /**
      * Returns whether the requirement is fulfilled.
      *
-     * @return bool true if fulfilled, otherwise false
+     * @return Boolean true if fulfilled, otherwise false
      */
     public function isFulfilled()
     {
@@ -99,7 +99,7 @@ class Requirement
     /**
      * Returns whether this is only an optional recommendation and not a mandatory requirement.
      *
-     * @return bool true if optional, false if mandatory
+     * @return Boolean true if optional, false if mandatory
      */
     public function isOptional()
     {
@@ -117,16 +117,16 @@ class PhpIniRequirement extends Requirement
     /**
      * Constructor that initializes the requirement.
      *
-     * @param string        $cfgName           The configuration name used for ini_get()
-     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
-     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string|null   $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
-     * @param string|null   $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
-     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
-     * @param bool          $optional          Whether this is only an optional recommendation not a mandatory requirement
+     * @param string           $cfgName    The configuration name used for ini_get()
+     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
+     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string|null $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
+     * @param string|null $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
+     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param Boolean     $optional        Whether this is only an optional recommendation not a mandatory requirement
      */
     public function __construct($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null, $optional = false)
     {
@@ -193,7 +193,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds a mandatory requirement.
      *
-     * @param bool        $fulfilled   Whether the requirement is fulfilled
+     * @param Boolean     $fulfilled   Whether the requirement is fulfilled
      * @param string      $testMessage The message for testing the requirement
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -206,7 +206,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds an optional recommendation.
      *
-     * @param bool        $fulfilled   Whether the recommendation is fulfilled
+     * @param Boolean     $fulfilled   Whether the recommendation is fulfilled
      * @param string      $testMessage The message for testing the recommendation
      * @param string      $helpHtml    The help text formatted in HTML for resolving the problem
      * @param string|null $helpText    The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
@@ -219,15 +219,15 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds a mandatory requirement in form of a php.ini configuration.
      *
-     * @param string        $cfgName           The configuration name used for ini_get()
-     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
-     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
-     * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
-     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param string           $cfgName    The configuration name used for ini_get()
+     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
+     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string      $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
+     * @param string      $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
+     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
     public function addPhpIniRequirement($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
@@ -237,15 +237,15 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Adds an optional recommendation in form of a php.ini configuration.
      *
-     * @param string        $cfgName           The configuration name used for ini_get()
-     * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
-     *                                         or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
-     * @param bool          $approveCfgAbsence If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
-     *                                         This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
-     *                                         Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
-     * @param string        $testMessage       The message for testing the requirement (when null and $evaluation is a boolean a default message is derived)
-     * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
-     * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
+     * @param string           $cfgName    The configuration name used for ini_get()
+     * @param Boolean|callback $evaluation Either a Boolean indicating whether the configuration should evaluate to true or false,
+     *                                     or a callback function receiving the configuration value as parameter to determine the fulfillment of the requirement
+     * @param Boolean $approveCfgAbsence   If true the Requirement will be fulfilled even if the configuration option does not exist, i.e. ini_get() returns false.
+     *                                     This is helpful for abandoned configs in later PHP versions or configs of an optional extension, like Suhosin.
+     *                                     Example: You require a config to be true but PHP later removes this config and defaults it to true internally.
+     * @param string      $testMessage     The message for testing the requirement (when null and $evaluation is a Boolean a default message is derived)
+     * @param string      $helpHtml        The help text formatted in HTML for resolving the problem (when null and $evaluation is a Boolean a default help is derived)
+     * @param string|null $helpText        The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
     public function addPhpIniRecommendation($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
@@ -343,7 +343,7 @@ class RequirementCollection implements IteratorAggregate
     /**
      * Returns whether a php.ini configuration is not correct.
      *
-     * @return bool php.ini configuration problem?
+     * @return Boolean php.ini configuration problem?
      */
     public function hasPhpIniConfigIssue()
     {
@@ -405,24 +405,22 @@ class SymfonyRequirements extends RequirementCollection
         $this->addRequirement(
             is_dir(__DIR__.'/../vendor/composer'),
             'Vendor libraries must be installed',
-            'Vendor libraries are missing. Install composer following instructions from <a href="http://getcomposer.org/">http://getcomposer.org/</a>. '.
+            'Vendor libraries are missing. Install composer following instructions from <a href="http://getcomposer.org/">http://getcomposer.org/</a>. ' .
                 'Then run "<strong>php composer.phar install</strong>" to install them.'
         );
 
-        $cacheDir = is_dir(__DIR__.'/../var/cache') ? __DIR__.'/../var/cache' : __DIR__.'/cache';
+        $baseDir = basename(__DIR__);
 
         $this->addRequirement(
-            is_writable($cacheDir),
-            'app/cache/ or var/cache/ directory must be writable',
-            'Change the permissions of either "<strong>app/cache/</strong>" or  "<strong>var/cache/</strong>" directory so that the web server can write into it.'
+            is_writable(__DIR__.'/cache'),
+            "$baseDir/cache/ directory must be writable",
+            "Change the permissions of the \"<strong>$baseDir/cache/</strong>\" directory so that the web server can write into it."
         );
 
-        $logsDir = is_dir(__DIR__.'/../var/logs') ? __DIR__.'/../var/logs' : __DIR__.'/logs';
-
         $this->addRequirement(
-            is_writable($logsDir),
-            'app/logs/ or var/logs/ directory must be writable',
-            'Change the permissions of either "<strong>app/logs/</strong>" or  "<strong>var/logs/</strong>" directory so that the web server can write into it.'
+            is_writable(__DIR__.'/logs'),
+            "$baseDir/logs/ directory must be writable",
+            "Change the permissions of the \"<strong>$baseDir/logs/</strong>\" directory so that the web server can write into it."
         );
 
         $this->addPhpIniRequirement(
@@ -440,17 +438,11 @@ class SymfonyRequirements extends RequirementCollection
             }
 
             $this->addRequirement(
-                isset($timezones[@date_default_timezone_get()]),
-                sprintf('Configured default timezone "%s" must be supported by your installation of PHP', @date_default_timezone_get()),
+                isset($timezones[date_default_timezone_get()]),
+                sprintf('Configured default timezone "%s" must be supported by your installation of PHP', date_default_timezone_get()),
                 'Your default timezone is not supported by PHP. Check for typos in your <strong>php.ini</strong> file and have a look at the list of deprecated timezones at <a href="http://php.net/manual/en/timezones.others.php">http://php.net/manual/en/timezones.others.php</a>.'
             );
         }
-
-        $this->addRequirement(
-            function_exists('iconv'),
-            'iconv() must be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
 
         $this->addRequirement(
             function_exists('json_encode'),
@@ -536,26 +528,16 @@ class SymfonyRequirements extends RequirementCollection
             'Install the <strong>PCRE</strong> extension (version 8.0+).'
         );
 
-        if (extension_loaded('mbstring')) {
-            $this->addPhpIniRequirement(
-                'mbstring.func_overload',
-                create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
-                true,
-                'string functions should not be overloaded',
-                'Set "<strong>mbstring.func_overload</strong>" to <strong>0</strong> in php.ini<a href="#phpini">*</a> to disable function overloading by the mbstring extension.'
-            );
-        }
-
         /* optional recommendations follow */
 
         if (file_exists(__DIR__.'/../vendor/composer')) {
             require_once __DIR__.'/../vendor/autoload.php';
 
             try {
-                $r = new ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
 
                 $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
-            } catch (ReflectionException $e) {
+            } catch (\ReflectionException $e) {
                 $contents = '';
             }
             $this->addRecommendation(
@@ -629,12 +611,6 @@ class SymfonyRequirements extends RequirementCollection
             'Install and enable the <strong>XML</strong> extension.'
         );
 
-        $this->addRecommendation(
-            function_exists('filter_var'),
-            'filter_var() should be available',
-            'Install and enable the <strong>filter</strong> extension.'
-        );
-
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->addRecommendation(
                 function_exists('posix_isatty'),
@@ -644,7 +620,7 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRecommendation(
-            extension_loaded('intl'),
+            class_exists('Locale'),
             'intl extension should be available',
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );
@@ -691,8 +667,6 @@ class SymfonyRequirements extends RequirementCollection
             ||
             (extension_loaded('apc') && ini_get('apc.enabled'))
             ||
-            (extension_loaded('Zend Optimizer+') && ini_get('zend_optimizerplus.enable'))
-            ||
             (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
             ||
             (extension_loaded('xcache') && ini_get('xcache.cacher'))
@@ -703,16 +677,8 @@ class SymfonyRequirements extends RequirementCollection
         $this->addRecommendation(
             $accelerator,
             'a PHP accelerator should be installed',
-            'Install and/or enable a <strong>PHP accelerator</strong> (highly recommended).'
+            'Install and enable a <strong>PHP accelerator</strong> like APC (highly recommended).'
         );
-
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $this->addRecommendation(
-                $this->getRealpathCacheSize() > 1000,
-                'realpath_cache_size should be above 1024 in php.ini',
-                'Set "<strong>realpath_cache_size</strong>" to e.g. "<strong>1024</strong>" in php.ini<a href="#phpini">*</a> to improve performance on windows.'
-            );
-        }
 
         $this->addPhpIniRecommendation('short_open_tag', false);
 
@@ -731,34 +697,10 @@ class SymfonyRequirements extends RequirementCollection
         if (class_exists('PDO')) {
             $drivers = PDO::getAvailableDrivers();
             $this->addRecommendation(
-                count($drivers) > 0,
+                count($drivers),
                 sprintf('PDO should have some drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
                 'Install <strong>PDO drivers</strong> (mandatory for Doctrine).'
             );
-        }
-    }
-
-    /**
-     * Loads realpath_cache_size from php.ini and converts it to int.
-     *
-     * (e.g. 16k is converted to 16384 int)
-     *
-     * @return int
-     */
-    protected function getRealpathCacheSize()
-    {
-        $size = ini_get('realpath_cache_size');
-        $size = trim($size);
-        $unit = strtolower(substr($size, -1, 1));
-        switch ($unit) {
-            case 'g':
-                return $size * 1024 * 1024 * 1024;
-            case 'm':
-                return $size * 1024 * 1024;
-            case 'k':
-                return $size * 1024;
-            default:
-                return (int) $size;
         }
     }
 }

--- a/tests/Frameworks/Symfony/Version_2_3/app/check.php
+++ b/tests/Frameworks/Symfony/Version_2_3/app/check.php
@@ -2,61 +2,141 @@
 
 require_once dirname(__FILE__).'/SymfonyRequirements.php';
 
+$lineSize = 70;
 $symfonyRequirements = new SymfonyRequirements();
-
 $iniPath = $symfonyRequirements->getPhpIniConfigPath();
 
-echo "********************************\n";
-echo "*                              *\n";
-echo "*  Symfony requirements check  *\n";
-echo "*                              *\n";
-echo "********************************\n\n";
+echo_title('Symfony Requirements Checker');
 
-echo $iniPath ? sprintf("* Configuration file used by PHP: %s\n\n", $iniPath) : "* WARNING: No configuration file (php.ini) used by PHP!\n\n";
-
-echo "** ATTENTION **\n";
-echo "*  The PHP CLI can use a different php.ini file\n";
-echo "*  than the one used with your web server.\n";
-if ('\\' == DIRECTORY_SEPARATOR) {
-    echo "*  (especially on the Windows platform)\n";
+echo '> PHP is using the following php.ini file:'.PHP_EOL;
+if ($iniPath) {
+    echo_style('green', '  '.$iniPath);
+} else {
+    echo_style('warning', '  WARNING: No configuration file (php.ini) used by PHP!');
 }
-echo "*  To be on the safe side, please also launch the requirements check\n";
-echo "*  from your web server using the web/config.php script.\n";
 
-echo_title('Mandatory requirements');
+echo PHP_EOL.PHP_EOL;
 
-$checkPassed = true;
+echo '> Checking Symfony requirements:'.PHP_EOL.'  ';
+
+$messages = array();
 foreach ($symfonyRequirements->getRequirements() as $req) {
     /** @var $req Requirement */
-    echo_requirement($req);
-    if (!$req->isFulfilled()) {
-        $checkPassed = false;
+    if ($helpText = get_error_message($req, $lineSize)) {
+        echo_style('red', 'E');
+        $messages['error'][] = $helpText;
+    } else {
+        echo_style('green', '.');
     }
 }
 
-echo_title('Optional recommendations');
+$checkPassed = empty($messages['error']);
 
 foreach ($symfonyRequirements->getRecommendations() as $req) {
-    echo_requirement($req);
+    if ($helpText = get_error_message($req, $lineSize)) {
+        echo_style('yellow', 'W');
+        $messages['warning'][] = $helpText;
+    } else {
+        echo_style('green', '.');
+    }
 }
+
+if ($checkPassed) {
+    echo_block('success', 'OK', 'Your system is ready to run Symfony projects');
+} else {
+    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony projects');
+
+    echo_title('Fix the following mandatory requirements', 'red');
+
+    foreach ($messages['error'] as $helpText) {
+        echo ' * '.$helpText.PHP_EOL;
+    }
+}
+
+if (!empty($messages['warning'])) {
+    echo_title('Optional recommendations to improve your setup', 'yellow');
+
+    foreach ($messages['warning'] as $helpText) {
+        echo ' * '.$helpText.PHP_EOL;
+    }
+}
+
+echo PHP_EOL;
+echo_style('title', 'Note');
+echo '  The command console could use a different php.ini file'.PHP_EOL;
+echo_style('title', '~~~~');
+echo '  than the one used with your web server. To be on the'.PHP_EOL;
+echo '      safe side, please check the requirements from your web'.PHP_EOL;
+echo '      server using the ';
+echo_style('yellow', 'web/config.php');
+echo ' script.'.PHP_EOL;
+echo PHP_EOL;
 
 exit($checkPassed ? 0 : 1);
 
-/**
- * Prints a Requirement instance
- */
-function echo_requirement(Requirement $requirement)
+function get_error_message(Requirement $requirement, $lineSize)
 {
-    $result = $requirement->isFulfilled() ? 'OK' : ($requirement->isOptional() ? 'WARNING' : 'ERROR');
-    echo ' ' . str_pad($result, 9);
-    echo $requirement->getTestMessage() . "\n";
-
-    if (!$requirement->isFulfilled()) {
-        echo sprintf("          %s\n\n", $requirement->getHelpText());
+    if ($requirement->isFulfilled()) {
+        return;
     }
+
+    $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
+    $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
+
+    return $errorMessage;
 }
 
-function echo_title($title)
+function echo_title($title, $style = null)
 {
-    echo "\n** $title **\n\n";
+    $style = $style ?: 'title';
+
+    echo PHP_EOL;
+    echo_style($style, $title.PHP_EOL);
+    echo_style($style, str_repeat('~', strlen($title)).PHP_EOL);
+    echo PHP_EOL;
+}
+
+function echo_style($style, $message)
+{
+    // ANSI color codes
+    $styles = array(
+        'reset' => "\033[0m",
+        'red' => "\033[31m",
+        'green' => "\033[32m",
+        'yellow' => "\033[33m",
+        'error' => "\033[37;41m",
+        'success' => "\033[37;42m",
+        'title' => "\033[34m",
+    );
+    $supports = has_color_support();
+
+    echo($supports ? $styles[$style] : '').$message.($supports ? $styles['reset'] : '');
+}
+
+function echo_block($style, $title, $message)
+{
+    $message = ' '.trim($message).' ';
+    $width = strlen($message);
+
+    echo PHP_EOL.PHP_EOL;
+
+    echo_style($style, str_repeat(' ', $width).PHP_EOL);
+    echo_style($style, str_pad(' ['.$title.']',  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
+    echo_style($style, str_pad($message,  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
+    echo_style($style, str_repeat(' ', $width).PHP_EOL);
+}
+
+function has_color_support()
+{
+    static $support;
+
+    if (null === $support) {
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $support = false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
+        } else {
+            $support = function_exists('posix_isatty') && @posix_isatty(STDOUT);
+        }
+    }
+
+    return $support;
 }

--- a/tests/Frameworks/Symfony/Version_2_3/app/check.php
+++ b/tests/Frameworks/Symfony/Version_2_3/app/check.php
@@ -2,141 +2,61 @@
 
 require_once dirname(__FILE__).'/SymfonyRequirements.php';
 
-$lineSize = 70;
 $symfonyRequirements = new SymfonyRequirements();
+
 $iniPath = $symfonyRequirements->getPhpIniConfigPath();
 
-echo_title('Symfony Requirements Checker');
+echo "********************************\n";
+echo "*                              *\n";
+echo "*  Symfony requirements check  *\n";
+echo "*                              *\n";
+echo "********************************\n\n";
 
-echo '> PHP is using the following php.ini file:'.PHP_EOL;
-if ($iniPath) {
-    echo_style('green', '  '.$iniPath);
-} else {
-    echo_style('warning', '  WARNING: No configuration file (php.ini) used by PHP!');
+echo $iniPath ? sprintf("* Configuration file used by PHP: %s\n\n", $iniPath) : "* WARNING: No configuration file (php.ini) used by PHP!\n\n";
+
+echo "** ATTENTION **\n";
+echo "*  The PHP CLI can use a different php.ini file\n";
+echo "*  than the one used with your web server.\n";
+if ('\\' == DIRECTORY_SEPARATOR) {
+    echo "*  (especially on the Windows platform)\n";
 }
+echo "*  To be on the safe side, please also launch the requirements check\n";
+echo "*  from your web server using the web/config.php script.\n";
 
-echo PHP_EOL.PHP_EOL;
+echo_title('Mandatory requirements');
 
-echo '> Checking Symfony requirements:'.PHP_EOL.'  ';
-
-$messages = array();
+$checkPassed = true;
 foreach ($symfonyRequirements->getRequirements() as $req) {
     /** @var $req Requirement */
-    if ($helpText = get_error_message($req, $lineSize)) {
-        echo_style('red', 'E');
-        $messages['error'][] = $helpText;
-    } else {
-        echo_style('green', '.');
+    echo_requirement($req);
+    if (!$req->isFulfilled()) {
+        $checkPassed = false;
     }
 }
 
-$checkPassed = empty($messages['error']);
+echo_title('Optional recommendations');
 
 foreach ($symfonyRequirements->getRecommendations() as $req) {
-    if ($helpText = get_error_message($req, $lineSize)) {
-        echo_style('yellow', 'W');
-        $messages['warning'][] = $helpText;
-    } else {
-        echo_style('green', '.');
-    }
+    echo_requirement($req);
 }
-
-if ($checkPassed) {
-    echo_block('success', 'OK', 'Your system is ready to run Symfony projects');
-} else {
-    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony projects');
-
-    echo_title('Fix the following mandatory requirements', 'red');
-
-    foreach ($messages['error'] as $helpText) {
-        echo ' * '.$helpText.PHP_EOL;
-    }
-}
-
-if (!empty($messages['warning'])) {
-    echo_title('Optional recommendations to improve your setup', 'yellow');
-
-    foreach ($messages['warning'] as $helpText) {
-        echo ' * '.$helpText.PHP_EOL;
-    }
-}
-
-echo PHP_EOL;
-echo_style('title', 'Note');
-echo '  The command console could use a different php.ini file'.PHP_EOL;
-echo_style('title', '~~~~');
-echo '  than the one used with your web server. To be on the'.PHP_EOL;
-echo '      safe side, please check the requirements from your web'.PHP_EOL;
-echo '      server using the ';
-echo_style('yellow', 'web/config.php');
-echo ' script.'.PHP_EOL;
-echo PHP_EOL;
 
 exit($checkPassed ? 0 : 1);
 
-function get_error_message(Requirement $requirement, $lineSize)
+/**
+ * Prints a Requirement instance
+ */
+function echo_requirement(Requirement $requirement)
 {
-    if ($requirement->isFulfilled()) {
-        return;
+    $result = $requirement->isFulfilled() ? 'OK' : ($requirement->isOptional() ? 'WARNING' : 'ERROR');
+    echo ' ' . str_pad($result, 9);
+    echo $requirement->getTestMessage() . "\n";
+
+    if (!$requirement->isFulfilled()) {
+        echo sprintf("          %s\n\n", $requirement->getHelpText());
     }
-
-    $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
-    $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
-
-    return $errorMessage;
 }
 
-function echo_title($title, $style = null)
+function echo_title($title)
 {
-    $style = $style ?: 'title';
-
-    echo PHP_EOL;
-    echo_style($style, $title.PHP_EOL);
-    echo_style($style, str_repeat('~', strlen($title)).PHP_EOL);
-    echo PHP_EOL;
-}
-
-function echo_style($style, $message)
-{
-    // ANSI color codes
-    $styles = array(
-        'reset' => "\033[0m",
-        'red' => "\033[31m",
-        'green' => "\033[32m",
-        'yellow' => "\033[33m",
-        'error' => "\033[37;41m",
-        'success' => "\033[37;42m",
-        'title' => "\033[34m",
-    );
-    $supports = has_color_support();
-
-    echo($supports ? $styles[$style] : '').$message.($supports ? $styles['reset'] : '');
-}
-
-function echo_block($style, $title, $message)
-{
-    $message = ' '.trim($message).' ';
-    $width = strlen($message);
-
-    echo PHP_EOL.PHP_EOL;
-
-    echo_style($style, str_repeat(' ', $width).PHP_EOL);
-    echo_style($style, str_pad(' ['.$title.']',  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
-    echo_style($style, str_pad($message,  $width, ' ', STR_PAD_RIGHT).PHP_EOL);
-    echo_style($style, str_repeat(' ', $width).PHP_EOL);
-}
-
-function has_color_support()
-{
-    static $support;
-
-    if (null === $support) {
-        if (DIRECTORY_SEPARATOR == '\\') {
-            $support = false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
-        } else {
-            $support = function_exists('posix_isatty') && @posix_isatty(STDOUT);
-        }
-    }
-
-    return $support;
+    echo "\n** $title **\n\n";
 }

--- a/tests/Frameworks/Yii/Version_2_0/composer.json
+++ b/tests/Frameworks/Yii/Version_2_0/composer.json
@@ -28,6 +28,9 @@
         "process-timeout": 1800,
         "fxp-asset": {
             "enabled": false
+        },
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
         }
     },
     "scripts": {

--- a/tests/Integrations/Custom/Autoloaded/StartupLoggingTest.php
+++ b/tests/Integrations/Custom/Autoloaded/StartupLoggingTest.php
@@ -71,6 +71,10 @@ final class StartupLoggingTest extends WebFrameworkTestCase
 
     public function testLogsNotGeneratedAfterFirstRequest()
     {
+        if (\getenv('DD_TRACE_TEST_SAPI') == 'apache2handler') {
+            $this->markTestSkipped("Test does not make sense with multi-processing");
+        }
+
         $this->tracesFromWebRequest(function () {
             $spec = GetSpec::create('Second request: Startup logs test', '/simple');
             $this->call($spec);

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -36,6 +36,18 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
+        $tags = [
+            'http.method' => 'GET',
+            'http.url' => 'http://localhost:' . self::PORT . '/',
+            'http.status_code' => 200,
+            'http.request.headers.first-header' => 'some value: with colon',
+            'http.request.headers.forth-header' => '123',
+            'http.response.headers.third-header' => 'separated: with  : colon',
+        ];
+        if (\getenv('DD_TRACE_TEST_SAPI') != 'apache2handler') {
+            $tags['http.request.headers.w__rd-header'] = 'foo';
+        }
+
         $this->assertFlameGraph(
             $traces,
             [
@@ -44,15 +56,7 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
                     'my-service',
                     'web',
                     'GET /'
-                )->withExactTags([
-                    'http.method' => 'GET',
-                    'http.url' => 'http://localhost:' . self::PORT . '/',
-                    'http.status_code' => 200,
-                    'http.request.headers.first-header' => 'some value: with colon',
-                    'http.request.headers.forth-header' => '123',
-                    'http.request.headers.w__rd-header' => 'foo',
-                    'http.response.headers.third-header' => 'separated: with  : colon',
-                ]),
+                )->withExactTags($tags),
             ]
         );
     }

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -26,6 +26,8 @@ class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
+        // Under Apache Symfony does redirection magic
+        $isApache = \getenv('DD_TRACE_TEST_SAPI') == 'apache2handler';
         $this->assertFlameGraph($traces, [
             SpanAssertion::build(
                 'web.request',
@@ -34,7 +36,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([
                 'http.method' => 'GET',
-                'http.url' => 'http://localhost:' . self::PORT . '/app.php',
+                'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -23,6 +23,7 @@ class RouteNameTest extends WebFrameworkTestCase
             $this->call($spec);
         });
 
+        $isApache = \getenv('DD_TRACE_TEST_SAPI') == 'apache2handler';
         $this->assertFlameGraph($traces, [
             SpanAssertion::build(
                 'web.request',
@@ -31,7 +32,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([
                 'http.method' => 'GET',
-                'http.url' => 'http://localhost:' . self::PORT . '/app.php',
+                'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -30,42 +30,46 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
     public function provideSpecs()
     {
-        return $this->buildDataProvider(
-            [
-                'A simple GET request returning a string' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@index default')
-                        ->withExactTags([
-                            'zf1.controller' => 'simple',
-                            'zf1.action' => 'index',
-                            'zf1.route_name' => 'default',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
-                            'http.status_code' => '200',
-                        ]),
-                ],
-                'A simple GET request with a view' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@view my_simple_view_route')
-                        ->withExactTags([
-                            'zf1.controller' => 'simple',
-                            'zf1.action' => 'view',
-                            'zf1.route_name' => 'my_simple_view_route',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
-                            'http.status_code' => '200',
-                        ]),
-                ],
-                'A GET request with an exception' => [
-                    SpanAssertion::build('zf1.request', 'zf1', 'web', 'error@error default')
-                        ->withExactTags([
-                            'zf1.controller' => 'error',
-                            'zf1.action' => 'error',
-                            'zf1.route_name' => 'default',
-                            'http.method' => 'GET',
-                            'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
-                            'http.status_code' => '500',
-                        ])->setError(),
-                ],
-            ]
-        );
+        $specs = [
+            'A simple GET request returning a string' => [
+                SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@index default')
+                    ->withExactTags([
+                        'zf1.controller' => 'simple',
+                        'zf1.action' => 'index',
+                        'zf1.route_name' => 'default',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
+                        'http.status_code' => '200',
+                    ]),
+            ],
+            'A simple GET request with a view' => [
+                SpanAssertion::build('zf1.request', 'zf1', 'web', 'simple@view my_simple_view_route')
+                    ->withExactTags([
+                        'zf1.controller' => 'simple',
+                        'zf1.action' => 'view',
+                        'zf1.route_name' => 'my_simple_view_route',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
+                        'http.status_code' => '200',
+                    ]),
+            ],
+            'A GET request with an exception' => [
+                SpanAssertion::build('zf1.request', 'zf1', 'web', 'error@error default')
+                    ->withExactTags([
+                        'zf1.controller' => 'error',
+                        'zf1.action' => 'error',
+                        'zf1.route_name' => 'default',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
+                        'http.status_code' => '500',
+                    ]),
+            ],
+        ];
+        if (\getenv('DD_TRACE_TEST_SAPI') == 'apache2handler') { // i.e. with opcache
+            $specs['A GET request with an exception'][0]->setError('Exception', 'Controller error', true);
+        } else {
+            $specs['A GET request with an exception'][0]->setError();
+        }
+        return $this->buildDataProvider($specs);
     }
 }

--- a/tests/Metrics/SigSegV/SigSegVTest.php
+++ b/tests/Metrics/SigSegV/SigSegVTest.php
@@ -5,6 +5,7 @@ namespace DDTrace\Tests\Metrics\SigSegV;
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 use DDTrace\Tests\WebServer;
+use PHPUnit\Framework\AssertionFailedError;
 
 class SigSegVTest extends WebFrameworkTestCase
 {
@@ -37,7 +38,10 @@ class SigSegVTest extends WebFrameworkTestCase
         self::assertFileNotExists($log);
 
         $spec = GetSpec::create('sigsegv', '/sigsegv.php');
-        $this->call($spec);
+        try {
+            $this->call($spec);
+        } catch (AssertionFailedError $e) {
+        }
 
         self::assertFileExists($log);
         $contents = \file_get_contents($log);

--- a/tests/Sapi/PhpApache/PhpApache.php
+++ b/tests/Sapi/PhpApache/PhpApache.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace DDTrace\Tests\Sapi\PhpApache;
+
+use DDTrace\Tests\Sapi\Sapi;
+use Symfony\Component\Process\Process;
+
+final class PhpApache implements Sapi
+{
+    const ERROR_LOG = 'apache_error.log';
+
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * @var array
+     */
+    private $envs;
+
+    /**
+     * @var array
+     */
+    private $inis;
+
+    /**
+     * @var string
+     */
+    private $configFile;
+
+    /**
+     * @var string
+     */
+    private $logFilePath;
+
+    /**
+     * @var resource
+     */
+    private $logFile;
+
+    /**
+     * @var bool
+     */
+    private $configChanged = false;
+
+    /**
+     * @var string
+     */
+    private $configContent;
+
+    /**
+     * @var string
+     */
+    private $runDir;
+
+    /**
+     * @param string $rootPath
+     * @param string $host
+     * @param int $port
+     * @param array $envs
+     * @param array $inis
+     */
+    public function loadConfig($rootPath, $host, $port, array $envs = [], array $inis = [])
+    {
+        $defaultInis = [
+            "opcache.enable" => "1",
+            "opcache.jit_buffer_size" => "100M",
+            "opcache.jit" => "1255",
+        ];
+
+        $this->envs = $envs;
+        $this->inis = $defaultInis + $inis;
+
+        $logPath = $rootPath . '/' . self::ERROR_LOG;
+
+        if (!$this->runDir) {
+            $this->runDir = sys_get_temp_dir() . uniqid('/apache2-rundir-', true);
+            mkdir($this->runDir);
+        }
+
+        $replacements = [
+            '{{document_root}}' => $rootPath,
+            '{{vhost_host}}' => $host === "0.0.0.0" ? "*" : $host,
+            '{{vhost_port}}' => $port,
+            '{{envs}}' => $this->envsForConfFile(),
+            '{{inis}}' => $this->inisForConfFile(),
+            '{{error_log}}' => $logPath,
+            '{{run_dir}}' => $this->runDir,
+        ];
+        $configContent = str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            file_get_contents(__DIR__ . '/apache2.conf')
+        );
+
+        if ($this->configContent === $configContent) {
+            error_log("[apache] Skipping config file regeneration, identical configs.");
+        } else {
+            if (!$this->configFile) {
+                $this->configFile = sys_get_temp_dir() . uniqid('/apache2-conf-', true);
+            }
+            $this->configChanged = true;
+            if ($this->logFilePath !== $logPath) {
+                $this->logFilePath = $logPath;
+                $this->logFile = fopen($logPath, "a+");
+            }
+
+            // This gets logged to phpunit_error.log (check CircleCI artifacts)
+            error_log("[apache] Generated config file '{$this->configFile}'");
+            error_log("[apache] Error log: '" . $replacements['{{error_log}}'] . "'");
+            error_log("[apache]\n{$configContent}");
+
+            $this->configContent = $configContent;
+            if (false === file_put_contents($this->configFile, $configContent)) {
+                throw new \Exception('Error creating temp apache config file: ' . $this->configFile);
+            }
+        }
+    }
+
+    public function start()
+    {
+        if ($this->process) {
+            if ($this->configChanged) {
+                $this->process->signal(SIGUSR1);
+                error_log("[apache] Reloading {$this->process->getPid()}");
+            }
+        } else {
+            $cmd = sprintf(
+                'apache2 -D FOREGROUND -f %s -E %s',
+                $this->configFile,
+                __DIR__ . "/" . self::ERROR_LOG
+            );
+            // setsid as apache broadcasts termination signals to its whole process group
+            $processCmd = "exec setsid $cmd";
+
+            // See phpunit_error.log in CircleCI artifacts
+            error_log("[apache] Starting: '{$cmd}'");
+
+            $this->process = new Process($processCmd);
+            $this->process->start();
+        }
+        $this->configChanged = false;
+    }
+
+    public function stop()
+    {
+        // I do not understand why we get a SIGTERM when we try to send a SIGTERM to apache.
+        // Somewhere something goes wrong, but I could not figure out where.
+        error_log("[apache] Stopping...");
+        $this->process->stop(1);
+    }
+
+    public function __destruct()
+    {
+        $this->stop();
+        if ($this->configFile) {
+            unlink($this->configFile);
+        }
+        if ($this->runDir) {
+            rmdir($this->runDir);
+        }
+    }
+
+    public function isFastCgi()
+    {
+        return false;
+    }
+
+    private function envsForConfFile()
+    {
+        $lines = [];
+        foreach ($this->envs as $name => $value) {
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+            if ('' !== $value) {
+                $lines[] = sprintf('SetEnv %s "%s"', $name, str_replace('"', '\"', $value));
+            }
+        }
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function inisForConfFile()
+    {
+        $lines = [];
+        foreach ($this->inis as $name => $value) {
+            switch ($value) {
+                case '0':
+                case '1':
+                case 'true':
+                case 'false':
+                case 'on':
+                case 'off':
+                case 'yes':
+                case 'no':
+                    $lines[] = sprintf('php_admin_flag %s "%s"', $name, $value);
+                    break;
+                default:
+                    $lines[] = sprintf('php_admin_value %s "%s"', $name, $value);
+                    break;
+            }
+        }
+        return implode(PHP_EOL, $lines);
+    }
+
+    public function checkErrors()
+    {
+        $newLogs = stream_get_contents($this->logFile);
+        if (preg_match("(=== Total [0-9]+ memory leaks detected ===)", $newLogs)) {
+            return $newLogs;
+        }
+
+        if (preg_match("(child [0-9]+ exited on signal)", $newLogs)) {
+            return $newLogs;
+        }
+
+        return null;
+    }
+}

--- a/tests/Sapi/PhpApache/apache2.conf
+++ b/tests/Sapi/PhpApache/apache2.conf
@@ -1,0 +1,38 @@
+ServerRoot /etc/apache2
+DefaultRuntimeDir {{run_dir}}
+PidFile {{run_dir}}/apache2.pid
+CoreDumpDirectory {{document_root}}
+Timeout 30
+KeepAlive On
+MaxKeepAliveRequests 100
+KeepAliveTimeout 5
+HostnameLookups Off
+ErrorLog {{error_log}}
+LogLevel info
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+IncludeOptional conf-enabled/*.conf
+
+<Directory />
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>
+
+Listen {{vhost_port}}
+<VirtualHost {{vhost_host}}:{{vhost_port}}>
+    DocumentRoot {{document_root}}
+
+    ErrorLog {{error_log}}
+    CustomLog {{error_log}} vhost_combined
+
+    RewriteEngine on
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^([^.]*)$ /index.php/$1 [L,QSA]
+
+{{envs}}
+
+{{inis}}
+</VirtualHost>

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -4,6 +4,7 @@ namespace DDTrace\Tests;
 
 use DDTrace\Tests\Nginx\NginxServer;
 use DDTrace\Tests\Sapi\CliServer\CliServer;
+use DDTrace\Tests\Sapi\PhpApache\PhpApache;
 use DDTrace\Tests\Sapi\PhpCgi\PhpCgi;
 use DDTrace\Tests\Sapi\PhpFpm\PhpFpm;
 use DDTrace\Tests\Sapi\Sapi;
@@ -71,6 +72,13 @@ final class WebServer
     ];
 
     /**
+     * Persisted apache instance for the life time of the testsuite - we use reload instead of restart to apply changes
+     *
+     * @var PhpApache
+     */
+    private static $apache = null;
+
+    /**
      * @param string $indexFile
      * @param string $host
      * @param int $port
@@ -104,6 +112,23 @@ final class WebServer
                     $this->envs,
                     $this->inis
                 );
+                break;
+            case 'apache2handler':
+                if (!self::$apache) {
+                    self::$apache = new PhpApache();
+                    register_shutdown_function(static function () {
+                        self::$apache->stop();
+                        self::$apache = null;
+                    });
+                }
+                self::$apache->loadConfig(
+                    dirname($this->indexFile),
+                    $this->host,
+                    $this->port,
+                    $this->envs,
+                    $this->inis
+                );
+                $this->sapi = self::$apache;
                 break;
             default:
                 $this->sapi = new CliServer(
@@ -143,7 +168,9 @@ final class WebServer
                 // are actually sent to the agent via the BGS.
                 \usleep($this->envs['DD_TRACE_AGENT_FLUSH_INTERVAL'] * 2 * 1000);
             }
-            $this->sapi->stop();
+            if ($this->sapi !== self::$apache) {
+                $this->sapi->stop();
+            }
         }
         if ($this->server) {
             $this->server->stop();

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -72,7 +72,8 @@ final class WebServer
     ];
 
     /**
-     * Persisted apache instance for the life time of the testsuite - we use reload instead of restart to apply changes
+     * Persisted apache instance for the lifetime of the testsuite - we use reload instead of restart to apply changes.
+     * The primary use case is verifying repeated MINIT+MSHUTDOWN invocations within a same process.
      *
      * @var PhpApache
      */

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -1127,3 +1127,22 @@ void zai_interceptor_rinit() {
 void zai_interceptor_rshutdown() {
     zend_hash_destroy(&zai_hook_memory);
 }
+
+void zai_interceptor_shutdown_resolving(void);
+void zai_interceptor_shutdown() {
+    zend_set_user_opcode_handler(ZEND_EXT_NOP, NULL);
+    zend_set_user_opcode_handler(ZEND_RETURN, NULL);
+    zend_set_user_opcode_handler(ZEND_RETURN_BY_REF, NULL);
+    zend_set_user_opcode_handler(ZEND_GENERATOR_RETURN, NULL);
+    zend_set_user_opcode_handler(ZEND_HANDLE_EXCEPTION, NULL);
+    zend_set_user_opcode_handler(ZEND_FAST_RET, NULL);
+    zend_set_user_opcode_handler(ZEND_YIELD, NULL);
+    zend_set_user_opcode_handler(ZEND_YIELD_FROM, NULL);
+    zend_set_user_opcode_handler(ZAI_INTERCEPTOR_GENERATOR_RESUMPTION_OP, NULL);
+#if PHP_VERSION_ID >= 70100
+    zend_set_user_opcode_handler(ZAI_INTERCEPTOR_POST_GENERATOR_CREATE_OP, NULL);
+    zend_set_user_opcode_handler(ZEND_GENERATOR_CREATE, NULL);
+#endif
+
+    zai_interceptor_shutdown_resolving();
+}

--- a/zend_abstract_interface/interceptor/php7/interceptor.h
+++ b/zend_abstract_interface/interceptor/php7/interceptor.h
@@ -9,6 +9,7 @@ void zai_interceptor_op_array_pass_two(zend_op_array *op_array);
 void zai_interceptor_startup(zend_module_entry *module_entry);
 void zai_interceptor_rinit(void);
 void zai_interceptor_rshutdown(void);
+void zai_interceptor_shutdown(void);
 
 void zai_interceptor_terminate_all_pending_observers(void);
 

--- a/zend_abstract_interface/interceptor/php7/resolver.c
+++ b/zend_abstract_interface/interceptor/php7/resolver.c
@@ -288,3 +288,16 @@ void zai_interceptor_setup_resolving_post_startup(void) {
     prev_exception_hook = zend_throw_exception_hook;
     zend_throw_exception_hook = zai_interceptor_exception_hook;
 }
+
+void zai_interceptor_shutdown_resolving(void) {
+    zend_set_user_opcode_handler(ZEND_DECLARE_FUNCTION, NULL);
+    zend_set_user_opcode_handler(ZEND_DECLARE_CLASS, NULL);
+#if PHP_VERSION_ID > 70400
+    zend_set_user_opcode_handler(ZEND_DECLARE_CLASS_DELAYED, NULL);
+#else
+    zend_set_user_opcode_handler(ZEND_DECLARE_INHERITED_CLASS, NULL);
+    zend_set_user_opcode_handler(ZEND_DECLARE_INHERITED_CLASS_DELAYED, NULL);
+    zend_set_user_opcode_handler(ZEND_BIND_TRAITS, NULL);
+#endif
+    zend_set_user_opcode_handler(ZAI_INTERCEPTOR_POST_DECLARE_OP, NULL);
+}

--- a/zend_abstract_interface/interceptor/php8/interceptor.h
+++ b/zend_abstract_interface/interceptor/php8/interceptor.h
@@ -5,5 +5,6 @@ void zai_interceptor_minit(void);
 void zai_interceptor_startup(void);
 void zai_interceptor_rinit(void);
 void zai_interceptor_rshutdown(void);
+void zai_interceptor_shutdown(void);
 
 #endif  // ZAI_INTERCEPTOR_H

--- a/zend_abstract_interface/interceptor/php8/resolver.c
+++ b/zend_abstract_interface/interceptor/php8/resolver.c
@@ -340,3 +340,11 @@ void zai_interceptor_setup_resolving_post_startup(void) {
 #endif
     }
 }
+
+void zai_interceptor_shutdown(void) {
+    zend_set_user_opcode_handler(ZEND_DECLARE_FUNCTION, NULL);
+    zend_set_user_opcode_handler(ZEND_DECLARE_CLASS, NULL);
+    zend_set_user_opcode_handler(ZEND_DECLARE_CLASS_DELAYED, NULL);
+    zend_set_user_opcode_handler(ZAI_INTERCEPTOR_POST_DECLARE_OP, NULL);
+    zend_set_user_opcode_handler(ZEND_HANDLE_EXCEPTION, NULL);
+}


### PR DESCRIPTION
### Description

Adding testing for apache as well as ensuring that apache tests (with opcache and JIT) are run with reloads, covering the scenario where another MINIT is executed after prior MSHUTDOWN.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
