### PR TITLE
Fix exceptions and errors in auto_prepend_file

### DIFF
--- a/ext/request_hooks.c
+++ b/ext/request_hooks.c
@@ -126,9 +126,9 @@ int dd_execute_php_file(const char *filename) {
 
 int dd_execute_auto_prepend_file(char *auto_prepend_file) {
     zend_file_handle prepend_file;
-    // We could technically do this to synthetically adjust the stack
-    // zend_execute_data *ex = EG(current_execute_data);
-    // EG(current_execute_data) = ex->prev_execute_data;
+    // We must emulate being at the root of the stack so that exception handling sees a root frame and reports the error rather than swallowing it.
+    zend_execute_data *ex = EG(current_execute_data);
+    EG(current_execute_data) = NULL;
 #if PHP_VERSION_ID < 80100
     memset(&prepend_file, 0, sizeof(zend_file_handle));
     prepend_file.type = ZEND_HANDLE_FILENAME;
@@ -139,13 +139,13 @@ int dd_execute_auto_prepend_file(char *auto_prepend_file) {
     int ret = zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &prepend_file) == SUCCESS;
     zend_destroy_file_handle(&prepend_file);
 #endif
+    EG(current_execute_data) = ex;
 #if PHP_VERSION_ID >= 80000
     // Exit no longer calls zend_bailout in PHP 8, so we need to "rethrow" the exit
     if (ret == 0) {
         zend_throw_unwind_exit();
     }
 #endif
-    // EG(current_execute_data) = ex;
     return ret;
 }
 

--- a/tests/ext/request-init-hook/auto_prepend_file_exception.inc
+++ b/tests/ext/request-init-hook/auto_prepend_file_exception.inc
@@ -1,0 +1,3 @@
+<?php
+
+throw new \Exception;

--- a/tests/ext/request-init-hook/exception_prepend_file.phpt
+++ b/tests/ext/request-init-hook/exception_prepend_file.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Gracefully handle exceptions in auto_prepend_file
+--INI--
+auto_prepend_file={PWD}/auto_prepend_file_exception.inc
+ddtrace.request_init_hook={PWD}/../includes/request_init_hook.inc
+--FILE--
+<?php
+
+// This should not be even invoked, but due to a bug it was. And when the exception handler got set, it segfaulted.
+set_exception_handler(function() {});
+echo "Unreachable\n";
+
+?>
+--EXPECTF--
+Calling ddtrace_init()...
+Called dd_init.php
+
+Fatal error: Uncaught Exception in %s:3
+Stack trace:
+#0 {main}
+  thrown in %s/auto_prepend_file_exception.inc on line 3

--- a/tests/ext/request-init-hook/invalid_prepend_file.phpt
+++ b/tests/ext/request-init-hook/invalid_prepend_file.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Gracefully handle exceptions in auto_prepend_file
+--INI--
+auto_prepend_file={PWD}/does_not_exist.inc
+ddtrace.request_init_hook={PWD}/../includes/request_init_hook.inc
+--FILE--
+<?php
+
+echo "Unreachable\n";
+
+?>
+--EXPECTF--
+Calling ddtrace_init()...
+Called dd_init.php
+
+Warning: Unknown: %cailed to open stream: No such file or directory in Unknown on line 0
+
+Fatal error:%sFailed opening required %s in Unknown on line 0


### PR DESCRIPTION
### Description

Fixes crashes and swallowing of exceptions in auto_prepend_file. 

Guess `zend_execute_scripts` needs a fat warning "do not invoke without EG(current_execute_data) == NULL".

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
