### PR TITLE
Check for datadog-profiling in startup only instead of inside a message_handler

### DIFF
--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -101,6 +101,10 @@ static void ddtrace_sort_modules(void *base, size_t count, size_t siz, compare_f
 #endif
 
 static int ddtrace_startup(zend_extension *extension) {
+    UNUSED(extension);
+
+    ddtrace_fetch_profiling_symbols();
+
 #if PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 70400
     // Turns out with zai config we have dynamically allocated INI entries. This does not play well with PHP 7.3
     // As of PHP 7.3 opcache stores INI entry values in SHM. However, only as of PHP 7.4 opcache delays detaching SHM.
@@ -115,7 +119,7 @@ static int ddtrace_startup(zend_extension *extension) {
     // We deliberately leave handler replacement during startup, even though this uses some config
     // This touches global state, which, while unlikely, may play badly when interacting with other extensions, if done
     // post-startup
-    ddtrace_internal_handlers_startup(extension);
+    ddtrace_internal_handlers_startup();
     return SUCCESS;
 }
 
@@ -137,7 +141,7 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   ddtrace_shutdown,
                                                   ddtrace_activate,
                                                   ddtrace_deactivate,
-                                                  ddtrace_message_handler,
+                                                  NULL,
                                                   zai_interceptor_op_array_pass_two,
                                                   NULL,
                                                   NULL,

--- a/ext/php7/engine_hooks.c
+++ b/ext/php7/engine_hooks.c
@@ -27,16 +27,8 @@ datadog_php_uuid (*ddtrace_profiling_runtime_id)(void) = dd_profiling_runtime_id
 
 void (*profiling_interrupt_function)(zend_execute_data *) = NULL;
 
-/**
- * The message handler is used to determine if the profiler is loaded, and if
- * so it will locate certain symbols so cross-product features can be enabled.
- */
-void ddtrace_message_handler(int message, void *arg) {
-    if (UNEXPECTED(message != ZEND_EXTMSG_NEW_EXTENSION)) {
-        // There are currently no other defined messages.
-        return;
-    }
-
+// Check if the profiler is loaded, and if, so it will locate certain symbols so cross-product features can be enabled.
+void dd_search_for_profiling_symbols(void *arg) {
     zend_extension *extension = (zend_extension *)arg;
     if (extension->name && strcmp(extension->name, "datadog-profiling") == 0) {
         DL_HANDLE handle = extension->handle;
@@ -55,6 +47,10 @@ void ddtrace_message_handler(int message, void *arg) {
                                extension->version, DL_ERROR());
         }
     }
+}
+
+void ddtrace_fetch_profiling_symbols(void) {
+    zend_llist_apply(&zend_extensions, dd_search_for_profiling_symbols);
 }
 
 void ddtrace_engine_hooks_minit(void) {

--- a/ext/php7/engine_hooks.h
+++ b/ext/php7/engine_hooks.h
@@ -13,7 +13,7 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
-void ddtrace_message_handler(int message, void *arg);
+void ddtrace_fetch_profiling_symbols(void);
 void ddtrace_engine_hooks_mshutdown(void);
 
 void ddtrace_compile_time_reset(void);

--- a/ext/php7/handlers_internal.c
+++ b/ext/php7/handlers_internal.c
@@ -39,20 +39,7 @@ void ddtrace_exception_handlers_rinit(void);
 
 void ddtrace_curl_handlers_rshutdown(void);
 
-static void dd_message_dispatcher(const zend_extension *extension, const zend_extension *ddtrace) {
-    if (ddtrace != extension) {
-        ddtrace_message_handler(ZEND_EXTMSG_NEW_EXTENSION, (void *)extension);
-    }
-}
-
-void ddtrace_internal_handlers_startup(zend_extension *ext) {
-    /* The zend_extension message_handler is used to detect if profiling is
-     * loaded, but it will not trigger for already loaded zend_extensions, so
-     * loop over existing zend_extensions to see if it's already there.
-     */
-    llist_apply_with_arg_func_t func = (llist_apply_with_arg_func_t)dd_message_dispatcher;
-    zend_llist_apply_with_argument(&zend_extensions, func, ext);
-
+void ddtrace_internal_handlers_startup(void) {
     // curl is different; it has pieces that always run.
     ddtrace_curl_handlers_startup();
     // pcntl handlers have to run even if tracing of pcntl extension is not enabled.

--- a/ext/php7/handlers_internal.h
+++ b/ext/php7/handlers_internal.h
@@ -20,7 +20,7 @@ void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_le
 
 void ddtrace_free_unregistered_class(zend_class_entry *ce);
 
-void ddtrace_internal_handlers_startup(zend_extension *ddtrace_extension);
+void ddtrace_internal_handlers_startup(void);
 void ddtrace_internal_handlers_shutdown(void);
 void ddtrace_internal_handlers_rinit(void);
 void ddtrace_internal_handlers_rshutdown(void);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -83,6 +83,10 @@ STD_PHP_INI_ENTRY("ddtrace.cgroup_file", "/proc/self/cgroup", PHP_INI_SYSTEM, On
 PHP_INI_END()
 
 static int ddtrace_startup(zend_extension *extension) {
+    UNUSED(extension);
+
+    ddtrace_fetch_profiling_symbols();
+
 #if PHP_VERSION_ID < 80200
     dd_has_other_observers = ZEND_OBSERVER_ENABLED;
 #endif
@@ -92,7 +96,7 @@ static int ddtrace_startup(zend_extension *extension) {
     // We deliberately leave handler replacement during startup, even though this uses some config
     // This touches global state, which, while unlikely, may play badly when interacting with other extensions, if done
     // post-startup
-    ddtrace_internal_handlers_startup(extension);
+    ddtrace_internal_handlers_startup();
     return SUCCESS;
 }
 
@@ -121,7 +125,7 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
                                                   ddtrace_shutdown,
                                                   ddtrace_activate,
                                                   ddtrace_deactivate,
-                                                  ddtrace_message_handler,
+                                                  NULL,
                                                   NULL,
                                                   NULL,
                                                   NULL,

--- a/ext/php8/engine_hooks.c
+++ b/ext/php8/engine_hooks.c
@@ -27,16 +27,8 @@ datadog_php_uuid (*ddtrace_profiling_runtime_id)(void) = dd_profiling_runtime_id
 
 void (*profiling_interrupt_function)(zend_execute_data *) = NULL;
 
-/**
- * The message handler is used to determine if the profiler is loaded, and if
- * so it will locate certain symbols so cross-product features can be enabled.
- */
-void ddtrace_message_handler(int message, void *arg) {
-    if (UNEXPECTED(message != ZEND_EXTMSG_NEW_EXTENSION)) {
-        // There are currently no other defined messages.
-        return;
-    }
-
+// Check if the profiler is loaded, and if, so it will locate certain symbols so cross-product features can be enabled.
+void dd_search_for_profiling_symbols(void *arg) {
     zend_extension *extension = (zend_extension *)arg;
     if (extension->name && strcmp(extension->name, "datadog-profiling") == 0) {
         DL_HANDLE handle = extension->handle;
@@ -55,6 +47,10 @@ void ddtrace_message_handler(int message, void *arg) {
                                extension->version, DL_ERROR());
         }
     }
+}
+
+void ddtrace_fetch_profiling_symbols(void) {
+    zend_llist_apply(&zend_extensions, dd_search_for_profiling_symbols);
 }
 
 void ddtrace_engine_hooks_minit(void) {

--- a/ext/php8/engine_hooks.h
+++ b/ext/php8/engine_hooks.h
@@ -14,7 +14,7 @@
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
 
 void ddtrace_engine_hooks_minit(void);
-void ddtrace_message_handler(int message, void *arg);
+void ddtrace_fetch_profiling_symbols(void);
 void ddtrace_engine_hooks_mshutdown(void);
 
 void ddtrace_compile_time_reset(void);

--- a/ext/php8/handlers_internal.c
+++ b/ext/php8/handlers_internal.c
@@ -47,20 +47,7 @@ void ddtrace_exception_handlers_rinit(void);
 
 void ddtrace_curl_handlers_rshutdown(void);
 
-static void dd_message_dispatcher(const zend_extension *extension, const zend_extension *ddtrace) {
-    if (ddtrace != extension) {
-        ddtrace_message_handler(ZEND_EXTMSG_NEW_EXTENSION, (void *)extension);
-    }
-}
-
-void ddtrace_internal_handlers_startup(zend_extension *ext) {
-    /* The zend_extension message_handler is used to detect if profiling is
-     * loaded, but it will not trigger for already loaded zend_extensions, so
-     * loop over existing zend_extensions to see if it's already there.
-     */
-    llist_apply_with_arg_func_t func = (llist_apply_with_arg_func_t)dd_message_dispatcher;
-    zend_llist_apply_with_argument(&zend_extensions, func, ext);
-
+void ddtrace_internal_handlers_startup(void) {
     // curl is different; it has pieces that always run.
     ddtrace_curl_handlers_startup();
     // pcntl handlers have to run even if tracing of pcntl extension is not enabled.

--- a/ext/php8/handlers_internal.h
+++ b/ext/php8/handlers_internal.h
@@ -20,7 +20,7 @@ void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_le
 
 void ddtrace_free_unregistered_class(zend_class_entry *ce);
 
-void ddtrace_internal_handlers_startup(zend_extension *ddtrace_extension);
+void ddtrace_internal_handlers_startup(void);
 void ddtrace_internal_handlers_shutdown(void);
 void ddtrace_internal_handlers_rinit(void);
 void ddtrace_internal_handlers_rshutdown(void);


### PR DESCRIPTION
### Description

Turns out that the message_handler implementation in Zend is broken since forever (since 2000). zend_llist_apply_with_arguments() does not va_copy() its va_args array and thus serves us a random pointer instead of a valid zend_extension pointer, if there is more than one simultaneous message_handler.

Note that web tests are broken due to not yet merged composer changes (see #1669).

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
