### PR TITLE
Laravel way of filtering exceptions for reporting

### DIFF
--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -238,8 +238,8 @@ class LaravelIntegration extends Integration
         \DDTrace\hook_method(
             'Illuminate\Contracts\Debug\ExceptionHandler',
             'report',
-            function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if ($args[0] && $args[0]->getStatusCode() >= 500) {
+            function ($exceptionHandler, $scope, $args) use ($rootSpan, $integration) {
+                if ($args[0] && $exceptionHandler->shouldReport($args[0])) {
                     $integration->setError($rootSpan, $args[0]);
                 }
             }


### PR DESCRIPTION
### Description

Bug fix. Instead of checking status code, use the built in laravel method to determine if exceptions should be reported. Not all 5XX errors needs reporting and not all 4XX needs to be skipped.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
