### PR TITLE
build: fix commit hashes in profiling release versions

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -450,6 +450,7 @@ commands:
                   -e DATADOG_HAVE_DEV_ENV=1 \
                   -e BASH_ENV=/home/circleci/bashenv/bash.sh \
                   -e CIRCLE_SHA1 \
+                  -e CIRCLE_BRANCH \
                   -v $(pwd):/home/circleci/datadog \
                   -v /tmp/bashenv:/home/circleci/bashenv \
                   -v /rust:/rust \

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -100,6 +100,10 @@ aliases:
       name: Append build id to version number
       command: |
         githash="${CIRCLE_SHA1?}"
+        if [[ "x$CIRCLE_BRANCH" == "x" ]] ; then
+          echo "The environment variable CIRCLE_BRANCH was not set or was empty."
+          exit 1
+        fi
         if [[ "$CIRCLE_BRANCH" =~ "ddtrace-" ]] ; then
           echo "Release branch detected; not adding git sha1 to version number."
         else


### PR DESCRIPTION
### Description

The most recent few releases of profiling have a commit hash in their version number. This is expected for non-releases, but shouldn't be there for releases.

This does two things in CI:

- Profiling jobs check that the env var `CIRCLE_BRANCH` exists and is not empty. If it's not set, the job isn't set up right.
- Propagates `CIRCLE_BRANCH` in the `setup_docker` command, which the profiling jobs use.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
