### PR TITLE
Disable telemetry by default until further stabilization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ RUN_TESTS_CMD := REPORT_EXIT_STATUS=1 TEST_PHP_SRCDIR=$(PROJECT_ROOT) USE_TRACKE
 
 C_FILES = $(shell find components components-rs ext src/dogstatsd zend_abstract_interface -name '*.c' -o -name '*.h' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_FILES = $(shell find tests/ext -name '*.php*' -o -name '*.inc' -o -name '*.json' -o -name 'CONFLICTS' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
-RUST_FILES = $(BUILD_DIR)/Cargo.toml $(shell find components-rs -name '*.c' -o -name '*.rs' -o -name 'Cargo.toml' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' ) $(shell find libdatadog -name '*.rs' -o -name '*.c' -o -name 'Cargo.toml')
+RUST_FILES = $(BUILD_DIR)/Cargo.toml $(shell find components-rs -name '*.c' -o -name '*.rs' -o -name 'Cargo.toml' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' ) $(shell find libdatadog/{ddcommon,ddcommon-ffi,ddtelemetry,ddtelemetry-ffi,ipc,sidecar,sidecar-ffi,spawn_worker,tools/{cc_utils,sidecar_mockgen},Cargo.toml} -type f \( -path "*/src*" -o -path "*Cargo.toml" -o -path "*/build.rs" \) -not -path "*/ipc/build.rs" -not -path "*/sidecar-ffi/build.rs")
 TEST_OPCACHE_FILES = $(shell find tests/opcache -name '*.php*' -o -name '.gitkeep' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 TEST_STUB_FILES = $(shell find tests/ext -type d -name 'stubs' -exec find '{}' -type f \; | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )
 INIT_HOOK_TEST_FILES = $(shell find tests/C2PHP -name '*.phpt' -o -name '*.inc' | awk '{ printf "$(BUILD_DIR)/%s\n", $$1 }' )

--- a/ddtrace.sym
+++ b/ddtrace.sym
@@ -1,5 +1,6 @@
 ddtrace_close_all_spans_and_flush
 ddtrace_get_profiling_context
 ddtrace_root_span_add_tag
+ddtrace_runtime_id
 get_module
 ddog_daemon_entry_point

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -85,7 +85,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                        \
     CONFIG(BOOL, DD_TRACE_DEBUG, "false")                                                                      \
     CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config)               \
-    CONFIG(BOOL, DD_TRACE_TELEMETRY_ENABLED, "true", .ini_change = zai_config_system_ini_change)               \
+    CONFIG(BOOL, DD_TRACE_TELEMETRY_ENABLED, "false", .ini_change = zai_config_system_ini_change)              \
     CONFIG(BOOL, DD_TRACE_HEALTH_METRICS_ENABLED, "false", .ini_change = zai_config_system_ini_change)         \
     CONFIG(DOUBLE, DD_TRACE_HEALTH_METRICS_HEARTBEAT_SAMPLE_RATE, "0.001")                                     \
     CONFIG(BOOL, DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE, "false")                                                \

--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -20,6 +20,7 @@ final class InstrumentationTest extends WebFrameworkTestCase
             'APP_NAME' => 'custom_autoloaded_app',
             'DD_TRACE_AGENT_PORT' => 80,
             'DD_AGENT_HOST' => 'request-replayer',
+            'DD_TRACE_TELEMETRY_ENABLED' => 1,
         ]);
     }
 

--- a/tests/ext/telemetry/composer.phpt
+++ b/tests/ext/telemetry/composer.phpt
@@ -7,6 +7,7 @@ if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing s
 ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TELEMETRY_ENABLED=1
 --INI--
 datadog.trace.agent_url=file://{PWD}/composer-telemetry.out
 --FILE--

--- a/tests/ext/telemetry/config.phpt
+++ b/tests/ext/telemetry/config.phpt
@@ -8,6 +8,7 @@ if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing s
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_TRACE_AUTOFINISH_SPANS=1
+DD_TRACE_TELEMETRY_ENABLED=1
 DD_AGENT_HOST=
 --INI--
 datadog.trace.agent_url=file://{PWD}/config-telemetry.out
@@ -61,6 +62,13 @@ Array
         )
 
     [2] => Array
+        (
+            [name] => datadog.trace.telemetry_enabled
+            [value] => 1
+            [origin] => EnvVar
+        )
+
+    [3] => Array
         (
             [name] => datadog.trace.generate_root_span
             [value] => 0

--- a/tests/ext/telemetry/integration.phpt
+++ b/tests/ext/telemetry/integration.phpt
@@ -8,6 +8,7 @@ if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing s
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
+DD_TRACE_TELEMETRY_ENABLED=1
 --INI--
 datadog.trace.agent_url=file://{PWD}/integration-telemetry.out
 ddtrace.request_init_hook={PWD}/../sandbox/deferred_loading_helper.php

--- a/tests/ext/telemetry/simple.phpt
+++ b/tests/ext/telemetry/simple.phpt
@@ -7,6 +7,7 @@ if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing s
 ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_TELEMETRY_ENABLED=1
 --INI--
 datadog.trace.agent_url=file://{PWD}/simple-telemetry.out
 --FILE--


### PR DESCRIPTION
### Description

Also fix runtime_id integration with profiler (missing exported symbol).

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
