### PR TITLE
(Laminas) Fix incorrect offset access

### DIFF
--- a/src/Integrations/Integrations/Laminas/LaminasIntegration.php
+++ b/src/Integrations/Integrations/Laminas/LaminasIntegration.php
@@ -371,7 +371,7 @@ class LaminasIntegration extends Integration
                 $span->meta[Tag::COMPONENT] = 'laminas';
 
                 /** @var MvcEvent $event */
-                $event = $retval[0];
+                $event = $retval;
 
                 $exception = $event->getParam('exception');
                 if ($exception) {


### PR DESCRIPTION
### Description

While doing some testing for logs correlation, I got an exception in the Laminas Integration. The issue was that `MvcEvent::setError` doesn't return an array (but an `MvcEvent`), yet the offset `0` was tried to be accessed.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
