### PR TITLE
Add phpt tests for profiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1494,10 +1494,12 @@ jobs:
           paths:
             - datadog-profiling
 
-  "cargo test":
+  "profiling tests":
     working_directory: ~/datadog
     parameters:
       docker_image:
+        type: string
+      abi_no:
         type: string
       triplet:
         type: string
@@ -1512,13 +1514,25 @@ jobs:
           keys:
             - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - run:
-          name: Test Profiler
+          name: cargo tests
           command: |
             set -u
             command -v switch-php && switch-php "${PHP_VERSION}"
             set -e
             cd profiling
             cargo test --release
+      - run:
+          name: phpt tests
+          command: |
+            set -u
+            command -v switch-php && switch-php "${PHP_VERSION}"
+            set -e
+            libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
+            cd profiling/tests
+            # don't anticipate there being more than one
+            run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
+            cp -v "${run_tests_php}" .
+            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" phpt
 
   compile_extension_centos:
     working_directory: ~/datadog
@@ -1802,35 +1816,41 @@ workflows:
 
       # These don't actually need the other job to complete, but this way
       # there are fewer resources used when the build step fails.
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.1 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.1"
+          abi_no: "20160303"
           triplet: "x86_64-alpine-linux-musl"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.2 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.2 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.2"
+          abi_no: "20170718"
           triplet: "x86_64-alpine-linux-musl"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.3 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.3 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.3"
+          abi_no: "20180731"
           triplet: "x86_64-alpine-linux-musl"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.4 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v7.4 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-7.4"
+          abi_no: "20190902"
           triplet: "x86_64-alpine-linux-musl"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v8.0 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v8.0 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
+          abi_no: "20200930"
           triplet: "x86_64-alpine-linux-musl"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v8.1 - x86_64-alpine-linux-musl" ]
           name: "Profiler test PHP v8.1 - x86_64-alpine-linux-musl"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.1"
+          abi_no: "20210902"
           triplet: "x86_64-alpine-linux-musl"
 
       - "cache cargo deps":
@@ -1870,35 +1890,41 @@ workflows:
 
       # These don't actually need the other job to complete, but this way
       # there are fewer resources used when the build step fails.
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.1 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
+          abi_no: "20160303"
           triplet: "x86_64-unknown-linux-gnu"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.2 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.2 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
+          abi_no: "20170718"
           triplet: "x86_64-unknown-linux-gnu"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.3 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.3 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
+          abi_no: "20180731"
           triplet: "x86_64-unknown-linux-gnu"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v7.4 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v7.4 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
+          abi_no: "20190902"
           triplet: "x86_64-unknown-linux-gnu"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v8.0 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v8.0 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
+          abi_no: "20200930"
           triplet: "x86_64-unknown-linux-gnu"
-      - "cargo test":
+      - "profiling tests":
           requires: [ "Profiler PHP v8.1 - x86_64-unknown-linux-gnu" ]
           name: "Profiler test PHP v8.1 - x86_64-unknown-linux-gnu"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
+          abi_no: "20210902"
           triplet: "x86_64-unknown-linux-gnu"
 
       - compile_alpine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1509,6 +1509,7 @@ jobs:
       - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
       - checkout
+      - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1534,7 +1534,7 @@ jobs:
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
             export TEST_PHP_EXECUTABLE=$(which php)
-            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" phpt
+            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1532,6 +1532,7 @@ jobs:
             # don't anticipate there being more than one
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
+            export TEST_PHP_EXECUTABLE=$(which php)
             php run-tests.php -d "extension=${libdir}/datadog-profiling.so" phpt
 
   compile_extension_centos:

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -424,10 +424,17 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
     // profiling is enabled or not.
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
+        // Don't log when profiling is disabled as that can mess up tests.
+        let profiling_log_level = if globals.profiling_enabled {
+            globals.profiling_log_level
+        } else {
+            LevelFilter::Off
+        };
+
         #[cfg(not(debug_assertions))]
-        logging::log_init(unsafe { std::mem::transmute(globals.profiling_log_level) });
+        logging::log_init(profiling_log_level);
         #[cfg(debug_assertions)]
-        log::set_max_level(globals.profiling_log_level);
+        log::set_max_level(profiling_log_level);
 
         if globals.profiling_enabled {
             /* Safety: sapi_module is initialized by rinit and shouldn't be

--- a/profiling/tests/phpt/disabled_hooks_01.phpt
+++ b/profiling/tests/phpt/disabled_hooks_01.phpt
@@ -1,0 +1,64 @@
+--TEST--
+[profiling] test when the profiler is disabled that hooks fire normally
+--DESCRIPTION--
+The profiler installs some hooks even when disabled, because it cannot
+generally know if it's disabled until the first request comes in. The profiler
+always installs these hooks:
+- `zend_execute_internal`
+- `zend_interrupt_function`
+
+The purpose of this test is to ensure that when the profiler is disabled that
+regular behaviors which might use these hooks are unaffected. Note that the
+PHP timeout limit is implemented using the VM interrupt handler, which is why
+it is set up for this test.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+if (PHP_VERSION_ID < 70100)
+  echo "skip: php 7.1 or above is required to execute VM interrupt hook.\n";
+?>
+--INI--
+max_execution_time = 3
+--ENV--
+DD_PROFILING_ENABLED=no
+--FILE--
+<?php
+
+register_shutdown_function(function () {
+    echo "Shutting down.\n";
+});
+
+/* PHP optimizes some internal function calls into opcodes, such as strlen.
+ * Avoid such functions in this test, since the purpose is to make sure
+ * internal calls and vm interrupts are still working while the profiler is
+ * disabled. For PHP 7.1 - 8.1, refer to `zend_try_compile_special_func`.
+ */
+
+while (true) {
+    $cities = [
+        "Boston",
+        "Dublin",
+        "Paris",
+        "Singapore",
+        "Sydney",
+        "Tokyo",
+    ];
+
+    $estimated_population = [
+        684379,
+        544107,
+        2175601,
+        5917077,
+        5367206,
+        14043239,
+    ];
+
+    $sorted_city_population = array_combine($cities, $estimated_population);
+    asort($sorted_city_population, SORT_NUMERIC);
+}
+
+?>
+--EXPECTF--
+Fatal error: Maximum execution time of %d seconds exceeded in %s on line %d
+Shutting down.

--- a/profiling/tests/phpt/phpinfo_01.phpt
+++ b/profiling/tests/phpt/phpinfo_01.phpt
@@ -1,0 +1,63 @@
+--TEST--
+[profiling] test profiler's extension info
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_PROFILING_LOG_LEVEL=info
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=yes
+DD_SERVICE=datadog-profiling-phpt
+DD_ENV=dev
+DD_VERSION=13
+DD_AGENT_HOST=localh0st
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_AGENT_URL=http://datadog:8126
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Profiling Enabled", "false"],
+    ["Experimental CPU Time Profiling Enabled", "true"],
+    ["Profiling Log Level", "info"],
+    ["Profiling Agent Endpoint", "http://datadog:8126/"],
+    ["Application's Environment (DD_ENV)", "dev"],
+    ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],
+    ["Application's Version (DD_VERSION)", "13"],
+];
+
+foreach ($sections as list($key, $value)) {
+    assert($values[$key] == $value, "Expected {$values[$key]} == {$value}");
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

These were ported from the DataDog/dd-prof-php repository. I made some
minor edits to update them.

I updated the names of the CI test jobs to better reflect that they run
more than cargo tests now.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
