### PR TITLE
Add missing span kind to CodeIgniter test

### DIFF
--- a/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
@@ -40,6 +40,7 @@ class NoCIControllertTest extends WebFrameworkTestCase
                     Tag::HTTP_METHOD => 'GET',
                     Tag::HTTP_URL => 'http://localhost:9999/health_check/ping',
                     Tag::HTTP_STATUS_CODE => '200',
+                    Tag::SPAN_KIND => 'server',
                 ])->withChildren([
                     SpanAssertion::build(
                         'Health_check.ping',


### PR DESCRIPTION
### Description

Add missing span kind to CodeIgniter test. This was overlooked by merging two PRs at the same time without first merging master back into the second one.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
