### PR TITLE
Add hooking for abstract methods

### DIFF
--- a/tests/ext/sandbox-regression/abstract_method_hook.phpt
+++ b/tests/ext/sandbox-regression/abstract_method_hook.phpt
@@ -1,0 +1,68 @@
+--TEST--
+[Sandbox regression] Hook implementations of abstract methods
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "EARLY Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("First", "Method", function() {
+    echo "EARLY First HOOK\n";
+});
+
+// Ensure run-time resolving
+if (true) {
+    abstract class Ancestor {
+        public abstract function Method();
+    }
+}
+
+class First extends Ancestor {
+    public function Method() {
+        echo "METHOD First\n";
+    }
+}
+
+class Second extends Ancestor {
+    public function Method() {
+        echo "METHOD Second\n";
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "LATE Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("First", "Method", function() {
+    echo "LATE First HOOK\n";
+});
+
+(new First())->Method();
+(new Second())->Method();
+
+// must have no side effect on the Ancestor hook
+dd_untrace("Method", "Second");
+(new Second())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new First())->Method();
+(new Second())->Method();
+
+?>
+--EXPECT--
+EARLY First HOOK
+LATE First HOOK
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD First
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Second
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Second
+EARLY First HOOK
+LATE First HOOK
+METHOD First
+METHOD Second

--- a/tests/ext/sandbox/abstract_trait_hook.phpt
+++ b/tests/ext/sandbox/abstract_trait_hook.phpt
@@ -1,0 +1,49 @@
+--TEST--
+[Sandbox] Hook implementations of abstract trait methods are not supported
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "EARLY Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "EARLY Base HOOK\n";
+});
+
+// Ensure run-time resolving
+if (true) {
+    trait Ancestor {
+        public abstract function Method();
+    }
+}
+
+class Base {
+    use Ancestor;
+
+    public function Method() {
+        echo "METHOD Base\n";
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "LATE Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "LATE Base HOOK\n";
+});
+
+(new Base())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new Base())->Method();
+
+?>
+--EXPECT--
+EARLY Base HOOK
+LATE Base HOOK
+METHOD Base
+EARLY Base HOOK
+LATE Base HOOK
+METHOD Base

--- a/tests/ext/sandbox/abstract_trait_hook_inherit.phpt
+++ b/tests/ext/sandbox/abstract_trait_hook_inherit.phpt
@@ -1,0 +1,53 @@
+--TEST--
+[Sandbox] Hook implementations of abstract trait methods are not supported
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "EARLY Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "EARLY Base HOOK\n";
+});
+
+// Ensure run-time resolving
+if (true) {
+    trait Ancestor {
+        public abstract function Method();
+    }
+}
+
+abstract class Base {
+    use Ancestor;
+}
+
+class Child extends Base {
+    use Ancestor;
+
+    public function Method() {
+        echo "METHOD Child\n";
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "LATE Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "LATE Base HOOK\n";
+});
+
+(new Child())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new Child())->Method();
+
+?>
+--EXPECT--
+EARLY Base HOOK
+LATE Base HOOK
+METHOD Child
+EARLY Base HOOK
+LATE Base HOOK
+METHOD Child

--- a/tests/ext/sandbox/interface_hook.phpt
+++ b/tests/ext/sandbox/interface_hook.phpt
@@ -1,0 +1,68 @@
+--TEST--
+[Sandbox] Hook implementations of interface methods
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "EARLY Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("First", "Method", function() {
+    echo "EARLY First HOOK\n";
+});
+
+// Ensure run-time resolving
+if (true) {
+    interface Ancestor {
+        public function Method();
+    }
+}
+
+class First implements Ancestor {
+    public function Method() {
+        echo "METHOD First\n";
+    }
+}
+
+class Second implements Ancestor {
+    public function Method() {
+        echo "METHOD Second\n";
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "LATE Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("First", "Method", function() {
+    echo "LATE First HOOK\n";
+});
+
+(new First())->Method();
+(new Second())->Method();
+
+// must have no side effect on the Ancestor hook
+dd_untrace("Method", "Second");
+(new Second())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new First())->Method();
+(new Second())->Method();
+
+?>
+--EXPECT--
+EARLY First HOOK
+LATE First HOOK
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD First
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Second
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Second
+EARLY First HOOK
+LATE First HOOK
+METHOD First
+METHOD Second

--- a/tests/ext/sandbox/interface_hook_internal.phpt
+++ b/tests/ext/sandbox/interface_hook_internal.phpt
@@ -1,0 +1,37 @@
+--TEST--
+[Sandbox] Hook implementations of internal interface methods
+--FILE--
+<?php
+
+DDTrace\hook_method("Throwable", "__toString", function() {
+    echo "Throwable HOOK\n";
+});
+
+class CustomError extends Error {
+    #[ReturnTypeWillChange]
+    public function __toString() {
+        return "CustomError __toString\n";
+    }
+}
+
+echo (new Exception("Exception __toString"))->__toString(), "\n";
+echo (new CustomError)->__toString();
+
+dd_untrace("__toString", "Throwable");
+
+echo (new Exception("Exception __toString\n"))->__toString(), "\n";
+echo (new CustomError)->__toString();
+
+?>
+--EXPECTF--
+Throwable HOOK
+Exception: Exception __toString in %s
+Stack trace:
+#0 {main}
+Throwable HOOK
+CustomError __toString
+Exception: Exception __toString
+ in %s
+Stack trace:
+#0 {main}
+CustomError __toString

--- a/tests/ext/sandbox/interface_inherit_hook.phpt
+++ b/tests/ext/sandbox/interface_inherit_hook.phpt
@@ -1,0 +1,54 @@
+--TEST--
+[Sandbox] Hook implementations of interface methods on direct implementor only
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", [
+    "prehook" => function() {
+        echo "EARLY Ancestor HOOK\n";
+    },
+    "recurse" => true,
+]);
+
+// Ensure run-time resolving
+if (true) {
+    interface Ancestor {
+        public function Method();
+    }
+}
+
+class Base implements Ancestor {
+    public function Method() {
+        echo "METHOD Base\n";
+    }
+}
+
+class Child extends Base {
+    public function Method() {
+        echo "METHOD Child\n";
+        parent::Method();
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", [
+    "prehook" => function() {
+        echo "LATE Ancestor HOOK\n";
+    },
+    "recurse" => true,
+]);
+
+(new Child())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new Child())->Method();
+
+?>
+--EXPECT--
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Child
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Base
+METHOD Child
+METHOD Base

--- a/tests/ext/sandbox/interface_inherit_hook_explicit_reimplement.phpt
+++ b/tests/ext/sandbox/interface_inherit_hook_explicit_reimplement.phpt
@@ -1,0 +1,54 @@
+--TEST--
+[Sandbox] Hook implementations of interface methods on all direct implementors
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", [
+    "prehook" => function() {
+        echo "EARLY Ancestor HOOK\n";
+    },
+    "recurse" => true,
+]);
+
+// Ensure run-time resolving
+if (true) {
+    interface Ancestor {
+        public function Method();
+    }
+}
+
+class Base implements Ancestor {
+    public function Method() {
+        echo "METHOD Base\n";
+    }
+}
+
+class Child extends Base implements Ancestor {
+    public function Method() {
+        echo "METHOD Child\n";
+        parent::Method();
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", [
+    "prehook" => function() {
+        echo "LATE Ancestor HOOK\n";
+    },
+    "recurse" => true,
+]);
+
+(new Child())->Method();
+
+dd_untrace("Method", "Ancestor");
+(new Child())->Method();
+
+?>
+--EXPECT--
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Child
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Base
+METHOD Child
+METHOD Base

--- a/tests/ext/sandbox/interface_inherit_hook_multiple.phpt
+++ b/tests/ext/sandbox/interface_inherit_hook_multiple.phpt
@@ -1,0 +1,53 @@
+--TEST--
+[Sandbox] Hook implementations of interface methods with multiple parent abstract methods of the same name
+--FILE--
+<?php
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "EARLY Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "EARLY Base HOOK\n";
+});
+
+// Ensure run-time resolving
+if (true) {
+    interface Ancestor {
+        public function Method();
+    }
+
+    abstract class Base {
+        public abstract function Method();
+    }
+}
+
+class Child extends Base implements Ancestor {
+    public function Method() {
+        echo "METHOD Child\n";
+    }
+}
+
+DDTrace\hook_method("Ancestor", "Method", function() {
+    echo "LATE Ancestor HOOK\n";
+});
+
+DDTrace\hook_method("Base", "Method", function() {
+    echo "LATE Base HOOK\n";
+});
+
+(new Child())->Method();
+
+dd_untrace("Method", "Base");
+(new Child())->Method();
+
+?>
+--EXPECT--
+EARLY Base HOOK
+LATE Base HOOK
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Child
+EARLY Ancestor HOOK
+LATE Ancestor HOOK
+METHOD Child

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -8,6 +8,7 @@
         Note: installation of hooks may occur after minit */
 bool zai_hook_minit(void);
 bool zai_hook_rinit(void);
+void zai_hook_post_startup(void);
 void zai_hook_activate(void);
 void zai_hook_clean(void);
 void zai_hook_rshutdown(void);

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -1024,6 +1024,7 @@ static int (*prev_post_startup)(void);
 int zai_interceptor_post_startup(void) {
     int result = prev_post_startup ? prev_post_startup() : SUCCESS; // first run opcache post_startup, then ours
 
+    zai_hook_post_startup();
     zai_interceptor_setup_resolving_post_startup();
 
     return result;
@@ -1106,6 +1107,7 @@ void zai_interceptor_startup(zend_module_entry *module_entry) {
     prev_post_startup = zend_post_startup_cb;
     zend_post_startup_cb = zai_interceptor_post_startup;
 #else
+    zai_hook_post_startup();
     zai_interceptor_setup_resolving_post_startup();
 #endif
 }

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -715,6 +715,7 @@ static zend_result (*prev_post_startup)(void);
 zend_result zai_interceptor_post_startup(void) {
     zend_result result = prev_post_startup ? prev_post_startup() : SUCCESS; // first run opcache post_startup, then ours
 
+    zai_hook_post_startup();
     zai_interceptor_setup_resolving_post_startup();
 #if PHP_VERSION_ID < 80200
     zai_registered_observers = (zend_op_array_extension_handles - zend_observer_fcall_op_array_extension) / 2;


### PR DESCRIPTION
### Description

This PR allows tracing of interface and abstract parent methods.

Abstract trait methods are not supported due to complexity with renaming etc. They may be considered in the future, but not now.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
