### PR TITLE
Allow for consuming an array via DDTrace\consume_distributed_tracing_headers

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -81,6 +81,11 @@
 #define ZVAL_EMPTY_ARRAY DD_ZVAL_EMPTY_ARRAY
 #endif
 
+// For manual ZPP
+#if PHP_VERSION_ID < 70400
+#define _error_code error_code
+#endif
+
 bool ddtrace_has_excluded_module;
 static zend_module_entry *ddtrace_module;
 #if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80200
@@ -1661,10 +1666,6 @@ PHP_FUNCTION(DDTrace_create_stack) {
     RETURN_OBJ(&stack->std);
 }
 
-#if PHP_VERSION_ID < 70400
-#define _error_code error_code
-#endif
-
 /* {{{ proto string DDTrace\switch_stack(DDTrace\SpanData|DDTrace\SpanStack) */
 PHP_FUNCTION(DDTrace_switch_stack) {
     ddtrace_span_stack *stack = NULL;
@@ -1696,8 +1697,6 @@ PHP_FUNCTION(DDTrace_switch_stack) {
 
     RETURN_OBJ_COPY(&DDTRACE_G(active_stack)->std);
 }
-
-#undef _error_code
 
 PHP_FUNCTION(DDTrace_flush) {
     if (zend_parse_parameters_ex(ddtrace_quiet_zpp(), ZEND_NUM_ARGS(), "")) {
@@ -1896,11 +1895,45 @@ static bool dd_read_userspace_header(zai_string_view zai_header, const char *low
     return true;
 }
 
+static bool dd_read_array_header(zai_string_view zai_header, const char *lowercase_header, zend_string **header_value, void *data) {
+    UNUSED(zai_header);
+    zend_array *array = (zend_array *) data;
+    zval *value = zend_hash_str_find(array, lowercase_header, strlen(lowercase_header));
+    if (!value) {
+        return false;
+    }
+
+    *header_value = zval_get_string(value);
+    return true;
+}
+
 PHP_FUNCTION(DDTrace_consume_distributed_tracing_headers) {
     dd_fci_fcc_pair func;
+    zend_array *array = NULL;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_FUNC(func.fci, func.fcc)
+        DD_PARAM_PROLOGUE(0, 0);
+        if (UNEXPECTED(!zend_parse_arg_func(_arg, &func.fci, &func.fcc, false, &_error))) {
+            if (!_error) {
+                zend_argument_type_error(1, "must be a valid callback or of type array, %s given", zend_zval_value_name(_arg));
+                _error_code = ZPP_ERROR_FAILURE;
+                break;
+            } else if (Z_TYPE_P(_arg) == IS_ARRAY) {
+                array = Z_ARR_P(_arg);
+                efree(_error);
+            } else {
+                _error_code = ZPP_ERROR_WRONG_CALLBACK;
+                break;
+            }
+#if PHP_VERSION_ID < 70300
+        } else if (UNEXPECTED(_error != NULL)) {
+#if PHP_VERSION_ID < 70200
+            zend_wrong_callback_error(E_DEPRECATED, 1, _error);
+#else
+            zend_wrong_callback_error(_flags & ZEND_PARSE_PARAMS_THROW, E_DEPRECATED, 1, _error);
+#endif
+#endif
+        }
     ZEND_PARSE_PARAMETERS_END();
 
     if (!get_DD_TRACE_ENABLED()) {
@@ -1917,7 +1950,11 @@ PHP_FUNCTION(DDTrace_consume_distributed_tracing_headers) {
     }
     dd_clear_propagated_tags_from_root_span();
 
-    ddtrace_read_distributed_tracing_ids(dd_read_userspace_header, &func);
+    if (array) {
+        ddtrace_read_distributed_tracing_ids(dd_read_array_header, array);
+    } else {
+        ddtrace_read_distributed_tracing_ids(dd_read_userspace_header, &func);
+    }
 
     if (DDTRACE_G(active_stack)->root_span) {
         ddtrace_get_propagated_tags(ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span));
@@ -1933,7 +1970,7 @@ PHP_FUNCTION(DDTrace_generate_distributed_tracing_headers) {
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
-        Z_PARAM_ARRAY_HT(inject)
+        Z_PARAM_ARRAY_HT_EX(inject, true, false)
     ZEND_PARSE_PARAMETERS_END();
 
     array_init(return_value);

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -362,15 +362,16 @@ namespace DDTrace {
      * Update datadog headers for distributed tracing for new spans. Also applies this information to the current trace,
      * if there is one, as well as the future ones if it isn't overwritten
      *
-     * @param callable(string):mixed $callback Given a header name for distributed tracing, return the value it should
-     * be updated to
+     * @param array|callable(string):mixed $headersOrCallback Either an array with a lowercase header to value mapping,
+     * or a callback, which given a header name for distributed tracing, returns the value it should be updated to.
      */
-    function consume_distributed_tracing_headers(callable $callback): void {}
+    function consume_distributed_tracing_headers(array|callable $headersOrCallback): void {}
 
     /**
      * Get information on the key-value pairs of the datadog headers for distributed tracing
      *
-     * @param array|null $inject dfdsq
+     * @param null|string[] $inject The types of sampling headers which shall be generated, equivalent to what
+     * DD_TRACE_PROPAGATION_STYLE_INJECT supports. Defaults to DD_TRACE_PROPAGATION_STYLE_INJECT if null.
      *
      * @return array{x-datadog-sampling-priority: string,
      *               x-datadog-origin: string,
@@ -380,7 +381,7 @@ namespace DDTrace {
      *               tracestate: string
      *          }
      */
-    function generate_distributed_tracing_headers(array $inject = null): array {}
+    function generate_distributed_tracing_headers(array|null $inject = null): array {}
 
     /**
      * Searches parent frames to see whether it's currently within a catch block and returns that exception.

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b4378a592421d6eb93d39533548a54fe0e02fe1a */
+ * Stub hash: 7862e3baa2bb1a55b87a99dba0ec7b2a10897cd0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -82,11 +82,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_sanitized_exception_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_consume_distributed_tracing_headers, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_MASK(0, headersOrCallback, MAY_BE_ARRAY|MAY_BE_CALLABLE, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_generate_distributed_tracing_headers, 0, 0, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, inject, IS_ARRAY, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, inject, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_DDTrace_find_active_exception, 0, 0, Throwable, 1)

--- a/tests/ext/distributed_tracing/distributed_trace_consume_array.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_consume_array.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test consume_distributed_tracing_headers() with array argument
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+DDTrace\consume_distributed_tracing_headers([
+    "x-datadog-trace-id" => 42,
+    "x-datadog-parent-id" => 10,
+    "x-datadog-origin" => "datadog",
+    "x-datadog-sampling-priority" => 3,
+]);
+var_dump(DDTrace\generate_distributed_tracing_headers(["tracecontext"]));
+
+?>
+--EXPECT--
+array(2) {
+  ["traceparent"]=>
+  string(55) "00-0000000000000000000000000000002a-000000000000000a-01"
+  ["tracestate"]=>
+  string(24) "dd=o:datadog;s:3;t.dm:-0"
+}

--- a/tests/ext/distributed_tracing/distributed_trace_consume_func.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_consume_func.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test consume_distributed_tracing_headers()
+Test consume_distributed_tracing_headers() with function argument
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--


### PR DESCRIPTION
### Description

This should be much more straightforward when generating headers to later consume them when doing manual injection and extraction.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
