### PR TITLE
Make active_stack infaillible: there always exists a stack

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1748,7 +1748,7 @@ static PHP_FUNCTION(close_span) {
 /* {{{ proto string DDTrace\active_stack() */
 static PHP_FUNCTION(active_stack) {
     UNUSED(execute_data);
-    if (DDTRACE_G(disable)) {
+    if (!DDTRACE_G(active_stack)) {
         RETURN_NULL();
     }
     RETURN_OBJ_COPY(&DDTRACE_G(active_stack)->std);
@@ -1777,7 +1777,7 @@ static PHP_FUNCTION(switch_stack) {
         RETURN_FALSE;
     }
 
-    if (DDTRACE_G(disable)) {
+    if (!DDTRACE_G(active_stack)) {
         RETURN_NULL();
     }
 
@@ -2050,7 +2050,7 @@ static PHP_FUNCTION(set_priority_sampling) {
         RETURN_FALSE;
     }
 
-    if (global || DDTRACE_G(disable) || !DDTRACE_G(active_stack)->root_span) {
+    if (global || !DDTRACE_G(active_stack) || !DDTRACE_G(active_stack)->root_span) {
         DDTRACE_G(default_priority_sampling) = priority;
     } else {
         ddtrace_set_prioritySampling_on_root(priority);
@@ -2065,7 +2065,7 @@ static PHP_FUNCTION(get_priority_sampling) {
         RETURN_NULL();
     }
 
-    if (global || DDTRACE_G(disable) || !DDTRACE_G(active_stack)->root_span) {
+    if (global || !DDTRACE_G(active_stack) || !DDTRACE_G(active_stack)->root_span) {
         RETURN_LONG(DDTRACE_G(default_priority_sampling));
     }
 

--- a/ext/profiling.c
+++ b/ext/profiling.c
@@ -8,7 +8,7 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 DDTRACE_PUBLIC struct ddtrace_profiling_context ddtrace_get_profiling_context(void) {
     struct ddtrace_profiling_context context = {0, 0};
-    if (get_DD_TRACE_ENABLED() && DDTRACE_G(active_stack)->root_span) {
+    if (get_DD_TRACE_ENABLED() && DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span) {
         context.local_root_span_id = DDTRACE_G(active_stack)->root_span->span_id;
         context.span_id = ddtrace_active_span()->span_id;
     }

--- a/ext/span.c
+++ b/ext/span.c
@@ -307,7 +307,7 @@ DDTRACE_PUBLIC bool ddtrace_root_span_add_tag(zend_string *tag, zval *value) {
 }
 
 bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {
-    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value) || DDTRACE_G(disable)) {
+    if (Z_TYPE_P(old_value) == Z_TYPE_P(new_value) || !DDTRACE_G(active_stack)) {
         return true;
     }
 

--- a/ext/span.c
+++ b/ext/span.c
@@ -25,8 +25,6 @@ static void dd_reset_span_counters(void) {
 }
 
 void ddtrace_init_span_stacks(void) {
-    DDTRACE_G(active_stack) = NULL;
-    DDTRACE_G(active_stack) = ddtrace_init_root_span_stack();
     DDTRACE_G(top_closed_stack) = NULL;
     dd_reset_span_counters();
 }
@@ -56,11 +54,14 @@ static void dd_free_span_ring(ddtrace_span_data *span) {
 }
 
 void ddtrace_free_span_stacks(bool silent) {
+    // ensure automatic stacks of trace root spans are popped
+    while (DDTRACE_G(active_stack)->root_span && DDTRACE_G(active_stack) == DDTRACE_G(active_stack)->root_span->stack) {
+        ddtrace_switch_span_stack(DDTRACE_G(active_stack)->parent_stack);
+    }
+
     zend_objects_store *objects = &EG(objects_store);
     zend_object **end = objects->object_buckets + 1;
     zend_object **obj_ptr = objects->object_buckets + objects->top;
-
-    OBJ_RELEASE(&DDTRACE_G(active_stack)->std);
 
     do {
         obj_ptr--;
@@ -111,7 +112,6 @@ void ddtrace_free_span_stacks(bool silent) {
     DDTRACE_G(open_spans_count) = 0;
     DDTRACE_G(dropped_spans_count) = 0;
     DDTRACE_G(closed_spans_count) = 0;
-    DDTRACE_G(active_stack) = NULL;
     DDTRACE_G(top_closed_stack) = NULL;
 }
 
@@ -312,7 +312,7 @@ bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {
     }
 
     if (Z_TYPE_P(old_value) == IS_FALSE) {
-        if (DDTRACE_G(active_stack) == NULL) {
+        if (DDTRACE_G(active_stack)->root_span == NULL) {
             ddtrace_push_root_span();
             return true;
         }
@@ -323,8 +323,10 @@ bool ddtrace_span_alter_root_span_config(zval *old_value, zval *new_value) {
         }
         if (DDTRACE_G(active_stack)->active == DDTRACE_G(active_stack)->root_span && DDTRACE_G(active_stack)->closed_ring == NULL) {
             ddtrace_span_data *span = DDTRACE_G(active_stack)->root_span;
+            ddtrace_span_stack *root_stack = span->stack->parent_stack;
             DDTRACE_G(active_stack)->root_span = NULL; // As a special case, always hard-drop a root span dropped due to a config change
             ddtrace_drop_span(span);
+            ddtrace_switch_span_stack(root_stack);
             return true;
         } else {
             return false;

--- a/tests/ext/fibers/enable_tracer_in_fiber.phpt
+++ b/tests/ext/fibers/enable_tracer_in_fiber.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Ensure the tracer can also be enabled or disabled in fibers
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) die("skip: Fibers are a PHP 8.1+ feature"); ?>
+--INI--
+datadog.trace.enabled=0
+--FILE--
+<?php
+
+$fiber = new Fiber(function() {
+    var_dump(spl_object_id(DDTrace\active_stack()));
+    ini_set("datadog.trace.enabled", "1");
+    var_dump(spl_object_id(DDTrace\active_stack()));
+});
+
+$fiber->start();
+
+var_dump(spl_object_id(DDTrace\active_stack()));
+
+$fiber = new Fiber(function() {
+    ini_set("datadog.trace.enabled", "0");
+});
+
+$fiber->start();
+
+var_dump(spl_object_id(DDTrace\active_stack()));
+
+?>
+--EXPECT--
+int(4)
+int(4)
+int(1)
+int(1)


### PR DESCRIPTION
### Description

This fixes a crash with toggling the tracing within fibers.

Additionally add another safety NULL-check to ensure #1880 cannot happen. (Blackfire executes code before ddtrace RINIT.)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
