### PR TITLE
Mitigate panic in profiler shutdown, bound timeout

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -1194,47 +1194,28 @@ mod tests {
     #[test]
     fn detect_uri_from_config_works() {
         // expected
-        let endpoint = detect_uri_from_config(
-            None,
-            None,
-            None
-        );
+        let endpoint = detect_uri_from_config(None, None, None);
         let expected = AgentEndpoint::default();
         assert_eq!(endpoint, expected);
 
         // ipv4 host
-        let endpoint = detect_uri_from_config(
-            None,
-            Some(Cow::Owned("127.0.0.1".to_owned())),
-            None
-        );
+        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("127.0.0.1".to_owned())), None);
         let expected = AgentEndpoint::Uri(Uri::from_static("http://127.0.0.1:8126"));
         assert_eq!(endpoint, expected);
 
         // ipv6 host
-        let endpoint = detect_uri_from_config(
-            None,
-            Some(Cow::Owned("::1".to_owned())),
-            None
-        );
+        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("::1".to_owned())), None);
         let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:8126"));
         assert_eq!(endpoint, expected);
 
         // ipv6 host, custom port
-        let endpoint = detect_uri_from_config(
-            None,
-            Some(Cow::Owned("::1".to_owned())),
-            Some(9000),
-        );
+        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("::1".to_owned())), Some(9000));
         let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:9000"));
         assert_eq!(endpoint, expected);
 
         // agent_url
-        let endpoint = detect_uri_from_config(
-            Some(Cow::Owned("http://[::1]:8126".to_owned())),
-            None,
-            None,
-        );
+        let endpoint =
+            detect_uri_from_config(Some(Cow::Owned("http://[::1]:8126".to_owned())), None, None);
         let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:8126"));
         assert_eq!(endpoint, expected);
 


### PR DESCRIPTION
### Description

This mitigation is for issue #1919. It doesn't fix the root cause, which we haven't been able to determine yet.

This also bounds our shutdown timeouts. Before, they _ought_ to have been bounded as a consequence of how the code was written, but this is explicit. It's also a tighter bound than before, 2 seconds instead of 10 seconds.

Also, the new Rust 1.64 formatter apparently formats some things differently, so those are included as well.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
