### PR TITLE
Set coredump_filter to include private file mapped areas in dumps

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -735,6 +735,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return SUCCESS;
     }
 
+    ddtrace_set_coredumpfilter();
+
     ddtrace_initialize_span_sampling_limiter();
     ddtrace_limiter_create();
 

--- a/ext/signals.h
+++ b/ext/signals.h
@@ -1,6 +1,7 @@
 #ifndef DD_TRACE_SIGNALS_H
 #define DD_TRACE_SIGNALS_H
 
+void ddtrace_set_coredumpfilter(void);
 void ddtrace_signals_first_rinit(void);
 void ddtrace_signals_mshutdown(void);
 


### PR DESCRIPTION
### Description

This will allow us to debug core dumps without having direct access to the executable.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
