### PR TITLE
fix(profiling): crashes when allocation sampling occurs in certain places

### DIFF
--- a/ext/handlers_curl_php7.c
+++ b/ext/handlers_curl_php7.c
@@ -145,6 +145,7 @@ static int dd_inject_distributed_tracing_headers(zval *ch) {
     ZVAL_COPY_VALUE(ZEND_CALL_ARG(call, 3), &headers);
 
     zend_execute_data *ex = EG(current_execute_data);
+    call->prev_execute_data = ex;
     EG(current_execute_data) = call;
     zval ret;
     dd_curl_setopt_handler(call, &ret);

--- a/tests/randomized/config/envs.php
+++ b/tests/randomized/config/envs.php
@@ -63,4 +63,5 @@ const ENVS = [
     'DD_TRACE_YII_ENABLED' => ['false'],
     'DD_TRACE_ZENDFRAMEWORK_ENABLED' => ['false'],
     'DD_PROFILING_ENABLED' => ['true'],
+    'DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' => ['true'],
 ];


### PR DESCRIPTION
### Description

In preparing allocation profiling GA we found some bugs in the profiler -> tracer interaction that this PR fixes.

- possible segfault when instrumenting `curl_setopt()` in PHP7
- possible segfault when fetching active span during priority sampling decision

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
