### PR TITLE
Fix opline being replaced by ZEND_HANDLE_EXCEPTION in uncaught finally on PHP 7

### DIFF
--- a/tests/ext/sandbox-regression/uncaught_exception_with_finally.phpt
+++ b/tests/ext/sandbox-regression/uncaught_exception_with_finally.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Finally block should only be entered once
+--FILE--
+<?php
+
+function triggerError() {
+    $a = null;
+    $a->hello();
+}
+
+function handle() {
+    try {
+        triggerError();
+    } catch (\Exception $e) {
+        echo "This should never be printed\n";
+    } finally {
+        echo "This should only be printed once\n";
+    }
+}
+
+\DDTrace\trace_function('handle', function (\DDTrace\SpanData $span) {
+    echo "handle called\n";
+});
+
+handle();
+
+?>
+--EXPECTF--
+This should only be printed once
+handle called
+
+Fatal error: Uncaught Error: Call to a member function hello() on null in %s:%d
+Stack trace:
+#0 %s: triggerError()
+#1 %s: handle()
+#2 {main}
+  thrown in %s

--- a/zend_abstract_interface/interceptor/php7/interceptor.c
+++ b/zend_abstract_interface/interceptor/php7/interceptor.c
@@ -392,7 +392,9 @@ static int zai_interceptor_fast_ret_handler(zend_execute_data *execute_data) {
                     zval retval;
                     ZVAL_NULL(&retval);
                     EG(exception) = Z_OBJ_P(fast_call);
+                    const zend_op *opline = EX(opline); // due to us lying about an exception existing, the sandbox will modify the opline
                     zai_hook_finish(execute_data, &retval, &frame_memory->hook_data);
+                    EX(opline) = opline; // restore it
                     EG(exception) = NULL;
                 }
                 zai_hook_memory_table_del(execute_data);


### PR DESCRIPTION
### Description

Fixes #2049, #1955.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
