### PR TITLE
Support custom ini names in installer

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -221,6 +221,17 @@ function install($options)
         // Writing the ini file
         if ($phpProperties[INI_SCANDIR]) {
             $iniFileName = '98-ddtrace.ini';
+            // Search for pre-existing files with extension = ddtrace.so to avoid conflicts
+            // See issue https://github.com/DataDog/dd-trace-php/issues/1833
+            foreach (scandir($phpProperties[INI_SCANDIR]) as $ini) {
+                $path = "{$phpProperties[INI_SCANDIR]}/$ini";
+                if (is_file($path)) {
+                    if (preg_match('(^\s*extension\s*=.+ddtrace\.so)m', file_get_contents($path))) {
+                        $iniFileName = $ini;
+                    }
+                }
+            }
+
             $iniFilePaths = [$phpProperties[INI_SCANDIR] . '/' . $iniFileName];
 
             if (\strpos($phpProperties[INI_SCANDIR], '/cli/conf.d') !== false) {
@@ -270,7 +281,7 @@ function install($options)
                  */
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
+                    "sed -i 's@ \?;\? \?extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
                         . escapeshellarg($iniFilePath)
                 );
 
@@ -308,12 +319,6 @@ function install($options)
 
             // phpcs:disable Generic.Files.LineLength.TooLong
             if ($shouldInstallAppsec) {
-                // Appsec crashes with missing symbols if tracing is not loaded
-                execute_or_exit(
-                    'Impossible to update the INI settings file.',
-                    "sed -i 's@ \?; \?extension \?= \?ddtrace.so@extension = ddtrace.so@g' "
-                        . escapeshellarg($iniFilePath)
-                );
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
                     "sed -i 's@ \?; \?extension \?= \?ddappsec.so@extension = ddappsec.so@g' "

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -72,6 +72,7 @@ test_first_install.sh \
 test_install_no_ldconfig_in_path.sh \
 test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
+test_install_custom_ini_name.sh \
 test_install_custom_installation_directory.sh \
 test_install_custom_installation_root.sh \
 test_install_non_root_user.sh \

--- a/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_no_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_no_curl_cli.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo php7-openssl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_yes_curl_cli.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_install_no_ext_curl_yes_curl_cli.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo curl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_ext_json.sh
@@ -10,7 +10,7 @@ apk add php7 curl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_alpine_no_libcurl.sh
+++ b/dockerfiles/verify_packages/installer/test_alpine_no_libcurl.sh
@@ -10,7 +10,7 @@ apk add php7
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_disabled.sh
@@ -4,16 +4,20 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+if ! is_appsec_installable; then
+  exit 0
+fi
+
 # Initially no ddtrace
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 
 assert_ddtrace_version "${new_version}"
-assert_appsec_version 0.3.2
+assert_appsec_version 0.4.0
 assert_appsec_disabled
 
 assert_file_exists "$(get_php_extension_dir)"/ddappsec.so

--- a/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_appsec_install_enabled.sh
@@ -4,15 +4,19 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+if ! is_appsec_installable; then
+  exit 0
+fi
+
 # Initially no ddtrace
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --enable-appsec
 assert_ddtrace_version "${new_version}"
-assert_appsec_version 0.3.2
+assert_appsec_version 0.4.0
 assert_appsec_enabled
 
 assert_file_exists "$(get_php_extension_dir)"/ddappsec.so

--- a/dockerfiles/verify_packages/installer/test_first_install.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_alpine.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_alpine.sh
@@ -10,7 +10,7 @@ apk add php7 php7-json libcurl libexecinfo curl
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_php_debug.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_debug.sh
@@ -13,7 +13,7 @@ sudo chmod a+w ./build/packages/*
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_first_install_php_debugzts.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_debugzts.sh
@@ -13,7 +13,7 @@ switch-php debug-zts-asan
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_first_install_php_zts.sh
+++ b/dockerfiles/verify_packages/installer/test_first_install_php_zts.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_fpm.sh
+++ b/dockerfiles/verify_packages/installer/test_fpm.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-fpm
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_install_custom_ini_name.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_ini_name.sh
@@ -14,20 +14,19 @@ php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"
 
 ini_file="$(get_php_conf_dir)/98-ddtrace.ini"
+custom_ini_file="$(get_php_conf_dir)/40-ddtrace.ini"
 
-assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
+# remove an INI to see that indeed that ini is changed
 assert_file_contains "${ini_file}" 'datadog.version'
-
-# Removing an enabled property and a commented out property
-sed -i 's/datadog\.trace\.request_init_hook.*//g' "${ini_file}"
 sed -i 's/datadog\.version.*//g' "${ini_file}"
-
-assert_file_not_contains "${ini_file}" 'datadog.trace.request_init_hook'
 assert_file_not_contains "${ini_file}" 'datadog.version'
+
+mv "$ini_file" "$custom_ini_file"
 
 php ./build/packages/datadog-setup.php --php-bin php
 
-assert_file_contains "${ini_file}" 'datadog.trace.request_init_hook'
-assert_file_contains "${ini_file}" 'datadog.version'
+assert_file_contains "${custom_ini_file}" 'datadog.version'
+
+assert_file_not_exists "${ini_file}"
 
 assert_request_init_hook_exists

--- a/dockerfiles/verify_packages/installer/test_install_custom_installation_directory.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_installation_directory.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php --install-dir /custom/dd
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_install_custom_installation_root.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_installation_root.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 # Verify that wrong installation dir (e.g. /) does not delete all files in root

--- a/dockerfiles/verify_packages/installer/test_install_no_ldconfig_in_path.sh
+++ b/dockerfiles/verify_packages/installer/test_install_no_ldconfig_in_path.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 PHP=$(which php)

--- a/dockerfiles/verify_packages/installer/test_install_non_binary.sh
+++ b/dockerfiles/verify_packages/installer/test_install_non_binary.sh
@@ -5,7 +5,7 @@ set -e
 . "$(dirname ${0})/utils.sh"
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin=all
 

--- a/dockerfiles/verify_packages/installer/test_install_non_root_user.sh
+++ b/dockerfiles/verify_packages/installer/test_install_non_root_user.sh
@@ -10,7 +10,7 @@ assert_no_ddtrace
 useradd -m datadog -p datadog
 usermod -a -G datadog datadog
 
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_install_subdir_from_file.sh
+++ b/dockerfiles/verify_packages/installer/test_install_subdir_from_file.sh
@@ -12,10 +12,13 @@ if [ "$CIRCLECI" = "true" ]; then
     exit 0
 fi
 
-new_version="0.74.0"
+uname=$(uname -a)
+arch=$(if [ -z "${uname##*arm*}" ] || [ -z "${uname##*aarch*}" ]; then echo aarch64; else echo x86_64; fi)
+
+new_version="0.78.0"
 generate_installers "${new_version}"
 repo_url=${DD_TEST_INSTALLER_REPO:-"https://github.com/DataDog/dd-trace-php"}
-curl -L -o /tmp/downloaded.tar.gz "${repo_url}/releases/download/${new_version}/dd-library-php-${new_version}-x86_64-linux-gnu.tar.gz"
+curl -L -o /tmp/downloaded.tar.gz "${repo_url}/releases/download/${new_version}/dd-library-php-${new_version}-${arch}-linux-gnu.tar.gz"
 
 # Install using the php installer
 php ./build/packages/datadog-setup.php --php-bin php --file /tmp/downloaded.tar.gz

--- a/dockerfiles/verify_packages/installer/test_install_subdir_from_version.sh
+++ b/dockerfiles/verify_packages/installer/test_install_subdir_from_version.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer.sh
@@ -11,7 +11,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_appsec.sh
@@ -4,6 +4,10 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+if ! is_appsec_installable; then
+  exit 0
+fi
+
 # Initially no ddtrace
 assert_no_ddtrace
 
@@ -11,7 +15,7 @@ extension_dir="$(php -i | grep '^extension_dir' | awk '{ print $NF }')"
 ini_dir="$(php -i | grep '^Scan' | awk '{ print $NF }')"
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 
@@ -22,7 +26,7 @@ assert_no_appsec
 assert_no_profiler
 
 php ./build/packages/datadog-setup.php --enable-appsec --php-bin php
-assert_appsec_version 0.3.2
+assert_appsec_version 0.4.0
 assert_appsec_enabled
 
 # Appsec requires ddtrace to be enabled, otherwise it crashes with missing symbols.

--- a/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
+++ b/dockerfiles/verify_packages/installer/test_install_uninstall_install_tracer_profiling.sh
@@ -4,6 +4,12 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+# 0.75.0 doesn't exist on arm
+uname=$(uname -a)
+if [ -z "${uname##*arm*}" ] || [ -z "${uname##*aarch*}" ]; then
+  exit 0
+fi
+
 # Initially no ddtrace
 assert_no_ddtrace
 

--- a/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
+++ b/dockerfiles/verify_packages/installer/test_install_without_scan_dir.sh
@@ -22,7 +22,7 @@ SCANDIR
 chmod +x $(dirname "$(which php)")/php-without-scan-dir
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php-without-scan-dir
 assert_ddtrace_version "${new_version}" php-without-scan-dir

--- a/dockerfiles/verify_packages/installer/test_profiler_install_disabled.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_disabled.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_enabled.sh
@@ -4,15 +4,23 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+uname=$(uname -a)
+arch=$(if [ -z "${uname##*arm*}" ] || [ -z "${uname##*aarch*}" ]; then echo aarch64; else echo x86_64; fi)
+
 # Initially no ddtrace
 assert_no_ddtrace
 
 # Install using the php installer
 trace_version=$(parse_trace_version)
 profiling_version=$(parse_profiling_version)
+file="./build/packages/dd-library-php-${trace_version}-${arch}-linux-gnu.tar.gz"
+if ! [ -f $file ]; then
+  trace_version="0.79.0"
+  profiling_version="0.10.0"
+fi
 generate_installers "$trace_version"
 php ./build/packages/datadog-setup.php --php-bin php --enable-profiling \
-    --file "./build/packages/dd-library-php-${trace_version}-x86_64-linux-gnu.tar.gz"
+    $(! [ -f $file ] || echo --file "$file")
 assert_ddtrace_version "${trace_version}"
 
 assert_file_exists "$(get_php_extension_dir)"/datadog-profiling.so

--- a/dockerfiles/verify_packages/installer/test_profiler_install_unsupported.sh
+++ b/dockerfiles/verify_packages/installer/test_profiler_install_unsupported.sh
@@ -8,7 +8,7 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 
 set +e

--- a/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
+++ b/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
@@ -4,6 +4,12 @@ set -e
 
 . "$(dirname ${0})/utils.sh"
 
+# 0.74.0 doesn't exist on arm
+uname=$(uname -a)
+if [ -z "${uname##*arm*}" ] || [ -z "${uname##*aarch*}" ]; then
+  exit 0
+fi
+
 # Initially no ddtrace
 assert_no_ddtrace
 
@@ -13,7 +19,7 @@ install_legacy_ddtrace "${old_version}"
 assert_ddtrace_version "${old_version}"
 
 # Upgrade using the php installer
-new_version="0.74.0"
+new_version="0.78.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/test_upgrade_from_php_installer.sh
+++ b/dockerfiles/verify_packages/installer/test_upgrade_from_php_installer.sh
@@ -8,13 +8,13 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-old_version="0.74.0"
+old_version="0.78.0"
 generate_installers "${old_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${old_version}"
 
 # Upgrade using the php installer
-new_version="0.75.0"
+new_version="0.79.0"
 generate_installers "${new_version}"
 php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -116,6 +116,16 @@ assert_file_exists() {
     fi
 }
 
+assert_file_not_exists() {
+    file="${1}"
+    if ! [ -f "${file}" ]; then
+        echo "Ok: File '${file}' does not exist\n"
+    else
+        echo "Error: File '${file}' exists\n"
+        exit 1
+    fi
+}
+
 install_legacy_ddtrace() {
     version=$1
     curl -L --output "/tmp/legacy-${version}.tar.gz" \
@@ -170,3 +180,9 @@ dashed_print() {
         printf '%s\n---\n' "$line"
     done
 }
+
+is_appsec_installable() {
+  uname=$(uname -a)
+  [ -n "${uname##*arm*}" ] && [ -n "${uname##*aarch*}" ]
+}
+

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -47,7 +47,7 @@ function ensure_bounded_nesting_depth()
         }
     }
 
-    if ($depth >= 10) {
+    if ($depth >= 8) {
         ini_set("datadog.trace.enabled", "0");
         ini_set("datadog.trace.enabled", "1");
     }

--- a/tests/randomized/README.md
+++ b/tests/randomized/README.md
@@ -139,9 +139,9 @@ docker run --rm -ti datadog/dd-trace-ci:php-randomizedtests-centos7-8.0 bash
 Install the specific version of the tracer from `CircleCI` > `build_packages` > `package extension` > `ARTIFACTS`
 
 ```
-curl -L -o /tmp/ddtrace-test.tar.gz https://557109-119990860-gh.circle-artifacts.com/0/datadog-php-tracer-1.0.0-nightly.x86_64.tar.gz
-tar -xf /tmp/ddtrace-test.tar.gz -C /
-bash /opt/datadog-php/bin/post-install.sh
+curl -L -o /tmp/datadog-setup.php https://557109-119990860-gh.circle-artifacts.com/0/datadog-setup.php
+curl -L -o /tmp/ddtrace-test.tar.gz https://557109-119990860-gh.circle-artifacts.com/0/dd-library-php-1.0.0-nightly-aarch64-linux-gnu.tar.gz
+php /tmp/datadog-setup.php --php-bin all --file /tmp/ddtrace-test.tar.gz --enable-profiling
 ```
 
 Download the generated core dump from `CircleCI` > `build_packages` > `randomized_tests-XX` > `ARTIFACTS` (search in artifact for the scenario that is failing based on the build report, the core dump file is called `core`):


### PR DESCRIPTION
### Description

Fixes #1833.

Also update randomized tests instructions and slightly lower the recursion depth for internal-api-stress-test.php

This PR also updates the installer tests so that they run natively on arm dev machines locally.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
