### PR TITLE
Accept pseudonym on via header as specified by rfc7230

### DIFF
--- a/tests/ext/extract_ip_addr.phpt
+++ b/tests/ext/extract_ip_addr.phpt
@@ -66,7 +66,8 @@ test('via', '1.0 127.0.0.1, HTTP/1.1 [2001::1]:8888');
 test('via', 'HTTP/1.1 [2001::1, HTTP/1.1 [2001::2]');
 test('via', '8.8.8.8');
 test('via', '8.8.8.8, 1.0 9.9.9.9:8888,');
-test('via', '1.0 bad_ip_address, 1.0 9.9.9.9:8888,');
+test('via', '1.0 pseudonym, 1.0 9.9.9.9:8888,');
+test('via', '1.0 172.32.255.1 comment');
 test('via', ",,8.8.8.8  127.0.0.1 6.6.6.6, 1.0\t  1.1.1.1\tcomment,");
 test('via', '2001:abcf:1f::55');
 
@@ -213,9 +214,11 @@ NULL
 via: 8.8.8.8, 1.0 9.9.9.9:8888,
 string(7) "9.9.9.9"
 
-via: 1.0 bad_ip_address, 1.0 9.9.9.9:8888,
-Not recognized as IP address: "bad_ip_address"
+via: 1.0 pseudonym, 1.0 9.9.9.9:8888,
 string(7) "9.9.9.9"
+
+via: 1.0 172.32.255.1 comment
+string(12) "172.32.255.1"
 
 via: ,,8.8.8.8  127.0.0.1 6.6.6.6, 1.0	  1.1.1.1	comment,
 string(7) "1.1.1.1"


### PR DESCRIPTION
This PR fixes #1692

### Description

The ip extraction module was not taking into consideration that the via header can contain pseudonym instead of IPs. When a pseudonym was parsed it was not detected as an IP and the extension was logging out an error. This PR accept pseudonyms as part of the header as specified on [rfc7230](https://httpwg.org/specs/rfc7230.html#header.via)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
