### PR TITLE
Change system.pid to process_id

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -526,7 +526,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
 
     zval pid;
     ZVAL_LONG(&pid, (long)getpid());
-    zend_hash_str_add_new(meta, ZEND_STRL("system.pid"), &pid);
+    zend_hash_str_add_new(meta, ZEND_STRL("process_id"), &pid);
 
     datadog_php_uuid runtime_id = ddtrace_profiling_runtime_id();
     if (!datadog_php_uuid_is_nil(runtime_id)) {

--- a/src/api/Tag.php
+++ b/src/api/Tag.php
@@ -11,7 +11,7 @@ class Tag
     const SERVICE_NAME = 'service.name';
     const MANUAL_KEEP = 'manual.keep';
     const MANUAL_DROP = 'manual.drop';
-    const PID = 'system.pid';
+    const PID = 'process_id';
     const RESOURCE_NAME = 'resource.name';
     const DB_STATEMENT = 'sql.query';
     const ERROR = 'error';

--- a/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_with_ddtrace_dependency/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "datadog/dd-trace": "0.49.0"
+    },
+    "config": {
+        "disable-tls": true
     }
 }

--- a/tests/AutoInstrumentation/scenarios/composer_without_ddtrace_dependency/composer.json
+++ b/tests/AutoInstrumentation/scenarios/composer_without_ddtrace_dependency/composer.json
@@ -1,4 +1,7 @@
 {
     "require": {
+    },
+    "config": {
+        "disable-tls": true
     }
 }

--- a/tests/AutoInstrumentation/scenarios/symfony_33_private_loader/composer.json
+++ b/tests/AutoInstrumentation/scenarios/symfony_33_private_loader/composer.json
@@ -1,4 +1,7 @@
 {
     "require": {
+    },
+    "config": {
+        "disable-tls": true
     }
 }

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -14,7 +14,7 @@ final class SpanAssertion
     /** @var string[] Tags the MUST match in both key and value */
     private $exactTags = SpanAssertion::NOT_TESTED;
     /** @var string[] Tags the MUST be present but with any value */
-    private $existingTags = ['system.pid'];
+    private $existingTags = ['process_id'];
     /** @var string[] Ignore any tags that match these regexp patterns */
     private $skipTagPatterns = [];
     /** @var array Exact metrics set on the span */
@@ -264,7 +264,7 @@ final class SpanAssertion
     {
         if ($isChildSpan) {
             return array_filter($this->existingTags, function ($name) {
-                return $name !== 'system.pid';
+                return $name !== 'process_id';
             });
         }
         return $this->existingTags;

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -76,7 +76,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'append',
                 ]))
-                ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
+                ->withExistingTagsNames(['process_id', 'error.msg', 'error.type', 'error.stack']),
         ]);
     }
 
@@ -113,7 +113,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ]))
-                ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
+                ->withExistingTagsNames(['process_id', 'error.msg', 'error.type', 'error.stack']),
         ]);
     }
 

--- a/tests/api/Unit/UserAvailableConstantsTest.php
+++ b/tests/api/Unit/UserAvailableConstantsTest.php
@@ -93,7 +93,7 @@ class UserAvailableConstantsTest extends BaseTestCase
             [Tag::SERVICE_NAME, 'service.name'],
             [Tag::MANUAL_KEEP, 'manual.keep'],
             [Tag::MANUAL_DROP, 'manual.drop'],
-            [Tag::PID, 'system.pid'],
+            [Tag::PID, 'process_id'],
             [Tag::RESOURCE_NAME, 'resource.name'],
             [Tag::DB_STATEMENT, 'sql.query'],
             [Tag::ERROR, 'error'],

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -35,7 +35,7 @@ object(DDTrace\SpanData)#%d (8) {
   string(3) "cli"
   ["meta"]=>
   array(1) {
-    ["system.pid"]=>
+    ["process_id"]=>
     int(%d)
   }
   ["metrics"]=>

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -37,7 +37,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(3) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.origin"]=>
       string(7) "datadog"

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -51,7 +51,7 @@ array(2) {
       string(14) "decoding_error"
       ["_dd.p.other_tag"]=>
       string(4) "also"
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.origin"]=>
       string(7) "datadog"

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
@@ -18,7 +18,7 @@ DDTrace\close_span();
 DDTrace\close_span();
 
 foreach (dd_trace_serialize_closed_spans() as $span) {
-    unset($span["meta"]["system.pid"], $span["meta"]["_dd.p.dm"]);
+    unset($span["meta"]["process_id"], $span["meta"]["_dd.p.dm"]);
     echo "parent: {$span["parent_id"]}, trace: {$span["trace_id"]}, meta: " . json_encode($span["meta"]) . "\n";
 }
 

--- a/tests/ext/extract_server_values.phpt
+++ b/tests/ext/extract_server_values.phpt
@@ -23,7 +23,7 @@ var_dump(dd_trace_serialize_closed_spans()[0]["meta"]);
 ?>
 --EXPECTF--
 array(3) {
-  ["system.pid"]=>
+  ["process_id"]=>
   string(%d) "%d"
   ["http.request.headers.0"]=>
   string(16) "http_zero_header"

--- a/tests/ext/fibers/fiber_observer_bailout.phpt
+++ b/tests/ext/fibers/fiber_observer_bailout.phpt
@@ -43,7 +43,7 @@ Fatal error: Allowed memory size of %d bytes exhausted %s in %s on line %d
 inFiber posthook
 spans(\DDTrace\SpanData) (1) {
   fiber_observer_bailout.php (fiber_observer_bailout.php, fiber_observer_bailout.php, cli) (error: Allowed memory size of %d bytes exhausted %s)
-    system.pid => %d
+    process_id => %d
     error.type => E_ERROR
     error.msg => Allowed memory size of %d bytes exhausted %s
     error.stack => #0 %s(%d): str_repeat()

--- a/tests/ext/fibers/fiber_stack_switch.phpt
+++ b/tests/ext/fibers/fiber_stack_switch.phpt
@@ -77,7 +77,7 @@ Hook: Fiber->resume
 Caught ex
 spans(\DDTrace\SpanData) (1) {
   fiber_stack_switch.php (fiber_stack_switch.php, fiber_stack_switch.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
     Fiber.start (fiber_stack_switch.php, Fiber.start, cli)
       inFiber (fiber_stack_switch.php, inFiber, cli)

--- a/tests/ext/root_span_add_tag.phpt
+++ b/tests/ext/root_span_add_tag.phpt
@@ -38,7 +38,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(3) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["after"]=>
       string(9) "root_span"

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -23,7 +23,7 @@ var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
 array(5) {
-  ["system.pid"]=>
+  ["process_id"]=>
   %s
   ["http.url"]=>
   string(26) "https://localhost:9999/foo"

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -19,7 +19,7 @@ var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
 array(5) {
-  ["system.pid"]=>
+  ["process_id"]=>
   %s
   ["http.url"]=>
   string(25) "http://localhost:8888/foo"

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -111,7 +111,7 @@ array(3) {
     string(7) "FooType"
     ["meta"]=>
     array(3) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
@@ -178,7 +178,7 @@ array(3) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -25,6 +25,6 @@ dd_dump_spans();
 bar(hello)
 spans(\DDTrace\SpanData) (1) {
   bar (alias, bar, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -112,7 +112,7 @@ array(5) {
     string(7) "BarType"
     ["meta"]=>
     array(6) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
@@ -201,7 +201,7 @@ array(5) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
@@ -236,7 +236,7 @@ array(5) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -43,7 +43,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -120,7 +120,7 @@ array(3) {
     string(7) "FooType"
     ["meta"]=>
     array(6) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["args.0"]=>
       string(18) "tracing is awesome"
@@ -195,7 +195,7 @@ array(3) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -29,6 +29,6 @@ dd_dump_spans();
 Foo::bar(hello)
 spans(\DDTrace\SpanData) (1) {
   Foo.bar (alias, Foo.bar, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -45,7 +45,7 @@ array(1) {
     int(1)
     ["meta"]=>
     array(3) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["error.msg"]=>
       string(9) "Foo error"

--- a/tests/ext/sandbox/safe_to_string_metadata.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata.phpt
@@ -65,7 +65,7 @@ meta_to_string(
 );
 
 list($span) = dd_trace_serialize_closed_spans();
-unset($span['meta']['system.pid']);
+unset($span['meta']['process_id']);
 $i = 0;
 foreach ($span['meta'] as $key => $value) {
     var_dump($allTheTypes[$i++]);

--- a/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
@@ -19,7 +19,7 @@ DDTrace\trace_function('meta_to_string', function (SpanData $span) {
 meta_to_string();
 
 list($span) = dd_trace_serialize_closed_spans();
-unset($span['meta']['system.pid']);
+unset($span['meta']['process_id']);
 var_dump($span['meta']);
 ?>
 --EXPECT--

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -33,7 +33,7 @@ object(DDTrace\SpanData)#%d (9) {
   string(3) "cli"
   ["meta"]=>
   array(1) {
-    ["system.pid"]=>
+    ["process_id"]=>
     int(%d)
   }
   ["metrics"]=>
@@ -67,7 +67,7 @@ object(DDTrace\SpanData)#%d (9) {
   string(3) "cli"
   ["meta"]=>
   array(1) {
-    ["system.pid"]=>
+    ["process_id"]=>
     int(%d)
   }
   ["metrics"]=>
@@ -98,7 +98,7 @@ object(DDTrace\SpanData)#%d (9) {
       string(3) "cli"
       ["meta"]=>
       array(1) {
-        ["system.pid"]=>
+        ["process_id"]=>
         int(%d)
       }
       ["metrics"]=>
@@ -134,7 +134,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/span_stack/span_stack_clone.phpt
+++ b/tests/ext/span_stack/span_stack_clone.phpt
@@ -51,18 +51,18 @@ A clone of the primary trace has the root stack as parent: bool(true)
 Switching to an initial stacks parent has no effect: bool(true)
 spans(\DDTrace\SpanData) (5) {
   primary (span_stack_clone.php, primary, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
   root (span_stack_clone.php, root, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
   root clone (span_stack_clone.php, root clone, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
   primary clone (span_stack_clone.php, primary clone, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
   initial clone (span_stack_clone.php, initial clone, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/span_stack/span_stack_swap.phpt
+++ b/tests/ext/span_stack/span_stack_swap.phpt
@@ -78,12 +78,12 @@ But we can still swap to stacks started before that: bool(true)
 We closed the active stack after all other stacks were closed. No other span is active right now: bool(true)
 spans(\DDTrace\SpanData) (2) {
   span_stack_swap.php (span_stack_swap.php, span_stack_swap.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
      (span_stack_swap.php, cli)
        (span_stack_swap.php, cli)
      (span_stack_swap.php, cli)
   span_stack_swap.php (span_stack_swap.php, span_stack_swap.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/span_stack/span_stack_swap_traced_function.phpt
+++ b/tests/ext/span_stack/span_stack_swap_traced_function.phpt
@@ -57,7 +57,7 @@ Now, we have explicitly closed it: bool(true)
 We closed the active stack after all other stacks were closed. No other span is active right now: bool(true)
 spans(\DDTrace\SpanData) (1) {
   span_stack_swap_traced_function.php (span_stack_swap_traced_function.php, span_stack_swap_traced_function.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
     outer (span_stack_swap_traced_function.php, outer, cli)
       creates_span_stack (span_stack_swap_traced_function.php, creates_span_stack, cli)

--- a/tests/ext/span_stack/span_trace_stack_autoclose.phpt
+++ b/tests/ext/span_stack/span_trace_stack_autoclose.phpt
@@ -34,7 +34,7 @@ We are back on our primary stack: bool(true)
 Having lost all references to the that span stacks objects, it is autoclosed: bool(true)
 spans(\DDTrace\SpanData) (1) {
   span_trace_stack_autoclose.php (span_trace_stack_autoclose.php, span_trace_stack_autoclose.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
      (span_trace_stack_autoclose.php, cli)
 }

--- a/tests/ext/span_stack/span_trace_swap.phpt
+++ b/tests/ext/span_stack/span_trace_swap.phpt
@@ -39,9 +39,9 @@ We closed the active stack after all other stacks were closed. No other span is 
 This automatically switches back to the parent stack: bool(true)
 spans(\DDTrace\SpanData) (2) {
   span_trace_swap.php (span_trace_swap.php, span_trace_swap.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
   span_trace_swap.php (span_trace_swap.php, span_trace_swap.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/span_stack/start_span_new_trace.phpt
+++ b/tests/ext/span_stack/start_span_new_trace.phpt
@@ -57,12 +57,12 @@ After closing the trace root, we swap back to the previously active stack: bool(
 With the trace root also accordingly updated: bool(true)
 spans(\DDTrace\SpanData) (2) {
   start_span_new_trace.php (start_span_new_trace.php, start_span_new_trace.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
      (start_span_new_trace.php, cli)
        (start_span_new_trace.php, cli)
   start_span_new_trace.php (start_span_new_trace.php, start_span_new_trace.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
      (start_span_new_trace.php, cli)
 }

--- a/tests/ext/span_stack/start_span_stack.phpt
+++ b/tests/ext/span_stack/start_span_stack.phpt
@@ -53,7 +53,7 @@ Active stack is swapped back when a span below the current span stack is closed:
 The stack still retains its direct parent as active: bool(true)
 spans(\DDTrace\SpanData) (1) {
   start_span_stack.php (start_span_stack.php, start_span_stack.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
      (start_span_stack.php, cli)
        (start_span_stack.php, cli)

--- a/tests/ext/span_stack/start_top_level_span_stack.phpt
+++ b/tests/ext/span_stack/start_top_level_span_stack.phpt
@@ -44,6 +44,6 @@ Now, we are back on the global span stack: bool(true)
 Impliying we also have no active span: bool(true)
 spans(\DDTrace\SpanData) (1) {
   start_top_level_span_stack.php (start_top_level_span_stack.php, start_top_level_span_stack.php, cli)
-    system.pid => %d
+    process_id => %d
     _dd.p.dm => -1
 }

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -62,7 +62,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
@@ -99,7 +99,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
@@ -136,7 +136,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -74,7 +74,7 @@ array(2) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
@@ -109,7 +109,7 @@ array(2) {
     string(6) "runner"
     ["meta"]=>
     array(3) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["aa"]=>
       string(2) "bb"

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -46,7 +46,7 @@ array(1) {
     string(3) "cli"
     ["meta"]=>
     array(2) {
-      ["system.pid"]=>
+      ["process_id"]=>
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"


### PR DESCRIPTION
### Description
Change system.pid to process_id to match new Datadog span attributes specification. Part of a larger effort to make tag naming more consistent among Datadog tracing libraries.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
