### PR TITLE
Fix running CI in external PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ aliases:
           echo 'Fetching from remote repository'
           if [ -n "$CIRCLE_TAG" ]; then
             git fetch --force --tags origin
-          else
+          elif [ -z "$CIRCLE_PR_NUMBER" ]; then
             git fetch --force origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH"
           fi
         else
@@ -188,6 +188,9 @@ aliases:
           git reset --hard "$CIRCLE_SHA1"
         else
           echo 'Checking out branch'
+          if [ -n "$CIRCLE_PR_NUMBER" ]; then
+            git fetch --force origin "+refs/pull/${CIRCLE_PR_NUMBER}/head:refs/remotes/origin/$CIRCLE_BRANCH"
+          fi
           git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
           git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
         fi


### PR DESCRIPTION
### Description

Allowing CI to run on external pull requests, otherwise it just fails with `fatal: reference is not a tree`.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
