### PR TITLE
[PROF-6813] add allocation profiling ini setting to `datadog-setup.php`

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1165,6 +1165,12 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
             'description' => 'Enable the CPU profile type.',
         ],
         [
+            'name' => 'datadog.profiling.experimental_allocation_enabled',
+            'default' => '1',
+            'commented' => true,
+            'description' => 'Enable the allocation profile type.',
+        ],
+        [
             'name' => 'datadog.profiling.log_level',
             'default' => 'off',
             'commented' => true,


### PR DESCRIPTION
### Description

This will add the `datadog.profiling.experimental_allocation_enabled` ini setting to the `datadog-setup.php`

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
