### PR TITLE
[profiling] Add .ini support

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1130,6 +1130,34 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
             'commented' => false,
             'description' => 'Enables the appsec module',
         ],
+
+        [
+            'name' => 'datadog.profiling.enabled',
+            'default' => '1',
+            'commented' => true,
+            'description' => 'Enable the Datadog profiling module.',
+        ],
+        [
+            'name' => 'datadog.trace.endpoint_collection_enabled',
+            'default' => '1',
+            'commented' => true,
+            'description' => 'Whether to enable the endpoint data collection in profiles.',
+        ],
+        [
+            'name' => 'datadog.profiling.experimental_cpu_time_enabled',
+            'default' => '1',
+            'commented' => true,
+            'description' => 'Enable the CPU profile type.',
+        ],
+        [
+            'name' => 'datadog.profiling.log_level',
+            'default' => 'off',
+            'commented' => true,
+            'description' => 'Set the profiler’s log level.'
+                . ' Acceptable values are off, error, warn, info, and debug.'
+                . ' The profiler’s logs are written to the standard error stream of the process.',
+        ],
+
         [
             'name' => 'datadog.trace.request_init_hook',
             'default' => $requestInitHookPath,

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1154,7 +1154,7 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
             'default' => 'off',
             'commented' => true,
             'description' => 'Set the profiler’s log level.'
-                . ' Acceptable values are off, error, warn, info, and debug.'
+                . ' Acceptable values are off, error, warn, info, debug, and trace.'
                 . ' The profiler’s logs are written to the standard error stream of the process.',
         ],
 

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -72,7 +72,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_SERVICE, "", CALIASES("DD_SERVICE_NAME"))                                                \
     CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                        \
     CALIAS(MAP, DD_TAGS, "", CALIASES("DD_TRACE_GLOBAL_TAGS"))                                                 \
-    CONFIG(INT, DD_TRACE_AGENT_PORT, "8126", .ini_change = zai_config_system_ini_change)                       \
+    CONFIG(INT, DD_TRACE_AGENT_PORT, "0", .ini_change = zai_config_system_ini_change)                          \
     CONFIG(BOOL, DD_TRACE_ANALYTICS_ENABLED, "false")                                                          \
     CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                         \
     CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                                \

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -119,7 +119,10 @@ fn generate_bindings(php_config_includes: &str) {
         .header("../ext/handlers_api.h")
         .clang_arg("-I../zend_abstract_interface")
         // Block some zend items that we'll provide manual definitions for
-        .blocklist_item("sapi_getenv")
+        .blocklist_item("zai_string_view_s")
+        .blocklist_item("zai_string_view")
+        .blocklist_item("zai_config_entry_s")
+        .blocklist_item("zai_config_memoized_entry_s")
         .blocklist_item("zend_bool")
         .blocklist_item("_zend_extension")
         .blocklist_item("zend_extension")
@@ -127,8 +130,7 @@ fn generate_bindings(php_config_includes: &str) {
         .blocklist_item("zend_module_entry")
         .blocklist_item("zend_result")
         .blocklist_item("zend_register_extension")
-        // ZAI config
-        .blocklist_item("zai_config_type")
+        .blocklist_item("_zend_string")
         // Block a few of functions that we'll provide defs for manually
         .blocklist_item("datadog_php_profiling_vm_interrupt_addr")
         // I had to block these for some reason *shrug*
@@ -144,6 +146,7 @@ fn generate_bindings(php_config_includes: &str) {
         .blocklist_item("FP_ZERO")
         .blocklist_item("IPPORT_RESERVED")
         .rustified_enum("datadog_php_profiling_log_level")
+        .rustified_enum("zai_config_type")
         .parse_callbacks(Box::new(ignored_macros))
         .clang_args(php_config_includes.split(' '))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/profiling/src/bindings/ffi.rs
+++ b/profiling/src/bindings/ffi.rs
@@ -3,9 +3,16 @@
 #![allow(warnings)]
 
 use crate::bindings::{
-    _zend_module_entry, zend_bool, zend_extension, zend_module_entry, zend_result, ZaiConfigType,
+    _zend_module_entry, zend_bool, zend_extension, zend_module_entry, zend_result, ZaiConfigEntry,
+    ZaiConfigMemoizedEntry, ZaiStringView, ZendString,
 };
 
-pub type zai_config_type = ZaiConfigType;
+pub type _zend_string = ZendString;
+
+pub type zai_string_view_s<'a> = ZaiStringView<'a>;
+pub type zai_string_view<'a> = zai_string_view_s<'a>;
+
+pub type zai_config_entry_s = ZaiConfigEntry;
+pub type zai_config_memoized_entry_s = ZaiConfigMemoizedEntry;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/profiling/src/bindings/ffi.rs
+++ b/profiling/src/bindings/ffi.rs
@@ -3,7 +3,9 @@
 #![allow(warnings)]
 
 use crate::bindings::{
-    _zend_module_entry, zend_bool, zend_extension, zend_module_entry, zend_result,
+    _zend_module_entry, zend_bool, zend_extension, zend_module_entry, zend_result, ZaiConfigType,
 };
+
+pub type zai_config_type = ZaiConfigType;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -425,6 +425,11 @@ impl<'a> ZaiStringView<'a> {
         }
     }
 
+    pub const unsafe fn from_raw_parts(ptr: *const c_char, len: size_t) -> ZaiStringView<'a> {
+        let _marker = PhantomData;
+        Self { len, ptr, _marker }
+    }
+
     pub fn is_empty(&self) -> bool {
         // Note: ptr shouldn't be null!
         self.len == 0 || self.ptr.is_null()

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -415,6 +415,16 @@ pub struct ZaiStringView<'a> {
     _marker: PhantomData<&'a [c_char]>,
 }
 
+impl<'a> From<&'a str> for ZaiStringView<'a> {
+    fn from(val: &'a str) -> Self {
+        Self {
+            len: val.len(),
+            ptr: val.as_ptr() as *const c_char,
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<'a> ZaiStringView<'a> {
     pub const fn new() -> ZaiStringView<'a> {
         const NULL: &[u8] = b"\0";
@@ -423,11 +433,6 @@ impl<'a> ZaiStringView<'a> {
             ptr: NULL.as_ptr() as *const c_char,
             _marker: PhantomData,
         }
-    }
-
-    pub const unsafe fn from_raw_parts(ptr: *const c_char, len: size_t) -> ZaiStringView<'a> {
-        let _marker = PhantomData;
-        Self { len, ptr, _marker }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -3,7 +3,8 @@ mod ffi;
 pub use ffi::*;
 
 use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, c_void, size_t};
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
+use std::marker::PhantomData;
 use std::str::Utf8Error;
 use std::sync::atomic::AtomicBool;
 
@@ -28,6 +29,91 @@ impl From<c_int> for ZendResult {
         match value {
             0 => Self::Success,
             _ => Self::Failure,
+        }
+    }
+}
+
+/// The zend_string struct uses a technique that has undefined behaviour in
+/// both C and C++, but it nonetheless very popular. One of the specific
+/// problems for PHP is that its headers will be used by both C and C++
+/// compilers. The official C remedy is called a flexible array member, but
+/// C++ does not yet support this (there was a recent proposal, I do not know
+/// the status).
+///
+/// Aside from the trickery above, Rust has some undefined behavior edges of
+/// its own specifically with dynamically sized types (DSTs), which the
+/// zend_string is.
+///
+/// Taking these two things into account, we treat this as an opaque type.
+#[repr(C)]
+pub struct ZendString {
+    _opaque: [u8; 0],
+}
+
+impl _zend_function {
+    /// Returns a slice to the zend_string's data if it's present and not
+    /// empty; otherwise returns None.
+    fn zend_string_to_optional_bytes(zstr: Option<&mut zend_string>) -> Option<&[u8]> {
+        /* Safety: datadog_php_profiling_zend_string_view can be called with
+         * any valid zend_string pointer, and the tailing .into_bytes() will
+         * be safe as the former will always return a view with a non-null
+         * pointer.
+         */
+        let bytes = unsafe { datadog_php_profiling_zend_string_view(zstr).into_bytes() };
+        if bytes.is_empty() {
+            None
+        } else {
+            Some(bytes)
+        }
+    }
+
+    /// Returns the function name, if there is one and it's not an empty string.
+    pub fn name(&self) -> Option<&[u8]> {
+        // Safety: function name is a valid mutable reference if not null.
+        Self::zend_string_to_optional_bytes(unsafe { self.common.function_name.as_mut() })
+    }
+
+    /// Returns the name of the function's stored scope (not runtime scope).
+    pub fn scope_name(&self) -> Option<&[u8]> {
+        // Safety: common is always safe to access.
+        if unsafe { self.common.scope.is_null() } {
+            return None;
+        }
+
+        // Safety: scope is a valid reference (not null was checked above).
+        let scope = unsafe { &mut *self.common.scope };
+
+        // Safety: scope name is a valid mutable reference if not null.
+        let scope_name = unsafe { scope.name.as_mut() };
+
+        Self::zend_string_to_optional_bytes(scope_name)
+    }
+
+    /// Returns the module name, if there is one and it's not an empty string.
+    pub fn module_name(&self) -> Option<&[u8]> {
+        // Safety: the function's type field is always safe to access.
+        if unsafe { self.type_ } == ZEND_INTERNAL_FUNCTION as u8 {
+            // Safety: if body is guarded by ZEND_INTERNAL_FUNCTION check.
+            let internal_function = unsafe { &self.internal_function };
+            if internal_function.module.is_null() {
+                return None;
+            }
+
+            // Safety: guarded null module case above.
+            let name = unsafe { (*internal_function.module).name };
+            if name.is_null() {
+                return None;
+            }
+
+            // Safety: null case is guarded above.
+            let bytes = unsafe { CStr::from_ptr(name as *const c_char) }.to_bytes();
+            if bytes.is_empty() {
+                return None;
+            }
+
+            Some(bytes)
+        } else {
+            None
         }
     }
 }
@@ -174,46 +260,7 @@ impl Default for ZendExtension {
     }
 }
 
-#[repr(C)]
-pub struct EfreePtr<T> {
-    ptr: *mut T,
-}
-
-impl EfreePtr<c_char> {
-    /// Converts the possibly-null string into an Option<CString>, treating an
-    /// empty string as a None.
-    pub fn into_c_string(self) -> Option<CString> {
-        if !self.ptr.is_null() {
-            /* Safety: If this is invalid when non-null, then someone else has
-             * messed up already, nothing we can do really.
-             */
-            let cstr = unsafe { CStr::from_ptr(self.ptr) };
-
-            // treat empty strings the same as no string
-            if cstr.to_bytes().is_empty() {
-                return None;
-            }
-
-            Some(cstr.to_owned())
-        } else {
-            None
-        }
-    }
-}
-
-impl<T> Drop for EfreePtr<T> {
-    fn drop(&mut self) {
-        if !self.ptr.is_null() {
-            unsafe { _efree(self.ptr as *mut c_void) }
-        }
-    }
-}
-
 extern "C" {
-    /// Get the env var from the SAPI. May be NULL. If non-null, it must be
-    /// efree'd, hence custom definition.
-    pub fn sapi_getenv(name: *const c_char, name_len: size_t) -> EfreePtr<c_char>;
-
     /// Retrieves the VM interrupt address of the calling PHP thread.
     /// # Safety
     /// Must be called from a PHP thread during a request.
@@ -227,6 +274,13 @@ extern "C" {
 
     #[cfg(php7)]
     pub fn zend_register_extension(extension: &ZendExtension, handle: *mut c_void) -> ZendResult;
+
+    /// Converts the `zstr` into a `zai_string_view`. A None as well as empty
+    /// strings will be converted into a string view to a static empty string
+    /// (single byte of null, len of 0).
+    pub fn datadog_php_profiling_zend_string_view(
+        zstr: Option<&mut zend_string>,
+    ) -> zai_string_view;
 }
 
 pub use zend_module_dep as ModuleDep;
@@ -323,12 +377,13 @@ impl TryFrom<&mut zval> for bool {
 }
 
 pub enum StringError {
-    Null,            // zval.value.str_ pointer was null, very bad.
-    Type(u8),        // Type didn't match.
-    Utf8(Utf8Error), // Wasn't a valid UTF8 string.
+    Null,     // zval.value.str_ pointer was null, very bad.
+    Type(u8), // Type didn't match.
 }
 
-impl TryFrom<&mut zval> for &str {
+/// Until we have safely abstracted zend_string*'s in Rust, we need to copy
+/// the String. This also means we can ensure UTF-8 through lossy conversion.
+impl TryFrom<&mut zval> for String {
     type Error = StringError;
 
     fn try_from(zval: &mut zval) -> Result<Self, Self::Error> {
@@ -339,20 +394,14 @@ impl TryFrom<&mut zval> for &str {
                 return Err(StringError::Null);
             }
 
-            // Safety: the pointer was checked to be not null above.
-            let zstr: &zend_string = unsafe { &*zval.value.str_ };
-            let bytes: &[u8] = if zstr.len == 0 {
-                // Always have a null terminated string, even with len = 0.
-                static EMPTY_STR: &[u8] = b"\0";
-                let ptr = EMPTY_STR.as_ptr() as *const u8;
-                unsafe { std::slice::from_raw_parts(ptr, 0) }
-            } else {
-                let ptr = zstr.val.as_ptr() as *const u8;
-                let len = zstr.len as usize;
-                // Safety: zend_strings have at least one byte when len > 0.
-                unsafe { std::slice::from_raw_parts(ptr, len) }
-            };
-            std::str::from_utf8(bytes).map_err(|e| StringError::Utf8(e))
+            // Safety: checked the pointer wasn't null above.
+            let view = unsafe { datadog_php_profiling_zend_string_view(zval.value.str_.as_mut()) };
+
+            // Safety: datadog_php_profiling_zend_string_view returns a fully populated string.
+            let bytes = unsafe { view.into_bytes() };
+
+            // PHP does not guarantee UTF-8 correctness, so lossy convert.
+            Ok(String::from_utf8_lossy(bytes).into_owned())
         } else {
             Err(StringError::Type(r#type))
         }
@@ -360,53 +409,87 @@ impl TryFrom<&mut zval> for &str {
 }
 
 #[repr(C)]
-pub enum ZaiConfigType {
-    Bool,
-    #[allow(dead_code)]
-    Double,
-    #[allow(dead_code)]
-    Int,
-    #[allow(dead_code)]
-    Map,
-    #[allow(dead_code)]
-    Set,
-    #[allow(dead_code)]
-    SetLowercase,
-    #[allow(dead_code)]
-    Json,
-    #[allow(dead_code)]
-    String,
-    Custom,
+pub struct ZaiStringView<'a> {
+    len: size_t,
+    ptr: *const c_char,
+    _marker: PhantomData<&'a [c_char]>,
 }
 
-impl zai_string_view {
-    pub const fn new() -> Self {
+impl<'a> ZaiStringView<'a> {
+    pub const fn new() -> ZaiStringView<'a> {
         const NULL: &[u8] = b"\0";
-        let len: u64 = 0;
-        let ptr = NULL.as_ptr() as *const c_char;
-        Self { len, ptr }
+        Self {
+            len: 0,
+            ptr: NULL.as_ptr() as *const c_char,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // Note: ptr shouldn't be null!
+        self.len == 0 || self.ptr.is_null()
     }
 
     /// # Safety
     /// `str` must be valid for [CStr::from_bytes_with_nul_unchecked]
     pub const unsafe fn literal(str: &'static [u8]) -> Self {
-        let ptr = str.as_ptr() as *const c_char;
         let mut i: usize = 0;
         while str[i] != b'\0' {
             i += 1;
         }
-        let len = i as u64;
-        Self { len, ptr }
+        Self {
+            len: i as size_t,
+            ptr: str.as_ptr() as *const c_char,
+            _marker: PhantomData,
+        }
     }
 
-    unsafe fn to_bytes(&self) -> &[u8] {
+    /// # Safety
+    /// Inherits the safety requirements of [std::slice::from_raw_parts], in
+    /// particular, the view must not use a null pointer.
+    pub unsafe fn into_bytes(self) -> &'a [u8] {
         assert!(!self.ptr.is_null());
-        let len: usize = self.len.try_into().unwrap();
+        let len = self.len;
         std::slice::from_raw_parts(self.ptr as *const u8, len)
     }
 
-    pub unsafe fn to_utf8(&self) -> Result<&str, Utf8Error> {
-        let bytes = self.to_bytes();
+    pub unsafe fn into_utf8(self) -> Result<&'a str, Utf8Error> {
+        let bytes = self.into_bytes();
         std::str::from_utf8(bytes)
     }
+}
+
+#[repr(C)]
+pub struct ZaiConfigEntry {
+    pub id: zai_config_id,
+    pub name: zai_string_view<'static>,
+    pub type_: zai_config_type,
+    pub default_encoded_value: zai_string_view<'static>,
+    pub aliases: *const zai_string_view<'static>,
+    pub aliases_count: u8,
+    pub ini_change: zai_config_apply_ini_change,
+    pub parser: zai_custom_parse,
+}
+
+#[repr(C)]
+pub struct ZaiConfigMemoizedEntry {
+    pub names: [zai_config_name; 4usize],
+    pub ini_entries: [*mut zend_ini_entry; 4usize],
+    pub names_count: u8,
+    pub type_: zai_config_type,
+    pub decoded_value: zval,
+    pub default_encoded_value: zai_string_view<'static>,
+    pub name_index: i16,
+    pub ini_change: zai_config_apply_ini_change,
+    pub parser: zai_custom_parse,
+    pub original_on_modify: Option<
+        unsafe extern "C" fn(
+            entry: *mut zend_ini_entry,
+            new_value: *mut zend_string,
+            mh_arg1: *mut c_void,
+            mh_arg2: *mut c_void,
+            mh_arg3: *mut c_void,
+            stage: c_int,
+        ) -> c_int,
+    >,
 }

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -1,8 +1,8 @@
 use crate::bindings::zai_config_type::*;
 use crate::bindings::{
-    datadog_php_profiling_parse_utf8, zai_config_entry, zai_config_get_value, zai_config_minit,
-    zai_config_name, zai_config_system_ini_change, zai_string_view, zend_long, zval, IS_LONG,
-    ZAI_CONFIG_ENTRIES_COUNT_MAX,
+    datadog_php_profiling_copy_string_view_into_zval, zai_config_entry, zai_config_get_value,
+    zai_config_minit, zai_config_name, zai_config_system_ini_change, zai_string_view, zend_long,
+    zval, ZaiStringView, IS_LONG, ZAI_CONFIG_ENTRIES_COUNT_MAX,
 };
 pub use datadog_profiling::exporter::Uri;
 use libc::{c_char, c_void, memcpy};
@@ -302,8 +302,8 @@ unsafe extern "C" fn parse_utf8_string(
     match value.into_utf8() {
         Ok(utf8) => {
             let ptr = utf8.as_ptr() as *const c_char;
-            let len = utf8.len() as u64;
-            datadog_php_profiling_parse_utf8(decoded_value, ptr, len, persistent);
+            let view = ZaiStringView::from_raw_parts(ptr, utf8.len());
+            datadog_php_profiling_copy_string_view_into_zval(decoded_value, view, persistent);
             true
         }
         Err(e) => {

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -1,10 +1,19 @@
+use crate::bindings::{
+    datadog_php_profiling_parse_utf8, zai_config_entry, zai_config_get_value, zai_config_minit,
+    zai_config_name, zai_config_system_ini_change, zai_string_view, zend_long, zval, ZaiConfigType,
+    IS_LONG, ZAI_CONFIG_ENTRIES_COUNT_MAX,
+};
 use crate::sapi_getenv;
 pub use datadog_profiling::exporter::Uri;
-use libc::c_char;
+use libc::{c_char, c_void, memcpy};
+use log::{warn, LevelFilter};
 use std::ffi::CStr;
 use std::fmt::{Display, Formatter};
+use std::mem::transmute;
 use std::path::Path;
 pub use std::path::PathBuf;
+use std::str::FromStr;
+use ConfigId::*;
 
 pub struct Env {
     pub agent_host: Option<String>,
@@ -147,6 +156,446 @@ impl Display for AgentEndpoint {
         match self {
             AgentEndpoint::Uri(uri) => write!(f, "{}", uri),
             AgentEndpoint::Socket(path) => write!(f, "unix://{}", path.to_string_lossy()),
+        }
+    }
+}
+
+unsafe extern "C" fn env_to_ini_name(env_name: zai_string_view, ini_name: *mut zai_config_name) {
+    assert!(!ini_name.is_null());
+    let ini_name = &mut *ini_name;
+
+    let name: &str = env_name.to_utf8().unwrap();
+
+    assert!(name.starts_with("DD_"));
+
+    // Env var name needs to fit.
+    let projection = "datadog.".len() - "DD_".len();
+    let null_byte = 1usize;
+    assert!(name.len() + projection + null_byte < ZAI_CONFIG_ENTRIES_COUNT_MAX as usize);
+
+    let (dest_prefix, src_prefix) = if name.starts_with("DD_TRACE_") {
+        ("datadog.trace.", "DD_TRACE_")
+    } else if name.starts_with("DD_PROFILING_") {
+        ("datadog.profiling.", "DD_PROFILING_")
+    } else if name.starts_with("DD_APPSEC_") {
+        ("datadog.appsec.", "DD_APPSEC_")
+    } else {
+        ("datadog.", "DD_")
+    };
+
+    memcpy(
+        ini_name.ptr.as_mut_ptr() as *mut c_void,
+        dest_prefix.as_ptr() as *const c_void,
+        dest_prefix.len(),
+    );
+
+    // Copy in the parts after the prefix, lowercasing as we go. For example,
+    // with DD_PROFILING_ENABLED copy `ENABLED` as `enabled` into the
+    // destination slice.
+    let dest_suffix = &mut ini_name.ptr[dest_prefix.len()..];
+    let src_suffix = &name[src_prefix.len()..];
+    for (dest, src) in dest_suffix.iter_mut().zip(src_suffix.bytes()) {
+        *dest = transmute(src.to_ascii_lowercase());
+    }
+
+    // Add the null terminator.
+    dest_suffix[src_suffix.len()] = transmute(b'\0');
+
+    // Store the length without the null.
+    ini_name.len = (dest_prefix.len() + src_suffix.len()).try_into().unwrap();
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in rshutdown.
+pub(crate) unsafe fn get_value(id: ConfigId) -> &'static mut zval {
+    let value = zai_config_get_value(transmute(id));
+    // Panic: the implementation makes this guarantee.
+    assert!(!value.is_null());
+    &mut *value
+}
+
+#[repr(u16)]
+#[derive(Clone, Copy)]
+pub(crate) enum ConfigId {
+    ProfilingEnabled = 0,
+    ProfilingEndpointCollectionEnabled,
+    ProfilingExperimentalCpuTimeEnabled,
+    ProfilingLogLevel,
+
+    // todo: do these need to be kept in sync with the tracer?
+    AgentHost,
+    Env,
+    Service,
+    Tags,
+    TraceAgentPort,
+    TraceAgentUrl,
+    Version,
+}
+
+impl ConfigId {
+    const fn to_env_var_name(&self) -> zai_string_view {
+        let bytes: &'static [u8] = match self {
+            ProfilingEnabled => b"DD_PROFILING_ENABLED\0",
+            ProfilingEndpointCollectionEnabled => b"DD_PROFILING_ENDPOINT_COLLECTION_ENABLED\0",
+            ProfilingExperimentalCpuTimeEnabled => b"DD_PROFILING_CPU_ENABLED\0",
+            ProfilingLogLevel => b"DD_PROFILING_LOG_LEVEL\0",
+
+            AgentHost => b"DD_AGENT_HOST\0",
+            Env => b"DD_ENV\0",
+            Service => b"DD_SERVICE\0",
+            Tags => b"DD_TAGS\0",
+            TraceAgentPort => b"DD_TRACE_AGENT_PORT\0",
+            TraceAgentUrl => b"DD_TRACE_AGENT_URL\0",
+            Version => b"DD_VERSION\0",
+        };
+
+        // Safety: all these byte strings are [CStr::from_bytes_with_nul_unchecked] compatible.
+        unsafe { zai_string_view::literal(bytes) }
+    }
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn profiling_enabled() -> bool {
+    get_bool(ConfigId::ProfilingEnabled, false)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn profiling_endpoint_collection_enabled() -> bool {
+    get_bool(ConfigId::ProfilingEndpointCollectionEnabled, true)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn profiling_experimental_cpu_time_enabled() -> bool {
+    get_bool(ProfilingExperimentalCpuTimeEnabled, true)
+}
+
+unsafe fn get_bool(id: ConfigId, default: bool) -> bool {
+    get_value(id).try_into().unwrap_or(default)
+}
+
+unsafe fn get_str(id: ConfigId) -> Option<&'static str> {
+    let str: Result<&str, _> = get_value(id).try_into();
+    match str {
+        Ok(value) => {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        }
+        Err(_err) => None,
+    }
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn agent_host() -> Option<&'static str> {
+    get_str(ConfigId::AgentHost)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn env() -> Option<&'static str> {
+    get_str(ConfigId::Env)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn service() -> Option<&'static str> {
+    get_str(ConfigId::Service)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn version() -> Option<&'static str> {
+    get_str(ConfigId::Version)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn trace_agent_port() -> Option<u16> {
+    let port = get_value(ConfigId::TraceAgentPort)
+        .try_into()
+        .unwrap_or(0 as zend_long);
+    if port <= 0 || port > (u16::MAX as zend_long) {
+        None
+    } else {
+        Some(port as u16)
+    }
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn trace_agent_url() -> Option<&'static str> {
+    get_str(ConfigId::TraceAgentUrl)
+}
+
+/// # Safety
+/// This function must only be called after config has been initialized in
+/// rinit, and before it is uninitialized in mshutdown.
+pub(crate) unsafe fn profiling_log_level() -> LevelFilter {
+    let value: Result<zend_long, u8> = get_value(ConfigId::ProfilingLogLevel).try_into();
+    match value {
+        // If this is an lval, then we know we can transmute it because the parser worked.
+        Ok(enabled) => transmute(enabled),
+        Err(zval_type) => {
+            warn!(
+                "zval of type {} encountered when calling config::profiling_log_level(), expected type int ({})",
+                zval_type, IS_LONG);
+            LevelFilter::Off // the default is off
+        }
+    }
+}
+
+unsafe extern "C" fn parse_level_filter(
+    value: zai_string_view,
+    decoded_value: *mut zval,
+    _persistent: bool,
+) -> bool {
+    if value.ptr.is_null() || decoded_value.is_null() {
+        return false;
+    }
+
+    let decoded_value = &mut *decoded_value;
+    match value.to_utf8() {
+        Ok(level) => match LevelFilter::from_str(level) {
+            Ok(filter) => {
+                decoded_value.value.lval = filter as zend_long;
+                decoded_value.u1.type_info = IS_LONG;
+                true
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+unsafe extern "C" fn parse_utf8_string(
+    value: zai_string_view,
+    decoded_value: *mut zval,
+    persistent: bool,
+) -> bool {
+    if value.ptr.is_null() || decoded_value.is_null() {
+        return false;
+    }
+
+    match value.to_utf8() {
+        Ok(utf8) => {
+            let ptr = utf8.as_ptr() as *const c_char;
+            let len = utf8.len() as u64;
+            datadog_php_profiling_parse_utf8(decoded_value, ptr, len, persistent);
+            true
+        }
+        Err(e) => {
+            warn!("Error while running config::parse_utf8_string(): {}", e);
+            false
+        }
+    }
+}
+
+pub(crate) fn minit(module_number: libc::c_int) {
+    unsafe {
+        const CPU_TIME_ALIASES: &[zai_string_view] = unsafe {
+            &[
+                zai_string_view::literal(b"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED\0"),
+                zai_string_view::literal(b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0"),
+            ]
+        };
+
+        // Note that function pointers cannot appear in const functions, so we
+        // can't extract each entry into a helper function.
+        static mut ENTRIES: &mut [zai_config_entry] = unsafe {
+            &mut [
+                zai_config_entry {
+                    id: transmute(ProfilingEnabled),
+                    name: ProfilingEnabled.to_env_var_name(),
+                    type_: ZaiConfigType::Bool,
+                    default_encoded_value: zai_string_view::literal(b"no\0"),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: None,
+                },
+                zai_config_entry {
+                    id: transmute(ProfilingEndpointCollectionEnabled),
+                    name: ProfilingEndpointCollectionEnabled.to_env_var_name(),
+                    type_: ZaiConfigType::Bool,
+                    default_encoded_value: zai_string_view::literal(b"yes\0"),
+                    aliases: CPU_TIME_ALIASES.as_ptr(),
+                    aliases_count: CPU_TIME_ALIASES.len() as u8,
+                    ini_change: None,
+                    parser: None,
+                },
+                zai_config_entry {
+                    id: transmute(ProfilingExperimentalCpuTimeEnabled),
+                    name: ProfilingExperimentalCpuTimeEnabled.to_env_var_name(),
+                    type_: ZaiConfigType::Bool,
+                    default_encoded_value: zai_string_view::literal(b"yes\0"),
+                    aliases: std::ptr::null_mut(), // todo: ALIASES
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: None,
+                },
+                zai_config_entry {
+                    id: transmute(ProfilingLogLevel),
+                    name: ProfilingLogLevel.to_env_var_name(),
+                    type_: ZaiConfigType::Custom, // store it as an int
+                    default_encoded_value: zai_string_view::literal(b"off\0"),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: Some(zai_config_system_ini_change),
+                    parser: Some(parse_level_filter),
+                },
+                zai_config_entry {
+                    id: transmute(AgentHost),
+                    name: AgentHost.to_env_var_name(),
+                    type_: ZaiConfigType::String,
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: Some(zai_config_system_ini_change),
+                    parser: Some(parse_utf8_string),
+                },
+                zai_config_entry {
+                    id: transmute(Env),
+                    name: Env.to_env_var_name(),
+                    type_: ZaiConfigType::String,
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: Some(parse_utf8_string),
+                },
+                zai_config_entry {
+                    id: transmute(Service),
+                    name: Service.to_env_var_name(),
+                    type_: ZaiConfigType::String,
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: Some(parse_utf8_string),
+                },
+                zai_config_entry {
+                    id: transmute(Tags),
+                    name: Tags.to_env_var_name(),
+                    type_: ZaiConfigType::Map,
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: None,
+                },
+                zai_config_entry {
+                    id: transmute(TraceAgentPort),
+                    name: TraceAgentPort.to_env_var_name(),
+                    type_: ZaiConfigType::Int,
+                    default_encoded_value: zai_string_view::literal(b"0\0"),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: Some(zai_config_system_ini_change),
+                    parser: Some(parse_utf8_string),
+                },
+                zai_config_entry {
+                    id: transmute(TraceAgentUrl),
+                    name: TraceAgentUrl.to_env_var_name(),
+                    type_: ZaiConfigType::String, // TYPE?
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: Some(zai_config_system_ini_change),
+                    parser: Some(parse_utf8_string),
+                },
+                zai_config_entry {
+                    id: transmute(Version),
+                    name: Version.to_env_var_name(),
+                    type_: ZaiConfigType::String,
+                    default_encoded_value: zai_string_view::new(),
+                    aliases: std::ptr::null_mut(),
+                    aliases_count: 0,
+                    ini_change: None,
+                    parser: Some(parse_utf8_string),
+                },
+            ]
+        };
+
+        let tmp = zai_config_minit(
+            ENTRIES.as_mut_ptr(),
+            ENTRIES.len().try_into().unwrap(),
+            Some(env_to_ini_name),
+            module_number,
+        );
+        assert!(tmp); // It's literally return true in the source.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libc::memcmp;
+    use std::mem::MaybeUninit;
+
+    #[test]
+    fn test_env_to_ini_name() {
+        let cases: &[(&[u8], &str)] = &[
+            (b"DD_SERVICE\0", "datadog.service"),
+            (b"DD_ENV\0", "datadog.env"),
+            (b"DD_VERSION\0", "datadog.version"),
+            (b"DD_TRACE_AGENT_URL\0", "datadog.trace.agent_url"),
+            (b"DD_TRACE_AGENT_PORT\0", "datadog.trace.agent_port"),
+            (b"DD_AGENT_HOST\0", "datadog.agent_host"),
+            (b"DD_PROFILING_ENABLED\0", "datadog.profiling.enabled"),
+            (
+                b"DD_PROFILING_ENDPOINT_COLLECTION_ENABLED\0",
+                "datadog.profiling.endpoint_collection_enabled",
+            ),
+            (
+                b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0",
+                "datadog.profiling.experimental_cpu_time_enabled",
+            ),
+            (b"DD_PROFILING_LOG_LEVEL\0", "datadog.profiling.log_level"),
+        ];
+
+        for (env_name, expected_ini_name) in cases {
+            unsafe {
+                let env = zai_string_view::literal(env_name);
+                let mut ini = MaybeUninit::uninit();
+                env_to_ini_name(env, ini.as_mut_ptr());
+                let ini = ini.assume_init();
+
+                // Check that .len matches.
+                assert_eq!(
+                    expected_ini_name.len(),
+                    ini.len as usize,
+                    "Env: {}, expected ini: {}",
+                    std::str::from_utf8(env_name).unwrap(),
+                    expected_ini_name
+                );
+
+                // Check that the bytes match.
+                let cmp = memcmp(
+                    transmute(expected_ini_name.as_ptr()),
+                    transmute(ini.ptr.as_ptr()),
+                    expected_ini_name.len(),
+                );
+                assert_eq!(0, cmp);
+
+                // Check that it is null terminated.
+                assert_eq!(ini.ptr[ini.len as usize] as u8, b'\0');
+            }
         }
     }
 }

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -165,7 +165,7 @@ impl ConfigId {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_enabled() -> bool {
-    get_bool(ProfilingEnabled, false)
+    get_bool(ProfilingEnabled, true)
 }
 
 /// # Safety
@@ -328,7 +328,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingEnabled),
                     name: ProfilingEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStringView::literal(b"no\0"),
+                    default_encoded_value: ZaiStringView::literal(b"1\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -338,7 +338,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingEndpointCollectionEnabled),
                     name: ProfilingEndpointCollectionEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStringView::literal(b"yes\0"),
+                    default_encoded_value: ZaiStringView::literal(b"1\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -348,7 +348,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingExperimentalCpuTimeEnabled),
                     name: ProfilingExperimentalCpuTimeEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStringView::literal(b"yes\0"),
+                    default_encoded_value: ZaiStringView::literal(b"1\0"),
                     aliases: CPU_TIME_ALIASES.as_ptr(),
                     aliases_count: CPU_TIME_ALIASES.len() as u8,
                     ini_change: None,

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -1,8 +1,8 @@
 use crate::bindings::zai_config_type::*;
 use crate::bindings::{
     datadog_php_profiling_copy_string_view_into_zval, zai_config_entry, zai_config_get_value,
-    zai_config_minit, zai_config_name, zai_config_system_ini_change, zai_string_view, zend_long,
-    zval, ZaiStringView, IS_LONG, ZAI_CONFIG_ENTRIES_COUNT_MAX,
+    zai_config_minit, zai_config_name, zai_config_system_ini_change, zend_long, zval,
+    ZaiStringView, IS_LONG, ZAI_CONFIG_ENTRIES_COUNT_MAX,
 };
 pub use datadog_profiling::exporter::Uri;
 use libc::{c_char, c_void, memcpy};
@@ -64,7 +64,7 @@ impl Display for AgentEndpoint {
     }
 }
 
-unsafe extern "C" fn env_to_ini_name(env_name: zai_string_view, ini_name: *mut zai_config_name) {
+unsafe extern "C" fn env_to_ini_name(env_name: ZaiStringView, ini_name: *mut zai_config_name) {
     assert!(!ini_name.is_null());
     let ini_name = &mut *ini_name;
 
@@ -140,7 +140,7 @@ pub(crate) enum ConfigId {
 use ConfigId::*;
 
 impl ConfigId {
-    const fn env_var_name(&self) -> zai_string_view {
+    const fn env_var_name(&self) -> ZaiStringView {
         let bytes: &'static [u8] = match self {
             ProfilingEnabled => b"DD_PROFILING_ENABLED\0",
             ProfilingEndpointCollectionEnabled => b"DD_PROFILING_ENDPOINT_COLLECTION_ENABLED\0",
@@ -157,7 +157,7 @@ impl ConfigId {
         };
 
         // Safety: all these byte strings are [CStr::from_bytes_with_nul_unchecked] compatible.
-        unsafe { zai_string_view::literal(bytes) }
+        unsafe { ZaiStringView::literal(bytes) }
     }
 }
 
@@ -268,7 +268,7 @@ pub(crate) unsafe fn profiling_log_level() -> LevelFilter {
 }
 
 unsafe extern "C" fn parse_level_filter(
-    value: zai_string_view,
+    value: ZaiStringView,
     decoded_value: *mut zval,
     _persistent: bool,
 ) -> bool {
@@ -291,7 +291,7 @@ unsafe extern "C" fn parse_level_filter(
 }
 
 unsafe extern "C" fn parse_utf8_string(
-    value: zai_string_view,
+    value: ZaiStringView,
     decoded_value: *mut zval,
     persistent: bool,
 ) -> bool {
@@ -315,8 +315,8 @@ unsafe extern "C" fn parse_utf8_string(
 
 pub(crate) fn minit(module_number: libc::c_int) {
     unsafe {
-        const CPU_TIME_ALIASES: &[zai_string_view] = unsafe {
-            &[zai_string_view::literal(
+        const CPU_TIME_ALIASES: &[ZaiStringView] = unsafe {
+            &[ZaiStringView::literal(
                 b"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED\0",
             )]
         };
@@ -329,7 +329,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingEnabled),
                     name: ProfilingEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: zai_string_view::literal(b"no\0"),
+                    default_encoded_value: ZaiStringView::literal(b"no\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -339,7 +339,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingEndpointCollectionEnabled),
                     name: ProfilingEndpointCollectionEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: zai_string_view::literal(b"yes\0"),
+                    default_encoded_value: ZaiStringView::literal(b"yes\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -349,7 +349,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingExperimentalCpuTimeEnabled),
                     name: ProfilingExperimentalCpuTimeEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: zai_string_view::literal(b"yes\0"),
+                    default_encoded_value: ZaiStringView::literal(b"yes\0"),
                     aliases: CPU_TIME_ALIASES.as_ptr(),
                     aliases_count: CPU_TIME_ALIASES.len() as u8,
                     ini_change: None,
@@ -359,7 +359,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingLogLevel),
                     name: ProfilingLogLevel.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_CUSTOM, // store it as an int
-                    default_encoded_value: zai_string_view::literal(b"off\0"),
+                    default_encoded_value: ZaiStringView::literal(b"off\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: Some(zai_config_system_ini_change),
@@ -369,7 +369,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(AgentHost),
                     name: AgentHost.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_STRING,
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: Some(zai_config_system_ini_change),
@@ -379,7 +379,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(Env),
                     name: Env.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_STRING,
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -389,7 +389,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(Service),
                     name: Service.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_STRING,
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -399,7 +399,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(Tags),
                     name: Tags.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_MAP,
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -409,7 +409,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(TraceAgentPort),
                     name: TraceAgentPort.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_INT,
-                    default_encoded_value: zai_string_view::literal(b"0\0"),
+                    default_encoded_value: ZaiStringView::literal(b"0\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: Some(zai_config_system_ini_change),
@@ -419,7 +419,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(TraceAgentUrl),
                     name: TraceAgentUrl.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_STRING, // TYPE?
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: Some(zai_config_system_ini_change),
@@ -429,7 +429,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(Version),
                     name: Version.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_STRING,
-                    default_encoded_value: zai_string_view::new(),
+                    default_encoded_value: ZaiStringView::new(),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,
@@ -477,7 +477,7 @@ mod tests {
 
         for (env_name, expected_ini_name) in cases {
             unsafe {
-                let env = zai_string_view::literal(env_name);
+                let env = ZaiStringView::literal(env_name);
                 let mut ini = MaybeUninit::uninit();
                 env_to_ini_name(env, ini.as_mut_ptr());
                 let ini = ini.assume_init();

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -144,7 +144,7 @@ impl ConfigId {
         let bytes: &'static [u8] = match self {
             ProfilingEnabled => b"DD_PROFILING_ENABLED\0",
             ProfilingEndpointCollectionEnabled => b"DD_PROFILING_ENDPOINT_COLLECTION_ENABLED\0",
-            ProfilingExperimentalCpuTimeEnabled => b"DD_PROFILING_CPU_ENABLED\0",
+            ProfilingExperimentalCpuTimeEnabled => b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0",
             ProfilingLogLevel => b"DD_PROFILING_LOG_LEVEL\0",
 
             AgentHost => b"DD_AGENT_HOST\0",
@@ -316,10 +316,9 @@ unsafe extern "C" fn parse_utf8_string(
 pub(crate) fn minit(module_number: libc::c_int) {
     unsafe {
         const CPU_TIME_ALIASES: &[zai_string_view] = unsafe {
-            &[
-                zai_string_view::literal(b"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED\0"),
-                zai_string_view::literal(b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0"),
-            ]
+            &[zai_string_view::literal(
+                b"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED\0",
+            )]
         };
 
         // Note that function pointers cannot appear in const functions, so we

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -5,7 +5,7 @@ use crate::bindings::{
     ZaiStringView, IS_LONG, ZAI_CONFIG_ENTRIES_COUNT_MAX,
 };
 pub use datadog_profiling::exporter::Uri;
-use libc::{c_char, c_void, memcpy};
+use libc::{c_void, memcpy};
 use log::{warn, LevelFilter};
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
@@ -301,8 +301,7 @@ unsafe extern "C" fn parse_utf8_string(
 
     match value.into_utf8() {
         Ok(utf8) => {
-            let ptr = utf8.as_ptr() as *const c_char;
-            let view = ZaiStringView::from_raw_parts(ptr, utf8.len());
+            let view = ZaiStringView::from(utf8);
             datadog_php_profiling_copy_string_view_into_zval(decoded_value, view, persistent);
             true
         }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -625,11 +625,11 @@ extern "C" fn rshutdown(r#type: c_int, module_number: c_int) -> ZendResult {
 /// Prints the module info. Calls many C functions from the Zend Engine,
 /// including calling variadic functions. It's essentially all unsafe, so be
 /// careful, and do not call this manually (only let the engine call it).
-unsafe extern "C" fn minfo(module: *mut zend::ModuleEntry) {
+unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
     #[cfg(debug_assertions)]
-    trace!("MINFO({:p})", module);
+    trace!("MINFO({:p})", module_ptr);
 
-    let module = &*module;
+    let module = &*module_ptr;
 
     REQUEST_LOCALS.with(|cell| {
         let locals = cell.borrow();
@@ -694,6 +694,8 @@ unsafe extern "C" fn minfo(module: *mut zend::ModuleEntry) {
         }
 
         zend::php_info_print_table_end();
+
+        zend::display_ini_entries(module_ptr);
     });
 }
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -59,18 +59,19 @@ void datadog_php_profiling_install_internal_function_handler(
     }
 }
 
-void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, bool persistent) {
+void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_view view,
+                                                      bool persistent) {
     ZEND_ASSERT(dest);
-    ZEND_ASSERT(ptr);
 
-    if (len == 0) {
+    if (view.len == 0) {
         if (persistent) {
             ZVAL_EMPTY_PSTRING(dest);
         } else {
             ZVAL_EMPTY_STRING(dest);
         }
     } else {
-        ZVAL_STR(dest, zend_string_init(ptr, len, persistent));
+        ZEND_ASSERT(view.ptr);
+        ZVAL_STR(dest, zend_string_init(view.ptr, view.len, persistent));
     }
 }
 
@@ -80,11 +81,7 @@ void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, b
  * string (single byte of null, len of 0).
  */
 zai_string_view datadog_php_profiling_zend_string_view(zend_string *zstr) {
-    if (!zstr) {
-        return ZAI_STRING_EMPTY;
-    }
-
-    if (ZSTR_LEN(zstr) == 0) {
+    if (!zstr || ZSTR_LEN(zstr) == 0) {
         return ZAI_STRING_EMPTY;
     }
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -73,3 +73,20 @@ void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, b
         ZVAL_STR(dest, zend_string_init(ptr, len, persistent));
     }
 }
+
+/**
+ * Converts the zend_string pointer into a string view. Null pointers and
+ * empty strings will be converted into a string view to a static empty
+ * string (single byte of null, len of 0).
+ */
+zai_string_view datadog_php_profiling_zend_string_view(zend_string *zstr) {
+    if (!zstr) {
+        return ZAI_STRING_EMPTY;
+    }
+
+    if (ZSTR_LEN(zstr) == 0) {
+        return ZAI_STRING_EMPTY;
+    }
+
+    return ZAI_STRING_FROM_ZSTR(zstr);
+}

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -58,3 +58,18 @@ void datadog_php_profiling_install_internal_function_handler(
         old_handler->internal_function.handler = handler.new_handler;
     }
 }
+
+void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, bool persistent) {
+    ZEND_ASSERT(dest);
+    ZEND_ASSERT(ptr);
+
+    if (len == 0) {
+        if (persistent) {
+            ZVAL_EMPTY_PSTRING(dest);
+        } else {
+            ZVAL_EMPTY_STRING(dest);
+        }
+    } else {
+        ZVAL_STR(dest, zend_string_init(ptr, len, persistent));
+    }
+}

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -7,6 +7,9 @@
 
 #include <ext/standard/info.h>
 
+// Profiling needs ZAI config for INI support.
+#include <config/config.h>
+
 /* C11 allows a duplicate typedef provided they are the same, so this should be
  * fine as long as we compile with C11 or higher.
  */
@@ -73,3 +76,5 @@ typedef struct {
 
 void datadog_php_profiling_install_internal_function_handler(
     datadog_php_profiling_internal_function_handler handler);
+
+void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, bool persistent);

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -10,6 +10,9 @@
 // Profiling needs ZAI config for INI support.
 #include <config/config.h>
 
+// Used to communicate strings from C -> Rust.
+#include <zai_string/string.h>
+
 /* C11 allows a duplicate typedef provided they are the same, so this should be
  * fine as long as we compile with C11 or higher.
  */

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -80,4 +80,14 @@ typedef struct {
 void datadog_php_profiling_install_internal_function_handler(
     datadog_php_profiling_internal_function_handler handler);
 
-void datadog_php_profiling_parse_utf8(zval *dest, const char *ptr, size_t len, bool persistent);
+/**
+ * Copies the bytes represented by `view` into a zend_string, which is stored
+ * in `dest`, passing `persistent` along so the right allocator is used.
+ *
+ * Does an empty string optimization.
+ *
+ * `dest` is expected to be uninitialized. Any existing content will not be
+ * dtor'.
+ */
+void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_view view,
+                                                      bool persistent);

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -186,7 +186,6 @@ unsafe fn extract_function_name(func: &zend_function) -> String {
         buffer.push(b'|');
     }
 
-    // todo: probably use EX(This) instead of func.common.scope.
     let class_name = func.scope_name().unwrap_or(b"");
     if !class_name.is_empty() {
         buffer.extend_from_slice(class_name);

--- a/profiling/tests/phpt/phpinfo_ini_01.phpt
+++ b/profiling/tests/phpt/phpinfo_ini_01.phpt
@@ -1,25 +1,24 @@
 --TEST--
-[profiling] test profiler's extension info
+[profiling] test profiler's extension info (.ini version)
 --DESCRIPTION--
 The profiler's phpinfo section contains important debugging information. This
-test verifies that certain information is present.
+test verifies that certain information is present when configured by .ini.
 --SKIPIF--
 <?php
 if (!extension_loaded('datadog-profiling'))
   echo "skip: test requires Datadog Continuous Profiler\n";
 ?>
---ENV--
-DD_PROFILING_ENABLED=no
-DD_PROFILING_LOG_LEVEL=info
-DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=yes
-DD_SERVICE=datadog-profiling-phpt
-DD_ENV=dev
-DD_VERSION=13
-DD_AGENT_HOST=localh0st
-DD_TRACE_AGENT_PORT=80
-DD_TRACE_AGENT_URL=http://datadog:8126
 --INI--
 assert.exception=1
+datadog.profiling.enabled=no
+datadog.profiling.log_level=info
+datadog.profiling.experimental_cpu_time_enabled=yes
+datadog.service=datadog-profiling-phpt
+datadog.env=dev
+datadog.version=13
+datadog.agent_host=localh0st
+datadog.trace.agent_port=80
+datadog.trace.agent_url=http://datadog:8126
 --FILE--
 <?php
 
@@ -31,7 +30,7 @@ $output = ob_get_clean();
 $lines = preg_split("/\R/", $output);
 $values = [];
 foreach ($lines as $line) {
-    $pair = explode("=>", $line);
+    $pair = explode("=>", $line, 2);
     if (count($pair) != 2) {
         continue;
     }

--- a/profiling/tests/phpt/service_web_01.phpt
+++ b/profiling/tests/phpt/service_web_01.phpt
@@ -35,10 +35,18 @@ $output = ob_get_clean();
 
 $values = [];
 
-// We're expecting a 2-column table, first is key, second is value.
+/* Expect two tables.
+ *  1. Two column layout, first column is the key and second is the value.
+ *  2. Three column layout for .ini settings. First is the directive, second
+ *     is the local value, and last is the master value.
+ * For this test, we're after the first table for DD_SERVICE.
+ */
 $dom = new DOMDocument();
 assert($dom->loadHTML($output));
-foreach ($dom->getElementsByTagName('tr') as $row) {
+$tables = iterator_to_array($dom->getElementsByTagName('table'));
+assert(count($tables) === 2);
+
+foreach ($tables[0]->getElementsByTagName('tr') as $row) {
     [$key, $value] = iterator_to_array($row->getElementsByTagName('td'));
     $key = html_entity_decode(trim($key->nodeValue));
     $value = html_entity_decode(trim($value->nodeValue));

--- a/tests/ext/read_c_configuration.phpt
+++ b/tests/ext/read_c_configuration.phpt
@@ -21,7 +21,7 @@ echo PHP_EOL;
 ?>
 --EXPECT--
 some_known_host
-8126
+0
 FALSE
 FALSE
 9999

--- a/tests/randomized/generate-scenarios.php
+++ b/tests/randomized/generate-scenarios.php
@@ -7,6 +7,7 @@ use RandomizedTests\Tooling\EnvFileGenerator;
 use RandomizedTests\Tooling\MakefileGenerator;
 use RandomizedTests\Tooling\MakefileScenarioGenerator;
 use RandomizedTests\Tooling\PhpFpmConfigGenerator;
+use RandomizedTests\Tooling\PhpIniGenerator;
 use RandomizedTests\Tooling\RequestTargetsGenerator;
 
 include __DIR__ . '/config/envs.php';
@@ -19,6 +20,7 @@ include __DIR__ . '/lib/EnvFileGenerator.php';
 include __DIR__ . '/lib/MakefileGenerator.php';
 include __DIR__ . '/lib/MakefileScenarioGenerator.php';
 include __DIR__ . '/lib/PhpFpmConfigGenerator.php';
+include __DIR__ . '/lib/PhpIniGenerator.php';
 include __DIR__ . '/lib/RequestTargetsGenerator.php';
 
 const TMP_SCENARIOS_FOLDER = './.tmp.scenarios';
@@ -91,10 +93,15 @@ function generateOne($scenarioSeed, array $restrictedPHPVersions)
     // INI settings modification
     $numberOfIniModifications = rand(0, min(MAX_INI_MODIFICATIONS, count(INIS)));
     $iniModifications = [];
+    $primaryIni = [];
     for ($iniModification = 0; $iniModification < $numberOfIniModifications; $iniModification++) {
         $currentIni = array_rand(INIS);
         $availableValues = INIS[$currentIni];
-        $iniModifications[$currentIni] = $availableValues[array_rand($availableValues)];
+        if ($currentIni == "extension" || rand(0, 1)) {
+            $primaryIni[$currentIni] = $availableValues[array_rand($availableValues)];
+        } else {
+            $iniModifications[$currentIni] = $availableValues[array_rand($availableValues)];
+        }
     }
     $identifier = "randomized-$scenarioSeed-$selectedOs-$selectedPhpVersion";
     $scenarioFolder = TMP_SCENARIOS_FOLDER . DIRECTORY_SEPARATOR . $identifier;
@@ -107,6 +114,7 @@ function generateOne($scenarioSeed, array $restrictedPHPVersions)
     // Writing scenario specific files
     (new ApacheConfigGenerator())->generate("$scenarioFolder/www.apache.conf", $envModifications, $iniModifications);
     (new PhpFpmConfigGenerator())->generate("$scenarioFolder/www.php-fpm.conf", $envModifications, $iniModifications);
+    (new PhpIniGenerator())->generate("$scenarioFolder/php.ini", $primaryIni);
     (new RequestTargetsGenerator())->generate("$scenarioFolder/vegeta-request-targets.txt", 2000);
     (new MakefileScenarioGenerator())->generate("$scenarioFolder/Makefile", $identifier);
     (new EnvFileGenerator())->generate("$scenarioFolder/.env", $identifier);

--- a/tests/randomized/lib/PhpIniGenerator.php
+++ b/tests/randomized/lib/PhpIniGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace RandomizedTests\Tooling;
+
+class PhpIniGenerator
+{
+    public function generate($destination, array $inis)
+    {
+        $inisString = "";
+        foreach ($inis as $iniName => $iniValue) {
+            $inisString .= sprintf("%s = %s\n", $iniName, is_bool($iniValue) ? $iniValue ? 'on' : 'off' : $iniValue);
+        }
+        file_put_contents($destination, $inisString);
+    }
+}

--- a/tests/randomized/lib/templates/docker-compose.template.yml
+++ b/tests/randomized/lib/templates/docker-compose.template.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - {{project_root}}:/dd-trace-php
       - ./app:/var/www/html
+      - ./php.ini:/opt/php/{{php_version}}/conf.d/randomized.ini
       - ./www.php-fpm.conf:/opt/php/{{php_version}}/etc/php-fpm.d/www.conf
       - ./www.php-fpm.conf:/opt/php/{{php_version}}-debug/etc/php-fpm.d/www.conf
       - ./www.php-fpm.conf:/opt/php/{{php_version}}-zts/etc/php-fpm.d/www.conf

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -40,7 +40,7 @@ struct zai_config_entry_s {
     // Alias env names in order of precedence:
     // (e.g. DD_SERVICE_NAME, DD_TRACE_APP_NAME, ddtrace_app_name)
     // TODO: Drop old names
-    zai_string_view *aliases;
+    const zai_string_view *aliases;
     uint8_t aliases_count;
     // Accept or reject ini changes, potentially apply to the currently running system
     zai_config_apply_ini_change ini_change;


### PR DESCRIPTION
### Description

Implements #1764. This uses the ZAI config component to add support for .ini configuration in profiling. Thank, @bwoebi, for laying the groundwork for this in #1765.

Note that the profiler now defaults to being enabled, but it is not installed by default. This is because it on Alpine it has a dependency on `libgcc` and the tracer does not have this dependency. If a user is only using the tracer and then upgrades, we would emit warnings about undefined symbols and such when it starts up whether they use the profiler or not.

This also moves the default of DD_AGENT_PORT from 8126 to 0. This is easier to work with when working with fallbacks to other connection settings.

There's a good bit of boilerplate to help Rust understand lifetimes for `zai_string_view`. There's also code which tries to bind lifetimes of certain strings to the owning object. In PHP's reference counted model, this is not quite correct. However, it is an improvement on what is there. Given that we are only borrowing this data for a very short amount of time, we are not executing user code during this time, and we ultimately copy it, we should be okay.


### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.
- [x] Manually check that the current install docs still work as expected:
    - [x] Apache
    - [x] CLI
    - [x] Nginx

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
