### PR TITLE
feat(profiling): compile `allocation-profiling` feature by default

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -28,6 +28,7 @@ rand = { version = "0.8.5" }
 rand_distr = { version = "0.4.3" }
 
 [features]
+default = ["allocation_profiling"]
 allocation_profiling = []
 
 [build-dependencies]


### PR DESCRIPTION
### Description

This will build the `allocation-profiling` feature by default from now on.

An alternative approach would have been to remove all `#[cfg(feature = "allocation_profiling")]` from the source code, but the chosen path allows a quicker (and easier) rollback in case something goes wrong in the time until the beta release.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
