### PR TITLE
Use ZEND_TLS/TSRM_TLS macros instead of __thread to only use thread local storage in ZTS builds

### DIFF
--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -21,8 +21,8 @@ extern void (*profiling_interrupt_function)(zend_execute_data *);
 
 zend_class_entry *ddtrace_hook_data_ce;
 
-static __thread HashTable dd_closure_hooks;
-static __thread HashTable dd_active_hooks;
+ZEND_TLS HashTable dd_closure_hooks;
+ZEND_TLS HashTable dd_active_hooks;
 
 typedef struct {
     size_t size;

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -439,6 +439,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
         profiling_experimental_cpu_time_enabled,
         profiling_experimental_allocation_enabled,
         log_level,
+        output_pprof,
     ) = unsafe {
         (
             config::profiling_enabled(),
@@ -446,6 +447,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
             config::profiling_experimental_cpu_time_enabled(),
             config::profiling_experimental_allocation_enabled(),
             config::profiling_log_level(),
+            config::profiling_output_pprof(),
         )
     };
 
@@ -543,7 +545,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
          */
         let mut profiler = PROFILER.lock().unwrap();
         if profiler.is_none() {
-            *profiler = Some(Profiler::new())
+            *profiler = Some(Profiler::new(output_pprof))
         }
     };
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -391,7 +391,7 @@ pub struct UploadMessage {
 }
 
 impl Profiler {
-    pub fn new() -> Self {
+    pub fn new(output_pprof: Option<Cow<'static, str>>) -> Self {
         let fork_barrier = Arc::new(Barrier::new(3));
         let (fork_sender0, fork_receiver0) = crossbeam_channel::bounded(1);
         let interrupt_manager = Arc::new(InterruptManager::new(Mutex::new(Vec::with_capacity(1))));
@@ -408,7 +408,13 @@ impl Profiler {
             upload_period: UPLOAD_PERIOD,
         };
 
-        let uploader = Uploader::new(fork_barrier.clone(), fork_receiver1, upload_receiver);
+        let uploader = Uploader::new(
+            fork_barrier.clone(),
+            fork_receiver1,
+            upload_receiver,
+            output_pprof,
+        );
+
         Profiler {
             fork_barrier,
             fork_senders: [fork_sender0, fork_sender1],

--- a/zend_abstract_interface/config/config_runtime.c
+++ b/zend_abstract_interface/config/config_runtime.c
@@ -2,16 +2,10 @@
 
 #include "config.h"
 
-#ifdef ZTS
-#define ZAI_TLS static __thread
-#else
-#define ZAI_TLS static
-#endif
-
 extern HashTable zai_config_name_map;
 
-ZAI_TLS zval *runtime_config;  // dynamically allocated, otherwise TLS alignment limits may be exceeded
-ZAI_TLS bool runtime_config_initialized = false;
+ZEND_TLS zval *runtime_config;  // dynamically allocated, otherwise TLS alignment limits may be exceeded
+ZEND_TLS bool runtime_config_initialized = false;
 
 void zai_config_replace_runtime_config(zai_config_id id, zval *value) {
     zval *rt_value = &runtime_config[id];

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -42,8 +42,8 @@ typedef struct {
     size_t dynamic_offset;
 } zai_hook_info;
 
-__thread zend_ulong zai_hook_invocation = 0;
-__thread zend_ulong zai_hook_id;
+ZEND_TLS zend_ulong zai_hook_invocation = 0;
+ZEND_TLS zend_ulong zai_hook_id;
 
 /* {{{ private tables */
 // zai_hook_static is a simple array of persistently allocated zai_hook_t
@@ -51,26 +51,24 @@ __thread zend_ulong zai_hook_id;
 static HashTable zai_hook_static;
 
 // zai_hook_request_functions is a map name -> array<zai_hook_t>
-__thread HashTable zai_hook_request_functions;
+ZEND_TLS HashTable zai_hook_request_functions;
 // zai_hook_request_classes is a map class name -> map function name -> array<zai_hook_t>
-__thread HashTable zai_hook_request_classes;
+ZEND_TLS HashTable zai_hook_request_classes;
 
 // zai_hook_resolved is a map op_array/internal_function -> array<zai_hook_t>
 // if indirect, then it's pointing to some hashtable in zai_hook_request_functions/classes
-__thread HashTable zai_hook_resolved;
+TSRM_TLS HashTable zai_hook_resolved;
 
 // zai_hook_inheritors is a map of persistent class entries (interfaces and abstract classes) to a list of persistent class entries
 static HashTable zai_hook_static_inheritors;
 
 // zai_hook_inheritors is a map of class entries (interfaces and abstract classes) to a list of class entries
-__thread HashTable zai_hook_inheritors;
+ZEND_TLS HashTable zai_hook_inheritors;
 
 typedef struct {
     size_t size;
     zend_class_entry *inheritor[];
 } zai_hook_inheritor_list;
-
-__thread HashTable zai_hook_resolved;
 
 typedef struct {
     uint32_t ordered;
@@ -79,7 +77,7 @@ typedef struct {
 } zai_function_location_entry;
 
 // zai_function_location_map maps from a filename to a possibly ordered array of values
-__thread HashTable zai_function_location_map; /* }}} */
+ZEND_TLS HashTable zai_function_location_map; /* }}} */
 
 #define ZAI_IS_SHARED_HOOK_PTR (IS_PTR+1)
 

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -250,7 +250,7 @@ static void zai_hook_sort_newest(zai_hooks_entry *hooks) {
 move: ;
         // prevPos is now the index where the new entry will be spliced in
         if (pos != prevPos) {
-            for (int32_t i = -1; i > -(int32_t)hooks->hooks.nTableSize; --i) {
+            for (int32_t i = -1; i >= (int32_t)hooks->hooks.nTableMask; --i) {
                 uint32_t *hash = &HT_HASH(&hooks->hooks, HT_IDX_TO_HASH(i));
                 if (*(int32_t*)hash >= (int32_t)prevPos) {
                     if (*hash == pos) {

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -89,7 +89,7 @@ void zai_hook_resolve_function(zend_function *function, zend_string *lcname);
 void zai_hook_resolve_class(zend_class_entry *ce, zend_string *lcname);
 
 /* {{{ private but externed for performance reasons */
-extern __thread HashTable zai_hook_resolved;
+extern TSRM_TLS HashTable zai_hook_resolved;
 /* }}} */
 
 #if PHP_VERSION_ID >= 80000

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -56,7 +56,7 @@ typedef struct {
     uint32_t temporary;
 } zai_interceptor_generator_frame_memory;
 
-__thread HashTable zai_hook_memory;
+ZEND_TLS HashTable zai_hook_memory;
 // execute_data is 16 byte aligned (except when it isn't, but it doesn't matter as zend_execute_data is big enough
 // our goal is to reduce conflicts
 static inline void zai_hook_memory_table_insert(zend_execute_data *index, zai_interceptor_frame_memory *inserting) {
@@ -611,7 +611,7 @@ static zend_object *zai_interceptor_generator_create(zend_class_entry *class_typ
 static zend_op_array zai_interceptor_empty_op_array;
 static zend_op zai_interceptor_generator_create_wrapper[2];
 static user_opcode_handler_t prev_post_generator_create_handler;
-static __thread zend_execute_data zai_interceptor_generator_create_frame;
+ZEND_TLS zend_execute_data zai_interceptor_generator_create_frame;
 static int zai_interceptor_post_generator_create_handler(zend_execute_data *execute_data) {
     if (EX(opline) == &zai_interceptor_generator_create_wrapper[0] || EX(opline) == &zai_interceptor_generator_create_wrapper[1]) {
         // working around the fact that we cannot modify execute_data directly here.
@@ -889,7 +889,7 @@ static zend_object_iterator *zai_interceptor_yield_from_wrapped_iterator(zend_cl
     return &it->it;
 }
 
-static __thread zend_class_entry yield_from_iterator_wrapper_class = {0};
+ZEND_TLS zend_class_entry yield_from_iterator_wrapper_class = {0};
 static user_opcode_handler_t prev_yield_from_handler;
 static int zai_interceptor_yield_from_handler(zend_execute_data *execute_data) {
     zai_interceptor_generator_frame_memory *gen_memory;

--- a/zend_abstract_interface/interceptor/php7/resolver.c
+++ b/zend_abstract_interface/interceptor/php7/resolver.c
@@ -74,9 +74,9 @@ PHP_FUNCTION(zai_interceptor_resolve_after_class_alias) {
 
 #define ZAI_INTERCEPTOR_POST_DECLARE_OP 224 // random 8 bit number greater than ZEND_VM_LAST_OPCODE
 static zend_op zai_interceptor_post_declare_op;
-static __thread zend_op zai_interceptor_post_declare_ops[4];
+ZEND_TLS zend_op zai_interceptor_post_declare_ops[4];
 struct zai_interceptor_opline { const zend_op *op; struct zai_interceptor_opline *prev; };
-static __thread struct zai_interceptor_opline zai_interceptor_opline_before_binding = {0};
+ZEND_TLS struct zai_interceptor_opline zai_interceptor_opline_before_binding = {0};
 static void zai_interceptor_install_post_declare_op(zend_execute_data *execute_data) {
     // We replace the current opline *before* it is executed. Thus we need to preserve opline data first:
     //  only the second opline can be our own opcode.

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -21,8 +21,8 @@ typedef struct {
     bool implicit;
 } zai_frame_memory;
 
-__thread HashTable zai_interceptor_implicit_generators;
-__thread HashTable zai_hook_memory;
+ZEND_TLS HashTable zai_interceptor_implicit_generators;
+ZEND_TLS HashTable zai_hook_memory;
 // execute_data is 16 byte aligned (except when it isn't, but it doesn't matter as zend_execute_data is big enough
 // our goal is to reduce conflicts
 static inline bool zai_hook_memory_table_insert(zend_execute_data *index, zai_frame_memory *inserting) {

--- a/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
+++ b/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
@@ -82,9 +82,9 @@ PHP_FUNCTION(zai_interceptor_resolve_after_class_alias) {
 #define ZAI_INTERCEPTOR_POST_DECLARE_OP (ZEND_VM_LAST_OPCODE + 1)
 
 static zend_op zai_interceptor_post_declare_op;
-static __thread zend_op zai_interceptor_post_declare_ops[4];
+ZEND_TLS zend_op zai_interceptor_post_declare_ops[4];
 struct zai_interceptor_opline { const zend_op *op; struct zai_interceptor_opline *prev; };
-static __thread struct zai_interceptor_opline zai_interceptor_opline_before_binding = {0};
+ZEND_TLS struct zai_interceptor_opline zai_interceptor_opline_before_binding = {0};
 static void zai_interceptor_install_post_declare_op(zend_execute_data *execute_data) {
     // We replace the current opline *before* it is executed. Thus we need to preserve opline data first:
     //  only the second opline can be our own opcode.


### PR DESCRIPTION
### Description

Fixes #1957.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
