### PR TITLE
Avoid deprecated zend_atol on PHP 8.2

### DIFF
--- a/zend_abstract_interface/config/config_decode.c
+++ b/zend_abstract_interface/config/config_decode.c
@@ -117,7 +117,20 @@ static bool zai_config_is_valid_int_format(const char *str) {
 static bool zai_config_decode_int(zai_string_view value, zval *decoded_value) {
     if (!zai_config_is_valid_int_format(value.ptr)) return false;
 
-    ZVAL_LONG(decoded_value, zend_atol(value.ptr, value.len));
+#if PHP_VERSION_ID >= 80200
+    zend_string *zstr = zend_string_init(value.ptr, value.len, 0);
+    zend_string *err = NULL;
+    zend_long l = zend_ini_parse_quantity(zstr, &err);
+    if (err) {
+        // what to do with err?
+        zend_string_free(err);
+    }
+    zend_string_free(zstr);
+#else
+    zend_long l = zend_atol(value.ptr, value.len);
+#endif
+
+    ZVAL_LONG(decoded_value, l);
     return true;
 }
 

--- a/zend_abstract_interface/config/config_decode.c
+++ b/zend_abstract_interface/config/config_decode.c
@@ -121,11 +121,15 @@ static bool zai_config_decode_int(zai_string_view value, zval *decoded_value) {
     zend_string *zstr = zend_string_init(value.ptr, value.len, 0);
     zend_string *err = NULL;
     zend_long l = zend_ini_parse_quantity(zstr, &err);
-    if (err) {
-        // what to do with err?
-        zend_string_free(err);
-    }
+
     zend_string_free(zstr);
+    if (err) {
+        /* Strings are supposed to be checked by zai_config_is_valid_int_format
+         * already, so we do not expect to hit any errors here.
+         */
+        zend_string_free(err);
+        return false;
+    }
 #else
     zend_long l = zend_atol(value.ptr, value.len);
 #endif


### PR DESCRIPTION
### Description

This was deprecated in PHP 8.2 with the recommendations to use:

 1. `ZEND_STRTOL()` for general purpose string to long conversion.
 2. A variant of `zend_ini_parse_quantity()` for parsing ini quantities.

For now at least, since this code is ZAI config which deals with .ini settings, I picked the latter.

We should probably re-plumb the function calls at some point to pass the ini setting name to this function so we can use `zend_ini_parse_quantity_warn()` instead.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
