### PR TITLE
Bump profiler version for upcoming release

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"


### PR DESCRIPTION
### Description

this will bump the profiler version from `0.12.0` to `0.13.0` for the upcoming release

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
