### PR TITLE
fix(profiling): prepare heap for `gc_mem_caches()`

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -138,9 +138,6 @@ static mut PREV_EXECUTE_INTERNAL: MaybeUninit<
 > = MaybeUninit::uninit();
 
 #[cfg(feature = "allocation_profiling")]
-const GC_MEM_CACHES: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0") };
-
-#[cfg(feature = "allocation_profiling")]
 static mut GC_MEM_CACHES_HANDLER: zend::InternalFunctionHandler = None;
 
 /// The engine's previous custom allocation function, if there is one.
@@ -935,7 +932,7 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
     #[cfg(feature = "allocation_profiling")]
     unsafe {
         let handle = datadog_php_zif_handler::new(
-            GC_MEM_CACHES,
+            CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0"),
             &mut GC_MEM_CACHES_HANDLER,
             Some(datadog_allocation_profiling_gc_mem_caches),
         );

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 use rand_distr::{Distribution, Poisson};
 
 #[cfg(feature = "allocation_profiling")]
-use crate::bindings::{datadog_php_install_handler, datadog_php_zif_handler, datadog_php_profiling_copy_long_into_zval};
+use crate::bindings::{datadog_php_install_handler, datadog_php_zif_handler, ddog_php_prof_copy_long_into_zval};
 
 /// The version of PHP at runtime, not the version compiled against. Sent as
 /// a profile tag.
@@ -1069,7 +1069,7 @@ unsafe extern "C" fn datadog_allocation_profiling_gc_mem_caches(
     // Better safe than sorry: `gc_mem_caches()` is a Zend core function which
     // always exists
     if GC_MEM_CACHES_HANDLER == None {
-        datadog_php_profiling_copy_long_into_zval(return_value, 0);
+        ddog_php_prof_copy_long_into_zval(return_value, 0);
         return;
     }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -284,16 +284,6 @@ extern "C" fn minit(r#type: c_int, module_number: c_int) -> ZendResult {
         zend::zend_execute_internal = Some(execute_internal);
     };
 
-    #[cfg(feature = "allocation_profiling")]
-    unsafe {
-        let handle = datadog_php_zif_handler::new(
-            GC_MEM_CACHES,
-            &mut GC_MEM_CACHES_HANDLER,
-            Some(datadog_allocation_profiling_gc_mem_caches),
-        );
-        datadog_php_install_handler(handle);
-    }
-
     /* Safety: all arguments are valid for this C call.
      * Note that on PHP 7 this never fails, and on PHP 8 it returns void.
      */
@@ -941,6 +931,16 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
 
     // Safety: calling this in zend_extension startup.
     unsafe { pcntl::startup() };
+
+    #[cfg(feature = "allocation_profiling")]
+    unsafe {
+        let handle = datadog_php_zif_handler::new(
+            GC_MEM_CACHES,
+            &mut GC_MEM_CACHES_HANDLER,
+            Some(datadog_allocation_profiling_gc_mem_caches),
+        );
+        datadog_php_install_handler(handle);
+    }
 
     ZendResult::Success
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -934,7 +934,7 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
         let handle = datadog_php_zif_handler::new(
             CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0"),
             &mut GC_MEM_CACHES_HANDLER,
-            Some(datadog_allocation_profiling_gc_mem_caches),
+            Some(alloc_profiling_gc_mem_caches),
         );
         datadog_php_install_handler(handle);
     }
@@ -1062,7 +1062,7 @@ unsafe fn restore_zend_heap(heap: *mut zend::_zend_mm_heap, custom_heap: c_int) 
 }
 
 #[cfg(feature = "allocation_profiling")]
-unsafe extern "C" fn datadog_allocation_profiling_gc_mem_caches(
+unsafe extern "C" fn alloc_profiling_gc_mem_caches(
     execute_data: *mut zend::zend_execute_data,
     return_value: *mut zend::zval,
 ) {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 use rand_distr::{Distribution, Poisson};
 
 #[cfg(feature = "allocation_profiling")]
-use crate::bindings::{datadog_php_install_handler, datadog_php_zif_handler};
+use crate::bindings::{datadog_php_install_handler, datadog_php_zif_handler, datadog_php_profiling_copy_long_into_zval};
 
 /// The version of PHP at runtime, not the version compiled against. Sent as
 /// a profile tag.
@@ -1069,7 +1069,7 @@ unsafe extern "C" fn datadog_allocation_profiling_gc_mem_caches(
     // Better safe then sorry: `gc_mem_caches()` is a Zend core function which
     // always exists
     if GC_MEM_CACHES_HANDLER == None {
-        // TODO: return 0;
+        datadog_php_profiling_copy_long_into_zval(return_value, 0);
         return;
     }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -1066,7 +1066,7 @@ unsafe extern "C" fn datadog_allocation_profiling_gc_mem_caches(
     execute_data: *mut zend::zend_execute_data,
     return_value: *mut zend::zval,
 ) {
-    // Better safe then sorry: `gc_mem_caches()` is a Zend core function which
+    // Better safe than sorry: `gc_mem_caches()` is a Zend core function which
     // always exists
     if GC_MEM_CACHES_HANDLER == None {
         datadog_php_profiling_copy_long_into_zval(return_value, 0);

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -75,7 +75,7 @@ void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_vie
     }
 }
 
-void datadog_php_profiling_copy_long_into_zval(zval *dest, long num) {
+void ddog_php_prof_copy_long_into_zval(zval *dest, long num) {
     ZEND_ASSERT(dest);
     ZVAL_LONG(dest, num);
     return;

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -75,6 +75,12 @@ void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_vie
     }
 }
 
+void datadog_php_profiling_copy_long_into_zval(zval *dest, long num) {
+    ZEND_ASSERT(dest);
+    ZVAL_LONG(dest, num);
+    return;
+}
+
 /**
  * Converts the zend_string pointer into a string view. Null pointers and
  * empty strings will be converted into a string view to a static empty

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -96,6 +96,14 @@ void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_vie
                                                       bool persistent);
 
 /**
+ * Copies the number in `num` into a zval, which is stored in `dest`
+ *
+ * `dest` is expected to be uninitialized. Any existing content will not be
+ * dtor'.
+ */
+void datadog_php_profiling_copy_long_into_zval(zval *dest, long num);
+
+/**
  * Wrapper to PHP's `zend_mm_set_custom_handlers()`. Starting from PHP 7.3
  * onwards the upstream `zend_mm_set_custom_handlers()` function will restore
  * the `use_custom_heap` flag on the `zend_mm_heap` to

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -101,7 +101,7 @@ void datadog_php_profiling_copy_string_view_into_zval(zval *dest, zai_string_vie
  * `dest` is expected to be uninitialized. Any existing content will not be
  * dtor'.
  */
-void datadog_php_profiling_copy_long_into_zval(zval *dest, long num);
+void ddog_php_prof_copy_long_into_zval(zval *dest, long num);
 
 /**
  * Wrapper to PHP's `zend_mm_set_custom_handlers()`. Starting from PHP 7.3

--- a/profiling/tests/phpt/gc_mem_caches_01.phpt
+++ b/profiling/tests/phpt/gc_mem_caches_01.phpt
@@ -1,0 +1,36 @@
+--TEST--
+[profiling] test allocation profiling not blocking `gc_mem_caches()` call
+--DESCRIPTION--
+Directly after rinit, the `gc_mem_caches()` function is able to cleanup some
+60KB of data, but with a custom allocator installed in the ZendMM it won't do
+anything and return `int(0)`. As we do prepare the heap for this call, the
+function should actually cleanup some memory and return the amount in bytes.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=yes
+DD_SERVICE=datadog-profiling-phpt
+DD_ENV=dev
+DD_VERSION=13
+DD_AGENT_HOST=localh0st
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_AGENT_URL=http://datadog:8126
+--FILE--
+<?php
+
+$cleaned = gc_mem_caches();
+
+if ($cleaned == 0) {
+    die('could not clean ZendMM');
+}
+
+echo 'Done.';
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

The PHP userland function `gc_mem_caches()` just forwards calls to `zend_mm_gc()` which will do exactly nothing and return `int(0)` in case a custom allocator is installed.
This PR makes sure we intercept userland calls to `gc_mem_caches()` and prepare the heap for such a call.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
