### PR TITLE
Handle non-binaries in installer

### DIFF
--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -100,6 +100,7 @@ test_first_install_php_zts.sh \
 	@echo "################### $(@) ###################"
 	docker run --rm -ti -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env --workdir=/app php:7.4-zts-buster sh dockerfiles/verify_packages/installer/$(@)
 
+test_install_non_binary.sh \
 test_fpm.sh \
 	:
 	@echo "################### $(@) ###################"

--- a/dockerfiles/verify_packages/installer/test_install_non_binary.sh
+++ b/dockerfiles/verify_packages/installer/test_install_non_binary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Install using the php installer
+new_version="0.75.0"
+generate_installers "${new_version}"
+php ./build/packages/datadog-setup.php --php-bin=all
+
+mv /usr/local/sbin/php-fpm /usr/local/sbin/php-fpm7.4
+cat <<'EOT' > /usr/local/sbin/php-fpm
+#!/usr/bin/env bash
+/usr/local/sbin/php-fpm7.4 -F -O 2>&1
+EOT
+chmod +x /usr/local/sbin/php-fpm
+
+assert_ddtrace_version "${new_version}" php
+assert_ddtrace_version "${new_version}" php-fpm7.4

--- a/tests/Integration/PHPInstallerTest.php
+++ b/tests/Integration/PHPInstallerTest.php
@@ -95,7 +95,7 @@ final class PHPInstallerTest extends BaseTestCase
     public function testSearchPhpBinaries()
     {
         $found = \search_php_binaries(sys_get_temp_dir() . '/dd-php-setup-tests');
-        $this->assertStringContains('/', $found['php']);
+        $this->assertStringContains('/', $found['php']["path"]);
 
         $shouldBeFound = [
             'php',
@@ -120,7 +120,7 @@ final class PHPInstallerTest extends BaseTestCase
         $rootPath = self::getTmpRootPath() . "/opt/remi/php74/root/usr/sbin";
         foreach ($shouldBeFound as $binary) {
             $this->assertArrayHasKey("${rootPath}/${binary}", $found);
-            $this->assertSame(realpath("${rootPath}/${binary}"), $found["${rootPath}/${binary}"]);
+            $this->assertSame(realpath("${rootPath}/${binary}"), $found["${rootPath}/${binary}"]["path"]);
         }
         foreach ($shouldNotBeFound as $binary) {
             $this->assertTrue(empty($found["${rootPath}/${binary}"]));


### PR DESCRIPTION
### Description

Avoid installing non-binaries even when matching the pattern by default (i.e. with `--php-bin=all`), because these may handle args differently, have unexpected side-effects or simply hang the installer.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
