### PR TITLE
perf(profiling): increased allocation sampling distance to 512KiB

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -323,7 +323,7 @@ pub struct RequestLocals {
 /// take a sample every X bytes
 /// this value is temporary but the overhead looks promising, Go profiler samples every 512 KiB
 #[cfg(feature = "allocation_profiling")]
-const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 50.0;
+const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 512.0;
 
 #[cfg(feature = "allocation_profiling")]
 pub struct AllocationProfilingStats {


### PR DESCRIPTION
### Description

Did some benchmarks in relenv and saw that we do not get a better resolution with 50 KB sampling distance compared to 512 KB, but we pay with a higher CPU time overhead.
This PR will lower the sampling distance to 512 KB.

PROF-7186

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~~Tests added for this feature/bug.~~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
