### PR TITLE
fix(profiling): issues when preloading and non-root php-fpm user are used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1879,11 +1879,15 @@ jobs:
       - run:
           name: Build Profiler
           command: |
+            if [ -d '/opt/rh/devtoolset-7' ] ; then
+                set +eo pipefail
+                source scl_source enable devtoolset-7
+                set -eo pipefail
+            fi
             set -u
             libdir=$PWD/datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
             mkdir -vp "${libdir}"
             command -v switch-php && switch-php "${PHP_VERSION}"
-            set -e
             cd profiling
             cargo build --release
             cp -v "${CARGO_TARGET_DIR}/release/libdatadog_php_profiling.so" "${libdir}/datadog-profiling.so"
@@ -1922,9 +1926,13 @@ jobs:
       - run:
           name: cargo tests
           command: |
+            if [ -d '/opt/rh/devtoolset-7' ] ; then
+                set +eo pipefail
+                source scl_source enable devtoolset-7
+                set -eo pipefail
+            fi
             set -u
             command -v switch-php && switch-php "${PHP_VERSION}"
-            set -e
             cd profiling
             cargo test --release
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1947,7 +1947,7 @@ jobs:
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
             export TEST_PHP_EXECUTABLE=$(which php)
-            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
+            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" -d zend_extension=opcache --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1947,7 +1947,7 @@ jobs:
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
             export TEST_PHP_EXECUTABLE=$(which php)
-            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" -d zend_extension=opcache --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
+            php run-tests.php -d "extension=${libdir}/datadog-profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-php-profiling"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.60"

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -272,9 +272,9 @@ extern "C" {
 
 #[cfg(php_preload)]
 extern "C" {
-    /// Returns true after zend_post_startup_cb has been called for the first
-    /// time. This is useful to know. For example, preloading occurs while
-    /// this is false.
+    /// Returns true after zend_post_startup_cb has been called for the current
+    /// startup/shutdown cycle. This is useful to know. For example,
+    /// preloading occurs while this is false.
     pub fn ddog_php_prof_is_post_startup() -> bool;
 }
 

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -270,6 +270,14 @@ extern "C" {
     pub fn ddog_php_prof_zend_string_view(zstr: Option<&mut zend_string>) -> zai_string_view;
 }
 
+#[cfg(php_preload)]
+extern "C" {
+    /// Returns true after zend_post_startup_cb has been called for the first
+    /// time. This is useful to know. For example, preloading occurs while
+    /// this is false.
+    pub fn ddog_php_prof_is_post_startup() -> bool;
+}
+
 pub use zend_module_dep as ModuleDep;
 
 impl ModuleDep {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -547,6 +547,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
     // but the  simplest is to not enable the profiler until the engine's
     // startup is complete. This means the preloading will not be profiled,
     // but this should be okay.
+    #[cfg(php_preload)]
     if !unsafe { bindings::ddog_php_prof_is_post_startup() } {
         debug!("zend_post_startup_cb hasn't happened yet; not enabling profiler.");
         return ZendResult::Success;

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -1,9 +1,12 @@
 #include "php_ffi.h"
 
 #include <assert.h>
-#include <stdatomic.h>
 #include <stdbool.h>
 #include <string.h>
+
+#if CFG_PRELOAD // defined by build.rs
+#include <stdatomic.h>
+#endif
 
 const char *datadog_extension_build_id(void) { return ZEND_EXTENSION_BUILD_ID; }
 const char *datadog_module_build_id(void) { return ZEND_MODULE_BUILD_ID; }
@@ -72,6 +75,7 @@ void datadog_php_profiling_startup(zend_extension *extension) {
     }
 
 #if CFG_PRELOAD // defined by build.rs
+    atomic_store(&_is_post_startup, false);
     orig_post_startup_cb = zend_post_startup_cb;
     zend_post_startup_cb = ddog_php_prof_post_startup_cb;
 #endif

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -70,6 +70,12 @@ extern ddtrace_profiling_context (*datadog_php_profiling_get_profiling_context)(
 void datadog_php_profiling_startup(zend_extension *extension);
 
 /**
+ * Returns true after zend_post_startup_cb has been called for the first time.
+ * This is useful to know. For example, preloading occurs while this is false.
+ */
+_Bool ddog_php_prof_is_post_startup(void);
+
+/**
  * Used to hold information for overwriting the internal function handler
  * pointer in the Zend Engine.
  */

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -70,12 +70,6 @@ extern ddtrace_profiling_context (*datadog_php_profiling_get_profiling_context)(
 void datadog_php_profiling_startup(zend_extension *extension);
 
 /**
- * Returns true after zend_post_startup_cb has been called for the first time.
- * This is useful to know. For example, preloading occurs while this is false.
- */
-_Bool ddog_php_prof_is_post_startup(void);
-
-/**
  * Used to hold information for overwriting the internal function handler
  * pointer in the Zend Engine.
  */

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -20,11 +20,12 @@ foreach (['datadog-profiling', 'Zend OPcache'] as $extension)
     if (!extension_loaded($extension))
         echo "skip: test requires {$extension}\n";
 ?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=debug
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=no
 --INI--
-datadog.profiling.enabled=yes
-datadog.profiling.log_level=debug
-datadog.profiling.experimental_allocation_enabled=no
-datadog.profiling.experimental_cpu_time_enabled=no
 opcache.enable=1
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php
@@ -33,7 +34,6 @@ opcache.preload={PWD}/preload_01_preload.php
 echo "Done.", PHP_EOL;
 ?>
 --EXPECTREGEX--
-.*
 .* zend_post_startup_cb hasn't happened yet; not enabling profiler.
 preloading
 .* Started with an upload period of 67 seconds and approximate wall-time period of 10 milliseconds.

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Profiling should only be enabled after preloading has happened
+--DESCRIPTION--
+This is a special case for when PHP-FPM running as non-root user and preloading
+is enabled. In this case, PHP will do preloading in the php-fpm: master process
+and not in one of it's childs. This will start profiling (including the threads)
+in the master process already before the fork happens to create workers. In the
+worker processes the global state indicates that profiling is running, but all 
+handles to the threads and channels are invalid leading to those channels
+filling up and PHP-FPM blocking ultimately.
+See: https://github.com/DataDog/dd-trace-php/issues/1919
+Due to limitations of PHPT, this test does not test PHP-FPM or processes run
+with different permissions, but it makes sure, that profiling is started after
+preloading is done.
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.preload={PWD}/preload_01_preload.php
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=debug
+--FILE--
+<?php
+echo "Done.", PHP_EOL;
+?>
+--EXPECTREGEX--
+.*
+.* zend_post_startup_cb hasn't happened yet; not enabling profiler.
+preloading
+.* Memory allocation profiling enabled.
+.* Started with an upload period of 67 seconds and approximate wall-time period of 10 milliseconds.
+Done.
+.* Stopping profiler.
+.* Notified other threads of cancellation.
+.* No profiles to upload.

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -12,13 +12,16 @@ See: https://github.com/DataDog/dd-trace-php/issues/1919
 Due to limitations of PHPT, this test does not test PHP-FPM or processes run
 with different permissions, but it makes sure, that profiling is started after
 preloading is done.
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) echo "skip: need preloading"; ?>
 --INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+datadog.profiling.experimental_allocation_enabled=no
+datadog.profiling.experimental_cpu_time_enabled=no
 opcache.enable=1
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php
---ENV--
-DD_PROFILING_ENABLED=yes
-DD_PROFILING_LOG_LEVEL=debug
 --FILE--
 <?php
 echo "Done.", PHP_EOL;
@@ -27,7 +30,6 @@ echo "Done.", PHP_EOL;
 .*
 .* zend_post_startup_cb hasn't happened yet; not enabling profiler.
 preloading
-.* Memory allocation profiling enabled.
 .* Started with an upload period of 67 seconds and approximate wall-time period of 10 milliseconds.
 Done.
 .* Stopping profiler.

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -29,6 +29,7 @@ DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=no
 opcache.enable=1
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php
+opcache.preload_user=circleci
 --FILE--
 <?php
 echo "Done.", PHP_EOL;

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -16,13 +16,15 @@ preloading is done.
 <?php
 if (PHP_VERSION_ID < 70400)
     echo "skip: need preloading";
+foreach (['datadog-profiling', 'Zend OPcache'] as $extension)
+    if (!extension_loaded($extension))
+        echo "skip: test requires {$extension}\n";
 ?>
 --INI--
 datadog.profiling.enabled=yes
 datadog.profiling.log_level=debug
 datadog.profiling.experimental_allocation_enabled=no
 datadog.profiling.experimental_cpu_time_enabled=no
-zend_extension=opcache
 opcache.enable=1
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -28,6 +28,7 @@ DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=no
 zend_extension=opcache
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php
+opcache.preload_user=root
 --FILE--
 <?php
 echo "Done.", PHP_EOL;

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -15,16 +15,15 @@ preloading is done.
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID < 70400)
-    echo "skip: need preloading and therefore PHP ";
+    echo "skip: need preloading and therefore PHP", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
-    echo "skip: test requires datadog-profiling\n";
+    echo "skip: test requires datadog-profiling", PHP_EOL;
 ?>
---ENV--
-DD_PROFILING_ENABLED=yes
-DD_PROFILING_LOG_LEVEL=debug
-DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
-DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=no
 --INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+datadog.profiling.experimental_allocation_enabled=no
+datadog.profiling.experimental_cpu_time_enabled=no
 zend_extension=opcache
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -13,12 +13,16 @@ Due to limitations of PHPT, this test does not test PHP-FPM or processes run
 with different permissions, but it makes sure, that profiling is started after
 preloading is done.
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70400) echo "skip: need preloading"; ?>
+<?php
+if (PHP_VERSION_ID < 70400)
+    echo "skip: need preloading";
+?>
 --INI--
 datadog.profiling.enabled=yes
 datadog.profiling.log_level=debug
 datadog.profiling.experimental_allocation_enabled=no
 datadog.profiling.experimental_cpu_time_enabled=no
+zend_extension=opcache
 opcache.enable=1
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -5,7 +5,7 @@ This is a special case for when PHP-FPM running as non-root user and preloading
 is enabled. In this case, PHP will do preloading in the php-fpm: master process
 and not in one of it's childs. This will start profiling (including the threads)
 in the master process already before the fork happens to create workers. In the
-worker processes the global state indicates that profiling is running, but all 
+worker processes the global state indicates that profiling is running, but all
 handles to the threads and channels are invalid leading to those channels
 filling up and PHP-FPM blocking ultimately.
 See: https://github.com/DataDog/dd-trace-php/issues/1919

--- a/profiling/tests/phpt/preload_01.phpt
+++ b/profiling/tests/phpt/preload_01.phpt
@@ -15,10 +15,9 @@ preloading is done.
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID < 70400)
-    echo "skip: need preloading";
-foreach (['datadog-profiling', 'Zend OPcache'] as $extension)
-    if (!extension_loaded($extension))
-        echo "skip: test requires {$extension}\n";
+    echo "skip: need preloading and therefore PHP ";
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires datadog-profiling\n";
 ?>
 --ENV--
 DD_PROFILING_ENABLED=yes
@@ -26,10 +25,9 @@ DD_PROFILING_LOG_LEVEL=debug
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
 DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED=no
 --INI--
-opcache.enable=1
+zend_extension=opcache
 opcache.enable_cli=1
 opcache.preload={PWD}/preload_01_preload.php
-opcache.preload_user=circleci
 --FILE--
 <?php
 echo "Done.", PHP_EOL;

--- a/profiling/tests/phpt/preload_01_preload.php
+++ b/profiling/tests/phpt/preload_01_preload.php
@@ -1,2 +1,3 @@
 <?php
+
 echo "preloading", PHP_EOL;

--- a/profiling/tests/phpt/preload_01_preload.php
+++ b/profiling/tests/phpt/preload_01_preload.php
@@ -1,0 +1,2 @@
+<?php
+echo "preloading", PHP_EOL;


### PR DESCRIPTION
### Description

Fixes #1919. An issue occurred when preloading and a non-root user for php-fpm were combined, and eventually php-fpm would hang when the Profiler's channels were full. The full channel was worked around in a previous commit that landed in dd-trace-php v0.85.0, but this PR addresses the core issue so that profiles will actually get sent. Sampling will no longer occur when preloading is happening.

This adds a `CFG_PRELOAD` define for C and `cfg(php_preload)` for Rust, which match. They are made by the `build.rs` script, and are based on PHP version (PHP 7.4+ has preloading).

Bumps the profiling version to v0.15.0.

In CI, this changes the `cargo build` and `cargo test` type of jobs to use devtoolset-7 if it's present. This was required in a previous version of the PR which used `stdatomic.h`, but the newer toolchain is likely preferred anyway, so I've kept it even though it's no longer required.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
