### PR TITLE
Fix profiling config in randomized tests

### DIFF
--- a/tests/randomized/config/inis.php
+++ b/tests/randomized/config/inis.php
@@ -6,5 +6,5 @@
 const INIS = [
     'opcache.enable' => [false],
     'opcache.jit_buffer_size' => ['256M'],
-    'zend_extension' => ['datadog-profiling.so'],
+    'extension' => ['datadog-profiling.so'],
 ];


### PR DESCRIPTION
### Description

This was still using `zend_extension` instead of `extension` for `datadog-profiling.so`.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ This is tests.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
