### PR TITLE
Add agent target URL to flush-message to help with debugging

### DIFF
--- a/ext/php7/auto_flush.c
+++ b/ext/php7/auto_flush.c
@@ -1,6 +1,7 @@
 #include "auto_flush.h"
 
 #include "comms_php.h"
+#include "coms.h"
 #include "ddtrace_string.h"
 #include "logging.h"
 #include "serializer.h"
@@ -41,8 +42,10 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
         } else {
             success = ddtrace_send_traces_via_thread(1, payload, size);
             if (success) {
-                ddtrace_log_debugf("Successfully triggered flush with trace of size %d",
-                                   zend_hash_num_elements(Z_ARR(trace)));
+                char *url = ddtrace_agent_url();
+                ddtrace_log_debugf("Flushing trace of size %d to send-queue for %s",
+                                   zend_hash_num_elements(Z_ARR(trace)), url);
+                free(url);
             }
             dd_prepare_for_new_trace();
         }

--- a/ext/php8/auto_flush.c
+++ b/ext/php8/auto_flush.c
@@ -1,6 +1,7 @@
 #include "auto_flush.h"
 
 #include "comms_php.h"
+#include "coms.h"
 #include "ddtrace_string.h"
 #include "logging.h"
 #include "serializer.h"
@@ -41,8 +42,10 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
         } else {
             success = ddtrace_send_traces_via_thread(1, payload, size);
             if (success) {
-                ddtrace_log_debugf("Successfully triggered flush with trace of size %d",
-                                   zend_hash_num_elements(Z_ARR(trace)));
+                char *url = ddtrace_agent_url();
+                ddtrace_log_debugf("Flushing trace of size %d to send-queue for %s",
+                                   zend_hash_num_elements(Z_ARR(trace)), url);
+                free(url);
             }
             dd_prepare_for_new_trace();
         }

--- a/tests/ext/close_spans_until.phpt
+++ b/tests/ext/close_spans_until.phpt
@@ -30,4 +30,4 @@ int(2)
 int(2)
 int(1)
 int(0)
-Successfully triggered flush with trace of size 7
+Flushing trace of size 7 to send-queue for %s

--- a/tests/ext/dd_trace_api_error.phpt
+++ b/tests/ext/dd_trace_api_error.phpt
@@ -47,7 +47,7 @@ var_dump(dd_trace('foo', 'foo', [
 var_dump(dd_trace('foo', 'foo', []));
 
 ?>
---EXPECT--
+--EXPECTF--
 Unexpected parameter combination, expected (class, function, closure | config_array) or (function, closure | config_array)
 bool(false)
 bool(false)
@@ -67,4 +67,4 @@ bool(false)
 bool(false)
 bool(false)
 bool(false)
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -40,4 +40,4 @@ array(2) {
 }
 bool(false)
 
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/dropped_spans_have_negative_duration.phpt
+++ b/tests/ext/dropped_spans_have_negative_duration.phpt
@@ -15,7 +15,7 @@ DDTrace\flush();
 var_dump($outerSpan->getDuration());
 
 ?>
---EXPECT--
-Successfully triggered flush with trace of size 1
+--EXPECTF--
+Flushing trace of size 1 to send-queue for %s
 int(-1)
 No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -96,4 +96,4 @@ x-datadog-trace-id: %d
 x-foo: after-the-copy
 
 Done.
-Successfully triggered flush with trace of size 5
+Flushing trace of size 5 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -66,4 +66,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -66,4 +66,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
@@ -83,4 +83,4 @@ x-datadog-parent-id: %d
 x-orig-header: foo
 
 Done.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -73,4 +73,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -74,4 +74,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -92,4 +92,4 @@ x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 x-foo: not copied
 Done.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -89,4 +89,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -93,4 +93,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -51,13 +51,13 @@ function long_running_entry_point()
 ?>
 --EXPECTF--
 child is enabled
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s
 No finished traces to be sent to the agent
 parent is enabled
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 child is enabled
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s
 No finished traces to be sent to the agent
 parent is enabled
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 No finished traces to be sent to the agent

--- a/tests/ext/request-init-hook/dd_init_open_basedir.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir.phpt
@@ -14,4 +14,4 @@ Calling dd_init.php from parent directory "%s/includes"
 Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
 Error opening request init hook: %s/dd_init.php
 Done.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -12,4 +12,4 @@ var_dump(error_get_last());
 --EXPECTF--
 %s in request init hook: Undefined variable%sthis_does_not_%s
 NULL
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -13,4 +13,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -12,4 +12,4 @@ echo "Request start" . PHP_EOL;
 --EXPECTF--
 Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -9,8 +9,8 @@ ddtrace.request_init_hook={PWD}/throws_exception.php
 echo "Request start" . PHP_EOL;
 
 ?>
---EXPECT--
+--EXPECTF--
 Throwing an exception...
 Exception thrown in request init hook: Oops!
 Request start
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -13,4 +13,4 @@ echo "Request start" . PHP_EOL;
 Calling a function that does not exist...
 Error %s in request init hook: Call to undefined function this_function_does_not_%s
 Request start
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_api_error.phpt
@@ -21,7 +21,7 @@ var_dump(DDTrace\trace_method('foo', 'foo', [
     'prehook' => new stdClass(),
 ]));
 ?>
---EXPECT--
+--EXPECTF--
 Expected 'prehook' to be an instance of Closure
 bool(false)
 Expected 'prehook' to be an instance of Closure
@@ -31,4 +31,4 @@ Expected 'prehook' to be an instance of Closure
 bool(false)
 Expected 'prehook' to be an instance of Closure
 bool(false)
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -14,4 +14,4 @@ var_dump($sum);
 --EXPECTF--
 RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
 int(9)
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -30,17 +30,17 @@ echo PHP_EOL;
 main(6);
 echo PHP_EOL;
 ?>
---EXPECT--
+--EXPECTF--
 3
 6
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 10
 15
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 21
 28
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -33,7 +33,7 @@ try {
     echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
 }
 ?>
---EXPECT--
+--EXPECTF--
 Caught exception: Oops!
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -35,17 +35,17 @@ echo PHP_EOL;
 main(6);
 echo PHP_EOL;
 ?>
---EXPECT--
+--EXPECTF--
 3
 6
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 10
 15
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 21
 28
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -32,7 +32,7 @@ try {
     echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
 }
 ?>
---EXPECT--
-Successfully triggered flush with trace of size 1
+--EXPECTF--
+Flushing trace of size 1 to send-queue for %s
 Caught exception: Oops!
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -29,20 +29,20 @@ echo PHP_EOL;
 main(6);
 echo PHP_EOL;
 ?>
---EXPECT--
+--EXPECTF--
 3
 6
 Has not flushed yet.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 10
 15
 Has not flushed yet.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 21
 28
 Has not flushed yet.
-Successfully triggered flush with trace of size 3
+Flushing trace of size 3 to send-queue for %s
 
 No finished traces to be sent to the agent

--- a/tests/ext/sandbox/dd_trace_api_error.phpt
+++ b/tests/ext/sandbox/dd_trace_api_error.phpt
@@ -39,7 +39,7 @@ var_dump(DDTrace\trace_method('foo', 'foo', [
 ]));
 var_dump(DDTrace\trace_method('foo', 'foo', []));
 ?>
---EXPECT--
+--EXPECTF--
 Unable to parse parameters for DDTrace\trace_function; expected (string $class_name, string $method_name, ?Closure $prehook = NULL, ?Closure $posthook = NULL)
 bool(false)
 Expected config_array to be an associative array
@@ -69,4 +69,4 @@ Expected 'posthook' to be an instance of Closure
 bool(false)
 DDTrace\trace_method was given neither prehook nor posthook.
 bool(false)
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
@@ -36,8 +36,8 @@ namespace
     Test::public_static_method();
 }
 ?>
---EXPECT--
+--EXPECTF--
 autoload_attempted
 PUBLIC STATIC METHOD
 PUBLIC STATIC METHOD
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -14,4 +14,4 @@ var_dump($sum);
 --EXPECTF--
 RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
 int(9)
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/03.phpt
+++ b/tests/ext/sandbox/hook_function/03.phpt
@@ -15,8 +15,8 @@ function greet($name)
 greet('Datadog');
 
 ?>
---EXPECT--
+--EXPECTF--
 DDTrace\hook_function was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02.phpt
@@ -27,4 +27,4 @@ greet('Datadog');
 Hello, Datadog.
 greet hooked.
 %s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
@@ -31,4 +31,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
 Sum = 4.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02.phpt
@@ -26,4 +26,4 @@ greet('Datadog');
 greet hooked.
 %s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
@@ -34,4 +34,4 @@ greet hooked.
 Exception thrown in ddtrace's closure defined at %s:%d for greet(): !
 Hello, Datadog.
 Done.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
@@ -29,4 +29,4 @@ try {
 array_sum hooked.
 Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
 Sum = 4.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/03.phpt
+++ b/tests/ext/sandbox/hook_method/03.phpt
@@ -18,8 +18,8 @@ final class Greeter
 Greeter::greet('Datadog');
 
 ?>
---EXPECT--
+--EXPECTF--
 DDTrace\hook_method was given neither prehook nor posthook.
 bool(false)
 Hello, Datadog.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/posthook_07.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07.phpt
@@ -52,8 +52,8 @@ $app = new App();
 $app->run();
 
 ?>
---EXPECT--
+--EXPECTF--
 App::__construct hooked.
 App::run
 App::run traced.
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02.phpt
@@ -30,4 +30,4 @@ Greeter::greet('Datadog');
 Hello, Datadog.
 Greeter::greet hooked.
 %s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02.phpt
@@ -30,4 +30,4 @@ Greeter::greet('Datadog');
 Greeter::greet hooked.
 %s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
@@ -35,4 +35,4 @@ Greeter::greet hooked.
 Exception thrown in ddtrace's closure defined at %s:%d for Greeter::greet(): !
 Hello, Datadog.
 Done.
-Successfully triggered flush with trace of size 1
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/manual_flush.phpt
+++ b/tests/ext/sandbox/manual_flush.phpt
@@ -20,6 +20,6 @@ DDTrace\flush();
 main();
 
 ?>
---EXPECT--
-Successfully triggered flush with trace of size 1
-Successfully triggered flush with trace of size 1
+--EXPECTF--
+Flushing trace of size 1 to send-queue for %s
+Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -26,8 +26,8 @@ try {
     echo $e->getMessage() . PHP_EOL;
 }
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 NULL
 Oops!
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -21,7 +21,7 @@ DDTrace\trace_method('Foo', 'test', static function () {
 $foo = new Foo();
 $foo->test();
 ?>
---EXPECT--
+--EXPECTF--
 Foo::test()
 TRACED Foo::test()
-Successfully triggered flush with trace of size 2
+Flushing trace of size 2 to send-queue for %s


### PR DESCRIPTION
### Description

Helping to spot mistakes if users don't provide phpinfo() output.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
