### PR TITLE
update docs on how to analyse segfaults

### DIFF
--- a/tests/randomized/README.md
+++ b/tests/randomized/README.md
@@ -139,9 +139,9 @@ docker run --rm -ti datadog/dd-trace-ci:php-randomizedtests-centos7-8.0 bash
 Install the specific version of the tracer from `CircleCI` > `build_packages` > `package extension` > `ARTIFACTS`
 
 ```
-curl -L -o /tmp/ddtrace-test.tar.gz https://557109-119990860-gh.circle-artifacts.com/0/datadog-php-tracer-1.0.0-nightly.x86_64.tar.gz
-tar -xf /tmp/ddtrace-test.tar.gz -C /
-bash /opt/datadog-php/bin/post-install.sh
+curl -L -o /tmp/datadog-setup.php https://output.circle-artifacts.com/output/job/82a1bc30-6ae8-4712-9ee3-0c01a7051f63/artifacts/0/datadog-setup.php
+curl -L -o /tmp/dd-library.tar.gz https://output.circle-artifacts.com/output/job/82a1bc30-6ae8-4712-9ee3-0c01a7051f63/artifacts/0/dd-library-php-1.0.0-nightly-x86_64-linux-gnu.tar.gz
+php /tmp/datadog-setup.php --file /tmp/dd-library.tar.gz --enable-profiling
 ```
 
 Download the generated core dump from `CircleCI` > `build_packages` > `randomized_tests-XX` > `ARTIFACTS` (search in artifact for the scenario that is failing based on the build report, the core dump file is called `core`):


### PR DESCRIPTION
### Description

This PR updates the docs about analysing a core dump that happened in CircleCI, thanks @bwoebi 