### PR TITLE
Revert catch logic for PHP 7.0 only

### DIFF
--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -92,9 +92,15 @@ static void dd_check_exception_in_header(int old_response_code) {
 
                 // Now iterate the individual catch blocks to find which one we are in and extract the CV
 #if PHP_VERSION_ID < 70300
+#if PHP_VERSION_ID < 70100
+                while (catch_op->result.num == 0 && catch_op->extended_value < op_num) {
+                    catch_op = &ex->func->op_array.opcodes[catch_op->extended_value];
+                }
+#else
                 while (catch_op->result.num == 0 && ZEND_OFFSET_TO_OPLINE(catch_op, catch_op->extended_value) < ex->opline) {
                     catch_op = ZEND_OFFSET_TO_OPLINE(catch_op, catch_op->extended_value);
                 }
+#endif
 
                 zval *exception = ZEND_CALL_VAR(ex, catch_op->op2.var);
 #else


### PR DESCRIPTION
### Description

The previous logic was actually correct for 7.0, but not for 7.1 and 7.2. Not it should always be correct.

Fixes regression from d9244963484536972f14ae4540ed9ad6c221fe25.

We actually had a CI test failing for that one, but apparently, we hadn't noticed.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
