### PR TITLE
Release 0.86.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 
 variables:
   LATEST_LIBRARY_x86_64_LINUX_GNU:
-    value: ""
+    value: "https://output.circle-artifacts.com/output/job/300ccc2b-afae-42fc-8d3f-d734e842c498/artifacts/0/dd-library-php-0.86.0-x86_64-linux-gnu.tar.gz"
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive. Leave empty to take it from the latest released github tag."
   DOWNSTREAM_REL_BRANCH:
     value: "master"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.86.0"
 #endif

--- a/package.xml
+++ b/package.xml
@@ -56,7 +56,60 @@
     <license uri="https://github.com/DataDog/dd-trace-php/blob/master/LICENSE">BSD 3-Clause</license>
     <notes>
         <![CDATA[
-${notes}
+### Added
+- Add MemcacheIntegration #1981
+- Add PSR18 tracing support in any PSR18 ClientInterface #1938
+
+### Fixed
+- Restrict backends on DBM propagation #1983
+- Allow for hooking of extended internal classes #1976
+
+### Internal changes
+- Include the circleci URL for 1.0.0-nightly installers #1977
+
+## Profiling (0.15.0)
+
+### Fixed
+- Fix issues when preloading and non-root php-fpm user are used #1975
+
+### Changed
+- perf: speed up stack walking by using function run_time_cache #1949
+
+### Internal changes
+- Fix system ini handling of invalid values in zai config #1982
+
+## Application Security Monitoring (v0.7.0)
+
+### Breaking Changes
+- Delete `enabled_on_cli` ini setting DataDog/dd-appsec-php#182
+
+### Fixed
+- Add uid and gid to sock and lock files DataDog/dd-appsec-php#183
+
+### Added
+- Remote configuration client DataDog/dd-appsec-php#115
+- Plug remote config service DataDog/dd-appsec-php#163
+- Add `config_sync` helper command DataDog/dd-appsec-php#164
+- Add ASM_DATA Product Listener DataDog/dd-appsec-php#188
+- IP Blocking DataDog/dd-appsec-php#188
+- Redirect support DataDog/dd-appsec-php#195
+- Add `request_exec` helper command DataDog/dd-appsec-php#196
+- ASM_DD Product Listener DataDog/dd-appsec-php#207
+- ASM Product Listener DataDog/dd-appsec-php#210
+- Rule Blocking DataDog/dd-appsec-php#210
+- Check if RC is available before polling DataDog/dd-appsec-php#212
+- User Blocking DataDog/dd-appsec-php#213
+
+### Internal Changes
+- Support actions and refactor DataDog/dd-appsec-php#184
+- Update `engine::subscriber` rule data DataDog/dd-appsec-php#186
+- Blocking templates, missing traces fix and set blocking parameters DataDog/dd-appsec-php#187
+- Upgrade tracer to v0.84.0 DataDog/dd-appsec-php#193
+- Upgrade WAF 1.8.2 DataDog/dd-appsec-php#202
+- Add init / commit stage to listeners DataDog/dd-appsec-php#208
+- Ruleset 1.5.2 DataDog/dd-appsec-php#213
+- Allow new and old default rules file to be loaded DataDog/dd-appsec-php#215
+- Fallback to local IP on extraction DataDog/dd-appsec-php#216
 ]]></notes>
     <contents>
         <dir name="/">

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -24,7 +24,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.86.0';
 
     /**
      * @var Span[][]


### PR DESCRIPTION
### Added
- Add MemcacheIntegration #1981
- Add PSR18 tracing support in any PSR18 ClientInterface #1938 

### Fixed
- Restrict backends on DBM propagation #1983 
- Allow for hooking of extended internal classes #1976

### Internal changes
- Include the circleci URL for 1.0.0-nightly installers #1977

## Profiling (0.15.0)


### Fixed
- Fix issues when preloading and non-root php-fpm user are used #1975

### Changed
- perf: speed up stack walking by using function run_time_cache #1949

### Internal changes
- Fix system ini handling of invalid values in zai config #1982

## Application Security Monitoring (v0.7.0)

### Breaking Changes
- Delete `enabled_on_cli` ini setting DataDog/dd-appsec-php#182

### Fixed
- Add uid and gid to sock and lock files DataDog/dd-appsec-php#183

### Added
- Remote configuration client DataDog/dd-appsec-php#115
- Plug remote config service DataDog/dd-appsec-php#163
- Add `config_sync` helper command DataDog/dd-appsec-php#164
- Add ASM_DATA Product Listener DataDog/dd-appsec-php#188
- IP Blocking DataDog/dd-appsec-php#188
- Redirect support DataDog/dd-appsec-php#195
- Add `request_exec` helper command DataDog/dd-appsec-php#196
- ASM_DD Product Listener DataDog/dd-appsec-php#207
- ASM Product Listener DataDog/dd-appsec-php#210
- Rule Blocking DataDog/dd-appsec-php#210
- Check if RC is available before polling DataDog/dd-appsec-php#212
- User Blocking DataDog/dd-appsec-php#213

### Internal Changes
- Support actions and refactor DataDog/dd-appsec-php#184
- Update `engine::subscriber` rule data DataDog/dd-appsec-php#186
- Blocking templates, missing traces fix and set blocking parameters DataDog/dd-appsec-php#187
- Upgrade tracer to v0.84.0 DataDog/dd-appsec-php#193
- Upgrade WAF 1.8.2 DataDog/dd-appsec-php#202
- Add init / commit stage to listeners DataDog/dd-appsec-php#208
- Ruleset 1.5.2 DataDog/dd-appsec-php#213
- Allow new and old default rules file to be loaded DataDog/dd-appsec-php#215
- Fallback to local IP on extraction DataDog/dd-appsec-php#216
