### PR TITLE
refactor(profiling): clean up stalk walking

### DIFF
--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -162,15 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,13 +300,14 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "0.9.0"
-source = "git+https://github.com/DataDog/libdatadog?tag=v0.9.0#64aa3e4295dc15fe833c3ffdb1e6d61be3827b3a"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?tag=v1.0.0#cab75f1ec2a64ca7e761423ffa9798412219820d"
 dependencies = [
  "anyhow",
  "bytes",
  "chrono",
  "ddcommon",
+ "derivative",
  "futures",
  "futures-core",
  "futures-util",
@@ -330,7 +322,8 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "prost",
- "prost-build",
+ "rustc-hash",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -338,8 +331,8 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "0.9.0"
-source = "git+https://github.com/DataDog/libdatadog?tag=v0.9.0#64aa3e4295dc15fe833c3ffdb1e6d61be3827b3a"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?tag=v1.0.0#cab75f1ec2a64ca7e761423ffa9798412219820d"
 dependencies = [
  "anyhow",
  "futures",
@@ -360,6 +353,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,21 +381,6 @@ dependencies = [
  "regex",
  "termcolor",
 ]
-
-[[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -510,12 +499,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -657,15 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,12 +765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,16 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,57 +867,25 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -1012,15 +938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,15 +953,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ring"
@@ -1237,20 +1145,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -86,12 +86,10 @@ void ddog_php_prof_copy_long_into_zval(zval *dest, long num) {
  * empty strings will be converted into a string view to a static empty
  * string (single byte of null, len of 0).
  */
-zai_string_view datadog_php_profiling_zend_string_view(zend_string *zstr) {
-    if (!zstr || ZSTR_LEN(zstr) == 0) {
-        return ZAI_STRING_EMPTY;
-    }
-
-    return ZAI_STRING_FROM_ZSTR(zstr);
+zai_string_view ddog_php_prof_zend_string_view(zend_string *zstr) {
+    return (!zstr || ZSTR_LEN(zstr) == 0)
+        ? ZAI_STRING_EMPTY
+        : ZAI_STRING_FROM_ZSTR(zstr);
 }
 
 void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -248,21 +248,21 @@ unsafe fn collect_stack_sample(
     let mut execute_data_ptr = top_execute_data;
 
     while let Some(execute_data) = execute_data_ptr.as_ref() {
-        /* -1 to reserve room for the [truncated] message. In case the backend
-         * and/or frontend have the same limit, without the -1 we'd ironically
-         * truncate our [truncated] message.
-         */
-        if samples.len() >= max_depth - 1 {
-            samples.push(ZendFrame {
-                function: "[truncated]".to_string(),
-                file: None,
-                line: 0,
-            });
-            break;
-        }
-
         if let Some(frame) = collect_call_frame(execute_data) {
             samples.push(frame);
+
+            /* -1 to reserve room for the [truncated] message. In case the
+             * backend and/or frontend have the same limit, without the -1
+             * then ironically the [truncated] message would be truncated.
+             */
+            if samples.len() == max_depth - 1 {
+                samples.push(ZendFrame {
+                    function: "[truncated]".to_string(),
+                    file: None,
+                    line: 0,
+                });
+                break;
+            }
         }
 
         execute_data_ptr = execute_data.prev_execute_data;


### PR DESCRIPTION
### Description

- Filename and lineno are both only used for user functions. Merging them into a single function simplifies the code.
- Using as_ref() on pointers cleans up the code in many places as it allows using methods like `filter` and `map`.
- Renames `datadog_php_profiling_zend_string_view` to `ddog_php_prof_zend_string_view` as per our modern naming.
- Adds new `collect_call_frame` function which is called by `collect_stack_sample` on each iteration of the stack-walking.
- Checking for stack truncation is moved from being done every loop, to only when a sample is pushed. For performance this should be slightly better but almost negligible. It's done because it's more maintainable code, the performance is just a nice cherry on top.

### Motivation

I was investigating the stalk walking in preparation to use the per-function runtime cache to store a `pprof.Function.id`, which should speed us up on a critical performance path. This has a few other prerequisites, but I noticed I could clean this code up. I figured I may as well get this part committed to make that PR smaller when the time comes.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ It's pure refactoring, no test changes.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
