### PR TITLE
Integrate with Symfony console commands

### DIFF
--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -70,6 +70,35 @@ class SymfonyIntegration extends Integration
             ]
         );
 
+        $symfonyCommandsIntegrated = [];
+        \DDTrace\hook_method(
+            'Symfony\Component\Console\Command\Command',
+            '__construct',
+            null,
+            function ($This, $scope) use (&$symfonyCommandsIntegrated) {
+                if (isset($symfonyCommandsIntegrated[$scope])) {
+                    return;
+                }
+
+                $symfonyCommandsIntegrated[$scope] = true;
+
+                \DDTrace\trace_method($scope, 'run', [
+                    /* Commands can evidently call other commands, so allow recursion:
+                     * > Console events are only triggered by the main command being executed.
+                     * > Commands called by the main command will not trigger any event.
+                     * - https://symfony.com/doc/current/components/console/events.html.
+                     */
+                    'recurse' => true,
+                    'prehook' => function (SpanData $span) use ($scope) {
+                        $span->name = 'symfony.console.command.run';
+                        $span->resource = $this->getName() ?: $span->name;
+                        $span->service = \ddtrace_config_app_name('symfony');
+                        $span->type = Type::CLI;
+                        $span->meta['symfony.console.command.class'] = $scope;
+                    }]);
+            }
+        );
+
         $rootSpan = \DDTrace\root_span();
         if (null == $rootSpan) {
             return Integration::NOT_LOADED;
@@ -168,13 +197,12 @@ class SymfonyIntegration extends Integration
          * Since the arguments passed to the tracing closure on PHP 7 are mutable,
          * the closure must be run _before_ the original call via 'prehook'.
         */
-        $commands = [];
         \DDTrace\trace_method(
             'Symfony\Component\EventDispatcher\EventDispatcher',
             'dispatch',
             [
                 'recurse' => true,
-                'prehook' => function (SpanData $span, $args) use ($integration, &$injectedActionInfo, &$commands) {
+                'prehook' => function (SpanData $span, $args) use ($integration, &$injectedActionInfo) {
                     if (!isset($args[0])) {
                         return false;
                     }
@@ -221,26 +249,6 @@ class SymfonyIntegration extends Integration
                                         }
                                     );
                                 }
-                            }
-                        }
-                    } elseif ($eventName === 'console.command') {
-                        if (\method_exists($event, 'getCommand') && ($command = $event->getCommand()) !== null) {
-                            $scope = \get_class($command);
-                            if (!isset($commands[$scope])) {
-                                $commands[$scope] = true;
-                                \DDTrace\trace_method(
-                                    $scope,
-                                    'run',
-                                    [
-                                        'prehook' => function (SpanData $span) use ($scope) {
-                                            $span->name = 'symfony.console.command.run';
-                                            $span->resource = $this->getName() ?: $span->name;
-                                            $span->service = \ddtrace_config_app_name('symfony');
-                                            $span->type = Type::CLI;
-                                            $span->meta['symfony.console.command.class'] = $scope;
-                                        },
-                                    ]
-                                );
                             }
                         }
                     }

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -89,7 +89,17 @@ final class SpanChecker
                     $expectedNodeRoot->getResource()
                 );
             } catch (\Exception $e) {
-                (function () use ($expectedNodeRoot) {
+                (function () use ($expectedNodeRoot, $node) {
+                    if (
+                        strpos($this->message, "Cannot find span") === 0
+                        && strpos($this->message, "parent operation/resource") === false
+                    ) {
+                        $actualNames = array_map(function (array $child) {
+                            return $child['span']['name'] . "/" . $child['span']['resource'];
+                        }, $node['children']);
+                        sort($actualNames);
+                        $this->message .= "\n\nAvailable spans:\n" . implode("\n", $actualNames) . "\n";
+                    }
                     $this->message .= sprintf(
                         "\nparent operation/resource: %s/%s",
                         $expectedNodeRoot->getOperationName(),

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -96,6 +96,7 @@ final class SpanChecker
                         $expectedNodeRoot->getResource()
                     );
                 })->call($e);
+                throw $e;
             }
         }
     }

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -48,15 +48,16 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
-                                SpanAssertion::exists('symfony.controller'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::build(
                                     'symfony.controller',
                                     'symfony',
                                     'web',
                                     'AppBundle\Controller\CommonScenariosController::simpleAction'
-                                )->skipIf(\PHP_MAJOR_VERSION !== 5), // call_user_func_array
+                                ),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
@@ -80,7 +81,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::build(
                                     'symfony.controller',
@@ -121,7 +124,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::build(
                                     'symfony.controller',
@@ -133,7 +138,23 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 ->withExistingTagsNames(['error.stack']),
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'symfony',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'symfony',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -162,7 +183,23 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'symfony',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'symfony',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.request')

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -51,7 +51,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                SpanAssertion::exists('symfony.security.authentication.success'),
+                            ]),
                             SpanAssertion::exists('symfony.kernel.controller'),
                             SpanAssertion::exists('symfony.kernel.controller'),
                             SpanAssertion::build(

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -48,7 +48,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -80,7 +82,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -123,7 +127,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -136,7 +142,24 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 ->withExistingTagsNames(['error.stack']),
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'symfony',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'symfony',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -165,7 +188,24 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'symfony',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'symfony',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.request')

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -51,7 +51,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                SpanAssertion::exists('symfony.security.authentication.success'),
+                            ]),
                             SpanAssertion::exists('symfony.kernel.controller'),
                             SpanAssertion::exists('symfony.kernel.controller_arguments'),SpanAssertion::build(
                                 'symfony.controller',

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -57,7 +57,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -89,7 +91,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -131,7 +135,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -144,7 +150,24 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 ->withExistingTagsNames(['error.stack']),
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'test_symfony_40',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'test_symfony_40',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -173,7 +196,24 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'test_symfony_40',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'test_symfony_40',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.request')

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -52,7 +52,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                            SpanAssertion::exists('symfony.kernel.request'),
+                            SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                SpanAssertion::exists('symfony.security.authentication.success'),
+                            ]),
                             SpanAssertion::exists('symfony.kernel.controller'),
                             SpanAssertion::exists('symfony.kernel.controller_arguments'),
                             SpanAssertion::build(

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -57,12 +57,12 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                SpanAssertion::exists('symfony.kernel.response')->withChildren([
-                                    SpanAssertion::exists('symfony.security.authentication.success')
-                                ]),
+                                SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                                 SpanAssertion::build(
                                     'symfony.controller',
@@ -90,7 +90,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::build(
                                     'symfony.controller',
@@ -106,9 +108,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                     )->withExactTags([]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
-                                SpanAssertion::exists('symfony.kernel.response')->withChildren([
-                                    SpanAssertion::exists('symfony.security.authentication.success')
-                                ]),
+                                SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
                         ]),
@@ -134,7 +134,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -146,7 +148,24 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 ->withExistingTagsNames(['error.stack']),
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'test_symfony_42',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'test_symfony_42',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -173,11 +192,26 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             SpanAssertion::exists('symfony.kernel.handle')->withChildren([
                                 SpanAssertion::exists('symfony.kernel.handleException')->withChildren([
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
-                                    SpanAssertion::exists('symfony.kernel.response')->withChildren([
-                                        SpanAssertion::exists('symfony.security.authentication.success')
-                                    ]),
+                                    SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.exception')->withChildren([
-                                        SpanAssertion::exists('symfony.templating.render'),
+                                        SpanAssertion::exists('symfony.kernel.request'),
+                                        SpanAssertion::exists('symfony.kernel.controller'),
+                                        SpanAssertion::exists('symfony.kernel.controller_arguments'),
+                                        SpanAssertion::build(
+                                            'symfony.controller',
+                                            'test_symfony_42',
+                                            'web',
+                                            'Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction'
+                                        )->withChildren([
+                                            SpanAssertion::build(
+                                                'symfony.templating.render',
+                                                'test_symfony_42',
+                                                'web',
+                                                'Twig\Environment @Twig/Exception/error.html.twig'
+                                            )->withExactTags([]),
+                                        ]),
+                                        SpanAssertion::exists('symfony.kernel.response'),
+                                        SpanAssertion::exists('symfony.kernel.finish_request'),
                                     ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.request')

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -53,7 +53,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
                         SpanAssertion::exists('symfony.kernel.handle')
                             ->withChildren([
-                                SpanAssertion::exists('symfony.kernel.request'),
+                                SpanAssertion::exists('symfony.kernel.request')->withChildren([
+                                    SpanAssertion::exists('symfony.security.authentication.success'),
+                                ]),
                                 SpanAssertion::exists('symfony.kernel.controller'),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::build(
@@ -62,9 +64,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                                     'web',
                                     'App\Controller\CommonScenariosController::simpleAction'
                                 ),
-                                SpanAssertion::exists('symfony.kernel.response')->withChildren([
-                                    SpanAssertion::exists('symfony.security.authentication.success')
-                                ]),
+                                SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
                             ]),
                     ]),

--- a/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
+++ b/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
@@ -21,8 +21,12 @@ class ConsoleCommandTest extends IntegrationTestCase
             [
                 SpanAssertion::build('console', 'console', 'cli', 'console')
                     ->withChildren([
-                        SpanAssertion::exists('symfony.console.terminate', 'symfony.console.terminate'),
+                        SpanAssertion::build('symfony.console.command.run', 'symfony', 'cli', 'about')
+                            ->withExactTags([
+                                'symfony.console.command.class' => 'Symfony\Bundle\FrameworkBundle\Command\AboutCommand',
+                            ]),
                         SpanAssertion::exists('symfony.console.command', 'symfony.console.command'),
+                        SpanAssertion::exists('symfony.console.terminate', 'symfony.console.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot', 'App\Kernel'),
                     ]),
             ]


### PR DESCRIPTION
### Description

This adds a span 'symfony.console.command.run' whose resource is the
name of the command (e.g. `$command->getName()`) if it's not null. It
attaches the command's class name as meta-data.

Suggestions are welcome for the name of the span and the metadata.

Here's a screenshot of the span created by the test:

![screenshot of symfony.console.command.run span](https://user-images.githubusercontent.com/253316/187926050-1fd1ed4c-6b4c-4569-b628-83f5b76af89f.png)


### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
