### PR TITLE
Add 128-bit trace id generation and propagation via _dd.p.tid

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -113,6 +113,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                    \
     CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
     CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \
+    CONFIG(BOOL, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED, "false")                                         \
     CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                       \
            DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                           \
     CONFIG(INT, DD_TRACE_AGENT_ATTEMPT_RETRY_TIME_MSEC,                                                        \

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1858,7 +1858,7 @@ static void dd_apply_propagated_values_to_existing_spans(void) {
         if (!DDTRACE_G(distributed_trace_id).low && !DDTRACE_G(distributed_trace_id).high) {
             span->trace_id = (ddtrace_trace_id) {
                 .low = span->root->span_id,
-                .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / 1000000000L : 0,
+                .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / UINT64_C(1000000000) : 0,
             };
         } else {
             span->trace_id = DDTRACE_G(distributed_trace_id);

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1858,7 +1858,7 @@ static void dd_apply_propagated_values_to_existing_spans(void) {
         if (!DDTRACE_G(distributed_trace_id).low && !DDTRACE_G(distributed_trace_id).high) {
             span->trace_id = (ddtrace_trace_id) {
                 .low = span->root->span_id,
-                .high = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start : 0,
+                .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / 1000000000L : 0,
             };
         } else {
             span->trace_id = DDTRACE_G(distributed_trace_id);

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -78,8 +78,11 @@ typedef struct {
     union {
         uint64_t high;
         struct {
-            uint32_t padding; // zeroes
-            uint32_t time;
+            ZEND_ENDIAN_LOHI(
+                uint32_t padding // zeroes
+            ,
+                uint32_t time
+            )
         };
     };
 } ddtrace_trace_id;

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -75,7 +75,13 @@ typedef struct {
 
 typedef struct {
     uint64_t low;
-    uint64_t high;
+    union {
+        uint64_t high;
+        struct {
+            uint32_t padding; // zeroes
+            uint32_t time;
+        };
+    };
 } ddtrace_trace_id;
 
 // clang-format off

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -745,6 +745,10 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
         add_assoc_long(el, "error", 1);
     }
 
+    if (span->trace_id.high) {
+        add_assoc_str(meta, "_dd.p.tid", zend_strpprintf(0, "%" PRIx64, span->trace_id.high));
+    }
+
     if (zend_array_count(Z_ARRVAL_P(meta))) {
         add_assoc_zval(el, "meta", meta);
     } else {

--- a/ext/span.c
+++ b/ext/span.c
@@ -142,6 +142,11 @@ void ddtrace_open_span(ddtrace_span_data *span) {
     // All open spans hold a ref to their stack
     ZVAL_OBJ_COPY(&span->property_stack, &stack->std);
 
+    span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);
+    // Start time is nanoseconds from unix epoch
+    // @see https://docs.datadoghq.com/api/?lang=python#send-traces
+    span->start = _get_nanoseconds(USE_REALTIME_CLOCK);
+
     span->span_id = ddtrace_generate_span_id();
     // if not a root span or the true root span (distributed tracing)
     bool root_span = DDTRACE_G(active_stack)->root_span == NULL;
@@ -158,12 +163,9 @@ void ddtrace_open_span(ddtrace_span_data *span) {
 set_trace_id_from_span_id:
         span->trace_id = (ddtrace_trace_id){
             .low = span->span_id,
+            .high = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start : 0,
         };
     }
-    span->duration_start = _get_nanoseconds(USE_MONOTONIC_CLOCK);
-    // Start time is nanoseconds from unix epoch
-    // @see https://docs.datadoghq.com/api/?lang=python#send-traces
-    span->start = _get_nanoseconds(USE_REALTIME_CLOCK);
 
     ddtrace_span_data *parent_span = DDTRACE_G(active_stack)->active;
     ZVAL_OBJ(&DDTRACE_G(active_stack)->property_active, &span->std);

--- a/ext/span.c
+++ b/ext/span.c
@@ -163,7 +163,7 @@ void ddtrace_open_span(ddtrace_span_data *span) {
 set_trace_id_from_span_id:
         span->trace_id = (ddtrace_trace_id){
             .low = span->span_id,
-            .high = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start : 0,
+            .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / 1000000000L : 0,
         };
     }
 

--- a/ext/span.c
+++ b/ext/span.c
@@ -120,7 +120,7 @@ void ddtrace_free_span_stacks(bool silent) {
 static uint64_t _get_nanoseconds(bool monotonic_clock) {
     struct timespec time;
     if (clock_gettime(monotonic_clock ? CLOCK_MONOTONIC : CLOCK_REALTIME, &time) == 0) {
-        return time.tv_sec * 1000000000L + time.tv_nsec;
+        return time.tv_sec * UINT64_C(1000000000) + time.tv_nsec;
     }
     return 0;
 }
@@ -163,7 +163,7 @@ void ddtrace_open_span(ddtrace_span_data *span) {
 set_trace_id_from_span_id:
         span->trace_id = (ddtrace_trace_id){
             .low = span->span_id,
-            .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / 1000000000L : 0,
+            .time = get_DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED() ? span->start / UINT64_C(1000000000) : 0,
         };
     }
 

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.c
@@ -102,6 +102,7 @@ zend_string *ddtrace_format_propagated_tags(void) {
     // we propagate all tags on the current root span which were originally propagated, including the explicitly
     // defined tags here
     zend_hash_str_del(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.upstream_services"));
+    zend_hash_str_del(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.tid"));
     zend_hash_str_add_empty_element(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.dm"));
 
     zend_array *tags = &DDTRACE_G(root_span_tags_preset);
@@ -111,6 +112,11 @@ zend_string *ddtrace_format_propagated_tags(void) {
     }
 
     smart_str taglist = {0};
+
+    ddtrace_trace_id trace_id = ddtrace_peek_trace_id();
+    if (trace_id.high) {
+        smart_str_append_printf(&taglist, "_dd.p.tid=%" PRIx64, trace_id.high);
+    }
 
     zend_string *tagname;
     ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {

--- a/tests/ext/generate_128_bit_trace_id.phpt
+++ b/tests/ext/generate_128_bit_trace_id.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test 128 bit generation
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+ini_set("datadog.trace.128_bit_traceid_generation_enabled", "1");
+DDTrace\start_span();
+var_dump(\DDTrace\trace_id() > 2 ** 64);
+
+ini_set("datadog.trace.128_bit_traceid_generation_enabled", "0");
+DDTrace\set_distributed_tracing_context(0, 0);
+var_dump(\DDTrace\trace_id() < 2 ** 64);
+
+ini_set("datadog.trace.128_bit_traceid_generation_enabled", "1");
+DDTrace\set_distributed_tracing_context(0, 0);
+var_dump(\DDTrace\trace_id() > 2 ** 64);
+$first_trace_id = \DDTrace\trace_id();
+DDTrace\close_span();
+
+ini_set("datadog.trace.128_bit_traceid_generation_enabled", "0");
+DDTrace\start_span();
+var_dump(\DDTrace\trace_id() < 2 ** 64);
+DDTrace\close_span();
+
+$spans = dd_trace_serialize_closed_spans();
+var_dump(!isset($spans[0]["meta"]["_dd.p.tid"]));
+var_dump(hexdec($spans[1]["meta"]["_dd.p.tid"]) == $spans[1]["start"]);
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/ext/generate_128_bit_trace_id.phpt
+++ b/tests/ext/generate_128_bit_trace_id.phpt
@@ -26,7 +26,7 @@ DDTrace\close_span();
 
 $spans = dd_trace_serialize_closed_spans();
 var_dump(!isset($spans[0]["meta"]["_dd.p.tid"]));
-var_dump(hexdec($spans[1]["meta"]["_dd.p.tid"]) == $spans[1]["start"]);
+var_dump(hexdec($spans[1]["meta"]["_dd.p.tid"]) == floor($spans[1]["start"] / 1000000000) * (1 << 32));
 
 ?>
 --EXPECT--

--- a/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
@@ -45,9 +45,9 @@ echo 'Done.' . PHP_EOL;
 --EXPECTF--
 b3: 12345678901234567890123456789012-6543210987654321-d
 traceparent: 00-12345678901234567890123456789012-6543210987654321-01
-tracestate: dd=o:phpt-test;s:2;t.test:qvalue;unknown1:val;unknown2:1,foo=bar:;=,baz=qux
+tracestate: dd=o:phpt-test;s:2;t.tid:1234567890123456;t.test:qvalue;unknown1:val;unknown2:1,foo=bar:;=,baz=qux
 x-datadog-origin: phpt-test
-x-datadog-tags: _dd.p.test=qvalue
+x-datadog-tags: _dd.p.tid=1234567890123456,_dd.p.test=qvalue
 bool(false)
 Done.
 No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

Adds a new `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false` config option.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
