### PR TITLE
Fix GH-1828: crash when copying an immutable array

### DIFF
--- a/ext/startup_logging.c
+++ b/ext/startup_logging.c
@@ -96,8 +96,12 @@ static bool _dd_parse_bool(const char *name, size_t name_len) {
 }
 
 static zend_array *_dd_array_copy(zend_array *array) {
-    GC_ADDREF(array);
-    return array;
+    if (!(GC_FLAGS(array) & IS_ARRAY_IMMUTABLE)) {
+        GC_ADDREF(array);
+        return array;
+    }
+
+    return zend_array_dup(array);
 }
 
 static zend_string *_dd_implode_keys(zend_array *array) {

--- a/ext/startup_logging.c
+++ b/ext/startup_logging.c
@@ -101,6 +101,7 @@ static zend_array *_dd_array_copy(zend_array *array) {
         return array;
     }
 
+    // If it's not duplicated, it may crash later e.g. in json encoding.
     return zend_array_dup(array);
 }
 

--- a/tests/ext/priority_sampling/001-default-sampling.phpt
+++ b/tests/ext/priority_sampling/001-default-sampling.phpt
@@ -26,10 +26,10 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
     } else {
         echo "_sampling_priority_v1 metric is missing from root span metrics\n";
     }
+    echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 } else {
     echo "Default priority sampling is not automatically kept\n";
 }
-echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
 ?>
 --EXPECT--
 \DDTrace\get_priority_sampling() OK

--- a/tests/ext/priority_sampling/gh-1828.phpt
+++ b/tests/ext/priority_sampling/gh-1828.phpt
@@ -1,0 +1,23 @@
+--TEST--
+priority_sampling regression for GH-1828
+--DESCRIPTION--
+When DD_TRACE_SAMPLING_RULES was set explicitly to the empty array, the
+ZAI/config component would try to increase the reference count on the global,
+immutable `zend_empty_array` when printing out `phpinfo()`.
+--ENV--
+DD_TRACE_SAMPLING_RULES='[]'
+--FILE--
+<?php
+
+$ddtrace = new ReflectionExtension('ddtrace');
+
+// This tests for a crash regression, no need for specific output.
+ob_start();
+$ddtrace->info();
+ob_clean();
+
+echo "Done.\n";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

Fixes GH-1828. When `DD_TRACE_SAMPLING_RULES` was set explicitly to the empty array, the ZAI/config component would try to increase the reference count on the global, immutable `zend_empty_array` when printing out `phpinfo()`.

If we don't duplicate the array, we get a crash in JSON encoding, so a simple `GC_TRY_ADDREF` is insufficient.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
