### PR TITLE
Avoid side effects from errors within the sandbox

### DIFF
--- a/ext/hook/uhook.h
+++ b/ext/hook/uhook.h
@@ -5,7 +5,7 @@
 #include <sandbox/sandbox.h>
 
 HashTable *dd_uhook_collect_args(zend_execute_data *execute_data);
-void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object *closure, zai_sandbox *sandbox);
+void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object *closure);
 
 void zai_uhook_rinit();
 void zai_uhook_rshutdown();

--- a/ext/hook/uhook_legacy.c
+++ b/ext/hook/uhook_legacy.c
@@ -75,8 +75,8 @@ static bool dd_uhook_call(zend_object *closure, bool tracing, dd_uhook_dynamic *
         }
     }
 
-    if (!success || (PG(last_error_message) && sandbox.error_state.message != PG(last_error_message))) {
-        dd_uhook_report_sandbox_error(execute_data, closure, &sandbox);
+    if (!success || PG(last_error_message)) {
+        dd_uhook_report_sandbox_error(execute_data, closure);
     }
     zai_sandbox_close(&sandbox);
 

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -16,6 +16,7 @@
 #include <exceptions/exceptions.h>
 #include <stdatomic.h>
 #include <zai_string/string.h>
+#include <sandbox/sandbox.h>
 
 #include "arrays.h"
 #include "compat_string.h"
@@ -1249,17 +1250,63 @@ void ddtrace_save_active_error_to_metadata(void) {
     }
 }
 
-void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
-    UNUSED(error_filename, error_lineno);
+static void clear_last_error(void) {
+    if (PG(last_error_message)) {
+#if PHP_VERSION_ID < 80000
+        free(PG(last_error_message));
+#else
+        zend_string_release(PG(last_error_message));
+#endif
+        PG(last_error_message) = NULL;
+    }
+    if (PG(last_error_file)) {
+#if PHP_VERSION_ID < 80100
+        free(PG(last_error_file));
+#else
+        zend_string_release(PG(last_error_file));
+#endif
+        PG(last_error_file) = NULL;
+    }
+}
 
-    /* We need the error handling to place nicely with the sandbox. The best
-     * idea so far is to execute fatal error handling code iff the error handling
-     * mode is set to EH_NORMAL. If it's something else, such as EH_SUPPRESS or
-     * EH_THROW, then they are likely to be handled and accordingly they
-     * shouldn't be treated as fatal.
-     */
+void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
+    // We need the error handling to place nicely with the sandbox. Our choice here is to skip any error handling if the sandbox is active.
+    // We just save the error for later handling by sandbox error reporting functionality.
+    // On fatal error we explicitly bail out.
     bool is_fatal_error = orig_type & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR);
-    if (EXPECTED(EG(active)) && EG(error_handling) == EH_NORMAL && UNEXPECTED(is_fatal_error)) {
+    if (zai_sandbox_active) {
+        clear_last_error();
+        PG(last_error_type) = orig_type & E_ALL;
+#if PHP_VERSION_ID < 80000
+        char *buf;
+        // vsssprintf uses Zend allocator, but PG(last_error_message) must be malloc() memory
+        vspprintf(&buf, PG(log_errors_max_len), format, args);
+        PG(last_error_message) = strdup(buf);
+        efree(buf);
+#else
+        PG(last_error_message) = zend_string_copy(message);
+#endif
+#if PHP_VERSION_ID < 80100
+        if (!error_filename) {
+            error_filename = "Unknown";
+        }
+        PG(last_error_file) = strdup(error_filename);
+#else
+        if (!error_filename) {
+            error_filename = ZSTR_KNOWN(ZEND_STR_UNKNOWN_CAPITALIZED);
+        }
+        PG(last_error_file) = zend_string_copy(error_filename);
+#endif
+        PG(last_error_lineno) = (int)error_lineno;
+
+        if (is_fatal_error) {
+            zend_bailout();
+        }
+        return;
+    }
+
+    // If this is a fatal error we have to handle it early. These are always bailing out, independently of the configured EG(error_handling) mode.
+    if (EXPECTED(EG(active)) && UNEXPECTED(is_fatal_error)) {
         /* If there is a fatal error in shutdown then this might not be an array
          * because we set it to IS_NULL in RSHUTDOWN. We probably want a more
          * robust way of detecting this, but I'm not sure how yet.

--- a/tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt
+++ b/tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Check that sandboxed hooks do not invoke error handlers or set the error code
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000 && getenv("SKIP_ASAN")) die("skip: Issue with passing ini to ASAN CGI on PHP 7.4"); ?>
+--GET--
+this+must+run+via+cgi
+--INI--
+datadog.trace.debug=1
+--FILE--
+<?php
+
+set_error_handler(function() {
+    echo "Unexpected Error handler invocation\n";
+    return false;
+});
+
+function foo() {}
+DDTrace\trace_function("foo", function() {
+    trigger_error("Fatal", E_USER_ERROR);
+});
+foo();
+
+var_dump(http_response_code());
+
+foo();
+
+?>
+--EXPECTF--
+int(200)
+Error raised in ddtrace's closure defined at %s:%d for foo(): Fatal in %s on line %d
+Flushing trace of size %s

--- a/zend_abstract_interface/sandbox/php7/sandbox.c
+++ b/zend_abstract_interface/sandbox/php7/sandbox.c
@@ -1,5 +1,7 @@
 #include "../sandbox.h"
 
+long zai_sandbox_active = 0;
+
 extern inline void zai_sandbox_open(zai_sandbox *sandbox);
 extern inline void zai_sandbox_close(zai_sandbox *sandbox);
 extern inline void zai_sandbox_bailout(zai_sandbox *sandbox);

--- a/zend_abstract_interface/sandbox/php8/sandbox.c
+++ b/zend_abstract_interface/sandbox/php8/sandbox.c
@@ -1,5 +1,7 @@
 #include "../sandbox.h"
 
+long zai_sandbox_active = 0;
+
 extern inline void zai_sandbox_open(zai_sandbox *sandbox);
 extern inline void zai_sandbox_close(zai_sandbox *sandbox);
 extern inline void zai_sandbox_bailout(zai_sandbox *sandbox);
@@ -16,16 +18,14 @@ extern inline void zai_sandbox_error_state_backup(zai_error_state *es);
  */
 void zai_sandbox_error_state_restore(zai_error_state *es) {
     if (PG(last_error_message)) {
-        if (PG(last_error_message) != es->message) {
-            zend_string_release(PG(last_error_message));
-        }
-        if (PG(last_error_file) != es->file) {
+        zend_string_release(PG(last_error_message));
+    }
+    if (PG(last_error_file)) {
 #if PHP_VERSION_ID < 80100
-            free(PG(last_error_file));
+        free(PG(last_error_file));
 #else
-            zend_string_release(PG(last_error_file));
+        zend_string_release(PG(last_error_file));
 #endif
-        }
     }
     zend_restore_error_handling(&es->error_handling);
     PG(last_error_type) = es->type;


### PR DESCRIPTION
### Description

In particular this avoids the side effect of setting the response code to 500 for fatal errors in a hook callback if display_errors=0.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
