### PR TITLE
Avoid deprecated in PHP 8.2 constructs in tests

### DIFF
--- a/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
+++ b/tests/ext/sandbox-regression/method_invoked_via_reflection.phpt
@@ -3,6 +3,8 @@
 --FILE--
 <?php
 class Test {
+    private $append;
+
     public function __construct($append = "") {
         $this->append = $append;
         echo "CONSTRUCT" . $this->append . PHP_EOL;

--- a/tests/ext/sandbox/hook_method/posthook_scope_01.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_scope_01.phpt
@@ -6,14 +6,14 @@ hook_method posthook is called with the correct scope (no override)
 DDTrace\hook_method('BaseClass', 'speak',
     null,
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in BaseClass.\n";
+        echo "{$scope}::speak hooked in BaseClass.\n";
     }
 );
 
 DDTrace\hook_method('ChildClass', 'speak',
     null,
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in ChildClass.\n";
+        echo "{$scope}::speak hooked in ChildClass.\n";
     }
 );
 

--- a/tests/ext/sandbox/hook_method/posthook_scope_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_scope_02.phpt
@@ -6,7 +6,7 @@ hook_method posthook is called with the correct scope (parent)
 DDTrace\hook_method('BaseClass', 'speak',
     null,
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked.\n";
+        echo "{$scope}::speak hooked.\n";
     }
 );
 

--- a/tests/ext/sandbox/hook_method/posthook_scope_03.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_scope_03.phpt
@@ -6,14 +6,14 @@ hook_method posthook is called with the correct scope (parent)
 DDTrace\hook_method('BaseClass', 'speak',
     null,
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in BaseClass.\n";
+        echo "{$scope}::speak hooked in BaseClass.\n";
     }
 );
 
 DDTrace\hook_method('ChildClass', 'speak',
     null,
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in ChildClass.\n";
+        echo "{$scope}::speak hooked in ChildClass.\n";
     }
 );
 

--- a/tests/ext/sandbox/hook_method/prehook_error_01.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_01.phpt
@@ -9,7 +9,7 @@ error_reporting=E_ALL
 
 DDTrace\hook_method('Greeter', 'greet',
     function ($This, $scope, $args) {
-        echo "${scope}::greet hooked.\n";
+        echo "{$scope}::greet hooked.\n";
         $i = $this_normally_raises_a_notice; // E_NOTICE
     }
 );

--- a/tests/ext/sandbox/hook_method/prehook_scope_01.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_scope_01.phpt
@@ -5,13 +5,13 @@ hook_method prehook is called with the correct scope (no override)
 
 DDTrace\hook_method('BaseClass', 'speak',
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in BaseClass.\n";
+        echo "{$scope}::speak hooked in BaseClass.\n";
     }
 );
 
 DDTrace\hook_method('ChildClass', 'speak',
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in ChildClass.\n";
+        echo "{$scope}::speak hooked in ChildClass.\n";
     }
 );
 

--- a/tests/ext/sandbox/hook_method/prehook_scope_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_scope_02.phpt
@@ -5,7 +5,7 @@ hook_method prehook is called with the correct scope (parent)
 
 DDTrace\hook_method('BaseClass', 'speak',
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked.\n";
+        echo "{$scope}::speak hooked.\n";
     }
 );
 

--- a/tests/ext/sandbox/hook_method/prehook_scope_03.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_scope_03.phpt
@@ -5,13 +5,13 @@ hook_method prehook is called with the correct scope (parent)
 
 DDTrace\hook_method('BaseClass', 'speak',
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in BaseClass.\n";
+        echo "{$scope}::speak hooked in BaseClass.\n";
     }
 );
 
 DDTrace\hook_method('ChildClass', 'speak',
     function ($This, $scope, $args) {
-        echo "${scope}::speak hooked in ChildClass.\n";
+        echo "{$scope}::speak hooked in ChildClass.\n";
     }
 );
 


### PR DESCRIPTION
### Description

This doesn't add full PHP 8.2 support; it just avoids some compatibility issues reported in #1738. However, there is a sigsegv in that issue and locally I get many failures; this is just a step.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
