### PR TITLE
Add exported function to close all spans and flush

### DIFF
--- a/ddtrace.sym
+++ b/ddtrace.sym
@@ -1,4 +1,4 @@
-ddtrace_flush_tracer
+ddtrace_close_all_spans_and_flush
 ddtrace_get_profiling_context
 ddtrace_root_span_add_tag
 get_module

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -58,7 +58,6 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
     return success ? SUCCESS : FAILURE;
 }
 
-
 DDTRACE_PUBLIC void ddtrace_close_all_spans_and_flush()
 {
     ddtrace_close_all_open_spans(true);

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -13,7 +13,6 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
     zval trace, traces;
     ddtrace_serialize_closed_spans(&trace);
 
-
     // Prevent traces from requests not executing any PHP code:
     // PG(during_request_startup) will only be set to 0 upon execution of any PHP code.
     // e.g. php-fpm call with uri pointing to non-existing file, fpm status page, ...

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -7,11 +7,12 @@
 #include "serializer.h"
 #include "span.h"
 
-DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
+ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
     bool success = true;
 
     zval trace, traces;
     ddtrace_serialize_closed_spans(&trace);
+
 
     // Prevent traces from requests not executing any PHP code:
     // PG(during_request_startup) will only be set to 0 upon execution of any PHP code.
@@ -56,4 +57,11 @@ DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
     zval_ptr_dtor(&traces);
 
     return success ? SUCCESS : FAILURE;
+}
+
+
+DDTRACE_PUBLIC void ddtrace_close_all_spans_and_flush()
+{
+    ddtrace_close_all_open_spans(true);
+    ddtrace_flush_tracer(true);
 }

--- a/ext/auto_flush.h
+++ b/ext/auto_flush.h
@@ -5,7 +5,9 @@
 #include <php.h>
 #include <stdbool.h>
 
+ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup);
+
 // This function is exported and used by appsec
-DDTRACE_PUBLIC ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup);
+DDTRACE_PUBLIC void ddtrace_close_all_spans_and_flush(void);
 
 #endif  // DDTRACE_AUTO_FLUSH_H


### PR DESCRIPTION
### Description

- Add and export `ddtrace_close_all_spans_and_flush`
- Unexport `ddtrace_flush_tracer`

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
