### PR TITLE
feat(profiling): add endpoint counts

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -295,7 +295,8 @@ impl TimeCollector {
         let local_root_span_id = message.local_root_span_id;
         for (_, profile) in profiles.iter_mut() {
             let endpoint = Cow::Borrowed(message.resource.as_str());
-            profile.add_endpoint(local_root_span_id, endpoint)
+            profile.add_endpoint(local_root_span_id, endpoint.clone());
+            profile.add_endpoint_count(endpoint, 1);
         }
     }
 

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -49,6 +49,7 @@ impl Uploader {
         )?;
 
         let serialized = profile.serialize(Some(message.end_time), message.duration)?;
+        let endpoint_counts = Some(&serialized.endpoints_stats);
         let start = serialized.start.into();
         let end = serialized.end.into();
         let files = &[File {
@@ -56,7 +57,7 @@ impl Uploader {
             bytes: serialized.buffer.as_slice(),
         }];
         let timeout = Duration::from_secs(10);
-        let request = exporter.build(start, end, files, None, None, timeout)?;
+        let request = exporter.build(start, end, files, None, endpoint_counts, timeout)?;
         debug!("Sending profile to: {}", index.endpoint);
         let result = exporter.send(request, None)?;
         Ok(result.status().as_u16())


### PR DESCRIPTION
### Description

This adds endpoint counts to the profiles, bring PHP up to feature parity in this regard. The UI can now show "per Minute by Endpoint" or "by Endpoint Call".

<img width="639" alt="Screenshot 2023-06-27 at 12 08 10 PM" src="https://github.com/DataDog/dd-trace-php/assets/253316/d3ff5e57-2161-4833-873f-4d6e30fef6d8">

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
