### PR TITLE
Add HookData->overrideArguments() method to replace arguments in a pre-hook

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -68,6 +68,7 @@ static inline const zend_function *dd_zend_get_closure_method_def(zend_object *o
 }
 #define zend_get_closure_method_def dd_zend_get_closure_method_def
 
+#define ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, classname, allow_null, default_value) ZEND_ARG_OBJ_INFO(pass_by_ref, name, classname, allow_null)
 #define ZEND_ARG_OBJ_TYPE_MASK(pass_by_ref, name, class_name, type_mask, default_value) ZEND_ARG_INFO(pass_by_ref, name)
 #define zend_declare_typed_property(ce, name, default, visibility, doc_comment, type) zend_declare_property_ex(ce, name, default, visibility, doc_comment); (void)type
 #define ZEND_TYPE_INIT_MASK(type) NULL

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -447,7 +447,7 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
 
     // pre-hook check
     if (!hookData->execute_data) {
-        RETURN_NULL();
+        RETURN_FALSE;
     }
 
     int passed_args = ZEND_CALL_NUM_ARGS(hookData->execute_data);
@@ -455,18 +455,18 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
     if (MAX(func->common.num_args, passed_args) < zend_hash_num_elements(args)) {
         // Adding args would mean that we would have to possibly transfer execute_data to a new stack, but changing that pointer may break all sorts of extensions
         ddtrace_log_errf("Cannot set more args than provided: got too many arguments for hook in %s:%d", zend_get_executed_filename(), zend_get_executed_lineno());
-        RETURN_NULL();
+        RETURN_FALSE;
     }
 
     if (func->common.required_num_args > zend_hash_num_elements(args)) {
         ddtrace_log_errf("Not enough args provided for hook in %s:%d", zend_get_executed_filename(), zend_get_executed_lineno());
-        RETURN_NULL();
+        RETURN_FALSE;
     }
 
     if (ZEND_USER_CODE(func->type) && hookData->execute_data->opline > func->op_array.opcodes + zend_hash_num_elements(args)) {
         ddtrace_log_errf("Can't pass less args to an untyped function than originally passed (minus extra args) in %s:%d",
                          zend_get_executed_filename(), zend_get_executed_lineno());
-        RETURN_NULL();
+        RETURN_FALSE;
     }
 
     // When observers are executed, moving extra args behind the last temporary already happened
@@ -502,7 +502,7 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
         zval_ptr_dtor(++arg);
     }
 
-    RETURN_NULL();
+    RETURN_TRUE;
 }
 
 void zai_uhook_rinit() {

--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -12,6 +12,7 @@ class HookData {
     public ?\Throwable $exception;
     /**
      * Creates a span if none exists yet, otherwise returns the span attached to the current function call.
+     * If called outside the pre-hook and no span is attached yet, it will also return null.
      *
      * @param SpanStack|SpanData|null $parent May be specified to start a span on a specific stack.
      *                                        As an example, when instrumenting closures, it might conceptually make
@@ -20,6 +21,15 @@ class HookData {
      *                                        provide the proper stack.
      */
     public function span(SpanStack|SpanData|null $parent = null): SpanData;
+
+    /**
+     * Replaces the arguments of a function call. Must be called within a pre-hook.
+     * It is not allowed to pass more arguments to a function that currently on the stack or total number or arguments,
+     * whichever is greater.
+     *
+     * @param array $arguments An array of arguments, which will replace the hooked functions arguments.
+     */
+    public function overrideArguments(array $arguments): void;
 }
 
 function install_hook(string|\Closure|\Generator $target, ?\Closure $begin, ?\Closure $end): int {}

--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -28,8 +28,9 @@ class HookData {
      * whichever is greater.
      *
      * @param array $arguments An array of arguments, which will replace the hooked functions arguments.
+     * @return bool 'true' on success, otherwise 'false'
      */
-    public function overrideArguments(array $arguments): void;
+    public function overrideArguments(array $arguments): bool;
 }
 
 function install_hook(string|\Closure|\Generator $target, ?\Closure $begin = null, ?\Closure $end = null): int {}

--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -32,5 +32,5 @@ class HookData {
     public function overrideArguments(array $arguments): void;
 }
 
-function install_hook(string|\Closure|\Generator $target, ?\Closure $begin, ?\Closure $end): int {}
+function install_hook(string|\Closure|\Generator $target, ?\Closure $begin = null, ?\Closure $end = null): int {}
 function remove_hook(int $id): void {}

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b351d95b93fa290c529679c1bdd7c4a42ed7d68 */
+ * Stub hash: dcc1a86fd80805580c286be7a183b1f2f30ccb63 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 1, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
@@ -15,7 +15,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_HookData_span, 0, 0
 	ZEND_ARG_OBJ_TYPE_MASK(0, parent, DDTrace\\SpanStack|DDTrace\\SpanData, MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DDTrace_HookData_overrideArguments, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DDTrace_HookData_overrideArguments, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8aa203fc66096c5880500cc858f94b1c13ba16f3 */
+ * Stub hash: 7b351d95b93fa290c529679c1bdd7c4a42ed7d68 */
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 3, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 1, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
-	ZEND_ARG_OBJ_INFO(0, begin, Closure, 1)
-	ZEND_ARG_OBJ_INFO(0, end, Closure, 1)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, begin, Closure, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, end, Closure, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_remove_hook, 0, 1, IS_VOID, 0)

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 21ff52413a495e771ae1b590efcab9349585887d */
+ * Stub hash: 8aa203fc66096c5880500cc858f94b1c13ba16f3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 3, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
@@ -15,10 +15,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_HookData_span, 0, 0
 	ZEND_ARG_OBJ_TYPE_MASK(0, parent, DDTrace\\SpanStack|DDTrace\\SpanData, MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DDTrace_HookData_overrideArguments, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(DDTrace_install_hook);
 ZEND_FUNCTION(DDTrace_remove_hook);
 ZEND_METHOD(DDTrace_HookData, span);
+ZEND_METHOD(DDTrace_HookData, overrideArguments);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -30,6 +35,7 @@ static const zend_function_entry ext_functions[] = {
 
 static const zend_function_entry class_DDTrace_HookData_methods[] = {
 	ZEND_ME(DDTrace_HookData, span, arginfo_class_DDTrace_HookData_span, ZEND_ACC_PUBLIC)
+	ZEND_ME(DDTrace_HookData, overrideArguments, arginfo_class_DDTrace_HookData_overrideArguments, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/tests/ext/sandbox/install_hook/replace_hook_args.phpt
+++ b/tests/ext/sandbox/install_hook/replace_hook_args.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Overriding function arguments via install_hook()
+--FILE--
+<?php
+
+function foo($a, $b) {
+    print_r(func_get_args());
+}
+
+$hook = DDTrace\install_hook("foo", function($hook) {
+    $hook->overrideArguments([5, 6, 7, 8]);
+});
+
+foo(1, 2, 3, 4, 5, 6); // more args
+foo(1, 2, 3, 4); // equal args
+foo(1, 2); // less args (fails)
+
+DDTrace\install_hook("foo", function ($hook) {
+    $hook->overrideArguments([0]); // less than required args, fails
+});
+DDTrace\remove_hook($hook);
+foo(1, 2);
+
+function optArg($a, $b = 3) {
+    print_r(func_get_args());
+    var_dump($a, $b);
+}
+
+DDTrace\install_hook("optArg", function ($hook) {
+    $hook->overrideArguments([5]);
+});
+optArg(1, 2);
+
+?>
+--EXPECTF--
+Array
+(
+    [0] => 5
+    [1] => 6
+    [2] => 7
+    [3] => 8
+)
+Array
+(
+    [0] => 5
+    [1] => 6
+    [2] => 7
+    [3] => 8
+)
+Cannot set more args than provided: got too many arguments for hook in %s:%d
+Array
+(
+    [0] => 1
+    [1] => 2
+)
+Not enough args provided for hook in %s:%d
+Array
+(
+    [0] => 1
+    [1] => 2
+)
+Array
+(
+    [0] => 5
+)
+int(5)
+int(3)

--- a/tests/ext/sandbox/install_hook/replace_hook_args.phpt
+++ b/tests/ext/sandbox/install_hook/replace_hook_args.phpt
@@ -59,9 +59,11 @@ Array
     [0] => 1
     [1] => 2
 )
+Can't pass less args to an untyped function than originally passed (minus extra args) in %s:%d
 Array
 (
-    [0] => 5
+    [0] => 1
+    [1] => 2
 )
-int(5)
-int(3)
+int(1)
+int(2)


### PR DESCRIPTION
### Description

This functionality is required to inject some data on method calls (like adding logging info, mostly trace/span ids).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
