### PR TITLE
Update relenv to use datadog-setup.php

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,6 @@ stages:
   - deploy
 
 variables:
-  LATEST_SETUP:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/datadog-setup.php"
-    description: "Location where to download latest datadog-setup.php script"
   LATEST_LIBRARY_x86_64_LINUX_GNU:
     value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/dd-library-php-0.77.0-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
@@ -22,9 +19,9 @@ build:
   tags: [ "runner:main", "size:large" ]
   script:
     - echo $LATEST_LIBRARY_x86_64_LINUX_GNU | sed -E 's/.*dd-library-php-(.+)-x86_64-linux-gnu.tar.gz.*/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
-    - curl --fail --location --output dd-library-php-x86_64-linux-gnu.tar.gz $LATEST_LIBRARY_x86_64_LINUX_GNU
-    - curl --fail --location -O $LATEST_SETUP
-    - tar -cf datadog-setup-x86_64-linux-gnu.tar datadog-setup.php dd-library-php-x86_64-linux-gnu.tar.gz
+    - curl --fail --location --output 'dd-library-php-x86_64-linux-gnu.tar.gz' "$LATEST_LIBRARY_x86_64_LINUX_GNU"
+    - curl --fail --location -O "$(dirname $LATEST_LIBRARY_x86_64_LINUX_GNU)/datadog-setup.php"
+    - tar -cf 'datadog-setup-x86_64-linux-gnu.tar' 'datadog-setup.php' 'dd-library-php-x86_64-linux-gnu.tar.gz'
   artifacts:
     paths:
       - 'upstream.env'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,12 @@ stages:
   - deploy
 
 variables:
-  LATEST_URL:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/datadog-php-tracer_0.77.0_amd64.deb"
-    description: "Location where to download latest built package"
+  LATEST_SETUP:
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/datadog-setup.php"
+    description: "Location where to download latest datadog-setup.php script"
+  LATEST_LIBRARY_x86_64_LINUX_GNU:
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/dd-library-php-0.77.0-x86_64-linux-gnu.tar.gz"
+    description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
   DOWNSTREAM_REL_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -18,12 +21,14 @@ build:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/base:bionic
   tags: [ "runner:main", "size:large" ]
   script:
-    - echo $LATEST_URL | sed -E 's/.+_(.+)_.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
-    - curl --fail --location --output php-linux-tracer-deb-latest.deb $LATEST_URL
+    - echo $LATEST_SETUP | sed -E 's/.+_(.+)_.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
+    - curl --fail --location --output dd-library-php-x86_64-linux-gnu.tar.gz $LATEST_LIBRARY_x86_64_LINUX_GNU
+    - curl --fail --location -O $LATEST_SETUP
+    - tar -cf datadog-setup-x86_64-linux-gnu.tar datadog-setup.php dd-library-php-x86_64-linux-gnu.tar.gz
   artifacts:
     paths:
       - 'upstream.env'
-      - 'php-linux-tracer-deb-latest.deb'
+      - 'datadog-setup-x86_64-linux-gnu.tar'
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ build:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/base:bionic
   tags: [ "runner:main", "size:large" ]
   script:
-    - echo $LATEST_SETUP | sed -E 's/.+_(.+)_.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
+    - echo $LATEST_SETUP | sed -E 's/.+\/([0-9]+\.[0-9]+\.[^/]+)\/.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
     - curl --fail --location --output dd-library-php-x86_64-linux-gnu.tar.gz $LATEST_LIBRARY_x86_64_LINUX_GNU
     - curl --fail --location -O $LATEST_SETUP
     - tar -cf datadog-setup-x86_64-linux-gnu.tar datadog-setup.php dd-library-php-x86_64-linux-gnu.tar.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ build:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/base:bionic
   tags: [ "runner:main", "size:large" ]
   script:
-    - echo $LATEST_SETUP | sed -E 's/.+\/([0-9]+\.[0-9]+\.[^/]+)\/.+/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
+    - echo $LATEST_LIBRARY_x86_64_LINUX_GNU | sed -E 's/.*dd-library-php-(.+)-x86_64-linux-gnu.tar.gz.*/UPSTREAM_TRACER_VERSION=\1/' >> upstream.env
     - curl --fail --location --output dd-library-php-x86_64-linux-gnu.tar.gz $LATEST_LIBRARY_x86_64_LINUX_GNU
     - curl --fail --location -O $LATEST_SETUP
     - tar -cf datadog-setup-x86_64-linux-gnu.tar datadog-setup.php dd-library-php-x86_64-linux-gnu.tar.gz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
     value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/dd-library-php-0.77.0-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
   DOWNSTREAM_REL_BRANCH:
-    value: "master"
+    value: "php/levi/setup"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
     value: "https://github.com/DataDog/dd-trace-php/releases/download/0.77.0/dd-library-php-0.77.0-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
   DOWNSTREAM_REL_BRANCH:
-    value: "php/levi/setup"
+    value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"


### PR DESCRIPTION
### Description

This updates the relenv deployment to use datadog-setup.php instead of
the .deb installer. Note that I deployed it using artifacts from #1688
so that I could grep the logs to make sure that they were wired up
correctly (latest and previous are currently the same due to the recent
release), but since appsec is only installed but not enabled, you
shouldn't see any differences on the current deployment.

This opens the door to run profiling and/or appsec configurations.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
