### PR TITLE
Cleanup _asan usages in Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,6 +665,7 @@ jobs:
           name: Run tests
           command: |
             set -euo pipefail
+            if [[ << parameters.switch_php_version >> == *asan* ]]; then export TEST_PHP_JUNIT=$(pwd)/asan-extension-test.xml; fi
             make << parameters.make_target >> 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }
       - when:
           # codecov uploader only on amd64
@@ -1791,7 +1792,7 @@ jobs:
           command: |
             set -eo pipefail
             switch-php debug-zts-asan
-            make asan
+            make
             cp -v tmp/build_extension/.libs/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug-zts.so
       - persist_to_workspace:
           root: '.'
@@ -3200,15 +3201,15 @@ workflows:
                 - medium
                 - arm.medium
               make_target:
-                - test_c_asan
-                - test_with_init_hook_asan
+                - test_c
+                - test_with_init_hook
                 - test_internal_api_randomized
-                - test_opcache_asan
+                - test_opcache
             exclude:
                 # apparently for no discernible reason, on x86 asan builds PHP 7.4. fails to allocate opcache shared memory
               - php_major_minor: '7.4'
                 resource_class: medium
-                make_target: test_opcache_asan
+                make_target: test_opcache
                 switch_php_version: debug-zts-asan
 
       - integration:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/vendor
 !/ext/vendor
 tmp/build_extension/
-composer.lock
+composer.lock*
 **/core*
 .DS_Store
 .scenarios.lock/

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -56,7 +56,7 @@ static void zai_hook_safe_finish(zend_execute_data *execute_data, zval *retval, 
     const size_t stack_size = 1 << 17;
     void *volatile stack = malloc(stack_size);
     if (SETJMP(target) == 0) {
-        void *stacktop = stack + stack_size, *stacktarget = stacktop - 0x400;
+        void *stacktop = stack + stack_size, *stacktarget = stacktop - 0x800;
 
 #ifdef __SANITIZE_ADDRESS__
         void *volatile fake_stack;

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -39,6 +39,9 @@ static inline bool zai_hook_memory_table_del(zend_execute_data *index) {
 }
 
 #if defined(__x86_64__) || defined(__aarch64__)
+# if defined(__GNUC__) && !defined(__clang__)
+__attribute__((no_sanitize_address))
+# endif
 static void zai_hook_safe_finish(zend_execute_data *execute_data, zval *retval, zai_frame_memory *frame_memory) {
     if (!CG(unclean_shutdown)) {
         zai_hook_finish(execute_data, retval, &frame_memory->hook_data);
@@ -56,7 +59,7 @@ static void zai_hook_safe_finish(zend_execute_data *execute_data, zval *retval, 
     const size_t stack_size = 1 << 17;
     void *volatile stack = malloc(stack_size);
     if (SETJMP(target) == 0) {
-        void *stacktop = stack + stack_size, *stacktarget = stacktop - 0x800;
+        void *stacktop = stack + stack_size, *stacktarget = stacktop - 0x400;
 
 #ifdef __SANITIZE_ADDRESS__
         void *volatile fake_stack;


### PR DESCRIPTION
### Description

Instead recognize libasan in the active php binary. "ASAN=" to disable, "ASAN=1" to enable explicitly.

I noticed that even though I have debug-zts-asan in my container, I usually did not have the extension itself built with asan, which sort of defeated the point mostly, given that I've not been adding `_asan` to my commands all the time.

Also optimizing Makefile to only do a `composer update` on missing lockfile or lockfile for different PHP version being installed when running `make test_*` commands.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
