### PR TITLE
[PROF-6331] fix linking on arm64 mac

### DIFF
--- a/profiling/.cargo/config
+++ b/profiling/.cargo/config
@@ -2,3 +2,8 @@
 # Leaving syntax here in case we decide to list them all specifically
 #rustflags = ["-C", "link-args=-Wl,-U,_zend_register_extension -Wl,-U,_zend_getenv -Wl,-U,_sapi_module -Wl,-U,_executor_globals"]
 rustflags = ["-C", "link-args=-undefined dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+# Leaving syntax here in case we decide to list them all specifically
+#rustflags = ["-C", "link-args=-Wl,-U,_zend_register_extension -Wl,-U,_zend_getenv -Wl,-U,_sapi_module -Wl,-U,_executor_globals"]
+rustflags = ["-C", "link-args=-undefined dynamic_lookup"]


### PR DESCRIPTION
### Description

While trying to compile and link the PHP profiler on an arm64 mac I got some linking issues from `ld` not finding some of the symbols.

Not writing / adding a test for this one, as we are not officially supporting MacOS.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
