### PR TITLE
Reduce the allocated heap size of the elasticsearch7 container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
     name: elasticsearch7_integration
     environment:
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - ES_JAVA_OPTS=-Xms1536m -Xmx1536m
 
   - &IMAGE_DOCKER_HTTPBIN
     image: kong/httpbin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
     name: elasticsearch7_integration
     environment:
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1536m -Xmx1536m
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
 
   - &IMAGE_DOCKER_HTTPBIN
     image: kong/httpbin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
     name: elasticsearch7_integration
     environment:
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms750m -Xmx750m
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
 
   - &IMAGE_DOCKER_HTTPBIN
     image: kong/httpbin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ aliases:
     name: elasticsearch7_integration
     environment:
       - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms750m -Xmx750m
 
   - &IMAGE_DOCKER_HTTPBIN
     image: kong/httpbin


### PR DESCRIPTION
### Description

It sometimes happened that the elasticsearch7 container would exit with the error code 137 in the CI, but with the introduction of the SQLSRV integration and its additional container, elasticsearch would often exit, hence making the integrations tests fail. 

This PR just changes the heap size of this container (or more specifically, the amount of memory the JVM is allowed to use), which is 2gb by default, to 1gb, which should be enough for testing purposes.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [X] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
