### PR TITLE
Set root span name only in HttpKernel::boot() to avoid side effects on CLI

### DIFF
--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -56,14 +56,13 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\HttpKernel\Kernel',
             'boot',
             [
-                "prehook" => function () {
+                "prehook" => function (SpanData $span) {
                     if ($rootSpan = \DDTrace\root_span()) {
                         $this->appName = \ddtrace_config_app_name('symfony');
                         $rootSpan->name = 'symfony.request';
                         $rootSpan->service = $this->appName;
                     }
-                },
-                "posthook" => function (SpanData $span) {
+
                     $span->name = 'symfony.httpkernel.kernel.boot';
                     $span->resource = \get_class($this);
                     $span->type = Type::WEB_SERVLET;

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -30,8 +30,8 @@ class RouteNameTest extends WebFrameworkTestCase
         $isApache = \getenv('DD_TRACE_TEST_SAPI') == 'apache2handler';
         $this->assertFlameGraph($traces, [
             SpanAssertion::build(
-                'web.request',
-                'web.request',
+                'symfony.request',
+                'symfony',
                 'web',
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -26,8 +26,8 @@ class RouteNameTest extends WebFrameworkTestCase
         $isApache = \getenv('DD_TRACE_TEST_SAPI') == 'apache2handler';
         $this->assertFlameGraph($traces, [
             SpanAssertion::build(
-                'web.request',
-                'web.request',
+                'symfony.request',
+                'symfony',
                 'web',
                 'AppBundle\Controller\DefaultController testingRouteNameAction'
             )->withExactTags([

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -9,6 +9,7 @@
     "require-dev": {
         "mockery/mockery": "*",
         "phpunit/phpunit": "*",
+        "phpspec/prophecy": "*",
         "symfony/process": "<5",
         "g1a/composer-test-scenarios": "~3.0"
     },


### PR DESCRIPTION
### Description

Fixes #1703.

Also fixing tests - phpunit has dropped its direct phpspec/prophesize dependency.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
