### PR TITLE
(PHP 7) Fix memory leak with custom CURLOPT_READFUNCTION

### DIFF
--- a/ext/handlers_curl_php7.c
+++ b/ext/handlers_curl_php7.c
@@ -532,7 +532,7 @@ static zend_object *dd_curl_wrap_ctor_obj(zend_class_entry *ce) {
 }
 
 static void dd_curl_wrap_dtor_obj(zend_object *obj) {
-    zend_objects_destroy_object(obj);
+    zend_object_std_dtor(obj);
 
     struct dd_curl_wrapper *wrapper = (struct dd_curl_wrapper *)obj;
     if (dd_multi_handles) {

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
@@ -14,6 +14,7 @@ function query_headers() {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_READFUNCTION, function () {}); // must not leak
     $response = curl_exec($ch);
     show_curl_error_on_fail($ch);
     curl_close($ch);


### PR DESCRIPTION
### Description

Used the wrong function to clean the object.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
