### PR TITLE
Upgrade CentOS 7 images to Rust 1.64

### DIFF
--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -109,8 +109,8 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.2.2
-        php_sha: d82dda50356cebf6b6e14dbb576b14bc8b85f0f4476a787f0f50611f11eb37d2
+        php_version: 8.2.1
+        php_sha: 6d7b1b8feb14fd1c65a2bc9d0f72c75589a61a946566cf9c3bf9536a5530b635
         php_api: 20220829
     command: build-dd-trace-php
     volumes:

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.2.2.tar.gz
-        phpSha256Hash: d82dda50356cebf6b6e14dbb576b14bc8b85f0f4476a787f0f50611f11eb37d2
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.1.tar.gz
+        phpSha256Hash: 6d7b1b8feb14fd1c65a2bc9d0f72c75589a61a946566cf9c3bf9536a5530b635
 
   php-8.1:
     image: datadog/dd-trace-ci:php-8.1_buster

--- a/dockerfiles/ci/centos/7/base.Dockerfile
+++ b/dockerfiles/ci/centos/7/base.Dockerfile
@@ -149,23 +149,10 @@ RUN source scl_source enable devtoolset-7 \
   && cd - \
   && rm -fr "$FILENAME" "${FILENAME%.tar.gz}" "protobuf-${PROTOBUF_VERSION}"
 
-ARG PROTOBUF_C_VERSION="1.4.0"
-ARG PROTOBUF_C_SHA256="26d98ee9bf18a6eba0d3f855ddec31dbe857667d269bc0b6017335572f85bbcb"
-RUN source scl_source enable devtoolset-7 \
-  && FILENAME=protobuf-c-${PROTOBUF_C_VERSION}.tar.gz \
-  && curl -L  -O "https://github.com/protobuf-c/protobuf-c/releases/download/v${PROTOBUF_C_VERSION}/${FILENAME}" \
-  && tar --no-same-owner -xf "$FILENAME" \
-  && cd ${FILENAME%.tar.gz} \
-  && ./configure --with-pic --disable-shared --enable-static --prefix=/usr/local --libdir=/usr/local/lib64 \
-  && make -j $(nproc) \
-  && make install \
-  && cd - \
-  && rm -fr "$FILENAME" "${FILENAME%.tar.gz}"
-
 # rust sha256sum generated locally after verifying it with sha256
-ARG RUST_VERSION="1.60.0"
-ARG RUST_SHA256_ARM="99c419c2f35d4324446481c39402c7baecd7a8baed7edca9f8d6bbd33c05550c"
-ARG RUST_SHA256_X86="b8a4c3959367d053825e31f90a5eb86418eb0d80cacda52bfa80b078e18150d5"
+ARG RUST_VERSION="1.64.0"
+ARG RUST_SHA256_ARM="7d8860572431bd4ee1b9cd0cd77cf7ff29fdd5b91ed7c92a820f872de6ced558"
+ARG RUST_SHA256_X86="a893977f238291370ab96726a74b6b9ae854dc75fbf5730954d901a93843bf9b"
 # Mount a cache into /rust/cargo if you want to pre-fetch packages or something
 ENV CARGO_HOME=/rust/cargo
 ENV RUSTUP_HOME=/rust/rustup

--- a/dockerfiles/ci/centos/7/docker-compose.yml
+++ b/dockerfiles/ci/centos/7/docker-compose.yml
@@ -98,5 +98,5 @@ services:
         # Avoiding PHP 8.2.2-8.2.3, which have a crash in fibers:
         # https://github.com/php/php-src/commit/95016138a54b3352a0988878cd71c2ebe7cdeca5
         phpTarGzUrl: https://www.php.net/distributions/php-8.2.1.tar.gz
-        phpSha256Hash: 584d2925889a7d388084150865fa238634043f38f2e060c27ffa8ac4d682d5ec
+        phpSha256Hash: 6d7b1b8feb14fd1c65a2bc9d0f72c75589a61a946566cf9c3bf9536a5530b635
     image: 'datadog/dd-trace-ci:php-8.2_centos-7'

--- a/dockerfiles/ci/centos/7/docker-compose.yml
+++ b/dockerfiles/ci/centos/7/docker-compose.yml
@@ -62,8 +62,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "7.4"
-        phpTarGzUrl: https://www.php.net/distributions/php-7.4.30.tar.gz
-        phpSha256Hash: e37ea37e0f79109351ac615da85eb7c2c336101fc5bc802ee79a124a4310dc10
+        phpTarGzUrl: https://www.php.net/distributions/php-7.4.33.tar.gz
+        phpSha256Hash: 5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e
     image: 'datadog/dd-trace-ci:php-7.4_centos-7'
 
   php-8.0:
@@ -73,8 +73,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.0"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.0.21.tar.gz
-        phpSha256Hash: 2f51f6e90e2e8efd3a20db08f0dd61d7f8d5a9362f8c7325f1ad28ccea5be0ac
+        phpTarGzUrl: https://www.php.net/distributions/php-8.0.27.tar.gz
+        phpSha256Hash: fe2376faaf91c28ead89a36e118c177f4a8c9a7280a189b97265da1af1f4d305
     image: 'datadog/dd-trace-ci:php-8.0_centos-7'
 
   php-8.1:
@@ -84,8 +84,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.1"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.1.14.tar.gz
-        phpSha256Hash: 4755af2563ad187ceaf4a3632359c55e3f3be4050e0299e0f713bbb5e0531965
+        phpTarGzUrl: https://www.php.net/distributions/php-8.1.15.tar.gz
+        phpSha256Hash: 4035236180efac535ff4f22db9ef3195672f31e3e0aa88f89c38ac0715beca3b
     image: 'datadog/dd-trace-ci:php-8.1_centos-7'
 
   php-8.2:
@@ -95,6 +95,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://github.com/php/php-src/archive/a814afb08823bb0cdf4ae45f67a7db83c8be9cd7.tar.gz
+        # Avoiding PHP 8.2.2-8.2.3, which have a crash in fibers:
+        # https://github.com/php/php-src/commit/95016138a54b3352a0988878cd71c2ebe7cdeca5
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.1.tar.gz
         phpSha256Hash: 584d2925889a7d388084150865fa238634043f38f2e060c27ffa8ac4d682d5ec
     image: 'datadog/dd-trace-ci:php-8.2_centos-7'


### PR DESCRIPTION
### Description

These images are already pushed, I just forgot to commit them.

We don't need protoc-c anymore since we use Rust.

Edit: We found the need to downgrade PHP 8.2 to 8.2.1 due to this bug:
https://github.com/php/php-src/commit/95016138a54b3352a0988878cd71c2ebe7cdeca5

So, we're taking the opportunity to rebuild and fix this in a few places.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
