### PR TITLE
[CI] Use the test agent instead of the real agent in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ commands:
                 -e DD_APM_ENABLED=true \
                 -e DD_BIND_HOST=0.0.0.0 \
                 -e DD_API_KEY=invalid_key_but_this_is_fine \
-                datadog/agent:7.39.2
+                ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
               docker run --detach --rm --net net \
                 --name httpbin_integration kong/httpbin
               docker run --detach --rm --net net \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,8 @@ aliases:
   - &CACHE_NPM_KEY
     key: 'betav1-lint-deps-{{ checksum "composer.json" }}'
 
-  - &IMAGE_DOCKER_DD_AGENT
-    image: datadog/agent:7.39.2
-    environment:
-      - DD_APM_ENABLED=true
-      - DD_BIND_HOST=0.0.0.0
-      - DD_API_KEY=invalid_key_but_this_is_fine
+  - &IMAGE_DOCKER_DD_TEST_AGENT
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
   - &IMAGE_DOCKER_REDIS
     image: datadog/dd-trace-ci:php-redis-5.0
@@ -280,7 +276,7 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
-      - <<: *IMAGE_DOCKER_DD_AGENT
+      - <<: *IMAGE_DOCKER_DD_TEST_AGENT
   with_httpbin_and_request_replayer:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
@@ -289,7 +285,7 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
-      - <<: *IMAGE_DOCKER_DD_AGENT
+      - <<: *IMAGE_DOCKER_DD_TEST_AGENT
       - <<: *IMAGE_DOCKER_HTTPBIN
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
   with_integrations:
@@ -301,7 +297,7 @@ executors:
         type: string
     docker:
       - image: << parameters.docker_image >>
-      - <<: *IMAGE_DOCKER_DD_AGENT
+      - <<: *IMAGE_DOCKER_DD_TEST_AGENT
       - <<: *IMAGE_DOCKER_ELASTICSEARCH2
       - <<: *IMAGE_DOCKER_ELASTICSEARCH7
       - <<: *IMAGE_DOCKER_HTTPBIN

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,11 @@ $ docker-compose run --rm 7.4-buster bash
 $ docker-compose run --rm 8.0-buster bash
 ```
 
-> :memo: **Note:** To run the container in debug mode, pass pass docker-composer an environment variable: `DD_TRACE_DOCKER_DEBUG=1`
+> :memo: **Note:** To run the container in debug mode, pass `docker-compose` an environment variable: `DD_TRACE_DOCKER_DEBUG=1`, eg:
+
+```bash
+docker-compose run --rm 8.0-buster -e DD_TRACE_DOCKER_DEBUG=1 bash
+```
 
 Once inside the container, update dependencies with Composer.
 

--- a/tests/randomized/lib/docker-compose.yml
+++ b/tests/randomized/lib/docker-compose.yml
@@ -3,11 +3,7 @@ version: '3'
 services:
   agent:
     container_name: agent
-    image: datadog/agent:7
-    environment:
-      - DD_API_KEY=${DATADOG_API_KEY:-not_a_valid_api_key}
-      - DD_APM_ENABLED=true
-      - DD_APM_NON_LOCAL_TRAFFIC=true
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
   redis:
     container_name: redis


### PR DESCRIPTION
### Description
Use [dd-apm-test-agent](https://github.com/DataDog/dd-apm-test-agent) instead of the real agent in CI. 
The test agent is used here only as a mock but we could imagine dumping the snapshots in some cases and verifying them. 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
