### PR TITLE
Fix ZEND_CATCH chaining logic

### DIFF
--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -90,14 +90,14 @@ static void dd_check_exception_in_header(int old_response_code) {
 
                 // Now iterate the individual catch blocks to find which one we are in and extract the CV
 #if PHP_VERSION_ID < 70300
-                while (catch_op->result.num == 0 && catch_op->extended_value < op_num) {
-                    catch_op = &ex->func->op_array.opcodes[catch_op->extended_value];
+                while (catch_op->result.num == 0 && ZEND_OFFSET_TO_OPLINE(catch_op, catch_op->extended_value) < ex->opline) {
+                    catch_op = ZEND_OFFSET_TO_OPLINE(catch_op, catch_op->extended_value);
                 }
 
                 zval *exception = ZEND_CALL_VAR(ex, catch_op->op2.var);
 #else
-                while (!(catch_op->extended_value & ZEND_LAST_CATCH) && catch_op->op2.opline_num < op_num) {
-                    catch_op = &ex->func->op_array.opcodes[catch_op->op2.opline_num];
+                while (!(catch_op->extended_value & ZEND_LAST_CATCH) && OP_JMP_ADDR(catch_op, catch_op->op2) < ex->opline) {
+                    catch_op = OP_JMP_ADDR(catch_op, catch_op->op2);
                 }
 
                 if (catch_op->result_type != IS_CV) {
@@ -111,6 +111,7 @@ static void dd_check_exception_in_header(int old_response_code) {
                 if (Z_TYPE_P(exception) == IS_OBJECT &&
                     instanceof_function(Z_OBJ_P(exception)->ce, zend_ce_throwable)) {
                     ZVAL_COPY(ddtrace_spandata_property_exception(root_span), exception);
+                    return;
                 }
 
                 // The final jump was eliminated from the current try  block, but possibly we are in a nested try/catch,

--- a/tests/Integration/ErrorReporting/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReporting/ErrorReportingTest.php
@@ -125,6 +125,14 @@ final class ErrorReportingTest extends WebFrameworkTestCase
         $this->assertError($traces[0][0], "Exception thrown by inner service", [['doThrow', 'index.php', '{main}']]);
     }
 
+    public function testUnhandledThrowableMultipleCatches()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $this->call(GetSpec::create('', '/unhandled-throwable-multiple-catch'));
+        });
+        $this->assertError($traces[0][0], "Exception thrown by inner service", [['doThrow', 'index.php', '{main}']]);
+    }
+
     public function testNestedHeaderHandledExceptionInClass()
     {
         $traces = $this->tracesFromWebRequest(function () {

--- a/tests/Integration/ErrorReporting/scripts/dispatcher.php
+++ b/tests/Integration/ErrorReporting/scripts/dispatcher.php
@@ -55,6 +55,18 @@ class Dispatcher
         }
     }
 
+    public function dispatchWithMultipleCatches()
+    {
+        try {
+            require_once __DIR__ . '/service_throwing_exception.php';
+            (new SomeServiceForExceptions())->doThrow();
+        } catch (\DomainException $ex) {
+        } catch (\RuntimeException $ex) {
+        } catch (\Throwable $ex) {
+            header('HTTP/1.1 500 Internal Server Obfuscated Error');
+        }
+    }
+
     public function nestedDispatchWithException()
     {
         require_once __DIR__ . '/service_throwing_exception.php';

--- a/tests/Integration/ErrorReporting/scripts/index.php
+++ b/tests/Integration/ErrorReporting/scripts/index.php
@@ -52,6 +52,11 @@ switch ($_SERVER['REQUEST_URI']) {
         (new MyApp\MyBundle\Dispatcher())->dispatchWithThrowable();
         break;
 
+    case "/unhandled-throwable-multiple-catch":
+        require __DIR__ . '/dispatcher.php';
+        (new MyApp\MyBundle\Dispatcher())->dispatchWithMultipleCatches();
+        break;
+
     case "/unhandled-nested-exception-class":
         require __DIR__ . '/dispatcher.php';
         (new MyApp\MyBundle\Dispatcher())->nestedDispatchWithException();


### PR DESCRIPTION
### Description

Apparently we have tested everything in detail, but multiple catches on a same try block.

Sometimes it works, sometimes it didn't intercept the exception, and sometimes it just hanged, depending on the surrounding opcodes.

This now properly mirrors the access happening in ZEND_CATCH handler in zend_vm_def.h.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
