### PR TITLE
Bump `libdatadog` to `v1.0.0`

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0" }
 cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
-datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.9.0" }
+datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v1.0.0" }
 env_logger = { version = "0.9.3" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -553,7 +553,7 @@ impl Uploader {
             bytes: serialized.buffer.as_slice(),
         }];
         let timeout = Duration::from_secs(10);
-        let request = exporter.build(start, end, files, None, timeout)?;
+        let request = exporter.build(start, end, files, None, None, timeout)?;
         debug!("Sending profile to: {}", index.endpoint);
         let result = exporter.send(request, None)?;
         Ok(result.status().as_u16())


### PR DESCRIPTION
### Description

As https://github.com/DataDog/libdatadog/ was just tagged `v1.0.0` this PR bumps the version in our `Cargo.toml`

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~~Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
