### PR TITLE
Initialize hooks and config early to prevent conflicts with code executed in early startup

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -206,9 +206,7 @@ static void ddtrace_activate(void) {
 
     if (DDTRACE_G(disable)) {
         ddtrace_disable_tracing_in_current_request();
-    }
-
-    if (!DDTRACE_G(disable)) {
+    } else {
         zai_hook_activate();
     }
 

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -185,7 +185,7 @@ static void ddtrace_activate(void) {
     zai_hook_rinit();
     zai_interceptor_activate();
     zai_uhook_rinit();
-    zend_hash_init(&DDTRACE_G(traced_spans), 8, shhhht, NULL, 0);
+    zend_hash_init(&DDTRACE_G(traced_spans), 8, unused, NULL, 0);
 
     if (ddtrace_has_excluded_module == true) {
         DDTRACE_G(disable) = 2;
@@ -675,8 +675,8 @@ static void dd_initialize_request() {
     DDTRACE_G(additional_global_tags) = zend_new_array(0);
     DDTRACE_G(default_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
     DDTRACE_G(propagated_priority_sampling) = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
-    zend_hash_init(&DDTRACE_G(root_span_tags_preset), 8, shhhht, ZVAL_PTR_DTOR, 0);
-    zend_hash_init(&DDTRACE_G(propagated_root_span_tags), 8, shhhht, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&DDTRACE_G(root_span_tags_preset), 8, unused, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&DDTRACE_G(propagated_root_span_tags), 8, unused, ZVAL_PTR_DTOR, 0);
 
     // Things that should only run on the first RINIT
     pthread_once(&dd_rinit_once_control, dd_rinit_once);

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -160,16 +160,14 @@ bool dd_save_sampling_rules_file_config(zend_string *path, int modify_type, int 
     zend_string *file = php_stream_copy_to_mem(stream, (ssize_t) PHP_STREAM_COPY_ALL, 0);
     php_stream_close(stream);
 
-    if (file && ZSTR_LEN(file) > 0) {
-        zend_alter_ini_entry_ex(zai_config_memoized_entries[DDTRACE_CONFIG_DD_SPAN_SAMPLING_RULES].ini_entries[0]->name, file, modify_type, stage, 1);
+    bool altered = false;
+    if (file) {
+        altered = ZSTR_LEN(file) > 0 && SUCCESS == zend_alter_ini_entry_ex(
+            zai_config_memoized_entries[DDTRACE_CONFIG_DD_SPAN_SAMPLING_RULES].ini_entries[0]->name,
+            file, modify_type, stage, 1);
         zend_string_release(file);
-        return true;
-    } else {
-        if (file) {
-            zend_string_release(file);
-        }
-        return false;
     }
+    return altered;
 }
 
 bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value) {

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -1114,17 +1114,19 @@ static void zai_hook_memory_dtor(zval *zv) {
     efree(Z_PTR_P(zv));
 }
 
-void zai_interceptor_rinit() {
-    // install bailout handler - shutdown functions are the first thing we can reliably hook into in case of bailout
-    php_shutdown_function_entry shutdown_function = { .arguments = emalloc(sizeof(zval)), .arg_count = 1 };
-    object_init_ex(shutdown_function.arguments, &zai_interceptor_bailout_ce);
-    Z_OBJ_P(shutdown_function.arguments)->handlers = &zai_interceptor_bailout_handlers;
-    register_user_shutdown_function(ZEND_STRL("_dd_bailout_handler"), &shutdown_function);
-
+void zai_interceptor_activate() {
     zend_hash_init(&zai_hook_memory, 8, nothing, zai_hook_memory_dtor, 0);
 }
 
-void zai_interceptor_rshutdown() {
+void zai_interceptor_rinit() {
+    // install bailout handler - shutdown functions are the first thing we can reliably hook into in case of bailout
+    php_shutdown_function_entry shutdown_function = {.arguments = emalloc(sizeof(zval)), .arg_count = 1};
+    object_init_ex(shutdown_function.arguments, &zai_interceptor_bailout_ce);
+    Z_OBJ_P(shutdown_function.arguments)->handlers = &zai_interceptor_bailout_handlers;
+    register_user_shutdown_function(ZEND_STRL("_dd_bailout_handler"), &shutdown_function);
+}
+
+void zai_interceptor_deactivate() {
     zend_hash_destroy(&zai_hook_memory);
 }
 

--- a/zend_abstract_interface/interceptor/php7/interceptor.h
+++ b/zend_abstract_interface/interceptor/php7/interceptor.h
@@ -7,8 +7,9 @@ void zai_interceptor_op_array_ctor(zend_op_array *op_array);
 void zai_interceptor_op_array_pass_two(zend_op_array *op_array);
 
 void zai_interceptor_startup(zend_module_entry *module_entry);
+void zai_interceptor_activate(void);
 void zai_interceptor_rinit(void);
-void zai_interceptor_rshutdown(void);
+void zai_interceptor_deactivate(void);
 void zai_interceptor_shutdown(void);
 
 void zai_interceptor_terminate_all_pending_observers(void);

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -738,12 +738,12 @@ static void zai_hook_memory_dtor(zval *zv) {
     efree(Z_PTR_P(zv));
 }
 
-void zai_interceptor_rinit() {
+void zai_interceptor_activate() {
     zend_hash_init(&zai_hook_memory, 8, nothing, zai_hook_memory_dtor, 0);
     zend_hash_init(&zai_interceptor_implicit_generators, 8, nothing, NULL, 0);
 }
 
-void zai_interceptor_rshutdown() {
+void zai_interceptor_deactivate() {
     zend_hash_destroy(&zai_hook_memory);
     zend_hash_destroy(&zai_interceptor_implicit_generators);
 }

--- a/zend_abstract_interface/interceptor/php8/interceptor.h
+++ b/zend_abstract_interface/interceptor/php8/interceptor.h
@@ -3,8 +3,8 @@
 
 void zai_interceptor_minit(void);
 void zai_interceptor_startup(void);
-void zai_interceptor_rinit(void);
-void zai_interceptor_rshutdown(void);
+void zai_interceptor_activate(void);
+void zai_interceptor_deactivate(void);
 void zai_interceptor_shutdown(void);
 
 #endif  // ZAI_INTERCEPTOR_H

--- a/zend_abstract_interface/interceptor/tests/interceptor.cc
+++ b/zend_abstract_interface/interceptor/tests/interceptor.cc
@@ -18,13 +18,16 @@ extern "C" {
     static PHP_RINIT_FUNCTION(ddtrace_testing_hook) {
         zai_hook_rinit();
         zai_hook_activate();
+        zai_interceptor_activate();
+#if PHP_VERSION_ID < 80000
         zai_interceptor_rinit();
+#endif
         return SUCCESS;
     }
 
     static PHP_RSHUTDOWN_FUNCTION(ddtrace_testing_hook) {
         zai_hook_rshutdown();
-        zai_interceptor_rshutdown();
+        zai_interceptor_deactivate();
         return SUCCESS;
     }
 

--- a/zend_abstract_interface/interceptor/tests/interceptor.cc
+++ b/zend_abstract_interface/interceptor/tests/interceptor.cc
@@ -17,6 +17,9 @@ extern "C" {
 
     static PHP_RINIT_FUNCTION(ddtrace_testing_hook) {
         zai_hook_rinit();
+        /* activates should be done in zend_extension's activate handler, but
+         * for this test it doesn't matter.
+         */
         zai_hook_activate();
         zai_interceptor_activate();
 #if PHP_VERSION_ID < 80000
@@ -27,6 +30,9 @@ extern "C" {
 
     static PHP_RSHUTDOWN_FUNCTION(ddtrace_testing_hook) {
         zai_hook_rshutdown();
+        /* deactivate should be done in zend_extension's dactivate handler,
+         * but for this test it doesn't matter.
+         */
         zai_interceptor_deactivate();
         return SUCCESS;
     }

--- a/zend_abstract_interface/interceptor/tests/resolver.cc
+++ b/zend_abstract_interface/interceptor/tests/resolver.cc
@@ -17,6 +17,9 @@ extern "C" {
 
     static PHP_RINIT_FUNCTION(ddtrace_testing_hook) {
         zai_hook_rinit();
+        /* activates should be done in zend_extension's activate handler, but
+         * for this test it doesn't matter.
+         */
         zai_hook_activate();
         // test ZEND_DECLARE_*_DELAYED opcodes for opcache
         CG(compiler_options) |= ZEND_COMPILE_DELAYED_BINDING;
@@ -28,6 +31,9 @@ extern "C" {
     }
 
     static PHP_RSHUTDOWN_FUNCTION(ddtrace_testing_hook) {
+        /* deactivate should be done in zend_extension's deactivate handler,
+         * but for this test it doesn't matter.
+         */
         zai_interceptor_deactivate();
         zai_hook_rshutdown();
         return SUCCESS;

--- a/zend_abstract_interface/interceptor/tests/resolver.cc
+++ b/zend_abstract_interface/interceptor/tests/resolver.cc
@@ -20,12 +20,15 @@ extern "C" {
         zai_hook_activate();
         // test ZEND_DECLARE_*_DELAYED opcodes for opcache
         CG(compiler_options) |= ZEND_COMPILE_DELAYED_BINDING;
+        zai_interceptor_activate();
+#if PHP_VERSION_ID < 80000
         zai_interceptor_rinit();
+#endif
         return SUCCESS;
     }
 
     static PHP_RSHUTDOWN_FUNCTION(ddtrace_testing_hook) {
-        zai_interceptor_rshutdown();
+        zai_interceptor_deactivate();
         zai_hook_rshutdown();
         return SUCCESS;
     }


### PR DESCRIPTION
### Description

Fixes compatibilty with the blackfire extension.

Fixes #1725.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
