### PR TITLE
Do not force cycle collection at runtime on flush by default

### DIFF
--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -7,11 +7,16 @@
 #include "serializer.h"
 #include "span.h"
 
-ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
+ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles) {
     bool success = true;
 
     zval trace, traces;
-    ddtrace_serialize_closed_spans(&trace);
+    array_init(&trace);
+    if (collect_cycles) {
+        ddtrace_serialize_closed_spans_with_cycle(&trace);
+    } else {
+        ddtrace_serialize_closed_spans(&trace);
+    }
 
     // Prevent traces from requests not executing any PHP code:
     // PG(during_request_startup) will only be set to 0 upon execution of any PHP code.
@@ -61,5 +66,5 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup) {
 DDTRACE_PUBLIC void ddtrace_close_all_spans_and_flush()
 {
     ddtrace_close_all_open_spans(true);
-    ddtrace_flush_tracer(true);
+    ddtrace_flush_tracer(true, true);
 }

--- a/ext/auto_flush.h
+++ b/ext/auto_flush.h
@@ -5,7 +5,7 @@
 #include <php.h>
 #include <stdbool.h>
 
-ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup);
+ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles);
 
 // This function is exported and used by appsec
 DDTRACE_PUBLIC void ddtrace_close_all_spans_and_flush(void);

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -92,6 +92,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(BOOL, DD_TRACE_REDIS_CLIENT_SPLIT_BY_HOST, "false")                                                 \
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
+    CONFIG(BOOL, DD_TRACE_FLUSH_COLLECT_CYCLES, "false")                                                       \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                    \

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -819,7 +819,7 @@ void dd_force_shutdown_tracing(void) {
     DDTRACE_G(in_shutdown) = true;
 
     ddtrace_close_all_open_spans(true);  // All remaining userland spans (and root span)
-    if (ddtrace_flush_tracer(false) == FAILURE) {
+    if (ddtrace_flush_tracer(false, true) == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }
 
@@ -1124,7 +1124,8 @@ PHP_FUNCTION(dd_trace_serialize_closed_spans) {
 
     ddtrace_mark_all_span_stacks_flushable();
 
-    ddtrace_serialize_closed_spans(return_value);
+    array_init(return_value);
+    ddtrace_serialize_closed_spans_with_cycle(return_value);
 
     ddtrace_free_span_stacks(false);
     ddtrace_init_span_stacks();
@@ -1764,7 +1765,7 @@ PHP_FUNCTION(DDTrace_flush) {
     if (get_DD_AUTOFINISH_SPANS()) {
         ddtrace_close_userland_spans_until(NULL);
     }
-    if (ddtrace_flush_tracer(false) == FAILURE) {
+    if (ddtrace_flush_tracer(false, get_DD_TRACE_FLUSH_COLLECT_CYCLES()) == FAILURE) {
         ddtrace_log_debug("Unable to flush the tracer");
     }
     RETURN_NULL();

--- a/ext/span.c
+++ b/ext/span.c
@@ -513,7 +513,7 @@ static void dd_close_entry_span_of_stack(ddtrace_span_stack *stack) {
             ddtrace_switch_span_stack(stack->parent_stack);
         }
 
-        if (get_DD_TRACE_AUTO_FLUSH_ENABLED() && ddtrace_flush_tracer(false) == FAILURE) {
+        if (get_DD_TRACE_AUTO_FLUSH_ENABLED() && ddtrace_flush_tracer(false, get_DD_TRACE_FLUSH_COLLECT_CYCLES()) == FAILURE) {
             // In case we have root spans enabled, we need to always flush if we close that one (RSHUTDOWN)
             ddtrace_log_debug("Unable to auto flush the tracer");
         }
@@ -568,6 +568,7 @@ void ddtrace_close_top_span_without_stack_swap(ddtrace_span_data *span) {
     if (!stack->active || stack->active->stack != stack) {
         dd_close_entry_span_of_stack(stack);
     }
+
 }
 
 // i.e. what DDTrace\active_span() reports. DDTrace\active_stack()->active is the active span which will be used as parent for new spans on that stack
@@ -671,10 +672,7 @@ void ddtrace_drop_span(ddtrace_span_data *span) {
 }
 
 void ddtrace_serialize_closed_spans(zval *serialized) {
-    array_init(serialized);
-
-    // We need to loop here, as closing the last span root stack could add other spans here
-    while (DDTRACE_G(top_closed_stack)) {
+    if (DDTRACE_G(top_closed_stack)) {
         ddtrace_span_stack *rootstack = DDTRACE_G(top_closed_stack);
         DDTRACE_G(top_closed_stack) = NULL;
         do {
@@ -707,14 +705,20 @@ void ddtrace_serialize_closed_spans(zval *serialized) {
                 }
             } while (stack);
         } while (rootstack);
-
-        // Also flush possible cycles here
-        zend_gc_collect_cycles();
     }
 
     // Reset closed span counter for limit-refresh, don't touch open spans
     DDTRACE_G(closed_spans_count) = 0;
     DDTRACE_G(dropped_spans_count) = 0;
+}
+
+void ddtrace_serialize_closed_spans_with_cycle(zval *serialized) {
+    // We need to loop here, as closing the last span root stack could add other spans here
+    while (DDTRACE_G(top_closed_stack)) {
+        ddtrace_serialize_closed_spans(serialized);
+        // Also flush possible cycles here
+        gc_collect_cycles();
+    }
 }
 
 zend_string *ddtrace_span_id_as_string(uint64_t id) { return zend_strpprintf(0, "%" PRIu64, id); }

--- a/ext/span.h
+++ b/ext/span.h
@@ -120,6 +120,7 @@ void ddtrace_close_all_open_spans(bool force_close_root_span);
 void ddtrace_drop_span(ddtrace_span_data *span);
 void ddtrace_mark_all_span_stacks_flushable(void);
 void ddtrace_serialize_closed_spans(zval *serialized);
+void ddtrace_serialize_closed_spans_with_cycle(zval *serialized);
 zend_string *ddtrace_span_id_as_string(uint64_t id);
 zend_string *ddtrace_trace_id_as_string(ddtrace_trace_id id);
 zend_string *ddtrace_span_id_as_hex_string(uint64_t id);


### PR DESCRIPTION
### Description

We had an user where it massively impacted their performance: And _practically_ it should rarely make a difference (it only matters with autoflush active and forgetting to close all of a stacks spans and GC running next to never in a long running script. But if it _does_ delay traces from arriving, there's an escape hatch configuration option.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~ Performance issue rather.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
