### PR TITLE
perf(profiling): optimize prepare_sample_message

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -565,23 +565,23 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
                 // later.
                 let mut tags = (*locals.tags).clone();
 
-                local_add_optional_tag(&mut tags, "service", &locals.service);
-                local_add_optional_tag(&mut tags, "env", &locals.env);
-                local_add_optional_tag(&mut tags, "version", &locals.version);
+                add_optional_tag(&mut tags, "service", &locals.service);
+                add_optional_tag(&mut tags, "env", &locals.env);
+                add_optional_tag(&mut tags, "version", &locals.version);
 
                 let runtime_id = runtime_id();
                 if !runtime_id.is_nil() {
-                    local_add_tag(&mut tags, "runtime-id", &runtime_id.to_string());
+                    add_tag(&mut tags, "runtime-id", &runtime_id.to_string());
                 }
 
                 if let Some(version) = PHP_VERSION.get() {
                     /* This should probably be "language_version", but this is
                      * the tag that was standardized for this purpose. */
-                    local_add_tag(&mut tags, "runtime_version", version);
+                    add_tag(&mut tags, "runtime_version", version);
                 }
 
                 if let Some(sapi) = SAPI.get() {
-                    local_add_tag(&mut tags, "php.sapi", sapi.as_ref());
+                    add_tag(&mut tags, "php.sapi", sapi.as_ref());
                 }
 
                 locals.tags = Arc::new(tags);
@@ -639,13 +639,13 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
     ZendResult::Success
 }
 
-fn local_add_optional_tag<T: AsRef<str>>(tags: &mut Vec<Tag>, key: &str, value: &Option<T>) {
+fn add_optional_tag<T: AsRef<str>>(tags: &mut Vec<Tag>, key: &str, value: &Option<T>) {
     if let Some(value) = value {
-        local_add_tag(tags, key, value.as_ref());
+        add_tag(tags, key, value.as_ref());
     }
 }
 
-fn local_add_tag(tags: &mut Vec<Tag>, key: &str, value: &str) {
+fn add_tag(tags: &mut Vec<Tag>, key: &str, value: &str) {
     assert!(!value.is_empty());
     match Tag::new(key, value) {
         Ok(tag) => {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -574,15 +574,10 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
                     add_tag(&mut tags, "runtime-id", &runtime_id.to_string());
                 }
 
-                if let Some(version) = PHP_VERSION.get() {
-                    /* This should probably be "language_version", but this is
-                     * the tag that was standardized for this purpose. */
-                    add_tag(&mut tags, "runtime_version", version);
-                }
-
-                if let Some(sapi) = SAPI.get() {
-                    add_tag(&mut tags, "php.sapi", sapi.as_ref());
-                }
+                /* This should probably be "language_version", but this is
+                 * the tag that was standardized for this purpose. */
+                add_optional_tag(&mut tags, "runtime_version", &PHP_VERSION.get());
+                add_optional_tag(&mut tags, "php.sapi", &SAPI.get());
 
                 locals.tags = Arc::new(tags);
             }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -575,12 +575,23 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
             let runtime_id = runtime_id();
             if !runtime_id.is_nil() {
                 match Tag::new("runtime-id", runtime_id.to_string()) {
-                    Ok(tag) => {
-                        locals.tags.push(tag);
-                    }
-                    Err(err) => {
-                        warn!("invalid tag: {err}");
-                    }
+                    Ok(tag) => locals.tags.push(tag),
+                    Err(err) => warn!("invalid tag: {err}"),
+                }
+            }
+
+            if let Some(version) = PHP_VERSION.get() {
+                /* This should probably be "language_version", but this is
+                 * the tag that was standardized for this purpose. */
+                let tag = Tag::new("runtime_version", version)
+                    .expect("runtime_version to be a valid tag");
+                locals.tags.push(tag);
+            }
+
+            if let Some(sapi) = SAPI.get() {
+                match Tag::new("php.sapi", sapi.to_string()) {
+                    Ok(tag) => locals.tags.push(tag),
+                    Err(err) => warn!("invalid tag: {err}"),
                 }
             }
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -118,7 +118,7 @@ impl ValueType {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ProfileIndex {
     pub sample_types: Vec<ValueType>,
-    pub tags: Vec<Tag>,
+    pub tags: Arc<Vec<Tag>>,
     pub endpoint: Box<AgentEndpoint>,
 }
 
@@ -661,7 +661,7 @@ impl Profiler {
             }
         }
 
-        let tags = locals.tags.clone();
+        let tags = Arc::clone(&locals.tags);
 
         SampleMessage {
             key: ProfileIndex {
@@ -704,7 +704,7 @@ mod tests {
             profiling_experimental_allocation_enabled: false,
             profiling_log_level: LevelFilter::Off,
             service: None,
-            tags: static_tags(),
+            tags: Arc::new(static_tags()),
             uri: Box::new(AgentEndpoint::default()),
             version: None,
             vm_interrupt_addr: std::ptr::null_mut(),

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -33,11 +33,14 @@ impl Uploader {
         let profiling_library_name: &str = &PROFILER_NAME_STR;
         let profiling_library_version: &str = &PROFILER_VERSION_STR;
         let endpoint: Endpoint = (&*index.endpoint).try_into()?;
+
+        // This is the currently unstable Arc::unwrap_or_clone.
+        let tags = Some(Arc::try_unwrap(index.tags).unwrap_or_else(|arc| (*arc).clone()));
         let exporter = datadog_profiling::exporter::ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",
-            Some(index.tags),
+            tags,
             endpoint,
         )?;
 

--- a/profiling/src/sapi.rs
+++ b/profiling/src/sapi.rs
@@ -91,9 +91,9 @@ impl Sapi {
     }
 }
 
-impl Display for Sapi {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
+impl AsRef<str> for Sapi {
+    fn as_ref(&self) -> &str {
+        match self {
             Sapi::Unknown => "unknown",
             Sapi::Apache2Handler => "apache2handler",
             Sapi::CgiFcgi => "cgi-fcgi",
@@ -104,7 +104,13 @@ impl Display for Sapi {
             Sapi::Litespeed => "litespeed",
             Sapi::PhpDbg => "phpdbg",
             Sapi::Tea => "tea",
-        };
+        }
+    }
+}
+
+impl Display for Sapi {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = self.as_ref();
         f.write_str(name)
     }
 }

--- a/profiling/src/sapi.rs
+++ b/profiling/src/sapi.rs
@@ -110,8 +110,7 @@ impl AsRef<str> for Sapi {
 
 impl Display for Sapi {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let name = self.as_ref();
-        f.write_str(name)
+        f.write_str(self.as_ref())
     }
 }
 


### PR DESCRIPTION
### Description

This function is called once per stack walk, so it's on the hot path but not as important to optimize as walking the stack itself.

However, it was showing up more than I would have expected in my profiles when examining it with the native profiler. Unfortunately I didn't have granular feedback on what was slowing it down, so I did some general optimization techniques:

 1. Statically store the sample types as an array instead of creating them on-demand.
 2. Replace Cow<'static, str> with &'static str in ValueType. All usages were already static strings, and I don't see this changing.
 3. Simplify the branching logic into slicing operations.
 4. Move tag creation to rinit, and share them with `Arc<Vec<Tag>>` instead of copying them. This makes the work to do on each stack sample be a simple atomic refcount increment. This will also reduce the number of total copies, which is also good.
 5. Initialize the sample's labels to the right size, and stop copying them unconditionally just for `trace` level diagnostics.

Aside from performance, it also adds `ValueType::new` to shorten up consecutive constructions (which happen frequently with this type). Between this and the changes to remove `Cow`, code is simplified:

```rust
    // before
    ValueType {
        r#type: Cow::Borrowed("sample"),
        unit: Cow::Borrowed("count"),
    },
    ValueType {
        r#type: Cow::Borrowed("wall-time"),
        unit: Cow::Borrowed("nanoseconds"),
    },

    // after
    ValueType::new("sample", "count"),
    ValueType::new("wall-time", "nanoseconds"),
```

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
