### PR TITLE
Installer: update appsec helper and rules path

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -342,18 +342,11 @@ function install($options)
                     . escapeshellarg($iniFilePath)
                 );
 
-                // Update rules path
+                // Update and comment rules path
                 $rulesPathRegex = $options[OPT_INSTALL_DIR] . "/[0-9\.]*/etc/recommended.json";
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@datadog.appsec.rules \?= \?" . $rulesPathRegex . "@datadog.appsec.rules = " . $appSecRulesPath . "@g' "
-                    . escapeshellarg($iniFilePath)
-                );
-
-                // Comment rules to allow remote config updates
-                execute_or_exit(
-                    'Impossible to update the INI settings file.',
-                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \?" . $appSecRulesPath . "\)@;\\1@g' "
+                    "sed -i 's@^[ ;]*datadog.appsec.rules \?= \?" . $rulesPathRegex . "@;datadog.appsec.rules = " . $appSecRulesPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -353,7 +353,7 @@ function install($options)
                 // Comment rules to allow remote config updates
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \?". $appSecRulesPath . "\)@;\\1@g' "
+                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \?" . $appSecRulesPath . "\)@;\\1@g' "
                     . escapeshellarg($iniFilePath)
                 );
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -353,7 +353,7 @@ function install($options)
                 // Comment rules to allow remote config updates
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \? ". $appSecRulesPath . "\)@\\1@g' "
+                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \?". $appSecRulesPath . "\)@;\\1@g' "
                     . escapeshellarg($iniFilePath)
                 );
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -343,16 +343,17 @@ function install($options)
                 );
 
                 // Update rules path
+                $rulesPathRegex = $options[OPT_INSTALL_DIR] . "/[0-9\.]*/etc/recommended.json";
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@datadog.appsec.rules \?= \?.*@datadog.appsec.rules = " . $appSecRulesPath . "@g' "
+                    "sed -i 's@datadog.appsec.rules \?= \?" . $rulesPathRegex . "@datadog.appsec.rules = " . $appSecRulesPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
                 // Comment rules to allow remote config updates
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@^[ ]*datadog.appsec.rules \?= \?.*@;datadog.appsec.rules = @g' "
+                    "sed -i 's@^[ ]*\(datadog.appsec.rules \?= \? ". $appSecRulesPath . "\)@\\1@g' "
                     . escapeshellarg($iniFilePath)
                 );
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -335,6 +335,27 @@ function install($options)
                     . escapeshellarg($iniFilePath)
                 );
 
+                // Update helper path
+                execute_or_exit(
+                    'Impossible to update the INI settings file.',
+                    "sed -i 's@datadog.appsec.helper_path \?= \?.*@datadog.appsec.helper_path = " . $appSecHelperPath . "@g' "
+                    . escapeshellarg($iniFilePath)
+                );
+
+                // Update rules path
+                execute_or_exit(
+                    'Impossible to update the INI settings file.',
+                    "sed -i 's@datadog.appsec.rules \?= \?.*@datadog.appsec.rules = " . $appSecRulesPath . "@g' "
+                    . escapeshellarg($iniFilePath)
+                );
+
+                // Comment rules to allow remote config updates
+                execute_or_exit(
+                    'Impossible to update the INI settings file.',
+                    "sed -i 's@^[ ]*datadog.appsec.rules \?= \?.*@;datadog.appsec.rules = @g' "
+                    . escapeshellarg($iniFilePath)
+                );
+
                 if (is_truthy($options[OPT_ENABLE_APPSEC])) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',


### PR DESCRIPTION
### Description

Changes in this PR:

- Update appsec helper path
- Update appsec rules path
- Comment appsec rules if default (so that remote configuration can be used instead by default)

Updating the rules path and commenting it might seem unintuitive, the former is done just to keep it up to date in case the customer wants to use it, the latter is used so that remote configuration can override the rules (if user-defined rules are provided we can't override them). Commenting the rules is only done if the path corresponds to the default one.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
