### PR TITLE
Reduce flakiness from docker containers not starting properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,17 +277,30 @@ commands:
           name: Setup docker image << parameters.docker_image >>
           command: |
             set -x
+            max_retries=3
             extra=<< parameters.extra >>
             docker network create net --driver=bridge -o "com.docker.network.bridge.name=br"
             if [[ $extra == "with_httpbin_and_request_replayer" ]]; then
-              docker run --detach --rm --net net \
+              function retry_docker() {
+                retries=$max_retries
+                while
+                  ! docker "${@}"
+                do
+                  if [[ $((--retries)) -eq 0 ]]; then
+                    exit 1
+                  fi
+                  sleep 1
+                done
+                true # Success
+              }
+              retry_docker run --detach --rm --net net \
                 -e DD_APM_ENABLED=true \
                 -e DD_BIND_HOST=0.0.0.0 \
                 -e DD_API_KEY=invalid_key_but_this_is_fine \
                 ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
-              docker run --detach --rm --net net \
+              retry_docker run --detach --rm --net net \
                 --name httpbin_integration kong/httpbin
-              docker run --detach --rm --net net \
+              retry_docker run --detach --rm --net net \
                 -e DD_REQUEST_DUMPER_FILE=dump.json \
                 --name request-replayer datadog/dd-trace-ci:php-request-replayer-2.0
             fi
@@ -296,7 +309,7 @@ commands:
             sudo mkdir /rust
             sudo chmod 777 /rust
             image=<< parameters.docker_image >>
-            retries=3
+            retries=$max_retries
             while
               nohup docker run --rm --net net \
                   -e DDAGENT_HOSTNAME=127.0.0.1 \

--- a/tests/randomized/analyze-results.php
+++ b/tests/randomized/analyze-results.php
@@ -107,7 +107,6 @@ function analyze_cli($tmpScenariosFolder)
     $notEnoughResults = [];
     $largeInterceptResults = [];
     $leaksResults = [];
-    $leaksResultsPhp54 = [];
 
     foreach (scandir($resultsFolder) as $identifier) {
         if (in_array($identifier, ['.', '..'])) {
@@ -119,7 +118,7 @@ function analyze_cli($tmpScenariosFolder)
         $absFilePath = $resultsFolder . DIRECTORY_SEPARATOR . $identifier . DIRECTORY_SEPARATOR . 'memory.out';
 
         $values = array_map('intval', array_filter(
-            explode("\n", file_get_contents($absFilePath)),
+            file($absFilePath),
             function ($l) {
                 // explicitly allow 0, as these occur when Zend MM is off
                 return $l != "";
@@ -131,6 +130,9 @@ function analyze_cli($tmpScenariosFolder)
             continue;
         }
 
+        // Skip the first runs to avoid false positives with runs where a path initializing something is entered late
+        $values = array_slice($values, 20);
+
         list($slope, $intercept) = calculate_trend_line($values);
 
         if ($intercept > 6.5 * 1000 * 1000) {
@@ -141,12 +143,7 @@ function analyze_cli($tmpScenariosFolder)
 
         // We must accept a 0.1% slope as elastic search has small increases even when tracer is not loaded.
         if (abs($slope) > ($intercept * 0.001)) {
-            if (substr($identifier, -3) === '5.4') {
-                // PHP 5.4 has leaks in long running CLI scripts regardless of the tracer loaded
-                $leaksResultsPhp54[] = $identifier;
-            } else {
-                $leaksResults[] = $identifier;
-            }
+            $leaksResults[] = $identifier;
             continue;
         }
     }
@@ -157,12 +154,6 @@ function analyze_cli($tmpScenariosFolder)
     if (count($leaksResults)) {
         echo "The following scenarios might have memory leaks in CLI. Check out their respective memory.out file:\n ";
         foreach ($leaksResults as $result) {
-            echo "    $result\n";
-        }
-    }
-    if (count($leaksResultsPhp54)) {
-        echo "The following scenarios leak memory on PHP 5.4 (expected, it happens also without tracing):\n ";
-        foreach ($leaksResultsPhp54 as $result) {
             echo "    $result\n";
         }
     }


### PR DESCRIPTION
### Description

Also reduce false positives from randomized memory report.

Should reduce errors in CI of type:
```
docker: Error response from daemon: Head "https://ghcr.io/v2/datadog/dd-apm-test-agent/ddapm-test-agent/manifests/latest": Get "https://ghcr.io/token?scope=repository%3Adatadog%2Fdd-apm-test-agent%2Fddapm-test-agent%3Apull&service=ghcr.io": context deadline exceeded (Client.Timeout exceeded while awaiting headers).
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
