### PR TITLE
fix compile time warning when compiling with features

### DIFF
--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -10,8 +10,13 @@ use std::sync::atomic::AtomicBool;
 
 pub type VmInterruptFn = unsafe extern "C" fn(execute_data: *mut zend_execute_data);
 
+#[cfg(feature = "allocation_profiling")]
 pub type VmMmCustomAllocFn = unsafe extern "C" fn(u64) -> *mut libc::c_void;
+
+#[cfg(feature = "allocation_profiling")]
 pub type VmMmCustomReallocFn = unsafe extern "C" fn(*mut libc::c_void, u64) -> *mut libc::c_void;
+
+#[cfg(feature = "allocation_profiling")]
 pub type VmMmCustomFreeFn = unsafe extern "C" fn(*mut libc::c_void);
 
 // todo: this a lie on some PHP versions; is it a problem even though zend_bool

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -131,12 +131,15 @@ static mut PREV_EXECUTE_INTERNAL: MaybeUninit<
 > = MaybeUninit::uninit();
 
 /// The engine's previous custom allocation function, if there is one.
+#[cfg(feature = "allocation_profiling")]
 static mut PREV_CUSTOM_MM_ALLOC: Option<zend::VmMmCustomAllocFn> = None;
 
 /// The engine's previous custom reallocation function, if there is one.
+#[cfg(feature = "allocation_profiling")]
 static mut PREV_CUSTOM_MM_REALLOC: Option<zend::VmMmCustomReallocFn> = None;
 
 /// The engine's previous custom free function, if there is one.
+#[cfg(feature = "allocation_profiling")]
 static mut PREV_CUSTOM_MM_FREE: Option<zend::VmMmCustomFreeFn> = None;
 
 /* Important note on the PHP lifecycle:
@@ -934,6 +937,7 @@ extern "C" fn execute_internal(
     interrupt_function(execute_data);
 }
 
+#[cfg(feature = "allocation_profiling")]
 unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
     let ptr: *mut libc::c_void;
 
@@ -977,6 +981,7 @@ unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
     ptr
 }
 
+#[cfg(feature = "allocation_profiling")]
 unsafe extern "C" fn alloc_profiling_free(ptr: *mut ::libc::c_void) {
     if PREV_CUSTOM_MM_FREE.is_none() {
         zend::_zend_mm_free(zend::zend_mm_get_heap(), ptr);
@@ -986,6 +991,7 @@ unsafe extern "C" fn alloc_profiling_free(ptr: *mut ::libc::c_void) {
     }
 }
 
+#[cfg(feature = "allocation_profiling")]
 unsafe extern "C" fn alloc_profiling_realloc(
     ptr: *mut ::libc::c_void,
     len: u64,

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -833,6 +833,7 @@ impl Profiler {
     }
 
     /// Collect a stack sample with memory allocations
+    #[cfg(feature = "allocation_profiling")]
     pub unsafe fn collect_allocations(
         &self,
         execute_data: *mut zend_execute_data,


### PR DESCRIPTION
### Description

This PR fixes compile time warnings when compiling without the feature `allocation_profiling`

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
