### PR TITLE
Add support for ports on x-forwarded-for header

### DIFF
--- a/ext/php7/ip_extraction.c
+++ b/ext/php7/ip_extraction.c
@@ -446,13 +446,9 @@ static bool dd_parse_ip_address_maybe_port_pair(const char *addr, size_t addr_le
     }
     const char *colon = memchr(addr, ':', addr_len);
     if (colon) {
-        char *tmp_addr = safe_emalloc(addr_len, 1, 1);
-        memcpy(tmp_addr, addr, addr_len);
-        tmp_addr[addr_len] = '\0';
-        int ret = inet_pton(AF_INET6, tmp_addr, &out->v6);
-        efree(tmp_addr);
-        if (ret != 1) {  // It has colon and it is not a valid ipv6 address
-            return dd_parse_ip_address(addr, colon - addr, out);
+        size_t colon_position = colon - addr;
+        if (colon_position + 1 < addr_len && !memchr(&colon[1], ':', &addr[addr_len] - &colon[1])) {
+            return dd_parse_ip_address(addr, colon_position, out);
         }
     }
 

--- a/ext/php7/ip_extraction.c
+++ b/ext/php7/ip_extraction.c
@@ -1,6 +1,9 @@
+#define _GNU_SOURCE
+
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <php.h>
+#include <string.h>
 #include <zend_API.h>
 #include <zend_smart_str.h>
 
@@ -8,6 +11,7 @@
 #include "logging.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 
 typedef struct _ipaddr {
     int af;
@@ -444,12 +448,10 @@ static bool dd_parse_ip_address_maybe_port_pair(const char *addr, size_t addr_le
         }
         return dd_parse_ip_address(addr + 1, pos_close - (addr + 1), out);
     }
+
     const char *colon = memchr(addr, ':', addr_len);
-    if (colon) {
-        size_t colon_position = colon - addr;
-        if (colon_position + 1 < addr_len && !memchr(&colon[1], ':', &addr[addr_len] - &colon[1])) {
-            return dd_parse_ip_address(addr, colon_position, out);
-        }
+    if (colon && memrchr(addr, ':', addr_len) == colon) { //There is one and only one colon
+        return dd_parse_ip_address(addr, colon - addr, out);
     }
 
     return dd_parse_ip_address(addr, addr_len, out);

--- a/ext/php8/ip_extraction.c
+++ b/ext/php8/ip_extraction.c
@@ -446,13 +446,9 @@ static bool dd_parse_ip_address_maybe_port_pair(const char *addr, size_t addr_le
     }
     const char *colon = memchr(addr, ':', addr_len);
     if (colon) {
-        char *tmp_addr = safe_emalloc(addr_len, 1, 1);
-        memcpy(tmp_addr, addr, addr_len);
-        tmp_addr[addr_len] = '\0';
-        int ret = inet_pton(AF_INET6, tmp_addr, &out->v6);
-        efree(tmp_addr);
-        if (ret != 1) {  // It has colon and it is not a valid ipv6 address
-            return dd_parse_ip_address(addr, colon - addr, out);
+        size_t colon_position = colon - addr;
+        if (colon_position + 1 < addr_len && !memchr(&colon[1], ':', &addr[addr_len] - &colon[1])) {
+            return dd_parse_ip_address(addr, colon_position, out);
         }
     }
 

--- a/ext/php8/ip_extraction.c
+++ b/ext/php8/ip_extraction.c
@@ -1,6 +1,9 @@
+#define _GNU_SOURCE
+
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <php.h>
+#include <string.h>
 #include <zend_API.h>
 #include <zend_smart_str.h>
 
@@ -8,6 +11,7 @@
 #include "logging.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 
 typedef struct _ipaddr {
     int af;
@@ -444,12 +448,10 @@ static bool dd_parse_ip_address_maybe_port_pair(const char *addr, size_t addr_le
         }
         return dd_parse_ip_address(addr + 1, pos_close - (addr + 1), out);
     }
+
     const char *colon = memchr(addr, ':', addr_len);
-    if (colon) {
-        size_t colon_position = colon - addr;
-        if (colon_position + 1 < addr_len && !memchr(&colon[1], ':', &addr[addr_len] - &colon[1])) {
-            return dd_parse_ip_address(addr, colon_position, out);
-        }
+    if (colon && memrchr(addr, ':', addr_len) == colon) { //There is one and only one colon
+        return dd_parse_ip_address(addr, colon - addr, out);
     }
 
     return dd_parse_ip_address(addr, addr_len, out);

--- a/tests/ext/extract_ip_addr.phpt
+++ b/tests/ext/extract_ip_addr.phpt
@@ -41,6 +41,7 @@ test('client_ip', '2.2.2.2');
 
 test('x_forwarded', 'for="[2001::1]:1111"');
 test('x_forwarded', 'fOr="[2001::1]:1111"');
+test('x_forwarded', 'for="2001:abcf::1"');
 test('x_forwarded', 'for=some_host');
 test('x_forwarded', 'for=127.0.0.1, FOR=1.1.1.1');
 test('x_forwarded', 'for="\"foobar";proto=http,FOR="1.1.1.1"');
@@ -59,6 +60,7 @@ test('x_cluster_client_ip', '172.16.0.1');
 test('forwarded_for', '::1, 127.0.0.1, 2001::1');
 
 test('forwarded', 'for=8.8.8.8');
+test('forwarded', 'for=2001:abcf:1f::55');
 
 test('via', '1.0 127.0.0.1, HTTP/1.1 [2001::1]:8888');
 test('via', 'HTTP/1.1 [2001::1, HTTP/1.1 [2001::2]');
@@ -66,6 +68,7 @@ test('via', '8.8.8.8');
 test('via', '8.8.8.8, 1.0 9.9.9.9:8888,');
 test('via', '1.0 bad_ip_address, 1.0 9.9.9.9:8888,');
 test('via', ",,8.8.8.8  127.0.0.1 6.6.6.6, 1.0\t  1.1.1.1\tcomment,");
+test('via', '2001:abcf:1f::55');
 
 test('true_client_ip', '8.8.8.8');
 
@@ -145,6 +148,9 @@ string(7) "2001::1"
 x_forwarded: fOr="[2001::1]:1111"
 string(7) "2001::1"
 
+x_forwarded: for="2001:abcf::1"
+string(12) "2001:abcf::1"
+
 x_forwarded: for=some_host
 Not recognized as IP address: "some_host"
 NULL
@@ -192,6 +198,9 @@ string(7) "2001::1"
 forwarded: for=8.8.8.8
 string(7) "8.8.8.8"
 
+forwarded: for=2001:abcf:1f::55
+string(16) "2001:abcf:1f::55"
+
 via: 1.0 127.0.0.1, HTTP/1.1 [2001::1]:8888
 string(7) "2001::1"
 
@@ -210,6 +219,9 @@ string(7) "9.9.9.9"
 
 via: ,,8.8.8.8  127.0.0.1 6.6.6.6, 1.0	  1.1.1.1	comment,
 string(7) "1.1.1.1"
+
+via: 2001:abcf:1f::55
+NULL
 
 true_client_ip: 8.8.8.8
 string(7) "8.8.8.8"

--- a/tests/ext/extract_ip_addr.phpt
+++ b/tests/ext/extract_ip_addr.phpt
@@ -18,9 +18,11 @@ function test($header, $value) {
 test('x_forwarded_for', '2001::1');
 test('x_forwarded_for', '::1, febf::1, fc00::1, fd00::1,2001:0000::1');
 test('x_forwarded_for', '172.16.0.1');
-test('x_forwarded_for', '172.16.0.1, 172.31.255.254, 172.32.255.1, 8.8.8.8');
+test('x_forwarded_for', '172.16.0.1, 172.31.255.254, 172.32.255.1, 8.8.8.8, 1.2.3.4:456, [2001::1]:1111');
 test('x_forwarded_for', '169.254.0.1, 127.1.1.1, 10.255.255.254,');
 test('x_forwarded_for', '127.1.1.1,, ');
+test('x_forwarded_for', '1.2.3.4:456');
+test('x_forwarded_for', '[2001::1]:1111');
 test('x_forwarded_for', 'bad_value, 1.1.1.1');
 
 test('x_real_ip', '2.2.2.2');
@@ -81,7 +83,7 @@ string(7) "2001::1"
 x_forwarded_for: 172.16.0.1
 NULL
 
-x_forwarded_for: 172.16.0.1, 172.31.255.254, 172.32.255.1, 8.8.8.8
+x_forwarded_for: 172.16.0.1, 172.31.255.254, 172.32.255.1, 8.8.8.8, 1.2.3.4:456, [2001::1]:1111
 string(12) "172.32.255.1"
 
 x_forwarded_for: 169.254.0.1, 127.1.1.1, 10.255.255.254,
@@ -89,6 +91,12 @@ NULL
 
 x_forwarded_for: 127.1.1.1,, 
 NULL
+
+x_forwarded_for: 1.2.3.4:456
+string(7) "1.2.3.4"
+
+x_forwarded_for: [2001::1]:1111
+string(7) "2001::1"
 
 x_forwarded_for: bad_value, 1.1.1.1
 Not recognized as IP address: "bad_value"


### PR DESCRIPTION
According to [Azzure Application Gateway documentation](https://docs.microsoft.com/en-us/azure/application-gateway/how-application-gateway-works#modifications-to-the-request) the IPs on x-forwarded-for header
can contain the port. Our ip extraction code was not expeting ports as part of this header.

This PR fixes DataDog/dd-trace-php#1672

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
