### PR TITLE
Always interpolate error message placeholders to avoid confusion

### DIFF
--- a/src/api/Log/InterpolateTrait.php
+++ b/src/api/Log/InterpolateTrait.php
@@ -21,9 +21,12 @@ trait InterpolateTrait
         $replace = array();
         foreach ($context as $key => $val) {
             // check that the value can be casted to string
-            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
-                $replace['{' . $key . '}'] = $val;
+            if (is_array($val)) {
+                $val = "{Array of size " . count($val) . "}";
+            } elseif (is_object($val) && !method_exists($val, '__toString')) {
+                $val = "{Object of type " . get_class($val) . "}";
             }
+            $replace['{' . $key . '}'] = $val;
         }
 
         // interpolate replacement values into the message and return


### PR DESCRIPTION
### Description

Otherwise "{name}" may appear and let the user wonder which span is named "{name}".

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
