### PR TITLE
[Profiling] Add fake frame when truncating stacks

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -271,7 +271,15 @@ unsafe fn collect_stack_sample(
     samples.reserve(max_depth); // todo: try_reserve
     let mut execute_data = top_execute_data;
 
-    while !execute_data.is_null() && samples.len() < samples.capacity() {
+    while !execute_data.is_null() {
+        if samples.len() >= max_depth {
+            samples.push(ZendFrame {
+                function: "[truncated]".to_string(),
+                file: None,
+                line: 0,
+            });
+            break;
+        }
         let func = (*execute_data).func;
         if !func.is_null() {
             let function = extract_function_name(&*func);

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -272,7 +272,11 @@ unsafe fn collect_stack_sample(
     let mut execute_data = top_execute_data;
 
     while !execute_data.is_null() {
-        if samples.len() >= max_depth {
+        /* -1 to reserve room for the [truncated] message. In case the backend
+         * and/or frontend have the same limit, without the -1 we'd ironically
+         * truncate our [truncated] message.
+         */
+        if samples.len() >= max_depth - 1 {
             samples.push(ZendFrame {
                 function: "[truncated]".to_string(),
                 file: None,


### PR DESCRIPTION
### Description

The exact fake frame name may change to align with other profilers,
but currently this information is missing and we can't easily tell if
a customer has hit a stalk walking bug, genuinely has weird stacks, or
if it's been truncated.

Here's a screenshot with an artificial max depth of 4 to illustrate it:
![Screenshot of Datadog profiling page with an example of a truncated stack](https://user-images.githubusercontent.com/253316/182190517-57719f79-90d2-4f25-befe-6188cadb5cd7.png)


### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
