### PR TITLE
Bug: Invocable classes don't work

### DIFF
--- a/tests/ext/sandbox/dd_trace_method_invocable.phpt
+++ b/tests/ext/sandbox/dd_trace_method_invocable.phpt
@@ -1,0 +1,26 @@
+--TEST--
+dd_trace_method() using Invocable Class
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function bar() {}
+}
+
+class Instrumentation
+{
+    public function __invoke(SpanData $span)
+    {
+        echo 'This should be called';
+    }
+}
+
+dd_trace_method('Foo', 'bar', new Instrumentation);
+
+$foo = new Foo();
+$foo->bar();
+?>
+--EXPECTF--
+This should be called

--- a/tests/ext/sandbox/dd_trace_method_invocable_closure.phpt
+++ b/tests/ext/sandbox/dd_trace_method_invocable_closure.phpt
@@ -1,0 +1,31 @@
+--TEST--
+dd_trace_method() using Invocable Closure
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+class Foo
+{
+    public function bar() {}
+}
+
+class Instrumentation
+{
+    public function __construct(private string $context) {}
+
+    public function __invoke(SpanData $span)
+    {
+        echo 'This works' . PHP_EOL;
+
+        echo 'This fails: ' . $this->context;
+    }
+}
+
+dd_trace_method('Foo', 'bar', \Closure::fromCallable(new Instrumentation('binding')));
+
+$foo = new Foo();
+$foo->bar();
+?>
+--EXPECTF--
+This works
+This fails: binding


### PR DESCRIPTION
### Description

I recently discovered what seems to be a bug on Datadog instrumentation where it just crashes when accessing `$this` in the context of an invocable class from a closure. I also noticed that if I don't convert the invocable class into a closure it also doesn't work at all.

Following the guide, I managed to write two tests that reproduce the issue, but this is unfortunately as far as I can get since I have no knowledge of C, PHP Extensions or the sorts. Hopefully this can be useful, even if just as a track history on why these features don't work.

I want to thank whoever wrote the Contributing.md file because that was truly amazing. We all learn to hate docker, but this project is a wonderful representation as to why we tolerate Docker.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
