### PR TITLE
Explicitly disable appsec in setup script

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -358,7 +358,7 @@ function install($options)
                 } else {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
+                        "sed -i 's@;\? \?datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 }


### PR DESCRIPTION
### Description

When `--enable-appsec` is not passed, this explicitly disables `datadog.appsec.enabled` in the setup script rather than relying on the default.

This is because, since its release 0.7.0, appsec is effectively on by default. See https://github.com/DataDog/dd-appsec-php/issues/242, which this works around.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
