### PR TITLE
feat(profiling) disable allocation profiling when JIT is active

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -624,7 +624,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
     {
         if profiling_allocation_enabled {
             let jit = JIT_ENABLED.get_or_init(|| unsafe { zend::ddog_php_jit_enabled() });
-            if *jit == true {
+            if *jit {
                 error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/2088");
                 REQUEST_LOCALS.with(|cell| {
                     let mut locals = cell.borrow_mut();
@@ -857,12 +857,10 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             b"Allocation Profiling Enabled\0".as_ptr(),
             if locals.profiling_allocation_enabled {
                 yes
+            } else if zend::ddog_php_jit_enabled() {
+                na
             } else {
-                if zend::ddog_php_jit_enabled() {
-                    na
-                } else {
-                    no
-                }
+                no
             },
         );
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -830,6 +830,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
         let locals = cell.borrow();
         let yes: &[u8] = b"true\0";
         let no: &[u8] = b"false\0";
+        let na: &[u8] = b"Not available\0";
         zend::php_info_print_table_start();
         zend::php_info_print_table_row(2, b"Version\0".as_ptr(), module.version);
         zend::php_info_print_table_row(
@@ -850,11 +851,15 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
 
         zend::php_info_print_table_row(
             2,
-            b"Experimental Allocation Profiling Enabled\0".as_ptr(),
+            b"Allocation Profiling Enabled\0".as_ptr(),
             if locals.profiling_allocation_enabled {
                 yes
             } else {
-                no
+                if zend::ddog_php_jit_enabled() {
+                    na
+                } else {
+                    no
+                }
             },
         );
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -249,7 +249,6 @@ void ddog_php_opcache_init_handle() {
             break;
         }
     }
-    return;
 }
 
 // This checks if the JIT actually has a buffer, if so, JIT is active, otherwise

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -253,7 +253,13 @@ void ddog_php_opcache_init_handle() {
 
 // This checks if the JIT actually has a buffer, if so, JIT is active, otherwise
 // JIT is inactive. This will only work after OPcache was initialized (after it
-// assigned its PHP.INI settings), so make sure to call this in RINIT.
+// assigned its PHP.INI settings), so make sure to call this in RINIT.a
+//
+// Attention: this will check for the `opcache.jit_buffer_size` setting as this
+// one is a PHP_INI_SYSTEM (can not be changed on a per directory basis). This
+// means that the `opcache.jit` setting could be `off` and this function would
+// still consider JIT to be enabled, as it could be enabled at anytime (runtime
+// and per directory settings).
 bool ddog_php_jit_enabled() {
     bool jit = false;
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -244,8 +244,7 @@ void ddog_php_opcache_init_handle() {
     zend_extension *maybe_opcache = NULL;
     for (const zend_llist_element *item = list->head; item; item = item->next) {
         maybe_opcache = (zend_extension *)item->data;
-        if (maybe_opcache->name && strcmp(maybe_opcache->name, "Zend OPcache") == 0)
-        {
+        if (maybe_opcache->name && strcmp(maybe_opcache->name, "Zend OPcache") == 0) {
             opcache_handle = maybe_opcache->handle;
             break;
         }

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -234,7 +234,7 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
 }
 #endif
 
-uint8_t *opcache_handle = NULL;
+void *opcache_handle = NULL;
 
 // OPcache NULLs its handle, so this function will only get the handle during
 // MINIT phase. You as the caller has to make sure to only call this function

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -127,3 +127,5 @@ zend_execute_data* ddog_php_prof_get_current_execute_data();
  */
 zend_execute_data* ddog_php_test_create_fake_zend_execute_data(int depth);
 void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data);
+
+bool ddog_php_jit_enabled();

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -128,4 +128,5 @@ zend_execute_data* ddog_php_prof_get_current_execute_data();
 zend_execute_data* ddog_php_test_create_fake_zend_execute_data(int depth);
 void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data);
 
+void ddog_php_opcache_init_handle();
 bool ddog_php_jit_enabled();

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -7,9 +7,12 @@ we make sure to disable allocation profiling when we detect the JIT is enabled.
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID < 80000)
-    echo "skip: no JIT before PHP 8.0", PHP_EOL;
+    echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
     echo "skip: test requires datadog-profiling", PHP_EOL;
+$arch = php_uname('m');
+if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
+    echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
 ?>
 --INI--
 datadog.profiling.enabled=yes

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Allocation profiling should be disabled when JIT is active
+--DESCRIPTION--
+We did find a crash in PHP when collecting a stack sample in allocation
+profiling when JIT is activated in a `ZEND_GENERATOR_RETURN`. For the time being
+we make sure to disable allocation profiling when we detect the JIT is enabled.
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000)
+    echo "skip: no JIT before PHP 8.0", PHP_EOL;
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+?>
+--INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+datadog.profiling.allocation_enabled=yes
+datadog.profiling.experimental_cpu_time_enabled=no
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
+--FILE--
+<?php
+echo "Done.", PHP_EOL;
+?>
+--EXPECTREGEX--
+.*Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling, please disable JIT.
+.*Done.
+.*

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -25,6 +25,6 @@ opcache.jit_buffer_size=4M
 echo "Done.", PHP_EOL;
 ?>
 --EXPECTREGEX--
-.*Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling, please disable JIT.
+.*Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https:\/\/github.com\/DataDog\/dd-trace-php\/pull\/2088
 .*Done.
 .*

--- a/profiling/tests/phpt/phpinfo_01.phpt
+++ b/profiling/tests/phpt/phpinfo_01.phpt
@@ -47,7 +47,7 @@ assert(isset($values["Version"]));
 $sections = [
     ["Profiling Enabled", "false"],
     ["Experimental CPU Time Profiling Enabled", "true"],
-    ["Experimental Allocation Profiling Enabled", "true"],
+    ["Allocation Profiling Enabled", "true"],
     ["Endpoint Collection Enabled", "true"],
     ["Profiling Log Level", "info"],
     ["Profiling Agent Endpoint", "http://datadog:8126/"],

--- a/profiling/tests/phpt/phpinfo_01.phpt
+++ b/profiling/tests/phpt/phpinfo_01.phpt
@@ -21,6 +21,7 @@ DD_TRACE_AGENT_PORT=80
 DD_TRACE_AGENT_URL=http://datadog:8126
 --INI--
 assert.exception=1
+opcache.jit=off
 --FILE--
 <?php
 

--- a/profiling/tests/phpt/phpinfo_02.phpt
+++ b/profiling/tests/phpt/phpinfo_02.phpt
@@ -1,12 +1,17 @@
 --TEST--
-[profiling] test profiler's extension info
+[profiling] test profiler's extension info with active JIT
 --DESCRIPTION--
 The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID < 80000)
+    echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
-    echo "skip: test requires Datadog Continuous Profiler\n";
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+$arch = php_uname('m');
+if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
+    echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
 ?>
 --ENV--
 DD_PROFILING_ENABLED=yes
@@ -37,9 +42,6 @@ foreach ($lines as $line) {
     $values[trim($pair[0])] = trim($pair[1]);
 }
 
-// Check that Version exists, but not its value
-assert(isset($values["Version"]));
-
 // Check exact values for this set
 $sections = [
     ["Allocation Profiling Enabled", "Not available"],
@@ -55,6 +57,5 @@ foreach ($sections as [$key, $expected]) {
 echo "Done.";
 
 ?>
---EXPECTREGEX--
-.*
+--EXPECT--
 Done.

--- a/profiling/tests/phpt/phpinfo_02.phpt
+++ b/profiling/tests/phpt/phpinfo_02.phpt
@@ -1,0 +1,60 @@
+--TEST--
+[profiling] test profiler's extension info
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=off
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_ALLOCATION_ENABLED=yes
+--INI--
+assert.exception=1
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Allocation Profiling Enabled", "Not available"],
+];
+
+foreach ($sections as [$key, $expected]) {
+    assert(
+        $values[$key] === $expected,
+        "Expected '{$expected}', found '{$values[$key]}', for key '{$key}'"
+    );
+}
+
+echo "Done.";
+
+?>
+--EXPECTREGEX--
+.*
+Done.

--- a/profiling/tests/phpt/phpinfo_ini_01.phpt
+++ b/profiling/tests/phpt/phpinfo_ini_01.phpt
@@ -46,7 +46,7 @@ assert(isset($values["Version"]));
 $sections = [
     ["Profiling Enabled", "false"],
     ["Experimental CPU Time Profiling Enabled", "true"],
-    ["Experimental Allocation Profiling Enabled", "true"],
+    ["Allocation Profiling Enabled", "true"],
     ["Endpoint Collection Enabled", "true"],
     ["Profiling Log Level", "info"],
     ["Profiling Agent Endpoint", "http://datadog:8126/"],

--- a/profiling/tests/phpt/phpinfo_ini_01.phpt
+++ b/profiling/tests/phpt/phpinfo_ini_01.phpt
@@ -10,6 +10,7 @@ if (!extension_loaded('datadog-profiling'))
 ?>
 --INI--
 assert.exception=1
+opcache.jit=off
 datadog.profiling.enabled=no
 datadog.profiling.log_level=info
 datadog.profiling.experimental_cpu_time_enabled=yes


### PR DESCRIPTION
### Description

We did find a crash under the following conditions:
- PHP JIT is enabled
- Allocation profiling is enabled
- a `ZEND_GENERATOR_RETURN` is being executed
- and we collect a stack frame at exactly this time

For the time being we decide to disable allocation profiling as long as JIT is enabled. This should only affect a small subset of users, as JIT is still (PHP 8.2) default disabled. Which means: if you have not manually enabled JIT, it won't be enabled at all.

In the future we will work around this problem and allow you to enable allocation profiling even when JIT is active.

This PR will also state this in the `phpinfo()` output and mark "Allocation Profiling Enabled" as "not available" in case an active JIT is detected:
```sh
php -d extension=datadog-profiling --ri datadog-profiling | grep "Allocation Profiling"
Allocation Profiling Enabled => Not available
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
