### PR TITLE
Fix span memory leak and packaging 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1614,7 +1614,7 @@ jobs:
             set -eu
             sudo apt-get install jq
             PIPELINE_ID=$(curl 'https://circleci.com/api/v2/project/gh/DataDog/dd-trace-php/pipeline?branch=PHP-5' | jq -r '.items[0].id')
-            WORKFLOW_ID=$(curl "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq -r '.items[]|select(.name == "build_packages").id')
+            WORKFLOW_ID=$(curl "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq -r '.items[]|select(.name == "build_packages").id' | head -1)
             JOB_ID=$(curl "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | jq -r '.items[]|select(.name == "package extension").id')
             curl -Lo php5.tar.gz "https://output.circle-artifacts.com/output/job/$JOB_ID/artifacts/0/datadog-php-tracer-1.0.0-nightly.x86_64.tar.gz"
             tar xzf php5.tar.gz

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -122,7 +122,7 @@ ddtrace_span_fci *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute
 
         zval zv;
         Z_PTR(zv) = span_fci;
-        Z_TYPE_INFO(zv) = 1;
+        Z_TYPE_INFO(zv) = 2;
         zend_hash_index_add_new(&DDTRACE_G(traced_spans), index, &zv);
     }
     return span_fci;
@@ -130,7 +130,7 @@ ddtrace_span_fci *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute
 
 void ddtrace_clear_execute_data_span(zend_ulong index, bool keep) {
     zval *span_zv = zend_hash_index_find(&DDTRACE_G(traced_spans), index);
-    if (--Z_TYPE_INFO_P(span_zv) == 0) {
+    if (--Z_TYPE_INFO_P(span_zv) == 1) {
         ddtrace_span_fci *span_fci = Z_PTR_P(span_zv);
         if (span_fci->span.duration != DDTRACE_DROPPED_SPAN) {
             if (keep) {

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -121,7 +121,7 @@ ddtrace_span_fci *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute
 
         zval zv;
         Z_PTR(zv) = span_fci;
-        Z_TYPE_INFO(zv) = 1;
+        Z_TYPE_INFO(zv) = 2;
         zend_hash_index_add_new(&DDTRACE_G(traced_spans), index, &zv);
     }
     return span_fci;
@@ -129,7 +129,7 @@ ddtrace_span_fci *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute
 
 void ddtrace_clear_execute_data_span(zend_ulong index, bool keep) {
     zval *span_zv = zend_hash_index_find(&DDTRACE_G(traced_spans), index);
-    if (--Z_TYPE_INFO_P(span_zv) == 0) {
+    if (--Z_TYPE_INFO_P(span_zv) == 1) {
         ddtrace_span_fci *span_fci = Z_PTR_P(span_zv);
         if (span_fci->span.duration != DDTRACE_DROPPED_SPAN) {
             if (keep) {


### PR DESCRIPTION
### Description

Fixes a memory leak if Z_TYPE_INFO() reaches zero and the hashtable implementation will consider the value inexistent.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
