### PR TITLE
Fix misbehaviour with 256+ hooks on a same function

### DIFF
--- a/tests/ext/sandbox-regression/handle_many_hooks.phpt
+++ b/tests/ext/sandbox-regression/handle_many_hooks.phpt
@@ -1,0 +1,26 @@
+--TEST--
+The tracer should not crash when many hooks are installed
+--FILE--
+<?php
+
+$spanId = [];
+for ($i = 1; $i <= 256; ++$i) {
+    DDTrace\trace_function("test", function ($span) use ($i, &$spanId, &$run) {
+        $run += $i;
+        $spanId[] = $span->id;
+    });
+}
+
+function test() {
+    echo "test\n";
+}
+
+test();
+var_dump($run);
+echo "Unique Spans: "; var_dump(count(array_unique($spanId)));
+
+?>
+--EXPECT--
+test
+int(32896)
+Unique Spans: int(1)


### PR DESCRIPTION
### Description

Might also crash sometimes.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
