### PR TITLE
perf(profiling): speed up stalk walking by using function run_time_cache

### DIFF
--- a/profiling-store/Cargo.toml
+++ b/profiling-store/Cargo.toml
@@ -1,0 +1,17 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+[package]
+name = "datadog-profiling-store"
+version = "2.0.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+ahash = "0.8.3"
+anyhow = "1.0.68"
+bumpalo = { version = "3.12.0", features = ["collections"] }
+crossbeam-channel = "0.5.6"
+derivative = "2.2.0"
+prost = "0.11.6"
+self_cell = "0.10.2"

--- a/profiling-store/rust-toolchain.toml
+++ b/profiling-store/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/profiling-store/src/lib.rs
+++ b/profiling-store/src/lib.rs
@@ -1,0 +1,3 @@
+mod string_table;
+
+pub use string_table::*;

--- a/profiling-store/src/string_table/borrowed.rs
+++ b/profiling-store/src/string_table/borrowed.rs
@@ -1,0 +1,87 @@
+use ahash::RandomState;
+use std::collections::HashMap;
+use std::ops::Range;
+
+pub struct BorrowedStringTable<'a> {
+    pub(super) vec: Vec<&'a str>,
+    pub(super) map: HashMap<&'a str, usize, RandomState>,
+}
+
+impl<'a> BorrowedStringTable<'a> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<'a> Default for BorrowedStringTable<'a> {
+    fn default() -> Self {
+        /// The initial size of the Vec. At the time of writing, Vec would
+        /// choose size 4. This is expected to be much too small for the
+        /// use-case, so use a larger initial capacity to save a few
+        /// re-allocations in the beginning.
+        /// This is just an educated estimate, not a finely tuned value.
+        const INITIAL_VEC_CAPACITY: usize = 1024 / std::mem::size_of::<&str>();
+
+        /// A HashMap is less straight-forward, but it uses more memory for
+        /// the same number of elements compared to a Vec, but not twice as
+        /// much for our situation, so dividing by 2 should be okay, at least
+        /// until further measurement is done.
+        const INITIAL_MAP_CAPACITY: usize = INITIAL_VEC_CAPACITY / 2;
+
+        let mut vec = Vec::with_capacity(INITIAL_VEC_CAPACITY);
+        vec.push("");
+        let mut map = HashMap::with_capacity_and_hasher(INITIAL_MAP_CAPACITY, Default::default());
+        map.insert("", 0);
+        Self { vec, map }
+    }
+}
+
+impl<'a> super::StringTable for BorrowedStringTable<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
+    fn insert_full(&mut self, str: &str) -> (usize, bool) {
+        match self.map.get(str) {
+            None => {
+                let id = self.vec.len();
+                // Safety: DEFINITELY NOT SAFE. The caller _must_
+                let borrowed = unsafe { std::mem::transmute(str) };
+                self.vec.push(borrowed);
+
+                self.map.insert(borrowed, id);
+                debug_assert_eq!(self.map.len(), self.vec.len());
+                (id, true)
+            }
+            Some(offset) => (*offset, false),
+        }
+    }
+
+    #[inline]
+    fn get_offset(&self, offset: usize) -> &str {
+        self.vec[offset]
+    }
+
+    #[inline]
+    fn get_range(&self, range: Range<usize>) -> &[&str] {
+        &self.vec[range]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn borrowed_string_table() {
+        let set = BorrowedStringTable::<'static>::new();
+        super::super::tests::basic(set);
+    }
+}

--- a/profiling-store/src/string_table/bump_owned.rs
+++ b/profiling-store/src/string_table/bump_owned.rs
@@ -1,0 +1,70 @@
+use bumpalo::{collections, Bump};
+use std::ops::Range;
+
+pub(super) struct BorrowedStringTable<'b> {
+    arena: &'b Bump,
+    pub(super) set: super::borrowed::BorrowedStringTable<'b>,
+}
+
+impl<'b> BorrowedStringTable<'b> {
+    #[inline]
+    pub(super) fn new(arena: &'b Bump) -> Self {
+        Self {
+            arena,
+            set: Default::default(),
+        }
+    }
+}
+
+impl<'b> super::StringTable for BorrowedStringTable<'b> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    fn insert_full(&mut self, str: &str) -> (usize, bool) {
+        match self.set.map.get(str) {
+            None => {
+                let owned = collections::String::from_str_in(str, self.arena);
+
+                /* Consume the string but retain a reference to its data in
+                 * the arena. The reference is valid as long as the arena
+                 * doesn't get reset. This is partly the reason for the unsafe
+                 * marker on `StringTable::new`.
+                 */
+                let bumped_str = owned.into_bump_str();
+
+                let id = self.set.vec.len();
+                self.set.vec.push(bumped_str);
+
+                self.set.map.insert(bumped_str, id);
+                assert_eq!(self.set.vec.len(), self.set.map.len());
+                (id, true)
+            }
+            Some(offset) => (*offset, false),
+        }
+    }
+
+    #[inline]
+    fn get_offset(&self, offset: usize) -> &str {
+        self.set.get_offset(offset)
+    }
+
+    #[inline]
+    fn get_range(&self, range: Range<usize>) -> &[&str] {
+        self.set.get_range(range)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn bump_owned_string_table() {
+        // small size, to allow testing re-alloc.
+        let bump = Bump::with_capacity(16);
+        let set = BorrowedStringTable::new(&bump);
+        super::super::tests::basic(set);
+    }
+}

--- a/profiling-store/src/string_table/mod.rs
+++ b/profiling-store/src/string_table/mod.rs
@@ -1,0 +1,74 @@
+use std::ops::Range;
+
+mod borrowed;
+mod bump_owned;
+mod owned;
+
+pub use borrowed::*;
+pub use owned::*;
+
+pub trait StringTable {
+    fn len(&self) -> usize;
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    fn insert(&mut self, item: &str) -> usize {
+        self.insert_full(item).0
+    }
+
+    fn insert_full(&mut self, item: &str) -> (usize, bool);
+
+    fn get_offset(&self, offset: usize) -> &str;
+    fn get_range(&self, range: Range<usize>) -> &[&str];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pass in an empty set, which should only include the empty string at 0.
+    pub(crate) fn basic<S: StringTable>(mut set: S) {
+        // the empty string must always be included in the set at 0.
+        let empty_str = set.get_offset(0);
+        assert_eq!("", empty_str);
+
+        let cases = &[
+            (0, ""),
+            (1, "local root span id"),
+            (2, "span id"),
+            (3, "trace endpoint"),
+            (4, "samples"),
+            (5, "count"),
+            (6, "wall-time"),
+            (7, "nanoseconds"),
+            (8, "cpu-time"),
+            (9, "<?php"),
+            (10, "/srv/demo/public/index.php"),
+            (11, "pid"),
+        ];
+
+        for (offset, str) in cases.iter() {
+            let actual_offset = set.insert(str);
+            assert_eq!(*offset, actual_offset);
+        }
+
+        // repeat them to ensure they aren't re-added
+        for (offset, str) in cases.iter() {
+            let actual_offset = set.insert(str);
+            assert_eq!(*offset, actual_offset);
+        }
+
+        // let's fetch some offsets
+        assert_eq!("", set.get_offset(0));
+        assert_eq!("/srv/demo/public/index.php", set.get_offset(10));
+
+        // Check a range too
+        let slice = set.get_range(7..10);
+        let expected_slice = &["nanoseconds", "cpu-time", "<?php"];
+        assert_eq!(expected_slice, slice);
+    }
+}

--- a/profiling-store/src/string_table/owned.rs
+++ b/profiling-store/src/string_table/owned.rs
@@ -1,0 +1,109 @@
+use super::bump_owned::BorrowedStringTable;
+use bumpalo::Bump;
+use self_cell::self_cell;
+use std::ops::Range;
+
+// todo: use ouroboros instead?
+self_cell!(
+    struct StringTableCell {
+        owner: Bump,
+
+        #[covariant]
+        dependent: BorrowedStringTable,
+    }
+);
+
+pub struct OwnedStringTable {
+    inner: StringTableCell,
+}
+
+impl Clone for OwnedStringTable {
+    fn clone(&self) -> Self {
+        let bytes = self
+            .inner
+            .with_dependent(|arena, _table| arena.allocated_bytes());
+
+        use super::StringTable as StringTableTrait;
+        let mut table = OwnedStringTable::with_capacity(bytes);
+        let len = self.len();
+        table.reserve(len);
+        for str in self.get_range(0..len) {
+            table.insert(str);
+        }
+        table
+    }
+}
+
+impl OwnedStringTable {
+    #[inline]
+    pub fn new() -> Self {
+        Self::with_capacity(4000)
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let inner = StringTableCell::new(Bump::with_capacity(capacity), |arena| {
+            BorrowedStringTable::new(arena)
+        });
+        Self { inner }
+    }
+
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        self.inner.with_dependent_mut(|_arena, table| {
+            table.set.vec.reserve(additional);
+            table.set.map.reserve(additional);
+        })
+    }
+}
+
+impl Default for OwnedStringTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl super::StringTable for OwnedStringTable {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.with_dependent(|_arena, set| set.len())
+    }
+
+    #[inline]
+    fn insert_full(&mut self, str: &str) -> (usize, bool) {
+        self.inner
+            .with_dependent_mut(|_arena, set| set.insert_full(str))
+    }
+
+    #[inline]
+    fn get_offset(&self, offset: usize) -> &str {
+        self.inner
+            .with_dependent(|_arena, set| set.get_offset(offset))
+    }
+
+    #[inline]
+    fn get_range(&self, range: Range<usize>) -> &[&str] {
+        self.inner
+            .with_dependent(|_arena, set| set.get_range(range))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// If this fails, bumpalo may have changed its allocation patterns, and
+    /// [OwnedStringTable::new] may need adjusted.
+    #[test]
+    fn test_bump() {
+        let arena = Bump::with_capacity(4000);
+        assert_eq!(4096 - 64, arena.chunk_capacity());
+    }
+
+    #[test]
+    fn owned_string_table() {
+        // small size, to allow testing re-alloc.
+        let set = OwnedStringTable::with_capacity(64);
+        super::super::tests::basic(set);
+    }
+}

--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +296,7 @@ dependencies = [
  "cpu-time",
  "crossbeam-channel",
  "datadog-profiling",
+ "datadog-profiling-store",
  "env_logger",
  "indexmap",
  "lazy_static",
@@ -324,6 +337,19 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "datadog-profiling-store"
+version = "2.0.0"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bumpalo",
+ "crossbeam-channel",
+ "derivative",
+ "prost",
+ "self_cell",
 ]
 
 [[package]]
@@ -1058,6 +1084,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "serde"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -13,9 +13,10 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = { version = "1.0" }
 cfg-if = { version = "1.0" }
-crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
+crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v2.0.0" }
+datadog-profiling-store = { path = "../profiling-store" }
 env_logger = { version = "0.9.3" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }
@@ -23,9 +24,9 @@ libc = "0.2"
 # TRACE set to max to support runtime configuration.
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"]}
 once_cell = { version = "1.12" }
-uuid = { version = "1.0", features = ["v4"] }
 rand = { version = "0.8.5" }
 rand_distr = { version = "0.4.3" }
+uuid = { version = "1.0", features = ["v4"] }
 
 [features]
 default = ["allocation_profiling"]

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -268,6 +268,16 @@ extern "C" {
     /// strings will be converted into a string view to a static empty string
     /// (single byte of null, len of 0).
     pub fn ddog_php_prof_zend_string_view(zstr: Option<&mut zend_string>) -> zai_string_view;
+
+    /// Registers the run_time_cache slot with the engine. Must be done in
+    /// module init or extension startup.
+    pub fn ddog_php_prof_function_run_time_cache_init(module_name: *const c_char);
+
+    /// Gets the address of a function's run_time_cache slot. May return None
+    /// if it detects incomplete initialization, which is always a bug but
+    /// none-the-less has been seen in the wild. It may also return None if
+    /// the run_time_cache is not available on this function type.
+    pub fn ddog_php_prof_function_run_time_cache(func: &zend_function) -> Option<&mut [usize; 2]>;
 }
 
 pub use zend_module_dep as ModuleDep;
@@ -489,4 +499,22 @@ pub struct ZaiConfigMemoizedEntry {
             stage: c_int,
         ) -> c_int,
     >,
+}
+
+#[cfg(test)]
+mod tests {
+
+    // If this fails, then ddog_php_prof_function_run_time_cache needs to be
+    // adjusted accordingly.
+    #[test]
+    fn test_sizeof_fixed_size_slice_is_same_as_pointer() {
+        assert_eq!(
+            std::mem::size_of::<&[usize; 2]>(),
+            std::mem::size_of::<*mut usize>()
+        );
+        assert_eq!(
+            std::mem::align_of::<&[usize; 2]>(),
+            std::mem::align_of::<*mut usize>()
+        );
+    }
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -49,16 +49,18 @@ static PROFILER: Mutex<Option<Profiler>> = Mutex::new(None);
 /// interior null bytes and must be null terminated.
 static PROFILER_NAME: &[u8] = b"datadog-profiling\0";
 
+/// Name of the profiling module and zend_extension, but as a &CStr.
+// Safety: null terminated, contains no interior null bytes.
+static PROFILER_NAME_CSTR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(PROFILER_NAME) };
+
 /// Version of the profiling module and zend_extension. Must not contain any
 /// interior null bytes and must be null terminated.
 static PROFILER_VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
 
 lazy_static! {
     // Safety: PROFILER_NAME is a byte slice that satisfies the safety requirements.
-    static ref PROFILER_NAME_STR: &'static str = unsafe { CStr::from_ptr(PROFILER_NAME.as_ptr() as *const c_char) }
-        .to_str()
-        // Panic: we own this string and it should be UTF8 (see PROFILER_NAME above).
-        .unwrap();
+    // Panic: we own this string and it should be UTF8 (see PROFILER_NAME above).
+    static ref PROFILER_NAME_STR: &'static str = PROFILER_NAME_CSTR.to_str().unwrap();
 
     // Safety: PROFILER_VERSION is a byte slice that satisfies the safety requirements.
     static ref PROFILER_VERSION_STR: &'static str = unsafe { CStr::from_ptr(PROFILER_VERSION.as_ptr() as *const c_char) }
@@ -106,7 +108,7 @@ pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
     ];
 
     let module = zend::ModuleEntry {
-        name: PROFILER_NAME.as_ptr() as *const u8,
+        name: PROFILER_NAME.as_ptr(),
         module_startup_func: Some(minit),
         module_shutdown_func: Some(mshutdown),
         request_startup_func: Some(rinit),
@@ -225,7 +227,7 @@ extern "C" fn minit(r#type: c_int, module_number: c_int) -> ZendResult {
          * At the time of this writing, PHP 8.2 isn't out yet so it's possible
          * it may get reverted if issues are found.
          */
-        let str = PROFILER_NAME.as_ptr();
+        let str = PROFILER_NAME_CSTR.as_ptr();
         let len = PROFILER_NAME.len() - 1; // ignore trailing null byte
 
         // Safety: str is valid for at least len values.
@@ -706,6 +708,14 @@ extern "C" fn rshutdown(r#type: c_int, module_number: c_int) -> ZendResult {
     #[cfg(debug_assertions)]
     trace!("RSHUTDOWN({}, {})", r#type, module_number);
 
+    #[cfg(php8)]
+    {
+        profiling::FUNCTION_CACHE_STATS.with(|cell| {
+            let stats = cell.borrow();
+            debug!("Process cumulative {stats:?}");
+        });
+    }
+
     REQUEST_LOCALS.with(|cell| {
         let mut locals = cell.borrow_mut();
 
@@ -907,6 +917,9 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
 
     // Safety: called during startup hook with correct params.
     unsafe { zend::datadog_php_profiling_startup(extension) };
+
+    // Safety: calling this in startup/minit as required.
+    unsafe { bindings::ddog_php_prof_function_run_time_cache_init(PROFILER_NAME_CSTR.as_ptr()) };
 
     // Ignore a failure as ZEND_VERSION.get() will return an Option if it's not set.
     let _ = ZEND_VERSION.get_or_try_init(|| {

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -42,8 +42,8 @@ void datadog_php_profiling_startup(zend_extension *extension) {
 
 void *datadog_php_profiling_vm_interrupt_addr(void) { return &EG(vm_interrupt); }
 
-zend_module_entry *datadog_get_module_entry(const uint8_t *str, uintptr_t len) {
-    return zend_hash_str_find_ptr(&module_registry, (const char *)str, len);
+zend_module_entry *datadog_get_module_entry(const char *str, uintptr_t len) {
+    return zend_hash_str_find_ptr(&module_registry, str, len);
 }
 
 ddtrace_profiling_context (*datadog_php_profiling_get_profiling_context)(void) =
@@ -95,8 +95,7 @@ zai_string_view ddog_php_prof_zend_string_view(zend_string *zstr) {
 void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
                                                void* (*_malloc)(size_t),
                                                void  (*_free)(void*),
-                                               void* (*_realloc)(void*, size_t))
-{
+                                               void* (*_realloc)(void*, size_t)) {
     zend_mm_set_custom_handlers(heap, _malloc, _free, _realloc);
 #if PHP_VERSION_ID < 70300
     if (!_malloc && !_free && !_realloc) {
@@ -105,7 +104,53 @@ void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
 #endif
 }
 
-zend_execute_data* ddog_php_prof_get_current_execute_data()
-{
+zend_execute_data* ddog_php_prof_get_current_execute_data() {
     return EG(current_execute_data);
+}
+
+#if PHP_VERSION_ID >= 80000
+static int ddog_php_prof_run_time_cache_handle = -1;
+#endif
+
+void ddog_php_prof_function_run_time_cache_init(const char *module_name) {
+#if PHP_VERSION_ID >= 80000
+    // Grab 2, one for function name and one for filename.
+    ddog_php_prof_run_time_cache_handle =
+        zend_get_op_array_extension_handles(module_name, 2);
+#endif
+
+    /* It's possible to work on PHP 7.4 as well, but there are opcache bugs
+     * that weren't truly fixed until PHP 8:
+     * https://github.com/php/php-src/pull/5871
+     * I would rather avoid these bugs for now.
+     */
+}
+
+uintptr_t *ddog_php_prof_function_run_time_cache(zend_function *func) {
+#if PHP_VERSION_ID < 80000
+    /* It's possible to work on PHP 7.4 as well, but there are opcache bugs
+     * that weren't truly fixed until PHP 8:
+     * https://github.com/php/php-src/pull/5871
+     * I would rather avoid these bugs for now.
+     */
+    return NULL;
+#else
+
+    // It should be initialized by this point, or we failed.
+    if (ddog_php_prof_run_time_cache_handle < 0) return NULL;
+
+#if PHP_VERSION_ID < 80200
+    // internal functions don't have a runtime cache until PHP 8.2
+    if (func->type == ZEND_INTERNAL_FUNCTION) return NULL;
+
+    uintptr_t *cache_addr = RUN_TIME_CACHE(&func->op_array);
+#else
+    uintptr_t *cache_addr = RUN_TIME_CACHE(&func->common);
+#endif
+
+    // To my knowledge, this is always a bug, but it has happened.
+    if (!cache_addr) return 0;
+
+    return cache_addr + ddog_php_prof_run_time_cache_handle;
+#endif
 }

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -35,11 +35,10 @@ const char *datadog_module_build_id(void);
 
 /**
  * Lookup module by name in the module registry. Returns NULL if not found.
- * This is meant to be called from Rust, so it uses types that are easy to use
- * in Rust. In Rust, strings are validated byte-slices instead of `char` slices
- * and array lengths use uintptr_t, not size_t.
+ * This is meant to be called from Rust, so it uses uintptr_t, not size_t, for
+ * the length for convenience.
  */
-zend_module_entry *datadog_get_module_entry(const uint8_t *str, uintptr_t len);
+zend_module_entry *datadog_get_module_entry(const char *str, uintptr_t len);
 
 /**
  * Fetches the VM interrupt address of the calling PHP thread.

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -4,7 +4,7 @@ mod thread_utils;
 mod uploader;
 
 pub use interrupts::*;
-use stalk_walking::*;
+pub use stalk_walking::*;
 use uploader::*;
 
 use crate::bindings::{datadog_php_profiling_get_profiling_context, zend_execute_data};
@@ -280,7 +280,7 @@ impl TimeCollector {
             let location = Location {
                 lines: vec![Line {
                     function: Function {
-                        name: frame.function.as_str(),
+                        name: frame.function.as_ref(),
                         system_name: "",
                         filename: frame.file.as_deref().unwrap_or(""),
                         start_line: 0,
@@ -695,8 +695,8 @@ mod tests {
 
     fn get_frames() -> Vec<ZendFrame> {
         vec![ZendFrame {
-            function: "foobar()".to_string(),
-            file: Some("foobar.php".to_string()),
+            function: "foobar()".into(),
+            file: Some("foobar.php".into()),
             line: 42,
         }]
     }

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -101,6 +101,7 @@ unsafe fn handle_file_cache_slot_helper(
     // Safety: changing the lifetime to 'static is safe because
     // the other threads using it are joined before this thread
     // ever dies.
+    // todo: this is _not_ ZTS safe.
     Some(Cow::Borrowed(transmute(str)))
 }
 
@@ -139,6 +140,7 @@ unsafe fn handle_function_cache_slot(
     // Safety: changing the lifetime to 'static is safe because
     // the other threads using it are joined before this thread
     // ever dies.
+    // todo: this is _not_ ZTS safe.
     Some(Cow::Borrowed(transmute(str)))
 }
 

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -1,15 +1,32 @@
 use crate::bindings::{
-    ddog_php_prof_zend_string_view, zend_execute_data, zend_function, zend_string,
-    ZEND_USER_FUNCTION,
+    ddog_php_prof_function_run_time_cache, ddog_php_prof_zend_string_view, zend_execute_data,
+    zend_function, zend_string, ZEND_USER_FUNCTION,
 };
+use datadog_profiling_store::{OwnedStringTable, StringTable};
+use log::debug;
+use std::borrow::Cow;
+use std::cell::{RefCell, RefMut};
+use std::mem::transmute;
 use std::str::Utf8Error;
+
+#[derive(Debug, Default)]
+pub struct FunctionRunTimeCacheStats {
+    hit: usize,
+    missed: usize,
+    not_applicable: usize,
+}
+
+thread_local! {
+    static CACHED_STRINGS: RefCell<OwnedStringTable> = RefCell::new(OwnedStringTable::new());
+    pub static FUNCTION_CACHE_STATS: RefCell<FunctionRunTimeCacheStats> = RefCell::new(Default::default())
+}
 
 #[derive(Default, Debug)]
 pub struct ZendFrame {
     // Most tools don't like frames that don't have function names, so use a
-    // fake name if you need to like "<php>".
-    pub function: String,
-    pub file: Option<String>,
+    // fake name if you need to like "<?php".
+    pub function: Cow<'static, str>,
+    pub file: Option<Cow<'static, str>>,
     pub line: u32, // use 0 for no line info
 }
 
@@ -59,6 +76,72 @@ unsafe fn extract_function_name(func: &zend_function) -> Option<String> {
     Some(String::from_utf8_lossy(buffer.as_slice()).into_owned())
 }
 
+unsafe fn handle_file_cache_slot_helper(
+    execute_data: &zend_execute_data,
+    string_table: &mut RefMut<OwnedStringTable>,
+    cache_slots: &mut [usize; 2],
+) -> Option<Cow<'static, str>> {
+    let offset = if cache_slots[1] > 0 {
+        cache_slots[1]
+    } else {
+        // Safety: if we have cache slots, we definitely have a func.
+        let func = &*execute_data.func;
+        let file = if func.type_ == ZEND_USER_FUNCTION as u8 {
+            let bytes = zend_string_to_bytes(func.op_array.filename.as_mut());
+            String::from_utf8_lossy(bytes)
+        } else {
+            return None;
+        };
+        let offset = string_table.insert(file.as_ref());
+        cache_slots[1] = offset;
+        offset
+    };
+    let str = string_table.get_offset(offset);
+
+    // Safety: changing the lifetime to 'static is safe because
+    // the other threads using it are joined before this thread
+    // ever dies.
+    Some(Cow::Borrowed(transmute(str)))
+}
+
+unsafe fn handle_file_cache_slot(
+    execute_data: &zend_execute_data,
+    string_table: &mut RefMut<OwnedStringTable>,
+    cache_slots: &mut [usize; 2],
+) -> (Option<Cow<'static, str>>, u32) {
+    match handle_file_cache_slot_helper(execute_data, string_table, cache_slots) {
+        Some(filename) => {
+            let lineno = match execute_data.opline.as_ref() {
+                Some(opline) => opline.lineno,
+                None => 0,
+            };
+            (Some(filename), lineno)
+        }
+        None => (None, 0),
+    }
+}
+
+unsafe fn handle_function_cache_slot(
+    func: &zend_function,
+    string_table: &mut RefMut<OwnedStringTable>,
+    cache_slots: &mut [usize; 2],
+) -> Option<Cow<'static, str>> {
+    let offset = if cache_slots[0] > 0 {
+        cache_slots[0]
+    } else {
+        let name = extract_function_name(func)?;
+        let offset = string_table.insert(name.as_ref());
+        cache_slots[0] = offset;
+        offset
+    };
+    let str = string_table.get_offset(offset);
+
+    // Safety: changing the lifetime to 'static is safe because
+    // the other threads using it are joined before this thread
+    // ever dies.
+    Some(Cow::Borrowed(transmute(str)))
+}
+
 unsafe fn extract_file_and_line(execute_data: &zend_execute_data) -> (Option<String>, u32) {
     // This should be Some, just being cautious.
     match execute_data.func.as_ref() {
@@ -76,22 +159,57 @@ unsafe fn extract_file_and_line(execute_data: &zend_execute_data) -> (Option<Str
 }
 
 unsafe fn collect_call_frame(execute_data: &zend_execute_data) -> Option<ZendFrame> {
-    if let Some(func) = execute_data.func.as_ref() {
-        let function = extract_function_name(func);
-        let (file, line) = extract_file_and_line(execute_data);
+    let func = execute_data.func.as_ref()?;
+    CACHED_STRINGS.with(|cell| {
+        let mut string_table = cell.borrow_mut();
+        let (function, file, line) = match ddog_php_prof_function_run_time_cache(func) {
+            Some(cache_slots) => {
+                FUNCTION_CACHE_STATS.with(|cell| {
+                    let mut stats = cell.borrow_mut();
+                    if cache_slots[0] == 0 {
+                        if cache_slots[1] != 0 {
+                            debug!(
+                                "function cache slot 0 was zero, but slot 1 was {}",
+                                cache_slots[1]
+                            );
+                        }
+                        stats.missed += 1;
+                    } else {
+                        if cache_slots[1] == 0 {
+                            debug!("function cache slot 0 was non-zero, but slot 1 was zero");
+                        }
+                        stats.hit += 1;
+                    }
+                });
+                let function = handle_function_cache_slot(func, &mut string_table, cache_slots);
+                let (file, line) =
+                    handle_file_cache_slot(execute_data, &mut string_table, cache_slots);
 
-        // Only create a new frame if there's file or function info.
-        if file.is_some() || function.is_some() {
-            // If there's no function name, use a fake name.
-            let function = function.unwrap_or_else(|| "<?php".to_owned());
-            return Some(ZendFrame {
-                function,
+                (function, file, line)
+            }
+
+            None => {
+                FUNCTION_CACHE_STATS.with(|cell| {
+                    let mut stats = cell.borrow_mut();
+                    stats.not_applicable += 1;
+                });
+                let function = extract_function_name(func).map(Cow::Owned);
+                let (file, line) = extract_file_and_line(execute_data);
+                let file = file.map(Cow::Owned);
+                (function, file, line)
+            }
+        };
+
+        if function.is_some() || file.is_some() {
+            Some(ZendFrame {
+                function: function.unwrap_or(Cow::Borrowed("<?php")),
                 file,
                 line,
-            });
+            })
+        } else {
+            None
         }
-    }
-    None
+    })
 }
 
 pub(super) unsafe fn collect_stack_sample(
@@ -111,7 +229,7 @@ pub(super) unsafe fn collect_stack_sample(
              */
             if samples.len() == max_depth - 1 {
                 samples.push(ZendFrame {
-                    function: "[truncated]".to_string(),
+                    function: "[truncated]".into(),
                     file: None,
                     line: 0,
                 });


### PR DESCRIPTION
### Description

This is for PHP 8 only. It uses two slots in the function run_time_cache to store:

- The function name, which looks something like `"module|Namespace\\ClassName::method"`.
- The file name.

These two strings are interned and live between requests. This allows us to share them as `Cow<'static, str>` with the `ddprof_time` thread.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
