### PR TITLE
fix(profiling): fix panic by explicitly depending on `ext-json`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2130,6 +2130,7 @@ jobs:
                 name: Fetch PHP 5 packages
                 command: |
                   set -eu
+                  sudo apt-get update
                   sudo apt-get install jq
                   PIPELINE_ID=$(curl 'https://circleci.com/api/v2/project/gh/DataDog/dd-trace-php/pipeline?branch=PHP-5' | jq -r '.items[0].id')
                   WORKFLOW_ID=$(curl "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq -r '.items[]|select(.name == "build_packages").id' | head -1)

--- a/profiling/Cargo.lock
+++ b/profiling/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "cpu-time",
  "crossbeam-channel",
  "datadog-profiling",
+ "ddcommon",
  "env_logger 0.10.0",
  "indexmap",
  "lazy_static",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -16,6 +16,7 @@ cfg-if = { version = "1.0" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 cpu-time = { version = "1.0" }
 datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v2.1.0" }
+ddcommon = { git = "https://github.com/DataDog/libdatadog", tag = "v2.1.0" }
 env_logger = { version = "0.10" }
 indexmap = { version = "1.8" }
 lazy_static = { version = "1.4" }

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -281,6 +281,15 @@ extern "C" {
 pub use zend_module_dep as ModuleDep;
 
 impl ModuleDep {
+    pub const fn required(name: &CStr) -> Self {
+        Self {
+            name: name.as_ptr(),
+            rel: std::ptr::null(),
+            version: std::ptr::null(),
+            type_: MODULE_DEP_REQUIRED as c_uchar,
+        }
+    }
+
     pub const fn optional(name: &CStr) -> Self {
         Self {
             name: name.as_ptr(),

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -332,7 +332,7 @@ unsafe extern "C" fn parse_level_filter(
                 }
                 _ => false,
             }
-        },
+        }
         _ => false,
     }
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -10,6 +10,7 @@ use bindings as zend;
 use bindings::{sapi_globals, ZendExtension, ZendResult};
 use config::AgentEndpoint;
 use datadog_profiling::exporter::{Tag, Uri};
+use ddcommon::cstr;
 use lazy_static::lazy_static;
 use libc::c_char;
 use log::{debug, error, info, trace, warn, LevelFilter};
@@ -101,9 +102,9 @@ pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
 
     static DEPS: [zend::ModuleDep; 4] = [
         // Safety: string is nul terminated with no interior nul bytes.
-        zend::ModuleDep::required(unsafe { CStr::from_bytes_with_nul_unchecked(b"standard\0") }),
-        zend::ModuleDep::required(unsafe { CStr::from_bytes_with_nul_unchecked(b"json\0") }),
-        zend::ModuleDep::optional(unsafe { CStr::from_bytes_with_nul_unchecked(b"ddtrace\0") }),
+        zend::ModuleDep::required(cstr!("standard")),
+        zend::ModuleDep::required(cstr!("json")),
+        zend::ModuleDep::optional(cstr!("ddtrace")),
         zend::ModuleDep::end(),
     ];
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -101,7 +101,6 @@ pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
      */
 
     static DEPS: [zend::ModuleDep; 4] = [
-        // Safety: string is nul terminated with no interior nul bytes.
         zend::ModuleDep::required(cstr!("standard")),
         zend::ModuleDep::required(cstr!("json")),
         zend::ModuleDep::optional(cstr!("ddtrace")),

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -99,8 +99,10 @@ pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
      * the result which avoids unsafe code and unnecessary locks.
      */
 
-    static DEPS: [zend::ModuleDep; 2] = [
+    static DEPS: [zend::ModuleDep; 4] = [
         // Safety: string is nul terminated with no interior nul bytes.
+        zend::ModuleDep::required(unsafe { CStr::from_bytes_with_nul_unchecked(b"standard\0") }),
+        zend::ModuleDep::required(unsafe { CStr::from_bytes_with_nul_unchecked(b"json\0") }),
         zend::ModuleDep::optional(unsafe { CStr::from_bytes_with_nul_unchecked(b"ddtrace\0") }),
         zend::ModuleDep::end(),
     ];

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -237,7 +237,9 @@ impl TimeCollector {
 
         // check if we have the `alloc-size` and `alloc-samples` sample types
         #[cfg(feature = "allocation_profiling")]
-        let alloc_samples_offset = sample_types.iter().position(|&x| x.r#type == "alloc-samples");
+        let alloc_samples_offset = sample_types
+            .iter()
+            .position(|&x| x.r#type == "alloc-samples");
         #[cfg(feature = "allocation_profiling")]
         let alloc_size_offset = sample_types.iter().position(|&x| x.r#type == "alloc-size");
 
@@ -259,9 +261,10 @@ impl TimeCollector {
             let upscaling_info = UpscalingInfo::Poisson {
                 sum_value_offset: alloc_size_offset.unwrap(),
                 count_value_offset: alloc_samples_offset.unwrap(),
-                sampling_distance: ALLOCATION_PROFILING_INTERVAL as u64
+                sampling_distance: ALLOCATION_PROFILING_INTERVAL as u64,
             };
-            let values_offset: Vec<usize> = vec![alloc_size_offset.unwrap(), alloc_samples_offset.unwrap()];
+            let values_offset: Vec<usize> =
+                vec![alloc_size_offset.unwrap(), alloc_samples_offset.unwrap()];
             match profile.add_upscaling_rule(values_offset.as_slice(), "", "", upscaling_info) {
                 Ok(_id) => {}
                 Err(err) => {

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -22,7 +22,9 @@ __attribute__((weak)) int php_json_encode(smart_str *buf, zval *val, int options
 __attribute__((weak)) int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options,
                                              zend_long depth);
 #endif
+#ifndef __APPLE__
 __attribute__((weak)) zend_class_entry *php_json_serializable_ce;
+#endif
 
 bool zai_json_setup_bindings(void) {
     if (php_json_encode && php_json_decode_ex && php_json_serializable_ce) {

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -22,7 +22,7 @@ __attribute__((weak)) int php_json_encode(smart_str *buf, zval *val, int options
 __attribute__((weak)) int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options,
                                              zend_long depth);
 #endif
-extern __attribute__((weak)) zend_class_entry *php_json_serializable_ce;
+__attribute__((weak)) zend_class_entry *php_json_serializable_ce;
 
 bool zai_json_setup_bindings(void) {
     if (php_json_encode && php_json_decode_ex && php_json_serializable_ce) {

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -22,7 +22,7 @@ __attribute__((weak)) int php_json_encode(smart_str *buf, zval *val, int options
 __attribute__((weak)) int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options,
                                              zend_long depth);
 #endif
-__attribute__((weak)) zend_class_entry *php_json_serializable_ce;
+extern __attribute__((weak)) zend_class_entry *php_json_serializable_ce;
 
 bool zai_json_setup_bindings(void) {
     if (php_json_encode && php_json_decode_ex && php_json_serializable_ce) {

--- a/zend_abstract_interface/json/json.h
+++ b/zend_abstract_interface/json/json.h
@@ -50,7 +50,7 @@ static inline int zai_json_decode_assoc(zval *return_value, const char *str, int
 #endif
 
 #ifdef __APPLE__
-extern __attribute__((weak)) __attribute__((weak_import)) zend_class_entry *php_json_serializable_ce;
+extern __attribute__((weak, weak_import)) zend_class_entry *php_json_serializable_ce;
 #else
 extern __attribute__((weak)) zend_class_entry *php_json_serializable_ce;
 #endif

--- a/zend_abstract_interface/json/json.h
+++ b/zend_abstract_interface/json/json.h
@@ -49,7 +49,11 @@ static inline int zai_json_decode_assoc(zval *return_value, const char *str, int
 }
 #endif
 
+#ifdef __APPLE__
+extern __attribute__((weak)) __attribute__((weak_import)) zend_class_entry *php_json_serializable_ce;
+#else
 extern __attribute__((weak)) zend_class_entry *php_json_serializable_ce;
+#endif
 
 bool zai_json_setup_bindings(void);
 


### PR DESCRIPTION
### Description

This makes the profilers dependency on `ext-json` explicit, as well as fixes a bug on MacOS, where `php_json_serializable_ce` was `NULL` in every case (due to the missing `extern`) and the profiler would panic:
```
[2023-05-10T13:25:27.409327Z TRACE datadog_php_profiling] MINIT(1, 36)
thread '<unnamed>' panicked at 'assertion failed: tmp', src/config.rs:513:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:48:5
   3: datadog_php_profiling::config::minit
             at ./src/config.rs:513:9
   4: datadog_php_profiling::minit
             at ./src/lib.rs:211:5
   5: zend_startup_module_ex
             at /usr/local/src/php/php-82/Zend/zend_API.c:2235:7
   6: zend_startup_module_zval
             at /usr/local/src/php/php-82/Zend/zend_API.c:2250:10
   7: zend_hash_apply
             at /usr/local/src/php/php-82/Zend/zend_hash.c:2018:13
   8: zend_startup_modules
             at /usr/local/src/php/php-82/Zend/zend_API.c:2361:2
   9: php_module_startup
             at /usr/local/src/php/php-82/main/main.c:2260:2
  10: php_cli_startup
             at /usr/local/src/php/php-82/sapi/cli/php_cli.c:410:9
  11: main
             at /usr/local/src/php/php-82/sapi/cli/php_cli.c:1300:6
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
zsh: abort      RUST_BACKTRACE=1 php -d extension=target/debug/libdatadog_php_profiling.dylib
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
