### PR TITLE
Add hooking for Closures

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -60,6 +60,14 @@
 #define RETURN_COPY(zv) do { RETVAL_COPY(zv); return; } while (0)
 #define RETURN_OBJ_COPY(r) do { RETVAL_OBJ_COPY(r); return; } while (0)
 
+ZEND_API const zend_function *zend_get_closure_method_def(zval *obj);
+static inline const zend_function *dd_zend_get_closure_method_def(zend_object *obj) {
+    zval zv;
+    ZVAL_OBJ(&zv, obj);
+    return zend_get_closure_method_def(&zv);
+}
+#define zend_get_closure_method_def dd_zend_get_closure_method_def
+
 #define ZEND_ARG_OBJ_TYPE_MASK(pass_by_ref, name, class_name, type_mask, default_value) ZEND_ARG_INFO(pass_by_ref, name)
 #define zend_declare_typed_property(ce, name, default, visibility, doc_comment, type) zend_declare_property_ex(ce, name, default, visibility, doc_comment); (void)type
 #define ZEND_TYPE_INIT_MASK(type) NULL
@@ -131,6 +139,9 @@ static inline HashTable *zend_new_array(uint32_t nSize) {
 #define Z_PROTECT_RECURSION_P(zv) (++Z_OBJPROP_P(zv)->u.v.nApplyCount)
 #define Z_UNPROTECT_RECURSION_P(zv) (--Z_OBJPROP_P(zv)->u.v.nApplyCount)
 
+#define ZEND_CLOSURE_OBJECT(op_array) \
+    ((zend_object*)((char*)(op_array) - sizeof(zend_object)))
+
 // make ZEND_STRL work
 #undef zend_hash_str_update
 #define zend_hash_str_update(...) _zend_hash_str_update(__VA_ARGS__ ZEND_FILE_LINE_CC)
@@ -146,6 +157,8 @@ static inline HashTable *zend_new_array(uint32_t nSize) {
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
 
 #if PHP_VERSION_ID < 70200
+#define ZEND_ACC_FAKE_CLOSURE ZEND_ACC_INTERFACE
+
 #define zend_strpprintf strpprintf
 #define zend_vstrpprintf vstrpprintf
 
@@ -159,7 +172,7 @@ static zend_always_inline zend_string *zend_string_init_interned(const char *str
         { (const char*)(zend_uintptr_t)(required_num_args), NULL, type, return_reference, allow_null, 0 },
 #define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
     static const zend_internal_arg_info name[] = { \
-        { (const char*)(zend_uintptr_t)(required_num_args), class_name, IS_OBJECT, return_reference, allow_null, 0 },
+        { (const char*)(zend_uintptr_t)(required_num_args), #class_name, IS_OBJECT, return_reference, allow_null, 0 },
 
 typedef void zend_type;
 

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -25,7 +25,7 @@ static __thread HashTable dd_active_hooks;
 
 typedef struct {
     size_t size;
-    zend_long id[1]; // struct hack
+    zend_long id[];
 } dd_closure_list;
 
 typedef struct {
@@ -313,9 +313,9 @@ PHP_FUNCTION(DDTrace_install_hook) {
             dd_closure_list *hooks;
             if ((hooks_zv = zend_hash_index_find(&dd_closure_hooks, (zend_ulong)(uintptr_t)closure))) {
                 hooks = Z_PTR_P(hooks_zv);
-                Z_PTR_P(hooks_zv) = hooks = erealloc(hooks, sizeof(dd_closure_list) + sizeof(zend_long) * hooks->size++);
+                Z_PTR_P(hooks_zv) = hooks = erealloc(hooks, sizeof(dd_closure_list) + sizeof(zend_long) * ++hooks->size);
             } else {
-                hooks = emalloc(sizeof(dd_closure_list));
+                hooks = emalloc(sizeof(dd_closure_list) + sizeof(zend_long));
                 hooks->size = 1;
                 zend_hash_index_add_new_ptr(&dd_closure_hooks, (zend_ulong)(uintptr_t)closure, hooks);
             }

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -5,31 +5,28 @@
 
 #include "../compatibility.h"
 #include "../configuration.h"
+#include "../logging.h"
 
 #include "uhook_arginfo.h"
 
 #include <hook/hook.h>
 
 #include "uhook.h"
+#include "../ddtrace.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 extern void (*profiling_interrupt_function)(zend_execute_data *);
 
-static inline zval *ddtrace_hookdata_property_id(zend_object *hookdata) {
-    return OBJ_PROP_NUM(hookdata, 0);
-}
-static inline zval *ddtrace_hookdata_property_args(zend_object *hookdata) {
-    return OBJ_PROP_NUM(hookdata, 1);
-}
-static inline zval *ddtrace_hookdata_property_returned(zend_object *hookdata) {
-    return OBJ_PROP_NUM(hookdata, 2);
-}
-static inline zval *ddtrace_hookdata_property_exception(zend_object *hookdata) {
-    return OBJ_PROP_NUM(hookdata, 3);
-}
-
 zend_class_entry *ddtrace_hook_data_ce;
 
+static __thread HashTable dd_closure_hooks;
 static __thread HashTable dd_active_hooks;
+
+typedef struct {
+    size_t size;
+    zend_long id[1]; // struct hack
+} dd_closure_list;
 
 typedef struct {
     zend_object *begin;
@@ -40,11 +37,33 @@ typedef struct {
     zend_function *resolved;
     zend_string *scope;
     zend_string *function;
+    zend_object *closure;
 } dd_uhook_def;
 
 typedef struct {
-    zend_object *hook_data;
+    zend_object std;
+    // first property is $data
+    zval property_id;
+    zval property_args;
+    zval property_returned;
+    zval property_exception;
+    zend_ulong invocation;
+    zend_execute_data *execute_data;
+    ddtrace_span_data *span;
+    ddtrace_span_stack *prior_stack;
+} dd_hook_data;
+
+typedef struct {
+    dd_hook_data *hook_data;
 } dd_uhook_dynamic;
+
+static zend_object *dd_hook_data_create(zend_class_entry *class_type) {
+    dd_hook_data *hook_data = ecalloc(1, sizeof(*hook_data));
+    zend_object_std_init(&hook_data->std, class_type);
+    object_properties_init(&hook_data->std, class_type);
+    hook_data->std.handlers = zend_get_std_object_handlers();
+    return &hook_data->std;
+}
 
 HashTable *dd_uhook_collect_args(zend_execute_data *execute_data) {
     uint32_t num_args = EX_NUM_ARGS();
@@ -89,10 +108,10 @@ HashTable *dd_uhook_collect_args(zend_execute_data *execute_data) {
     return ht;
 }
 
-static void dd_uhook_call_hook(zend_execute_data *execute_data, zend_object *closure, zend_object *hook_data) {
+static void dd_uhook_call_hook(zend_execute_data *execute_data, zend_object *closure, dd_hook_data *hook_data) {
     zval closure_zv, hook_data_zv;
     ZVAL_OBJ(&closure_zv, closure);
-    ZVAL_OBJ(&hook_data_zv, hook_data);
+    ZVAL_OBJ(&hook_data_zv, &hook_data->std);
 
     bool has_this = getThis() != NULL;
     zval rv;
@@ -103,31 +122,49 @@ static void dd_uhook_call_hook(zend_execute_data *execute_data, zend_object *clo
 }
 
 static bool dd_uhook_begin(zend_ulong invocation, zend_execute_data *execute_data, void *auxiliary, void *dynamic) {
-    (void) invocation;
-
     dd_uhook_def *def = auxiliary;
     dd_uhook_dynamic *dyn = dynamic;
 
-    dyn->hook_data = zend_objects_new(ddtrace_hook_data_ce);
-    object_properties_init(dyn->hook_data, ddtrace_hook_data_ce);
+    if (def->closure && def->closure != ZEND_CLOSURE_OBJECT(EX(func))) {
+        dyn->hook_data = NULL;
+        return true;
+    }
 
-    ZVAL_LONG(ddtrace_hookdata_property_id(dyn->hook_data), def->id);
-    ZVAL_ARR(ddtrace_hookdata_property_args(dyn->hook_data), dd_uhook_collect_args(execute_data));
+    dyn->hook_data = (dd_hook_data *)dd_hook_data_create(ddtrace_hook_data_ce);
+
+    dyn->hook_data->invocation = invocation;
+    ZVAL_LONG(&dyn->hook_data->property_id, def->id);
+    ZVAL_ARR(&dyn->hook_data->property_args, dd_uhook_collect_args(execute_data));
 
     if (def->begin && !def->running) {
+        dyn->hook_data->execute_data = execute_data;
+
         def->running = true;
         dd_uhook_call_hook(execute_data, def->begin, dyn->hook_data);
         def->running = false;
     }
+    dyn->hook_data->execute_data = NULL;
 
     return true;
 }
 
 static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data, zval *retval, void *auxiliary, void *dynamic) {
-    (void) invocation;
-
     dd_uhook_def *def = auxiliary;
     dd_uhook_dynamic *dyn = dynamic;
+
+    if (!dyn->hook_data) {
+        return;
+    }
+
+    ddtrace_span_data *span = dyn->hook_data->span;
+    if (span && span->duration != DDTRACE_DROPPED_SPAN && span->duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
+        zval *exception_zv = ddtrace_spandata_property_exception(span);
+        if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
+            ZVAL_OBJ_COPY(exception_zv, EG(exception));
+        }
+
+        dd_trace_stop_span_time(span);
+    }
 
     if (def->end && !def->running) {
         zval tmp;
@@ -143,12 +180,12 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
             profiling_interrupt_function(execute_data);
         }
 
-        zval *returned = ddtrace_hookdata_property_returned(dyn->hook_data);
+        zval *returned = &dyn->hook_data->property_returned;
         ZVAL_COPY_VALUE(&tmp, returned);
         ZVAL_COPY(returned, retval);
         zval_ptr_dtor(&tmp);
 
-        zval *exception = ddtrace_hookdata_property_exception(dyn->hook_data);
+        zval *exception = &dyn->hook_data->property_exception;
         ZVAL_COPY_VALUE(&tmp, exception);
         if (EG(exception)) {
             ZVAL_OBJ_COPY(exception, EG(exception));
@@ -162,7 +199,16 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
         def->running = false;
     }
 
-    OBJ_RELEASE(dyn->hook_data);
+    if (span) {
+        dyn->hook_data->span = NULL;
+        ddtrace_clear_execute_data_span(invocation, true);
+        if (dyn->hook_data->prior_stack) {
+            ddtrace_switch_span_stack(dyn->hook_data->prior_stack);
+            OBJ_RELEASE(&dyn->hook_data->prior_stack->std);
+        }
+    }
+
+    OBJ_RELEASE(&dyn->hook_data->std);
 }
 
 static void dd_uhook_dtor(void *data) {
@@ -193,8 +239,9 @@ PHP_FUNCTION(DDTrace_install_hook) {
     zend_function *resolved = NULL;
     zval *begin = NULL;
     zval *end = NULL;
+    zend_object *closure = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 3)
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 1, 3)
 #if PHP_VERSION_ID < 70200
         Z_PARAM_PROLOGUE(0);
 #else
@@ -205,25 +252,23 @@ PHP_FUNCTION(DDTrace_install_hook) {
 // We disable hooking closures for *now*. The zend_function * of the closure may have a smaller lifetime than any hook. (leading to use after free)
 // Also disabling generators as these may reference closures...
 // A possibility would be that hooking closures only affects the specific closure (override closure dtor / weakref it)? To be evaluated...
-#if 0
         } else if (Z_TYPE_P(_arg) == IS_OBJECT && (Z_OBJCE_P(_arg) == zend_ce_closure || Z_OBJCE_P(_arg) == zend_ce_generator)) {
             if (Z_OBJCE_P(_arg) == zend_ce_closure) {
-#if PHP_VERSION_ID >= 80000
+                closure = Z_OBJ_P(_arg);
                 resolved = (zend_function *)zend_get_closure_method_def(Z_OBJ_P(_arg));
-#else
-                resolved = (zend_function *)zend_get_closure_method_def(_arg);
-#endif
             } else {
                 zend_generator *generator = (zend_generator *)Z_OBJ_P(_arg);
                 if (generator->execute_data) {
                     resolved = generator->execute_data->func;
+                    if (ZEND_CALL_INFO(generator->execute_data) & ZEND_CALL_CLOSURE) {
+                        closure = ZEND_CLOSURE_OBJECT(resolved);
+                    }
                 } else {
                     // we're silent here, right?
                     _error_code = ZPP_ERROR_FAILURE;
                     break;
                 }
             }
-#endif
         } else {
             // we're silent here, right?
             _error_code = ZPP_ERROR_FAILURE;
@@ -258,22 +303,38 @@ PHP_FUNCTION(DDTrace_install_hook) {
     if (resolved) {
         def->resolved = resolved;
         def->function = NULL;
-
+        def->closure = closure;
         id = zai_hook_install_resolved(resolved,
             dd_uhook_begin, dd_uhook_end,
             ZAI_HOOK_AUX(def, dd_uhook_dtor), sizeof(dd_uhook_dynamic));
+
+        if (id >= 0 && closure) {
+            zval *hooks_zv;
+            dd_closure_list *hooks;
+            if ((hooks_zv = zend_hash_index_find(&dd_closure_hooks, (zend_ulong)(uintptr_t)closure))) {
+                hooks = Z_PTR_P(hooks_zv);
+                Z_PTR_P(hooks_zv) = hooks = erealloc(hooks, sizeof(dd_closure_list) + sizeof(zend_long) * hooks->size++);
+            } else {
+                hooks = emalloc(sizeof(dd_closure_list));
+                hooks->size = 1;
+                zend_hash_index_add_new_ptr(&dd_closure_hooks, (zend_ulong)(uintptr_t)closure, hooks);
+            }
+            hooks->id[hooks->size - 1] = id;
+        }
     } else {
         const char *colon = strchr(ZSTR_VAL(name), ':');
         zai_string_view scope = ZAI_STRING_EMPTY, function = {.ptr = ZSTR_VAL(name), .len = ZSTR_LEN(name)};
         if (colon) {
-            function.len = ZSTR_VAL(name) - colon;
+            def->scope = zend_string_init(function.ptr, colon - ZSTR_VAL(name), 0);
             do ++colon; while (*colon == ':');
-            def->scope = zend_string_init(colon, ZSTR_VAL(name) + ZSTR_LEN(name) - colon, 0);
+            def->function = zend_string_init(colon, ZSTR_VAL(name) + ZSTR_LEN(name) - colon, 0);
             scope = (zai_string_view) {.ptr = ZSTR_VAL(def->scope), .len = ZSTR_LEN(def->scope)};
+            function = (zai_string_view) {.ptr = ZSTR_VAL(def->function), .len = ZSTR_LEN(def->function)};
         } else {
             def->scope = NULL;
+            def->function = zend_string_init(function.ptr, function.len, 0);
         }
-        def->function = zend_string_init(function.ptr, function.len, 0);
+        def->closure = NULL;
 
         id = zai_hook_install(
                 scope, function,
@@ -315,12 +376,86 @@ PHP_FUNCTION(DDTrace_remove_hook) {
     }
 }
 
+ZEND_METHOD(DDTrace_HookData, span) {
+    zend_object *stack = NULL;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 0, 1)
+        Z_PARAM_OPTIONAL
+#if PHP_VERSION_ID < 70200
+        Z_PARAM_PROLOGUE(0);
+#else
+        Z_PARAM_PROLOGUE(0, 0);
+#endif
+        if (Z_TYPE_P(_arg) == IS_OBJECT && (Z_OBJCE_P(_arg) == ddtrace_ce_span_data || Z_OBJCE_P(_arg) == ddtrace_ce_span_stack)) {
+            stack = Z_OBJ_P(_arg);
+            if (Z_OBJCE_P(_arg) == ddtrace_ce_span_data) {
+                stack = &((ddtrace_span_data *)stack)->stack->std;
+            }
+        } else {
+            // we're silent here, right?
+            _error_code = ZPP_ERROR_FAILURE;
+            break;
+        }
+    ZEND_PARSE_PARAMETERS_END();
+
+    dd_hook_data *hookData = (dd_hook_data *)Z_OBJ_P(ZEND_THIS);
+
+    if (hookData->span) {
+        RETURN_OBJ_COPY(&hookData->span->std);
+    }
+
+    if (!hookData->execute_data) {
+        RETURN_NULL();
+    }
+
+    // By this functionality we provide the ability to also switch the stack automatically back when the span attached to the function is closed
+    if (stack) {
+        ddtrace_span_data *span = zend_hash_index_find_ptr(&DDTRACE_G(traced_spans), hookData->invocation);
+        if (span) {
+            if (span->stack != (ddtrace_span_stack *)stack) {
+                ddtrace_log_errf("Could not switch stack for hook in %s:%d", zend_get_executed_filename(), zend_get_executed_lineno());
+            }
+        } else {
+            hookData->prior_stack = DDTRACE_G(active_stack);
+            GC_ADDREF(&DDTRACE_G(active_stack)->std);
+            ddtrace_switch_span_stack((ddtrace_span_stack *)stack);
+        }
+    } else if ((hookData->execute_data->func->common.fn_flags & ZEND_ACC_GENERATOR)) {
+        if (!zend_hash_index_exists(&DDTRACE_G(traced_spans), hookData->invocation)) {
+            hookData->prior_stack = DDTRACE_G(active_stack);
+            GC_ADDREF(&DDTRACE_G(active_stack)->std);
+            ddtrace_switch_span_stack(ddtrace_init_span_stack());
+            GC_DELREF(&DDTRACE_G(active_stack)->std);
+        }
+    }
+
+    hookData->span = ddtrace_alloc_execute_data_span(hookData->invocation, hookData->execute_data);
+
+    RETURN_OBJ_COPY(&hookData->span->std);
+}
+
 void zai_uhook_rinit() {
     zend_hash_init(&dd_active_hooks, 8, NULL, NULL, 0);
+    zend_hash_init(&dd_closure_hooks, 8, NULL, NULL, 0);
 }
 
 void zai_uhook_rshutdown() {
+    zend_hash_destroy(&dd_closure_hooks);
     zend_hash_destroy(&dd_active_hooks);
+}
+
+static zend_object_free_obj_t dd_uhook_closure_free_obj;
+static void dd_uhook_closure_free_wrapper(zend_object *object) {
+    dd_closure_list *hooks;
+    zai_install_address address = zai_hook_install_address(zend_get_closure_method_def(object));
+    if ((hooks = zend_hash_index_find_ptr(&dd_closure_hooks, (zend_ulong)(uintptr_t)object))) {
+        for (size_t i = 0; i < hooks->size; ++i) {
+            zai_hook_remove_resolved(address, hooks->id[i]);
+        }
+        efree(hooks);
+        zend_hash_index_del(&dd_closure_hooks, (zend_ulong) (uintptr_t) object);
+    }
+    dd_uhook_closure_free_obj(object);
 }
 
 #if PHP_VERSION_ID >= 80000
@@ -328,17 +463,37 @@ void zai_uhook_attributes_minit(void);
 #endif
 void zai_uhook_minit() {
     ddtrace_hook_data_ce = register_class_DDTrace_HookData();
+    ddtrace_hook_data_ce->create_object = dd_hook_data_create;
+
     zend_register_functions(NULL, ext_functions, NULL, MODULE_PERSISTENT);
+
 #if PHP_VERSION_ID >= 80000
     zai_uhook_attributes_minit();
 #endif
+
+    // get hold of a Closure object to access handlers
+    zend_objects_store objects_store = EG(objects_store);
+    zend_object *closure;
+    EG(objects_store) = (zend_objects_store){
+        .object_buckets = &closure,
+        .free_list_head = 0,
+        .size = 1,
+        .top = 0
+    };
+    zend_ce_closure->create_object(zend_ce_closure);
+
+    dd_uhook_closure_free_obj = closure->handlers->free_obj;
+    ((zend_object_handlers *)closure->handlers)->free_obj = dd_uhook_closure_free_wrapper;
+
+    efree(closure);
+    EG(objects_store) = objects_store;
 }
 
 #if PHP_VERSION_ID >= 80000
 void zai_uhook_attributes_mshutdown(void);
 #endif
 void zai_uhook_mshutdown() {
-    zend_unregister_functions(ext_functions,sizeof(ext_functions) / sizeof(zend_function_entry) - 1,NULL);
+    zend_unregister_functions(ext_functions, sizeof(ext_functions) / sizeof(zend_function_entry) - 1, NULL);
 #if PHP_VERSION_ID >= 80000
     zai_uhook_attributes_mshutdown();
 #endif

--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -5,11 +5,21 @@
 namespace DDTrace;
 
 class HookData {
+    public mixed $data;
     public int $id;
     public array $args;
     public mixed $returned;
     public ?\Throwable $exception;
-    public mixed $data;
+    /**
+     * Creates a span if none exists yet, otherwise returns the span attached to the current function call.
+     *
+     * @param SpanStack|SpanData|null $parent May be specified to start a span on a specific stack.
+     *                                        As an example, when instrumenting closures, it might conceptually make
+     *                                        sense to attach the Closure to the current executing function instead of
+     *                                        where it ends up called. In that case the initial call to span() needs to
+     *                                        provide the proper stack.
+     */
+    public function span(SpanStack|SpanData|null $parent = null): SpanData;
 }
 
 function install_hook(string|\Closure|\Generator $target, ?\Closure $begin, ?\Closure $end): int {}

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9d121c2053e69043217e9fe88d197e9dfcea77a4 */
+ * Stub hash: 21ff52413a495e771ae1b590efcab9349585887d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 3, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
@@ -11,9 +11,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_remove_hook, 0, 1, IS_VO
 	ZEND_ARG_TYPE_INFO(0, id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_HookData_span, 0, 0, DDTrace\\SpanData, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, parent, DDTrace\\SpanStack|DDTrace\\SpanData, MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(DDTrace_install_hook);
 ZEND_FUNCTION(DDTrace_remove_hook);
+ZEND_METHOD(DDTrace_HookData, span);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -24,6 +29,7 @@ static const zend_function_entry ext_functions[] = {
 
 
 static const zend_function_entry class_DDTrace_HookData_methods[] = {
+	ZEND_ME(DDTrace_HookData, span, arginfo_class_DDTrace_HookData_span, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -33,6 +39,12 @@ static zend_class_entry *register_class_DDTrace_HookData(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "HookData", class_DDTrace_HookData_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	zval property_data_default_value;
+	ZVAL_UNDEF(&property_data_default_value);
+	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
+	zend_string_release(property_data_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
@@ -58,12 +70,6 @@ static zend_class_entry *register_class_DDTrace_HookData(void)
 	zend_string *property_exception_name = zend_string_init("exception", sizeof("exception") - 1, 1);
 	zend_declare_typed_property(class_entry, property_exception_name, &property_exception_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_exception_class_Throwable, 0, MAY_BE_NULL));
 	zend_string_release(property_exception_name);
-
-	zval property_data_default_value;
-	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
-	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
-	zend_string_release(property_data_name);
 
 	return class_entry;
 }

--- a/ext/hook/uhook_attributes_arginfo.h
+++ b/ext/hook/uhook_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f89e44d830bdaf827effa53dd5d7643c90974b11 */
+ * Stub hash: 6e695ec08c44692b1b361afd99a4521067cfb6de */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DDTrace_Trace___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 0, "\"\"")

--- a/ext/hook/uhook_legacy.c
+++ b/ext/hook/uhook_legacy.c
@@ -88,11 +88,7 @@ static bool dd_uhook_call(zend_object *closure, bool tracing, dd_uhook_dynamic *
 
         char *deffile;
         int defline = 0;
-#if PHP_VERSION_ID < 80000
-        const zend_function *func = zend_get_closure_method_def(&closure_zv);
-#else
         const zend_function *func = zend_get_closure_method_def(closure);
-#endif
         if (func->type == ZEND_USER_FUNCTION) {
             deffile = ZSTR_VAL(func->op_array.filename);
             defline = (int) func->op_array.opcodes[0].lineno;

--- a/tests/ext/sandbox/dd_dumper.inc
+++ b/tests/ext/sandbox/dd_dumper.inc
@@ -1,6 +1,6 @@
 <?php
 
-function dd_dump_spans()
+function dd_dump_spans($skipMeta = false)
 {
     $spans = dd_trace_serialize_closed_spans();
     $roots = $children = [];
@@ -12,7 +12,7 @@ function dd_dump_spans()
         }
     }
 
-    $printSpan = function($span, $indent = 2) {
+    $printSpan = function($span, $indent = 2) use ($skipMeta) {
         $values = [];
         if (isset($span['service'])) {
             $values[] = $span['service'];
@@ -35,6 +35,9 @@ function dd_dump_spans()
             echo ' (error: ' . $span['meta']['error.message'] . ')';
         }
         if (isset($span['meta'])) {
+            if ($skipMeta) {
+                unset($span['meta']['_dd.p.dm']);
+            }
             echo PHP_EOL;
             foreach ($span['meta'] as $k => $v) {
                 echo str_repeat(' ', $indent) . '  ' . $k . ' => ' . $v . PHP_EOL;

--- a/tests/ext/sandbox/install_hook/trace_closure.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure.phpt
@@ -1,0 +1,82 @@
+--TEST--
+Tracing Closures via install_hook()
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+namespace test;
+
+$topLevelClosure = function($a) {
+    return $a + 1;
+};
+
+function foo() {
+    return function($a) {
+        return $a + 2;
+    };
+}
+
+class bar {
+    static function foo() {
+        return function($a) {
+            return $a + 3;
+        };
+    }
+}
+
+$closures = [$topLevelClosure, foo(), bar::foo()];
+$hooks = [];
+
+foreach ($closures as $i => $closure) {
+    $hooks[] = \DDTrace\install_hook($closure, function(\DDTrace\HookData $hook) use ($i) {
+        $hook->span()->resource = $i;
+        $hook->data = $hook->args[0];
+    }, function(\DDTrace\HookData $hook) {
+        $hook->span()->meta['result'] = $hook->returned;
+    });
+
+    $closure(0);
+}
+
+foo()(0); // Not traced
+
+// Still traced
+foreach ($closures as $closure) {
+    $closure(1);
+}
+
+foreach ($hooks as $hook) {
+    \DDTrace\remove_hook($hook);
+}
+
+// Not traced
+foreach ($closures as $closure) {
+    $closure(2);
+}
+
+include __DIR__ . '/../dd_dumper.inc';
+\dd_dump_spans(true);
+
+?>
+--EXPECTF--
+spans(\DDTrace\SpanData) (6) {
+  test\trace_closure.php:5\{closure} (trace_closure.php, 0, cli)
+    closure.declaration => %s:5
+    result => 1
+  test\foo.{closure} (trace_closure.php, 1, cli)
+    closure.declaration => %s:10
+    result => 2
+  test\bar.foo.{closure} (trace_closure.php, 2, cli)
+    closure.declaration => %s:17
+    result => 3
+  test\trace_closure.php:5\{closure} (trace_closure.php, 0, cli)
+    closure.declaration => %s:5
+    result => 2
+  test\foo.{closure} (trace_closure.php, 1, cli)
+    closure.declaration => %s:10
+    result => 3
+  test\bar.foo.{closure} (trace_closure.php, 2, cli)
+    closure.declaration => %s:17
+    result => 4
+}

--- a/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Tracing Fake Closures via install_hook()
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+function foo() {
+}
+
+$closure = (new ReflectionFunction('foo'))->getClosure();
+
+\DDTrace\install_hook('foo', function(\DDTrace\HookData $hook) {
+    $hook->span()->meta['global'] = 1;
+}, null);
+
+$hook = \DDTrace\install_hook($closure, function(\DDTrace\HookData $hook) {
+    $hook->span()->meta['fake'] = 1;
+}, null);
+
+foo(); // Not traced by closure hook
+$closure();
+
+DDTrace\remove_hook($hook);
+
+// Only foo hook
+$closure();
+foo();
+
+include __DIR__ . '/../dd_dumper.inc';
+\dd_dump_spans(true);
+
+?>
+--EXPECT--
+spans(\DDTrace\SpanData) (4) {
+  foo (trace_closure_from_callable.php, foo, cli)
+    global => 1
+  foo (trace_closure_from_callable.php, foo, cli)
+    global => 1
+    fake => 1
+  foo (trace_closure_from_callable.php, foo, cli)
+    global => 1
+  foo (trace_closure_from_callable.php, foo, cli)
+    global => 1
+}

--- a/tests/ext/sandbox/install_hook/trace_function.phpt
+++ b/tests/ext/sandbox/install_hook/trace_function.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Tracing Functions via install_hook()
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+namespace test;
+
+function foo() {
+    return 1;
+}
+
+class bar {
+    static function foo() {
+        return 2;
+    }
+}
+
+$ids = ['test\foo', 'test\bar::foo'];
+$hooks = [];
+foreach ($ids as $i => $id) {
+    $hooks[] = \DDTrace\install_hook($id, function(\DDTrace\HookData $hook) use ($i) {
+        $hook->span()->resource = $i;
+        $hook->data = $hook->args[0];
+    }, function(\DDTrace\HookData $hook) {
+        $hook->span()->meta['result'] = $hook->returned;
+    });
+
+    $id();
+}
+
+foreach ($hooks as $hook) {
+    \DDTrace\remove_hook($hook);
+}
+
+// Not traced
+foreach ($ids as $id) {
+    $id();
+}
+
+include __DIR__ . '/../dd_dumper.inc';
+\dd_dump_spans(true);
+
+?>
+--EXPECTF--
+spans(\DDTrace\SpanData) (2) {
+  test\foo (trace_function.php, 0, cli)
+    result => 1
+  test\bar.foo (trace_function.php, 1, cli)
+    result => 2
+}

--- a/tests/ext/sandbox/install_hook/trace_generator.phpt
+++ b/tests/ext/sandbox/install_hook/trace_generator.phpt
@@ -30,8 +30,8 @@ include __DIR__ . '/../dd_dumper.inc';
 ?>
 --EXPECTF--
 spans(\DDTrace\SpanData) (1) {
-  test\trace_generator.php:5\{closure} (trace_generator.php, test\trace_generator.php:5\{closure}, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_generator.php:5
+  test\trace_generator.php:%d\{closure} (trace_generator.php, test\trace_generator.php:%d\{closure}, cli)
+    closure.declaration => %s:%d
     result => 3
      (trace_generator.php, cli)
 }

--- a/tests/ext/sandbox/install_hook/trace_generator.phpt
+++ b/tests/ext/sandbox/install_hook/trace_generator.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Tracing Closures via install_hook()
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+namespace test;
+
+$topLevelClosure = function() {
+    yield 1;
+    \DDTrace\start_span();
+    yield 2;
+    \DDTrace\close_span();
+    return 3;
+};
+
+$hooks[] = \DDTrace\install_hook($topLevelClosure, function(\DDTrace\HookData $hook) {
+    $hook->span();
+}, function(\DDTrace\HookData $hook) {
+    $hook->span()->meta['result'] = $hook->returned;
+});
+
+foreach ($topLevelClosure() as $val) {
+}
+
+include __DIR__ . '/../dd_dumper.inc';
+\dd_dump_spans(true);
+
+?>
+--EXPECTF--
+spans(\DDTrace\SpanData) (1) {
+  test\trace_generator.php:5\{closure} (trace_generator.php, test\trace_generator.php:5\{closure}, cli)
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_generator.php:5
+    result => 3
+     (trace_generator.php, cli)
+}

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -96,6 +96,8 @@ extern void (*zai_hook_on_update)(zend_function *func, bool remove);
 extern void (*zai_hook_on_function_resolve)(zend_function *func);
 #endif
 
+zend_function *zai_hook_find_containing_function(zend_function *func);
+
 typedef struct {
     bool active;
     zend_ulong index;
@@ -115,13 +117,13 @@ void zai_hook_iterator_advance(zai_hook_iterator *iterator);
 void zai_hook_iterator_free(zai_hook_iterator *iterator);
 
 /* {{{ */
-static inline zai_install_address zai_hook_install_address_user(zend_op_array *op_array) {
+static inline zai_install_address zai_hook_install_address_user(const zend_op_array *op_array) {
     return ((zend_ulong)op_array->opcodes) >> 5;
 }
-static inline zai_install_address zai_hook_install_address_internal(zend_internal_function *function) {
+static inline zai_install_address zai_hook_install_address_internal(const zend_internal_function *function) {
     return ((zend_ulong)function) >> 5;
 }
-static inline zai_install_address zai_hook_install_address(zend_function *function) {
+static inline zai_install_address zai_hook_install_address(const zend_function *function) {
     if (function->type == ZEND_INTERNAL_FUNCTION) {
         return zai_hook_install_address_internal(&function->internal_function);
     }

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -474,7 +474,7 @@ static void zai_interceptor_observer_placeholder_handler(zend_execute_data *exec
 }
 
 void zai_interceptor_replace_observer(zend_function *func, bool remove) {
-    if (!RUN_TIME_CACHE(&func->op_array)) {
+    if (!RUN_TIME_CACHE(&func->op_array) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
         return;
     }
 
@@ -543,7 +543,7 @@ void zai_interceptor_replace_observer(zend_function *func, bool remove) {
     ZEND_OP_ARRAY_EXTENSION((&(function)->common), zend_observer_fcall_op_array_extension)
 
 void zai_interceptor_replace_observer(zend_function *func, bool remove) {
-    if (!RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func)) {
+    if (!RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
         return;
     }
 


### PR DESCRIPTION
### Description

Extracted from my experiments with revolt; the DDTrace\install_hook() API now got proper instrumentation for Closures. Note that hooks applied to closures only apply to the lifetime of the specific hooked closure.

This makes it trivial to check with a WeakMap whether the Closure already has been hooked.

Additionally the DDTrace\HookData API got a span() method which must be called in the begin handler at least once if the hook is to be traced.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
