### PR TITLE
Fix crash during preloading on 8.1+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,27 +391,6 @@ jobs:
           name: Test post-install hook
           command: bash tests/PostInstallHook/run-tests.sh
 
-  opcache_tests:
-    parameters:
-      docker_image:
-        type: string
-    working_directory: ~/datadog
-    executor:
-      name: with_agent
-      docker_image: << parameters.docker_image >>
-    steps:
-      - <<: *STEP_ATTACH_WORKSPACE
-      - <<: *STEP_EXT_INSTALL
-      - <<: *STEP_EXPORT_CI_ENV
-      - <<: *STEP_PREPARE_TEST_RESULTS_DIR
-      - run:
-          name: Run opcache tests
-          command: |
-            export REPORT_EXIT_STATUS=1
-            export DD_TRACE_CLI_ENABLED=1
-            cd tmp/build_extension
-            php run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP -p $(which php) --show-all -d zend_extension=opcache.so ../../tests/opcache
-
   xdebug_tests:
     parameters:
       docker_image:
@@ -482,13 +461,14 @@ jobs:
           command: |
             set -euo pipefail
             make << parameters.make_target >> PHPUNIT_OPTS="--log-junit test-results/php-unit/results.xml" 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }
+            rm -rf tmp/build_extension/tests/opcache/file_cache/* || true
       - <<: *STEP_PERSIST_TO_WORKSPACE
       - <<: *STEP_STORE_TEST_RESULTS
       - run:
           command: |
             mkdir -p /tmp/artifacts/core_dumps
             find tmp -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
-            cp -a tmp/build_extension/tests/ext /tmp/artifacts/tests
+            cp -a tmp/build_extension/tests/$(if [[ << parameters.make_target >> == *opcache* ]]; then echo opcache; else echo ext; fi) /tmp/artifacts/tests
           when: on_fail
       - store_artifacts:
           path: /tmp/artifacts
@@ -2752,6 +2732,7 @@ workflows:
                 - test_c2php
                 - test_c_disabled
                 - test_internal_api_randomized
+                - test_opcache
       - coverage:
           requires: [ 'Prepare Code' ]
           matrix:
@@ -2783,6 +2764,13 @@ workflows:
                 - test_c_asan
                 - test_with_init_hook_asan
                 - test_internal_api_randomized
+                - test_opcache_asan
+            exclude:
+                # apparently for no discernible reason, on x86 asan builds PHP 7.4. fails to allocate opcache shared memory
+              - php_major_minor: '7.4'
+                resource_class: medium
+                make_target: test_opcache_asan
+                switch_php_version: debug-zts-asan
 
       - integration:
           requires: [ 'Prepare Code' ]
@@ -2856,19 +2844,6 @@ workflows:
                 - nts
               make_target:
                 - test_integrations_phpredis5
-
-      - opcache_tests:
-          requires: [ 'Prepare Code' ]
-          matrix:
-            parameters:
-              docker_image:
-                - datadog/dd-trace-ci:php-7.0_buster
-                - datadog/dd-trace-ci:php-7.1_buster
-                - datadog/dd-trace-ci:php-7.2_buster
-                - datadog/dd-trace-ci:php-7.3_buster
-                - datadog/dd-trace-ci:php-7.4_buster
-                - datadog/dd-trace-ci:php-8.0_buster
-                - datadog/dd-trace-ci:php-8.1_buster
 
       - xdebug_tests:
           requires: [ 'Prepare Code' ]

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -65,6 +65,7 @@ void dd_prepare_for_new_trace(void);
 void ddtrace_disable_tracing_in_current_request(void);
 bool ddtrace_alter_dd_trace_disabled_config(zval *old_value, zval *new_value);
 bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value);
+void dd_force_shutdown_tracing(void);
 
 typedef struct {
     int type;

--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -2,6 +2,7 @@
 #include <exceptions/exceptions.h>
 #include <php.h>
 
+#include "configuration.h"
 #include "engine_hooks.h"  // For 'ddtrace_resource'
 #include "handlers_internal.h"
 #include "serializer.h"
@@ -13,7 +14,8 @@
 // Adding support for both is open to future scope, should the need arise.
 
 static zend_class_entry dd_exception_or_error_handler_ce;
-static zend_object_handlers dd_exception_or_error_handler_handlers;
+static zend_object_handlers dd_exception_handler_handlers;
+static zend_object_handlers dd_error_handler_handlers;
 
 static zval *dd_exception_or_error_handler_handler(zend_object *obj) { return OBJ_PROP_NUM(obj, 0); }
 
@@ -136,19 +138,11 @@ static PHP_FUNCTION(ddtrace_http_response_code) {
     dd_check_exception_in_header(old_response_code);
 }
 
-#if PHP_VERSION_ID < 80000
-#define GC_NOT_COLLECTABLE GC_IMMUTABLE
-#endif
-
 // inject ourselves into a set_exception_handler
 static void dd_wrap_exception_or_error_handler(zval *target, zend_bool is_error_handler) {
     zval wrapper;
     object_init_ex(&wrapper, &dd_exception_or_error_handler_ce);
-    if (is_error_handler) {
-        // this does not participate in GC, so fine to mark it that way, to distinguish from exception handler
-        GC_ADD_FLAGS(Z_OBJ(wrapper), GC_NOT_COLLECTABLE);
-    }
-    Z_OBJ(wrapper)->handlers = &dd_exception_or_error_handler_handlers;
+    Z_OBJ(wrapper)->handlers = is_error_handler ? &dd_error_handler_handlers : &dd_exception_handler_handlers;
     ZVAL_COPY_VALUE(dd_exception_or_error_handler_handler(Z_OBJ(wrapper)), target);
     ZVAL_COPY_VALUE(target, &wrapper);
 }
@@ -204,7 +198,7 @@ ZEND_END_ARG_INFO()
 #endif
 static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
     volatile zend_bool has_bailout = false;
-    zend_bool is_error_handler = (GC_FLAGS(Z_OBJ_P(ZEND_THIS)) & GC_NOT_COLLECTABLE) != 0;
+    zend_bool is_error_handler = Z_OBJ_P(ZEND_THIS)->handlers == &dd_error_handler_handlers;
     zval *handler = dd_exception_or_error_handler_handler(Z_OBJ_P(ZEND_THIS));
 
     if (is_error_handler) {
@@ -358,6 +352,19 @@ static int dd_exception_handler_get_closure(zend_object *obj, zend_class_entry *
     return SUCCESS;
 }
 
+#if PHP_VERSION_ID >= 80100
+void dd_exception_handler_freed(zend_object *object) {
+    zend_object_std_dtor(object);
+
+    if (!EG(current_execute_data) && get_DD_TRACE_ENABLED()) {
+        // Here we are at the very last chance before objects are unconditionally freed.
+        // Let's force-disable the tracing in case it wasn't yet
+        // Typically RSHUTDOWN would handle that, but since 8.1.0 opcache will free our objects before module_shutdown during preloading
+        dd_force_shutdown_tracing();
+    }
+}
+#endif
+
 void ddtrace_exception_handlers_startup(void) {
     ddtrace_exception_or_error_handler = (zend_internal_function){
         .type = ZEND_INTERNAL_FUNCTION,
@@ -373,8 +380,12 @@ void ddtrace_exception_handlers_startup(void) {
     zend_initialize_class_data(&dd_exception_or_error_handler_ce, false);
     dd_exception_or_error_handler_ce.info.internal.module = &ddtrace_module_entry;
     zend_declare_property_null(&dd_exception_or_error_handler_ce, "handler", sizeof("handler") - 1, ZEND_ACC_PUBLIC);
-    memcpy(&dd_exception_or_error_handler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-    dd_exception_or_error_handler_handlers.get_closure = dd_exception_handler_get_closure;
+    memcpy(&dd_error_handler_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    dd_error_handler_handlers.get_closure = dd_exception_handler_get_closure;
+    memcpy(&dd_exception_handler_handlers, &dd_error_handler_handlers, sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 80100
+    dd_exception_handler_handlers.free_obj = dd_exception_handler_freed;
+#endif
 
     datadog_php_zif_handler handlers[] = {
         {ZEND_STRL("header"), &dd_header, ZEND_FN(ddtrace_header)},


### PR DESCRIPTION
### Description

Fixes #1795.

Since 8.1.0 opcache will free our objects before module_shutdown during preloading. Work around it by intercepting the latest possible point in time before objects freeing, then do our normal rshutdown sequence early.

Adding asan for opcache tests.
Looking at asan output, also some small changes had to be done to zai config and hooking.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
