### PR TITLE
Show error message when PDO returns an error

### DIFF
--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -136,13 +136,15 @@ class PDOIntegration extends Integration
 
         // Driver-specific error message will be in the rest of the array
         // The spec suggests the error message to be at pos 2 only,
-        // but e.g. SQLServer doc states that the array can contain monre than 3 elements
+        // for ODBC: the SQLSTATE in [3] (but e.g. SQLServer doc states that the array can contain monre than 3 elements)
+        // for DBLIB: in [3] an OSerror (integer), in [4] a severity and optionally a string representation of the OSerror in [5].
         if (count($errorInfo) > 2) {
-            $span->meta[Tag::ERROR_MSG] .= '. Driver-specific error message: ' ;
-
+            $additionalInfo = [];
             for ($i = 2; $i < count($errorInfo); $i++) {
-                $span->meta[Tag::ERROR_MSG] .= $errorInfo[$i];
+                $additionalInfo[] = $errorInfo[$i];
             }
+
+            $span->meta[Tag::ERROR_MSG] .= '. Driver-specific error data: ' . implode('. ', $additionalInfo);
         }
 
         $span->meta[Tag::ERROR_TYPE] = get_class($pdoOrStatement) . ' error';

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -136,15 +136,10 @@ class PDOIntegration extends Integration
 
         // Driver-specific error message will be in the rest of the array
         // The spec suggests the error message to be at pos 2 only,
-        // for ODBC: the SQLSTATE in [3] (but e.g. SQLServer doc states that the array can contain monre than 3 elements)
-        // for DBLIB: in [3] an OSerror (integer), in [4] a severity and optionally a string representation of the OSerror in [5].
+        // ODBC: the SQLSTATE in [3] (but e.g. SQLServer doc states that the array can contain monre than 3 elements)
+        // DBLIB: [3] an OSerror (int), [4] a severity and optionally a string representation of the OSerror in [5]
         if (count($errorInfo) > 2) {
-            $additionalInfo = [];
-            for ($i = 2; $i < count($errorInfo); $i++) {
-                $additionalInfo[] = $errorInfo[$i];
-            }
-
-            $span->meta[Tag::ERROR_MSG] .= '. Driver-specific error data: ' . implode('. ', $additionalInfo);
+            $span->meta[Tag::ERROR_MSG] .= '. Driver-specific error data: ' . implode('. ', array_slice($errorInfo, 2));
         }
 
         $span->meta[Tag::ERROR_TYPE] = get_class($pdoOrStatement) . ' error';

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -133,6 +133,18 @@ class PDOIntegration extends Integration
         }
         $errorInfo = $pdoOrStatement->errorInfo();
         $span->meta[Tag::ERROR_MSG] = 'SQL error: ' . $errorCode . '. Driver error: ' . $errorInfo[1];
+
+        // Driver-specific error message will be in the rest of the array
+        // The spec suggests the error message to be at pos 2 only,
+        // but e.g. SQLServer doc states that the array can contain monre than 3 elements
+        if (count($errorInfo) > 2) {
+            $span->meta[Tag::ERROR_MSG] .= '. Driver-specific error message: ' ;
+
+            for ($i = 2; $i < count($errorInfo); $i++) {
+                $span->meta[Tag::ERROR_MSG] .= $errorInfo[$i];
+            }
+        }
+
         $span->meta[Tag::ERROR_TYPE] = get_class($pdoOrStatement) . ' error';
     }
 

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -208,7 +208,7 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error message: You have an error in your SQL syntax')
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error data: You have an error in your SQL syntax')
                 ->withExactTags($this->baseTags()),
             SpanAssertion::exists('PDO.commit'),
         ]);
@@ -271,7 +271,7 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error message: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\'')
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error data: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\'')
                 ->withExactTags($this->baseTags()),
         ]);
     }

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -208,7 +208,7 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error message: You have an error in your SQL syntax')
                 ->withExactTags($this->baseTags()),
             SpanAssertion::exists('PDO.commit'),
         ]);
@@ -271,7 +271,7 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
-                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064')
+                ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error message: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\'')
                 ->withExactTags($this->baseTags()),
         ]);
     }


### PR DESCRIPTION
### Description

Adds the error message in the error message tag when available. This gives more information on where the issue is. Error messages are contained inside the [errorInfo array](https://www.php.net/manual/en/pdo.errorinfo.php). The specs state it contains 3 elements but [SQLServer seems to set more than that.](https://learn.microsoft.com/en-us/sql/connect/php/pdo-errorinfo?view=sql-server-ver16#additional-odbc-messages)

This extra data shouldn't contain sensitive data as it should be close to what we get on PDOException when there is one. 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
