### PR TITLE
Add configuration to save profiles to disk

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -560,6 +560,11 @@ impl Uploader {
     }
 
     pub fn run(&self) {
+        // DD_PROFILING_OUTPUT_DIR
+        // DD_PROFILING_OUTPUT_PPROF=filename
+        let pprof_filename = std::env::var("DD_PROFILING_OUTPUT_PPROF").ok();
+        let mut i = 0;
+
         loop {
             /* Since profiling uploads are going over the Internet and not just
              * the local network, it would be ideal if they were the lowest
@@ -581,19 +586,28 @@ impl Uploader {
                 },
 
                 recv(self.upload_receiver) -> message => match message {
-                    Ok(upload_message) => match Self::upload(upload_message) {
-                        Ok(status) => {
-                            if status >= 400 {
-                                warn!(
-                                    "Unexpected HTTP status when sending profile (HTTP {}).",
-                                    status
-                                )
-                            } else {
-                                info!("Successfully uploaded profile (HTTP {}).", status)
-                            }
-                        }
-                        Err(err) => {
-                            warn!("Failed to upload profile: {}", err)
+                    Ok(upload_message) => {
+                        match pprof_filename.as_ref() {
+                            Some(filename) => {
+                                let r = upload_message.profile.serialize(None, None).unwrap();
+                                i += 1;
+                                std::fs::write(format!("{}.{}", filename, i), r.buffer).expect("write to succeed")
+                            },
+                            None => match Self::upload(upload_message) {
+                                Ok(status) => {
+                                    if status >= 400 {
+                                        warn!(
+                                            "Unexpected HTTP status when sending profile (HTTP {}).",
+                                            status
+                                        )
+                                    } else {
+                                        info!("Successfully uploaded profile (HTTP {}).", status)
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!("Failed to upload profile: {}", err)
+                                }
+                            },
                         }
                     },
                     _ => {

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -597,16 +597,13 @@ impl Uploader {
                             None => match Self::upload(upload_message) {
                                 Ok(status) => {
                                     if status >= 400 {
-                                        warn!(
-                                            "Unexpected HTTP status when sending profile (HTTP {}).",
-                                            status
-                                        )
+                                        warn!("Unexpected HTTP status when sending profile (HTTP {status}).")
                                     } else {
-                                        info!("Successfully uploaded profile (HTTP {}).", status)
+                                        info!("Successfully uploaded profile (HTTP {status}).")
                                     }
                                 }
                                 Err(err) => {
-                                    warn!("Failed to upload profile: {}", err)
+                                    warn!("Failed to upload profile: {err}")
                                 }
                             },
                         }

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -560,9 +560,10 @@ impl Uploader {
     }
 
     pub fn run(&self) {
-        // DD_PROFILING_OUTPUT_DIR
-        // DD_PROFILING_OUTPUT_PPROF=filename
-        let pprof_filename = std::env::var("DD_PROFILING_OUTPUT_PPROF").ok();
+        /* Safety: Called from Profiling::new, which is after config is
+         * initialized, and before it's destroyed in mshutdown.
+         */
+        let pprof_filename = unsafe { crate::config::profiling_output_pprof() };
         let mut i = 0;
 
         loop {
@@ -591,7 +592,7 @@ impl Uploader {
                             Some(filename) => {
                                 let r = upload_message.profile.serialize(None, None).unwrap();
                                 i += 1;
-                                std::fs::write(format!("{}.{}", filename, i), r.buffer).expect("write to succeed")
+                                std::fs::write(format!("{filename}.{i}"), r.buffer).expect("write to succeed")
                             },
                             None => match Self::upload(upload_message) {
                                 Ok(status) => {


### PR DESCRIPTION
### Description

Being able to save the profiles to disk instead of sending them to Datadog is nicer for certain kinds of tests, including the prof-correctness ones that Erwan and others are working on.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
