### PR TITLE
Revert bogus revert commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ aliases:
 
         export CIRCLE_REPOSITORY_URL="${CIRCLE_REPOSITORY_URL/git@github.com:/https://github.com/}"
 
-        if [ -e '/home/circleci/datadog/.git' ] ; then
+        if [ -e "$HOME/datadog/.git" ] ; then
           echo 'Fetching into existing repository'
           existing_repo='true'
-          cd '/home/circleci/datadog'
+          cd "$HOME/datadog"
           git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
 
           echo 'Fetching from remote repository'
@@ -177,8 +177,8 @@ aliases:
         else
           echo 'Cloning git repository'
           existing_repo='false'
-          mkdir -p '/home/circleci/datadog'
-          cd '/home/circleci/datadog'
+          mkdir -p "$HOME/datadog"
+          cd "$HOME/datadog"
           git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
         fi
 
@@ -370,6 +370,10 @@ jobs:
     docker:
       - image: cimg/php:8.1-node
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - lib_curl_workaround:
           command: sudo apt update; sudo apt -y install libcurl4-nss-dev
@@ -415,6 +419,10 @@ jobs:
     docker:
       - image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - lib_curl_workaround:
           command: sudo apt update; sudo apt -y install libcurl4-nss-dev
@@ -434,6 +442,15 @@ jobs:
     docker:
       - image: datadog/dd-trace-ci:php-nginx-apache2
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Install git
+          command: |
+            apt-get update
+            apt-get install -y git
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Start Supervisor
@@ -442,8 +459,8 @@ jobs:
       - run:
           name: Copy post-install script
           command: |
-              mkdir -p /src/ddtrace-scripts
-              cp package/post-install.sh /src/ddtrace-scripts
+            mkdir -p /src/ddtrace-scripts
+            cp package/post-install.sh /src/ddtrace-scripts
       - run:
           name: Test post-install hook
           command: bash tests/PostInstallHook/run-tests.sh
@@ -462,6 +479,10 @@ jobs:
       name: with_agent
       docker_image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_EXPORT_CI_ENV
@@ -508,6 +529,10 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
@@ -556,6 +581,10 @@ jobs:
     #   DD_AGENT_HOST: 127.0.0.1
     #   DATADOG_HAVE_DEV_ENV: 1
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install php
@@ -616,6 +645,10 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
@@ -681,6 +714,10 @@ jobs:
     environment:
       COMPOSER_PROCESS_TIMEOUT: 0
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
@@ -723,6 +760,10 @@ jobs:
       name: with_agent
       docker_image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
@@ -804,6 +845,10 @@ jobs:
     environment:
       COMPOSER_PROCESS_TIMEOUT: 0
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
@@ -848,6 +893,10 @@ jobs:
       name: with_httpbin_and_request_replayer
       docker_image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
@@ -905,6 +954,10 @@ jobs:
       name: with_httpbin_and_request_replayer
       docker_image: datadog/dd-trace-ci:php-<< parameters.php_version >>-shared-ext
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
@@ -945,6 +998,10 @@ jobs:
       name: with_agent
       docker_image: cimg/php:7.3
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_remote_docker
       - run: make -f dockerfiles/frameworks/Makefile << parameters.framework_target >>
@@ -977,6 +1034,13 @@ jobs:
           # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
           name: Install ca-certificates
           command: apk add --no-cache ca-certificates
+      - run:
+          name: Install git
+          command: apk add git
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Validate alpine package
@@ -1007,6 +1071,15 @@ jobs:
           INSTALL_TYPE: << parameters.install_type >>
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Install git
+          command: |
+            yum update -y
+            yum install -y git
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Validate centos package
@@ -1023,6 +1096,15 @@ jobs:
     machine:
       image: ubuntu-2004:202111-02
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Install git
+          command: |
+            yum update -y
+            yum install -y git
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run: mkdir -p test-results
       - run:
@@ -1060,6 +1142,15 @@ jobs:
           INSTALL_TYPE: << parameters.install_type >>
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Install git
+          command: |
+            apt-get update
+            apt-get install -y git
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Validate debian package
@@ -1075,6 +1166,15 @@ jobs:
         default: medium
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - run:
+          name: Install git
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y git
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: debian:buster
@@ -1092,6 +1192,13 @@ jobs:
           # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
           name: Install ca-certificates
           command: apk add --no-cache ca-certificates
+      - run:
+          name: Install git
+          command: apk add git
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Test
@@ -1102,6 +1209,10 @@ jobs:
     machine:
       image: ubuntu-2004:202111-02
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           # In order to hard-code the proper version required in tests, we need to regenerate the 'released' installer
@@ -1124,6 +1235,10 @@ jobs:
         # Batch is only used to run a number of this jobs in parallel via a testing matrix.
         type: integer
     steps: &randomized_tests_steps
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           command: ls -al
@@ -1196,6 +1311,10 @@ jobs:
       name: with_agent
       docker_image: "datadog/dd-trace-ci:php-7.4_buster"
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Make PECL build
@@ -1220,6 +1339,10 @@ jobs:
       name: with_httpbin_and_request_replayer
       docker_image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install from PECL build
@@ -1259,6 +1382,10 @@ jobs:
     docker:
       - image: << parameters.docker_image >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cmake << parameters.cmake_version >>
@@ -1368,6 +1495,10 @@ jobs:
     docker:
       - image: datadog/dd-trace-ci:php-<< parameters.php_version >>_<< parameters.os >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cmake << parameters.cmake_version >>
@@ -1513,6 +1644,10 @@ jobs:
     docker:
       - image: datadog/dd-trace-ci:php-<< parameters.php_version >>-shared-ext
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Switch PHP to nts
@@ -1599,6 +1734,10 @@ jobs:
         default: medium
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_major_minor >>
@@ -1629,6 +1768,10 @@ jobs:
         default: medium # mostly for more RAM for ramdisk
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -1741,6 +1884,9 @@ jobs:
     environment:
       - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
@@ -1789,6 +1935,10 @@ jobs:
         type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -1839,12 +1989,9 @@ jobs:
       - run:
           name: Showing folder containing generated files
           command: ls -al ~/datadog/bridge
-      - run:
-          name: Removing composer generated files
-          command: rm -rf ~/datadog/composer.lock ~/datadog/vendor
       - persist_to_workspace:
           root: '.'
-          paths: ['./']
+          paths: ['./bridge/_generated*.php']
 
   "package extension":
     working_directory: ~/datadog
@@ -1854,6 +2001,10 @@ jobs:
         type: boolean
         default: false
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - unless:
           condition: << parameters.asan_build >>
@@ -1903,6 +2054,10 @@ jobs:
     docker:
       - image: datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_major_minor >>
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Run cross-product profiling phpt tests
@@ -1931,6 +2086,10 @@ jobs:
     resource_class: large
     working_directory: ~/datadog
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install good version of docker-compose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_LIBRARY_x86_64_LINUX_GNU:
-    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.81.0/dd-library-php-0.81.0-x86_64-linux-gnu.tar.gz"
+    value: "https://github.com/DataDog/dd-trace-php/releases/download/0.83.1/dd-library-php-0.83.1-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive"
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -842,7 +842,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     if (span->parent) {
         ddtrace_span_data *parent = span->parent;
         while (ddtrace_span_is_dropped(parent)) {
-            parent = span->parent;
+            parent = parent->parent;
         }
         span->parent_id = parent->span_id;
     }

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0" }
 cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
-datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v0.9.0" }
+datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v1.0.0" }
 env_logger = { version = "0.9.3" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -562,7 +562,7 @@ impl Uploader {
             bytes: serialized.buffer.as_slice(),
         }];
         let timeout = Duration::from_secs(10);
-        let request = exporter.build(start, end, files, None, timeout)?;
+        let request = exporter.build(start, end, files, None, None, timeout)?;
         debug!("Sending profile to: {}", index.endpoint);
         let result = exporter.send(request, None)?;
         Ok(result.status().as_u16())

--- a/tests/ext/sandbox-regression/nested_dropped_spans.phpt
+++ b/tests/ext/sandbox-regression/nested_dropped_spans.phpt
@@ -1,0 +1,33 @@
+--TEST--
+[regression] Properly skip nested dropped spans
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+function foo() {
+    DDTrace\start_span()->name = "inner span";
+    DDTrace\close_span();
+}
+
+function bar() {
+    foo();
+}
+
+DDTrace\trace_function('foo', function() { return false; });
+DDTrace\trace_function('bar', function() { return false; });
+
+DDTrace\start_span()->name = "root span";
+bar();
+DDTrace\close_span();
+
+include __DIR__ . '/../sandbox/dd_dumper.inc';
+dd_dump_spans();
+
+?>
+--EXPECTF--
+spans(\DDTrace\SpanData) (1) {
+  root span (nested_dropped_spans.php, root span, cli)
+    _dd.p.dm => -1
+    inner span (nested_dropped_spans.php, inner span, cli)
+}


### PR DESCRIPTION
### Description

Concerning a libdatadog bump to 1.0 and a fix for an infinite loop with nested dropped spans.

This reverts commit 152e5dd79c2101125d2410fa5e4ea99e0d4e4f42.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
