### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/tests/randomized/docker/buster.Dockerfile
+++ b/tests/randomized/docker/buster.Dockerfile
@@ -22,7 +22,7 @@ RUN switch-php debug-zts-asan
 # If not generated, see: https://fromdual.com/hunting-the-core
 RUN mkdir -p /tmp/corefiles
 RUN chmod -R a+w /tmp/corefiles
-ADD enable-coredump.sh /scripts/enable-coredump.sh
+COPY enable-coredump.sh /scripts/enable-coredump.sh
 
 # Add the wait script to the image: note SHA 672a28f0509433e3b4b9bcd4d9cd7668cea7e31a has been reviewed and should not
 # be changed without an appropriate code review.
@@ -45,25 +45,25 @@ RUN set -eux; \
 
 # Preparing PHP-FPM
 RUN for DIR in /opt/php/*; do mkdir -p $DIR/etc/php-fpm.d; done
-ADD php-fpm.conf /home/circleci/php-fpm.conf
+COPY php-fpm.conf /home/circleci/php-fpm.conf
 RUN for DIR in /opt/php/*; do cp /home/circleci/php-fpm.conf $DIR/etc/; mv $DIR/etc/php-fpm.d/www.conf.default $DIR/etc/php-fpm.d/www.conf; done; rm /home/circleci/php-fpm.conf
 
 # Preparing NGINX
 RUN groupadd nginx
 RUN adduser --system --group nginx
-ADD nginx.conf /etc/nginx/nginx.conf
-ADD nginx.site.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.site.conf /etc/nginx/conf.d/default.conf
 
 # Preparing HTTPD
-ADD apache.php.conf /etc/apache2/conf-enabled/docker-php.conf
+COPY apache.php.conf /etc/apache2/conf-enabled/docker-php.conf
 RUN sed -i 's/Listen 80/Listen 81/' /etc/apache2/ports.conf
 RUN echo "CoreDumpDirectory /tmp/corefiles" >> /etc/apache2/apache.conf
 RUN mkdir -p /etc/httpd/conf.d /var/log/httpd
 RUN ln -s /etc/httpd/conf.d/www.conf /etc/apache2/sites-enabled/www.conf
 RUN sed -i 's/apache2/httpd/' /etc/apache2/envvars
 
-ADD run.sh /scripts/run.sh
-ADD prepare.sh /scripts/prepare.sh
+COPY run.sh /scripts/run.sh
+COPY prepare.sh /scripts/prepare.sh
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
### Description

Hi!
The Dockerfile placed at "tests/randomized/docker/buster.Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors, the reviewer is in charge of this task.
