### PR TITLE
Release 0.83.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_LIBRARY_x86_64_LINUX_GNU:
-    value: "https://output.circle-artifacts.com/output/job/07137924-8d07-4204-ad68-0a4090b88ce1/artifacts/0/dd-library-php-0.83.0-x86_64-linux-gnu.tar.gz"
+    value: "https://output.circle-artifacts.com/output/job/5626298d-80a7-4bc5-ba21-4e1cb6b743e6/artifacts/0/dd-library-php-0.83.1-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.83.0"
+#define PHP_DDTRACE_VERSION "0.83.1"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -56,39 +56,10 @@
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
         <![CDATA[
-### Added
-- Add span.kind tagging #1801, #1843
-
-### Changed
-- Change error.msg to error.message #1821
-- Change process_id to metrics tag #1826
-- Remove libexecinfo on Alpine #1838
-- Always interpolate error message placeholders to avoid confusion #1849
-
 ### Fixed
-- Fix installer name in help output in datadog-setup.php #1829
-- Fix #1828: crash when copying an immutable array #1832
-- Fix CodeIgniter integration to not depend on CI_Controller class #1835
-- (PHP 7) Fix memory leak with custom CURLOPT_READFUNCTION #1841
-- Support custom ini names in installer #1846, #1851
-- Clear the active closed stack head when resetting the tracer #1853
-
-### Internal changes
-- Speed up "Attaching workspace" step in CI #1823
-- Improve test suite flakiness & randomized asan #1817
-
-## Profiling (0.12.0)
-
-### Added
-- Add configuration to save profiles to disk #1837
-
-### Changed
-- Bump libdatadog to 1.0 #1825
-- Bump profiling version for release #1848
-
-### Internal changes
-- Fix compile time warnings when compiling without features #1819
-- Avoid putting .package-cache into the cache, commit Cargo.lock #1852
+- Use the HttpWorker instead of the Psr7Worker for Roadrunner for more generic usage #1864
+- Fix trace_id reset in DDTrace\set_distributed_tracing_context() #1863
+- Work around broken enum functions run_time_cache on PHP 8.2.0 and 8.2.1 #1862
 ]]></notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -24,7 +24,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.83.0';
+    const VERSION = '0.83.1';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Fixed
- Use the HttpWorker instead of the Psr7Worker for Roadrunner for more generic usage #1864
- Fix trace_id reset in DDTrace\set_distributed_tracing_context() #1863
- Work around broken enum functions run_time_cache on PHP 8.2.0 and 8.2.1 #1862
