### PR TITLE
[PROF-6420] bump env_logger to `0.9.3`

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
 datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.9.0" }
-env_logger = { version = "0.9" }
+env_logger = { version = "0.9.3" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }
 libc = "0.2"


### PR DESCRIPTION
### Description

This fixes the

```
warning: use of deprecated tuple variant `env_logger::Target::Pipe`: This functionality is [broken](https://github.com/env-logger-rs/env_logger/issues/208) and nobody is working on fixing it
  --> src/logging.rs:23:29
   |
23 |             .target(Target::Pipe(target))
   |                             ^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

during `cargo build`

See: https://github.com/rust-cli/env_logger/issues/208

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
