### PR TITLE
Implement #[DDTrace\Trace] attribute

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -69,7 +69,10 @@ if test "$PHP_DDTRACE" != "no"; then
     "
   elif test $PHP_VERSION_ID -lt 90000; then
     dnl PHP 8.x
-    EXTRA_PHP_SOURCES="ext/handlers_curl.c"
+    EXTRA_PHP_SOURCES="\
+        ext/handlers_curl.c \
+        ext/hook/uhook_attributes.c \
+    "
     ZAI_RESOLVER_SUFFIX=""
 
     if test $PHP_VERSION_ID -lt 80200; then

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -188,7 +188,7 @@ static void dd_uhook_dtor(void *data) {
 #endif
 
 /* {{{ proto int DDTrace\install_hook(string|Closure|Generator target, ?Closure begin = null, ?Closure end = null) */
-PHP_FUNCTION(install_hook) {
+PHP_FUNCTION(DDTrace_install_hook) {
     zend_string *name = NULL;
     zend_function *resolved = NULL;
     zval *begin = NULL;
@@ -293,7 +293,7 @@ PHP_FUNCTION(install_hook) {
 } /* }}} */
 
 /* {{{ proto void DDTrace\remove_hook(int $id) */
-PHP_FUNCTION(remove_hook) {
+PHP_FUNCTION(DDTrace_remove_hook) {
     (void)return_value;
 
     zend_long id;
@@ -323,11 +323,23 @@ void zai_uhook_rshutdown() {
     zend_hash_destroy(&dd_active_hooks);
 }
 
+#if PHP_VERSION_ID >= 80000
+void zai_uhook_attributes_minit(void);
+#endif
 void zai_uhook_minit() {
     ddtrace_hook_data_ce = register_class_DDTrace_HookData();
     zend_register_functions(NULL, ext_functions, NULL, MODULE_PERSISTENT);
+#if PHP_VERSION_ID >= 80000
+    zai_uhook_attributes_minit();
+#endif
 }
 
+#if PHP_VERSION_ID >= 80000
+void zai_uhook_attributes_mshutdown(void);
+#endif
 void zai_uhook_mshutdown() {
     zend_unregister_functions(ext_functions,sizeof(ext_functions) / sizeof(zend_function_entry) - 1,NULL);
+#if PHP_VERSION_ID >= 80000
+    zai_uhook_attributes_mshutdown();
+#endif
 }

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4de8a73e8b57bbbe50f608e017bfbae5378df804 */
+ * Stub hash: 9d121c2053e69043217e9fe88d197e9dfcea77a4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 3, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
@@ -12,13 +12,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_remove_hook, 0, 1, IS_VO
 ZEND_END_ARG_INFO()
 
 
-ZEND_FUNCTION(install_hook);
-ZEND_FUNCTION(remove_hook);
+ZEND_FUNCTION(DDTrace_install_hook);
+ZEND_FUNCTION(DDTrace_remove_hook);
 
 
 static const zend_function_entry ext_functions[] = {
-	ZEND_NS_FE("DDTrace", install_hook, arginfo_DDTrace_install_hook)
-	ZEND_NS_FE("DDTrace", remove_hook, arginfo_DDTrace_remove_hook)
+	ZEND_NS_FALIAS("DDTrace", install_hook, DDTrace_install_hook, arginfo_DDTrace_install_hook)
+	ZEND_NS_FALIAS("DDTrace", remove_hook, DDTrace_remove_hook, arginfo_DDTrace_remove_hook)
 	ZEND_FE_END
 };
 

--- a/ext/hook/uhook_attributes.c
+++ b/ext/hook/uhook_attributes.c
@@ -371,7 +371,7 @@ void dd_uhook_on_function_resolve(zend_function *func) {
                 if (!def->type) {
                     def->type = zend_string_copy(Z_STR(value));
                 }
-            } else if (zend_string_equals_literal(name, "args")) {
+            } else if (zend_string_equals_literal(name, "saveArgs")) {
                 if (!def->arg_whitelist) {
                     if (Z_TYPE(value) == IS_ARRAY) {
                         def->args = true;
@@ -386,7 +386,7 @@ void dd_uhook_on_function_resolve(zend_function *func) {
                         def->args = zend_is_true(&value);
                     }
                 }
-            } else if (zend_string_equals_literal(name, "return")) {
+            } else if (zend_string_equals_literal(name, "saveReturn")) {
                 def->retval = zend_is_true(&value);
             } else if (zend_string_equals_literal(name, "run_if_limited")) {
                 def->run_if_limited = zend_is_true(&value);
@@ -412,7 +412,7 @@ void dd_uhook_on_function_resolve(zend_function *func) {
 void zai_uhook_attributes_minit(void) {
     zai_hook_on_function_resolve = dd_uhook_on_function_resolve;
 
-    ddtrace_hook_attribute_ce = register_class_DDTrace_Traced();
+    ddtrace_hook_attribute_ce = register_class_DDTrace_Trace();
 #if PHP_VERSION_ID >= 80200
     zend_mark_internal_attribute(ddtrace_hook_attribute_ce);
 #endif
@@ -423,6 +423,6 @@ void zai_uhook_attributes_mshutdown(void) {
     zend_string_release(dd_hook_attribute_lcname);
 }
 
-ZEND_METHOD(DDTrace_Traced, __construct) {
+ZEND_METHOD(DDTrace_Trace, __construct) {
     (void) execute_data, (void) return_value;
 }

--- a/ext/hook/uhook_attributes.c
+++ b/ext/hook/uhook_attributes.c
@@ -1,0 +1,428 @@
+#include <php.h>
+#include <Zend/zend_attributes.h>
+#include <Zend/zend_smart_str.h>
+#include "uhook_attributes_arginfo.h"
+#include "../ddtrace.h"
+#include "../configuration.h"
+#include "uhook.h"
+
+#include <hook/hook.h>
+
+zend_class_entry *ddtrace_hook_attribute_ce;
+static zend_string *dd_hook_attribute_lcname;
+
+typedef struct {
+    zend_string *name;
+    zend_string *resource;
+    zend_string *service;
+    zend_string *type;
+    zend_array *tags;
+    bool args;
+    zend_array *arg_whitelist;
+    bool retval;
+    bool run_if_limited;
+    bool active;
+    bool disallow_recursion;
+} dd_uhook_def;
+
+typedef struct {
+    ddtrace_span_data *span;
+    bool skipped;
+    bool was_primed;
+} dd_uhook_dynamic;
+
+static void dd_uhook_save_value_nested(smart_str *str, zval *value, int remaining_nesting) {
+    const int string_maxlen = 255;
+    ZVAL_DEREF(value);
+    if (Z_TYPE_P(value) == IS_ARRAY) {
+        HashTable *ht = Z_ARR_P(value);
+
+        if (remaining_nesting == 0) {
+            smart_str_append_printf(str, "[size %d]", zend_hash_num_elements(ht));
+        }
+
+        smart_str_appendc(str, '[');
+        const int max_values = remaining_nesting == 1 ? 3 : 10;
+        int counter = 0;
+        zend_string *strkey;
+        zend_long numkey;
+        zval *arrval;
+        ZEND_HASH_FOREACH_KEY_VAL(ht, numkey, strkey, arrval) {
+            if (++counter > max_values) {
+                break;
+            }
+            if (counter > 1) {
+                smart_str_appends(str, ", ");
+            }
+            if (strkey) {
+                smart_str_appendc(str, '\'');
+                smart_str_append(str, strkey);
+                smart_str_append_printf(str, "%.*s", MIN(string_maxlen, (int)ZSTR_LEN(strkey)), ZSTR_VAL(strkey));
+                smart_str_appendc(str, '\'');
+            } else {
+                smart_str_append_printf(str, ZEND_LONG_FMT, numkey);
+            }
+            smart_str_appends(str, " => ");
+
+            dd_uhook_save_value_nested(str, arrval, remaining_nesting - 1);
+        } ZEND_HASH_FOREACH_END();
+        if (counter > max_values) {
+            smart_str_appends(str, ", ...");
+        }
+        smart_str_appendc(str, ']');
+    } else if (Z_TYPE_P(value) == IS_OBJECT) {
+        smart_str_appends(str, "Object of type ");
+        smart_str_append(str, Z_OBJCE_P(value)->name);
+    } else if (Z_TYPE_P(value) == IS_FALSE) {
+        smart_str_appends(str, "false");
+    } else if (Z_TYPE_P(value) == IS_TRUE) {
+        smart_str_appends(str, "true");
+    } else if (Z_TYPE_P(value) == IS_NULL) {
+        smart_str_appends(str, "null");
+    } else {
+        if (remaining_nesting < 2) {
+            smart_str_appendc(str, '\'');
+        }
+        zend_string *val = zval_get_string(value);
+        smart_str_append_printf(str, "%.*s", MIN(string_maxlen, (int)ZSTR_LEN(val)), ZSTR_VAL(val));
+        zend_string_release(val);
+        if (remaining_nesting < 2) {
+            smart_str_appendc(str, '\'');
+        }
+    }
+}
+
+static zval dd_uhook_save_value(zval *value) {
+    smart_str str = {0};
+    dd_uhook_save_value_nested(&str, value, 2);
+    smart_str_0(&str);
+    zval ret;
+    ZVAL_STR(&ret, str.s);
+    return ret;
+}
+
+static void dd_fill_span_data(dd_uhook_def *def, ddtrace_span_data *span) {
+    if (def->name) {
+        zval *name = ddtrace_spandata_property_name(span);
+        zval_ptr_dtor(name);
+        ZVAL_STR_COPY(name, def->name);
+    }
+    if (def->resource) {
+        zval *resource = ddtrace_spandata_property_resource(span);
+        zval_ptr_dtor(resource);
+        ZVAL_STR_COPY(resource, def->resource);
+    }
+    if (def->service) {
+        zval *service = ddtrace_spandata_property_service(span);
+        zval_ptr_dtor(service);
+        ZVAL_STR_COPY(service, def->service);
+    }
+    if (def->type) {
+        zval *type = ddtrace_spandata_property_type(span);
+        zval_ptr_dtor(type);
+        ZVAL_STR_COPY(type, def->type);
+    }
+    if (def->tags) {
+        zend_array *meta = ddtrace_spandata_property_meta(span);
+        zend_string *key;
+        zval *value;
+        ZEND_HASH_FOREACH_STR_KEY_VAL(def->tags, key, value) {
+            if (key) {
+                zend_hash_update(meta, key, value);
+            }
+        } ZEND_HASH_FOREACH_END();
+    }
+}
+
+void dd_uhook_fill_args_in_meta(dd_uhook_def *def, HashTable *meta, zend_execute_data *execute_data) {
+    uint32_t num_args = EX_NUM_ARGS();
+
+    if (!num_args || !def->args) {
+        return;
+    }
+
+    zval *p = EX_VAR_NUM(0);
+    zend_function *func = EX(func);
+
+    uint32_t first_extra_arg = MIN(num_args, func->common.num_args);
+
+    if (func->type == ZEND_USER_FUNCTION) {
+        uint32_t varnum = 0;
+        for (zval *end = p + first_extra_arg; p < end; ++p) {
+            zend_string *arg_name = func->op_array.vars[varnum++];
+            if (!def->arg_whitelist || zend_hash_exists(def->arg_whitelist, arg_name)) {
+                zend_string *arg = zend_strpprintf(0, "arg.%.*s", (int) ZSTR_LEN(arg_name), ZSTR_VAL(arg_name));
+                zval zv = dd_uhook_save_value(p);
+                zend_hash_update(meta, arg, &zv);
+                zend_string_release(arg);
+            }
+        }
+
+        p = EX_VAR_NUM(func->op_array.last_var + func->op_array.T);
+    } else {
+        uint32_t varnum = 0;
+        for (zval *end = p + first_extra_arg; p < end; ++p) {
+            zend_string *arg_name = func->common.arg_info[varnum++].name;
+            if (!def->arg_whitelist || zend_hash_exists(def->arg_whitelist, arg_name)) {
+                zend_string *arg = zend_strpprintf(0, "arg.%.*s", (int) ZSTR_LEN(arg_name), ZSTR_VAL(arg_name));
+                zval zv = dd_uhook_save_value(p);
+                zend_hash_update(meta, arg, &zv);
+                zend_string_release(arg);
+            }
+        }
+    }
+
+    num_args -= first_extra_arg;
+    if (!def->arg_whitelist) {
+        // collect trailing variadic args
+        uint32_t varnum = first_extra_arg;
+        for (zval *end = p + num_args; p < end; ++p) {
+            zend_string *arg = zend_strpprintf(0, "arg.%d", varnum++);
+            zval zv = dd_uhook_save_value(p);
+            zend_hash_update(meta, arg, &zv);
+            zend_string_release(arg);
+        }
+    }
+}
+
+
+static bool dd_uhook_begin(zend_ulong invocation, zend_execute_data *execute_data, void *auxiliary, void *dynamic) {
+    dd_uhook_def *def = auxiliary;
+    dd_uhook_dynamic *dyn = dynamic;
+
+    if ((!def->run_if_limited && ddtrace_tracer_is_limited()) || (def->active && def->disallow_recursion) || !get_DD_TRACE_ENABLED()) {
+        dyn->skipped = false;
+        dyn->span = NULL;
+        return true;
+    }
+
+    def->active = true; // recursion protection
+    dyn->was_primed = false;
+
+    dyn->span = ddtrace_alloc_execute_data_span(invocation, execute_data);
+    dd_fill_span_data(def, dyn->span);
+    dd_uhook_fill_args_in_meta(def, ddtrace_spandata_property_meta(dyn->span), execute_data);
+
+    return true;
+}
+
+// create an own span for every generator resumption
+static void dd_uhook_generator_resumption(zend_ulong invocation, zend_execute_data *execute_data, zval *value, void *auxiliary, void *dynamic) {
+    (void)value;
+
+    dd_uhook_def *def = auxiliary;
+    dd_uhook_dynamic *dyn = dynamic;
+
+    if (dyn->skipped || !dyn->was_primed) {
+        dyn->was_primed = true;
+        return;
+    }
+
+    if (!get_DD_TRACE_ENABLED()) {
+        dyn->span = NULL;
+        return;
+    }
+
+    dyn->span = ddtrace_alloc_execute_data_span(invocation, execute_data);
+    dd_fill_span_data(def, dyn->span);
+    if (def->retval) {
+        zend_array *meta = ddtrace_spandata_property_meta(dyn->span);
+        zval val = dd_uhook_save_value(value);
+        zend_hash_str_update(meta, ZEND_STRL("send_value"), &val);
+    }
+}
+
+static void dd_uhook_generator_yield(zend_ulong invocation, zend_execute_data *execute_data, zval *key, zval *value, void *auxiliary, void *dynamic) {
+    (void)key, (void)execute_data;
+
+    dd_uhook_def *def = auxiliary;
+    dd_uhook_dynamic *dyn = dynamic;
+
+    if (!dyn->span) {
+        return;
+    }
+
+    if (dyn->span->duration == DDTRACE_DROPPED_SPAN) {
+        dyn->span = NULL;
+        ddtrace_clear_execute_data_span(invocation, false);
+    } else {
+        zval *exception_zv = ddtrace_spandata_property_exception(dyn->span);
+        if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
+            ZVAL_OBJ_COPY(exception_zv, EG(exception));
+        }
+
+        dd_trace_stop_span_time(dyn->span);
+
+        if (def->retval) {
+            zend_array *meta = ddtrace_spandata_property_meta(dyn->span);
+            zval keyzv = dd_uhook_save_value(key);
+            zend_hash_str_update(meta, ZEND_STRL("yield_key"), &keyzv);
+            zval val = dd_uhook_save_value(value);
+            zend_hash_str_update(meta, ZEND_STRL("yield_value"), &val);
+        }
+    }
+
+    ddtrace_clear_execute_data_span(invocation, true);
+    dyn->span = NULL;
+}
+
+extern void (*profiling_interrupt_function)(zend_execute_data *);
+static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data, zval *retval, void *auxiliary, void *dynamic) {
+    dd_uhook_def *def = auxiliary;
+    dd_uhook_dynamic *dyn = dynamic;
+
+    if (!dyn->span) {
+        return;
+    }
+
+    if (dyn->span->duration == DDTRACE_DROPPED_SPAN) {
+        ddtrace_clear_execute_data_span(invocation, false);
+    } else {
+        zval *exception_zv = ddtrace_spandata_property_exception(dyn->span);
+        if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
+            ZVAL_OBJ_COPY(exception_zv, EG(exception));
+        }
+
+        dd_trace_stop_span_time(dyn->span);
+
+        if (def->retval) {
+            zend_array *meta = ddtrace_spandata_property_meta(dyn->span);
+            zval val = dd_uhook_save_value(retval);
+            zend_hash_str_update(meta, ZEND_STRL("return_value"), &val);
+        }
+    }
+
+    /* If the profiler doesn't handle a potential pending interrupt before
+     * the observer's end function, then the callback will be at the top of
+     * the stack even though it's not responsible.
+     * This is why the profiler's interrupt function is called here, to
+     * give the profiler an opportunity to take a sample before calling the
+     * tracing function.
+     */
+    if (profiling_interrupt_function) {
+        profiling_interrupt_function(execute_data);
+    }
+
+    ddtrace_clear_execute_data_span(invocation, true);
+
+    def->active = false;
+}
+
+static void dd_uhook_dtor(void *data) {
+    dd_uhook_def *def = data;
+    if (def->name) {
+        zend_string_release(def->name);
+    }
+    if (def->resource) {
+        zend_string_release(def->resource);
+    }
+    if (def->service) {
+        zend_string_release(def->service);
+    }
+    if (def->type) {
+        zend_string_release(def->type);
+    }
+    if (def->arg_whitelist) {
+        zend_array_release(def->arg_whitelist);
+    }
+    if (def->tags) {
+        zend_array_release(def->tags);
+    }
+    efree(def);
+}
+
+
+void dd_uhook_on_function_resolve(zend_function *func) {
+    zend_attribute *attr = zend_get_attribute(func->common.attributes, dd_hook_attribute_lcname);
+    if (attr) {
+        dd_uhook_def *def = ecalloc(1, sizeof(*def));
+        zend_arg_info *arg_info = ddtrace_hook_attribute_ce->constructor->common.arg_info;
+        uint32_t max_num_args = ddtrace_hook_attribute_ce->constructor->common.num_args;
+        for (uint32_t i = 0; i < attr->argc; ++i) {
+            zend_attribute_arg *arg = &attr->args[i];
+            zend_string *name = arg->name;
+            if (!name && i < max_num_args) {
+                name = zend_string_copy(arg_info[i].name);
+            }
+
+            zval value;
+            ZVAL_COPY_OR_DUP(&value, &arg->value);
+
+            if (Z_TYPE(value) == IS_CONSTANT_AST) {
+                if (SUCCESS != zval_update_constant_ex(&value, func->common.scope)) {
+                    zval_ptr_dtor(&value);
+                    continue;
+                }
+            }
+
+            if (zend_string_equals_literal(name, "name") && Z_TYPE(value) == IS_STRING) {
+                if (!def->name) {
+                    def->name = zend_string_copy(Z_STR(value));
+                }
+            } else if (zend_string_equals_literal(name, "resource") && Z_TYPE(value) == IS_STRING) {
+                if (!def->resource) {
+                    def->resource = zend_string_copy(Z_STR(value));
+                }
+            } else if (zend_string_equals_literal(name, "service") && Z_TYPE(value) == IS_STRING) {
+                if (!def->service) {
+                    def->service = zend_string_copy(Z_STR(value));
+                }
+            } else if (zend_string_equals_literal(name, "type") && Z_TYPE(value) == IS_STRING) {
+                if (!def->type) {
+                    def->type = zend_string_copy(Z_STR(value));
+                }
+            } else if (zend_string_equals_literal(name, "args")) {
+                if (!def->arg_whitelist) {
+                    if (Z_TYPE(value) == IS_ARRAY) {
+                        def->args = true;
+                        def->arg_whitelist = zend_new_array(zend_hash_num_elements(Z_ARR(value)));
+                        zval *val;
+                        ZEND_HASH_FOREACH_VAL(Z_ARR(value), val) {
+                            if (Z_TYPE_P(val) == IS_STRING) {
+                                zend_hash_add_empty_element(def->arg_whitelist, Z_STR_P(val));
+                            }
+                        } ZEND_HASH_FOREACH_END();
+                    } else {
+                        def->args = zend_is_true(&value);
+                    }
+                }
+            } else if (zend_string_equals_literal(name, "return")) {
+                def->retval = zend_is_true(&value);
+            } else if (zend_string_equals_literal(name, "run_if_limited")) {
+                def->run_if_limited = zend_is_true(&value);
+            } else if (zend_string_equals_literal(name, "recurse")) {
+                def->disallow_recursion = !zend_is_true(&value);
+            } else if (zend_string_equals_literal(name, "tags") && Z_TYPE(value) == IS_ARRAY) {
+                if (!def->tags) {
+                    def->tags = Z_ARR(value);
+                    GC_ADDREF(def->tags);
+                }
+            }
+
+            zval_ptr_dtor(&value);
+        }
+
+        zai_hook_install_resolved_generator(func,
+                                            dd_uhook_begin, dd_uhook_generator_resumption, dd_uhook_generator_yield, dd_uhook_end,
+                                            ZAI_HOOK_AUX(def, dd_uhook_dtor), sizeof(dd_uhook_dynamic));
+
+    }
+}
+
+void zai_uhook_attributes_minit(void) {
+    zai_hook_on_function_resolve = dd_uhook_on_function_resolve;
+
+    ddtrace_hook_attribute_ce = register_class_DDTrace_Traced();
+#if PHP_VERSION_ID >= 80200
+    zend_mark_internal_attribute(ddtrace_hook_attribute_ce);
+#endif
+    dd_hook_attribute_lcname = zend_string_tolower_ex(ddtrace_hook_attribute_ce->name, true);
+}
+
+void zai_uhook_attributes_mshutdown(void) {
+    zend_string_release(dd_hook_attribute_lcname);
+}
+
+ZEND_METHOD(DDTrace_Traced, __construct) {
+    (void) execute_data, (void) return_value;
+}

--- a/ext/hook/uhook_attributes.stub.php
+++ b/ext/hook/uhook_attributes.stub.php
@@ -7,15 +7,15 @@ namespace DDTrace;
 require "Zend/zend_attributes.stub.php";
 
 #[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
-final class Traced {
+final class Trace {
     public function __construct(
         string $name = "",
         string $resource = "",
         string $type = "",
         string $service = "",
         array $tags = [],
-        bool|array $args = false,
-        bool $return = false,
+        bool|array $saveArgs = false,
+        bool $saveReturn = false,
         bool $recurse = true,
         bool $run_if_limited = false
     ) {}

--- a/ext/hook/uhook_attributes.stub.php
+++ b/ext/hook/uhook_attributes.stub.php
@@ -1,0 +1,22 @@
+<?php
+
+/** @generate-class-entries */
+
+namespace DDTrace;
+
+require "Zend/zend_attributes.stub.php";
+
+#[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
+final class Traced {
+    public function __construct(
+        string $name = "",
+        string $resource = "",
+        string $type = "",
+        string $service = "",
+        array $tags = [],
+        bool|array $args = false,
+        bool $return = false,
+        bool $recurse = true,
+        bool $run_if_limited = false
+    ) {}
+}

--- a/ext/hook/uhook_attributes.stub.php
+++ b/ext/hook/uhook_attributes.stub.php
@@ -6,6 +6,8 @@ namespace DDTrace;
 
 require "Zend/zend_attributes.stub.php";
 
+// phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.Indent
+
 /**
  * If specified, this attribute ensures that all calls to that function are traced.
  */
@@ -29,8 +31,10 @@ final class Trace {
         string $type = "",
         string $service = "",
         array $tags = [],
+/* disable for now, until final decision on the API is taken
         bool|array $saveArgs = false,
         bool $saveReturn = false,
+*/
         bool $recurse = true,
         bool $run_if_limited = false
     ) {}

--- a/ext/hook/uhook_attributes.stub.php
+++ b/ext/hook/uhook_attributes.stub.php
@@ -6,8 +6,23 @@ namespace DDTrace;
 
 require "Zend/zend_attributes.stub.php";
 
+/**
+ * If specified, this attribute ensures that all calls to that function are traced.
+ */
 #[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
 final class Trace {
+    /**
+     * @param string $name The operation name to be assigned to the span. Defaults to the function name.
+     * @param string $resource The resource to be assigned to the span.
+     * @param string $type The type to be assigned to the span.
+     * @param string $service The service to be assigned to the span. Defaults to default or inherited service name.
+     * @param array $tags The tags to be assigned to the span.
+     * @param bool|array $saveArgs Whether arguments shall be saved as tags on the span. True to save them all.
+                                    False to save none. An array with parameter names to save only select ones.
+     * @param bool $saveReturn Whether to save return values (including yielded values on generators) on the span.
+     * @param bool $recurse Whether recursive calls shall be traced.
+     * @param bool $run_if_limited Whether the function shall be traced in limited mode. (E.g. when span limit exceeded)
+     */
     public function __construct(
         string $name = "",
         string $resource = "",

--- a/ext/hook/uhook_attributes_arginfo.h
+++ b/ext/hook/uhook_attributes_arginfo.h
@@ -1,0 +1,36 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 26ac9ee2c5d1e35c0eb029b40187bbebd9373f14 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Traced___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, resource, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, service, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tags, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(DDTrace_Traced, __construct);
+
+
+static const zend_function_entry class_DDTrace_Traced_methods[] = {
+	ZEND_ME(DDTrace_Traced, __construct, arginfo_class_DDTrace_Traced___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_DDTrace_Traced(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "Traced", class_DDTrace_Traced_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zend_string *attribute_name_Attribute_class_DDTrace_Traced = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_DDTrace_Traced = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_DDTrace_Traced, 1);
+	zend_string_release(attribute_name_Attribute_class_DDTrace_Traced);
+	zval attribute_Attribute_class_DDTrace_Traced_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_DDTrace_Traced_arg0, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_DDTrace_Traced->args[0].value, &attribute_Attribute_class_DDTrace_Traced_arg0);
+
+	return class_entry;
+}

--- a/ext/hook/uhook_attributes_arginfo.h
+++ b/ext/hook/uhook_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 74318ff1b60991ce6efcb1d59bf97c2e70e6f9b3 */
+ * Stub hash: 92149a7e3aedf1da0726b9ab377e4de4872d0813 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Trace___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 0, "\"\"")
@@ -34,7 +34,7 @@ static zend_class_entry *register_class_DDTrace_Trace(void)
 	zend_attribute *attribute_Attribute_class_DDTrace_Trace = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_DDTrace_Trace, 1);
 	zend_string_release(attribute_name_Attribute_class_DDTrace_Trace);
 	zval attribute_Attribute_class_DDTrace_Trace_arg0;
-	ZVAL_LONG(&attribute_Attribute_class_DDTrace_Trace_arg0, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION);
+	ZVAL_LONG(&attribute_Attribute_class_DDTrace_Trace_arg0, ZEND_ATTRIBUTE_TARGET_FUNCTION | ZEND_ATTRIBUTE_TARGET_METHOD);
 	ZVAL_COPY_VALUE(&attribute_Attribute_class_DDTrace_Trace->args[0].value, &attribute_Attribute_class_DDTrace_Trace_arg0);
 
 	return class_entry;

--- a/ext/hook/uhook_attributes_arginfo.h
+++ b/ext/hook/uhook_attributes_arginfo.h
@@ -1,36 +1,41 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 26ac9ee2c5d1e35c0eb029b40187bbebd9373f14 */
+ * Stub hash: 74318ff1b60991ce6efcb1d59bf97c2e70e6f9b3 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Traced___construct, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Trace___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, resource, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, service, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tags, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_MASK(0, saveArgs, MAY_BE_BOOL|MAY_BE_ARRAY, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, saveReturn, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, recurse, _IS_BOOL, 0, "true")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, run_if_limited, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 
-ZEND_METHOD(DDTrace_Traced, __construct);
+ZEND_METHOD(DDTrace_Trace, __construct);
 
 
-static const zend_function_entry class_DDTrace_Traced_methods[] = {
-	ZEND_ME(DDTrace_Traced, __construct, arginfo_class_DDTrace_Traced___construct, ZEND_ACC_PUBLIC)
+static const zend_function_entry class_DDTrace_Trace_methods[] = {
+	ZEND_ME(DDTrace_Trace, __construct, arginfo_class_DDTrace_Trace___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_DDTrace_Traced(void)
+static zend_class_entry *register_class_DDTrace_Trace(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "Traced", class_DDTrace_Traced_methods);
+	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "Trace", class_DDTrace_Trace_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 
-	zend_string *attribute_name_Attribute_class_DDTrace_Traced = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
-	zend_attribute *attribute_Attribute_class_DDTrace_Traced = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_DDTrace_Traced, 1);
-	zend_string_release(attribute_name_Attribute_class_DDTrace_Traced);
-	zval attribute_Attribute_class_DDTrace_Traced_arg0;
-	ZVAL_LONG(&attribute_Attribute_class_DDTrace_Traced_arg0, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION);
-	ZVAL_COPY_VALUE(&attribute_Attribute_class_DDTrace_Traced->args[0].value, &attribute_Attribute_class_DDTrace_Traced_arg0);
+	zend_string *attribute_name_Attribute_class_DDTrace_Trace = zend_string_init_interned("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_DDTrace_Trace = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_DDTrace_Trace, 1);
+	zend_string_release(attribute_name_Attribute_class_DDTrace_Trace);
+	zval attribute_Attribute_class_DDTrace_Trace_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_DDTrace_Trace_arg0, ZEND_ATTRIBUTE_TARGET_METHOD | ZEND_ATTRIBUTE_TARGET_FUNCTION);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_DDTrace_Trace->args[0].value, &attribute_Attribute_class_DDTrace_Trace_arg0);
 
 	return class_entry;
 }

--- a/ext/hook/uhook_attributes_arginfo.h
+++ b/ext/hook/uhook_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 92149a7e3aedf1da0726b9ab377e4de4872d0813 */
+ * Stub hash: f89e44d830bdaf827effa53dd5d7643c90974b11 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Trace___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 0, "\"\"")
@@ -7,8 +7,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Trace___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, service, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, tags, IS_ARRAY, 0, "[]")
-	ZEND_ARG_TYPE_MASK(0, saveArgs, MAY_BE_BOOL|MAY_BE_ARRAY, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, saveReturn, _IS_BOOL, 0, "false")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, recurse, _IS_BOOL, 0, "true")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, run_if_limited, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,6 +37,7 @@
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>bridge/autoload.php</exclude-pattern>
         <exclude-pattern>build/packages/*</exclude-pattern>
+        <exclude-pattern>ext/*</exclude-pattern>
         <exclude-pattern>datadog-setup.php</exclude-pattern>
         <exclude-pattern>examples/long-running/long-running-script.php</exclude-pattern>
         <exclude-pattern>src/api/GlobalTracer.php</exclude-pattern>

--- a/tests/ext/traced_attribute.phpt
+++ b/tests/ext/traced_attribute.phpt
@@ -1,0 +1,76 @@
+--TEST--
+Set DDTrace\start_span() properties
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: No attributes pre-PHP 8'); ?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+include __DIR__ . '/sandbox/dd_dumper.inc';
+
+class Foo {
+    #[DDTrace\Traced(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", 1 => "ignored"])]
+    static function simple($arg) {}
+
+    #[DDTrace\Traced(args: ["foo"])]
+    static function argRestricted($bar, $foo) {
+        return 2;
+    }
+
+    #[DDTrace\Traced(args: true, return: true)]
+    static function allArgs($bar, $foo) {
+        return 2;
+    }
+}
+
+#[DDTrace\Traced]
+function bar() {
+    Foo::simple(1);
+}
+
+#[DDTrace\Traced]
+function recursion($i = 2) {
+    if ($i) {
+        recursion($i - 1);
+    }
+}
+
+#[DDTrace\Traced(recurse: false)]
+function noRecursion($i = 2) {
+    if ($i) {
+        noRecursion($i - 1);
+    }
+}
+
+bar();
+Foo::argRestricted("foo", "bar");
+Foo::allArgs([[1, 2, []], 3, 4, 5, 6, true, null, "9!", false, 11, 12, 13], "bar", "additional");
+recursion();
+noRecursion();
+
+dd_dump_spans();
+
+?>
+--EXPECT--
+spans(\DDTrace\SpanData) (5) {
+  bar (traced_attribute.php, bar, cli)
+    _dd.p.dm => -1
+    simplename (test, rsrc, typeee)
+      a => b
+  Foo.argRestricted (traced_attribute.php, Foo.argRestricted, cli)
+    arg.foo => bar
+    _dd.p.dm => -1
+  Foo.allArgs (traced_attribute.php, Foo.allArgs, cli)
+    arg.bar => [0 => [0 => '1', 1 => '2', 2 => [size 0][]], 1 => '3', 2 => '4', 3 => '5', 4 => '6', 5 => true, 6 => null, 7 => '9!', 8 => false, 9 => '11', ...]
+    arg.foo => bar
+    arg.2 => additional
+    return_value => 2
+    _dd.p.dm => -1
+  recursion (traced_attribute.php, recursion, cli)
+    _dd.p.dm => -1
+    recursion (traced_attribute.php, recursion, cli)
+      recursion (traced_attribute.php, recursion, cli)
+  noRecursion (traced_attribute.php, noRecursion, cli)
+    _dd.p.dm => -1
+}

--- a/tests/ext/traced_attribute.phpt
+++ b/tests/ext/traced_attribute.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/sandbox/dd_dumper.inc';
 class Foo {
     #[DDTrace\Trace(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", 1 => "ignored"])]
     static function simple($arg) {}
-
+/*
     #[DDTrace\Trace(saveArgs: ["foo"])]
     static function argRestricted($bar, $foo) {
         return 2;
@@ -22,6 +22,7 @@ class Foo {
     static function allArgs($bar, $foo) {
         return 2;
     }
+*/
 }
 
 #[DDTrace\Trace]
@@ -44,8 +45,10 @@ function noRecursion($i = 2) {
 }
 
 bar();
+/*
 Foo::argRestricted("foo", "bar");
 Foo::allArgs([[1, 2, []], 3, 4, 5, 6, true, null, "9!", false, 11, 12, 13], "bar", "additional");
+*/
 recursion();
 noRecursion();
 
@@ -53,20 +56,11 @@ dd_dump_spans();
 
 ?>
 --EXPECT--
-spans(\DDTrace\SpanData) (5) {
+spans(\DDTrace\SpanData) (3) {
   bar (traced_attribute.php, bar, cli)
     _dd.p.dm => -1
     simplename (test, rsrc, typeee)
       a => b
-  Foo.argRestricted (traced_attribute.php, Foo.argRestricted, cli)
-    arg.foo => bar
-    _dd.p.dm => -1
-  Foo.allArgs (traced_attribute.php, Foo.allArgs, cli)
-    arg.bar => [0 => [0 => '1', 1 => '2', 2 => [size 0][]], 1 => '3', 2 => '4', 3 => '5', 4 => '6', 5 => true, 6 => null, 7 => '9!', 8 => false, 9 => '11', ...]
-    arg.foo => bar
-    arg.2 => additional
-    return_value => 2
-    _dd.p.dm => -1
   recursion (traced_attribute.php, recursion, cli)
     _dd.p.dm => -1
     recursion (traced_attribute.php, recursion, cli)

--- a/tests/ext/traced_attribute.phpt
+++ b/tests/ext/traced_attribute.phpt
@@ -10,33 +10,33 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 include __DIR__ . '/sandbox/dd_dumper.inc';
 
 class Foo {
-    #[DDTrace\Traced(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", 1 => "ignored"])]
+    #[DDTrace\Trace(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", 1 => "ignored"])]
     static function simple($arg) {}
 
-    #[DDTrace\Traced(args: ["foo"])]
+    #[DDTrace\Trace(saveArgs: ["foo"])]
     static function argRestricted($bar, $foo) {
         return 2;
     }
 
-    #[DDTrace\Traced(args: true, return: true)]
+    #[DDTrace\Trace(saveArgs: true, saveReturn: true)]
     static function allArgs($bar, $foo) {
         return 2;
     }
 }
 
-#[DDTrace\Traced]
+#[DDTrace\Trace]
 function bar() {
     Foo::simple(1);
 }
 
-#[DDTrace\Traced]
+#[DDTrace\Trace]
 function recursion($i = 2) {
     if ($i) {
         recursion($i - 1);
     }
 }
 
-#[DDTrace\Traced(recurse: false)]
+#[DDTrace\Trace(recurse: false)]
 function noRecursion($i = 2) {
     if ($i) {
         noRecursion($i - 1);

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -44,9 +44,15 @@ typedef zend_ulong zai_install_address;
 /* {{{ zai_hook_install_resolved may only be executed during request
         this API requires no symbol names, or resolution, it may be used
         to associate a hook with anonymous symbols
-        ie. generators, closures, fibers */
+        i.e. generators, closures, fibers */
 zend_long zai_hook_install_resolved(zend_function *function,
         zai_hook_begin begin, zai_hook_end end,
+        zai_hook_aux aux, size_t dynamic); /* }}} */
+
+/* {{{ zai_hook_install_resolved_generator may only be executed during request
+        this API works similarly to zai_hook_install_resolved */
+zend_long zai_hook_install_resolved_generator(zend_function *function,
+        zai_hook_begin begin, zai_hook_generator_resume resumption, zai_hook_generator_yield yield, zai_hook_end end,
         zai_hook_aux aux, size_t dynamic); /* }}} */
 
 /* {{{ zai_hook_remove removes a hook from the request local hook tables. It does not touch static hook tables. */
@@ -87,6 +93,7 @@ extern __thread HashTable zai_hook_resolved;
 
 #if PHP_VERSION_ID >= 80000
 extern void (*zai_hook_on_update)(zend_function *func, bool remove);
+extern void (*zai_hook_on_function_resolve)(zend_function *func);
 #endif
 
 typedef struct {


### PR DESCRIPTION
### Description

Adds a DDTrace\Trace Attribute for PHP 8, to trace functions inline with annotations.

It provides the following named args:
```
        string $name = "",
        string $resource = "",
        string $type = "",
        string $service = "",
        array $tags = [],
        bool|array $args = false,
        bool $return = false,
        bool $recurse = true,
        bool $run_if_limited = false
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
