### PR TITLE
Skip error assignment on the root span for 5xx errors that shouldn't be reported

### DIFF
--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -122,7 +122,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Http\Response',
             'send',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                $ignoreError = $rootSpan->meta['error.ignored'] ?? false;
+                $ignoreError = isset($rootSpan->meta['error.ignored']) && $rootSpan->meta['error.ignored'];
                 if (isset($This->exception) && $This->getStatusCode() >= 500 && !$ignoreError) {
                     $integration->setError($rootSpan, $This->exception);
                 }

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -122,7 +122,8 @@ class LaravelIntegration extends Integration
             'Illuminate\Http\Response',
             'send',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (isset($This->exception) && $This->getStatusCode() >= 500) {
+                $ignoreError = $rootSpan->meta['error.ignored'] ?? false;
+                if (isset($This->exception) && $This->getStatusCode() >= 500 && !$ignoreError) {
                     $integration->setError($rootSpan, $This->exception);
                 }
             }
@@ -241,6 +242,9 @@ class LaravelIntegration extends Integration
             function ($exceptionHandler, $scope, $args) use ($rootSpan, $integration) {
                 if ($args[0] && $exceptionHandler->shouldReport($args[0])) {
                     $integration->setError($rootSpan, $args[0]);
+                    $rootSpan->meta['error.ignored'] = 0;
+                } elseif ($args[0] && !$exceptionHandler->shouldReport($args[0])) {
+                    $rootSpan->meta['error.ignored'] = 1;
                 }
             }
         );

--- a/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
+++ b/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
@@ -55,11 +55,6 @@ class InternalExceptionsTest extends WebFrameworkTestCase
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
                     ])
-                    ->setError(
-                        'Symfony\Component\HttpKernel\Exception\HttpException',
-                        'Not Implemented',
-                        true
-                    )
                     ->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'not-implemented')
                             ->withExactTags([


### PR DESCRIPTION
### Description

With #2062, it has been noted that not all 5xx errors should be reported in Laravel (e.g., the following [list](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Exceptions/Handler.php#L97-L108)). However, currently the [serializer](https://github.com/DataDog/dd-trace-php/blob/49b694a307272e4236258f90bd1952bfd3fc0bc1/ext/serializer.c#L830-L838) marks all root spans with 5xx status code as internal server errors.

For this reason, this PR adds a **_temporary_** tag `error.ignored` allowing to skip the assignments of these errors on the **root span**. This tag is added by the integration in the root span's metadata, but it isn't added to the serialized metadata.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
