### PR TITLE
test(profiling) add stack walking test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2003,7 +2003,7 @@ jobs:
             set -u
             command -v switch-php && switch-php "${PHP_VERSION}"
             cd profiling
-            cargo test --release
+            cargo test --release --feature stalk_walking_tests
       - run:
           name: phpt tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2003,7 +2003,7 @@ jobs:
             set -u
             command -v switch-php && switch-php "${PHP_VERSION}"
             cd profiling
-            cargo test --release --features stalk_walking_tests
+            cargo test --release --features stack_walking_tests
       - run:
           name: phpt tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2003,7 +2003,7 @@ jobs:
             set -u
             command -v switch-php && switch-php "${PHP_VERSION}"
             cd profiling
-            cargo test --release --feature stalk_walking_tests
+            cargo test --release --features stalk_walking_tests
       - run:
           name: phpt tests
           command: |

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -30,6 +30,7 @@ rand_distr = { version = "0.4.3" }
 [features]
 default = ["allocation_profiling"]
 allocation_profiling = []
+stack_walking_tests = []
 
 [build-dependencies]
 bindgen = { version = "0.59" }

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -40,7 +40,8 @@ cases where they are ABI compatible.
 
 ## Testing
 
-The command `cargo test` will run the tests on the profiler.
+The command `cargo test` will run the tests on the profiler. To also run the
+stack walking test run `cargo test --features stack_walking_tests`.
 
 To see if the profiler is recognised by your PHP version as an extension you
 may run `/path/to/php -d extension=target/debug/libdatadog_php_profiling.so

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -98,9 +98,16 @@ fn build_zend_php_ffis(php_config_includes: &str, preload: bool) {
     let files = ["src/php_ffi.c", "../ext/handlers_api.c"];
     let preload = if preload { "1" } else { "0" };
 
+    #[cfg(any(feature = "stack_walking_tests"))]
+    let stack_walking_tests = "1";
+
+    #[cfg(not(feature = "stack_walking_tests"))]
+    let stack_walking_tests = "0";
+
     cc::Build::new()
         .files(files.into_iter().chain(zai_c_files.into_iter()))
         .define("CFG_PRELOAD", preload)
+        .define("CFG_STACK_WALKING_TESTS", stack_walking_tests)
         .includes([Path::new("../ext")])
         .includes(
             str::replace(php_config_includes, "-I", "")

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -4,6 +4,10 @@
 #include <stdbool.h>
 #include <string.h>
 
+#if CFG_STACK_WALKING_TESTS
+#include <dlfcn.h> // for dlsym
+#endif
+
 const char *datadog_extension_build_id(void) { return ZEND_EXTENSION_BUILD_ID; }
 const char *datadog_module_build_id(void) { return ZEND_MODULE_BUILD_ID; }
 
@@ -149,41 +153,36 @@ zend_execute_data* ddog_php_prof_get_current_execute_data()
 
 #if CFG_STACK_WALKING_TESTS
 zend_execute_data* ddog_php_test_create_fake_zend_execute_data(int depth) {
-    if (depth <= 0 || depth > 99) {
+    if (depth <= 0) {
         return NULL;
     }
-
     zend_execute_data *execute_data = (zend_execute_data *) malloc(sizeof(zend_execute_data));
     memset(execute_data, 0, sizeof(zend_execute_data));
 
     execute_data->prev_execute_data = ddog_php_test_create_fake_zend_execute_data(depth - 1);
 
+    int (*original_snprintf)(char *, size_t, const char *, ...);
+    original_snprintf = dlsym(RTLD_NEXT, "snprintf");
+
+    int len = 0;
+
     // add function name to stack frame
-    zend_string *func_name = malloc(sizeof(zend_string) + 16);
+    len = original_snprintf(NULL, 0, "function name %03d", depth) + 1;
+    zend_string *func_name = malloc(sizeof(zend_string) + len);
     func_name->h = 0;
-    func_name->len = 16;
-    memcpy(func_name->val, "function name 00", 16);
-    if (depth > 9) {
-        func_name->val[12] = depth / 10 + '0';
-        func_name->val[15] = depth % 10 + '0';
-    } else {
-        func_name->val[15] = depth + '0';
-    }
+    func_name->len = len-1;
+    original_snprintf(func_name->val, len, "function name %03d", depth);
+
     execute_data->func = (zend_function *) malloc(sizeof(zend_function));
     memset(execute_data->func, 0, sizeof(zend_function));
     execute_data->func->common.function_name = func_name;
 
     // add file name to stack frame
-    zend_string *file_name = malloc(sizeof(zend_string) + 15);
+    len = original_snprintf(NULL, 0, "filename-%03d.php", depth) + 1;
+    zend_string *file_name = malloc(sizeof(zend_string) + len);
     file_name->h = 0;
-    file_name->len = 15;
-    memcpy(file_name->val, "filename-00.php", 15);
-    if (depth > 9) {
-        file_name->val[9] = depth / 10 + '0';
-        file_name->val[10] = depth % 10 + '0';
-    } else {
-        file_name->val[10] = depth + '0';
-    }
+    file_name->len = len-1;
+    original_snprintf(file_name->val, len, "filename-%03d.php", depth);
     execute_data->func->op_array.filename = file_name;
     execute_data->func->type = ZEND_USER_FUNCTION;
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -196,6 +196,7 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
 
     ddog_php_test_free_fake_zend_execute_data(execute_data->prev_execute_data);
 
+    // free function name
     if (execute_data->func) {
         if (execute_data->func->common.function_name) {
             free(execute_data->func->common.function_name);
@@ -203,8 +204,9 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
         free(execute_data->func);
     }
 
-    if (execute_data->opline) {
-        /* free(execute_data->opline); */
+    // free filename
+    if (execute_data->func->op_array.filename) {
+        free(execute_data->func->op_array.filename);
     }
 
     free(execute_data);

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -121,5 +121,9 @@ void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
 
 zend_execute_data* ddog_php_prof_get_current_execute_data();
 
+/**
+ * The following two functions exist for the sole purpose of creating fake stack
+ * frames that can be used in testing/benchmarking scenarios
+ */
 zend_execute_data* ddog_php_test_create_fake_zend_execute_data(int depth);
 void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data);

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -120,3 +120,6 @@ void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
                                                void* (*_realloc)(void*, size_t));
 
 zend_execute_data* ddog_php_prof_get_current_execute_data();
+
+zend_execute_data* ddog_php_test_create_fake_zend_execute_data(int depth);
+void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data);

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -123,3 +123,33 @@ pub(super) unsafe fn collect_stack_sample(
     }
     Ok(samples)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bindings as zend;
+
+    #[test]
+    #[cfg(feature = "stack_walking_tests")]
+    fn test_collect_stack_sample() {
+        unsafe {
+            let fake_execute_data = zend::ddog_php_test_create_fake_zend_execute_data(3);
+
+            let stack = collect_stack_sample(fake_execute_data).unwrap();
+
+            assert_eq!(stack.len(), 3);
+
+            assert_eq!(stack[0].function, "function name 03");
+            assert_eq!(stack[0].line, 0);
+
+            assert_eq!(stack[1].function, "function name 02");
+            assert_eq!(stack[1].line, 0);
+
+            assert_eq!(stack[2].function, "function name 01");
+            assert_eq!(stack[2].line, 0);
+
+            // Free the allocated memory
+            zend::ddog_php_test_free_fake_zend_execute_data(fake_execute_data);
+        }
+    }
+}

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -139,13 +139,16 @@ mod tests {
 
             assert_eq!(stack.len(), 3);
 
-            assert_eq!(stack[0].function, "function name 03");
+            assert_eq!(stack[0].function, "function name 003");
+            assert_eq!(stack[0].file, Some("filename-003.php".to_string()));
             assert_eq!(stack[0].line, 0);
 
-            assert_eq!(stack[1].function, "function name 02");
+            assert_eq!(stack[1].function, "function name 002");
+            assert_eq!(stack[1].file, Some("filename-002.php".to_string()));
             assert_eq!(stack[1].line, 0);
 
-            assert_eq!(stack[2].function, "function name 01");
+            assert_eq!(stack[2].function, "function name 001");
+            assert_eq!(stack[2].file, Some("filename-001.php".to_string()));
             assert_eq!(stack[2].line, 0);
 
             // Free the allocated memory


### PR DESCRIPTION
### Description

This PR will add a test for stack walking to the profiler, that can be run without PHP being around. The main reason for this PR is that it provides the foundation of building micro benchmarks for the profiler that run without PHP.

- adds a unit test that validates the resulting stack frames against a fake PHP stack
- adds function to create a fake stack frame
- which is only compiled when enabling the `stack_walking_tests` feature

When reviewing please keep on eye on the following: The `ddog_php_test_*` functions in the `php_ffi.c` should not be compiled when building a release, but only when running tests. Currently this is implemented with a cargo feature `stack_walking_tests`, but maybe in the future we find a more automatic way.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
