### PR TITLE
Disable root span generation and removes orphans for Laravel Horizon

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -95,6 +95,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
     CONFIG(BOOL, DD_TRACE_FLUSH_COLLECT_CYCLES, "false")                                                       \
     CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
+    CONFIG(BOOL, DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS, "false")                                         \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                    \

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -94,6 +94,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
     CONFIG(BOOL, DD_TRACE_FLUSH_COLLECT_CYCLES, "false")                                                       \
+    CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING, "")                                                    \

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -94,7 +94,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
     CONFIG(BOOL, DD_TRACE_FLUSH_COLLECT_CYCLES, "false")                                                       \
-    CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "false")                                              \
+    CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS, "false")                                         \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -94,7 +94,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(STRING, DD_TRACE_MEMORY_LIMIT, "")                                                                  \
     CONFIG(BOOL, DD_TRACE_REPORT_HOSTNAME, "false")                                                            \
     CONFIG(BOOL, DD_TRACE_FLUSH_COLLECT_CYCLES, "false")                                                       \
-    CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
+    CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "false")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS, "false")                                         \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -41,7 +41,7 @@ class LaravelIntegration extends Integration
 
     public function isArtisanQueueCommand()
     {
-        $artisanCommand = $_SERVER['argv'][1] ?? '';
+        $artisanCommand = $_SERVER['argv'][1] ?: '';
 
         return !empty($artisanCommand)
             && (strpos($artisanCommand, 'horizon:work') !== false

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -152,6 +152,7 @@ class LaravelIntegration extends Integration
                     if (
                         dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                         && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                        && \DDTrace\trace_id() == $span->id
                     ) {
                         \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                     }
@@ -176,6 +177,7 @@ class LaravelIntegration extends Integration
                     if (
                         dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                         && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                        && \DDTrace\trace_id() == $span->id
                     ) {
                         \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                     }
@@ -223,6 +225,7 @@ class LaravelIntegration extends Integration
                 if (
                     dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                     && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                    && \DDTrace\trace_id() == $span->id
                 ) {
                     \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                 }

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -41,7 +41,7 @@ class LaravelIntegration extends Integration
 
     public function isArtisanQueueCommand()
     {
-        $artisanCommand = $_SERVER['argv'][1] ?: '';
+        $artisanCommand = isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : '';
 
         return !empty($artisanCommand)
             && (strpos($artisanCommand, 'horizon:work') !== false

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -7,7 +7,6 @@ use DDTrace\SpanData;
 use DDTrace\Integrations\Integration;
 use DDTrace\Tag;
 use DDTrace\Type;
-use stdClass;
 
 /**
  * The base Laravel integration which delegates loading to the appropriate integration version.

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -38,7 +38,7 @@ class LaravelIntegration extends Integration
         return false;
     }
 
-    public function isArtisanQueueCommand(): bool
+    public function isArtisanQueueCommand()
     {
         $artisanCommand = $_SERVER['argv'][1];
 

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -43,8 +43,8 @@ class LaravelIntegration extends Integration
         $artisanCommand = $_SERVER['argv'][1];
 
         return !empty($artisanCommand)
-            && (str_contains($artisanCommand, 'horizon:work')
-                || str_contains($artisanCommand, 'queue:work'));
+            && (strpos($artisanCommand, 'horizon:work') !== false
+                || strpos($artisanCommand, 'queue:work') !== false);
     }
 
     /**

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -7,6 +7,7 @@ use DDTrace\SpanData;
 use DDTrace\Integrations\Integration;
 use DDTrace\Tag;
 use DDTrace\Type;
+use stdClass;
 
 /**
  * The base Laravel integration which delegates loading to the appropriate integration version.
@@ -40,7 +41,7 @@ class LaravelIntegration extends Integration
 
     public function isArtisanQueueCommand()
     {
-        $artisanCommand = $_SERVER['argv'][1];
+        $artisanCommand = $_SERVER['argv'][1] ?? '';
 
         return !empty($artisanCommand)
             && (strpos($artisanCommand, 'horizon:work') !== false

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -64,7 +64,7 @@ class LaravelIntegration extends Integration
 
         $integration = $this;
 
-        if ($this->isArtisanQueueCommand()) {
+        if (\ddtrace_config_app_name("DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE") && $this->isArtisanQueueCommand()) {
             ini_set("datadog.trace.auto_flush", 1);
             ini_set("datadog.trace.generate_root_span", 0);
         }
@@ -149,8 +149,10 @@ class LaravelIntegration extends Integration
             'fire',
             [
                 'prehook' => function (SpanData $span, $args) use ($integration) {
-                    if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
-                        && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+                    if (
+                        dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                        && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                    ) {
                         \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                     }
 
@@ -171,8 +173,10 @@ class LaravelIntegration extends Integration
             'dispatch',
             [
                 'prehook' => function (SpanData $span, $args) use ($integration) {
-                    if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
-                    && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+                    if (
+                        dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                        && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                    ) {
                         \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                     }
 
@@ -216,8 +220,10 @@ class LaravelIntegration extends Integration
             'Illuminate\Foundation\ProviderRepository',
             'load',
             function (SpanData $span) use ($rootSpan, $integration) {
-                if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
-                    && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+                if (
+                    dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                    && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                ) {
                     \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                 }
 

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -64,7 +64,7 @@ class LaravelIntegration extends Integration
 
         $integration = $this;
 
-        if (\ddtrace_config_app_name("DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE") && $this->isArtisanQueueCommand()) {
+        if (dd_trace_env_config("DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE") && $this->isArtisanQueueCommand()) {
             ini_set("datadog.trace.auto_flush", 1);
             ini_set("datadog.trace.generate_root_span", 0);
         }

--- a/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
+++ b/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Jobs\JobName;
 use function DDTrace\active_span;
 use function DDTrace\close_span;
 use function DDTrace\remove_hook;
+use function DDTrace\set_distributed_tracing_context;
 use function DDTrace\start_trace_span;
 use function DDTrace\trace_method;
 use function DDTrace\install_hook;
@@ -77,6 +78,13 @@ class LaravelQueueIntegration extends Integration
                             $exception
                         );
                         close_span();
+
+                        if (
+                            dd_trace_env_config("DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE")
+                            && dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                        ) {
+                            set_distributed_tracing_context("0", "0");
+                        }
                     }
 
                     $integration->setSpanAttributes($span, 'laravel.queue.process', 'receive', $job, $exception);

--- a/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
+++ b/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
@@ -62,6 +62,7 @@ class LaravelQueueIntegration extends Integration
 
                         $integration->extractContext($payload);
                         $span->links[] = $newTrace->getLink();
+                        $newTrace->links[] = $span->getLink();
                     }
                 },
                 'posthook' => function (SpanData $span, $args, $retval, $exception) use ($integration, &$newTrace) {

--- a/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
+++ b/src/Integrations/Integrations/LaravelQueue/LaravelQueueIntegration.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Jobs\JobName;
 
 use function DDTrace\active_span;
 use function DDTrace\close_span;
+use function DDTrace\remove_hook;
 use function DDTrace\start_trace_span;
 use function DDTrace\trace_method;
 use function DDTrace\install_hook;
@@ -105,29 +106,35 @@ class LaravelQueueIntegration extends Integration
                         $method = 'handle';
                     }
 
-                    trace_method($class, $method, function (SpanData $span) use ($integration, $class, $method) {
-                        $span->name = 'laravel.queue.action';
-                        $span->type = 'queue';
-                        $span->service = $integration->getName();
-                        $span->resource = $class . '@' . $method;
-                        $span->meta[Tag::COMPONENT] = LaravelQueueIntegration::NAME;
+                    install_hook(
+                        "$class::$method",
+                        function (HookData $hook) use ($integration, $class, $method) {
+                            $span = $hook->span();
+                            $span->name = 'laravel.queue.action';
+                            $span->type = 'queue';
+                            $span->service = $integration->getName();
+                            $span->resource = $class . '@' . $method;
+                            $span->meta[Tag::COMPONENT] = LaravelQueueIntegration::NAME;
 
-                        if (isset($this->batchId)) { // Uses the Batchable trait; Laravel 8
-                            $span->meta[Tag::LARAVELQ_BATCH_ID] = $this->batchId ?? null;
-                        }
+                            if (isset($this->batchId)) { // Uses the Batchable trait; Laravel 8
+                                $span->meta[Tag::LARAVELQ_BATCH_ID] = $this->batchId ?? null;
+                            }
 
-                        if (isset($this->job)) {
-                            $integration->setSpanAttributes(
-                                $span,
-                                'laravel.queue.action',
-                                null,
-                                $this->job,
-                                null,
-                                null,
-                                $class . '@' . $method
-                            );
+                            if (isset($this->job)) {
+                                $integration->setSpanAttributes(
+                                    $span,
+                                    'laravel.queue.action',
+                                    null,
+                                    $this->job,
+                                    null,
+                                    null,
+                                    $class . '@' . $method
+                                );
+                            }
+
+                            remove_hook($hook->id);
                         }
-                    });
+                    );
                 }
             );
         }

--- a/src/Integrations/Integrations/Predis/PredisIntegration.php
+++ b/src/Integrations/Integrations/Predis/PredisIntegration.php
@@ -39,6 +39,11 @@ class PredisIntegration extends Integration
         $integration = $this;
 
         \DDTrace\trace_method('Predis\Client', '__construct', function (SpanData $span, $args) {
+            if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+                \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
+            }
+
             $span->name = 'Predis.Client.__construct';
             $span->type = Type::REDIS;
             $span->resource = 'Predis.Client.__construct';
@@ -54,6 +59,11 @@ class PredisIntegration extends Integration
         });
 
         \DDTrace\trace_method('Predis\Client', 'executeCommand', function (SpanData $span, $args) use ($integration) {
+            if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+                \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
+            }
+
             $span->name = 'Predis.Client.executeCommand';
             $span->type = Type::REDIS;
             PredisIntegration::setMetaAndServiceFromConnection($this, $span);

--- a/src/Integrations/Integrations/Predis/PredisIntegration.php
+++ b/src/Integrations/Integrations/Predis/PredisIntegration.php
@@ -114,6 +114,13 @@ class PredisIntegration extends Integration
         // tasks are dequeued.
         if (Versions::phpVersionMatches('5')) {
             \DDTrace\trace_method('Predis\Pipeline\Pipeline', 'executePipeline', function (SpanData $span, $args) {
+                if (
+                    dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                    && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                ) {
+                    \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
+                }
+
                 $span->name = 'Predis.Pipeline.executePipeline';
                 $span->resource = $span->name;
                 $span->type = Type::REDIS;
@@ -125,6 +132,13 @@ class PredisIntegration extends Integration
                 'executePipeline',
                 [
                     'prehook' => function (SpanData $span, $args) {
+                        if (
+                            dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                            && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                        ) {
+                            \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
+                        }
+
                         $span->name = 'Predis.Pipeline.executePipeline';
                         $span->resource = $span->name;
                         $span->type = Type::REDIS;

--- a/src/Integrations/Integrations/Predis/PredisIntegration.php
+++ b/src/Integrations/Integrations/Predis/PredisIntegration.php
@@ -42,6 +42,7 @@ class PredisIntegration extends Integration
             if (
                 dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                 && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                && \DDTrace\trace_id() == $span->id
             ) {
                 \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
             }
@@ -64,6 +65,7 @@ class PredisIntegration extends Integration
             if (
                 dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                 && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                && \DDTrace\trace_id() == $span->id
             ) {
                 \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
             }
@@ -117,6 +119,7 @@ class PredisIntegration extends Integration
                 if (
                     dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                     && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                    && \DDTrace\trace_id() == $span->id
                 ) {
                     \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                 }
@@ -135,6 +138,7 @@ class PredisIntegration extends Integration
                         if (
                             dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
                             && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+                            && \DDTrace\trace_id() == $span->id
                         ) {
                             \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
                         }

--- a/src/Integrations/Integrations/Predis/PredisIntegration.php
+++ b/src/Integrations/Integrations/Predis/PredisIntegration.php
@@ -39,8 +39,10 @@ class PredisIntegration extends Integration
         $integration = $this;
 
         \DDTrace\trace_method('Predis\Client', '__construct', function (SpanData $span, $args) {
-            if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
-                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+            if (
+                dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+            ) {
                 \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
             }
 
@@ -59,8 +61,10 @@ class PredisIntegration extends Integration
         });
 
         \DDTrace\trace_method('Predis\Client', 'executeCommand', function (SpanData $span, $args) use ($integration) {
-            if (dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
-                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+            if (
+                dd_trace_env_config("DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS")
+                && \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
+            ) {
                 \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
             }
 

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -384,12 +384,12 @@ class QueueTest extends WebFrameworkTestCase
         )->withExactTags([
             Tag::HTTP_URL => 'http://localhost:9999/queue/workOn',
             Tag::HTTP_METHOD => 'GET',
-            Tag::HTTP_STATUS_CODE => 200,
-            '_dd.span_links'
+            Tag::HTTP_STATUS_CODE => 200
         ])->withExactTags(
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
-            Tag::MQ_MESSAGE_ID
+            Tag::MQ_MESSAGE_ID,
+            '_dd.span_links'
         ])->withChildren([
             $this->spanEventJobProcessing(),
             $this->spanQueueFire($connection, $queue, $resourceDetails)

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -110,7 +110,6 @@ class QueueTest extends WebFrameworkTestCase
                     SpanAssertion::exists('laravel.action')
                         ->withChildren([
                             $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                                ->withExistingTagsNames(['_dd.span_links'])
                         ])
                 ])
         ], false);
@@ -213,7 +212,6 @@ class QueueTest extends WebFrameworkTestCase
                             ->withChildren([
                                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
                                     ->setError('Exception', 'Triggered Exception', true)
-                                    ->withExistingTagsNames(['_dd.span_links'])
                             ])
                     ])
             ],
@@ -367,7 +365,8 @@ class QueueTest extends WebFrameworkTestCase
             return $span;
         } else {
             return $span->withExistingTagsNames([
-                Tag::MQ_MESSAGE_ID
+                Tag::MQ_MESSAGE_ID,
+                '_dd.span_links'
             ]);
         }
     }

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -384,7 +384,8 @@ class QueueTest extends WebFrameworkTestCase
         )->withExactTags([
             Tag::HTTP_URL => 'http://localhost:9999/queue/workOn',
             Tag::HTTP_METHOD => 'GET',
-            Tag::HTTP_STATUS_CODE => 200
+            Tag::HTTP_STATUS_CODE => 200,
+            '_dd.span_links'
         ])->withExactTags(
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -27,7 +27,8 @@ class QueueTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_AUTO_FLUSH_ENABLED' => '1',
             'DD_TRACE_CLI_ENABLED' => '1',
-            'APP_NAME' => 'laravel_queue_test'
+            'APP_NAME' => 'laravel_queue_test',
+            'DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE' => '0'
         ]);
     }
 

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -502,7 +502,8 @@ class QueueTest extends WebFrameworkTestCase
         ])->withExactTags(
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
-            Tag::MQ_MESSAGE_ID
+            Tag::MQ_MESSAGE_ID,
+            '_dd.span_links'
         ])->withChildren([
             $this->spanEventJobProcessing(),
             $this->spanQueueFire($connection, $queue, $resourceDetails)

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -130,7 +130,6 @@ class QueueTest extends WebFrameworkTestCase
                     SpanAssertion::exists('laravel.action')
                         ->withChildren([
                             $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                                ->withExistingTagsNames(['_dd.span_links'])
                         ])
                 ])
         ], false);
@@ -236,7 +235,6 @@ class QueueTest extends WebFrameworkTestCase
                             ->withChildren([
                                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
                                     ->setError('Exception', 'Triggered Exception', true)
-                                    ->withExistingTagsNames(['_dd.span_links'])
                             ])
                     ])
             ],
@@ -280,12 +278,9 @@ class QueueTest extends WebFrameworkTestCase
         $this->assertFlameGraph($artisanTrace, [
             SpanAssertion::exists('laravel.artisan')->withChildren([
                 SpanAssertion::exists('laravel.action')->withChildren([
+                    $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
+                    $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
                     $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                        ->withExistingTagsNames(['_dd.span_links']),
-                    $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                        ->withExistingTagsNames(['_dd.span_links']),
-                    $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                        ->withExistingTagsNames(['_dd.span_links']),
                 ])
             ])
         ], false);
@@ -483,7 +478,8 @@ class QueueTest extends WebFrameworkTestCase
             return $span;
         } else {
             return $span->withExistingTagsNames([
-                Tag::MQ_MESSAGE_ID
+                Tag::MQ_MESSAGE_ID,
+                '_dd.span_links'
             ]);
         }
     }

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -27,8 +27,7 @@ class QueueTest extends WebFrameworkTestCase
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_AUTO_FLUSH_ENABLED' => '1',
             'DD_TRACE_CLI_ENABLED' => '1',
-            'APP_NAME' => 'laravel_queue_test',
-            'DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE' => '0'
+            'APP_NAME' => 'laravel_queue_test'
         ]);
     }
 


### PR DESCRIPTION
### Description

Fix #2080.

Two configuration options are added:
- `DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE`: Defaults to `true`. If enabled and a Laravel Queue/Horizon command was used (more specifically, `queue:work` and `horizon:work`), then the environment variables `DD_TRACE_GENERATE_ROOT_SPAN` and `DD_TRACE_AUTO_FLUSH` will be set to `0` and `1`, respectively, during the Laravel integration's initialization phase.
- `DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS`: Defaults to `false`. If enabled, the following 'solo-trace-span' will be ignored by the backend
  - `laravel.event.handle`
  - `laravel.provider.load`
  - `Predis.Client.__construct`
  - `Predis.Client.executeCommand`
  - `Predis.Pipeline.executePipeline`

**Additionally**, it will also remove the hook that was installed on the job method call after it is instrumented. Otherwise, the hook limit was hit after running some tests for long enough.

**What's more**, bidirectional span links will be used on the `laravel.queue.process` spans.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
