### PR TITLE
Work around broken enum functions run_time_cache on PHP 8.2.0 and 8.2.1

### DIFF
--- a/zend_abstract_interface/interceptor/php8/resolver.c
+++ b/zend_abstract_interface/interceptor/php8/resolver.c
@@ -13,12 +13,9 @@ static inline void zai_reset_enum_rt_cache(zend_class_entry *ce, zend_string *na
         memset(RUN_TIME_CACHE(&func->op_array), 0, zend_internal_run_time_cache_reserved_size());
     }
 }
-#endif
-
-static void zai_interceptor_class_linked(zend_class_entry *ce, zend_string *name) {
+static void zai_interceptor_class_linked_fix_enums(zend_class_entry *ce, zend_string *name) {
     zai_hook_resolve_class(ce, name);
 
-#if PHP_VERSION_ID < 80300
     if (ce->ce_flags & ZEND_ACC_ENUM) {
         zai_reset_enum_rt_cache(ce, ZSTR_KNOWN(ZEND_STR_CASES));
         if (ce->enum_backing_type != IS_UNDEF) {
@@ -26,7 +23,11 @@ static void zai_interceptor_class_linked(zend_class_entry *ce, zend_string *name
             zai_reset_enum_rt_cache(ce, ZSTR_KNOWN(ZEND_STR_TRYFROM_LOWERCASE));
         }
     }
+}
 #endif
+
+static void zai_interceptor_class_linked(zend_class_entry *ce, zend_string *name) {
+    zai_hook_resolve_class(ce, name);
 }
 
 static zend_op_array *(*prev_compile_file)(zend_file_handle *file_handle, int type);
@@ -40,11 +41,21 @@ static zend_op_array *zai_interceptor_compile_file(zend_file_handle *file_handle
 }
 
 void zai_interceptor_minit(void) {
-    zend_observer_function_declared_register(zai_interceptor_function_declared);
-    zend_observer_class_linked_register(zai_interceptor_class_linked);
 }
 
 void zai_interceptor_setup_resolving_post_startup(void) {
+#if PHP_VERSION_ID < 80300
+    zend_long patch_version = Z_LVAL_P(zend_get_constant_str(ZEND_STRL("PHP_RELEASE_VERSION")));
+    if (patch_version < 2) { // affects only 8.2.0 and 8.2.1
+        zend_observer_class_linked_register(zai_interceptor_class_linked_fix_enums);
+    } else
+#endif
+    {
+        zend_observer_class_linked_register(zai_interceptor_class_linked);
+    }
+
+    zend_observer_function_declared_register(zai_interceptor_function_declared);
+
     prev_compile_file = zend_compile_file;
     zend_compile_file = zai_interceptor_compile_file;
 }

--- a/zend_abstract_interface/interceptor/php8/resolver.c
+++ b/zend_abstract_interface/interceptor/php8/resolver.c
@@ -5,8 +5,28 @@ static void zai_interceptor_function_declared(zend_op_array *op_array, zend_stri
     zai_hook_resolve_function((zend_function *)op_array, name);
 }
 
+#if PHP_VERSION_ID < 80300
+#include "zend_extensions.h"
+static inline void zai_reset_enum_rt_cache(zend_class_entry *ce, zend_string *name) {
+    zend_function *func;
+    if ((func = zend_hash_find_ptr(&ce->function_table, name))) {
+        memset(RUN_TIME_CACHE(&func->op_array), 0, zend_internal_run_time_cache_reserved_size());
+    }
+}
+#endif
+
 static void zai_interceptor_class_linked(zend_class_entry *ce, zend_string *name) {
     zai_hook_resolve_class(ce, name);
+
+#if PHP_VERSION_ID < 80300
+    if (ce->ce_flags & ZEND_ACC_ENUM) {
+        zai_reset_enum_rt_cache(ce, ZSTR_KNOWN(ZEND_STR_CASES));
+        if (ce->enum_backing_type != IS_UNDEF) {
+            zai_reset_enum_rt_cache(ce, ZSTR_KNOWN(ZEND_STR_FROM));
+            zai_reset_enum_rt_cache(ce, ZSTR_KNOWN(ZEND_STR_TRYFROM_LOWERCASE));
+        }
+    }
+#endif
 }
 
 static zend_op_array *(*prev_compile_file)(zend_file_handle *file_handle, int type);


### PR DESCRIPTION
### Description

Fixes #1859.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
