### PR TITLE
Increase the number of configuration entries in zai config

### DIFF
--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -17,7 +17,7 @@ typedef uint16_t zai_config_id;
 
 #include "config_ini.h"
 
-#define ZAI_CONFIG_ENTRIES_COUNT_MAX 160
+#define ZAI_CONFIG_ENTRIES_COUNT_MAX 180
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
 #define ZAI_CONFIG_NAME_BUFSIZ 60
 

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -17,7 +17,7 @@ typedef uint16_t zai_config_id;
 
 #include "config_ini.h"
 
-#define ZAI_CONFIG_ENTRIES_COUNT_MAX 180
+#define ZAI_CONFIG_ENTRIES_COUNT_MAX 200
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
 #define ZAI_CONFIG_NAME_BUFSIZ 60
 


### PR DESCRIPTION
### Description

Increase the value of `ZAI_CONFIG_ENTRIES_COUNT_MAX` from 160 to 200. This will fix the failed assertion that appeared on master after merging the recent integrations (#1996 and #1990).

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [X] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
