### PR TITLE
Work around fiber->execute_data only being correct upon yielding

### DIFF
--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -16,6 +16,7 @@ Zend/tests/bug75921.phpt
 Zend/tests/bug78182.phpt
 Zend/tests/bug81104.phpt
 Zend/tests/each_002.phpt
+Zend/tests/fibers/gh10496-001.phpt
 Zend/tests/gc_031.phpt
 Zend/tests/gc_037.phpt
 Zend/tests/gc_045.phpt
@@ -143,6 +144,7 @@ ext/standard/tests/math/base_convert_variation1.phpt
 ext/standard/tests/math/bindec_variation1_64bit.phpt
 ext/standard/tests/math/hexdec_variation1_64bit.phpt
 ext/standard/tests/math/octdec_variation1.phpt
+ext/standard/tests/network/bug80067.phpt
 ext/standard/tests/serialize/005.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -15,6 +15,7 @@ Zend/tests/bug72038.phpt
 Zend/tests/bug75921.phpt
 Zend/tests/bug78182.phpt
 Zend/tests/bug81104.phpt
+Zend/tests/fibers/gh10496-001.phpt
 Zend/tests/gc_031.phpt
 Zend/tests/gc_037.phpt
 Zend/tests/gc_045.phpt
@@ -139,6 +140,7 @@ ext/standard/tests/math/base_convert_variation1.phpt
 ext/standard/tests/math/bindec_variation1_64bit.phpt
 ext/standard/tests/math/hexdec_variation1_64bit.phpt
 ext/standard/tests/math/octdec_variation1.phpt
+ext/standard/tests/network/bug80067.phpt
 ext/standard/tests/serialize/005.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -152,3 +152,7 @@ SKIP Test if socket_create_listen() returns false, when it cannot bind to the po
 ## `Zend/fibers/out-of-memory-in*`
 
 ddtrace request init hook consumes more than 2 MB of memory and fails too early instead of testing what it should.
+
+## `Zend/tests/fibers/gh10496-001.phpt`
+
+ddtrace affects the order of destructor execution due to creating span stacks etc.

--- a/ext/span.h
+++ b/ext/span.h
@@ -69,7 +69,12 @@ struct ddtrace_span_stack {
     struct ddtrace_span_stack *root_stack;
     union {
         struct ddtrace_span_stack *next; // closed chunk chain
-        zend_function *fiber_entry_function;
+        struct {
+            zend_function *fiber_entry_function;
+#if PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80200
+            zend_execute_data *fiber_initial_execute_data;
+#endif
+        };
     };
     struct ddtrace_span_stack *top_closed_stack;
     // closed ring: linked list where the last element links to the first. The last inserted element is always reachable via closed_ring->next.


### PR DESCRIPTION
### Description

Fixes language tests.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests exposed the bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
