### PR TITLE
refactor(profiling): move allocation profiling to its own module

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -1,0 +1,387 @@
+use crate::bindings as zend;
+use crate::config;
+use crate::PROFILER;
+use crate::PROFILER_NAME;
+use crate::REQUEST_LOCALS;
+use libc::c_char;
+use libc::c_int;
+use log::{debug, error, info};
+use once_cell::sync::OnceCell;
+use std::cell::RefCell;
+use std::ffi::CStr;
+
+use rand_distr::{Distribution, Poisson};
+
+use crate::bindings::{
+    datadog_php_install_handler, datadog_php_zif_handler, ddog_php_prof_copy_long_into_zval,
+};
+
+static JIT_ENABLED: OnceCell<bool> = OnceCell::new();
+
+static mut GC_MEM_CACHES_HANDLER: zend::InternalFunctionHandler = None;
+
+/// The engine's previous custom allocation function, if there is one.
+static mut PREV_CUSTOM_MM_ALLOC: Option<zend::VmMmCustomAllocFn> = None;
+
+/// The engine's previous custom reallocation function, if there is one.
+static mut PREV_CUSTOM_MM_REALLOC: Option<zend::VmMmCustomReallocFn> = None;
+
+/// The engine's previous custom free function, if there is one.
+static mut PREV_CUSTOM_MM_FREE: Option<zend::VmMmCustomFreeFn> = None;
+
+pub fn allocation_profiling_minit() {
+    unsafe { zend::ddog_php_opcache_init_handle() };
+}
+
+/// take a sample every 2048 KB
+pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 2048.0;
+
+pub struct AllocationProfilingStats {
+    /// number of bytes until next sample collection
+    next_sample: i64,
+}
+
+impl AllocationProfilingStats {
+    fn new() -> AllocationProfilingStats {
+        AllocationProfilingStats {
+            next_sample: AllocationProfilingStats::next_sampling_interval(),
+        }
+    }
+
+    fn next_sampling_interval() -> i64 {
+        Poisson::new(ALLOCATION_PROFILING_INTERVAL)
+            .unwrap()
+            .sample(&mut rand::thread_rng()) as i64
+    }
+
+    fn track_allocation(&mut self, len: u64) {
+        self.next_sample -= len as i64;
+
+        if self.next_sample > 0 {
+            return;
+        }
+
+        self.next_sample = AllocationProfilingStats::next_sampling_interval();
+
+        REQUEST_LOCALS.with(|cell| {
+            // Panic: there might already be a mutable reference to `REQUEST_LOCALS`
+            let locals = cell.try_borrow();
+            if locals.is_err() {
+                return;
+            }
+            let locals = locals.unwrap();
+
+            if let Some(profiler) = PROFILER.lock().unwrap().as_ref() {
+                // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
+                unsafe {
+                    profiler.collect_allocations(
+                        zend::ddog_php_prof_get_current_execute_data(),
+                        1 as i64,
+                        len as i64,
+                        &locals,
+                    )
+                };
+            }
+        });
+    }
+}
+
+thread_local! {
+    static ALLOCATION_PROFILING_STATS: RefCell<AllocationProfilingStats> = RefCell::new(AllocationProfilingStats::new());
+}
+
+/* If Failure is returned the VM will do a C exit; try hard to avoid that,
+ * using it for catastrophic errors only.
+ */
+pub fn allocation_profiling_rinit() {
+    let profiling_allocation_enabled = unsafe { config::profiling_allocation_enabled() };
+
+    {
+        if profiling_allocation_enabled {
+            let jit = JIT_ENABLED.get_or_init(|| unsafe { zend::ddog_php_jit_enabled() });
+            if *jit {
+                error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/2088");
+                REQUEST_LOCALS.with(|cell| {
+                    let mut locals = cell.borrow_mut();
+                    locals.profiling_allocation_enabled = false;
+                });
+            } else {
+                if !is_zend_mm() {
+                    // Neighboring custom memory handlers found
+                    debug!("Found another extension using the ZendMM custom handler hook");
+                    unsafe {
+                        zend::zend_mm_get_custom_handlers(
+                            zend::zend_mm_get_heap(),
+                            &mut PREV_CUSTOM_MM_ALLOC,
+                            &mut PREV_CUSTOM_MM_FREE,
+                            &mut PREV_CUSTOM_MM_REALLOC,
+                        );
+                        ALLOCATION_PROFILING_ALLOC = allocation_profiling_prev_alloc;
+                        ALLOCATION_PROFILING_FREE = allocation_profiling_prev_free;
+                        ALLOCATION_PROFILING_REALLOC = allocation_profiling_prev_realloc;
+                    }
+                } else {
+                    unsafe {
+                        ALLOCATION_PROFILING_ALLOC = allocation_profiling_orig_alloc;
+                        ALLOCATION_PROFILING_FREE = allocation_profiling_orig_free;
+                        ALLOCATION_PROFILING_REALLOC = allocation_profiling_orig_realloc;
+                    }
+                }
+
+                unsafe {
+                    zend::ddog_php_prof_zend_mm_set_custom_handlers(
+                        zend::zend_mm_get_heap(),
+                        Some(alloc_profiling_malloc),
+                        Some(alloc_profiling_free),
+                        Some(alloc_profiling_realloc),
+                    );
+                }
+
+                if is_zend_mm() {
+                    error!("Memory allocation profiling could not be enabled. Please feel free to fill an issue stating the PHP version and installed modules. Most likely the reason is your PHP binary was compiled with `ZEND_MM_CUSTOM` being disabled.");
+                    REQUEST_LOCALS.with(|cell| {
+                        let mut locals = cell.borrow_mut();
+                        locals.profiling_allocation_enabled = false;
+                    });
+                } else {
+                    info!("Memory allocation profiling enabled.")
+                }
+            }
+        }
+    }
+}
+
+pub fn allocation_profiling_rshutdown() {
+    REQUEST_LOCALS.with(|cell| {
+        let mut locals = cell.borrow_mut();
+
+        {
+            if locals.profiling_allocation_enabled {
+                // If `is_zend_mm()` is true, the custom handlers have been reset to `None`
+                // already. This is unexpected, therefore we will not touch the ZendMM handlers
+                // anymore as resetting to prev handlers might result in segfaults and other
+                // undefined behaviour.
+                if !is_zend_mm() {
+                    let mut custom_mm_malloc: Option<zend::VmMmCustomAllocFn> = None;
+                    let mut custom_mm_free: Option<zend::VmMmCustomFreeFn> = None;
+                    let mut custom_mm_realloc: Option<zend::VmMmCustomReallocFn> = None;
+                    unsafe {
+                        zend::zend_mm_get_custom_handlers(
+                            zend::zend_mm_get_heap(),
+                            &mut custom_mm_malloc,
+                            &mut custom_mm_free,
+                            &mut custom_mm_realloc,
+                        );
+                    }
+                    if custom_mm_free != Some(alloc_profiling_free)
+                        || custom_mm_malloc != Some(alloc_profiling_malloc)
+                        || custom_mm_realloc != Some(alloc_profiling_realloc)
+                    {
+                        // Custom handlers are installed, but it's not us. Someone, somewhere might have
+                        // function pointers to our custom handlers. Best bet to avoid segfaults is to not
+                        // touch custom handlers in ZendMM and make sure our extension will not be
+                        // `dlclose()`-ed so the pointers stay valid
+                        let zend_extension = unsafe {
+                            zend::zend_get_extension(PROFILER_NAME.as_ptr() as *const c_char)
+                        };
+                        if !zend_extension.is_null() {
+                            // Safety: Checked for null pointer above.
+                            unsafe {
+                                (*zend_extension).handle = std::ptr::null_mut();
+                            }
+                        }
+                        // disable any further allocation profiling
+                        locals.profiling_allocation_enabled = false;
+                        info!("Memory allocation profiling disabled.");
+                    } else {
+                        // This is the happy path (restore previously installed custom handlers)!
+                        unsafe {
+                            zend::ddog_php_prof_zend_mm_set_custom_handlers(
+                                zend::zend_mm_get_heap(),
+                                PREV_CUSTOM_MM_ALLOC,
+                                PREV_CUSTOM_MM_FREE,
+                                PREV_CUSTOM_MM_REALLOC,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+pub fn allocation_profiling_startup() {
+    unsafe {
+        let handle = datadog_php_zif_handler::new(
+            CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0"),
+            &mut GC_MEM_CACHES_HANDLER,
+            Some(alloc_profiling_gc_mem_caches),
+        );
+        datadog_php_install_handler(handle);
+    }
+}
+
+/// Overrides the ZendMM heap's `use_custom_heap` flag with the default `ZEND_MM_CUSTOM_HEAP_NONE`
+/// (currently a `u32: 0`). This needs to be done, as the `zend_mm_gc()` and `zend_mm_shutdown()`
+/// functions alter behaviour in case custom handlers are installed.
+/// - `zend_mm_gc()` will not do anything anymore.
+/// - `zend_mm_shutdown()` wont cleanup chunks anymore, leading to memory leaks
+/// The `_zend_mm_heap`-struct itself is private, but we are lucky, as the `use_custom_heap` flag
+/// is the first element and thus the first 4 bytes.
+/// Take care and call `restore_zend_heap()` afterwards!
+unsafe fn prepare_zend_heap(heap: *mut zend::_zend_mm_heap) -> c_int {
+    let custom_heap: c_int = std::ptr::read(heap as *const c_int);
+    std::ptr::write(heap as *mut c_int, zend::ZEND_MM_CUSTOM_HEAP_NONE as c_int);
+    custom_heap
+}
+
+/// Restore the ZendMM heap's `use_custom_heap` flag, see `prepare_zend_heap` for details
+unsafe fn restore_zend_heap(heap: *mut zend::_zend_mm_heap, custom_heap: c_int) {
+    std::ptr::write(heap as *mut c_int, custom_heap);
+}
+
+/// The PHP userland function `gc_mem_caches()` directly calls the `zend_mm_gc()` function which
+/// does nothing in case custom handlers are installed on the heap used. So we prepare the heap for
+/// this operation, call the original function and restore the heap again
+unsafe extern "C" fn alloc_profiling_gc_mem_caches(
+    execute_data: *mut zend::zend_execute_data,
+    return_value: *mut zend::zval,
+) {
+    let allocation_profiling: bool = REQUEST_LOCALS.with(|cell| {
+        // Panic: there might already be a mutable reference to `REQUEST_LOCALS`
+        let locals = cell.try_borrow();
+        if locals.is_err() {
+            // we can't check and don't know so assume it is not activated
+            return false;
+        }
+        let locals = locals.unwrap();
+        locals.profiling_allocation_enabled
+    });
+
+    if let Some(func) = GC_MEM_CACHES_HANDLER {
+        if allocation_profiling {
+            let heap = zend::zend_mm_get_heap();
+            let custom_heap = prepare_zend_heap(heap);
+            func(execute_data, return_value);
+            restore_zend_heap(heap, custom_heap);
+        } else {
+            func(execute_data, return_value);
+        }
+    } else {
+        ddog_php_prof_copy_long_into_zval(return_value, 0);
+    }
+}
+
+unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
+    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_ALLOC(len);
+
+    // during startup, minit, rinit, ... current_execute_data is null
+    // we are only interested in allocations during userland operations
+    if zend::ddog_php_prof_get_current_execute_data().is_null() {
+        return ptr;
+    }
+
+    ALLOCATION_PROFILING_STATS.with(|cell| {
+        let mut allocations = cell.borrow_mut();
+        allocations.track_allocation(len)
+    });
+
+    ptr
+}
+
+static mut ALLOCATION_PROFILING_ALLOC: unsafe fn(u64) -> *mut ::libc::c_void =
+    allocation_profiling_orig_alloc;
+
+unsafe fn allocation_profiling_prev_alloc(len: u64) -> *mut ::libc::c_void {
+    let prev = PREV_CUSTOM_MM_ALLOC.unwrap();
+    prev(len)
+}
+
+unsafe fn allocation_profiling_orig_alloc(len: u64) -> *mut ::libc::c_void {
+    let ptr: *mut libc::c_void;
+    let heap = zend::zend_mm_get_heap();
+    let custom_heap = prepare_zend_heap(heap);
+    ptr = zend::_zend_mm_alloc(heap, len);
+    restore_zend_heap(heap, custom_heap);
+    ptr
+}
+
+// The reason this function exists is because when calling `zend_mm_set_custom_handlers()` you need
+// to pass a pointer to a `free()` function as well, otherwise your custom handlers won't be
+// installed. We can not just point to the original `zend::_zend_mm_free()` as the function
+// definitions differ.
+unsafe extern "C" fn alloc_profiling_free(ptr: *mut ::libc::c_void) {
+    ALLOCATION_PROFILING_FREE(ptr);
+}
+
+static mut ALLOCATION_PROFILING_FREE: unsafe fn(*mut ::libc::c_void) =
+    allocation_profiling_orig_free;
+
+unsafe fn allocation_profiling_prev_free(ptr: *mut ::libc::c_void) {
+    let prev = PREV_CUSTOM_MM_FREE.unwrap();
+    prev(ptr);
+}
+
+unsafe fn allocation_profiling_orig_free(ptr: *mut ::libc::c_void) {
+    let heap = zend::zend_mm_get_heap();
+    zend::_zend_mm_free(heap, ptr);
+}
+
+unsafe extern "C" fn alloc_profiling_realloc(
+    prev_ptr: *mut ::libc::c_void,
+    len: u64,
+) -> *mut ::libc::c_void {
+    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_REALLOC(prev_ptr, len);
+
+    // during startup, minit, rinit, ... current_execute_data is null
+    // we are only interested in allocations during userland operations
+    if zend::ddog_php_prof_get_current_execute_data().is_null() || ptr == prev_ptr {
+        return ptr;
+    }
+
+    ALLOCATION_PROFILING_STATS.with(|cell| {
+        let mut allocations = cell.borrow_mut();
+        allocations.track_allocation(len)
+    });
+
+    ptr
+}
+
+static mut ALLOCATION_PROFILING_REALLOC: unsafe fn(
+    *mut ::libc::c_void,
+    u64,
+) -> *mut ::libc::c_void = allocation_profiling_orig_realloc;
+
+unsafe fn allocation_profiling_prev_realloc(
+    prev_ptr: *mut ::libc::c_void,
+    len: u64,
+) -> *mut ::libc::c_void {
+    let prev = PREV_CUSTOM_MM_REALLOC.unwrap();
+    prev(prev_ptr, len)
+}
+
+unsafe fn allocation_profiling_orig_realloc(
+    prev_ptr: *mut ::libc::c_void,
+    len: u64,
+) -> *mut ::libc::c_void {
+    let ptr: *mut libc::c_void;
+    let heap = zend::zend_mm_get_heap();
+    let custom_heap = prepare_zend_heap(heap);
+    ptr = zend::_zend_mm_realloc(heap, prev_ptr, len);
+    restore_zend_heap(heap, custom_heap);
+    ptr
+}
+
+/// safe wrapper for `zend::is_zend_mm()`.
+/// `true` means the internal ZendMM is being used, `false` means that a custom memory manager is
+/// installed. Upstream returns a `c_bool` as of PHP 8.0. PHP 7 returns a `c_int`
+fn is_zend_mm() -> bool {
+    #[cfg(php7)]
+    {
+        unsafe { zend::is_zend_mm() == 1 }
+    }
+    #[cfg(php8)]
+    {
+        unsafe { zend::is_zend_mm() }
+    }
+}

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -645,6 +645,12 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
                         ALLOCATION_PROFILING_FREE = allocation_profiling_prev_free;
                         ALLOCATION_PROFILING_REALLOC = allocation_profiling_prev_realloc;
                     }
+                } else {
+                    unsafe {
+                        ALLOCATION_PROFILING_ALLOC = allocation_profiling_orig_alloc;
+                        ALLOCATION_PROFILING_FREE = allocation_profiling_orig_free;
+                        ALLOCATION_PROFILING_REALLOC = allocation_profiling_orig_realloc;
+                    }
                 }
 
                 unsafe {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -6,6 +6,9 @@ mod pcntl;
 mod profiling;
 mod sapi;
 
+#[cfg(feature = "allocation_profiling")]
+mod allocation;
+
 use bindings as zend;
 use bindings::{sapi_globals, ZendExtension, ZendResult};
 use config::AgentEndpoint;
@@ -30,19 +33,9 @@ use std::sync::{Arc, Mutex, Once};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
-#[cfg(feature = "allocation_profiling")]
-use rand_distr::{Distribution, Poisson};
-
-#[cfg(feature = "allocation_profiling")]
-use crate::bindings::{
-    datadog_php_install_handler, datadog_php_zif_handler, ddog_php_prof_copy_long_into_zval,
-};
-
 /// The version of PHP at runtime, not the version compiled against. Sent as
 /// a profile tag.
 static PHP_VERSION: OnceCell<String> = OnceCell::new();
-
-static JIT_ENABLED: OnceCell<bool> = OnceCell::new();
 
 /// The global profiler. Profiler gets made during the first rinit after an
 /// minit, and is destroyed on mshutdown.
@@ -141,21 +134,6 @@ static mut PREV_INTERRUPT_FUNCTION: MaybeUninit<Option<zend::VmInterruptFn>> =
 static mut PREV_EXECUTE_INTERNAL: MaybeUninit<
     unsafe extern "C" fn(execute_data: *mut zend::zend_execute_data, return_value: *mut zend::zval),
 > = MaybeUninit::uninit();
-
-#[cfg(feature = "allocation_profiling")]
-static mut GC_MEM_CACHES_HANDLER: zend::InternalFunctionHandler = None;
-
-/// The engine's previous custom allocation function, if there is one.
-#[cfg(feature = "allocation_profiling")]
-static mut PREV_CUSTOM_MM_ALLOC: Option<zend::VmMmCustomAllocFn> = None;
-
-/// The engine's previous custom reallocation function, if there is one.
-#[cfg(feature = "allocation_profiling")]
-static mut PREV_CUSTOM_MM_REALLOC: Option<zend::VmMmCustomReallocFn> = None;
-
-/// The engine's previous custom free function, if there is one.
-#[cfg(feature = "allocation_profiling")]
-static mut PREV_CUSTOM_MM_FREE: Option<zend::VmMmCustomFreeFn> = None;
 
 /* Important note on the PHP lifecycle:
  * Based on how some SAPIs work and the documentation, one might expect that
@@ -291,10 +269,8 @@ extern "C" fn minit(r#type: c_int, module_number: c_int) -> ZendResult {
      */
     unsafe { zend::zend_register_extension(&extension, handle) };
 
-    /* We need to fetch the handle for the OPcache extension during MINIT, as OPcache will NULL
-     * it's handle later
-     */
-    unsafe { zend::ddog_php_opcache_init_handle() };
+    #[cfg(feature = "allocation_profiling")]
+    allocation::allocation_profiling_minit();
 
     ZendResult::Success
 }
@@ -328,62 +304,6 @@ pub struct RequestLocals {
     pub vm_interrupt_addr: *const AtomicBool,
 }
 
-/// take a sample every 2048 KB
-#[cfg(feature = "allocation_profiling")]
-pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 2048.0;
-
-#[cfg(feature = "allocation_profiling")]
-pub struct AllocationProfilingStats {
-    /// number of bytes until next sample collection
-    next_sample: i64,
-}
-
-#[cfg(feature = "allocation_profiling")]
-impl AllocationProfilingStats {
-    fn new() -> AllocationProfilingStats {
-        AllocationProfilingStats {
-            next_sample: AllocationProfilingStats::next_sampling_interval(),
-        }
-    }
-
-    fn next_sampling_interval() -> i64 {
-        Poisson::new(ALLOCATION_PROFILING_INTERVAL)
-            .unwrap()
-            .sample(&mut rand::thread_rng()) as i64
-    }
-
-    fn track_allocation(&mut self, len: u64) {
-        self.next_sample -= len as i64;
-
-        if self.next_sample > 0 {
-            return;
-        }
-
-        self.next_sample = AllocationProfilingStats::next_sampling_interval();
-
-        REQUEST_LOCALS.with(|cell| {
-            // Panic: there might already be a mutable reference to `REQUEST_LOCALS`
-            let locals = cell.try_borrow();
-            if locals.is_err() {
-                return;
-            }
-            let locals = locals.unwrap();
-
-            if let Some(profiler) = PROFILER.lock().unwrap().as_ref() {
-                // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
-                unsafe {
-                    profiler.collect_allocations(
-                        zend::ddog_php_prof_get_current_execute_data(),
-                        1 as i64,
-                        len as i64,
-                        &locals,
-                    )
-                };
-            }
-        });
-    }
-}
-
 fn static_tags() -> Vec<Tag> {
     vec![
         Tag::from_value("language:php").expect("static tags to be valid"),
@@ -412,9 +332,6 @@ thread_local! {
         version: None,
         vm_interrupt_addr: std::ptr::null_mut(),
     });
-
-    #[cfg(feature = "allocation_profiling")]
-    static ALLOCATION_PROFILING_STATS: RefCell<AllocationProfilingStats> = RefCell::new(AllocationProfilingStats::new());
 }
 
 /// Gets the runtime-id for the process.
@@ -621,59 +538,7 @@ extern "C" fn rinit(r#type: c_int, module_number: c_int) -> ZendResult {
     }
 
     #[cfg(feature = "allocation_profiling")]
-    {
-        if profiling_allocation_enabled {
-            let jit = JIT_ENABLED.get_or_init(|| unsafe { zend::ddog_php_jit_enabled() });
-            if *jit {
-                error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/2088");
-                REQUEST_LOCALS.with(|cell| {
-                    let mut locals = cell.borrow_mut();
-                    locals.profiling_allocation_enabled = false;
-                });
-            } else {
-                if !is_zend_mm() {
-                    // Neighboring custom memory handlers found
-                    debug!("Found another extension using the ZendMM custom handler hook");
-                    unsafe {
-                        zend::zend_mm_get_custom_handlers(
-                            zend::zend_mm_get_heap(),
-                            &mut PREV_CUSTOM_MM_ALLOC,
-                            &mut PREV_CUSTOM_MM_FREE,
-                            &mut PREV_CUSTOM_MM_REALLOC,
-                        );
-                        ALLOCATION_PROFILING_ALLOC = allocation_profiling_prev_alloc;
-                        ALLOCATION_PROFILING_FREE = allocation_profiling_prev_free;
-                        ALLOCATION_PROFILING_REALLOC = allocation_profiling_prev_realloc;
-                    }
-                } else {
-                    unsafe {
-                        ALLOCATION_PROFILING_ALLOC = allocation_profiling_orig_alloc;
-                        ALLOCATION_PROFILING_FREE = allocation_profiling_orig_free;
-                        ALLOCATION_PROFILING_REALLOC = allocation_profiling_orig_realloc;
-                    }
-                }
-
-                unsafe {
-                    zend::ddog_php_prof_zend_mm_set_custom_handlers(
-                        zend::zend_mm_get_heap(),
-                        Some(alloc_profiling_malloc),
-                        Some(alloc_profiling_free),
-                        Some(alloc_profiling_realloc),
-                    );
-                }
-
-                if is_zend_mm() {
-                    error!("Memory allocation profiling could not be enabled. Please feel free to fill an issue stating the PHP version and installed modules. Most likely the reason is your PHP binary was compiled with `ZEND_MM_CUSTOM` being disabled.");
-                    REQUEST_LOCALS.with(|cell| {
-                        let mut locals = cell.borrow_mut();
-                        locals.profiling_allocation_enabled = false;
-                    });
-                } else {
-                    info!("Memory allocation profiling enabled.")
-                }
-            }
-        }
-    }
+    allocation::allocation_profiling_rinit();
 
     ZendResult::Success
 }
@@ -770,61 +635,10 @@ extern "C" fn rshutdown(r#type: c_int, module_number: c_int) -> ZendResult {
             }
             locals.tags = Arc::new(static_tags());
         }
-
-        #[cfg(feature = "allocation_profiling")]
-        {
-            if locals.profiling_allocation_enabled {
-                // If `is_zend_mm()` is true, the custom handlers have been reset to `None`
-                // already. This is unexpected, therefore we will not touch the ZendMM handlers
-                // anymore as resetting to prev handlers might result in segfaults and other
-                // undefined behaviour.
-                if !is_zend_mm() {
-                    let mut custom_mm_malloc: Option<zend::VmMmCustomAllocFn> = None;
-                    let mut custom_mm_free: Option<zend::VmMmCustomFreeFn> = None;
-                    let mut custom_mm_realloc: Option<zend::VmMmCustomReallocFn> = None;
-                    unsafe {
-                        zend::zend_mm_get_custom_handlers(
-                            zend::zend_mm_get_heap(),
-                            &mut custom_mm_malloc,
-                            &mut custom_mm_free,
-                            &mut custom_mm_realloc,
-                        );
-                    }
-                    if custom_mm_free != Some(alloc_profiling_free)
-                        || custom_mm_malloc != Some(alloc_profiling_malloc)
-                        || custom_mm_realloc != Some(alloc_profiling_realloc)
-                    {
-                        // Custom handlers are installed, but it's not us. Someone, somewhere might have
-                        // function pointers to our custom handlers. Best bet to avoid segfaults is to not
-                        // touch custom handlers in ZendMM and make sure our extension will not be
-                        // `dlclose()`-ed so the pointers stay valid
-                        let zend_extension = unsafe {
-                            zend::zend_get_extension(PROFILER_NAME.as_ptr() as *const c_char)
-                        };
-                        if !zend_extension.is_null() {
-                            // Safety: Checked for null pointer above.
-                            unsafe {
-                                (*zend_extension).handle = std::ptr::null_mut();
-                            }
-                        }
-                        // disable any further allocation profiling
-                        locals.profiling_allocation_enabled = false;
-                        info!("Memory allocation profiling disabled.");
-                    } else {
-                        // This is the happy path (restore previously installed custom handlers)!
-                        unsafe {
-                            zend::ddog_php_prof_zend_mm_set_custom_handlers(
-                                zend::zend_mm_get_heap(),
-                                PREV_CUSTOM_MM_ALLOC,
-                                PREV_CUSTOM_MM_FREE,
-                                PREV_CUSTOM_MM_REALLOC,
-                            );
-                        }
-                    }
-                }
-            }
-        }
     });
+
+    #[cfg(feature = "allocation_profiling")]
+    allocation::allocation_profiling_rshutdown();
 
     ZendResult::Success
 }
@@ -984,14 +798,7 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
     unsafe { pcntl::startup() };
 
     #[cfg(feature = "allocation_profiling")]
-    unsafe {
-        let handle = datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0"),
-            &mut GC_MEM_CACHES_HANDLER,
-            Some(alloc_profiling_gc_mem_caches),
-        );
-        datadog_php_install_handler(handle);
-    }
+    allocation::allocation_profiling_startup();
 
     ZendResult::Success
 }
@@ -1097,178 +904,6 @@ extern "C" fn execute_internal(
         prev_execute_internal(execute_data, return_value);
     }
     interrupt_function(execute_data);
-}
-
-/// Overrides the ZendMM heap's `use_custom_heap` flag with the default `ZEND_MM_CUSTOM_HEAP_NONE`
-/// (currently a `u32: 0`). This needs to be done, as the `zend_mm_gc()` and `zend_mm_shutdown()`
-/// functions alter behaviour in case custom handlers are installed.
-/// - `zend_mm_gc()` will not do anything anymore.
-/// - `zend_mm_shutdown()` wont cleanup chunks anymore, leading to memory leaks
-/// The `_zend_mm_heap`-struct itself is private, but we are lucky, as the `use_custom_heap` flag
-/// is the first element and thus the first 4 bytes.
-/// Take care and call `restore_zend_heap()` afterwards!
-#[cfg(feature = "allocation_profiling")]
-unsafe fn prepare_zend_heap(heap: *mut zend::_zend_mm_heap) -> c_int {
-    let custom_heap: c_int = std::ptr::read(heap as *const c_int);
-    std::ptr::write(heap as *mut c_int, zend::ZEND_MM_CUSTOM_HEAP_NONE as c_int);
-    custom_heap
-}
-
-/// Restore the ZendMM heap's `use_custom_heap` flag, see `prepare_zend_heap` for details
-#[cfg(feature = "allocation_profiling")]
-unsafe fn restore_zend_heap(heap: *mut zend::_zend_mm_heap, custom_heap: c_int) {
-    std::ptr::write(heap as *mut c_int, custom_heap);
-}
-
-#[cfg(feature = "allocation_profiling")]
-/// The PHP userland function `gc_mem_caches()` directly calls the `zend_mm_gc()` function which
-/// does nothing in case custom handlers are installed on the heap used. So we prepare the heap for
-/// this operation, call the original function and restore the heap again
-unsafe extern "C" fn alloc_profiling_gc_mem_caches(
-    execute_data: *mut zend::zend_execute_data,
-    return_value: *mut zend::zval,
-) {
-    let allocation_profiling: bool = REQUEST_LOCALS.with(|cell| {
-        // Panic: there might already be a mutable reference to `REQUEST_LOCALS`
-        let locals = cell.try_borrow();
-        if locals.is_err() {
-            // we can't check and don't know so assume it is not activated
-            return false;
-        }
-        let locals = locals.unwrap();
-        locals.profiling_allocation_enabled
-    });
-
-    if let Some(func) = GC_MEM_CACHES_HANDLER {
-        if allocation_profiling {
-            let heap = zend::zend_mm_get_heap();
-            let custom_heap = prepare_zend_heap(heap);
-            func(execute_data, return_value);
-            restore_zend_heap(heap, custom_heap);
-        } else {
-            func(execute_data, return_value);
-        }
-    } else {
-        ddog_php_prof_copy_long_into_zval(return_value, 0);
-    }
-}
-
-#[cfg(feature = "allocation_profiling")]
-unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_ALLOC(len);
-
-    // during startup, minit, rinit, ... current_execute_data is null
-    // we are only interested in allocations during userland operations
-    if zend::ddog_php_prof_get_current_execute_data().is_null() {
-        return ptr;
-    }
-
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
-
-    ptr
-}
-
-static mut ALLOCATION_PROFILING_ALLOC: unsafe fn(u64) -> *mut ::libc::c_void =
-    allocation_profiling_orig_alloc;
-
-unsafe fn allocation_profiling_prev_alloc(len: u64) -> *mut ::libc::c_void {
-    let prev = PREV_CUSTOM_MM_ALLOC.unwrap();
-    prev(len)
-}
-
-unsafe fn allocation_profiling_orig_alloc(len: u64) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void;
-    let heap = zend::zend_mm_get_heap();
-    let custom_heap = prepare_zend_heap(heap);
-    ptr = zend::_zend_mm_alloc(heap, len);
-    restore_zend_heap(heap, custom_heap);
-    ptr
-}
-
-// The reason this function exists is because when calling `zend_mm_set_custom_handlers()` you need
-// to pass a pointer to a `free()` function as well, otherwise your custom handlers won't be
-// installed. We can not just point to the original `zend::_zend_mm_free()` as the function
-// definitions differ.
-#[cfg(feature = "allocation_profiling")]
-unsafe extern "C" fn alloc_profiling_free(ptr: *mut ::libc::c_void) {
-    ALLOCATION_PROFILING_FREE(ptr);
-}
-
-static mut ALLOCATION_PROFILING_FREE: unsafe fn(*mut ::libc::c_void) =
-    allocation_profiling_orig_free;
-
-unsafe fn allocation_profiling_prev_free(ptr: *mut ::libc::c_void) {
-    let prev = PREV_CUSTOM_MM_FREE.unwrap();
-    prev(ptr);
-}
-
-unsafe fn allocation_profiling_orig_free(ptr: *mut ::libc::c_void) {
-    let heap = zend::zend_mm_get_heap();
-    zend::_zend_mm_free(heap, ptr);
-}
-
-#[cfg(feature = "allocation_profiling")]
-unsafe extern "C" fn alloc_profiling_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_REALLOC(prev_ptr, len);
-
-    // during startup, minit, rinit, ... current_execute_data is null
-    // we are only interested in allocations during userland operations
-    if zend::ddog_php_prof_get_current_execute_data().is_null() || ptr == prev_ptr {
-        return ptr;
-    }
-
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
-
-    ptr
-}
-
-static mut ALLOCATION_PROFILING_REALLOC: unsafe fn(
-    *mut ::libc::c_void,
-    u64,
-) -> *mut ::libc::c_void = allocation_profiling_orig_realloc;
-
-unsafe fn allocation_profiling_prev_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
-    let prev = PREV_CUSTOM_MM_REALLOC.unwrap();
-    prev(prev_ptr, len)
-}
-
-unsafe fn allocation_profiling_orig_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void;
-    let heap = zend::zend_mm_get_heap();
-    let custom_heap = prepare_zend_heap(heap);
-    ptr = zend::_zend_mm_realloc(heap, prev_ptr, len);
-    restore_zend_heap(heap, custom_heap);
-    ptr
-}
-
-/// safe wrapper for `zend::is_zend_mm()`.
-/// `true` means the internal ZendMM is being used, `false` means that a custom memory manager is
-/// installed. Upstream returns a `c_bool` as of PHP 8.0. PHP 7 returns a `c_int`
-#[cfg(feature = "allocation_profiling")]
-fn is_zend_mm() -> bool {
-    #[cfg(php7)]
-    {
-        unsafe { zend::is_zend_mm() == 1 }
-    }
-    #[cfg(php8)]
-    {
-        unsafe { zend::is_zend_mm() }
-    }
 }
 
 #[cfg(test)]

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -25,7 +25,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime};
 
 #[cfg(feature = "allocation_profiling")]
-use crate::ALLOCATION_PROFILING_INTERVAL;
+use crate::allocation::ALLOCATION_PROFILING_INTERVAL;
 #[cfg(feature = "allocation_profiling")]
 use datadog_profiling::profile::api::UpscalingInfo;
 


### PR DESCRIPTION
### Description

This PR extracts the allocation profiling specific parts into their own mod. Main motivations are:
- `lib.rs` is > 1270 lines, ¼ of this is allocation profiling
- there is `#[cfg(feature = "allocation_profiling")]` spread everywhere (and missing in some places, where it should be)
- IIRC the `lib.rs` intention was to bind to the Zend Engine, so I guess it is a good idea to move allocation profiling specific parts away from this file

**Attention**: besides moving code around this PR will also do a change in how we call the orginal / previous allocation function. Prior to this PR in every `malloc()`/`realloc()`/`free()` call we did check if we found custom handlers during `RINIT`, then called those, and otherwise called the original handlers.
Now we initialise a function pointer depending on the state of the ZendMM during `RINIT`. This will move the decision wether to call a previous handler or the original one to the `RINIT` phase and out of the hot path.
In theory another extension could hook into the ZendMM and install/uninstall custom handlers during the request phase at will without us noticing. This "problem" did already exist in the prior version (we only check for custom handlers in `RINIT`) and we decided to not handle chaotic evil neighbours.

To review just this one behaviour change [see these commits](https://github.com/DataDog/dd-trace-php/pull/2090/files/85a5957cd1ceaa2169b75bc75dd8145d87a7e8dd), please note that this change was done prior to extracting allocation profiling bits (all those changes are in `src/lib.rs`).

![feels-good](https://github.com/DataDog/dd-trace-php/assets/14161194/69020063-0dff-49df-9b1e-d99071706423)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
