### PR TITLE
Use proper variable for php-config

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -964,9 +964,6 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts/
       - <<: *STEP_COMPOSER_CACHE_SAVE
-      - persist_to_workspace:
-          root: .
-          paths: [tmp/build_extension]
       - <<: *STEP_STORE_TEST_RESULTS
 
   integration:

--- a/config.m4
+++ b/config.m4
@@ -268,7 +268,7 @@ if test "$PHP_DDTRACE" != "no"; then
   if test "$ext_shared" = "yes"; then
     all_object_files=$(for src in $DD_TRACE_PHP_SOURCES $ZAI_SOURCES; do printf ' %s' "${src%?}lo"; done)
     all_object_files_newlines=$(for src in $DD_TRACE_PHP_SOURCES $ZAI_SOURCES; do printf '\\n$(builddir)/%s' "$(dirname "$src")/$objdir/$(basename "${src%?}o")"; done)
-    php_binary=$(php-config --php-binary)
+    php_binary=$($PHP_CONFIG --php-binary)
     ddtrace_mock_sources='DD_SIDECAR_MOCK_SOURCES="$$(printf "'"$php_binary$all_object_files_newlines"'")"'
   else
     all_object_files=


### PR DESCRIPTION
### Description

Fixes #2113.

Works around the fact that it might be called e.g. php-config8.2 or similar.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
