### PR TITLE
build: pin guzzlehttp/promises to ^1.5.3

### DIFF
--- a/tests/composer.json
+++ b/tests/composer.json
@@ -65,7 +65,8 @@
             },
             "guzzle7": {
                 "require": {
-                    "guzzlehttp/guzzle": "~7.0"
+                    "guzzlehttp/guzzle": "~7.0",
+                    "guzzlehttp/promises": "^1.5.3"
                 },
                 "scenario-options": {
                     "create-lockfile": false


### PR DESCRIPTION
### Description

v2 was released yesterday and it dropped support for PHP <7.2. We don't support promises v2 yet so our tests fail without the pin.

Thanks, @realFlowControl, for investigating why CI was failing suddenly.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
