### PR TITLE
Add DD_TRACE_HOOK_LIMIT

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -142,6 +142,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_ENABLED, "false")                                                          \
     CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \
     CONFIG(BOOL, DD_TRACE_FORKED_PROCESS, "true")                                                              \
+    CONFIG(INT, DD_TRACE_HOOK_LIMIT, "100")                                                                    \
     CONFIG(INT, DD_TRACE_AGENT_MAX_PAYLOAD_SIZE, "52428800", .ini_change = zai_config_system_ini_change)       \
     CONFIG(INT, DD_TRACE_AGENT_STACK_INITIAL_SIZE, "131072", .ini_change = zai_config_system_ini_change)       \
     CONFIG(INT, DD_TRACE_AGENT_STACK_BACKLOG, "12", .ini_change = zai_config_system_ini_change)                \

--- a/tests/ext/sandbox-regression/handle_many_hooks.phpt
+++ b/tests/ext/sandbox-regression/handle_many_hooks.phpt
@@ -1,5 +1,7 @@
 --TEST--
 The tracer should not crash when many hooks are installed
+--ENV--
+DD_TRACE_HOOK_LIMIT=0
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/hook_limit.phpt
+++ b/tests/ext/sandbox/hook_limit.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Ensure the hook limit is not exceeded
+--INI--
+datadog.trace.hook_limit=2
+--FILE--
+<?php
+
+function foo() {
+}
+
+$cb = function () use (&$invocations) {
+    ++$invocations;
+};
+
+DDTrace\hook_function("foo", $cb);
+DDTrace\install_hook("foo", $cb);
+var_dump(DDTrace\hook_function("foo", $cb));
+var_dump(DDTrace\install_hook("foo", $cb));
+
+foo();
+print "foo hooks were $invocations times invoked\n";
+
+?>
+--EXPECTF--
+Could not add hook to foo with more than datadog.trace.hook_limit = 2 installed hooks in %s:%d This message is only displayed once. Use DD_TRACE_DEBUG=1 to show all messages.
+bool(false)
+int(0)
+foo hooks were 2 times invoked

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -117,6 +117,9 @@ zai_hook_iterator zai_hook_iterate_resolved(zend_function *function);
 void zai_hook_iterator_advance(zai_hook_iterator *iterator);
 void zai_hook_iterator_free(zai_hook_iterator *iterator);
 
+uint32_t zai_hook_count_installed(zai_string_view scope, zai_string_view function);
+uint32_t zai_hook_count_resolved(zend_function *function);
+
 /* {{{ */
 static inline zai_install_address zai_hook_install_address_user(const zend_op_array *op_array) {
     return ((zend_ulong)op_array->opcodes) >> 5;


### PR DESCRIPTION
### Description

The primary motivation is users mistakenly installing hooks in a loop and observing memory leaking / increasing overhead.

Closes #1956.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
