### PR TITLE
Fix #1687 datadog-setup.php failing in environments without scan directory

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -175,9 +175,11 @@ function install($options)
                                     "because there is no scan directory and no configuration file loaded.");
             }
 
-            print_warning("Performing an installation without a scan directory may result in fragile installations that are broken " .
-                        "by normal system upgrades. " .
-                        "It is advisable to use the configure switch --with-config-file-scan-dir when building PHP");
+            print_warning("Performing an installation without a scan directory may result in " .
+                        "fragile installations that are broken by normal system upgrades. " .
+                        "It is advisable to use the configure switch " .
+                        "--with-config-file-scan-dir " .
+                        "when building PHP");
         }
 
         // Copying the extension

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -171,12 +171,13 @@ function install($options)
 
         if (!isset($phpProperties[INI_SCANDIR])) {
             if (!isset($phpProperties[INI_MAIN])) {
-                print_error_and_exit("It is not possible to perform installation on this system ".
+                print_error_and_exit("It is not possible to perform installation on this system " .
                                     "because there is no scan directory and no configuration file loaded.");
             }
 
-            print_warning("Performing an installation without a scan directory may result in fragile installations that are broken ".
-                            "by normal system upgrades. It is advisable to use the configure switch --with-config-file-scan-dir when building PHP");
+            print_warning("Performing an installation without a scan directory may result in fragile installations that are broken " .
+                        "by normal system upgrades. " .
+                        "It is advisable to use the configure switch --with-config-file-scan-dir when building PHP");
         }
 
         // Copying the extension
@@ -418,7 +419,7 @@ function uninstall($options)
             }
         } else {
             if (!isset($phpProperties[INI_MAIN])) {
-                print_error_and_exit("It is not possible to perform uninstallation on this system ".
+                print_error_and_exit("It is not possible to perform uninstallation on this system " .
                                     "because there is no scan directory and no configuration file loaded.");
             }
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -167,14 +167,16 @@ function install($options)
         $phpProperties = ini_values($fullPath);
         if (is_truthy($phpProperties[THREAD_SAFETY]) && is_truthy($phpProperties[IS_DEBUG])) {
             print_error_and_exit('(ZTS DEBUG) builds of PHP are currently not supported');
-        } else if (!isset($phpProperties[INI_SCANDIR])) {
+        }
+
+        if (!isset($phpProperties[INI_SCANDIR])) {
             if (!isset($phpProperties[INI_MAIN])) {
                 print_error_and_exit("It is not possible to perform installation on this system ".
-                                     "because there is no scan directory and no configuration file loaded.");
+                                    "because there is no scan directory and no configuration file loaded.");
             }
 
             print_warning("Performing an installation without a scan directory may result in fragile installations that are broken ".
-                          "by normal system upgrades. It is advisable to use the configure switch --with-config-file-scan-dir when building PHP");
+                            "by normal system upgrades. It is advisable to use the configure switch --with-config-file-scan-dir when building PHP");
         }
 
         // Copying the extension
@@ -417,7 +419,7 @@ function uninstall($options)
         } else {
             if (!isset($phpProperties[INI_MAIN])) {
                 print_error_and_exit("It is not possible to perform uninstallation on this system ".
-                                     "because there is no scan directory and no configuration file loaded.");
+                                    "because there is no scan directory and no configuration file loaded.");
             }
 
             $iniFilePaths = [$phpProperties[INI_MAIN]];

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -69,6 +69,7 @@ test_installer: $(shell find installer -name 'test_*.sh' -exec basename {} \;)
 test_appsec_install_disabled.sh \
 test_appsec_install_enabled.sh \
 test_first_install.sh \
+test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
 test_install_custom_installation_directory.sh \
 test_install_custom_installation_root.sh \

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+cat <<- "SCANDIR" >$(dirname "$(which php)")/php-without-scan-dir
+#!/usr/bin/env bash
+php="$(dirname "$0")/php"
+if [[ "$@" == *-i* ]]; then
+  "$php" "$@" | grep -v "Scan this dir for additional .ini files"
+else
+  "$php" "$@"
+fi
+SCANDIR
+chmod +x $(dirname "$(which php)")/php-without-scan-dir
+
+# Install using the php installer
+new_version="0.74.0"
+generate_installers "${new_version}"
+php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+assert_ddtrace_version "${new_version}"
+
+ini_file=$(get_php_main_conf)
+
+assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
+assert_file_contains "${ini_file}" 'datadog.version'
+
+# Removing an enabled property and a commented out property
+sed -i 's/datadog\.trace\.request_init_hook.*//g' "${ini_file}"
+sed -i 's/datadog\.version.*//g' "${ini_file}"
+
+assert_file_not_contains "${ini_file}" 'datadog.trace.request_init_hook'
+assert_file_not_contains "${ini_file}" 'datadog.version'
+
+php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+
+assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
+assert_file_contains "${ini_file}" 'datadog.version'
+
+assert_request_init_hook_exists

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -26,7 +26,7 @@ new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 cat /tmp/php-empty.ini
-assert_ddtrace_version "${new_version}"
+assert_ddtrace_version "${new_version}" php-without-scan-dir
 
 ini_file=$(get_php_main_conf)
 
@@ -45,4 +45,4 @@ php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_contains "${ini_file}" 'datadog.version'
 
-assert_request_init_hook_exists
+assert_request_init_hook_exists php-without-scan-dir

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -18,10 +18,13 @@ fi
 SCANDIR
 chmod +x $(dirname "$(which php)")/php-without-scan-dir
 
+# Must be a main php.ini file
+echo "" > /tmp/php-empty.ini
+
 # Install using the php installer
 new_version="0.74.0"
 generate_installers "${new_version}"
-php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+php -c /tmp/php-empty.ini ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 assert_ddtrace_version "${new_version}"
 
 ini_file=$(get_php_main_conf)

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -25,7 +25,6 @@ chmod +x $(dirname "$(which php)")/php-without-scan-dir
 new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
-cat /tmp/php-empty.ini
 assert_ddtrace_version "${new_version}" php-without-scan-dir
 
 ini_file=$(get_php_main_conf php-without-scan-dir)

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -7,9 +7,12 @@ set -e
 # Initially no ddtrace
 assert_no_ddtrace
 
+# Must be a main php.ini file
+echo "" > /tmp/php-empty.ini
+
 cat <<- "SCANDIR" >$(dirname "$(which php)")/php-without-scan-dir
 #!/usr/bin/env bash
-php="$(dirname "$0")/php"
+php="$(dirname "$0")/php -c /tmp/php-empty.ini"
 if [[ "$@" == *-i* ]]; then
   "$php" "$@" | grep -v "Scan this dir for additional .ini files"
 else
@@ -18,13 +21,10 @@ fi
 SCANDIR
 chmod +x $(dirname "$(which php)")/php-without-scan-dir
 
-# Must be a main php.ini file
-echo "" > /tmp/php-empty.ini
-
 # Install using the php installer
 new_version="0.74.0"
 generate_installers "${new_version}"
-php -c /tmp/php-empty.ini ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 assert_ddtrace_version "${new_version}"
 
 ini_file=$(get_php_main_conf)
@@ -39,7 +39,7 @@ sed -i 's/datadog\.version.*//g' "${ini_file}"
 assert_file_not_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_not_contains "${ini_file}" 'datadog.version'
 
-php -c /tmp/php-empty.ini ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 
 assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_contains "${ini_file}" 'datadog.version'

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -25,6 +25,7 @@ chmod +x $(dirname "$(which php)")/php-without-scan-dir
 new_version="0.74.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+cat /tmp/php-empty.ini
 assert_ddtrace_version "${new_version}"
 
 ini_file=$(get_php_main_conf)

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -28,7 +28,7 @@ php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 cat /tmp/php-empty.ini
 assert_ddtrace_version "${new_version}" php-without-scan-dir
 
-ini_file=$(get_php_main_conf)
+ini_file=$(get_php_main_conf php-without-scan-dir)
 
 assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_contains "${ini_file}" 'datadog.version'

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -39,7 +39,7 @@ sed -i 's/datadog\.version.*//g' "${ini_file}"
 assert_file_not_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_not_contains "${ini_file}" 'datadog.version'
 
-php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
+php -c /tmp/php-empty.ini ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 
 assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_contains "${ini_file}" 'datadog.version'

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -12,11 +12,11 @@ echo "" > /tmp/php-empty.ini
 
 cat <<- "SCANDIR" >$(dirname "$(which php)")/php-without-scan-dir
 #!/usr/bin/env bash
-php="$(dirname "$0")/php -c /tmp/php-empty.ini"
+php="$(dirname "$0")/php"
 if [[ "$@" == *-i* ]]; then
-  "$php" "$@" | grep -v "Scan this dir for additional .ini files"
+  "$php" -c /tmp/php-empty.ini "$@" | grep -v "Scan this dir for additional .ini files"
 else
-  "$php" "$@"
+  "$php" -c /tmp/php-empty.ini "$@"
 fi
 SCANDIR
 chmod +x $(dirname "$(which php)")/php-without-scan-dir

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -125,15 +125,18 @@ install_legacy_ddtrace() {
 }
 
 get_php_conf_dir() {
-    php -i | grep -i 'scan this dir for additional .ini files' | awk '{print $NF}'
+    php_bin=${1:-php}
+    $php_bin -i | grep -i 'scan this dir for additional .ini files' | awk '{print $NF}'
 }
 
 get_php_main_conf() {
-    php -i | grep -i 'Loaded Configuration File' | awk '{print $NF}'
+    php_bin=${1:-php}
+    $php_bin -i | grep -i 'Loaded Configuration File' | awk '{print $NF}'
 }
 
 get_php_extension_dir() {
-    php -i | grep -i '^extension_dir' | awk '{print $NF}'
+    php_bin=${1:-php}
+    $php_bin -i | grep -i '^extension_dir' | awk '{print $NF}'
 }
 
 generate_installers() {

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -127,6 +127,10 @@ get_php_conf_dir() {
     php -i | grep -i 'scan this dir for additional .ini files' | awk '{print $NF}'
 }
 
+get_php_main_conf() {
+    php -i | grep -i 'Loaded Configuration File' | awk '{print $NF}'
+}
+
 get_php_extension_dir() {
     php -i | grep -i '^extension_dir' | awk '{print $NF}'
 }

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -102,7 +102,8 @@ assert_appsec_disabled() {
 }
 
 assert_request_init_hook_exists() {
-    assert_file_exists $(php -r 'echo ini_get("datadog.trace.request_init_hook");')
+    php_bin=${1:-php}
+    assert_file_exists $($php_bin -r 'echo ini_get("datadog.trace.request_init_hook");')
 }
 
 assert_file_exists() {

--- a/tests/Integration/PHPInstallerTest.php
+++ b/tests/Integration/PHPInstallerTest.php
@@ -130,7 +130,8 @@ final class PHPInstallerTest extends BaseTestCase
     public function testIniValues()
     {
         $values = \ini_values(\PHP_BINARY);
-        $this->assertNotEmpty($values[INI_CONF]);
+        $this->assertNotEmpty($values[INI_MAIN]);
+        $this->assertNotEmpty($values[INI_SCANDIR]);
         $this->assertNotEmpty($values[EXTENSION_DIR]);
         $this->assertNotEmpty($values[THREAD_SAFETY]);
         $this->assertNotEmpty($values[PHP_API]);

--- a/tests/Integration/PHPInstallerTest.php
+++ b/tests/Integration/PHPInstallerTest.php
@@ -130,8 +130,13 @@ final class PHPInstallerTest extends BaseTestCase
     public function testIniValues()
     {
         $values = \ini_values(\PHP_BINARY);
-        $this->assertNotEmpty($values[INI_MAIN]);
-        $this->assertNotEmpty($values[INI_SCANDIR]);
+
+        foreach ($values as $value) {
+            /* we drop (none) values */
+            $this->assertNotEquals($value, "(none)");
+        }
+
+        /* we rely on these being some sensible value */
         $this->assertNotEmpty($values[EXTENSION_DIR]);
         $this->assertNotEmpty($values[THREAD_SAFETY]);
         $this->assertNotEmpty($values[PHP_API]);


### PR DESCRIPTION
### Description

Fix #1687 datadog-setup.php failing in environments without scan directory

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
