### PR TITLE
[profiling] Match the service names of the tracer when unset or empty

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -602,11 +602,11 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zval *prop_name = ddtrace_spandata_property_name(span);
     if (strcmp(sapi_module.name, "cli") == 0) {
         ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("cli"), 0));
-        if (SG(request_info).argc > 0) {
-            ZVAL_STR(prop_name, php_basename(SG(request_info).argv[0], strlen(SG(request_info).argv[0]), NULL, 0));
-        } else {
-            ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("cli.command"), 0));
-        }
+        const char *script_name;
+        ZVAL_STR(prop_name,
+            (SG(request_info).argc > 0 && (script_name = SG(request_info).argv[0]) && script_name[0] != '\0')
+                ? php_basename(script_name, strlen(script_name), NULL, 0)
+                : zend_string_init(ZEND_STRL("cli.command"), 0));
     } else {
         ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("web"), 0));
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));

--- a/profiling/tests/phpt/service_01.phpt
+++ b/profiling/tests/phpt/service_01.phpt
@@ -1,0 +1,45 @@
+--TEST--
+[profiling] test profiler's service when none is given
+--DESCRIPTION--
+When DD_SERVICE isn't provided, default to the script name.
+Technically there is another fallback if there isn't a script name, but this
+is hard to exercise because even for code over standard input, PHP sets a name
+of "Standard input code."
+This behavior matches the tracer's and should be kept in sync.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_SERVICE=
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+$key = "Application's Service (DD_SERVICE)";
+$value = basename(__FILE__);
+assert($values[$key] == $value, "Expected {$values[$key]} == {$value}");
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.

--- a/profiling/tests/phpt/service_cli_01.phpt
+++ b/profiling/tests/phpt/service_cli_01.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[profiling] test profiler's service when none is given
+[profiling] test profiler's service when none is given (cli)
 --DESCRIPTION--
 When DD_SERVICE isn't provided, default to the script name.
 Technically there is another fallback if there isn't a script name, but this

--- a/profiling/tests/phpt/service_web_01.phpt
+++ b/profiling/tests/phpt/service_web_01.phpt
@@ -1,0 +1,56 @@
+--TEST--
+[profiling] test profiler's service when none is given (web)
+--DESCRIPTION--
+When DD_SERVICE isn't provided, default to web.request.
+This behavior matches the tracer's and should be kept in sync.
+--SKIPIF--
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_SERVICE=
+HTTPS=off
+SERVER_NAME=localhost:8888
+HTTP_HOST=localhost:9999
+SCRIPT_NAME=/foo.php
+REQUEST_URI=/foo?some=query&parameters
+QUERY_STRING=some=query&parameters
+METHOD=GET
+--GET--
+some=query&parameters
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+// Test has been screwed up, be sure to run with a web SAPI.
+assert(php_sapi_name() !== 'cli');
+
+// Can't be in the SKIPIF for CGI requests for some reason
+assert(extension_loaded('datadog-profiling'));
+assert(extension_loaded('dom'));
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$values = [];
+
+// We're expecting a 2-column table, first is key, second is value.
+$dom = new DOMDocument();
+assert($dom->loadHTML($output));
+foreach ($dom->getElementsByTagName('tr') as $row) {
+    [$key, $value] = iterator_to_array($row->getElementsByTagName('td'));
+    $key = html_entity_decode(trim($key->nodeValue));
+    $value = html_entity_decode(trim($value->nodeValue));
+    $values[$key] = $value;
+}
+
+$key = "Application's Service (DD_SERVICE)";
+$value = 'web.request';
+assert($values[$key] == $value, "Expected {$values[$key]} == {$value}");
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

If DD_SERVICE is unset or empty, then the tracer defaults the service name to one of these:

 - the script name, aka argv[0]
 - cli.command
 - web.request

The profiler now does the same which should result in fewer services named unnamed-php-service.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
