### PR TITLE
Release 0.76.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://output.circle-artifacts.com/output/job/7b76f0d9-154c-4a15-9f17-5b739e5fa41e/artifacts/0/datadog-php-tracer_0.76.1_amd64.deb"
+    value: "https://output.circle-artifacts.com/output/job/07a78e76-edb1-4bd5-8c10-5fb35cc8d7d7/artifacts/0/datadog-php-tracer_0.76.2_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.76.1"
+#define PHP_DDTRACE_VERSION "0.76.2"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -50,13 +50,17 @@
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
     ### Fixed
-
-    - Bump PHP minimum version in PECL #1652
-    - PHP 7.3+ Fix compatibility with opcache #1656
-
+    - Check for datadog-profiling in startup only instead of inside a message_handler #1670. This fixes a possible crash when all of tracer, profiler and appsec are loaded.
+    - Add opcode shutdown handlers, fix integrations after repeated minit #1669. This fixes a crash when using reload on apache (sending SIGUSR1).
+    - (PHP 7) Fix curl wrapper use after free #1662. This fixes a possible crash when curl handles are manually released within destructors inside the PHP shutdown sequence.
+    - Fix -Werror=address-of-packed-member (#1664).
+    
     ### Internal changes
+    - Skip curl test if curl is not loaded #1668
 
-    - %d resource ids in language tests #1657
+    ## Profiling (v0.7.2)
+    - Fix crash with SAPI env vars DataDog/dd-prof-php#46
+    - Avoid .message_handler due to upstream bug DataDog/dd-prof-php#47
     </notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -23,7 +23,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.76.1';
+    const VERSION = '0.76.2';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Fixed
  - Check for datadog-profiling in startup only instead of inside a message_handler #1670. This fixes a possible crash when all of tracer, profiler and appsec are loaded.
  - Add opcode shutdown handlers, fix integrations after repeated minit #1669. This fixes a crash when using reload on apache (sending SIGUSR1).
  - (PHP 7) Fix curl wrapper use after free #1662. This fixes a possible crash when curl handles are manually released within destructors inside the PHP shutdown sequence.
  - Fix -Werror=address-of-packed-member (#1664).

### Internal changes
  - Skip curl test if curl is not loaded #1668

## Profiling (v0.7.2)
  - Fix crash with SAPI env vars DataDog/dd-prof-php#46
  - Avoid .message_handler due to upstream bug DataDog/dd-prof-php#47

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
