### PR TITLE
Reusability of zai config across products

### DIFF
--- a/zend_abstract_interface/config/CMakeLists.txt
+++ b/zend_abstract_interface/config/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(
 
 target_compile_features(zai_config PUBLIC c_std_99)
 
-target_link_libraries(zai_config PUBLIC "${PHP_LIB}" Zai::Env)
+target_link_libraries(zai_config PUBLIC "${PHP_LIB}" Zai::Json Zai::Env)
 
 set_target_properties(zai_config PROPERTIES EXPORT_NAME Config
                                             VERSION ${PROJECT_VERSION})

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -91,6 +91,7 @@ static zai_config_memoized_entry *zai_config_memoize_entry(zai_config_entry *ent
         assert(0 && "Error decoding default value");
     }
     memoized->name_index = -1;
+    memoized->original_on_modify = NULL;
     memoized->ini_change = entry->ini_change;
 
     return memoized;

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -44,6 +44,7 @@ struct zai_config_entry_s {
     uint8_t aliases_count;
     // Accept or reject ini changes, potentially apply to the currently running system
     zai_config_apply_ini_change ini_change;
+    zai_custom_parse parser;
 };
 
 struct zai_config_name_s {
@@ -63,6 +64,7 @@ struct zai_config_memoized_entry_s {
     //     -1 == not set from env or system ini
     int16_t name_index;
     zai_config_apply_ini_change ini_change;
+    zai_custom_parse parser;
     ZEND_INI_MH((*original_on_modify)); // when some other extension has registered that INI
 };
 

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -63,6 +63,7 @@ struct zai_config_memoized_entry_s {
     //     -1 == not set from env or system ini
     int16_t name_index;
     zai_config_apply_ini_change ini_change;
+    ZEND_INI_MH((*original_on_modify)); // when some other extension has registered that INI
 };
 
 // Memoizes config entries to default values

--- a/zend_abstract_interface/config/config_decode.c
+++ b/zend_abstract_interface/config/config_decode.c
@@ -278,7 +278,7 @@ static bool zai_config_decode_string(zai_string_view value, zval *decoded_value,
     return true;
 }
 
-bool zai_config_decode_value(zai_string_view value, zai_config_type type, zval *decoded_value, bool persistent) {
+bool zai_config_decode_value(zai_string_view value, zai_config_type type, zai_custom_parse custom_parser, zval *decoded_value, bool persistent) {
     assert((Z_TYPE_P(decoded_value) <= IS_NULL) && "The decoded_value must be IS_UNDEF or IS_NULL");
     switch (type) {
         case ZAI_CONFIG_TYPE_BOOL:
@@ -297,6 +297,8 @@ bool zai_config_decode_value(zai_string_view value, zai_config_type type, zval *
             return zai_config_decode_json(value, decoded_value, persistent);
         case ZAI_CONFIG_TYPE_STRING:
             return zai_config_decode_string(value, decoded_value, persistent);
+        case ZAI_CONFIG_TYPE_CUSTOM:
+            return custom_parser(value, decoded_value, persistent);
         default:
             assert(false && "Unknown zai_config_type");
     }

--- a/zend_abstract_interface/config/config_decode.h
+++ b/zend_abstract_interface/config/config_decode.h
@@ -15,9 +15,12 @@ typedef enum {
     ZAI_CONFIG_TYPE_SET_LOWERCASE,
     ZAI_CONFIG_TYPE_JSON,
     ZAI_CONFIG_TYPE_STRING,
+    ZAI_CONFIG_TYPE_CUSTOM,
 } zai_config_type;
 
+typedef bool (*zai_custom_parse)(zai_string_view value, zval *decoded_value, bool persistent);
+
 void zai_config_dtor_pzval(zval *pval);
-bool zai_config_decode_value(zai_string_view value, zai_config_type type, zval *decoded_value, bool persistent);
+bool zai_config_decode_value(zai_string_view value, zai_config_type type, zai_custom_parse custom_parser, zval *decoded_value, bool persistent);
 
 #endif  // ZAI_CONFIG_DECODE_H

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -34,8 +34,6 @@ static void zai_config_lock_ini_copying(THREAD_T thread_id) {
 // values retrieved here are assumed to be valid
 int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_count, zai_string_view *buf,
                                         zai_string_view default_value, zai_config_id entry_id) {
-    UNUSED(entry_id);
-
     if (!env_to_ini_name) return -1;
 
 #if ZTS
@@ -73,51 +71,53 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
         }
     }
 
-    for (int16_t i = 0; i < ini_count; ++i) {
-        bool duplicate = false;
-        for (int j = i + 1; j < ini_count; ++j) {
-            if (entries[i] == entries[j]) {
-                duplicate = true;
+    if (!zai_config_memoized_entries[entry_id].original_on_modify) {
+        for (int16_t i = 0; i < ini_count; ++i) {
+            bool duplicate = false;
+            for (int j = i + 1; j < ini_count; ++j) {
+                if (entries[i] == entries[j]) {
+                    duplicate = true;
+                }
             }
-        }
-        if (duplicate) {
-            continue;
-        }
+            if (duplicate) {
+                continue;
+            }
 
-        zend_string **target = entries[i]->modified ? &entries[i]->orig_value : &entries[i]->value;
-        if (i > 0) {
-            zend_string_release(*target);
-            *target = zend_string_copy(entries[0]->modified ? entries[0]->orig_value : entries[0]->value);
-        } else if (buf->ptr != NULL) {
-            zend_string_release(*target);
-            *target = zend_string_init(buf->ptr, buf->len, 1);
-        } else if (parsed_ini_value != NULL) {
-            zend_string_release(*target);
-            *target = zend_string_copy(parsed_ini_value);
+            zend_string **target = entries[i]->modified ? &entries[i]->orig_value : &entries[i]->value;
+            if (i > 0) {
+                zend_string_release(*target);
+                *target = zend_string_copy(entries[0]->modified ? entries[0]->orig_value : entries[0]->value);
+            } else if (buf->ptr != NULL) {
+                zend_string_release(*target);
+                *target = zend_string_init(buf->ptr, buf->len, 1);
+            } else if (parsed_ini_value != NULL) {
+                zend_string_release(*target);
+                *target = zend_string_copy(parsed_ini_value);
+            }
+
+            if (runtime_value) {
+                if (entries[i]->modified) {
+                    if (entries[i]->value != entries[i]->orig_value) {
+                        zend_string_release(entries[i]->value);
+                    }
+                } else {
+                    entries[i]->orig_value = entries[i]->value;
+                    entries[i]->modified = true;
+                    entries[i]->orig_modifiable = entries[i]->modifiable;
+                    zend_hash_add_ptr(EG(modified_ini_directives), entries[i]->name, entries[i]);
+                }
+                entries[i]->value = zend_string_copy(runtime_value);
+            }
         }
 
         if (runtime_value) {
-            if (entries[i]->modified) {
-                if (entries[i]->value != entries[i]->orig_value) {
-                    zend_string_release(entries[i]->value);
-                }
-            } else {
-                entries[i]->orig_value = entries[i]->value;
-                entries[i]->modified = true;
-                entries[i]->orig_modifiable = entries[i]->modifiable;
-                zend_hash_add_ptr(EG(modified_ini_directives), entries[i]->name, entries[i]);
-            }
-            entries[i]->value = zend_string_copy(runtime_value);
+            buf->ptr = ZSTR_VAL(runtime_value);
+            buf->len = ZSTR_LEN(runtime_value);
+            zend_string_release(runtime_value);
+        } else if (parsed_ini_value && buf->ptr == NULL) {
+            buf->ptr = ZSTR_VAL(parsed_ini_value);
+            buf->len = ZSTR_LEN(parsed_ini_value);
         }
-    }
-
-    if (runtime_value) {
-        buf->ptr = ZSTR_VAL(runtime_value);
-        buf->len = ZSTR_LEN(runtime_value);
-        zend_string_release(runtime_value);
-    } else if (parsed_ini_value && buf->ptr == NULL) {
-        buf->ptr = ZSTR_VAL(parsed_ini_value);
-        buf->len = ZSTR_LEN(parsed_ini_value);
     }
 
     if (parsed_ini_value) {
@@ -132,10 +132,6 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
 }
 
 static ZEND_INI_MH(ZaiConfigOnUpdateIni) {
-    UNUSED(mh_arg1);
-    UNUSED(mh_arg2);
-    UNUSED(mh_arg3);
-
     // ensure validity at any stage
     zai_config_id id;
     zai_string_view name = {.len = ZSTR_LEN(entry->name), .ptr = ZSTR_VAL(entry->name)};
@@ -144,6 +140,12 @@ static ZEND_INI_MH(ZaiConfigOnUpdateIni) {
     if (!zai_config_get_id_by_name(name, &id)) {
         // TODO Log cannot find ID
         return FAILURE;
+    }
+
+    if (zai_config_memoized_entries[id].original_on_modify) {
+        if (zai_config_memoized_entries[id].original_on_modify(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage) == FAILURE) {
+            return FAILURE;
+        }
     }
 
     zval new_zv;
@@ -213,6 +215,14 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
 
     zai_config_register_config_id(ini_name, id);
 
+    zend_ini_entry *existing;
+    if ((existing = zend_hash_str_find_ptr(EG(ini_directives), ini_name->ptr, ini_name->len))) {
+        memoized->original_on_modify = existing->on_modify;
+        existing->on_modify = ZaiConfigOnUpdateIni;
+
+        return;
+    }
+
     /* ZEND_INI_END() adds a null terminating entry */
     zend_ini_entry_def entry_defs[1 + /* terminator entry */ 1] = {{0}, {0}};
     zend_ini_entry_def *entry = &entry_defs[0];
@@ -269,31 +279,33 @@ void zai_config_ini_rinit() {
     if (env_to_ini_name) {
         for (uint8_t i = 0; i < zai_config_memoized_entries_count; ++i) {
             zai_config_memoized_entry *memoized = &zai_config_memoized_entries[i];
-            bool applied_update = false;
-            for (uint8_t n = 0; n < memoized->names_count; ++n) {
-                zend_ini_entry *source = memoized->ini_entries[n],
-                               *ini = zend_hash_find_ptr(EG(ini_directives), source->name);
-                if (ini->modified) {
-                    if (ini->orig_value == ini->value) {
-                        ini->value = source->value;
-                    }
-                    zend_string_release(ini->orig_value);
-                    ini->orig_value = zend_string_copy(source->value);
-
-                    if (!applied_update) {
-                        if (ZaiConfigOnUpdateIni(ini, ini->value, NULL, NULL, NULL, PHP_INI_STAGE_RUNTIME) == SUCCESS) {
-                            // first encountered name has highest priority
-                            applied_update = true;
-                        } else {
-                            zend_string_release(ini->value);
-                            ini->value = ini->orig_value;
-                            ini->modified = false;
-                            ini->orig_value = NULL;
+            if (!memoized->original_on_modify) {
+                bool applied_update = false;
+                for (uint8_t n = 0; n < memoized->names_count; ++n) {
+                    zend_ini_entry *source = memoized->ini_entries[n],
+                                   *ini = zend_hash_find_ptr(EG(ini_directives), source->name);
+                    if (ini->modified) {
+                        if (ini->orig_value == ini->value) {
+                            ini->value = source->value;
                         }
+                        zend_string_release(ini->orig_value);
+                        ini->orig_value = zend_string_copy(source->value);
+
+                        if (!applied_update) {
+                            if (ZaiConfigOnUpdateIni(ini, ini->value, NULL, NULL, NULL, PHP_INI_STAGE_RUNTIME) == SUCCESS) {
+                                // first encountered name has highest priority
+                                applied_update = true;
+                            } else {
+                                zend_string_release(ini->value);
+                                ini->value = ini->orig_value;
+                                ini->modified = false;
+                                ini->orig_value = NULL;
+                            }
+                        }
+                    } else {
+                        zend_string_release(ini->value);
+                        ini->value = zend_string_copy(source->value);
                     }
-                } else {
-                    zend_string_release(ini->value);
-                    ini->value = zend_string_copy(source->value);
                 }
             }
         }
@@ -304,7 +316,7 @@ void zai_config_ini_rinit() {
 
     for (uint8_t i = 0; i < zai_config_memoized_entries_count; ++i) {
         zai_config_memoized_entry *memoized = &zai_config_memoized_entries[i];
-        if (memoized->ini_change == zai_config_system_ini_change) {
+        if (memoized->ini_change == zai_config_system_ini_change || memoized->original_on_modify) {
             continue;
         }
 

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -131,6 +131,7 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
     return name_index;
 }
 
+bool zai_config_is_initialized(void);
 static ZEND_INI_MH(ZaiConfigOnUpdateIni) {
     // ensure validity at any stage
     zai_config_id id;
@@ -161,6 +162,11 @@ static ZEND_INI_MH(ZaiConfigOnUpdateIni) {
      * first-time RINIT. */
     if (stage != PHP_INI_STAGE_RUNTIME) {
         zai_config_dtor_pzval(&new_zv);
+        return SUCCESS;
+    }
+
+    if (!zai_config_is_initialized()) {
+        zval_dtor(&new_zv);
         return SUCCESS;
     }
 

--- a/zend_abstract_interface/config/config_runtime.c
+++ b/zend_abstract_interface/config/config_runtime.c
@@ -20,6 +20,10 @@ void zai_config_replace_runtime_config(zai_config_id id, zval *value) {
     ZVAL_COPY(rt_value, value);
 }
 
+bool zai_config_is_initialized(void) {
+    return runtime_config_initialized;
+}
+
 void zai_config_runtime_config_ctor(void) {
     if (runtime_config_initialized == true) return;
     runtime_config = emalloc(sizeof(zval) * ZAI_CONFIG_ENTRIES_COUNT_MAX);

--- a/zend_abstract_interface/config/tests/CMakeLists.txt
+++ b/zend_abstract_interface/config/tests/CMakeLists.txt
@@ -3,6 +3,6 @@ add_executable(config ext_zai_config.cc default.cc env.cc id.cc decode.cc ini.cc
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-target_link_libraries(config PUBLIC catch2_main Tea::Tea Zai::Config Zai::Json Threads::Threads)
+target_link_libraries(config PUBLIC catch2_main Tea::Tea Zai::Config Threads::Threads)
 
 catch_discover_tests(config)

--- a/zend_abstract_interface/config/tests/decode.cc
+++ b/zend_abstract_interface/config/tests/decode.cc
@@ -28,7 +28,7 @@ TEA_TEST_CASE("config/decode", "bool", {
 
     for (zai_string_view name : truthy) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_TRUE);
@@ -48,7 +48,7 @@ TEA_TEST_CASE("config/decode", "bool", {
 
     for (zai_string_view name : falsey) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_FALSE);
@@ -78,7 +78,7 @@ TEA_TEST_CASE("config/decode", "double", {
 
     for (expected_double expected : successes) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(expected.name, type, &value, false);
+        ret = zai_config_decode_value(expected.name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_DOUBLE);
@@ -100,7 +100,7 @@ TEA_TEST_CASE("config/decode", "double", {
 
     for (zai_string_view name : errors) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == false);
         REQUIRE(Z_TYPE(value) <= IS_NULL);
@@ -130,7 +130,7 @@ TEA_TEST_CASE("config/decode", "int", {
 
     for (expected_int expected : successes) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(expected.name, type, &value, false);
+        ret = zai_config_decode_value(expected.name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_LONG);
@@ -152,7 +152,7 @@ TEA_TEST_CASE("config/decode", "int", {
 
     for (zai_string_view name : errors) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == false);
         REQUIRE(Z_TYPE(value) <= IS_NULL);
@@ -183,7 +183,7 @@ TEA_TEST_CASE("config/decode", "map", {
 
     for (expected_map expected : successes) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(expected.name, type, &value, false);
+        ret = zai_config_decode_value(expected.name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_ARRAY);
@@ -211,7 +211,7 @@ TEA_TEST_CASE("config/decode", "map", {
 
     for (zai_string_view name : errors) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == false);
         REQUIRE(Z_TYPE(value) <= IS_NULL);
@@ -241,7 +241,7 @@ TEA_TEST_CASE("config/decode", "set", {
 
     for (expected_set expected : successes) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(expected.name, type, &value, false);
+        ret = zai_config_decode_value(expected.name, type, NULL, &value, false);
 
         REQUIRE(ret == true);
         REQUIRE(Z_TYPE(value) == IS_ARRAY);
@@ -264,7 +264,7 @@ TEA_TEST_CASE("config/decode", "set", {
 
     for (zai_string_view name : errors) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == false);
         REQUIRE(Z_TYPE(value) <= IS_NULL);
@@ -292,7 +292,7 @@ TEA_TEST_CASE_BARE("config/decode", "json", {
 
     for (zai_string_view name : errors) {
         ZVAL_UNDEF(&value);
-        ret = zai_config_decode_value(name, type, &value, false);
+        ret = zai_config_decode_value(name, type, NULL, &value, false);
 
         REQUIRE(ret == false);
         REQUIRE(Z_TYPE(value) <= IS_NULL);
@@ -301,7 +301,7 @@ TEA_TEST_CASE_BARE("config/decode", "json", {
     // ---
 
     ZVAL_UNDEF(&value);
-    ret = zai_config_decode_value(ZAI_STRL_VIEW("{\"foo\":1,\"bar\":\"str\",\"baz\":[1],\"empty\":[]}"), type, &value, true);
+    ret = zai_config_decode_value(ZAI_STRL_VIEW("{\"foo\":1,\"bar\":\"str\",\"baz\":[1],\"empty\":[]}"), type, NULL, &value, true);
 
     // ---
 


### PR DESCRIPTION
### Description

This PR modifies zai config in a way that multiple extensions can share common settings.

Required for #1764 and https://github.com/DataDog/dd-appsec-php/pull/114.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
