### PR TITLE
Sync profiling version with tracer; append git sha1 to non-release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2076,6 +2076,7 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_APPEND_BUILD_ID
       - unless:
           condition: << parameters.asan_build >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ aliases:
       name: Append build id to version number
       command: |
         githash="${CIRCLE_SHA1?}"
-        if [ "$CIRCLE_BRANCH" =~ "ddtrace-" ] ; then
+        if [[ "$CIRCLE_BRANCH" =~ "ddtrace-" ]] ; then
           echo "Release branch detected; not adding git sha1 to version number."
         else
           sed -E -i "s/const\s+VERSION\s*=\s*'(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1900,14 +1900,14 @@ jobs:
       - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
       - <<: *STEP_CHECKOUT
-      - setup_docker:
-          docker_image: << parameters.docker_image >>
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
             - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
-      # Append the build id after restoring cache
+      # Append the build id after restoring cache, and before docker
       - <<: *STEP_APPEND_BUILD_ID
+      - setup_docker:
+          docker_image: << parameters.docker_image >>
       - run:
           name: Build Profiler
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2061,7 +2061,12 @@ jobs:
           command: ls -al ~/datadog/bridge
       - persist_to_workspace:
           root: '.'
-          paths: ['./bridge/_generated*.php']
+          paths:
+            - './bridge/_generated*.php'
+            # Persist files below because we generate a new version number.
+            - './src/DDTrace/Tracer.php'
+            - './ext/version.h'
+            - './profiling/Cargo.toml'
 
   "package extension":
     working_directory: ~/datadog
@@ -2076,7 +2081,6 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
-      - <<: *STEP_APPEND_BUILD_ID
       - unless:
           condition: << parameters.asan_build >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,10 @@ aliases:
     run:
       name: Append build id to version number
       command: |
-        githash="$CIRCLE_SHA1"
-        sed -E -i "s/const VERSION = '(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"
-        sed -E -i "s/define PHP_DDTRACE_VERSION \"(.*)\"/define PHP_DDTRACE_VERSION \"\1+$githash\"/g" "ext/version.h"
-        sed -E -i "s/^version = \"(.*)\"/version = \"\1+$githash\"/g" "profiling/Cargo.toml"
+        githash="${CIRCLE_SHA1?}"
+        sed -E -i "s/const\s+VERSION\s*=\s*'(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"
+        sed -E -i "s/define\s+PHP_DDTRACE_VERSION\s*\"(.*)\"/define PHP_DDTRACE_VERSION \"\1+$githash\"/g" "ext/version.h"
+        sed -E -i "s/^version\s*=\s*\"(.*)\"/version = \"\1+$githash\"/g" "profiling/Cargo.toml"
 
   - &STEP_EXT_INSTALL
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,15 @@ aliases:
     attach_workspace:
       at: ~/datadog
 
+  - &STEP_APPEND_BUILD_ID
+    run:
+      name: Append build id to version number
+      command: |
+        githash="$CIRCLE_SHA1"
+        sed -E -i "s/const VERSION = '(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"
+        sed -E -i "s/define PHP_DDTRACE_VERSION \"(.*)\"/define PHP_DDTRACE_VERSION \"\1+$githash\"/g" "ext/version.h"
+        sed -E -i "s/^version = \"(.*)\"/version = \"\1+$githash\"/g" "profiling/Cargo.toml"
+
   - &STEP_EXT_INSTALL
     run:
       name: Build and install extension
@@ -1897,6 +1906,8 @@ jobs:
           name: Restore Cargo Package Cache
           keys:
             - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+      # Append the build id after restoring cache
+      - <<: *STEP_APPEND_BUILD_ID
       - run:
           name: Build Profiler
           command: |
@@ -2036,6 +2047,7 @@ jobs:
           paths:
             - ".git"
       - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_APPEND_BUILD_ID
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_GENERATE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,14 @@ aliases:
       name: Append build id to version number
       command: |
         githash="${CIRCLE_SHA1?}"
-        sed -E -i "s/const\s+VERSION\s*=\s*'(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"
-        sed -E -i "s/define\s+PHP_DDTRACE_VERSION\s*\"(.*)\"/define PHP_DDTRACE_VERSION \"\1+$githash\"/g" "ext/version.h"
-        sed -E -i "s/^version\s*=\s*\"(.*)\"/version = \"\1+$githash\"/g" "profiling/Cargo.toml"
+        if [ "$CIRCLE_BRANCH" =~ "ddtrace-" ] ; then
+          echo "Release branch detected; not adding git sha1 to version number."
+        else
+          sed -E -i "s/const\s+VERSION\s*=\s*'(.*)'/const VERSION = '\1+$githash'/g" "src/DDTrace/Tracer.php"
+          sed -E -i "s/define\s+PHP_DDTRACE_VERSION\s*\"(.*)\"/define PHP_DDTRACE_VERSION \"\1+$githash\"/g" "ext/version.h"
+          sed -E -i "s/^version\s*=\s*\"(.*)\"/version = \"\1+$githash\"/g" "profiling/Cargo.toml"
+          echo "Appended +$githash to version number."
+        fi
 
   - &STEP_EXT_INSTALL
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ commands:
                   -e DD_AGENT_HOST=127.0.0.1 \
                   -e DATADOG_HAVE_DEV_ENV=1 \
                   -e BASH_ENV=/home/circleci/bashenv/bash.sh \
+                  -e CIRCLE_SHA1 \
                   -v $(pwd):/home/circleci/datadog \
                   -v /tmp/bashenv:/home/circleci/bashenv \
                   -v /rust:/rust \
@@ -1905,14 +1906,13 @@ jobs:
       - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
       - <<: *STEP_CHECKOUT
+      - setup_docker:
+          docker_image: << parameters.docker_image >>
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
             - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
-      # Append the build id after restoring cache, and before docker
       - <<: *STEP_APPEND_BUILD_ID
-      - setup_docker:
-          docker_image: << parameters.docker_image >>
       - run:
           name: Build Profiler
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2113,7 +2113,30 @@ jobs:
           command: |
             <<# parameters.asan_build >>export DDTRACE_MAKE_PACKAGES_ASAN=1<</ parameters.asan_build >>
             make packages
-      - run: cd build/packages && find . -type f -exec sha256sum {} +
+      - run:
+          name: Display sha256sums
+          command: cd build/packages && find . -type f -exec sha256sum {} + && cd -
+      - run:
+          name: Spot-check shape of library name
+          command: |
+            version=$(awk -F\' '/const VERSION/ { print $2 }' < src/DDTrace/Tracer.php)
+            filename="dd-library-php-${version}-x86_64-linux-gnu.tar.gz"
+            if ! [[ -f "build/packages/$filename" ]] ; then
+              echo "Expected file 'build/packages/$filename' to exist!"
+              exit 1
+            fi
+
+            if ! [[ "$CIRCLE_BRANCH" =~ "ddtrace-" ]] ; then
+              githash="${CIRCLE_SHA1?}"
+              echo "Non-release branch detected. Checking for git sha1: $githash."
+              if echo "$filename" | grep -q "+$githash" ; then
+                echo "Confirmed: '$filename' contains git sha1 hash '$githash'."
+              else
+                echo "'$filename' didn't contain git sha1 hash '$githash'."
+                exit 1
+              fi
+            fi
+
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
       - store_artifacts: { path: 'pecl', destination: '/pecl' }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
     value: ""
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive. Leave empty to take it from the latest released github tag."
   DOWNSTREAM_REL_BRANCH:
-    value: "levi/sync-version"
+    value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
     value: ""
     description: "Location where to download latest dd-library-php-*-x86_64-linux-gnu.tar.gz archive. Leave empty to take it from the latest released github tag."
   DOWNSTREAM_REL_BRANCH:
-    value: "master"
+    value: "levi/sync-version"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "1.0.0-nightly"
+#define PHP_DDTRACE_VERSION "0.86.3"
 #endif

--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-php-profiling"
-version = "0.87.0-alpha.1"
+version = "0.86.3"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-php-profiling"
-version = "0.15.1"
+version = "0.87.0-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.87.0-alpha.1"
+version = "0.86.3"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.64"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "datadog-php-profiling"
-version = "0.15.1"
+version = "0.87.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -24,7 +24,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '1.0.0-nightly';
+    const VERSION = '0.86.3';
 
     /**
      * @var Span[][]

--- a/tooling/bin/generate-installers.sh
+++ b/tooling/bin/generate-installers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 

--- a/tooling/bin/generate-installers.sh
+++ b/tooling/bin/generate-installers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -9,6 +9,6 @@ packages_build_dir=$2
 # Installers
 ########################
 sed "s|@release_version@|${release_version}|g" ./datadog-setup.php > "${packages_build_dir}/datadog-setup.php"
-if [[ ${release_version} == "1.0.0-nightly" && -n ${CIRCLE_WORKFLOW_JOB_ID:-} ]]; then
+if [[ ${release_version} =~ ".*\+.*" && -n ${CIRCLE_WORKFLOW_JOB_ID:-} ]]; then
   sed -ri "s|define\('RELEASE_URL_PREFIX'[^;]+|const RELEASE_URL_PREFIX = 'https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/'|" "${packages_build_dir}/datadog-setup.php"
 fi

--- a/tooling/bin/generate-installers.sh
+++ b/tooling/bin/generate-installers.sh
@@ -9,6 +9,6 @@ packages_build_dir=$2
 # Installers
 ########################
 sed "s|@release_version@|${release_version}|g" ./datadog-setup.php > "${packages_build_dir}/datadog-setup.php"
-if [[ ${release_version} =~ ".*\+.*" && -n ${CIRCLE_WORKFLOW_JOB_ID:-} ]]; then
+if echo "${release_version}" | grep -qE '\+' && [ -n ${CIRCLE_WORKFLOW_JOB_ID:-} ]; then
   sed -ri "s|define\('RELEASE_URL_PREFIX'[^;]+|const RELEASE_URL_PREFIX = 'https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/'|" "${packages_build_dir}/datadog-setup.php"
 fi

--- a/tooling/bin/pecl-build
+++ b/tooling/bin/pecl-build
@@ -8,7 +8,7 @@ composer -dtooling/generation generate
 composer -dtooling/generation verify
 
 # PECL doesn't like the "-nightly" part of the nightly version number so we have to change it
-dd_version=$(awk -F\' '/const VERSION/ {sub(/-nightly/, "", $2); print $2}' < src/DDTrace/Tracer.php)
+dd_version=$(awk -F\' '/const VERSION/ {sub(/\+.*$/, "", $2); print $2}' < src/DDTrace/Tracer.php)
 
 configuration_placeholder='
                 <tasks:replace from="@php_dir@" to="php_dir" type="pear-config" />

--- a/tooling/bin/pecl-build
+++ b/tooling/bin/pecl-build
@@ -7,7 +7,8 @@ composer -dtooling/generation update
 composer -dtooling/generation generate
 composer -dtooling/generation verify
 
-# PECL doesn't like the "-nightly" part of the nightly version number so we have to change it
+# PECL doesn't like the "+$gitsha1" part of the non-release version number.
+# Currently these aren't published, so truncating it is fine.
 dd_version=$(awk -F\' '/const VERSION/ {sub(/\+.*$/, "", $2); print $2}' < src/DDTrace/Tracer.php)
 
 configuration_placeholder='

--- a/tooling/ci/download-binary-php.sh
+++ b/tooling/ci/download-binary-php.sh
@@ -9,7 +9,7 @@ cd tooling/ci/binaries
 source /download-binary-tracer.sh
 
 if [ $VERSION = 'dev' ]; then
-    get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "datadog-php-tracer-.*-nightly.x86_64.tar.gz" "datadog-php-tracer.x86_64.tar.gz"
+    get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "datadog-php-tracer-.*.x86_64.tar.gz" "datadog-php-tracer.x86_64.tar.gz"
     get_github_action_artifact "DataDog/dd-appsec-php" "package.yml" "master" "dd-appsec-php-*-amd64.tar.gz" "dd-appsec-php-amd64.tar.gz"
 elif [ $VERSION = 'prod' ]; then
     get_github_release_asset "DataDog/dd-trace-php" "datadog-php-tracer-.*.x86_64.tar.gz" "datadog-php-tracer.x86_64.tar.gz"


### PR DESCRIPTION
### Description

- The profiling version will now be synchronized with the tracer version.
- The tracer version on master will be the latest feature release instead of `1.0.0-nightly`.
- Non-release builds will append '+' followed by the git sha1 to the version number.
- Bump rust version in the Cargo.toml file. We had previously already bumped the version in other places and just missed this one.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
