### PR TITLE
Inherit version, env and _dd.origin from parent span

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -407,24 +407,6 @@ static void dd_add_header_to_meta(zend_array *meta, const char *type, zend_strin
 
 void ddtrace_set_global_span_properties(ddtrace_span_data *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
-    zval value;
-
-    zend_string *version = get_DD_VERSION();
-    if (ZSTR_LEN(version) > 0) {  // non-empty
-        ZVAL_STR_COPY(&value, version);
-        zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
-    }
-
-    zend_string *env = get_DD_ENV();
-    if (ZSTR_LEN(env) > 0) {  // non-empty
-        ZVAL_STR_COPY(&value, env);
-        zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
-    }
-
-    if (DDTRACE_G(dd_origin)) {
-        ZVAL_STR_COPY(&value, DDTRACE_G(dd_origin));
-        zend_hash_str_add_new(meta, ZEND_STRL("_dd.origin"), &value);
-    }
 
     zend_array *global_tags = get_DD_TAGS();
     zend_string *global_key;
@@ -665,6 +647,25 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
             ZVAL_STR(&hostname_zv, hostname);
             zend_hash_str_add_new(meta, ZEND_STRL("_dd.hostname"), &hostname_zv);
         }
+    }
+
+    zval value;
+
+    zend_string *version = get_DD_VERSION();
+    if (ZSTR_LEN(version) > 0) {  // non-empty
+        ZVAL_STR_COPY(&value, version);
+        zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
+    }
+
+    zend_string *env = get_DD_ENV();
+    if (ZSTR_LEN(env) > 0) {  // non-empty
+        ZVAL_STR_COPY(&value, env);
+        zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
+    }
+
+    if (DDTRACE_G(dd_origin)) {
+        ZVAL_STR_COPY(&value, DDTRACE_G(dd_origin));
+        zend_hash_str_add_new(meta, ZEND_STRL("_dd.origin"), &value);
     }
 
     ddtrace_integration *web_integration = &ddtrace_integrations[DDTRACE_INTEGRATION_WEB];

--- a/ext/span.c
+++ b/ext/span.c
@@ -192,6 +192,25 @@ set_trace_id_from_span_id:
         zval *prop_type = ddtrace_spandata_property_type(span);
         zval_ptr_dtor(prop_type);
         ZVAL_COPY(prop_type, ddtrace_spandata_property_type(parent_span));
+
+        zend_array *meta = ddtrace_spandata_property_meta(span), *parent_meta = ddtrace_spandata_property_meta(parent_span);
+        zval *version;
+        if ((version = zend_hash_str_find(parent_meta, ZEND_STRL("version")))) {
+            Z_TRY_ADDREF_P(version);
+            zend_hash_str_add_new(meta, ZEND_STRL("version"), version);
+        }
+
+        zval *env;
+        if ((env = zend_hash_str_find(parent_meta, ZEND_STRL("env")))) {
+            Z_TRY_ADDREF_P(env);
+            zend_hash_str_add_new(meta, ZEND_STRL("env"), env);
+        }
+
+        zval *origin;
+        if ((origin = zend_hash_str_find(parent_meta, ZEND_STRL("_dd.origin")))) {
+            Z_TRY_ADDREF_P(origin);
+            zend_hash_str_add_new(meta, ZEND_STRL("_dd.origin"), origin);
+        }
     }
 
     span->root = DDTRACE_G(active_stack)->root_span;

--- a/tests/ext/inherit_meta_from_parent.phpt
+++ b/tests/ext/inherit_meta_from_parent.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Inherit some global metadata from parent span
+--INI--
+datadog.trace.generate_root_span=0
+datadog.env = badenv
+datadog.version = badversion
+--ENV--
+HTTP_X_DATADOG_ORIGIN=badorigin
+--FILE--
+<?php
+
+$span = \DDTrace\start_span();
+$span->meta["version"] = "goodversion";
+$span->meta["env"] = "goodenv";
+$span->meta["_dd.origin"] = "goodorigin";
+
+\DDTrace\start_span();
+\DDTrace\close_span();
+
+\DDTrace\close_span();
+
+var_dump(array_intersect_key(dd_trace_serialize_closed_spans()[1]["meta"], [
+    "_dd.origin" => 1,
+    "env" => 1,
+    "version" => 1,
+]));
+
+?>
+--EXPECT--
+array(3) {
+  ["version"]=>
+  string(11) "goodversion"
+  ["env"]=>
+  string(7) "goodenv"
+  ["_dd.origin"]=>
+  string(10) "goodorigin"
+}


### PR DESCRIPTION
### Description

Fetch things from parent span in order to ensure consistency of global tags, if the root spans metadata is changed after start.

Relates to #1958.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
