### PR TITLE
Export ddtrace_flush_tracer and allow flushing during request startup

### DIFF
--- a/ddtrace.sym
+++ b/ddtrace.sym
@@ -1,3 +1,4 @@
+ddtrace_flush_tracer
 ddtrace_get_profiling_context
 ddtrace_root_span_add_tag
 get_module

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -7,7 +7,7 @@
 #include "serializer.h"
 #include "span.h"
 
-ZEND_RESULT_CODE ddtrace_flush_tracer() {
+DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
     bool success = true;
 
     zval trace, traces;
@@ -16,7 +16,7 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
     // Prevent traces from requests not executing any PHP code:
     // PG(during_request_startup) will only be set to 0 upon execution of any PHP code.
     // e.g. php-fpm call with uri pointing to non-existing file, fpm status page, ...
-    if (PG(during_request_startup)) {
+    if (!force_on_startup && PG(during_request_startup)) {
         zend_array_destroy(Z_ARR(trace));
         return SUCCESS;
     }

--- a/ext/auto_flush.h
+++ b/ext/auto_flush.h
@@ -3,6 +3,7 @@
 
 #include <ddtrace_export.h>
 #include <php.h>
+#include <stdbool.h>
 
 // This function is exported and used by appsec
 DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup);

--- a/ext/auto_flush.h
+++ b/ext/auto_flush.h
@@ -1,8 +1,10 @@
 #ifndef DDTRACE_AUTO_FLUSH_H
 #define DDTRACE_AUTO_FLUSH_H
 
+#include <ddtrace_export.h>
 #include <php.h>
 
-ZEND_RESULT_CODE ddtrace_flush_tracer(void);
+// This function is exported and used by appsec
+DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup);
 
 #endif  // DDTRACE_AUTO_FLUSH_H

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -899,7 +899,7 @@ void dd_force_shutdown_tracing(void) {
     DDTRACE_G(in_shutdown) = true;
 
     ddtrace_close_all_open_spans(true);  // All remaining userland spans (and root span)
-    if (ddtrace_flush_tracer() == FAILURE) {
+    if (ddtrace_flush_tracer(false) == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }
 
@@ -1796,7 +1796,7 @@ static PHP_FUNCTION(flush) {
     if (get_DD_AUTOFINISH_SPANS()) {
         ddtrace_close_userland_spans_until(NULL);
     }
-    if (ddtrace_flush_tracer() == FAILURE) {
+    if (ddtrace_flush_tracer(false) == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }
     RETURN_NULL();

--- a/ext/span.c
+++ b/ext/span.c
@@ -419,7 +419,7 @@ static void dd_close_entry_span_of_stack(ddtrace_span_stack *stack) {
             ddtrace_switch_span_stack(stack->parent_stack);
         }
 
-        if (get_DD_TRACE_AUTO_FLUSH_ENABLED() && ddtrace_flush_tracer() == FAILURE) {
+        if (get_DD_TRACE_AUTO_FLUSH_ENABLED() && ddtrace_flush_tracer(false) == FAILURE) {
             // In case we have root spans enabled, we need to always flush if we close that one (RSHUTDOWN)
             ddtrace_log_debug("Unable to auto flush the tracer");
         }


### PR DESCRIPTION
### Description

Export `ddtrace_flush_tracer` and allow flushing during request startup. Currently appsec blocks the request primarily on RINIT, which results in no traces in the backend, this should allow the ASM extension to flush the traces before blocking.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
