### PR TITLE
Add PSR18 tracing support in Guzzle 7

### DIFF
--- a/src/Integrations/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/Integrations/Integrations/Guzzle/GuzzleIntegration.php
@@ -63,6 +63,32 @@ class GuzzleIntegration extends Integration
             }
         );
 
+        /* Until we support both pre- and post- hooks on the same function, do
+         * not send distributed tracing headers; curl will almost guaranteed do
+         * it for us anyway. Just do a post-hook to get the response.
+         */
+        \DDTrace\trace_method(
+            'GuzzleHttp\Client',
+            'sendRequest',
+            function (SpanData $span, $args, $retval) use ($integration) {
+                $span->resource = 'sendRequest';
+                $span->name = 'GuzzleHttp\Client.sendRequest';
+                $span->service = 'guzzle';
+                $span->type = Type::HTTP_CLIENT;
+                $span->meta[Tag::SPAN_KIND] = 'client';
+                $span->meta[Tag::COMPONENT] = GuzzleIntegration::NAME;
+
+                if (isset($args[0])) {
+                    $integration->addRequestInfo($span, $args[0]);
+                }
+
+                if (isset($retval)) {
+                    /** @var \Psr\Http\Message\ResponseInterface $retval */
+                    $span->meta[Tag::HTTP_STATUS_CODE] = $retval->getStatusCode();
+                }
+            }
+        );
+
         \DDTrace\trace_method(
             'GuzzleHttp\Client',
             'transfer',


### PR DESCRIPTION
### Description

Guzzle 7 implement the PSR18 (Http client) interface. That means the client has a new method named "sendRequest" with an implementation very similar to the "send" method. 

This PR is to add tracing to this "sendRequest" method.

NOTE: I didn't add tests as I'm not really sure how to handle them (currently the tests are for Guzzle V5 and V6 only, but V7 was released in 2020. The V5 is not supported anymore and the V6 is in security fixes only.)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
