### PR TITLE
feat(profiling) raise sampling distance for allocation profiling

### DIFF
--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -210,7 +210,7 @@ pub(crate) unsafe fn profiling_experimental_cpu_time_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_allocation_enabled() -> bool {
-    get_bool(ProfilingExperimentalAllocationEnabled, false)
+    get_bool(ProfilingExperimentalAllocationEnabled, true)
 }
 
 /// # Safety
@@ -405,7 +405,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingExperimentalAllocationEnabled),
                     name: ProfilingExperimentalAllocationEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStringView::literal(b"0\0"),
+                    default_encoded_value: ZaiStringView::literal(b"1\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -210,7 +210,7 @@ pub(crate) unsafe fn profiling_experimental_cpu_time_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_allocation_enabled() -> bool {
-    get_bool(ProfilingExperimentalAllocationEnabled, true)
+    get_bool(ProfilingExperimentalAllocationEnabled, false)
 }
 
 /// # Safety
@@ -405,7 +405,7 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     id: transmute(ProfilingExperimentalAllocationEnabled),
                     name: ProfilingExperimentalAllocationEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStringView::literal(b"1\0"),
+                    default_encoded_value: ZaiStringView::literal(b"0\0"),
                     aliases: std::ptr::null_mut(),
                     aliases_count: 0,
                     ini_change: None,

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -315,10 +315,9 @@ pub struct RequestLocals {
     pub vm_interrupt_addr: *const AtomicBool,
 }
 
-/// take a sample every X bytes
-/// this value is temporary but the overhead looks promising, Go profiler samples every 512 KiB
+/// take a sample every 2048 KB
 #[cfg(feature = "allocation_profiling")]
-pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 512.0;
+pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 2048.0;
 
 #[cfg(feature = "allocation_profiling")]
 pub struct AllocationProfilingStats {


### PR DESCRIPTION
### Description

This PR will raise the sampling distance for allocation profiling from 512 KB to 2048 KB to prepare for GAing

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
