### PR TITLE
Fix symfony service and root span name

### DIFF
--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -45,6 +45,12 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\HttpKernel\Kernel',
             'handle',
             function (SpanData $span) {
+                if ($rootSpan = \DDTrace\root_span()) {
+                    $this->appName = \ddtrace_config_app_name('symfony');
+                    $rootSpan->name = 'symfony.request';
+                    $rootSpan->service = $this->appName;
+                }
+
                 $span->name = 'symfony.httpkernel.kernel.handle';
                 $span->resource = \get_class($this);
                 $span->type = Type::WEB_SERVLET;
@@ -55,20 +61,12 @@ class SymfonyIntegration extends Integration
         \DDTrace\trace_method(
             'Symfony\Component\HttpKernel\Kernel',
             'boot',
-            [
-                "prehook" => function (SpanData $span) {
-                    if ($rootSpan = \DDTrace\root_span()) {
-                        $this->appName = \ddtrace_config_app_name('symfony');
-                        $rootSpan->name = 'symfony.request';
-                        $rootSpan->service = $this->appName;
-                    }
-
-                    $span->name = 'symfony.httpkernel.kernel.boot';
-                    $span->resource = \get_class($this);
-                    $span->type = Type::WEB_SERVLET;
-                    $span->service = \ddtrace_config_app_name('symfony');
-                }
-            ]
+            function (SpanData $span) {
+                $span->name = 'symfony.httpkernel.kernel.boot';
+                $span->resource = \get_class($this);
+                $span->type = Type::WEB_SERVLET;
+                $span->service = \ddtrace_config_app_name('symfony');
+            }
         );
 
         $rootSpan = \DDTrace\root_span();

--- a/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
+++ b/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V5_2;
+
+use DDTrace\Tests\Common\IntegrationTestCase;
+use DDTrace\Tests\Common\SpanAssertion;
+
+class ConsoleCommandTest extends IntegrationTestCase
+{
+    protected static function getConsoleScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/bin/console';
+    }
+
+    public function testScenario()
+    {
+        list($traces) = $this->inCli(self::getConsoleScript(), [], [], 'about');
+
+        $this->assertFlameGraph(
+            $traces,
+            [
+                SpanAssertion::build('console', 'console', 'cli', 'console')
+                    ->withChildren([
+                        SpanAssertion::exists('symfony.console.terminate', 'symfony.console.terminate'),
+                        SpanAssertion::exists('symfony.console.command', 'symfony.console.command'),
+                        SpanAssertion::exists('symfony.httpkernel.kernel.boot', 'App\Kernel'),
+                    ]),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Description

Previous fix for #1703 didn't cover the full problem since Kernel::boot is also used in symfony cli commands, instead root span name should be set to symfony.request only when Kernel actually handles a request which is the case when Kernel::handle is called.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
