### PR TITLE
fix(ci) this will update the container used for `package extension`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2112,7 +2112,7 @@ jobs:
 
   "package extension":
     working_directory: ~/datadog
-    docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging_FLO_TEST' ]
     parameters:
       asan_build:
         type: boolean
@@ -2130,7 +2130,6 @@ jobs:
                 name: Fetch PHP 5 packages
                 command: |
                   set -eu
-                  sudo curl -L -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
                   PIPELINE_ID=$(curl 'https://circleci.com/api/v2/project/gh/DataDog/dd-trace-php/pipeline?branch=PHP-5' | jq -r '.items[0].id')
                   WORKFLOW_ID=$(curl "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq -r '.items[]|select(.name == "build_packages").id' | head -1)
                   JOB_ID=$(curl "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | jq -r '.items[]|select(.name == "package extension").id')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2113,7 +2113,7 @@ jobs:
   "package extension":
     working_directory: ~/datadog
     # The `Dockerfile` to this image is located at https://github.com/DataDog/docker-library/blob/master/dd-trace-php/Dockerfile_fpm
-    docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging_FLO_TEST' ]
+    docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
     parameters:
       asan_build:
         type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ aliases:
       PORT: 9126
       DD_SUPPRESS_TRACE_PARSE_ERRORS: true
       DISABLED_CHECKS: trace_content_length
-      
+
   - &IMAGE_DOCKER_SQLSRV
     image: mcr.microsoft.com/mssql/server:2022-latest
     name: sqlsrv_integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2112,6 +2112,7 @@ jobs:
 
   "package extension":
     working_directory: ~/datadog
+    # The `Dockerfile` to this image is located at https://github.com/DataDog/docker-library/blob/master/dd-trace-php/Dockerfile_fpm
     docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging_FLO_TEST' ]
     parameters:
       asan_build:


### PR DESCRIPTION
### Description

This will remove the installation of `jq` as it is now backed into the container, see https://github.com/DataDog/docker-library/pull/93

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
