### PR TITLE
Clear the active closed stack head when resetting the tracer

### DIFF
--- a/ext/span.c
+++ b/ext/span.c
@@ -102,6 +102,8 @@ void ddtrace_free_span_stacks(bool silent) {
             dd_free_span_ring(stack->closed_ring_flush);
             stack->closed_ring_flush = NULL;
 
+            stack->top_closed_stack = NULL;
+
             OBJ_RELEASE(&stack->std);
         }
     } while (obj_ptr != end);


### PR DESCRIPTION
### Description

Fixes crash found in internal API stresstest.

It seems to me that the crash occurs, when a stack has been created on top of an existing stack, all its child spans closed and the tracer then reset.
Then new child spans must have been created on top of both stacks, and all of them closed.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug - not exactly sure how to reconstruct this artificially.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
