### PR TITLE
Include the circleci URL for 1.0.0-nightly installers

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -21,6 +21,12 @@ const OPT_ENABLE_PROFILING = 'enable-profiling';
 // Release version is set while generating the final release files
 const RELEASE_VERSION = '@release_version@';
 
+// phpcs:disable Generic.Files.LineLength.TooLong
+// For testing purposes, we need an alternate repo where we can push bundles that includes changes that we are
+// trying to test, as the previously released versions would not have those changes.
+define('RELEASE_URL_PREFIX', (getenv('DD_TEST_INSTALLER_REPO') ?: "https://github.com/DataDog/dd-trace-php") . "/releases/download/" . RELEASE_VERSION . "/");
+// phpcs:enable Generic.Files.LineLength.TooLong
+
 function main()
 {
     if (is_truthy(getenv('DD_TEST_EXECUTION'))) {
@@ -106,15 +112,8 @@ function install($options)
         print_warning('--' . OPT_FILE . ' option is intended for internal usage and can be removed without notice');
         $tmpDirTarGz = $options[OPT_FILE];
     } else {
-        $version = RELEASE_VERSION;
-        // phpcs:disable Generic.Files.LineLength.TooLong
-        // For testing purposes, we need an alternate repo where we can push bundles that includes changes that we are
-        // trying to test, as the previously released versions would not have those changes.
-        $url = (getenv('DD_TEST_INSTALLER_REPO') ?: "https://github.com/DataDog/dd-trace-php")
-            . "/releases/download/{$version}/dd-library-php-{$version}-{$platform}.tar.gz";
-        // phpcs:enable Generic.Files.LineLength.TooLong
+        $url = RELEASE_URL_PREFIX . "dd-library-php-" . RELEASE_VERSION . "-{$platform}.tar.gz";
         download($url, $tmpDirTarGz);
-        unset($version);
     }
     execute_or_exit(
         "Cannot extract the archive",

--- a/tooling/bin/generate-installers.sh
+++ b/tooling/bin/generate-installers.sh
@@ -9,3 +9,6 @@ packages_build_dir=$2
 # Installers
 ########################
 sed "s|@release_version@|${release_version}|g" ./datadog-setup.php > "${packages_build_dir}/datadog-setup.php"
+if [[ ${release_version} == "1.0.0-nightly" && -n ${CIRCLE_WORKFLOW_JOB_ID:-} ]]; then
+  sed -ri "s|define\('RELEASE_URL_PREFIX'[^;]+|const RELEASE_URL_PREFIX = 'https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/'|" "${packages_build_dir}/datadog-setup.php"
+fi


### PR DESCRIPTION
### Description

This makes it easier to install directly from master or a branch, without having to install the .tar.gz manually.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
