### PR TITLE
Restrict backends on DBM propagation

### DIFF
--- a/src/Integrations/Integrations/DatabaseIntegrationHelper.php
+++ b/src/Integrations/Integrations/DatabaseIntegrationHelper.php
@@ -12,6 +12,7 @@ class DatabaseIntegrationHelper
             "sqlsrv" => true,
             "mysql" => true,
             "pgsql" => true,
+            "mssql" => true, // part of dblib
             "dblib" => true,
             "odbc" => true,
         ];
@@ -23,7 +24,7 @@ class DatabaseIntegrationHelper
                 "pgsql" => true,
             ];
 
-            if ($propagationMode == \DDTrace\DBM_PROPAGATION_FULL && !is($fullPropagationBackends[$backend])) {
+            if ($propagationMode == \DDTrace\DBM_PROPAGATION_FULL && !isset($fullPropagationBackends[$backend])) {
                 $propagationMode = \DDTrace\DBM_PROPAGATION_SERVICE;
             }
 

--- a/src/Integrations/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/Integrations/Integrations/Mysqli/MysqliIntegration.php
@@ -91,7 +91,7 @@ class MysqliIntegration extends Integration
                 $integration->setDefaultAttributes($span, 'mysqli_query', $query);
                 $integration->addTraceAnalyticsIfEnabled($span);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 1);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1);
             }, function (HookData $hook) use ($integration) {
                 list($mysqli, $query) = $hook->args;
                 $span = $hook->span();
@@ -112,7 +112,7 @@ class MysqliIntegration extends Integration
                 $span = $hook->span();
                 $integration->setDefaultAttributes($span, 'mysqli_prepare', $query);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 1);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1);
             }, function (HookData $hook) use ($integration) {
                 list($mysqli, $query) = $hook->args;
                 $span = $hook->span();
@@ -134,7 +134,7 @@ class MysqliIntegration extends Integration
                 $integration->setDefaultAttributes($span, 'mysqli.query', $query);
                 $integration->addTraceAnalyticsIfEnabled($span);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql');
             }, function (HookData $hook) use ($integration) {
                 list($query) = $hook->args;
                 $span = $hook->span();
@@ -156,7 +156,7 @@ class MysqliIntegration extends Integration
                 $span = $hook->span();
                 $integration->setDefaultAttributes($span, 'mysqli.prepare', $query);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql');
             }, function (HookData $hook) use ($integration) {
                 list($query) = $hook->args;
                 $span = $hook->span();
@@ -179,7 +179,7 @@ class MysqliIntegration extends Integration
                     $integration->setDefaultAttributes($span, 'mysqli_execute_query', $query);
                     $integration->addTraceAnalyticsIfEnabled($span);
 
-                    DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 1);
+                    DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1);
                 }, function (HookData $hook) use ($integration) {
                     list($mysqli, $query) = $hook->args;
                     $span = $hook->span();
@@ -202,7 +202,7 @@ class MysqliIntegration extends Integration
                     $integration->setDefaultAttributes($span, 'mysqli.execute_query', $query);
                     $integration->addTraceAnalyticsIfEnabled($span);
 
-                    DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                    DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql');
                 }, function (HookData $hook) use ($integration) {
                     list($query) = $hook->args;
                     $span = $hook->span();

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -72,7 +72,8 @@ class PDOIntegration extends Integration
                 PDOIntegration::setCommonSpanInfo($this, $span);
                 $integration->addTraceAnalyticsIfEnabled($span);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, $driver);
             }, function (HookData $hook) use ($integration) {
                 $span = $hook->span();
                 if (is_numeric($hook->returned)) {
@@ -95,7 +96,8 @@ class PDOIntegration extends Integration
                 PDOIntegration::setCommonSpanInfo($this, $span);
                 $integration->addTraceAnalyticsIfEnabled($span);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, $driver);
             }, function (HookData $hook) use ($integration) {
                 $span = $hook->span();
                 if ($hook->returned instanceof \PDOStatement) {
@@ -114,7 +116,8 @@ class PDOIntegration extends Integration
                 $span->resource = Integration::toString($query);
                 PDOIntegration::setCommonSpanInfo($this, $span);
 
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook);
+                $driver = $this->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, $driver);
             }, function (HookData $hook) use ($integration) {
                 ObjectKVStore::propagate($this, $hook->returned, PDOIntegration::CONNECTION_TAGS_KEY);
             });

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -77,4 +77,17 @@ class DatabaseMonitoringTest extends IntegrationTestCase
 
         $this->resetTracer();
     }
+
+    public function noInjectionWithUnsupportedDriver()
+    {
+        try {
+            $hook = \DDTrace\install_hook(self::class . "::instrumented", function (HookData $hook) {
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'sqlite');
+            });
+            self::putEnv("DD_DBM_PROPAGATION_MODE=full");
+            $this->assertSame("SELECT 1", $this->instrumented(0, "SELECT 1"));
+        } finally {
+            \DDTrace\remove_hook($hook);
+        }
+    }
 }

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -31,7 +31,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
             $hook = \DDTrace\install_hook(self::class . "::instrumented", function (HookData $hook) {
                 $hook->span()->service = "testdb";
                 $hook->span()->name = "instrumented";
-                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 1);
+                DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1);
             });
             self::putEnv("DD_TRACE_DEBUG_PRNG_SEED=42");
             self::putEnv("DD_DBM_PROPAGATION_MODE=full");


### PR DESCRIPTION
### Description

mssql is service-mode only, given it full context propagation messes with the query plan caching.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
