### PR TITLE
Add automatic Laravel 5.8 user tracking events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RUST_DEBUG_SYMBOLS ?= $(shell [ -n "${DD_TRACE_DOCKER_DEBUG}" ] && echo 1)
 
 VERSION := $(shell awk -F\' '/const VERSION/ {print $$2}' < src/DDTrace/Tracer.php)
 PROFILING_RELEASE_URL := https://github.com/DataDog/dd-prof-php/releases/download/v0.7.2/datadog-profiling.tar.gz
-APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.9.0/dd-appsec-php-0.9.0-amd64.tar.gz
+APPSEC_RELEASE_URL := https://github.com/DataDog/dd-appsec-php/releases/download/v0.10.0/dd-appsec-php-0.10.0-amd64.tar.gz
 
 INI_FILE := $(shell ASAN_OPTIONS=detect_leaks=0 php -i | awk -F"=>" '/Scan this dir for additional .ini files/ {print $$2}')/ddtrace.ini
 

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -389,7 +389,7 @@ class LaravelIntegration extends Integration
             }
         );
 
-        // Used by Laravel >= 5.0
+        // Used by Laravel < 5.0
         \DDTrace\hook_method(
             'Illuminate\Auth\Guard',
             'attempt',

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -166,24 +166,20 @@ class LaravelIntegration extends Integration
 
                     //New user created, assume sign up
                     if ($span->resource == 'eloquent.created: User') {
-                        if (!function_exists('\datadog\appsec\track_user_signup_event'))
-                        {
+                        $authClass = '\User';
+                        if (
+                            !function_exists('\datadog\appsec\track_user_signup_event') ||
+                            !isset($args[1]) ||
+                            !$args[1] ||
+                            !($args[1] instanceof $authClass)
+                        ) {
                             return;
                         }
-                        if (!isset($args[1])) {
-                            return;
-                        }
-                        $user = $args[1];
-                        $authClass = 'User';
-                        if (!$user || !($user instanceof $authClass)) {
-                            return;
-                        }
-                        $metadata = [];
                         $id = null;
-                        if (isset($user['id'])) {
-                          $id = $user['id'];
+                        if (isset($args[1]['id'])) {
+                          $id = $args[1]['id'];
                         }
-                        \datadog\appsec\track_user_signup_event($id, $metadata, true);
+                        \datadog\appsec\track_user_signup_event($id, [], true);
                     }
 
                 },
@@ -317,11 +313,7 @@ class LaravelIntegration extends Integration
             'attempt',
             null,
             function ($This, $scope, $args, $loginSuccess) use ($rootSpan, $integration) {
-                if ($loginSuccess) {
-                    return;
-                }
-
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event'))
+                if ($loginSuccess || !function_exists('\datadog\appsec\track_user_login_failure_event'))
                 {
                     return;
                 }
@@ -334,28 +326,23 @@ class LaravelIntegration extends Integration
             'Illuminate\Auth\SessionGuard',
             'setUser',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (!function_exists('\datadog\appsec\track_user_login_success_event'))
-                {
-                    return;
-                }
-                if (!isset($args[0])) {
-                    return;
-                }
-                $user = $args[0];
-                $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
-                if (!$user || !($user instanceof $authClass)) {
-                    return;
-                }
-
-                $metadata = [];
-                if (isset($user['name'])) {
-                    $metadata['name'] = $user['name'];
-                }
-                if (isset($user['email'])) {
-                    $metadata['email'] = $user['email'];
-                }
-
-                \datadog\appsec\track_user_login_success_event($user->getAuthIdentifier(), $metadata, true);
+                $authClass = '\Illuminate\Contracts\Auth\Authenticatable';
+                if (
+                   !function_exists('\datadog\appsec\track_user_login_success_event') ||
+                   !isset($args[0]) ||
+                   !$args[0] ||
+                   !($args[0] instanceof $authClass)
+               ) {
+                   return;
+               }
+               $metadata = [];
+               if (isset($args[0]['name'])) {
+                   $metadata['name'] = $args[0]['name'];
+               }
+               if (isset($args[0]['email'])) {
+                   $metadata['email'] = $args[0]['email'];
+               }
+               \datadog\appsec\track_user_login_success_event($args[0]->getAuthIdentifier(), $metadata, true);
             }
         );
 
@@ -364,28 +351,25 @@ class LaravelIntegration extends Integration
             'Illuminate\Auth\Guard',
             'setUser',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (!function_exists('\datadog\appsec\track_user_login_success_event'))
-                {
-                    return;
-                }
-                if (!isset($args[0])) {
-                    return;
-                }
-                $user = $args[0];
-                $authClass = 'Illuminate\Auth\UserInterface';
-                if (!$user || !($user instanceof $authClass)) {
+                $authClass = '\Illuminate\Auth\UserInterface';
+                if (
+                    !function_exists('\datadog\appsec\track_user_login_success_event') ||
+                    !isset($args[0]) ||
+                    !$args[0] ||
+                    !($args[0] instanceof $authClass)
+                ) {
                     return;
                 }
 
                 $metadata = [];
-                if (isset($user['name'])) {
-                    $metadata['name'] = $user['name'];
+                if (isset($args[0]['name'])) {
+                    $metadata['name'] = $args[0]['name'];
                 }
-                if (isset($user['email'])) {
-                    $metadata['email'] = $user['email'];
+                if (isset($args[0]['email'])) {
+                    $metadata['email'] = $args[0]['email'];
                 }
 
-                \datadog\appsec\track_user_login_success_event($user->getAuthIdentifier(), $metadata, true);
+                \datadog\appsec\track_user_login_success_event($args[0]->getAuthIdentifier(), $metadata, true);
             }
         );
 
@@ -395,11 +379,7 @@ class LaravelIntegration extends Integration
             'attempt',
             null,
             function ($This, $scope, $args, $loginSuccess) use ($rootSpan, $integration) {
-                if ($loginSuccess) {
-                    return;
-                }
-
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event'))
+                if ($loginSuccess || !function_exists('\datadog\appsec\track_user_login_failure_event'))
                 {
                     return;
                 }
@@ -412,21 +392,16 @@ class LaravelIntegration extends Integration
             '__construct',
             null,
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                if (!function_exists('\datadog\appsec\track_user_signup_event'))
-                {
-                    return;
-                }
-                if (!isset($args[0])) {
-                    return;
-                }
-                $user = $args[0];
                 $authClass = '\Illuminate\Contracts\Auth\Authenticatable';
-                if (!$user || !($user instanceof $authClass)) {
+                if (
+                    !function_exists('\datadog\appsec\track_user_signup_event') ||
+                    !isset($args[0]) ||
+                    !$args[0] ||
+                    !($args[0] instanceof $authClass)
+                ) {
                     return;
                 }
-
-                $metadata = [];
-                \datadog\appsec\track_user_signup_event($user->getAuthIdentifier(), $metadata, true);
+                \datadog\appsec\track_user_signup_event($args[0]->getAuthIdentifier(), [], true);
             }
         );
 

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -166,7 +166,7 @@ class LaravelIntegration extends Integration
 
                     //New user created, assume sign up
                     if ($span->resource == 'eloquent.created: User') {
-                        $authClass = '\User';
+                        $authClass = 'User';
                         if (
                             !function_exists('\datadog\appsec\track_user_signup_event') ||
                             !isset($args[1]) ||
@@ -326,7 +326,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Auth\SessionGuard',
             'setUser',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                $authClass = '\Illuminate\Contracts\Auth\Authenticatable';
+                $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
                 if (
                    !function_exists('\datadog\appsec\track_user_login_success_event') ||
                    !isset($args[0]) ||
@@ -351,7 +351,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Auth\Guard',
             'setUser',
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                $authClass = '\Illuminate\Auth\UserInterface';
+                $authClass = 'Illuminate\Auth\UserInterface';
                 if (
                     !function_exists('\datadog\appsec\track_user_login_success_event') ||
                     !isset($args[0]) ||
@@ -392,7 +392,7 @@ class LaravelIntegration extends Integration
             '__construct',
             null,
             function ($This, $scope, $args) use ($rootSpan, $integration) {
-                $authClass = '\Illuminate\Contracts\Auth\Authenticatable';
+                $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
                 if (
                     !function_exists('\datadog\appsec\track_user_signup_event') ||
                     !isset($args[0]) ||

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -87,3 +87,15 @@ function track_user_login_failure_event($userId, $exists, $metadata, $automated)
     AppsecStatus::getInstance()->addEvent($event, 'track_user_login_failure_event');
 }
 
+/**
+ * This function is exposed by appsec but here we are mocking it for tests
+ */
+function track_user_signup_event($userId, $metadata, $automated) {
+    $event = [
+        'userId' => $userId,
+        'metadata' => $metadata,
+        'automated' => $automated
+
+    ];
+    AppsecStatus::getInstance()->addEvent($event, 'track_user_signup_event');
+}

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace datadog\appsec;
+
+class AppsecStatus {
+
+    private static $instance = null;
+    const CONFIGURATION_ID = 123;
+    
+    protected function __construct() {
+    }
+    
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            self::$instance = new static();
+        }
+
+        return self::$instance;
+    }
+
+    protected function getDbPdo()
+    {
+        return new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
+    }
+
+    public function init()
+    {
+        $this->getDbPdo()->exec("CREATE TABLE IF NOT EXISTS appsec_configuration (id int, enabled int)");
+        $this->getDbPdo()->exec("CREATE TABLE IF NOT EXISTS appsec_events (event varchar(1000))");
+    }
+
+    public function destroy()
+    {
+        $this->getDbPdo()->exec("DROP TABLE appsec_configuration");
+        $this->getDbPdo()->exec("DROP TABLE appsec_events");
+    }   
+
+
+    public function setDefaults()
+    {
+        $this->getDbPdo()->exec("DELETE FROM appsec_configuration");
+        $this->getDbPdo()->exec("DELETE FROM appsec_events");
+        $this->getDbPdo()->exec(sprintf("INSERT INTO appsec_configuration VALUES (%s, 0)", AppsecStatus::CONFIGURATION_ID));
+
+    }
+
+    public function isEnabled()
+    {
+        $result = $this->getDbPdo()->query("SELECT enabled FROM appsec_configuration WHERE id=" . AppsecStatus::CONFIGURATION_ID)->fetch();
+        return $result['enabled'] ==  1;
+    }
+
+    public function setEnabled()
+    {
+        $this->getDbPdo()->exec(sprintf("UPDATE appsec_configuration SET enabled=1 WHERE id=" . AppsecStatus::CONFIGURATION_ID));
+    }
+
+    public function setDisabled()
+    {
+        $this->getDbPdo()->exec(sprintf("UPDATE appsec_configuration SET enabled=0 WHERE id=" . AppsecStatus::CONFIGURATION_ID));
+    }
+
+    public function addEvent(array $event, $eventName)
+    {
+        $event['eventName'] = $eventName;
+        $this->getDbPdo()->exec(sprintf("INSERT INTO appsec_events VALUES ('%s')", json_encode($event)));
+    }
+
+    public function getEvents()
+    {
+        $result = [];
+        
+        $events = $this->getDbPdo()->query("SELECT * FROM appsec_events")->fetchAll();
+
+        foreach ($events as $event) {
+            $result[] = json_decode($event['event'], true);
+        }
+
+        return $result;
+    }
+}
+
+/**
+ * This function is exposed by appsec but here we are mocking it for tests
+ */
+function is_enabled() {
+    return AppsecStatus::getInstance()->isEnabled();
+}
+
+/**
+ * This function is exposed by appsec but here we are mocking it for tests
+ */
+function track_user_login_success_event($userId, $metadata) {
+    $event = [
+        'userId' => $userId,
+        'metadata' => $metadata
+
+    ];
+    AppsecStatus::getInstance()->addEvent($event, 'track_user_login_success_event');
+}
+
+/**
+ * This function is exposed by appsec but here we are mocking it for tests
+ */
+function track_user_login_failure_event($userId, $exists, $metadata) {
+    $event = [
+        'userId' => $userId,
+        'exists' => $exists,
+        'metadata' => $metadata
+
+    ];
+    AppsecStatus::getInstance()->addEvent($event, 'track_user_login_failure_event');
+}
+

--- a/tests/Frameworks/Laravel/Version_4_2/app/controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_4_2/app/controllers/LoginTestController.php
@@ -17,4 +17,17 @@ class LoginTestController extends BaseController
 
         return "error";
     }
+
+    public function register()
+    {
+        $user = new User;
+
+        $user->email = Input::get('email');
+        $user->name = Input::get('name');
+        $user->password = Input::get('password');
+
+        $user->save();
+
+        return "registered";
+    }
 }

--- a/tests/Frameworks/Laravel/Version_4_2/app/controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_4_2/app/controllers/LoginTestController.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Routing\Controller as BaseController;
+
+class LoginTestController extends BaseController
+{
+    public function auth()
+    {
+        $credentials = [
+            'email' => Input::get('email'),
+            'password' => 'password',
+        ];
+
+        if (Auth::attempt($credentials)) {
+            return "success";
+        }
+
+        return "error";
+    }
+}

--- a/tests/Frameworks/Laravel/Version_4_2/app/routes.php
+++ b/tests/Frameworks/Laravel/Version_4_2/app/routes.php
@@ -20,3 +20,4 @@ Route::get('/eloquent/update', 'EloquentTestController@update');
 Route::get('/eloquent/delete', 'EloquentTestController@delete');
 Route::get('/eloquent/destroy', 'EloquentTestController@destroy');
 Route::get('/eloquent/refresh', 'EloquentTestController@refresh');
+Route::get('/login/auth', 'LoginTestController@auth');

--- a/tests/Frameworks/Laravel/Version_4_2/app/routes.php
+++ b/tests/Frameworks/Laravel/Version_4_2/app/routes.php
@@ -21,3 +21,4 @@ Route::get('/eloquent/delete', 'EloquentTestController@delete');
 Route::get('/eloquent/destroy', 'EloquentTestController@destroy');
 Route::get('/eloquent/refresh', 'EloquentTestController@refresh');
 Route::get('/login/auth', 'LoginTestController@auth');
+Route::get('/login/signup', 'LoginTestController@register');

--- a/tests/Frameworks/Laravel/Version_4_2/composer.json
+++ b/tests/Frameworks/Laravel/Version_4_2/composer.json
@@ -19,6 +19,9 @@
 			"App\\": "app/"
 		}
 	},
+	"autoload-dev": {
+		"files": ["../../../Appsec/Mock.php"]
+	},
 	"scripts": {
 		"post-install-cmd": [
 			"php artisan clear-compiled",

--- a/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/LoginTestController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginTestController extends BaseController
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function auth(Request $request)
+    {
+        $credentials = [
+            'email' => $request->get('email'),
+            'password' => 'password',
+        ];
+
+        if (Auth::attempt($credentials)) {
+            return response('Login successful', 200);
+        }
+
+        return response('Invalid credentials', 403);
+    }
+}

--- a/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_5_7/app/Http/Controllers/LoginTestController.php
@@ -5,9 +5,14 @@ namespace App\Http\Controllers;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Support\Facades\Validator;
+use App\User;
 
 class LoginTestController extends BaseController
 {
+    use RegistersUsers;
+
     /**
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
@@ -24,5 +29,29 @@ class LoginTestController extends BaseController
         }
 
         return response('Invalid credentials', 403);
+    }
+
+    protected function validator(array $data)
+    {
+        return Validator::make(
+            $data,
+            [
+                'name' => 'required',
+                'email' => 'required',
+                'password' => 'required',
+            ],
+            []
+        );
+    }
+
+    protected function create(array $data)
+    {
+        $user = User::create([
+            'name' => strip_tags($data['name']),
+            'email' => strip_tags($data['email']),
+            'password' => strip_tags($data['password']),
+        ]);
+
+        return $user;
     }
 }

--- a/tests/Frameworks/Laravel/Version_5_7/composer.json
+++ b/tests/Frameworks/Laravel/Version_5_7/composer.json
@@ -27,6 +27,9 @@
             "App\\": "app/"
         }
     },
+    "autoload-dev": {
+        "files": ["../../../Appsec/Mock.php"]
+    },
     "extra": {
         "laravel": {
             "dont-discover": [

--- a/tests/Frameworks/Laravel/Version_5_7/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_5_7/routes/web.php
@@ -28,3 +28,4 @@ Route::get('queue/create', 'QueueTestController@create');
 Route::get('queue/jobFailure', 'QueueTestController@jobFailure');
 Route::get('queue/workOn', 'QueueTestController@workOn');
 Route::get('login/auth', 'LoginTestController@auth');
+Route::get('login/signup', 'LoginTestController@register');

--- a/tests/Frameworks/Laravel/Version_5_7/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_5_7/routes/web.php
@@ -27,3 +27,4 @@ Route::get('queue/batchDefault', 'QueueTestController@batchDefault');
 Route::get('queue/create', 'QueueTestController@create');
 Route::get('queue/jobFailure', 'QueueTestController@jobFailure');
 Route::get('queue/workOn', 'QueueTestController@workOn');
+Route::get('login/auth', 'LoginTestController@auth');

--- a/tests/Frameworks/Laravel/Version_5_8/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_5_8/app/Http/Controllers/LoginTestController.php
@@ -5,9 +5,14 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Support\Facades\Validator;
+use App\User;
 
 class LoginTestController extends BaseController
 {
+    use RegistersUsers;
+
     /**
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
@@ -24,5 +29,29 @@ class LoginTestController extends BaseController
         }
 
         return response('Invalid credentials', 403);
-    }    
+    }
+
+    protected function validator(array $data)
+    {
+        return Validator::make(
+            $data,
+            [
+                'name' => 'required',
+                'email' => 'required',
+                'password' => 'required',
+            ],
+            []
+        );
+    }
+
+    protected function create(array $data)
+    {
+        $user = User::create([
+            'name' => strip_tags($data['name']),
+            'email' => strip_tags($data['email']),
+            'password' => strip_tags($data['password']),
+        ]);
+
+        return $user;
+    }
 }

--- a/tests/Frameworks/Laravel/Version_5_8/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_5_8/app/Http/Controllers/LoginTestController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Routing\Controller as BaseController;
+
+class LoginTestController extends BaseController
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function auth(Request $request)
+    {
+        $credentials = [
+            'email' => $request->get('email'),
+            'password' => 'password',
+        ];
+
+        if (Auth::attempt($credentials)) {
+            return response('Login successful', 200);
+        }
+
+        return response('Invalid credentials', 403);
+    }    
+}

--- a/tests/Frameworks/Laravel/Version_5_8/composer.json
+++ b/tests/Frameworks/Laravel/Version_5_8/composer.json
@@ -46,7 +46,8 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": ["../../../Appsec/Mock.php"]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/Frameworks/Laravel/Version_5_8/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_5_8/routes/web.php
@@ -25,3 +25,4 @@ Route::get('queue/create', 'QueueTestController@create');
 Route::get('queue/jobFailure', 'QueueTestController@jobFailure');
 Route::get('queue/workOn', 'QueueTestController@workOn');
 Route::get('login/auth', 'LoginTestController@auth');
+Route::get('login/signup', 'LoginTestController@register');

--- a/tests/Frameworks/Laravel/Version_5_8/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_5_8/routes/web.php
@@ -24,3 +24,4 @@ Route::get('queue/batchDefault', 'QueueTestController@batchDefault');
 Route::get('queue/create', 'QueueTestController@create');
 Route::get('queue/jobFailure', 'QueueTestController@jobFailure');
 Route::get('queue/workOn', 'QueueTestController@workOn');
+Route::get('login/auth', 'LoginTestController@auth');

--- a/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/LoginTestController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginTestController extends Controller
+{
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function auth(Request $request)
+    {
+        $credentials = [
+            'email' => $request->get('email'),
+            'password' => 'password',
+        ];
+
+        if (Auth::attempt($credentials)) {
+            return response('Login successful', 200);
+        }
+
+        return response('Invalid credentials', 403);
+    }
+}

--- a/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/LoginTestController.php
+++ b/tests/Frameworks/Laravel/Version_8_x/app/Http/Controllers/LoginTestController.php
@@ -4,6 +4,11 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\RedirectResponse;
+use App\Providers\RouteServiceProvider;
+use App\Models\User;
 
 class LoginTestController extends Controller
 {
@@ -23,5 +28,26 @@ class LoginTestController extends Controller
         }
 
         return response('Invalid credentials', 403);
+    }
+
+    public function register(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'name' => ['required'],
+            'email' => ['required'],
+            'password' => ['required'],
+        ]);
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        event(new Registered($user));
+
+        Auth::login($user);
+
+        return redirect(RouteServiceProvider::HOME);
     }
 }

--- a/tests/Frameworks/Laravel/Version_8_x/composer.json
+++ b/tests/Frameworks/Laravel/Version_8_x/composer.json
@@ -42,7 +42,8 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": ["../../../Appsec/Mock.php"]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/Frameworks/Laravel/Version_8_x/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_8_x/routes/web.php
@@ -36,6 +36,7 @@ Route::get('queue/create', [QueueTestController::class, 'create']);
 Route::get('queue/jobFailure', [QueueTestController::class, 'jobFailure']);
 Route::get('queue/workOn', [QueueTestController::class, 'workOn']);
 Route::get('login/auth', [LoginTestController::class, 'auth']);
+Route::get('login/signup', [LoginTestController::class, 'register']);
 
 // This route has to remain unnamed so we test both route cached and not cached.
 Route::get('/unnamed-route', [RouteCachingController::class, 'unnamed']);

--- a/tests/Frameworks/Laravel/Version_8_x/routes/web.php
+++ b/tests/Frameworks/Laravel/Version_8_x/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\EloquentTestController;
 use App\Http\Controllers\InternalErrorController;
 use App\Http\Controllers\QueueTestController;
 use App\Http\Controllers\RouteCachingController;
+use App\Http\Controllers\LoginTestController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -34,6 +35,7 @@ Route::get('queue/batchDefault', [QueueTestController::class, 'batchDefault']);
 Route::get('queue/create', [QueueTestController::class, 'create']);
 Route::get('queue/jobFailure', [QueueTestController::class, 'jobFailure']);
 Route::get('queue/workOn', [QueueTestController::class, 'workOn']);
+Route::get('login/auth', [LoginTestController::class, 'auth']);
 
 // This route has to remain unnamed so we test both route cached and not cached.
 Route::get('/unnamed-route', [RouteCachingController::class, 'unnamed']);

--- a/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Laravel\V4;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+class AutomatedLoginEventsTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Laravel/Version_4_2/public/index.php';
+    }
+
+    protected function connection()
+    {
+        return new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
+    }
+
+    public static function ddSetUpBeforeClass()
+    {
+        parent::ddSetUpBeforeClass();
+        AppsecStatus::getInstance()->init();
+    }
+
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    public static function ddTearDownAfterClass()
+    {
+        AppsecStatus::getInstance()->destroy();
+        parent::ddTearDownAfterClass();
+    }
+
+    protected function login($email)
+    {
+        $this->call(
+            GetSpec::create('Login success event', '/login/auth?email='.$email)
+        );
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $id = 1234;
+        $name = 'someName';
+        $email = 'test-user@email.com';
+        //Password is password
+        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($id, $events[0]['userId']);
+        $this->assertEquals($name, $events[0]['metadata']['name']);
+        $this->assertEquals($email, $events[0]['metadata']['email']);
+        $this->assertTrue($events[0]['automated']);
+        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
+    }
+
+    public function testUserLoginFailureEvent()
+    {
+        $email = 'test-user-non-existing@email.com';
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertTrue($events[0]['automated']);
+        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
+    }
+}

--- a/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
@@ -74,4 +74,30 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
         $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
     }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-new@email.com';
+        $name = 'somename';
+        $password = 'somepassword';
+
+       $this->call(
+           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
+       );
+
+       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = null;
+        foreach(AppsecStatus::getInstance()->getEvents() as $event)
+        {
+            if ($event['eventName'] == 'track_user_signup_event') {
+                $signUpEvent = $event;
+            }
+        }
+
+        $this->assertTrue($signUpEvent['automated']);
+        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
+    }
 }

--- a/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\Laravel\V5_8;
+namespace DDTrace\Tests\Integrations\Laravel\V5_7;
 
 use DDTrace\Tests\Common\WebFrameworkTestCase;
 use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
@@ -10,7 +10,7 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
 {
     protected static function getAppIndexScript()
     {
-        return __DIR__ . '/../../../Frameworks/Laravel/Version_5_8/public/index.php';
+        return __DIR__ . '/../../../Frameworks/Laravel/Version_5_7/public/index.php';
     }
 
     protected function connection()

--- a/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
@@ -74,4 +74,30 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
         $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
     }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-new@email.com';
+        $name = 'somename';
+        $password = 'somepassword';
+
+       $this->call(
+           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
+       );
+
+       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = null;
+        foreach(AppsecStatus::getInstance()->getEvents() as $event)
+        {
+            if ($event['eventName'] == 'track_user_signup_event') {
+                $signUpEvent = $event;
+            }
+        }
+
+        $this->assertTrue($signUpEvent['automated']);
+        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
+    }
 }

--- a/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
@@ -48,16 +48,19 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
     public function testUserLoginSuccessEvent()
     {
         $id = 1234;
+        $name = 'someName';
         $email = 'test-user@email.com';
         //Password is password
-        $this->connection()->exec("insert into users (id, email, password) VALUES (".$id.", '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
+        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
 
-        AppsecStatus::getInstance()->setEnabled();
         $this->login($email);
 
         $events = AppsecStatus::getInstance()->getEvents();
         $this->assertEquals(1, count($events));
         $this->assertEquals($id, $events[0]['userId']);
+        $this->assertEquals($name, $events[0]['metadata']['name']);
+        $this->assertEquals($email, $events[0]['metadata']['email']);
+        $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
     }
 
@@ -65,11 +68,11 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
     {
         $email = 'test-user-non-existing@email.com';
 
-        AppsecStatus::getInstance()->setEnabled();
         $this->login($email);
 
         $events = AppsecStatus::getInstance()->getEvents();
         $this->assertEquals(1, count($events));
+        $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
     }
 }

--- a/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
@@ -74,4 +74,30 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
         $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
     }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-new@email.com';
+        $name = 'somename';
+        $password = 'somepassword';
+
+       $this->call(
+           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
+       );
+
+       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = null;
+        foreach(AppsecStatus::getInstance()->getEvents() as $event)
+        {
+            if ($event['eventName'] == 'track_user_signup_event') {
+                $signUpEvent = $event;
+            }
+        }
+
+        $this->assertTrue($signUpEvent['automated']);
+        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
+    }
 }

--- a/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Laravel\V8_x;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+class AutomatedLoginEventsTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Laravel/Version_8_x/public/index.php';
+    }
+
+    protected function connection()
+    {
+        return new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
+    }
+
+    public static function ddSetUpBeforeClass()
+    {
+        parent::ddSetUpBeforeClass();
+        AppsecStatus::getInstance()->init();
+    }
+
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    public static function ddTearDownAfterClass()
+    {
+        AppsecStatus::getInstance()->destroy();
+        parent::ddTearDownAfterClass();
+    }
+
+    protected function login($email)
+    {
+        $this->call(
+            GetSpec::create('Login success event', '/login/auth?email='.$email)
+        );
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $id = 1234;
+        $name = 'someName';
+        $email = 'test-user@email.com';
+        //Password is password
+        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($id, $events[0]['userId']);
+        $this->assertEquals($name, $events[0]['metadata']['name']);
+        $this->assertEquals($email, $events[0]['metadata']['email']);
+        $this->assertTrue($events[0]['automated']);
+        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
+    }
+
+    public function testUserLoginFailureEvent()
+    {
+        $email = 'test-user-non-existing@email.com';
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents();
+        $this->assertEquals(1, count($events));
+        $this->assertTrue($events[0]['automated']);
+        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
+    }
+}

--- a/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
@@ -74,4 +74,30 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
         $this->assertTrue($events[0]['automated']);
         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
     }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-new@email.com';
+        $name = 'somename';
+        $password = 'somepassword';
+
+       $this->call(
+           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
+       );
+
+       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = null;
+        foreach(AppsecStatus::getInstance()->getEvents() as $event)
+        {
+            if ($event['eventName'] == 'track_user_signup_event') {
+                $signUpEvent = $event;
+            }
+        }
+
+        $this->assertTrue($signUpEvent['automated']);
+        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
+    }
 }

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -4,7 +4,8 @@
     "autoload-dev": {
         "psr-4": {
             "DDTrace\\Tests\\": "./"
-        }
+        },
+        "files": ["Appsec/Mock.php"]
     },
     "require-dev": {
         "mockery/mockery": "*",


### PR DESCRIPTION
### Description

First ATO integration for PHP login success, login failure, and signup events for Laravel.

The event model is designed to be consistent across frameworks: same semantics, same span tags, regardless of how the framework internally handles authentication. Laravel was picked first based on customer usage data (largest share of PHP AppSec customers at the time).

The wrapped methods are:
- `Illuminate\Events\Dispatcher::fire`: This generic method was already wrapped for some other purposes. I filtered within this method the event `eloquent.created: User` to trigger appsec event `signup` on Laravel 4
- `Illuminate\Auth\SessionGuard::attempt`: This method will trigger the appsec event login attempt failure on Laravel >=5
- `Illuminate\Auth\Guard::attempt`:  This method will trigger the appsec event login attempt failure on Laravel <5
- `Illuminate\Auth\SessionGuard::setUser`: This method will trigger the appsec event login succesful on Laravel >=5
- `Illuminate\Auth\Guard::setUser`: This method will trigger the appsec event login succesful on Laravel <5
- `Illuminate\Auth\Events\Registered::__construct`: This method will trigger the appsec event sign up

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
