### PR TITLE
fix(tests) free filename while the op_array still exists

### DIFF
--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -211,12 +211,11 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
         if (execute_data->func->common.function_name) {
             free(execute_data->func->common.function_name);
         }
+        // free filename
+        if (execute_data->func->op_array.filename) {
+            free(execute_data->func->op_array.filename);
+        }
         free(execute_data->func);
-    }
-
-    // free filename
-    if (execute_data->func->op_array.filename) {
-        free(execute_data->func->op_array.filename);
     }
 
     free(execute_data);

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -206,16 +206,20 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
 
     ddog_php_test_free_fake_zend_execute_data(execute_data->prev_execute_data);
 
-    // free function name
     if (execute_data->func) {
+        // free function name
         if (execute_data->func->common.function_name) {
             free(execute_data->func->common.function_name);
+            execute_data->func->common.function_name = NULL;
         }
         // free filename
         if (execute_data->func->op_array.filename) {
             free(execute_data->func->op_array.filename);
+            execute_data->func->op_array.filename = NULL;
         }
+        // free zend_op_array
         free(execute_data->func);
+        execute_data->func = NULL;
     }
 
     free(execute_data);


### PR DESCRIPTION
### Description

This fixes a segfault in the test suite where I was `free()`ing memory in an already `free()`d memory region.
Thanks @morrisonlevi for digging into and providing a stack trace.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
