### PR TITLE
[Profiling] Raise max stack depth to 512

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -271,7 +271,15 @@ unsafe fn collect_stack_sample(
     samples.reserve(max_depth); // todo: try_reserve
     let mut execute_data = top_execute_data;
 
-    while !execute_data.is_null() && samples.len() < samples.capacity() {
+    while !execute_data.is_null() {
+        if samples.len() >= max_depth {
+            samples.push(ZendFrame {
+                function: "[truncated]".to_string(),
+                file: None,
+                line: 0,
+            });
+            break;
+        }
         let func = (*execute_data).func;
         if !func.is_null() {
             let function = extract_function_name(&*func);

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -266,9 +266,8 @@ unsafe fn extract_line_no(execute_data: &zend_execute_data) -> u32 {
 unsafe fn collect_stack_sample(
     top_execute_data: *mut zend_execute_data,
 ) -> Result<Vec<ZendFrame>, Utf8Error> {
-    let mut samples = Vec::new();
-    let max_depth = 128;
-    samples.reserve(max_depth); // todo: try_reserve
+    let max_depth = 512;
+    let mut samples = Vec::with_capacity(max_depth >> 3);
     let mut execute_data = top_execute_data;
 
     while !execute_data.is_null() {


### PR DESCRIPTION
### Description

Some customers are seeing truncated stacks. This PR allows going up
to 512 frames deep now but it no longer allocates the max stack depth
when initializing samples buffer. This avoids waste when the stack is
much smaller than the limit, which it very often will be with a higher
limit.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
