### PR TITLE
Null the parent span of span stacks when resetting the tracer

### DIFF
--- a/tests/ext/span_stack/stack_dropped_parent.phpt
+++ b/tests/ext/span_stack/stack_dropped_parent.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Span stacks are fully reset when the tracer is disabled and re-enabled
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+DDTrace\start_span();
+$stack = DDTrace\create_stack();
+
+ini_set("datadog.trace.enabled", 0);
+ini_set("datadog.trace.enabled", 1);
+
+DDTrace\switch_stack($stack);
+DDTrace\start_span();
+DDTrace\close_span();
+
+$spans = dd_trace_serialize_closed_spans();
+var_dump(count($spans));
+var_dump(isset($spans[0]["parent_id"]));
+
+?>
+--EXPECT--
+int(1)
+bool(false)


### PR DESCRIPTION
### Description

Fixing a crash (under some circumstances, but the test also shows a related misbehaviour) found by internal-api-stress-test.php.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
