### PR TITLE
Update removed methods used in Guzzle V6 & V7 test suites

### DIFF
--- a/tests/Integrations/Guzzle/V6/guzzle_in_distributed_web_request.php
+++ b/tests/Integrations/Guzzle/V6/guzzle_in_distributed_web_request.php
@@ -5,7 +5,8 @@ require __DIR__ . '/../../../vendor/autoload.php';
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Is;
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 
 $curl = new CurlMultiHandler();
@@ -29,8 +30,8 @@ $promise2 = $client->getAsync('http://httpbin_integration/headers', [
     ],
 ])->then($resolver);
 
-$aggregate = Promise\all([$promise1, $promise2]);
-while (!Promise\is_settled($aggregate)) {
+$aggregate = Utils::all([$promise1, $promise2]);
+while (!Is::settled($aggregate)) {
     $curl->tick();
 }
 

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -65,7 +65,8 @@
             },
             "guzzle7": {
                 "require": {
-                    "guzzlehttp/guzzle": "~7.0"
+                    "guzzlehttp/guzzle": "~7.0",
+                    "guzzlehttp/promises": "~2.0"
                 },
                 "scenario-options": {
                     "create-lockfile": false

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -65,8 +65,7 @@
             },
             "guzzle7": {
                 "require": {
-                    "guzzlehttp/guzzle": "~7.0",
-                    "guzzlehttp/promises": "^1.5.3"
+                    "guzzlehttp/guzzle": "~7.0"
                 },
                 "scenario-options": {
                     "create-lockfile": false


### PR DESCRIPTION
### Description

Change some methods in the guzzle test suites that were removed with the v2 of guzzle promises:
- [all](https://github.com/guzzle/promises/blob/136a635e2b4a49b9d79e9c8fee267ffb257fdba0/src/functions.php#L177): `Promises\all` --> `Utils::all`
- [is_settled](https://github.com/guzzle/promises/blob/136a635e2b4a49b9d79e9c8fee267ffb257fdba0/src/functions.php#L346): `Promises\is_settled`--> `Is:settled`

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
