### PR TITLE
Fix #2030: Segmentation fault with autoloaders bailing out

### DIFF
--- a/tests/ext/sandbox-regression/class_resolver_bailout_hook.phpt
+++ b/tests/ext/sandbox-regression/class_resolver_bailout_hook.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Assert bailouts are gracefully handled within class autoloading
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 70400) die('skip: Bailing out in autoloaders is fundamentally broken in PHP 7.3'); ?>
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+ddtrace\trace_function("x", function() { class C extends D {} print "Should not appear...\n"; });
+
+function x() {}
+
+spl_autoload_register(function() use (&$s) {
+    if ($s) {
+        trigger_error("No D", E_USER_ERROR);
+    } else {
+        $s = true;
+        x();
+        class B {}
+        print "Leaving Autoloader\n";
+    }
+});
+
+class A extends B {}
+
+?>
+--EXPECTF--
+Error raised in ddtrace's closure defined at %s:%d for x(): No D in %s
+Leaving Autoloader
+Flushing trace of size 2 to send-queue for %s

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -403,11 +403,11 @@ static int zai_interceptor_fast_ret_handler(zend_execute_data *execute_data) {
     return prev_fast_ret_handler ? prev_fast_ret_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;
 }
 
-void zai_interceptor_check_for_opline_before_exception(void);
+void zai_interceptor_check_for_opline_before_exception(zend_execute_data *execute_data);
 static user_opcode_handler_t prev_handle_exception_handler;
 static int zai_interceptor_handle_exception_handler(zend_execute_data *execute_data) {
     // not everything goes through zend_throw_exception_hook, in particular when zend_rethrow_exception alone is used (e.g. during zend_call_function)
-    zai_interceptor_check_for_opline_before_exception();
+    zai_interceptor_check_for_opline_before_exception(execute_data);
 
     zai_interceptor_frame_memory *frame_memory;
     if (ZEND_HANDLE_EXCEPTION == EX(opline)->opcode && zai_hook_memory_table_find(execute_data, &frame_memory)) {
@@ -1170,7 +1170,10 @@ static void zai_hook_memory_dtor(zval *zv) {
     efree(Z_PTR_P(zv));
 }
 
+void zai_interceptor_reset_resolver(void);
 void zai_interceptor_activate() {
+    zai_interceptor_reset_resolver();
+
     zend_hash_init(&zai_hook_memory, 8, nothing, zai_hook_memory_dtor, 0);
 }
 

--- a/zend_abstract_interface/interceptor/php7/resolver.c
+++ b/zend_abstract_interface/interceptor/php7/resolver.c
@@ -281,7 +281,7 @@ static void zai_interceptor_exception_hook(zval *ex) {
     }
 }
 
-void zai_interceptor_reset_resolver() {
+void zai_interceptor_reset_resolver(void) {
     // reset in case a prior request had a bailout
     zai_interceptor_opline_before_binding = (struct zai_interceptor_opline){0};
 }

--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -818,9 +818,16 @@ static void zai_hook_memory_dtor(zval *zv) {
     efree(Z_PTR_P(zv));
 }
 
+#if PHP_VERSION_ID < 80200
+void zai_interceptor_reset_resolver(void);
+#endif
 void zai_interceptor_activate(void) {
     zend_hash_init(&zai_hook_memory, 8, nothing, zai_hook_memory_dtor, 0);
     zend_hash_init(&zai_interceptor_implicit_generators, 8, nothing, NULL, 0);
+
+#if PHP_VERSION_ID < 80200
+    zai_interceptor_reset_resolver();
+#endif
 }
 
 void zai_interceptor_deactivate(void) {

--- a/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
+++ b/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
@@ -274,7 +274,7 @@ static void zai_interceptor_exception_hook(zend_object *ex) {
     }
 }
 
-void zai_interceptor_reset_resolver() {
+void zai_interceptor_reset_resolver(void) {
     // reset in case a prior request had a bailout
     zai_interceptor_opline_before_binding = (struct zai_interceptor_opline){0};
 }

--- a/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
+++ b/zend_abstract_interface/interceptor/php8/resolver_pre-8_2.c
@@ -82,7 +82,7 @@ PHP_FUNCTION(zai_interceptor_resolve_after_class_alias) {
 
 static zend_op zai_interceptor_post_declare_op;
 ZEND_TLS zend_op zai_interceptor_post_declare_ops[4];
-struct zai_interceptor_opline { const zend_op *op; struct zai_interceptor_opline *prev; };
+struct zai_interceptor_opline { const zend_op *op; const zend_execute_data *execute_data; struct zai_interceptor_opline *prev; };
 ZEND_TLS struct zai_interceptor_opline zai_interceptor_opline_before_binding = {0};
 static void zai_interceptor_install_post_declare_op(zend_execute_data *execute_data) {
     // We replace the current opline *before* it is executed. Thus we need to preserve opline data first:
@@ -110,10 +110,24 @@ static void zai_interceptor_install_post_declare_op(zend_execute_data *execute_d
         zai_interceptor_opline_before_binding.prev = backup;
     }
     zai_interceptor_opline_before_binding.op = EX(opline);
+    zai_interceptor_opline_before_binding.execute_data = execute_data;
     EX(opline) = zai_interceptor_post_declare_ops;
 }
 
-static void zai_interceptor_pop_opline_before_binding() {
+static void zai_interceptor_pop_opline_before_binding(zend_execute_data *execute_data) {
+    // Normally the zai_interceptor_opline_before_binding stack should be in sync with the actual executing stack, but it might not after bailouts
+    if (execute_data) {
+        if (zai_interceptor_opline_before_binding.execute_data == execute_data) {
+            return;
+        }
+
+        while (zai_interceptor_opline_before_binding.prev && zai_interceptor_opline_before_binding.prev->execute_data != execute_data) {
+            struct zai_interceptor_opline *backup = zai_interceptor_opline_before_binding.prev;
+            zai_interceptor_opline_before_binding = *backup;
+            efree(backup);
+        }
+    }
+
     struct zai_interceptor_opline *backup = zai_interceptor_opline_before_binding.prev;
     if (backup) {
         zai_interceptor_opline_before_binding = *backup;
@@ -154,8 +168,9 @@ static int zai_interceptor_post_declare_handler(zend_execute_data *execute_data)
             }
         }
         // preserve offset
+        zai_interceptor_pop_opline_before_binding(execute_data);
         EX(opline) = zai_interceptor_opline_before_binding.op + (EX(opline) - &zai_interceptor_post_declare_ops[0]);
-        zai_interceptor_pop_opline_before_binding();
+        zai_interceptor_pop_opline_before_binding(NULL);
         return ZEND_USER_OPCODE_CONTINUE;
     } else if (prev_post_declare_handler) {
         return prev_post_declare_handler(execute_data);
@@ -237,8 +252,9 @@ static user_opcode_handler_t prev_handle_exception_handler;
 static int zai_interceptor_handle_exception_handler(zend_execute_data *execute_data) {
     // not everything goes through zend_throw_exception_hook, in particular when zend_rethrow_exception alone is used (e.g. during zend_call_function)
     if (EG(opline_before_exception) == zai_interceptor_post_declare_ops) {
+        zai_interceptor_pop_opline_before_binding(execute_data);
         EG(opline_before_exception) = zai_interceptor_opline_before_binding.op;
-        zai_interceptor_pop_opline_before_binding();
+        zai_interceptor_pop_opline_before_binding(NULL);
     }
 
     return prev_handle_exception_handler ? prev_handle_exception_handler(execute_data) : ZEND_USER_OPCODE_DISPATCH;
@@ -249,12 +265,18 @@ static void zai_interceptor_exception_hook(zend_object *ex) {
     zend_function *func = EG(current_execute_data)->func;
     if (func && ZEND_USER_CODE(func->type) && EG(current_execute_data)->opline == zai_interceptor_post_declare_ops) {
         // called right before setting EG(opline_before_exception), reset to original value to ensure correct throw_op handling
+        zai_interceptor_pop_opline_before_binding(EG(current_execute_data));
         EG(current_execute_data)->opline = zai_interceptor_opline_before_binding.op;
-        zai_interceptor_pop_opline_before_binding();
+        zai_interceptor_pop_opline_before_binding(NULL);
     }
     if (prev_exception_hook) {
         prev_exception_hook(ex);
     }
+}
+
+void zai_interceptor_reset_resolver() {
+    // reset in case a prior request had a bailout
+    zai_interceptor_opline_before_binding = (struct zai_interceptor_opline){0};
 }
 
 static void *opcache_handle;


### PR DESCRIPTION
### Description

We fix this issue by ensuring that the opline is always connected to its proper execute_data and popping newer entries if they aren't matching.

Note for the reviewer: the PHP 7 and PHP 8 changes are identical.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
