### PR TITLE
Add "recurse" => true option to hook/trace config array

### DIFF
--- a/tests/ext/sandbox/hook_function/recursion.phpt
+++ b/tests/ext/sandbox/hook_function/recursion.phpt
@@ -1,0 +1,33 @@
+--TEST--
+DDTrace\hook_function supports recursion
+--FILE--
+<?php
+
+DDTrace\hook_function('greet', [
+    'prehook' => function ($args) {
+        echo "greet prehook: {$args[0]}\n";
+    },
+    'posthook' => function ($args) {
+        echo "greet posthook: {$args[0]}\n";
+    },
+    'recurse' => true
+]);
+
+function greet($name)
+{
+    echo "Hello, {$name}.\n";
+    if ($name === 'Datadog') {
+        greet('Woof');
+    }
+}
+
+greet('Datadog');
+
+?>
+--EXPECT--
+greet prehook: Datadog
+Hello, Datadog.
+greet prehook: Woof
+Hello, Woof.
+greet posthook: Woof
+greet posthook: Datadog


### PR DESCRIPTION
### Description

Thus, it is now possible to write code like

```php
DDTrace\hook_function('greet', [
    'prehook' => function ($args) {
        echo "greet prehook: {$args[0]}\n";
    },
    'posthook' => function ($args) {
        echo "greet posthook: {$args[0]}\n";
    },
    'recurse' => true
]);
```

to have traces also trigger upon recursion

Fixes #1105.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
