### PR TITLE
[profiling] Prevent deadlocks when forking

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"

--- a/profiling/src/pcntl.rs
+++ b/profiling/src/pcntl.rs
@@ -2,90 +2,112 @@ use crate::bindings::{
     datadog_php_install_handler, datadog_php_zif_handler, zend_execute_data, zend_long, zval,
     InternalFunctionHandler,
 };
-use crate::{RequestLocals, PROFILER, REQUEST_LOCALS};
+use crate::{Profiler, PROFILER, REQUEST_LOCALS};
 use log::{error, warn};
-use std::cell::RefMut;
 use std::ffi::CStr;
 use std::mem::{forget, swap};
+use std::sync::atomic::Ordering;
 
 static mut PCNTL_FORK_HANDLER: InternalFunctionHandler = None;
 static mut PCNTL_RFORK_HANDLER: InternalFunctionHandler = None;
 static mut PCNTL_FORKX_HANDLER: InternalFunctionHandler = None;
 
-fn handle_child_fork(mut locals: RefMut<RequestLocals>, retval: &mut zval) {
-    let result: Result<zend_long, _> = retval.try_into();
-    match result {
-        Ok(pid) => {
-            // The child gets pid of 0. For now, stop profiling for safety.
-            if pid == 0 {
-                match PROFILER.lock() {
-                    Ok(mut profiler) => {
-                        let mut new_profiler = None;
-                        swap(&mut *profiler, &mut new_profiler);
+fn handle_pcntl_fork(
+    name: &str,
+    handler: unsafe extern "C" fn(*mut zend_execute_data, *mut zval),
+    execute_data: *mut zend_execute_data,
+    return_value: *mut zval,
+) {
+    /* Hold mutexes across the handler. If there are any spurious wakeups by
+     * the threads while the fork is occurring, they cannot acquire locks
+     * since this thread holds them, preventing a deadlock situation.
+     */
+    let mut profiler_lock = PROFILER.lock().unwrap();
+    if let Some(profiler) = profiler_lock.as_ref() {
+        profiler.fork_prepare();
+    }
 
-                        /* Due to the swap, this has the old profiler.
-                         * Forget about it, it has garbage in it.
-                         */
-                        forget(new_profiler);
-                        locals.profiling_enabled = false;
+    // Safety: we're calling the original handler with correct args.
+    unsafe { handler(execute_data, return_value) };
 
-                        /* When we fully support forking remember:
-                         *  - Reset last_cpu_time and last_wall_time
-                         *  - Reset process_id and runtime-id tags.
-                         */
-                    }
-                    Err(err) => {
-                        error!(
-                            "Forked child failed to acquire profiler lock; a crash is likely: {}",
-                            err
-                        )
+    if return_value.is_null() {
+        // This _shouldn't_ ever be hit.
+
+        if profiler_lock.is_some() {
+            error!(
+                "Failed to read return value of {}. A crash or deadlock may occur.",
+                name
+            );
+        }
+
+        /* We don't know if this is actually the parent or not, so do our best
+         * to to prevent further profiling which could cause a crash/deadlock.
+         */
+
+        stop_profiling(&mut profiler_lock);
+    } else {
+        // Safety: we checked it wasn't null above.
+        let result: Result<zend_long, _> = unsafe { &mut *return_value }.try_into();
+        match result {
+            Err(r#type) => {
+                warn!(
+                    "Return type of {} was unexpected: {}. A crash or deadlock may occur.",
+                    name, r#type
+                );
+
+                stop_profiling(&mut profiler_lock);
+            }
+            Ok(pid) => {
+                // The child gets pid of 0. For now, stop profiling for safety.
+                if pid == 0 {
+                    stop_profiling(&mut profiler_lock);
+
+                    /* When we fully support forking remember:
+                     *  - Reset last_cpu_time and last_wall_time.
+                     *  - Reset process_id and runtime-id tags.
+                     */
+                } else {
+                    /* If it's negative, then no child process was made so we must be the parent.
+                     * If it's positive then this is definitely the parent process.
+                     */
+                    if let Some(profiler) = profiler_lock.as_ref() {
+                        profiler.post_fork_parent();
                     }
                 }
             }
         }
-        Err(r#type) => {
-            warn!(
-                "Return type of pcntl_*fork* function was unexpected: {}",
-                r#type
-            )
-        }
     }
 }
 
-unsafe fn handle_pcntl_fork(return_value: *mut zval) {
-    /* This hook is installed prior to knowing if the profiler will be enabled,
-     * so we must guard it with a runtime check.
-     */
+fn stop_profiling(maybe_profiler: &mut Option<Profiler>) {
+    let mut old_profiler = None;
+    swap(&mut *maybe_profiler, &mut old_profiler);
+
+    forget(old_profiler);
+
     REQUEST_LOCALS.with(|cell| {
-        let locals = cell.borrow_mut();
-        if locals.profiling_enabled && !return_value.is_null() {
-            /* Safety: we just checked it's not null; if any other invariants
-             * are messed up then we're totally hosed already.
-             */
-            handle_child_fork(locals, &mut *return_value);
-        }
+        let mut locals = cell.borrow_mut();
+        locals.profiling_enabled = false;
+        locals.interrupt_count.store(0, Ordering::SeqCst);
     });
 }
 
 unsafe extern "C" fn pcntl_fork(execute_data: *mut zend_execute_data, return_value: *mut zval) {
     // Safety: this function is only called if PCNTL_FORK_HANDLER was set.
     let handler = PCNTL_FORK_HANDLER.unwrap();
-    handler(execute_data, return_value);
-    handle_pcntl_fork(return_value);
+    handle_pcntl_fork("pcntl_fork", handler, execute_data, return_value);
 }
 
 unsafe extern "C" fn pcntl_rfork(execute_data: *mut zend_execute_data, return_value: *mut zval) {
     // Safety: this function is only called if PCNTL_RFORK_HANDLER was set.
     let handler = PCNTL_RFORK_HANDLER.unwrap();
-    handler(execute_data, return_value);
-    handle_pcntl_fork(return_value);
+    handle_pcntl_fork("pcntl_rfork", handler, execute_data, return_value);
 }
 
 unsafe extern "C" fn pcntl_forkx(execute_data: *mut zend_execute_data, return_value: *mut zval) {
     // Safety: this function is only called if PCNTL_FORKX_HANDLER was set.
     let handler = PCNTL_FORKX_HANDLER.unwrap();
-    handler(execute_data, return_value);
-    handle_pcntl_fork(return_value);
+    handle_pcntl_fork("pcntl_forkx", handler, execute_data, return_value);
 }
 
 // Safety: the provided slices are nul-terminated and don't contain any interior nul bytes.


### PR DESCRIPTION
### Description

Deadlocks are prevented by the following technique:

- Prior to the fork, all profiling threads will wait on the same barrier.
- After the fork in the parent process, all threads will wait on the same barrier. They are then free to resume regular operations.
- After the fork in the child process, the barrier will not be joined, the profiler object will be forgotten, and profiling will be disabled.

It should be easy to support profiling the child process from here.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
