### PR TITLE
Use span links in the RabbitMQ Integration

### DIFF
--- a/src/Integrations/Integrations/AMQP/AMQPIntegration.php
+++ b/src/Integrations/Integrations/AMQP/AMQPIntegration.php
@@ -3,7 +3,6 @@
 namespace DDTrace\Integrations\AMQP;
 
 use DDTrace\Integrations\Integration;
-use DDTrace\Log\Logger;
 use DDTrace\Propagator;
 use DDTrace\SpanData;
 use DDTrace\SpanLink;
@@ -32,7 +31,7 @@ class AMQPIntegration extends Integration
         return self::NAME;
     }
 
-    protected static function largeBaseConvert($numString, $fromBase, $toBase)
+    public static function largeBaseConvert($numString, $fromBase, $toBase)
     {
         $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
         $toString = substr($chars, 0, $toBase);
@@ -86,14 +85,12 @@ class AMQPIntegration extends Integration
                     /** @var AMQPMessage $message */
                     $message = $args[1];
                     if ($integration->hasDistributedHeaders($message)) {
-                        Logger::get()->debug("AMQP message has distributed headers");
                         $newTrace = start_trace_span();
                         $integration->extractContext($message);
                         $span->links[] = $newTrace->getLink();
                     }
                 },
                 'posthook' => function (SpanData $span, $args) use ($integration, &$newTrace) {
-                    Logger::get()->debug("AMQP basic_deliver posthook");
                     /** @var AMQPMessage $message */
                     $message = $args[1];
 

--- a/src/Integrations/Integrations/AMQP/AMQPIntegration.php
+++ b/src/Integrations/Integrations/AMQP/AMQPIntegration.php
@@ -30,6 +30,7 @@ class AMQPIntegration extends Integration
         return self::NAME;
     }
 
+    // Source: https://magp.ie/2015/09/30/convert-large-integer-to-hexadecimal-without-php-math-extension/
     public static function largeBaseConvert($numString, $fromBase, $toBase)
     {
         $chars = "0123456789abcdefghijklmnopqrstuvwxyz";

--- a/src/Integrations/Integrations/AMQP/AMQPIntegration.php
+++ b/src/Integrations/Integrations/AMQP/AMQPIntegration.php
@@ -384,12 +384,22 @@ class AMQPIntegration extends Integration
                         $headers = $message->get('application_headers')->getNativeData();
                         $traceId = $headers[Propagator::DEFAULT_TRACE_ID_HEADER] ?? null;
                         $parentId = $headers[Propagator::DEFAULT_PARENT_ID_HEADER] ?? null;
-                        if ($traceId && $parentId) {
-                            $traceId = AMQPIntegration::largeBaseConvert($traceId, 10, 16);
-                            $traceId = str_pad(strtolower($traceId), 32, '0', STR_PAD_LEFT);
 
-                            $parentId = AMQPIntegration::largeBaseConvert($parentId, 10, 16);
-                            $parentId = str_pad(strtolower($parentId), 16, '0', STR_PAD_LEFT);
+                        if ($traceId && $parentId) {
+                            // Only convert to hex if it's not already in hex
+                            if (preg_match('/^[a-fA-F0-9]{32}$/', $traceId)) {
+                                $traceId = strtolower($traceId);
+                            } else {
+                                $traceId = AMQPIntegration::largeBaseConvert($traceId, 10, 16);
+                                $traceId = str_pad(strtolower($traceId), 32, '0', STR_PAD_LEFT);
+                            }
+
+                            if (preg_match('/^[a-fA-F0-9]{16}$/', $parentId)) {
+                                $parentId = strtolower($parentId);
+                            } else {
+                                $parentId = AMQPIntegration::largeBaseConvert($parentId, 10, 16);
+                                $parentId = str_pad(strtolower($parentId), 16, '0', STR_PAD_LEFT);
+                            }
 
                             $spanLinkInstance = new SpanLink();
                             $spanLinkInstance->traceId = $traceId;

--- a/src/Integrations/Integrations/AMQP/AMQPIntegration.php
+++ b/src/Integrations/Integrations/AMQP/AMQPIntegration.php
@@ -87,6 +87,7 @@ class AMQPIntegration extends Integration
                         $newTrace = start_trace_span();
                         $integration->extractContext($message);
                         $span->links[] = $newTrace->getLink();
+                        $newTrace->links[] = $span->getLink();
                     }
                 },
                 'posthook' => function (SpanData $span, $args) use ($integration, &$newTrace) {

--- a/src/Integrations/Integrations/AMQP/AMQPIntegration.php
+++ b/src/Integrations/Integrations/AMQP/AMQPIntegration.php
@@ -14,7 +14,6 @@ use function DDTrace\active_span;
 use function DDTrace\close_span;
 use function DDTrace\hook_method;
 use function DDTrace\start_trace_span;
-use function DDTrace\trace_id;
 use function DDTrace\trace_method;
 
 class AMQPIntegration extends Integration

--- a/tests/Integrations/AMQP/AMQPTest.php
+++ b/tests/Integrations/AMQP/AMQPTest.php
@@ -170,7 +170,8 @@ final class AMQPTest extends IntegrationTestCase
                     Tag::MQ_OPERATION               => 'receive',
                     Tag::RABBITMQ_EXCHANGE          => '<default>',
                 ])->withExistingTagsNames([
-                    Tag::MQ_CONSUMER_ID
+                    Tag::MQ_CONSUMER_ID,
+                    '_dd.span_links'
                 ])
             ]),
             SpanAssertion::build(
@@ -425,7 +426,8 @@ final class AMQPTest extends IntegrationTestCase
                     Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 29,
                     Tag::MQ_OPERATION               => 'receive',
                 ])->withExistingTagsNames([
-                    Tag::MQ_CONSUMER_ID
+                    Tag::MQ_CONSUMER_ID,
+                    '_dd.span_links'
                 ])
             ]),
             SpanAssertion::build(

--- a/tests/Integrations/AMQP/AMQPTest.php
+++ b/tests/Integrations/AMQP/AMQPTest.php
@@ -152,6 +152,26 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 12,
                 Tag::MQ_OPERATION               => 'send',
                 Tag::RABBITMQ_EXCHANGE          => '<default>',
+            ])->withChildren([
+                SpanAssertion::build(
+                    'amqp.basic.deliver',
+                    'amqp',
+                    'queue',
+                    'basic.deliver <default> -> hello'
+                )->withExactTags([
+                    Tag::SPAN_KIND                  => 'consumer',
+                    Tag::COMPONENT                  => 'amqp',
+                    Tag::MQ_SYSTEM                  => 'rabbitmq',
+                    Tag::RABBITMQ_ROUTING_KEY       => 'hello',
+                    Tag::MQ_DESTINATION_KIND        => 'queue',
+                    Tag::MQ_PROTOCOL                => 'AMQP',
+                    Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+                    Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 12,
+                    Tag::MQ_OPERATION               => 'receive',
+                    Tag::RABBITMQ_EXCHANGE          => '<default>',
+                ])->withExistingTagsNames([
+                    Tag::MQ_CONSUMER_ID
+                ])
             ]),
             SpanAssertion::build(
                 'amqp.basic.deliver',
@@ -170,7 +190,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_OPERATION               => 'receive',
                 Tag::RABBITMQ_EXCHANGE          => '<default>',
             ])->withExistingTagsNames([
-                Tag::MQ_CONSUMER_ID
+                Tag::MQ_CONSUMER_ID,
+                '_dd.span_links'
             ])
         ]);
 
@@ -386,6 +407,26 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::RABBITMQ_ROUTING_KEY       => 'error',
                 Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 29,
                 Tag::MQ_OPERATION               => 'send',
+            ])->withChildren([
+                SpanAssertion::build(
+                    'amqp.basic.deliver',
+                    'amqp',
+                    'queue',
+                    'basic.deliver direct_logs -> error'
+                )->withExactTags([
+                    Tag::SPAN_KIND                  => 'consumer',
+                    Tag::COMPONENT                  => 'amqp',
+                    Tag::MQ_SYSTEM                  => 'rabbitmq',
+                    Tag::MQ_DESTINATION_KIND        => 'queue',
+                    Tag::MQ_PROTOCOL                => 'AMQP',
+                    Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+                    Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
+                    Tag::RABBITMQ_ROUTING_KEY       => 'error',
+                    Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 29,
+                    Tag::MQ_OPERATION               => 'receive',
+                ])->withExistingTagsNames([
+                    Tag::MQ_CONSUMER_ID
+                ])
             ]),
             SpanAssertion::build(
                 'amqp.basic.deliver',
@@ -404,7 +445,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 29,
                 Tag::MQ_OPERATION               => 'receive',
             ])->withExistingTagsNames([
-                Tag::MQ_CONSUMER_ID
+                Tag::MQ_CONSUMER_ID,
+                '_dd.span_links'
             ])
         ]);
 
@@ -775,6 +817,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::RABBITMQ_ROUTING_KEY       => '<all>',
                 Tag::RABBITMQ_EXCHANGE          => 'basic_get_test',
                 Tag::RABBITMQ_DELIVERY_MODE     => '2'
+            ])->withExistingTagsNames([
+                '_dd.span_links'
             ]),
             SpanAssertion::build(
                 'amqp.basic.ack',


### PR DESCRIPTION
Draft PR

### Description

This PR changes the behavior of the consuming methods in a distributed context.

Related to `basic_deliver`:
- If the message has distributed headers, a new trace will be started in the prehook and closed in the posthook. 
- The message's distributed context will be extracted onto this newly created trace.
- A bidirectional span link between this newly created `basic_deliver` and the original `basic_deliver` will be created.

Related to `basic_get`:
- The automatic context extraction from the message is **removed**.
- Instead, a span link to the emitting trace will be created using the message's distributed headers and converting the trace identifiers to the required format, if needed. 

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
