### PR TITLE
refactor: cleanup after Rust 1.64 upgrade

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -42,13 +42,9 @@ use crate::bindings::{
 /// a profile tag.
 static PHP_VERSION: OnceCell<String> = OnceCell::new();
 
-lazy_static! {
-    /// The global profiler. Profiler gets made during the first rinit after
-    /// an rinit, and is destroyed on mshutdown.
-    /// In Rust 1.63+, Mutex::new is const and this can be made a regular
-    /// global instead of a lazy_static one.
-    static ref PROFILER: Mutex<Option<Profiler>> = Mutex::new(None);
-}
+/// The global profiler. Profiler gets made during the first rinit after an
+/// minit, and is destroyed on mshutdown.
+static PROFILER: Mutex<Option<Profiler>> = Mutex::new(None);
 
 /// Name of the profiling module and zend_extension. Must not contain any
 /// interior null bytes and must be null terminated.

--- a/profiling/src/profiling.rs
+++ b/profiling/src/profiling.rs
@@ -490,8 +490,8 @@ impl TimeCollector {
                         let vm_interrupts = self.vm_interrupts.lock().unwrap();
 
                         vm_interrupts.iter().for_each(|obj| unsafe {
-                            (&*obj.engine_ptr).store(true, Ordering::SeqCst);
-                            (&*obj.interrupt_count_ptr).fetch_add(1, Ordering::SeqCst);
+                            (*obj.engine_ptr).store(true, Ordering::SeqCst);
+                            (*obj.interrupt_count_ptr).fetch_add(1, Ordering::SeqCst);
                         });
                     }
                 },


### PR DESCRIPTION
### Description

These are minor cleanups from the rust upgrade:

1. Fix a clippy warning.
2. Remove one lazy_static! that held a Mutex. Since Rust 1.63, `Mutex::new` is const.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
