### PR TITLE
improve ldconfig operation in installer

### DIFF
--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -69,6 +69,7 @@ test_installer: $(shell find installer -name 'test_*.sh' -exec basename {} \;)
 test_appsec_install_disabled.sh \
 test_appsec_install_enabled.sh \
 test_first_install.sh \
+test_install_no_ldconfig_in_path.sh \
 test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
 test_install_custom_installation_directory.sh \

--- a/dockerfiles/verify_packages/installer/test_install_no_ldconfig_in_path.sh
+++ b/dockerfiles/verify_packages/installer/test_install_no_ldconfig_in_path.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+# Install using the php installer
+new_version="0.74.0"
+generate_installers "${new_version}"
+
+PHP=$(which php)
+
+# ldconfig is typically found in /sbin
+export PATH=/usr/bin:/bin:/usr/local/bin
+
+set +e
+output=$($PHP ./build/packages/datadog-setup.php --php-bin $PHP)
+exit_status=$?
+set -e
+
+assert_ddtrace_version "${new_version}" $PHP


### PR DESCRIPTION
### Description

The installer depends on a working ldconfig (for glibc install) and assumes it is in PATH.

It is becoming common place for /sbin to be omitted from the PATH of normal users, so we must search outside of PATH in the most common paths for a working ldconfig and use its full path on execution.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
