### PR TITLE
Allow DDTrace\install_hook to take any callable

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -105,7 +105,7 @@ static inline zend_string *get_active_function_or_method_name(void) {
 
 #define zend_argument_type_error(arg_num, format, ...) do { \
         zend_string *func_name = get_active_function_or_method_name(); \
-        zend_internal_type_error(ZEND_ARG_USES_STRICT_TYPES(), "%s(): Argument #%d " format, ZSTR_VAL(func_name), arg_num, #__VA_ARGS__); \
+        zend_internal_type_error(ZEND_ARG_USES_STRICT_TYPES(), "%s(): Argument #%d " format, ZSTR_VAL(func_name), arg_num, ##__VA_ARGS__); \
         zend_string_release(func_name); \
     } while (0)
 

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -277,7 +277,7 @@ static zend_extension _dd_zend_extension_entry = {"ddtrace",
 #else
                                                   NULL,
 #endif
-                                                  zai_hook_unresolve_file,
+                                                  zai_hook_unresolve_op_array,
 
                                                   STANDARD_ZEND_EXTENSION_PROPERTIES};
 

--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -72,6 +72,14 @@ class HookData {
 const HOOK_ALL_FILES = "";
 
 /**
+ * Only hooks the specific instance of the Closure, i.e. independent instantiations of the same Closure are not hooked.
+ *
+ * @var int
+ * @cvalue HOOK_INSTANCE
+ */
+const HOOK_INSTANCE = UNKNOWN;
+
+/**
  * @param string|\Closure|\Generator $target The function to hook.
  *                                           If a string is passed, it must be either a function name or referencing
  *                                           a method in "Classname::methodname" format. Alternatively it may be a file
@@ -83,9 +91,15 @@ const HOOK_ALL_FILES = "";
  *                                           and the hook applied to that.
  * @param null|\Closure(\DDTrace\HookData) $begin Called before the hooked function is invoked.
  * @param null|\Closure(\DDTrace\HookData) $end Called after the hooked function is invoked.
+ * @param int $flags The only accepted flag currently is DDTrace\HOOK_INSTANCE.
  * @return int An integer which can be used to remove a hook via DDTrace\remove_hook.
  */
-function install_hook(string|\Closure|\Generator $target, ?\Closure $begin = null, ?\Closure $end = null): int {}
+function install_hook(
+    string|callable|\Closure|\Generator $target,
+    ?\Closure $begin = null,
+    ?\Closure $end = null,
+    int $flags = 0
+): int {}
 
 /**
  * Removes an installed hook by its id, as returned by install_hook or HookData->id.

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,10 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a41178ef641dee18fe54b13fe1505884a691826b */
+ * Stub hash: a0aadd4ea121ed2731f3f530753c4e458c97fad2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING, NULL)
+	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING|MAY_BE_CALLABLE, NULL)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, begin, Closure, 1, "null")
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, end, Closure, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_remove_hook, 0, 1, IS_VOID, 0)
@@ -46,6 +47,7 @@ static const zend_function_entry class_DDTrace_HookData_methods[] = {
 static void register_uhook_symbols(int module_number)
 {
 	REGISTER_STRING_CONSTANT("DDTrace\\HOOK_ALL_FILES", "", CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("DDTrace\\HOOK_INSTANCE", HOOK_INSTANCE, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class_DDTrace_HookData(void)

--- a/tests/ext/sandbox/hook_function/hook_internal_fake_closure.phpt
+++ b/tests/ext/sandbox/hook_function/hook_internal_fake_closure.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test hooking fake closures of internal functions
+--SKIPIF--
+<?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support XFAIL");
+?>
+--XFAIL--
+Not implemented yet
+--FILE--
+<?php
+
+DDTrace\hook_function("time", function() {
+    echo "invoked\n";
+});
+
+((new ReflectionFunction("time"))->getClosure())();
+
+?>
+--EXPECT--
+invoked

--- a/tests/ext/sandbox/install_hook/hook_internal_fake_closure.phpt
+++ b/tests/ext/sandbox/install_hook/hook_internal_fake_closure.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test hooking fake closures of internal functions via install_hook()
+--SKIPIF--
+<?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support XFAIL");
+?>
+--XFAIL--
+Not implemented yet
+--FILE--
+<?php
+
+DDTrace\install_hook((new ReflectionFunction("time"))->getClosure(), function() {
+    echo "invoked\n";
+});
+
+((new ReflectionFunction("time"))->getClosure())();
+
+?>
+--EXPECT--
+invoked

--- a/tests/ext/sandbox/install_hook/trace_callable.phpt
+++ b/tests/ext/sandbox/install_hook/trace_callable.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Tracing generic callables via install_hook()
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+namespace test;
+
+function foo() {
+    return 1;
+}
+
+class bar {
+    static function foo() {
+        return 2;
+    }
+}
+
+function closure() {
+    return function() {
+        return 3;
+    };
+}
+
+$ids = function() {
+    return [
+        (new \ReflectionFunction('test\foo'))->getClosure(),
+        (new \ReflectionClass(bar::class))->getMethod("foo")->getClosure(),
+        closure(),
+    ];
+};
+$hooks = [];
+foreach ($ids() as $i => $id) {
+    $hooks[] = \DDTrace\install_hook($id, function(\DDTrace\HookData $hook) use ($i) {
+        $hook->span()->resource = $i;
+        $hook->data = $hook->args[0];
+    }, function(\DDTrace\HookData $hook) {
+        $hook->span()->meta['result'] = $hook->returned;
+    });
+}
+
+foreach ($ids() as $id) {
+    $id();
+}
+
+foreach ($hooks as $hook) {
+    \DDTrace\remove_hook($hook);
+}
+
+// Not traced
+foreach ($ids() as $id) {
+    $id();
+}
+
+include __DIR__ . '/../dd_dumper.inc';
+\dd_dump_spans(true);
+
+?>
+--EXPECTF--
+spans(\DDTrace\SpanData) (3) {
+  test\foo (trace_callable.php, 0, cli)
+    result => 1
+  test\bar.foo (trace_callable.php, 1, cli)
+    result => 2
+  test\closure.{closure} (trace_callable.php, 2, cli)
+    closure.declaration => %s:%d
+    result => 3
+}

--- a/tests/ext/sandbox/install_hook/trace_closure.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure.phpt
@@ -7,6 +7,8 @@ datadog.trace.generate_root_span=0
 
 namespace test;
 
+$internalFakeClosure = (new \ReflectionFunction("intval"))->getClosure();
+
 $topLevelClosure = function($a) {
     return $a + 1;
 };
@@ -25,16 +27,15 @@ class bar {
     }
 }
 
-$closures = [$topLevelClosure, foo(), bar::foo()];
+$closures = [$internalFakeClosure, $topLevelClosure, foo(), bar::foo()];
 $hooks = [];
 
 foreach ($closures as $i => $closure) {
     $hooks[] = \DDTrace\install_hook($closure, function(\DDTrace\HookData $hook) use ($i) {
         $hook->span()->resource = $i;
-        $hook->data = $hook->args[0];
     }, function(\DDTrace\HookData $hook) {
         $hook->span()->meta['result'] = $hook->returned;
-    });
+    }, \DDTrace\HOOK_INSTANCE);
 
     $closure(0);
 }
@@ -60,23 +61,27 @@ include __DIR__ . '/../dd_dumper.inc';
 
 ?>
 --EXPECTF--
-spans(\DDTrace\SpanData) (6) {
-  test\trace_closure.php:5\{closure} (trace_closure.php, 0, cli)
-    closure.declaration => %s:5
+spans(\DDTrace\SpanData) (8) {
+  intval (trace_closure.php, 0, cli)
+    result => 0
+  test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
+    closure.declaration => %s:7
     result => 1
-  test\foo.{closure} (trace_closure.php, 1, cli)
-    closure.declaration => %s:10
+  test\foo.{closure} (trace_closure.php, 2, cli)
+    closure.declaration => %s:12
     result => 2
-  test\bar.foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => %s:17
+  test\bar.foo.{closure} (trace_closure.php, 3, cli)
+    closure.declaration => %s:19
     result => 3
-  test\trace_closure.php:5\{closure} (trace_closure.php, 0, cli)
-    closure.declaration => %s:5
+  intval (trace_closure.php, 0, cli)
+    result => 1
+  test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
+    closure.declaration => %s:7
     result => 2
-  test\foo.{closure} (trace_closure.php, 1, cli)
-    closure.declaration => %s:10
+  test\foo.{closure} (trace_closure.php, 2, cli)
+    closure.declaration => %s:12
     result => 3
-  test\bar.foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => %s:17
+  test\bar.foo.{closure} (trace_closure.php, 3, cli)
+    closure.declaration => %s:19
     result => 4
 }

--- a/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
@@ -12,11 +12,11 @@ $closure = (new ReflectionFunction('foo'))->getClosure();
 
 \DDTrace\install_hook('foo', function(\DDTrace\HookData $hook) {
     $hook->span()->meta['global'] = 1;
-}, null);
+}, null, DDTrace\HOOK_INSTANCE);
 
 $hook = \DDTrace\install_hook($closure, function(\DDTrace\HookData $hook) {
     $hook->span()->meta['fake'] = 1;
-}, null);
+}, null, DDTrace\HOOK_INSTANCE);
 
 foo(); // Not traced by closure hook
 $closure();

--- a/tests/ext/sandbox/install_hook/trace_file.phpt
+++ b/tests/ext/sandbox/install_hook/trace_file.phpt
@@ -12,13 +12,17 @@ DDTrace\install_hook(DDTrace\HOOK_ALL_FILES, function($hook) {
 });
 
 echo include "testinclude.inc", "\n";
+echo include "testinclude.inc", "\n";
 
 dd_dump_spans();
 
 ?>
 --EXPECTF--
 test
-spans(\DDTrace\SpanData) (1) {
+test
+spans(\DDTrace\SpanData) (2) {
+  %s/testinclude.inc (trace_file.php, %s/install_hook/testinclude.inc, cli)
+    _dd.p.dm => -1
   %s/testinclude.inc (trace_file.php, %s/install_hook/testinclude.inc, cli)
     _dd.p.dm => -1
 }

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -90,7 +90,7 @@ void zai_hook_resolve_class(zend_class_entry *ce, zend_string *lcname);
 void zai_hook_resolve_file(zend_op_array *op_array);
 
 /* cleanup function to avoid memory leaking */
-void zai_hook_unresolve_file(zend_op_array *op_array);
+void zai_hook_unresolve_op_array(zend_op_array *op_array);
 
 /* {{{ private but externed for performance reasons */
 extern TSRM_TLS HashTable zai_hook_resolved;

--- a/zend_abstract_interface/interceptor/tests/resolver.cc
+++ b/zend_abstract_interface/interceptor/tests/resolver.cc
@@ -61,7 +61,7 @@ extern "C" {
         tea_extension_op_array_ctor(zai_interceptor_op_array_ctor);
         tea_extension_op_array_handler(zai_interceptor_op_array_pass_two);
 #endif
-        tea_extension_op_array_dtor(zai_hook_unresolve_file);
+        tea_extension_op_array_dtor(zai_hook_unresolve_op_array);
         tea_extension_startup(ddtrace_testing_startup);
         tea_extension_minit(PHP_MINIT(ddtrace_testing_hook));
         tea_extension_rinit(PHP_RINIT(ddtrace_testing_hook));


### PR DESCRIPTION
### Description

Also by default, apply closure hooks to the actual closure source; adding a flag DDTrace\HOOK_INSTANCE to only hook the specific Closure instance.
Given that the API is new and everyone I talked to was surprised by the behaviour, I'm changing it.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
