### PR TITLE
Setup python 3.9 for system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2145,10 +2145,16 @@ jobs:
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
+          # TODO: removes this step once host-in-runner is merged on system tests
           name: Install good version of docker-compose
           command: |
             sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             sudo chmod +x /usr/local/bin/docker-compose
+
+      - run:
+          name: Install python 3.9
+          command: sudo apt-get install python3.9-venv
+
       - run:
           name: versions
           command: |


### PR DESCRIPTION
### Description

This PR installs python 3.9 for system tests jobs.

System test executor will run on the host rather than inside a container (see https://github.com/DataDog/system-tests/pull/958). It will allow users to do step-by-step debugging, and will allow to unify architecture with parametric tests.

As now, the change will do nothing but installing python 3.9 on system tests job. Once the PR on system repo will be merge, it'll work silently (and we'll be able to remove the installation of docker compose, not required anymore).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document. -> n/a
- [x] Tests added for this feature/bug. -> n/a

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
