### PR TITLE
fix(datadog-setup.php): remove return types for compatibility with PHP 5

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -241,7 +241,7 @@ function cmd_config_get(array $options)
  * Set 'datadog.profiling.experimental_allocation_enabled' to 'On' in INI file: /opt/php/etc/conf.d/98-ddtrace.ini
  * Set 'datadog.profiling.experimental_cpu_time_enabled' to 'On' in INI file: /opt/php/etc/conf.d/98-ddtrace.ini
  */
-function cmd_config_set(array $options): void
+function cmd_config_set(array $options)
 {
     if (!isset($options['d'])) {
         print_help();
@@ -739,7 +739,7 @@ function install($options)
  * @see ini_values
  * @return string[]
  */
-function find_all_ini_files(array $phpProperties): array
+function find_all_ini_files(array $phpProperties)
 {
     $iniFilePaths = [];
 
@@ -798,7 +798,7 @@ function find_all_ini_files(array $phpProperties): array
  * @see ini_values
  * @return string[]
  */
-function find_main_ini_files(array $phpProperties): array
+function find_main_ini_files(array $phpProperties)
 {
     $iniFilePaths = [];
     if (isset($phpProperties[INI_SCANDIR])) {


### PR DESCRIPTION
### Description

I'm trying to install Datadog APM in a legacy PHP 5 application and it's failing with a syntax error because of the return types on lines [244](https://github.com/DataDog/dd-trace-php/blob/8979b7c3742389208c56bbc0de7b6b16568aa8fe/datadog-setup.php#L244), [742](https://github.com/DataDog/dd-trace-php/blob/8979b7c3742389208c56bbc0de7b6b16568aa8fe/datadog-setup.php#L742) and [801](https://github.com/DataDog/dd-trace-php/blob/8979b7c3742389208c56bbc0de7b6b16568aa8fe/datadog-setup.php#L801). This error was apparently introduced in #1951

This PR removes the return types so it's syntax-compatible with PHP 5 (tested with `php -l` on PHP 5.6.40, which is the version my app uses).

I guess #2021 was merged after #1951, otherwise the "Lint PHP 5" would've caught it.

The installer for dd-trace-php 0.86.3 works fine.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
