### PR TITLE
Bump profiling version for release

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"


### PR DESCRIPTION
### Description

We've made these changes and haven't bumped the version number yet:

- #1819
- #1825
- #1837

So doing that now.

I'm simultaneously seeing if I have my new signing setup working. It appears I do not.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
