### PR TITLE
Bump `libdatadog` to `0.9`

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0" }
 cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
-datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.8.0" }
+datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.9.0" }
 env_logger = { version = "0.9" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }


### PR DESCRIPTION
### Description

This PR will bump the `libdatadog` version used to `0.9`

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
