### PR TITLE
Fix #2012: Remove PHP 7-only types from signatures 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,30 @@ executors:
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
 
 jobs:
+  "Lint PHP 5":
+    parameters:
+      resource_class:
+        type: string
+        default: small
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          command: |
+            docker run --rm -v "$HOME/datadog:/src" -i php:5.4-cli bash \<<'CMD'
+              set -eu
+              cd /src/bridge
+              for file in *.php; do
+                if [ "$file" != "_generated_integrations.php" ]; then
+                  php -l "$file"
+                fi
+              done
+            CMD
+
   "Lint files":
     working_directory: ~/datadog
     docker:
@@ -3513,6 +3537,8 @@ workflows:
           ext_name: "curl"
           docker_image: "datadog/dd-trace-ci:php-8.0-shared-ext"
       - "Lint files":
+          requires: [ 'Prepare Code' ]
+      - "Lint PHP 5":
           requires: [ 'Prepare Code' ]
       - static_analysis:
           requires: [ 'Prepare Code' ]

--- a/src/Integrations/Util/Normalizer.php
+++ b/src/Integrations/Util/Normalizer.php
@@ -205,7 +205,8 @@ class Normalizer
         return preg_replace('/[^a-zA-Z0-9\-\_)]+/', '_', $str);
     }
 
-    private static function generateFilteredPostFields($postKey, $postVal, array $whitelist, $isPrefixed) {
+    private static function generateFilteredPostFields($postKey, $postVal, array $whitelist, $isPrefixed)
+    {
         if (is_array($postVal)) {
             $filteredPostFields = [];
             foreach ($postVal as $key => $val) {

--- a/src/Integrations/Util/Normalizer.php
+++ b/src/Integrations/Util/Normalizer.php
@@ -200,17 +200,12 @@ class Normalizer
         );
     }
 
-    private static function normalizeString(string $str)
+    private static function normalizeString($str)
     {
         return preg_replace('/[^a-zA-Z0-9\-\_)]+/', '_', $str);
     }
 
-    private static function generateFilteredPostFields(
-        string $postKey,
-        $postVal,
-        array $whitelist,
-        bool $isPrefixed
-    ): array {
+    private static function generateFilteredPostFields($postKey, $postVal, array $whitelist, $isPrefixed) {
         if (is_array($postVal)) {
             $filteredPostFields = [];
             foreach ($postVal as $key => $val) {
@@ -252,13 +247,13 @@ class Normalizer
         }
     }
 
-    private static function cleanRequestBody(array $requestBody, string $allowedParams): array
+    private static function cleanRequestBody(array $requestBody, $allowedParams)
     {
         $whitelist = self::decodeConfigSet($allowedParams);
         return self::generateFilteredPostFields('', $requestBody, $whitelist, false);
     }
 
-    public static function sanitizePostFields(array $postFields): array
+    public static function sanitizePostFields(array $postFields)
     {
         return self::cleanRequestBody(
             $postFields,


### PR DESCRIPTION
### Description

And adding a CI check for that...

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
