### PR TITLE
build: bump cmake and catch2 versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1518,6 +1518,7 @@ jobs:
               echo 'cmake << parameters.cmake_version >> already installed'
               exit 0
             fi
+
             if [ -e /etc/alpine-release ]
             then
               # We build from source on Alpine (slow)
@@ -2318,10 +2319,9 @@ workflows:
                 - "datadog/dd-trace-ci:alpine"
                 - "datadog/dd-trace-ci:buster"
               cmake_version:
-                - "3.19.8"
-                - "3.21.4"
+                - "3.24.4"
               catch2_version:
-                - "2.13.7"
+                - "2.13.10"
 
   zend_abstract_interface:
     jobs:
@@ -2343,10 +2343,9 @@ workflows:
                 - "8.1"
                 - "8.2"
               cmake_version:
-                - "3.19.7"
-                - "3.20.1"
+                - "3.24.4"
               catch2_version:
-                - "2.13.5"
+                - "2.13.10"
 
   zend_abstract_interface_shared_exts:
     jobs:

--- a/dockerfiles/ci/alpine/Dockerfile
+++ b/dockerfiles/ci/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.17
 
 ENV PHP_SRC_DIR=/usr/local/src/php
 ENV PHP_INSTALL_DIR=/opt/php
@@ -11,6 +11,7 @@ RUN set -eux; \
         bison \
         bash \
         ca-certificates \
+        cmake \
         coreutils \
         curl \
         curl-dev \
@@ -38,8 +39,6 @@ RUN set -eux; \
         openssl-dev \
         postgresql-dev \
         pkgconf \
-        py-pip \
-        python-dev \
         re2c \
         sqlite-dev \
         sudo \
@@ -48,18 +47,18 @@ RUN set -eux; \
         vim \
         xz \
         zlib-dev \
-    ; \
+    ;
+
+RUN set -eux; \
 # Add user/group for circleci
     addgroup -g 3434 -S circleci; \
-    adduser -u 3434 -D -S -G circleci -G wheel circleci; \
+    adduser -u 3434 -D -S -G circleci -G wheel circleci --shell /bin/bash; \
     sed -e 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' -i /etc/sudoers; \
     adduser circleci wheel; \
 # Fix "sudo: setrlimit(RLIMIT_CORE): Operation not permitted" error
     echo "Set disable_coredump false" >> /etc/sudo.conf; \
 # Add www-data user
-    addgroup -g 82 -S www-data; \
     adduser -u 82 -D -S -G www-data www-data; \
-# 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # allow running as an arbitrary user (https://github.com/docker-library/php/issues/743)
     [ ! -d /var/www/html ]; \
@@ -76,7 +75,7 @@ RUN set -eux; \
     mkdir -p $PHP_INSTALL_DIR; \
     chown -R circleci:circleci /opt; \
 # Install Docker
-    export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1); \
+    export DOCKER_VERSION=$(curl --silent --fail --retry 3 "https://download.docker.com/linux/static/stable/$(uname -m)/" | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1); \
     DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}"; \
     curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}"; \
     ls -lha /tmp/docker.tgz; \
@@ -86,16 +85,30 @@ RUN set -eux; \
     which docker; \
     (docker version || true); \
 # Install docker-compose
-    curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose; \
+    curl -L "https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose; \
     chmod +x /usr/local/bin/docker-compose; \
     which docker-compose; \
-    (docker-compose --version || true); \
-# Install dockerize
-    DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz"; \
-    curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL; \
-    tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz; \
-    rm -rf /tmp/dockerize-linux-amd64.tar.gz; \
-    dockerize --version;
+    (docker-compose --version || true);
+
+# symlink cmake
+RUN version=$(cmake --version | awk '/cmake version/ {print $3}') \
+    && mkdir -vp "/opt/cmake/$version/bin" \
+    && cd "/opt/cmake/$version/bin" \
+    && ln -s $(command -v cmake) cmake
+
+# catch2
+ARG CATCH2_VERSION="2.13.10"
+ARG CATCH2_SHA256="d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943"
+RUN cd /tmp \
+    && curl -o catch2.tar.gz -L https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz \
+    && (echo "${CATCH2_SHA256}  catch2.tar.gz" | sha256sum -c -) \
+    && mkdir catch2 \
+    && cd catch2 \
+    && tar -xf ../catch2.tar.gz --strip 1 \
+    && cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2 \
+    && cmake --build build/ --target install \
+    && cd /tmp \
+    && rm -fr catch2
 
 # Run everything else as circleci user
 USER circleci

--- a/dockerfiles/ci/alpine/docker-compose.yml
+++ b/dockerfiles/ci/alpine/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     image: datadog/dd-trace-ci:alpine
     build:
       context: .
+      x-bake: &bake
+        platforms:
+          - linux/arm64
+          - linux/amd64
 
   php-8.0:
     image: datadog/dd-trace-ci:php-8.0_alpine

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -109,14 +109,14 @@ RUN set -eux; \
 # Allow nginx to be run as non-root for tests
     chown -R circleci:circleci /var/log/nginx/ /var/lib/nginx/;
 
-ENV CMAKE_VERSION="3.21.4"
+ENV CMAKE_VERSION="3.24.4"
 
 # Install CMake
 RUN set -eux; \
     if [ "$(uname -m)" = "aarch64" ]; then \
-        CMAKE_SHA256="abe24e2e6ae8a706e771a612603ec93457dc6b71bdb09e35d2a26f051e2fa818"; \
+        CMAKE_SHA256="86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee"; \
     else \
-        CMAKE_SHA256="eddba9da5b60e0b5ec5cbb1a65e504d776e247573204df14f6d004da9bc611f9"; \
+        CMAKE_SHA256="cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19"; \
     fi; \
     cd /tmp && curl -L --output cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-$(uname -m).tar.gz; \
     (echo "${CMAKE_SHA256} cmake.tar.gz" | sha256sum -c -); \
@@ -128,10 +128,10 @@ RUN set -eux; \
 
 # Install Catch2
 RUN set -eux; \
-    CATCH2_VERSION="2.13.7"; \
-    CATCH2_SHA256=""3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae; \
+    CATCH2_VERSION="2.13.10"; \
+    CATCH2_SHA256="d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943"; \
     cd /tmp && curl -OL https://github.com/catchorg/Catch2/archive/v${CATCH2_VERSION}.tar.gz; \
-    (echo "${CATCH2_SHA256} v${CATCH2_VERSION}.tar.gz" | sha256sum -c -); \
+    (echo "${CATCH2_SHA256}  v${CATCH2_VERSION}.tar.gz" | sha256sum -c -); \
     mkdir catch2 && cd catch2; \
     tar -xf ../v${CATCH2_VERSION}.tar.gz --strip 1; \
     /opt/cmake/${CMAKE_VERSION}/bin/cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/opt/catch2 -DCATCH_BUILD_STATIC_LIBRARY=ON; \


### PR DESCRIPTION
### Description

- Rebuilds some base containers to reduce CI time spent fetching/building these dependencies. The PHP images which depend on the base images have not been rebuilt yet.
    - On alpine in particular, this saves a lot of time because building cmake from source is slow there. Cuts job time from 12+ minutes to less than 1.
    - Updates the Alpine image used from 3.11 to 3.17.
 - Runs CI against only one cmake version -- this is just wasting CPU cycles at this point.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
