### PR TITLE
Ensure that internal functions we trace in our integrations are always traced under JIT

### DIFF
--- a/ext/handlers_internal.c
+++ b/ext/handlers_internal.c
@@ -1,10 +1,7 @@
 #include "handlers_internal.h"
 
 #include "arrays.h"
-#include "configuration.h"
 #include "ddtrace.h"
-#include "engine_hooks.h"
-#include "logging.h"
 
 void ddtrace_free_unregistered_class(zend_class_entry *ce) {
 #if PHP_VERSION_ID >= 80100
@@ -33,6 +30,87 @@ void ddtrace_curl_handlers_startup(void);
 void ddtrace_exception_handlers_startup(void);
 void ddtrace_pcntl_handlers_startup(void);
 
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80200
+#include <hook/hook.h>
+#include <interceptor/php8/interceptor.h>
+
+static HashTable dd_orig_internal_funcs;
+
+static inline zend_ulong dd_identify_internal_func(zend_function *func) {
+    return ((zend_ulong)(uintptr_t)func->common.scope) ^ zend_string_hash_val(func->common.function_name);
+}
+
+static void dd_wrap_internal_func(INTERNAL_FUNCTION_PARAMETERS) {
+    zif_handler handler;
+    if ((handler = zend_hash_index_find_ptr(&dd_orig_internal_funcs, dd_identify_internal_func(EX(func))))) {
+        zai_interceptor_execute_internal_with_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, handler);
+    }
+}
+
+static inline void dd_install_internal_func(zend_function *func) {
+    zend_hash_index_add_ptr(&dd_orig_internal_funcs, dd_identify_internal_func(func), func->internal_function.handler);
+    func->internal_function.handler = dd_wrap_internal_func;
+}
+
+static inline void dd_install_internal_func_name(HashTable *baseTable, const char *name) {
+    zend_function *func;
+    if ((func = zend_hash_str_find_ptr(baseTable, name, strlen(name)))) {
+        dd_install_internal_func(func);
+    }
+}
+
+static inline void dd_install_internal_function(const char *function) {
+    dd_install_internal_func_name(CG(function_table), function);
+}
+
+static inline void dd_install_internal_method(const char *class, const char *method) {
+    zend_class_entry *ce;
+    if ((ce = zend_hash_str_find_ptr(CG(class_table), class, strlen(class)))) {
+        dd_install_internal_func_name(&ce->function_table, method);
+    }
+}
+
+static inline void dd_install_internal_class(const char *class) {
+    zend_class_entry *ce;
+    if ((ce = zend_hash_str_find_ptr(CG(class_table), class, strlen(class)))) {
+        zend_function *func;
+        ZEND_HASH_FOREACH_PTR(&ce->function_table, func) {
+            dd_install_internal_func(func);
+        } ZEND_HASH_FOREACH_END();
+    }
+}
+
+static void dd_install_internal_handlers(void) {
+    zend_hash_init(&dd_orig_internal_funcs, 32, NULL, NULL, true);
+    dd_install_internal_class("memcached");
+    dd_install_internal_class("redis");
+    dd_install_internal_class("rediscluster");
+    dd_install_internal_method("mysqli", "__construct");
+    dd_install_internal_method("mysqli", "real_connect");
+    dd_install_internal_method("mysqli", "query");
+    dd_install_internal_method("mysqli", "prepare");
+    dd_install_internal_method("mysqli", "commit");
+    dd_install_internal_method("mysqli_stmt", "execute");
+    dd_install_internal_method("mysqli_stmt", "get_result");
+    dd_install_internal_method("PDO", "__construct");
+    dd_install_internal_method("PDO", "exec");
+    dd_install_internal_method("PDO", "query");
+    dd_install_internal_method("PDO", "prepare");
+    dd_install_internal_method("PDO", "commit");
+    dd_install_internal_method("PDOStatement", "execute");
+    dd_install_internal_function("mysqli_connect");
+    dd_install_internal_function("mysqli_real_connect");
+    dd_install_internal_function("mysqli_query");
+    dd_install_internal_function("mysqli_prepare");
+    dd_install_internal_function("mysqli_commit");
+    dd_install_internal_function("mysqli_stmt_execute");
+    dd_install_internal_function("mysqli_stmt_get_result");
+    dd_install_internal_function("curl_exec");
+    dd_install_internal_function("pcntl_fork");
+    dd_install_internal_function("pcntl_rfork");
+}
+#endif
+
 #if PHP_VERSION_ID < 80000
 void ddtrace_curl_handlers_shutdown(void);
 #endif
@@ -44,6 +122,17 @@ void ddtrace_exception_handlers_rinit(void);
 void ddtrace_curl_handlers_rshutdown(void);
 
 void ddtrace_internal_handlers_startup(void) {
+    // On PHP 8.0 zend_execute_internal is not executed in JIT. Manually ensure internal hooks are executed.
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80200
+#if PHP_VERSION_ID >= 80100
+    zend_long patch_version = Z_LVAL_P(zend_get_constant_str(ZEND_STRL("PHP_RELEASE_VERSION")));
+    if (patch_version < 18)
+#endif
+    {
+        dd_install_internal_handlers();
+    }
+#endif
+
     // curl is different; it has pieces that always run.
     ddtrace_curl_handlers_startup();
     // pcntl handlers have to run even if tracing of pcntl extension is not enabled.
@@ -53,6 +142,10 @@ void ddtrace_internal_handlers_startup(void) {
 }
 
 void ddtrace_internal_handlers_shutdown(void) {
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80200
+    zend_hash_destroy(&dd_orig_internal_funcs);
+#endif
+
     ddtrace_exception_handlers_shutdown();
 #if PHP_VERSION_ID < 80000
     ddtrace_curl_handlers_shutdown();

--- a/tests/ext/sandbox/internal_hook_jit.phpt
+++ b/tests/ext/sandbox/internal_hook_jit.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test internal functions are hooked within JIT
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
+--INI--
+opcache.enable = 1
+opcache.enable_cli = 1
+opcache.jit_buffer_size = 10M
+opcache.jit = 1202
+zend_extension = opcache.so
+--FILE--
+<?php
+
+function jitted_exec($ch) {
+    curl_exec($ch);
+}
+
+DDTrace\hook_function("curl_exec", function() {
+    print "Internal curl_exec() function JITed";
+});
+
+// create a new cURL resource
+$ch = curl_init();
+
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+curl_setopt($ch, CURLOPT_URL, "$url");
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+jitted_exec($ch);
+
+?>
+--EXPECT--
+Internal curl_exec() function JITed

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -675,7 +675,7 @@ static void zai_interceptor_generator_dtor_wrapper(zend_object *object) {
 
 #if PHP_VERSION_ID < 80200
 static void (*prev_execute_internal)(zend_execute_data *execute_data, zval *return_value);
-static inline void zai_interceptor_execute_internal_impl(zend_execute_data *execute_data, zval *return_value, bool prev) {
+static inline void zai_interceptor_execute_internal_impl(zend_execute_data *execute_data, zval *return_value, bool prev, zif_handler handler) {
     zend_function *func = execute_data->func;
     if (UNEXPECTED(zai_hook_installed_internal(&func->internal_function))) {
         zai_frame_memory frame_memory;
@@ -689,7 +689,7 @@ static inline void zai_interceptor_execute_internal_impl(zend_execute_data *exec
             if (prev) {
                 prev_execute_internal(execute_data, return_value);
             } else {
-                func->internal_function.handler(execute_data, return_value);
+                handler(execute_data, return_value);
             }
         } zend_catch {
             zend_execute_data *active_execute_data = EG(current_execute_data);
@@ -723,17 +723,26 @@ static inline void zai_interceptor_execute_internal_impl(zend_execute_data *exec
         if (prev) {
             prev_execute_internal(execute_data, return_value);
         } else {
-            func->internal_function.handler(execute_data, return_value);
+            handler(execute_data, return_value);
         }
     }
 }
 
 static void zai_interceptor_execute_internal_no_prev(zend_execute_data *execute_data, zval *return_value) {
-    zai_interceptor_execute_internal_impl(execute_data, return_value, false);
+    zai_interceptor_execute_internal_impl(execute_data, return_value, false, execute_data->func->internal_function.handler);
 }
 
 static void zai_interceptor_execute_internal(zend_execute_data *execute_data, zval *return_value) {
-    zai_interceptor_execute_internal_impl(execute_data, return_value, true);
+    zai_interceptor_execute_internal_impl(execute_data, return_value, true, NULL);
+}
+
+void zai_interceptor_execute_internal_with_handler(INTERNAL_FUNCTION_PARAMETERS, zif_handler handler) {
+    zai_frame_memory *frame_memory;
+    if (zai_hook_memory_table_find(execute_data, &frame_memory)) {
+        handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+    } else {
+        zai_interceptor_execute_internal_impl(execute_data, return_value, false, handler);
+    }
 }
 #endif
 

--- a/zend_abstract_interface/interceptor/php8/interceptor.h
+++ b/zend_abstract_interface/interceptor/php8/interceptor.h
@@ -3,6 +3,8 @@
 
 #if PHP_VERSION_ID < 80200
 extern int zai_registered_observers;
+
+void zai_interceptor_execute_internal_with_handler(INTERNAL_FUNCTION_PARAMETERS, zif_handler handler);
 #endif
 
 void zai_interceptor_minit(void);


### PR DESCRIPTION
### Description

On PHP 8.0 and PHP <=8.1.17, zend_execute_internal is not called in JIT. This replaces the handlers by a thin wrapper calling our zend_execute_internal handler directly.

This has been fixed in php-src via https://github.com/php/php-src/commit/c53e8d3e309a3c6154d9875d2a491822ecf78b9d.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
