### PR TITLE
refactor(profiling): cleanup add/remove interrupts

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -595,7 +595,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
                     engine_ptr: locals.vm_interrupt_addr,
                 };
                 if let Err((index, interrupt)) = profiler.add_interrupt(interrupt) {
-                    warn!("VM interrupt {index} already exists at offset {interrupt}");
+                    warn!("VM interrupt {interrupt} already exists at offset {index}");
                 }
             }
         });

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -663,10 +663,8 @@ impl Profiler {
 
     pub fn add_interrupt(&self, interrupt: VmInterrupt) -> Result<(), (usize, VmInterrupt)> {
         let mut vm_interrupts = self.vm_interrupts.lock().unwrap();
-        for (index, value) in vm_interrupts.iter().enumerate() {
-            if *value == interrupt {
-                return Err((index, interrupt));
-            }
+        if let Some(index) = vm_interrupts.iter().position(|v| v == &interrupt) {
+            return Err((index, interrupt))
         }
         vm_interrupts.push(interrupt);
         Ok(())
@@ -674,19 +672,12 @@ impl Profiler {
 
     pub fn remove_interrupt(&self, interrupt: VmInterrupt) -> Result<(), VmInterrupt> {
         let mut vm_interrupts = self.vm_interrupts.lock().unwrap();
-        let mut offset = None;
-        for (index, value) in vm_interrupts.iter().enumerate() {
-            if *value == interrupt {
-                offset = Some(index);
-                break;
+        match vm_interrupts.iter().position(|v| v == &interrupt) {
+            None => Err(interrupt),
+            Some(index) => {
+                vm_interrupts.swap_remove(index);
+                Ok(())
             }
-        }
-
-        if let Some(index) = offset {
-            vm_interrupts.swap_remove(index);
-            Ok(())
-        } else {
-            Err(interrupt)
         }
     }
 

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -664,7 +664,7 @@ impl Profiler {
     pub fn add_interrupt(&self, interrupt: VmInterrupt) -> Result<(), (usize, VmInterrupt)> {
         let mut vm_interrupts = self.vm_interrupts.lock().unwrap();
         if let Some(index) = vm_interrupts.iter().position(|v| v == &interrupt) {
-            return Err((index, interrupt))
+            return Err((index, interrupt));
         }
         vm_interrupts.push(interrupt);
         Ok(())


### PR DESCRIPTION
### Description

Simplifies the add/remove interrupt code by using the [Iterator::position](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position) function.

Also fixes a very minor mistake in a warning log where `index` and `interrupt` were swapped.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
