### PR TITLE
Fix #1709 appsec attempting to load erroneously

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -337,7 +337,7 @@ function install($options)
                             . escapeshellarg($iniFilePath)
                     );
                 }
-            } elseif (is_truthy($options[OPT_ENABLE_APPSEC])) {
+            } else {
                 // Ensure AppSec isn't loaded if not compatible
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
@@ -345,8 +345,10 @@ function install($options)
                         . escapeshellarg($iniFilePath)
                 );
 
-                $enableAppsec = OPT_ENABLE_APPSEC;
-                print_error_and_exit("Option --${enableAppsec} was provided, but it is not supported on this PHP build or version.\n");
+                if (is_truthy($options[OPT_ENABLE_APPSEC])) {
+                    $enableAppsec = OPT_ENABLE_APPSEC;
+                    print_error_and_exit("Option --${enableAppsec} was provided, but it is not supported on this PHP build or version.\n");
+                }
             }
             // phpcs:enable Generic.Files.LineLength.TooLong
 


### PR DESCRIPTION
### Description

The installer adds appsec.so without commenting it out, so it's always necessary to run the replacement to comment it out when we are not installing appsec.

This should be picked into the 5 branch also.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
