### PR TITLE
Use checked_sub duration ops for handling cpu time

### DIFF
--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -742,9 +742,9 @@ impl Profiler {
                     let now = cpu_time::ThreadTime::try_now()
                         .expect("CPU time to work since it's worked before during this process");
                     let old_cpu_time = now
-                        .duration_since(last_cpu_time)
-                        .as_nanos()
-                        .try_into()
+                        .as_duration()
+                        .checked_sub(last_cpu_time.as_duration())
+                        .and_then(|t| t.as_nanos().try_into().ok())
                         .unwrap_or(i64::MAX);
                     cpu_time = old_cpu_time;
                     locals.last_cpu_time = Some(now);


### PR DESCRIPTION
### Description

This is never supposed to fail, but better check for it than avoiding it.

Fixes an issue reported in #1880.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
