### PR TITLE
Update artifact URL for v0.77.0 gitlab deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.76.2/datadog-php-tracer_0.76.2_amd64.deb"
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/datadog-php-tracer_0.77.0_amd64.deb"
     description: "Location where to download latest built package"
   DOWNSTREAM_REL_BRANCH:
     value: "master"


### PR DESCRIPTION
### Description

Updates the gitlab deployments to use v0.77.0.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
