### PR TITLE
Add an error.stack to curl_exec() on failure

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -114,6 +114,26 @@ static zend_always_inline bool zend_parse_arg_obj(zval *arg, zend_object **dest,
 #define Z_PARAM_OBJ_OR_NULL(dest) \
     Z_PARAM_OBJ_EX(dest, 1, 0)
 
+#define Z_PARAM_OBJ_OF_CLASS_EX2(dest, _ce, check_null, deref, separate) \
+        DD_PARAM_PROLOGUE(deref, separate); \
+        if (UNEXPECTED(!zend_parse_arg_obj(_arg, &dest, _ce, check_null))) { \
+            if (_ce) { \
+                _error = ZSTR_VAL((_ce)->name); \
+                DD_PARAM_ERROR_CODE = ZPP_ERROR_WRONG_CLASS; \
+                break; \
+            } else { \
+                _expected_type = Z_EXPECTED_OBJECT; \
+                DD_PARAM_ERROR_CODE = ZPP_ERROR_WRONG_ARG; \
+                break; \
+            } \
+        }
+
+#define Z_PARAM_OBJ_OF_CLASS_EX(dest, _ce, check_null, separate) \
+    Z_PARAM_OBJ_OF_CLASS_EX2(dest, _ce, check_null, separate, separate)
+
+#define Z_PARAM_OBJ_OF_CLASS(dest, _ce) \
+    Z_PARAM_OBJ_OF_CLASS_EX(dest, _ce, 0, 0)
+
 typedef ZEND_RESULT_CODE zend_result;
 #endif
 

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -59,6 +59,7 @@
 #include "../hook/uhook.h"
 #include "handlers_fiber.h"
 #include "handlers_exception.h"
+#include "exceptions/exceptions.h"
 
 bool ddtrace_has_excluded_module;
 static zend_module_entry *ddtrace_module;
@@ -392,6 +393,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_extract_ip_from_headers, 0, 0, 1)
 ZEND_ARG_INFO(0, headers)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ddtrace_get_sanitized_exception_trace, 0, 0, 1)
+ZEND_ARG_INFO(0, exception)
 ZEND_END_ARG_INFO()
 
 /* Legacy API */
@@ -2149,6 +2154,19 @@ static PHP_FUNCTION(get_priority_sampling) {
     RETURN_LONG(ddtrace_fetch_prioritySampling_from_root());
 }
 
+static PHP_FUNCTION(get_sanitized_exception_trace) {
+    zend_object *ex;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 1, 1)
+        Z_PARAM_OBJ_OF_CLASS(ex, zend_ce_throwable)
+    ZEND_PARSE_PARAMETERS_END_EX({
+        ddtrace_log_debug("unexpected parameter for DDTrace\\get_sanitized_exception_trace. The first argument must be a Throwable.");
+        RETURN_FALSE;
+    });
+
+    RETURN_STR(zai_get_trace_without_args_from_exception(ex));
+}
+
 static PHP_FUNCTION(startup_logs) {
     UNUSED(execute_data);
 
@@ -2237,6 +2255,7 @@ static const zend_function_entry ddtrace_functions[] = {
     DDTRACE_FALIAS(dd_trace_method, trace_method, arginfo_ddtrace_trace_method),
     DDTRACE_NS_FE(hook_function, arginfo_ddtrace_hook_function),
     DDTRACE_NS_FE(hook_method, arginfo_ddtrace_hook_method),
+    DDTRACE_NS_FE(get_sanitized_exception_trace, arginfo_ddtrace_get_sanitized_exception_trace),
     DDTRACE_NS_FE(startup_logs, arginfo_ddtrace_void),
     DDTRACE_NS_FE(find_active_exception, arginfo_ddtrace_void),
     DDTRACE_NS_FE(get_priority_sampling, arginfo_get_priority_sampling),

--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -61,6 +61,9 @@ final class CurlIntegration extends Integration
                 if (isset($retval) && $retval === false) {
                     $span->meta[Tag::ERROR_MSG] = \curl_error($ch);
                     $span->meta[Tag::ERROR_TYPE] = 'curl error';
+                    if (PHP_VERSION_ID >= 70000) {
+                        $span->meta[Tag::ERROR_STACK] = \DDTrace\get_sanitized_exception_trace(new \Exception());
+                    }
                 }
 
                 $info = \curl_getinfo($ch);

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -282,6 +282,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     Tag::COMPONENT => 'curl',
                 ])
                 ->withExistingTagsNames([Tag::ERROR_MSG])
+                ->withExistingTagsNames([Tag::ERROR_STACK])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/')
                 ->setError('curl error'),
@@ -307,6 +308,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     Tag::COMPONENT => 'curl',
                 ])
                 ->withExistingTagsNames([Tag::ERROR_MSG])
+                ->withExistingTagsNames([Tag::ERROR_STACK])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/')
                 ->setError('curl error'),
@@ -333,7 +335,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/')
-                ->setError('curl error', 'Could not resolve host: __i_am_not_real__.invalid'),
+                ->setError('curl error', 'Could not resolve host: __i_am_not_real__.invalid', true),
         ]);
     }
 


### PR DESCRIPTION
### Description

There's no reason for it not be there...

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
