### PR TITLE
Send telemetry for all configs, including unchanged ones

### DIFF
--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -105,9 +105,19 @@ typedef struct ddog_Vec_Tag_ParseResult {
   struct ddog_Error *error_message;
 } ddog_Vec_Tag_ParseResult;
 
+typedef enum ddog_ConfigurationOrigin {
+  DDOG_CONFIGURATION_ORIGIN_ENV_VAR,
+  DDOG_CONFIGURATION_ORIGIN_CODE,
+  DDOG_CONFIGURATION_ORIGIN_DD_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_REMOTE_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_DEFAULT,
+} ddog_ConfigurationOrigin;
+
 typedef struct ddog_BlockingTransport_TelemetryInterfaceResponse__TelemetryInterfaceRequest ddog_BlockingTransport_TelemetryInterfaceResponse__TelemetryInterfaceRequest;
 
 typedef struct ddog_InstanceId ddog_InstanceId;
+
+typedef struct ddog_TelemetryActionsBuffer ddog_TelemetryActionsBuffer;
 
 typedef struct ddog_BlockingTransport_TelemetryInterfaceResponse__TelemetryInterfaceRequest ddog_TelemetryTransport;
 
@@ -126,14 +136,6 @@ typedef struct ddog_Option_VecU8 {
 } ddog_Option_VecU8;
 
 typedef struct ddog_Option_VecU8 ddog_MaybeError;
-
-typedef enum ddog_ConfigurationOrigin {
-  DDOG_CONFIGURATION_ORIGIN_ENV_VAR,
-  DDOG_CONFIGURATION_ORIGIN_CODE,
-  DDOG_CONFIGURATION_ORIGIN_DD_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_REMOTE_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_DEFAULT,
-} ddog_ConfigurationOrigin;
 
 typedef enum ddog_LogLevel {
   DDOG_LOG_LEVEL_ERROR,

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -134,4 +134,21 @@ bool ddtrace_detect_composer_installed_json(ddog_TelemetryTransport **transport,
 
 ddog_MaybeError ddog_sidecar_connect_php(ddog_TelemetryTransport **connection);
 
+struct ddog_TelemetryActionsBuffer *ddog_sidecar_telemetry_buffer_alloc(void);
+
+void ddog_sidecar_telemetry_addIntegration_buffer(struct ddog_TelemetryActionsBuffer *buffer,
+                                                  ddog_CharSlice integration_name,
+                                                  ddog_CharSlice integration_version,
+                                                  bool integration_enabled);
+
+void ddog_sidecar_telemetry_enqueueConfig_buffer(struct ddog_TelemetryActionsBuffer *buffer,
+                                                 ddog_CharSlice config_key,
+                                                 ddog_CharSlice config_value,
+                                                 enum ddog_ConfigurationOrigin origin);
+
+ddog_MaybeError ddog_sidecar_telemetry_buffer_flush(ddog_TelemetryTransport **transport,
+                                                    const struct ddog_InstanceId *instance_id,
+                                                    const ddog_QueueId *queue_id,
+                                                    struct ddog_TelemetryActionsBuffer *buffer);
+
 #endif /* DDTRACE_PHP_H */

--- a/tests/ext/telemetry/config.phpt
+++ b/tests/ext/telemetry/config.phpt
@@ -31,7 +31,12 @@ foreach (file(__DIR__ . '/config-telemetry.out') as $l) {
             print_r(array_values(array_filter($cfg, function($c) {
                 return $c["origin"] == "EnvVar";
             })));
-            var_dump(count($cfg) > 100); // all the configs, no point in asserting them all here
+            var_dump(count(array_filter($cfg, function($c) {
+                return $c["origin"] == "Default";
+            })) > 100); // all the configs, no point in asserting them all here
+            var_dump(count(array_filter($cfg, function($c) {
+                return $c["origin"] != "Default" && $c["origin"] != "EnvVar";
+            }))); // all other configs
         }
     }
 }
@@ -64,6 +69,7 @@ Array
 
 )
 bool(true)
+int(0)
 --CLEAN--
 <?php
 

--- a/tests/ext/telemetry/config.phpt
+++ b/tests/ext/telemetry/config.phpt
@@ -27,7 +27,11 @@ foreach (file(__DIR__ . '/config-telemetry.out') as $l) {
     if ($l) {
         $json = json_decode($l, true);
         if ($json["request_type"] == "app-started") {
-            print_r($json["payload"]["configuration"]);
+            $cfg = $json["payload"]["configuration"];
+            print_r(array_values(array_filter($cfg, function($c) {
+                return $c["origin"] == "EnvVar";
+            })));
+            var_dump(count($cfg) > 100); // all the configs, no point in asserting them all here
         }
     }
 }
@@ -59,6 +63,7 @@ Array
         )
 
 )
+bool(true)
 --CLEAN--
 <?php
 


### PR DESCRIPTION
### Description

Telemetry v2 also expects default configs to be sent.
Buffering sending config data to avoid I/O overhead.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
