### PR TITLE
[profiling] Avoid crashing when pcntl_fork is called

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1833,7 +1833,7 @@ jobs:
               cd -
               # run phpize just to get run-tests.php
               phpize
-              php run-tests.php -p $(which php) tests/ext/profiling
+              php run-tests.php -p $(which php) --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" tests/ext/profiling
 
   placeholder:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2375,6 +2375,7 @@ workflows:
       - pecl_build:
           requires: [ 'Prepare Code' ]
           name: "Build PECL"
+
       - "package extension":
           requires:
             - compile_alpine
@@ -2432,6 +2433,8 @@ workflows:
                 - '7.3'
                 - '7.4'
                 - '8.0'
+                - '8.1'
+
       - randomized_tests:
           requires: [ 'package extension' ]
           matrix:

--- a/config.m4
+++ b/config.m4
@@ -98,6 +98,7 @@ if test "$PHP_DDTRACE" != "no"; then
     ext/engine_api.c \
     ext/engine_hooks.c \
     ext/excluded_modules.c \
+    ext/handlers_api.c \
     ext/handlers_exception.c \
     ext/handlers_internal.c \
     ext/handlers_pcntl.c \

--- a/ext/handlers_api.c
+++ b/ext/handlers_api.c
@@ -1,0 +1,12 @@
+#include "handlers_api.h"
+
+// This file is compiled by both the tracer and profiler.
+
+void datadog_php_install_handler(datadog_php_zif_handler handler) {
+    zend_function *old_handler;
+    old_handler = zend_hash_str_find_ptr(CG(function_table), handler.name, handler.name_len);
+    if (old_handler != NULL) {
+        *handler.old_handler = old_handler->internal_function.handler;
+        old_handler->internal_function.handler = handler.new_handler;
+    }
+}

--- a/ext/handlers_api.h
+++ b/ext/handlers_api.h
@@ -1,0 +1,22 @@
+#ifndef DDTRACE_HANDLERS_API_H
+#define DDTRACE_HANDLERS_API_H
+
+// This api is used by both the tracer and profiler.
+
+#include <php.h>
+
+typedef struct datadog_php_zif_handler_s {
+    const char *name;
+    size_t name_len;
+    void (**old_handler)(INTERNAL_FUNCTION_PARAMETERS);
+    void (*new_handler)(INTERNAL_FUNCTION_PARAMETERS);
+} datadog_php_zif_handler;
+
+/**
+ * Installs the `handler` if the function represented by `name` + `name_len`
+ * is found; otherwise does nothing.
+ */
+void datadog_php_install_handler(datadog_php_zif_handler handler);
+
+#endif  // DDTRACE_HANDLERS_API_H
+

--- a/ext/handlers_curl.c
+++ b/ext/handlers_curl.c
@@ -359,7 +359,7 @@ void ddtrace_curl_handlers_startup(void) {
      * The latter expects the former is already done because it needs a span id for the distributed tracing headers;
      * register them inside-out.
      */
-    dd_zif_handler handlers[] = {
+    datadog_php_zif_handler handlers[] = {
         {ZEND_STRL("curl_close"), &dd_curl_close_handler, ZEND_FN(ddtrace_curl_close)},
         {ZEND_STRL("curl_copy_handle"), &dd_curl_copy_handle_handler, ZEND_FN(ddtrace_curl_copy_handle)},
         {ZEND_STRL("curl_exec"), &dd_curl_exec_handler, ZEND_FN(ddtrace_curl_exec)},
@@ -374,7 +374,7 @@ void ddtrace_curl_handlers_startup(void) {
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     for (size_t i = 0; i < handlers_len; ++i) {
-        dd_install_handler(handlers[i]);
+        datadog_php_install_handler(handlers[i]);
     }
 }
 

--- a/ext/handlers_curl_php7.c
+++ b/ext/handlers_curl_php7.c
@@ -613,7 +613,7 @@ void ddtrace_curl_handlers_startup(void) {
      * The latter expects the former is already done because it needs a span id for the distributed tracing headers;
      * register them inside-out.
      */
-    dd_zif_handler handlers[] = {
+    datadog_php_zif_handler handlers[] = {
             {ZEND_STRL("curl_close"), &dd_curl_close_handler, ZEND_FN(ddtrace_curl_close)},
             {ZEND_STRL("curl_copy_handle"), &dd_curl_copy_handle_handler, ZEND_FN(ddtrace_curl_copy_handle)},
             {ZEND_STRL("curl_exec"), &dd_curl_exec_handler, ZEND_FN(ddtrace_curl_exec)},
@@ -629,7 +629,7 @@ void ddtrace_curl_handlers_startup(void) {
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     for (size_t i = 0; i < handlers_len; ++i) {
-        dd_install_handler(handlers[i]);
+        datadog_php_install_handler(handlers[i]);
     }
 }
 

--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -374,7 +374,7 @@ void ddtrace_exception_handlers_startup(void) {
     memcpy(&dd_exception_or_error_handler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
     dd_exception_or_error_handler_handlers.get_closure = dd_exception_handler_get_closure;
 
-    dd_zif_handler handlers[] = {
+    datadog_php_zif_handler handlers[] = {
         {ZEND_STRL("header"), &dd_header, ZEND_FN(ddtrace_header)},
         {ZEND_STRL("http_response_code"), &dd_http_response_code, ZEND_FN(ddtrace_http_response_code)},
         {ZEND_STRL("set_error_handler"), &dd_set_error_handler, ZEND_FN(ddtrace_set_error_handler)},
@@ -384,7 +384,7 @@ void ddtrace_exception_handlers_startup(void) {
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     for (size_t i = 0; i < handlers_len; ++i) {
-        dd_install_handler(handlers[i]);
+        datadog_php_install_handler(handlers[i]);
     }
 }
 

--- a/ext/handlers_internal.c
+++ b/ext/handlers_internal.c
@@ -6,15 +6,6 @@
 #include "engine_hooks.h"
 #include "logging.h"
 
-void dd_install_handler(dd_zif_handler handler) {
-    zend_function *old_handler;
-    old_handler = zend_hash_str_find_ptr(CG(function_table), handler.name, handler.name_len);
-    if (old_handler != NULL) {
-        *handler.old_handler = old_handler->internal_function.handler;
-        old_handler->internal_function.handler = handler.new_handler;
-    }
-}
-
 void ddtrace_free_unregistered_class(zend_class_entry *ce) {
 #if PHP_VERSION_ID >= 80100
     zend_property_info *prop_info;

--- a/ext/handlers_internal.h
+++ b/ext/handlers_internal.h
@@ -1,19 +1,10 @@
 #ifndef DDTRACE_HANDLERS_INTERNAL_H
 #define DDTRACE_HANDLERS_INTERNAL_H
 
-#include <Zend/zend_extensions.h>
 #include <php.h>
 
+#include "handlers_api.h"
 #include "ddtrace_string.h"
-
-typedef struct dd_zif_handler {
-    const char *name;
-    size_t name_len;
-    void (**old_handler)(INTERNAL_FUNCTION_PARAMETERS);
-    void (*new_handler)(INTERNAL_FUNCTION_PARAMETERS);
-} dd_zif_handler;
-
-void dd_install_handler(dd_zif_handler handler);
 
 void ddtrace_replace_internal_function(const HashTable *ht, ddtrace_string fname);
 void ddtrace_replace_internal_functions(const HashTable *ht, size_t functions_len, ddtrace_string functions[]);

--- a/ext/handlers_pcntl.c
+++ b/ext/handlers_pcntl.c
@@ -83,7 +83,7 @@ void ddtrace_pcntl_handlers_startup(void) {
         return;
     }
 
-    dd_zif_handler handlers[] = {
+    datadog_php_zif_handler handlers[] = {
         {ZEND_STRL("pcntl_fork"), &dd_pcntl_fork_handler, ZEND_FN(ddtrace_pcntl_fork)},
 #if PHP_VERSION_ID >= 80100
         {ZEND_STRL("pcntl_rfork"), &dd_pcntl_rfork_handler, ZEND_FN(ddtrace_pcntl_rfork)},
@@ -94,6 +94,6 @@ void ddtrace_pcntl_handlers_startup(void) {
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     for (size_t i = 0; i < handlers_len; ++i) {
-        dd_install_handler(handlers[i]);
+        datadog_php_install_handler(handlers[i]);
     }
 }

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -72,6 +72,7 @@ impl From<uuid::Uuid> for Uuid {
 }
 
 /// Fetch the runtime id of the process. Note that it may return the nil UUID.
+/// Only call this from a PHP thread.
 #[no_mangle]
 pub extern "C" fn datadog_profiling_runtime_id() -> Uuid {
     runtime_id().into()

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -2,7 +2,7 @@
 //! ddtrace extension.
 
 use crate::bindings::zend_execute_data;
-use crate::RUNTIME_ID;
+use crate::runtime_id;
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
@@ -60,39 +60,21 @@ pub extern "C" fn datadog_profiling_notify_trace_finished(
     );
 }
 
+/// Alignment to 16 bytes was done by the C version of the profiler. It's not
+/// strictly necessary, but changing it requires a change to the tracer too.
 #[repr(C, align(16))]
-#[derive(Copy, Clone)]
 pub struct Uuid(uuid::Uuid);
-
-impl Uuid {
-    pub const fn new() -> Self {
-        Self {
-            0: uuid::Uuid::nil(),
-        }
-    }
-}
-
-impl Default for Uuid {
-    fn default() -> Self {
-        Uuid::new()
-    }
-}
 
 impl From<uuid::Uuid> for Uuid {
     fn from(uuid: uuid::Uuid) -> Self {
-        Self { 0: uuid }
+        Self(uuid)
     }
 }
 
-impl From<Uuid> for uuid::Uuid {
-    fn from(uuid: Uuid) -> Self {
-        uuid.0
-    }
-}
-
+/// Fetch the runtime id of the process. Note that it may return the nil UUID.
 #[no_mangle]
 pub extern "C" fn datadog_profiling_runtime_id() -> Uuid {
-    *RUNTIME_ID
+    runtime_id().into()
 }
 
 /// Gathers a time sample if the configured period has elapsed. Used by the
@@ -111,20 +93,6 @@ pub extern "C" fn datadog_profiling_interrupt_function(execute_data: *mut zend_e
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_uuid() {
-        const NIL_UUID: Uuid = Uuid::new();
-        let uuid: uuid::Uuid = NIL_UUID.into();
-        assert!(uuid.is_nil());
-
-        // Asserting we can losslessly convert both ways.
-        let uuidv4 = uuid::Uuid::new_v4();
-        let uuid = Uuid::from(uuidv4);
-        let actual = uuid::Uuid::from(uuid);
-        assert_eq!(uuidv4, actual);
-        assert_eq!(4, actual.get_version_num());
-    }
 
     #[test]
     fn test_string_view() {

--- a/profiling/src/pcntl.rs
+++ b/profiling/src/pcntl.rs
@@ -1,0 +1,118 @@
+use crate::bindings::{
+    datadog_php_install_handler, datadog_php_zif_handler, zend_execute_data, zend_long, zval,
+    InternalFunctionHandler,
+};
+use crate::{RequestLocals, PROFILER, REQUEST_LOCALS};
+use log::{error, warn};
+use std::cell::RefMut;
+use std::ffi::CStr;
+use std::mem::{forget, swap};
+
+static mut PCNTL_FORK_HANDLER: InternalFunctionHandler = None;
+static mut PCNTL_RFORK_HANDLER: InternalFunctionHandler = None;
+static mut PCNTL_FORKX_HANDLER: InternalFunctionHandler = None;
+
+fn handle_child_fork(mut locals: RefMut<RequestLocals>, retval: &mut zval) {
+    let result: Result<zend_long, _> = retval.try_into();
+    match result {
+        Ok(pid) => {
+            // The child gets pid of 0. For now, stop profiling for safety.
+            if pid == 0 {
+                match PROFILER.lock() {
+                    Ok(mut profiler) => {
+                        let mut new_profiler = None;
+                        swap(&mut *profiler, &mut new_profiler);
+
+                        /* Due to the swap, this has the old profiler.
+                         * Forget about it, it has garbage in it.
+                         */
+                        forget(new_profiler);
+                        locals.profiling_enabled = false;
+
+                        /* When we fully support forking remember:
+                         *  - Reset last_cpu_time and last_wall_time
+                         *  - Reset process_id and runtime-id tags.
+                         */
+                    }
+                    Err(err) => {
+                        error!(
+                            "Forked child failed to acquire profiler lock; a crash is likely: {}",
+                            err
+                        )
+                    }
+                }
+            }
+        }
+        Err(r#type) => {
+            warn!(
+                "Return type of pcntl_*fork* function was unexpected: {}",
+                r#type
+            )
+        }
+    }
+}
+
+unsafe fn handle_pcntl_fork(return_value: *mut zval) {
+    /* This hook is installed prior to knowing if the profiler will be enabled,
+     * so we must guard it with a runtime check.
+     */
+    REQUEST_LOCALS.with(|cell| {
+        let locals = cell.borrow_mut();
+        if locals.profiling_enabled && !return_value.is_null() {
+            /* Safety: we just checked it's not null; if any other invariants
+             * are messed up then we're totally hosed already.
+             */
+            handle_child_fork(locals, &mut *return_value);
+        }
+    });
+}
+
+unsafe extern "C" fn pcntl_fork(execute_data: *mut zend_execute_data, return_value: *mut zval) {
+    // Safety: this function is only called if PCNTL_FORK_HANDLER was set.
+    let handler = PCNTL_FORK_HANDLER.unwrap();
+    handler(execute_data, return_value);
+    handle_pcntl_fork(return_value);
+}
+
+unsafe extern "C" fn pcntl_rfork(execute_data: *mut zend_execute_data, return_value: *mut zval) {
+    // Safety: this function is only called if PCNTL_RFORK_HANDLER was set.
+    let handler = PCNTL_RFORK_HANDLER.unwrap();
+    handler(execute_data, return_value);
+    handle_pcntl_fork(return_value);
+}
+
+unsafe extern "C" fn pcntl_forkx(execute_data: *mut zend_execute_data, return_value: *mut zval) {
+    // Safety: this function is only called if PCNTL_FORKX_HANDLER was set.
+    let handler = PCNTL_FORKX_HANDLER.unwrap();
+    handler(execute_data, return_value);
+    handle_pcntl_fork(return_value);
+}
+
+/* Safety: CStr invariants are met (at least one byte, last byte is null,
+ * no null bytes before that). Note that they require their own unsafe
+ * blocks because they are const, despite being in th
+ */
+const PCNTL_FORK: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_fork\0") };
+const PCNTL_RFORK: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_rfork\0") };
+const PCNTL_FORKX: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_forkx\0") };
+
+/// # Safety
+/// Only call this from zend_extension's startup function. It's not designed
+/// to be called from anywhere else.
+pub(crate) unsafe fn startup() {
+    /* Some of these handlers exist only on recent PHP versions, but since
+     * datadog_php_install_handler fails gracefully on a missing function, we
+     * don't have to worry about creating Rust configurations for them.
+     * Safety: we can modify our own globals in the startup context.
+     */
+    let handlers = [
+        datadog_php_zif_handler::new(PCNTL_FORK, &mut PCNTL_FORK_HANDLER, Some(pcntl_fork)),
+        datadog_php_zif_handler::new(PCNTL_RFORK, &mut PCNTL_RFORK_HANDLER, Some(pcntl_rfork)),
+        datadog_php_zif_handler::new(PCNTL_FORKX, &mut PCNTL_FORKX_HANDLER, Some(pcntl_forkx)),
+    ];
+
+    for handler in handlers.into_iter() {
+        // Safety: we've set all the parameters correctly for this C call.
+        datadog_php_install_handler(handler);
+    }
+}

--- a/profiling/src/pcntl.rs
+++ b/profiling/src/pcntl.rs
@@ -88,10 +88,7 @@ unsafe extern "C" fn pcntl_forkx(execute_data: *mut zend_execute_data, return_va
     handle_pcntl_fork(return_value);
 }
 
-/* Safety: CStr invariants are met (at least one byte, last byte is null,
- * no null bytes before that). Note that they require their own unsafe
- * blocks because they are const, despite being in th
- */
+// Safety: the provided slices are nul-terminated and don't contain any interior nul bytes.
 const PCNTL_FORK: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_fork\0") };
 const PCNTL_RFORK: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_rfork\0") };
 const PCNTL_FORKX: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pcntl_forkx\0") };

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -48,3 +48,13 @@ zend_module_entry *datadog_get_module_entry(const uint8_t *str, uintptr_t len) {
 
 ddtrace_profiling_context (*datadog_php_profiling_get_profiling_context)(void) =
     noop_get_profiling_context;
+
+void datadog_php_profiling_install_internal_function_handler(
+    datadog_php_profiling_internal_function_handler handler) {
+    zend_function *old_handler;
+    old_handler = zend_hash_str_find_ptr(CG(function_table), handler.name, handler.name_len);
+    if (old_handler != NULL) {
+        *handler.old_handler = old_handler->internal_function.handler;
+        old_handler->internal_function.handler = handler.new_handler;
+    }
+}

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -59,3 +59,17 @@ extern ddtrace_profiling_context (*datadog_php_profiling_get_profiling_context)(
  * registry and finding the ddtrace_get_profiling_context function.
  */
 void datadog_php_profiling_startup(zend_extension *extension);
+
+/**
+ * Used to hold information for overwriting the internal function handler
+ * pointer in the Zend Engine.
+ */
+typedef struct {
+    const char *name;
+    size_t name_len;
+    void (**old_handler)(INTERNAL_FUNCTION_PARAMETERS);
+    void (*new_handler)(INTERNAL_FUNCTION_PARAMETERS);
+} datadog_php_profiling_internal_function_handler;
+
+void datadog_php_profiling_install_internal_function_handler(
+    datadog_php_profiling_internal_function_handler handler);

--- a/profiling/tests/phpt/fork_01.phpt
+++ b/profiling/tests/phpt/fork_01.phpt
@@ -1,0 +1,43 @@
+--TEST--
+[profiling] test that the profiler doesn't crash on pcntl_fork
+--DESCRIPTION--
+The profiler does not yet support forking, but it shouldn't crash if the
+process is forked. Logging to stderr will acquire a lock, so that's why the
+log level is set for this test to the highest setting, to hopefully provide
+opportunities to lock or crash if that lock is held.
+--SKIPIF--
+<?php
+foreach (['datadog-profiling', 'pcntl'] as $extension)
+    if (!extension_loaded($extension))
+        echo "skip: test requires {$extension}\n";
+?>
+--INI--
+assert.exception=1
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=debug
+--FILE--
+<?php
+// sleep to simulate the process doing something prior to the fork
+usleep($microseconds = 10000);
+
+echo "Forking.\n";
+$pid = pcntl_fork();
+assert($pid != -1);
+
+if ($pid == 0) { // the child has pid of 0
+    usleep($microseconds = 10000);
+} else {
+    $status = 0;
+    pcntl_wait($status);
+    $exit_code = pcntl_wifexited($status) ? pcntl_wexitstatus($status) : 1;
+    if ($exit_code === 0) {
+        echo "Child exited successfully.\n";
+    }
+    exit($exit_code);
+}
+
+?>
+--EXPECTREGEX--
+.*
+Child exited successfully.*


### PR DESCRIPTION
### Description

The profiler doesn't support forking yet. However, it shouldn't crash.
This PR reduces some crash surface, but there is more to be done.

Since the tracer already has an API for overwriting the internal
function handler of a given function, I moved those bits into their own
file and made a note that the profiler also compiles these files.

I investigated adding full forking support but decided it would be too
much work to do right now. However, I left some comments about what I
learned, and did leave in some refactoring.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
