### PR TITLE
Fix install_hook on functions returning by-reference

### DIFF
--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -20,6 +20,9 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 extern void (*profiling_interrupt_function)(zend_execute_data *);
 
 zend_class_entry *ddtrace_hook_data_ce;
+#if PHP_VERSION_ID >= 70400
+zend_property_info *ddtrace_hook_data_returned_prop_info;
+#endif
 
 ZEND_TLS HashTable dd_closure_hooks;
 ZEND_TLS HashTable dd_active_hooks;
@@ -236,6 +239,15 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
         zval *returned = &dyn->hook_data->property_returned;
         ZVAL_COPY_VALUE(&tmp, returned);
         ZVAL_COPY(returned, retval);
+#if PHP_VERSION_ID >= 70400
+        zend_property_info *prop_info = ddtrace_hook_data_returned_prop_info;
+        if (Z_ISREF(tmp)) {
+            ZEND_REF_DEL_TYPE_SOURCE(Z_REF(tmp), prop_info);
+        }
+        if (Z_ISREF_P(returned)) {
+            ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(returned), prop_info);
+        }
+#endif
         zval_ptr_dtor(&tmp);
 
         zval *exception = &dyn->hook_data->property_exception;
@@ -620,6 +632,9 @@ void zai_uhook_attributes_minit(void);
 void zai_uhook_minit() {
     ddtrace_hook_data_ce = register_class_DDTrace_HookData();
     ddtrace_hook_data_ce->create_object = dd_hook_data_create;
+#if PHP_VERSION_ID >= 70400
+    ddtrace_hook_data_returned_prop_info = zend_hash_str_find_ptr(&ddtrace_hook_data_ce->properties_info, ZEND_STRL("returned"));
+#endif
 
     zend_register_functions(NULL, ext_functions, NULL, MODULE_PERSISTENT);
 

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -20,7 +20,7 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 extern void (*profiling_interrupt_function)(zend_execute_data *);
 
 zend_class_entry *ddtrace_hook_data_ce;
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
 zend_property_info *ddtrace_hook_data_returned_prop_info;
 #endif
 
@@ -239,7 +239,7 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
         zval *returned = &dyn->hook_data->property_returned;
         ZVAL_COPY_VALUE(&tmp, returned);
         ZVAL_COPY(returned, retval);
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
         zend_property_info *prop_info = ddtrace_hook_data_returned_prop_info;
         if (Z_ISREF(tmp)) {
             ZEND_REF_DEL_TYPE_SOURCE(Z_REF(tmp), prop_info);
@@ -632,7 +632,7 @@ void zai_uhook_attributes_minit(void);
 void zai_uhook_minit() {
     ddtrace_hook_data_ce = register_class_DDTrace_HookData();
     ddtrace_hook_data_ce->create_object = dd_hook_data_create;
-#if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
     ddtrace_hook_data_returned_prop_info = zend_hash_str_find_ptr(&ddtrace_hook_data_ce->properties_info, ZEND_STRL("returned"));
 #endif
 

--- a/tests/ext/sandbox/install_hook/install_hook_return_by_ref.phpt
+++ b/tests/ext/sandbox/install_hook/install_hook_return_by_ref.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Test install_hook() on functions returning by reference
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) die('skip: Typed properties were added on PHP 7.4'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+--FILE--
+<?php
+
+class A {
+    public static ?int $var = 1;
+}
+
+function &ref(): int {
+    return A::$var;
+}
+
+$firstHook = DDTrace\install_hook("ref", null, function($hook) {
+    $hook->returned++;
+});
+var_dump(ref());
+var_dump(A::$var);
+
+$hook = DDTrace\install_hook("ref", null, function($hook) {
+    $hook->returned = "invalid";
+});
+var_dump(ref());
+var_dump(A::$var);
+DDTrace\remove_hook($hook);
+
+DDTrace\remove_hook($firstHook);
+
+DDTrace\install_hook("ref", null, function($hook) {
+    $hook->returned = null;
+});
+var_dump(ref());
+var_dump(A::$var);
+
+?>
+--EXPECTF--
+int(2)
+int(2)
+TypeError thrown in ddtrace's closure defined at %s:%d for ref(): Cannot assign string to reference held by property A::$var of type ?int
+int(3)
+int(3)
+NULL
+NULL
+No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

Two issues:
- IS_VAR passed to ZEND_RETURN(_BY_REF) on PHP 7 may be IS_INDIRECT. When copying these, we must ensure to not copy the IS_INDIRECT itself. It largely was unproblematic, but manipulating $hookData->returned could have unexpected side effects.
- On PHP 8 we need to track type sources as the $returned property is typed mixed and thus, the type source needs to be carried around. Otherwise we run into an assertion failure.

Note that these changes on the PHP 7 side also enable changing the return value (on PHP 8 no extra handling is needed).

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
