### PR TITLE
Ensure no crashes happen with multiple observers installed

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -639,6 +639,51 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  test_multi_observer:
+    parameters:
+      php_major_minor:
+        # Expected in the format: <major>.<minor>, e.g. 8.2
+        type: string
+      switch_php_version:
+        type: string
+        default: none
+      resource_class:
+        type: string
+        default: medium
+    working_directory: ~/datadog
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
+          extra: with_httpbin_and_request_replayer
+      - switch_php:
+          php_version: << parameters.switch_php_version >>
+      - prepare_extension_and_composer_with_cache
+      - <<: *STEP_COMPOSER_TESTS_UPDATE
+      - <<: *STEP_PREPARE_TEST_RESULTS_DIR
+      - <<: *STEP_EXPORT_CI_ENV
+      - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
+      - <<: *STEP_WAIT_TEST_AGENT
+      - run:
+          name: Run tests
+          command: |
+            set -euo pipefail
+            make test_c_observer RUST_DEBUG_SYMBOLS=1 PHPUNIT_OPTS="--log-junit test-results/php-unit/results.xml" 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }
+      - <<: *STEP_STORE_TEST_RESULTS
+      - run:
+          command: |
+            mkdir -p /tmp/artifacts/core_dumps
+            find tmp -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/artifacts
+
   test_arm:
     machine:
       image: ubuntu-2004:2023.04.2
@@ -3175,6 +3220,18 @@ workflows:
                 - test_c_disabled
                 - test_internal_api_randomized
                 - test_opcache
+
+      - test_multi_observer:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              php_major_minor:
+                - "8.0"
+                - "8.1"
+                - "8.2"
+              switch_php_version:
+                - debug-zts-asan
+
       - coverage:
           requires: [ 'Prepare Code' ]
           matrix:

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,11 @@ test_c_coverage: dist_clean
 test_c_disabled: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	( \
 	DD_TRACE_CLI_ENABLED=0 DD_TRACE_DEBUG=1 $(RUN_TESTS_CMD) -d extension=$(SO_FILE) $(BUILD_DIR)/$(TESTS) || true; \
-	! grep -E 'Successfully triggered flush with trace of size|=== Total [0-9]+ memory leaks detected ===|Segmentation fault' $$(find $(BUILD_DIR)/$(TESTS) -name "*.out" | grep -v segfault_backtrace_enabled.out); \
+	! grep -E 'Successfully triggered flush with trace of size|=== Total [0-9]+ memory leaks detected ===|Segmentation fault|Assertion ' $$(find $(BUILD_DIR)/$(TESTS) -name "*.out" | grep -v segfault_backtrace_enabled.out); \
 	)
+
+test_c_observer: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
+	$(if $(ASAN), USE_ZEND_ALLOC=0 USE_TRACKED_ALLOC=1) DD_TRACE_CLI_ENABLED=1 $(RUN_TESTS_CMD) -d extension=$(SO_FILE) -d extension=zend_test.so -d zend_test.observer.enabled=1 -d zend_test.observer.observe_all=1 -d zend_test.observer.show_output=0 $(BUILD_DIR)/$(TESTS)
 
 test_opcache: $(SO_FILE) $(TEST_OPCACHE_FILES)
 	$(if $(ASAN), USE_ZEND_ALLOC=0 USE_TRACKED_ALLOC=1) DD_TRACE_CLI_ENABLED=1 $(RUN_TESTS_CMD) -d extension=$(SO_FILE) -d zend_extension=opcache.so $(BUILD_DIR)/tests/opcache

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -eux
 
-# The '=' is to avoid cases like:
-#     $_ENV['sharedBuild'] => 0
-# Which is an env-var we set ourselves.
-SHARED_BUILD=$(if php -i | grep -q =shared; then echo 1; else echo 0; fi)
+# We can't match for "shared" only, as zend_test is built shared. Match something explicitly.
+SHARED_BUILD=$(if php -i | grep -q enable-pcntl=shared; then echo 1; else echo 0; fi)
 PHP_VERSION_ID=$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 
 XDEBUG_VERSIONS=(-3.1.2)

--- a/dockerfiles/ci/buster/build-php.sh
+++ b/dockerfiles/ci/buster/build-php.sh
@@ -39,6 +39,7 @@ ${PHP_SRC_DIR}/configure \
         --enable-ftp \
         --enable-mbstring \
         --enable-opcache \
+        $(if [[ ${PHP_VERSION_ID} -ge 80 ]]; then echo --enable-zend-test=shared; fi) \
         --enable-pcntl \
         --enable-sockets \
         $(if [[ ${PHP_VERSION_ID} -le 73 ]]; then echo --enable-zip; fi) \

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -153,6 +153,7 @@ ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/tokenizer/tests/PhpToken_getAll.phpt
 ext/zip/tests/bug38943.phpt
+ext/zend_test/tests/
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -125,6 +125,7 @@ ext/standard/tests/array/array_key_exists_object2.phpt
 ext/standard/tests/array/array_map_variation4.phpt
 ext/standard/tests/array/array_reverse_variation4.phpt
 ext/standard/tests/array/array_unique_variation3.phpt
+ext/standard/tests/file/bug52820.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
 ext/standard/tests/filters/bug54350.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -22,6 +22,7 @@ Zend/tests/gc_045.phpt
 Zend/tests/get_defined_functions_basic.phpt
 Zend/tests/get_required_files.phpt
 Zend/tests/gh7958.phpt
+Zend/tests/gh10346.phpt
 Zend/tests/list_keyed_conversions.phpt
 Zend/tests/multibyte/multibyte_encoding_004.phpt
 Zend/tests/object_gc_in_shutdown.phpt
@@ -121,6 +122,7 @@ ext/spl/tests/spl_autoload_013.phpt
 ext/standard/tests/array/array_map_variation4.phpt
 ext/standard/tests/array/array_reverse_variation4.phpt
 ext/standard/tests/array/array_unique_variation3.phpt
+ext/standard/tests/file/bug52820.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
 ext/standard/tests/filters/bug54350.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -147,6 +147,7 @@ ext/standard/tests/streams/proc_open_bug69900.phpt
 ext/standard/tests/streams/stream_context_tcp_nodelay_fopen.phpt
 ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
+ext/zend_test/tests/
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -156,3 +156,7 @@ ddtrace request init hook consumes more than 2 MB of memory and fails too early 
 ## `Zend/tests/fibers/gh10496-001.phpt`
 
 ddtrace affects the order of destructor execution due to creating span stacks etc.
+
+## `ext/zend_test/tests/`
+
+Observer tests trace all functions, including dd setup. Exclude these from being observed.

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -157,6 +157,6 @@ ddtrace request init hook consumes more than 2 MB of memory and fails too early 
 
 ddtrace affects the order of destructor execution due to creating span stacks etc.
 
-## `ext/zend_test/tests/`
+## `ext/zend_test/tests/`, `Zend/tests/gh10346.phpt`
 
 Observer tests trace all functions, including dd setup. Exclude these from being observed.

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -17,7 +17,7 @@
 
 #if PHP_VERSION_ID >= 80000
 // stack allocate some memory to avoid overwriting stack allocated things needed for observers
-static char (*throwaway_buffer_pointer)[];
+char (*zai_call_throwaway_buffer_pointer)[];
 zend_result zend_call_function_wrapper(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) {
 #ifdef __SANITIZE_ADDRESS__
 #define STACK_BUFFER_SIZE 8192 // asan has more overhead
@@ -25,7 +25,7 @@ zend_result zend_call_function_wrapper(zend_fcall_info *fci, zend_fcall_info_cac
 #define STACK_BUFFER_SIZE 6144
 #endif
     char buffer[STACK_BUFFER_SIZE];  // dynamic runtime symbol resolving can have some stack overhead
-    throwaway_buffer_pointer = &buffer;
+    zai_call_throwaway_buffer_pointer = &buffer;
     return zend_call_function(fci, fci_cache);
 }
 


### PR DESCRIPTION
This PR mirrors the changes done to https://github.com/php/php-src/commit/709540ccdc5a3fc25fcdfceba322e6ad3aa3ce6f for the 8.1 implementation.

Additionally, given that PHP 8.2 is broken up to now, we default to our own implementation for PHP 8.2, and use the proper php-src API only from PHP 8.3 on.

Fixes #2075.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
