### PR TITLE
style: fix clippy lints

### DIFF
--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -119,6 +119,10 @@ typedef ddog_Bytes ddog_Uuid;
 
 extern ddog_Uuid ddtrace_runtime_id;
 
+/**
+ * # Safety
+ * Must be called from a single-threaded context, such as MINIT.
+ */
 void ddtrace_generate_runtime_id(void);
 
 void ddtrace_format_runtime_id(uint8_t (*buf)[36]);

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -11,18 +11,20 @@ pub use ddtelemetry_ffi::*;
 
 #[no_mangle]
 #[allow(non_upper_case_globals)]
-pub static mut ddtrace_runtime_id: Uuid = Uuid::from_bytes([0; 16]);
+pub static mut ddtrace_runtime_id: Uuid = Uuid::nil();
 
-#[must_use]
+/// # Safety
+/// Must be called from a single-threaded context, such as MINIT.
 #[no_mangle]
 pub unsafe extern "C" fn ddtrace_generate_runtime_id() {
     ddtrace_runtime_id = Uuid::new_v4();
 }
 
-#[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddtrace_format_runtime_id(buf: &mut [u8; 36]) {
-    ddtrace_runtime_id.as_hyphenated().encode_lower(buf);
+pub extern "C" fn ddtrace_format_runtime_id(buf: &mut [u8; 36]) {
+    // Safety: ddtrace_runtime_id is only supposed to be mutated from single-
+    // threaded contexts, so reads should always be safe.
+    unsafe { ddtrace_runtime_id.as_hyphenated().encode_lower(buf) };
 }
 
 #[must_use]
@@ -31,7 +33,6 @@ pub extern "C" fn ddtrace_get_container_id() -> CharSlice<'static> {
     get_container_id().map_or(CharSlice::default(), CharSlice::from)
 }
 
-#[must_use]
 #[no_mangle]
 pub unsafe extern "C" fn ddtrace_set_container_cgroup_path(path: CharSlice) {
     set_cgroup_file(String::from(path.try_to_utf8().unwrap()))

--- a/components-rs/telemetry.rs
+++ b/components-rs/telemetry.rs
@@ -51,7 +51,7 @@ fn parse_composer_installed_json(
         }
     }
 
-    if deps.len() > 0 {
+    if !deps.is_empty() {
         blocking::enqueue_actions(transport, instance_id, queue_id, deps)?;
     }
 
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addIntegration_buffer(
     integration_name: CharSlice,
     integration_version: CharSlice,
     integration_enabled: bool,
-) -> () {
+) {
     let version = integration_version
         .is_empty()
         .then(|| integration_version.to_utf8_lossy().into_owned());
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_enqueueConfig_buffer(
     config_key: CharSlice,
     config_value: CharSlice,
     origin: data::ConfigurationOrigin,
-) -> () {
+) {
     let action = TelemetryActions::AddConfig(data::Configuration {
         name: config_key.to_utf8_lossy().into_owned(),
         value: config_value.to_utf8_lossy().into_owned(),


### PR DESCRIPTION
### Description

Explanation of lints:

- `#[must_use]` doesn't make sense on functions that return `()` aka `void`.
- Rust prefers using `!foo.is_empty()` over `foo.len() > 0`
- Clippy likes unsafe functions to have their safety conditions documented.
- There's no need to explicitly type the unit return type `-> ()`; it's implicit in Rust.

There are more lints, but these ones were trivial to fix.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
