### PR TITLE
Fix behaviour of return false in trace hooks

### DIFF
--- a/tests/ext/sandbox/hook_function/dropping_trace_hook.phpt
+++ b/tests/ext/sandbox/hook_function/dropping_trace_hook.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test dropping spans from multiple trace hooks
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function a() {}
+
+DDTrace\trace_function("a", function() { }); // first function, creates span
+DDTrace\trace_function("a", function() { return false; });
+
+a();
+var_dump(count(dd_trace_serialize_closed_spans()));
+
+dd_untrace("a");
+DDTrace\trace_function("a", function() { }); // first function, creates span
+DDTrace\trace_function("a", ["prehook" => function() { return false; }]);
+
+a();
+var_dump(count(dd_trace_serialize_closed_spans()));
+
+dd_untrace("a");
+DDTrace\trace_function("a", function() { return false; }); // first function, creates span
+DDTrace\trace_function("a", function() { });
+
+a();
+var_dump(count(dd_trace_serialize_closed_spans()));
+
+// Note that in this case we have a prehook as first function. A prehook returning false will drop an existing span, but not affect future spans.
+dd_untrace("a");
+DDTrace\trace_function("a", ["prehook" => function() { return false; }]); // first function, creates span
+DDTrace\trace_function("a", function() { });
+
+a();
+var_dump(count(dd_trace_serialize_closed_spans()));
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(0)
+int(1)


### PR DESCRIPTION
### Description

Previously return false was ignored in any trace hook, but the first one.

This now properly allows for (as intended) to write code like:
```
DDTrace\trace_method("mysqli", "prepare", function() { return false; });
```

Dropping all spans from trace hooks on mysqli->prepare.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
