### PR TITLE
test(profiling) add a test to ensure we do not crash with fibers

### DIFF
--- a/profiling/tests/phpt/fibers_01.phpt
+++ b/profiling/tests/phpt/fibers_01.phpt
@@ -1,0 +1,36 @@
+--TEST--
+[profiling] test that the profiler doesn't crash when fibers are used
+--DESCRIPTION--
+At this point we do not have active support for fibers, but we at least want to
+make sure to not crash when fibers are in use
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires {$extension}\n";
+if (PHP_VERSION_ID < 80100)
+    echo "skip: php 8.1 or above is required for fibers.\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=info
+--FILE--
+<?php
+$fiber = new Fiber(function (): void {
+    usleep(20000);
+    $value = Fiber::suspend('fiber');
+    usleep(20000);
+    echo "Value used to resume fiber: ", $value, PHP_EOL;
+});
+
+usleep(20000);
+$value = $fiber->start();
+usleep(20000);
+echo "Value from fiber suspending: ", $value, PHP_EOL;
+usleep(20000);
+$fiber->resume('test');
+?>
+--EXPECTREGEX--
+.*
+Value from fiber suspending: fiber
+Value used to resume fiber: test
+.*


### PR DESCRIPTION
### Description

This will add a `.phpt` test to ensure we are not crashing with fibers being used.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
