### PR TITLE
[Profiling] Switch `<php>` to `<?php`

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -271,7 +271,15 @@ unsafe fn collect_stack_sample(
     samples.reserve(max_depth); // todo: try_reserve
     let mut execute_data = top_execute_data;
 
-    while !execute_data.is_null() && samples.len() < samples.capacity() {
+    while !execute_data.is_null() {
+        if samples.len() >= max_depth {
+            samples.push(ZendFrame {
+                function: "[truncated]".to_string(),
+                file: None,
+                line: 0,
+            });
+            break;
+        }
         let func = (*execute_data).func;
         if !func.is_null() {
             let function = extract_function_name(&*func);

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -291,8 +291,8 @@ unsafe fn collect_stack_sample(
 
             // Only insert a new frame if there's file or function info.
             if file.is_some() || function.is_some() {
-                // If there's no function name, use the fake name "<php>".
-                let function = function.unwrap_or_else(|| "<php>".to_owned());
+                // If there's no function name, use a fake name.
+                let function = function.unwrap_or_else(|| "<?php".to_owned());
                 let frame = ZendFrame {
                     function,
                     file,


### PR DESCRIPTION
### Description

When a call frame refers to top-level PHP code, the profiler will now
display this as `<?php` mirroring an open PHP tag instead of `<php>`.
This should be more intuitive to new users.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
