### PR TITLE
Force the replacement of the appsec helper when reinstalling

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -144,7 +144,7 @@ function install($options)
     if (file_exists($tmpArchiveAppsecRoot)) {
         execute_or_exit(
             "Cannot copy files from '$tmpArchiveAppsecBin' to '$installDir'",
-            "cp -r " . escapeshellarg("$tmpArchiveAppsecBin") . ' ' . escapeshellarg($installDir)
+            "cp -rf " . escapeshellarg("$tmpArchiveAppsecBin") . ' ' . escapeshellarg($installDir)
         );
         execute_or_exit(
             "Cannot copy files from '$tmpArchiveAppsecEtc' to '$installDir'",


### PR DESCRIPTION
### Description

When installing a version of the library on top of an existing installation of the same version, in the circumstance in which the appsec helper process is running, the installer fails as it's unable to replace the helper binary. This fixes the issue by forcing  the copy, which results in the removal of the previous binary and the addition of the new (existing) one.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
