### PR TITLE
[profiling] Avoid PHP per-request interning

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -95,9 +95,8 @@ fn generate_bindings(php_config_includes: &str) {
         .blocklist_item("zend_module_entry")
         .blocklist_item("zend_result")
         .blocklist_item("zend_register_extension")
-        // Block our own globals
-        .blocklist_item("zend_datadog_php_profiling_globals")
-        .blocklist_item("datadog_php_profiling_globals_get")
+        // Block a few of functions that we'll provide defs for manually
+        .blocklist_item("datadog_php_profiling_vm_interrupt_addr")
         // I had to block these for some reason *shrug*
         .blocklist_item("FP_INFINITE")
         .blocklist_item("FP_INT_DOWNWARD")

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -4,24 +4,8 @@
 #include <php.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
 
 #include <ext/standard/info.h>
-
-/**
- * Represents a non-owning slice of chars. The order here matches GCC std::span,
- * which changed in v11 to be ptr-size instead of size-ptr to match iovec on
- * most platforms.
- *
- * Please do not use a null pointer; instead use an empty string with a `size`
- * of 0.
- *
- * todo: unify with ../components/string_view
- */
-typedef struct datadog_php_str {
-    const char *ptr;
-    size_t size;
-} datadog_php_str;
 
 /* C11 allows a duplicate typedef provided they are the same, so this should be
  * fine as long as we compile with C11 or higher.
@@ -40,37 +24,6 @@ const char *datadog_extension_build_id(void);
  */
 const char *datadog_module_build_id(void);
 
-/* Expose globals so we can bridge them with Rust. */
-// clang-format off
-ZEND_BEGIN_MODULE_GLOBALS(datadog_php_profiling)
-    bool profiling_enabled;
-    bool profiling_experimental_cpu_time_enabled;
-    uint32_t interrupt_count;
-
-    // Maps to Rust's log::LevelFilter which is repr(usize).
-    uintptr_t profiling_log_level;
-
-    zend_bool *vm_interrupt_addr;
-
-    // The strings will be interned but potentially only for the request, so be
-    // careful to not use them outside a request (such as from other threads).
-    datadog_php_str env;
-    datadog_php_str service;
-    datadog_php_str version;
-ZEND_END_MODULE_GLOBALS(datadog_php_profiling)
-// clang-format on
-
-/**
- * A helper for Rust to fetch this extension's globals.
- */
-zend_datadog_php_profiling_globals *datadog_php_profiling_globals_get(void);
-
-/**
- * Interns the given string in the ZendEngine, returning a `datadog_php_str`
- * struct for ABI compatibility with Rust.
- */
-datadog_php_str datadog_php_profiling_intern(const char *str, size_t size, bool permanent);
-
 /**
  * Lookup module by name in the module registry. Returns NULL if not found.
  * This is meant to be called from Rust, so it uses types that are easy to use
@@ -80,10 +33,9 @@ datadog_php_str datadog_php_profiling_intern(const char *str, size_t size, bool 
 zend_module_entry *datadog_get_module_entry(const uint8_t *str, uintptr_t len);
 
 /**
- * Called by this extension's rinit handler. Does things that are burdensome in
- * Rust like fetching EG(vm_interrupt).
+ * Fetches the VM interrupt address of the calling PHP thread.
  */
-void datadog_php_profiling_rinit(void);
+void *datadog_php_profiling_vm_interrupt_addr(void);
 
 /**
  * For Code Hotspots, we need the tracer's local root span id and the current


### PR DESCRIPTION
### Description

Since opcache overrides the intern function and you still have to
provide refcounting anyway, the previous version of the code would
leak.

At this point, the Rust <-> C globals bridge isn't providing any value
at all. Although in the future we there may be value in bridging these
things, such as to support INI handling, today it's just dragging us
down. So, I removed it, resulting in about twice as many lines deleted
as I added.

Also bump profiling version to v0.9.0.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
