### PR TITLE
Fix $integration->setError() to also accept \Error instances

### DIFF
--- a/src/Integrations/Integrations/Integration.php
+++ b/src/Integrations/Integrations/Integration.php
@@ -68,9 +68,9 @@ abstract class Integration
      * Sets common error tags for an exception.
      *
      * @param SpanData $span
-     * @param \Exception $exception
+     * @param \Throwable $exception
      */
-    public function setError(SpanData $span, \Exception $exception)
+    public function setError(SpanData $span, $exception)
     {
         $span->meta[Tag::ERROR_MSG] = $exception->getMessage();
         $span->meta[Tag::ERROR_TYPE] = get_class($exception);


### PR DESCRIPTION
### Description

We got a report that sometimes Symfony may emit \Error objects, which then emits another TypeError here.

I'm not sure exactly on how we get there, so, no test attached.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
