### PR TITLE
Fix automatic injection of w3c headers

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2382,7 +2382,7 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_string_view, c
     }
 
     // "{version:2}-{trace-id:32}-{parent-id:16}-{trace-flags:2}"
-    if (parse_tracestate && read_header(ZAI_STRL_VIEW("X_TRACEPARENT"), "traceparent", &traceparent, data)) {
+    if (parse_tracestate && read_header(ZAI_STRL_VIEW("TRACEPARENT"), "traceparent", &traceparent, data)) {
         do {
             // version
             char *start = ZSTR_VAL(traceparent), *end = strchr(start, '-');
@@ -2420,7 +2420,7 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_string_view, c
         zend_string_release(traceparent);
 
        // header format: "[*,]dd=s:1;o:rum;t.dm:-4;t.usr.id:12345[,*]"
-        if (read_header(ZAI_STRL_VIEW("X_TRACESTATE"), "tracestate", &tracestate, data)) {
+        if (read_header(ZAI_STRL_VIEW("TRACESTATE"), "tracestate", &tracestate, data)) {
             bool last_comma = true;
             DDTRACE_G(tracestate) = zend_string_alloc(ZSTR_LEN(tracestate), 0);
             char *persist = ZSTR_VAL(DDTRACE_G(tracestate));

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2332,7 +2332,7 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_string_view, c
         ZVAL_STR(&trace_zv, trace_id_str);
         DDTRACE_G(distributed_trace_id) = (ddtrace_trace_id){ .low = ddtrace_parse_userland_span_id(&trace_zv) };
         zend_string_release(trace_id_str);
-    } else if (parse_b3 && read_header(ZAI_STRL_VIEW("X_B3_TRACEID"), "b3-traceid", &trace_id_str, data)) {
+    } else if (parse_b3 && read_header(ZAI_STRL_VIEW("X_B3_TRACEID"), "x-b3-traceid", &trace_id_str, data)) {
         DDTRACE_G(distributed_trace_id) = dd_parse_b3_trace_id(ZSTR_VAL(trace_id_str), ZSTR_LEN(trace_id_str));
         zend_string_release(trace_id_str);
     }
@@ -2351,7 +2351,7 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_string_view, c
         }
     }
 
-    read_header(ZAI_STRL_VIEW("X_DATADOG_ORIGIN"), "datadog-origin", &DDTRACE_G(dd_origin), data);
+    read_header(ZAI_STRL_VIEW("X_DATADOG_ORIGIN"), "x-datadog-origin", &DDTRACE_G(dd_origin), data);
 
     if (parse_datadog && read_header(ZAI_STRL_VIEW("X_DATADOG_SAMPLING_PRIORITY"), "x-datadog-sampling-priority", &priority_str, data)) {
         priority_sampling = strtol(ZSTR_VAL(priority_str), NULL, 10);

--- a/tests/ext/distributed_tracing/distributed_trace_consume.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_consume.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test consume_distributed_tracing_headers()
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+DDTrace\consume_distributed_tracing_headers(function ($header) {
+    return [
+            "x-datadog-trace-id" => 42,
+            "x-datadog-parent-id" => 10,
+            "x-datadog-origin" => "datadog",
+            "x-datadog-sampling-priority" => 3,
+        ][$header] ?? null;
+});
+var_dump(DDTrace\generate_distributed_tracing_headers());
+
+?>
+--EXPECT--
+array(6) {
+  ["x-datadog-sampling-priority"]=>
+  string(1) "3"
+  ["x-datadog-origin"]=>
+  string(7) "datadog"
+  ["x-datadog-trace-id"]=>
+  string(2) "42"
+  ["x-datadog-parent-id"]=>
+  string(2) "10"
+  ["traceparent"]=>
+  string(55) "00-0000000000000000000000000000002a-000000000000000a-01"
+  ["tracestate"]=>
+  string(16) "dd=o:datadog;s:3"
+}

--- a/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
@@ -8,8 +8,8 @@ ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_GENERATE_ROOT_SPAN=0
-HTTP_X_TRACEPARENT=00-12345678901234567890123456789012-6543210987654321-01
-HTTP_X_TRACESTATE=foo=bar:;=,dd=o:phpt-test;unknown1:val;t.test:qvalue;s:2;unknown2:1,baz=qux
+HTTP_TRACEPARENT=00-12345678901234567890123456789012-6543210987654321-01
+HTTP_TRACESTATE=foo=bar:;=,dd=o:phpt-test;unknown1:val;t.test:qvalue;s:2;unknown2:1,baz=qux
 DD_PROPAGATION_STYLE_INJECT=B3 single header,tracecontext
 --FILE--
 <?php


### PR DESCRIPTION
### Description

And manual injection of x-datadog-origin.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
