### PR TITLE
Fix empty profiles if sample types and samples values mismatch

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -890,13 +890,6 @@ impl Profiler {
             sample_values.push(samples.alloc_size);
         }
 
-        let mut sample_values = vec![
-            samples.interrupt_count,
-            samples.wall_time,
-            samples.alloc_samples,
-            samples.alloc_size,
-        ];
-
         if locals.profiling_experimental_cpu_time_enabled {
             sample_types.push(ValueType {
                 r#type: Cow::Borrowed("cpu-time"),


### PR DESCRIPTION
### Description

This removes left over code that leads to a situation where profiles could be empty, when allocation profiling was disabled as the `sample_values` and `sample_types` would not match anymore.

The code removed is leftover from an earlier refactoring in #1815 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
