### PR TITLE
[profiling] Add Unix Domain Socket (UDS) support

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0" }
 cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
-ddprof = { git = "https://github.com/DataDog/libdatadog", tag = "v0.7.0" }
+datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.8.0" }
 env_logger = { version = "0.9" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -1,0 +1,142 @@
+use crate::sapi_getenv;
+pub use datadog_profiling::exporter::Uri;
+use libc::c_char;
+use std::ffi::CStr;
+use std::fmt::{Display, Formatter};
+use std::path::Path;
+pub use std::path::PathBuf;
+
+pub struct Env {
+    pub agent_host: Option<String>,
+    pub env: Option<String>,
+    pub profiling_enabled: Option<String>,
+    pub profiling_experimental_cpu_enabled: Option<String>,
+    pub profiling_experimental_cpu_time_enabled: Option<String>,
+    pub profiling_log_level: Option<String>,
+    pub service: Option<String>,
+    pub trace_agent_port: Option<String>,
+    pub trace_agent_url: Option<String>,
+    pub version: Option<String>,
+}
+
+impl Env {
+    /// Fetches the env var represented by `name`. Treats an empty string the
+    /// same as the env var not being set.
+    unsafe fn getenv(name: &CStr) -> Option<String> {
+        // CStr doesn't have a len() so turn it into a slice.
+        let name = name.to_bytes();
+
+        // Safety: called CStr, so invariants have all been checked by this point.
+        let val = sapi_getenv(name.as_ptr() as *const c_char, name.len());
+        let val = val.into_string();
+        if val.is_some() {
+            return val;
+        }
+
+        /* If the sapi didn't have an env var, try the libc.
+         * Safety: pointer comes from valid CStr.
+         */
+        let val = libc::getenv(name.as_ptr() as *const c_char);
+        if val.is_null() {
+            return None;
+        }
+
+        /* Safety: `val` has been checked for NULL, though I haven't checked that
+         * `libc::getenv` always return a string less than `isize::MAX`.
+         */
+        let val = CStr::from_ptr(val);
+        let maybe_str = val.to_str().ok();
+        // treat empty strings the same as no string
+        maybe_str.filter(|str| !str.is_empty()).map(String::from)
+    }
+
+    /// # Safety
+    /// This can only be called during rinit.
+    pub unsafe fn get() -> Self {
+        let env = Self::getenv(CStr::from_bytes_with_nul_unchecked(b"DD_ENV\0"));
+        let profiling_enabled = Self::getenv(CStr::from_bytes_with_nul_unchecked(
+            b"DD_PROFILING_ENABLED\0",
+        ));
+        let profiling_log_level = Self::getenv(CStr::from_bytes_with_nul_unchecked(
+            b"DD_PROFILING_LOG_LEVEL\0",
+        ));
+
+        // This is the older, undocumented name.
+        let profiling_experimental_cpu_enabled = Self::getenv(CStr::from_bytes_with_nul_unchecked(
+            b"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED\0",
+        ));
+        let profiling_experimental_cpu_time_enabled = Self::getenv(
+            CStr::from_bytes_with_nul_unchecked(b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0"),
+        );
+        let agent_host = Self::getenv(CStr::from_bytes_with_nul_unchecked(b"DD_AGENT_HOST\0"));
+        let trace_agent_port = Self::getenv(CStr::from_bytes_with_nul_unchecked(
+            b"DD_TRACE_AGENT_PORT\0",
+        ));
+        let trace_agent_url =
+            Self::getenv(CStr::from_bytes_with_nul_unchecked(b"DD_TRACE_AGENT_URL\0"));
+        let service = Self::getenv(CStr::from_bytes_with_nul_unchecked(b"DD_SERVICE\0"));
+        let version = Self::getenv(CStr::from_bytes_with_nul_unchecked(b"DD_VERSION\0"));
+        Self {
+            agent_host,
+            env,
+            profiling_enabled,
+            profiling_experimental_cpu_enabled,
+            profiling_experimental_cpu_time_enabled,
+            profiling_log_level,
+            service,
+            trace_agent_port,
+            trace_agent_url,
+            version,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum AgentEndpoint {
+    Uri(Uri),
+    Socket(PathBuf),
+}
+
+impl Default for AgentEndpoint {
+    /// Returns a socket configuration if the default socket exists, otherwise
+    /// it returns http://localhost:8126/. This does not consult environment
+    /// variables.
+    fn default() -> Self {
+        let path = Path::new("/var/run/datadog/apm.socket");
+        if path.exists() {
+            return AgentEndpoint::Socket(path.into());
+        }
+        AgentEndpoint::Uri(Uri::from_static("http://localhost:8126"))
+    }
+}
+
+impl TryFrom<AgentEndpoint> for datadog_profiling::exporter::Endpoint {
+    type Error = anyhow::Error;
+
+    fn try_from(value: AgentEndpoint) -> Result<Self, Self::Error> {
+        match value {
+            AgentEndpoint::Uri(uri) => datadog_profiling::exporter::config::agent(uri),
+            AgentEndpoint::Socket(path) => datadog_profiling::exporter::config::agent_uds(&path),
+        }
+    }
+}
+
+impl TryFrom<&AgentEndpoint> for datadog_profiling::exporter::Endpoint {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &AgentEndpoint) -> Result<Self, Self::Error> {
+        match value {
+            AgentEndpoint::Uri(uri) => datadog_profiling::exporter::config::agent(uri.clone()),
+            AgentEndpoint::Socket(path) => datadog_profiling::exporter::config::agent_uds(path),
+        }
+    }
+}
+
+impl Display for AgentEndpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentEndpoint::Uri(uri) => write!(f, "{}", uri),
+            AgentEndpoint::Socket(path) => write!(f, "unix://{}", path.to_string_lossy()),
+        }
+    }
+}

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -53,14 +53,10 @@ ZEND_BEGIN_MODULE_GLOBALS(datadog_php_profiling)
     zend_bool *vm_interrupt_addr;
 
     // The strings will be interned but potentially only for the request, so be
-    // careful to not use them outside of a request (such as from other
-    // threads).
+    // careful to not use them outside a request (such as from other threads).
     datadog_php_str env;
     datadog_php_str service;
     datadog_php_str version;
-    datadog_php_str trace_agent_host;
-    datadog_php_str trace_agent_port;
-    datadog_php_str trace_agent_url;
 ZEND_END_MODULE_GLOBALS(datadog_php_profiling)
 // clang-format on
 

--- a/profiling/tests/phpt/uds_01.phpt
+++ b/profiling/tests/phpt/uds_01.phpt
@@ -1,0 +1,44 @@
+--TEST--
+[profiling] invalid UDS socket path falls back to DD_AGENT_HOST
+--DESCRIPTION--
+This test verifies that an invalid Unix Domain Socket (UDS) path used in
+DD_TRACE_AGENT_URL will cause it to fall back to DD_AGENT_HOST if set.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_TRACE_AGENT_URL=unix:///invalid/path/to/apm.socket
+DD_AGENT_HOST=ddagent
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+$key = "Profiling Agent Endpoint";
+$value = "http://ddagent:8126/";
+
+assert($values[$key] == $value, "Expected {$values[$key]} == {$value}");
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.

--- a/profiling/tests/phpt/uds_02.phpt
+++ b/profiling/tests/phpt/uds_02.phpt
@@ -1,0 +1,48 @@
+--TEST--
+[profiling] invalid UDS socket path falls back to default socket path
+--DESCRIPTION--
+This test verifies that an invalid Unix Domain Socket (UDS) path used in
+DD_TRACE_AGENT_URL will cause it to fall back to the default socket path (as
+long as DD_AGENT_HOST is not set or is empty).
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+$socket_path = "/var/run/datadog/apm.socket";
+if (!file_exists($socket_path))
+  echo "skip: test requires '$socket_path' to exist on startup\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_TRACE_AGENT_URL=unix:///invalid/path/to/apm.socket
+DD_AGENT_HOST=
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+$key = "Profiling Agent Endpoint";
+$value = "unix:///var/run/datadog/apm.socket";
+
+assert($values[$key] == $value, "Expected {$values[$key]} == {$value}");
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

If any configuration is set, it prioritizes that over UDS. If the
socket file doesn't exist then it falls back to http://localhost:8126.

There are tests for various units, and I have tested this manually for
end-to-end for both the default and setting `DD_TRACE_AGENT_URL` to
`unix:///var/run/datadog/apm.socket`.

I had to upgrade libdatadog; this PR is blocked on a release.
Various things have been renamed:

- `ddprof::profiles` -> `datadog_profiling::profile`
- `ddprof::exporter` -> `datadog_profiling::exporter`

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
