### PR TITLE
ci: make sure core file is where it should be

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -696,6 +696,10 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Set core pattern
+          command: |
+            sudo sh -c "echo '/tmp/core.%e.%p.%t' > /proc/sys/kernel/core_pattern"
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
           extra: with_httpbin_and_request_replayer
@@ -718,7 +722,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/artifacts/core_dumps
-            find tmp -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
+            find /tmp -name "core*" -type f | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
             cp -a tmp/build_extension/tests/$(if [[ << parameters.make_target >> == *opcache* ]]; then echo opcache; else echo ext; fi) /tmp/artifacts/tests
           when: on_fail
       - store_artifacts:


### PR DESCRIPTION
### Description

In the internal API randomized tests the core file (in case a segfault happens) would not be in `/tmp/core`,  because `/proc/sys/kernel/core_pattern` is set to `|/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E` on the host which is inherited by the container. Now inside the container the `apport` binaray does not exists, so core dumps are lost.
We can not change the core pattern from inside the container, as this is not a privileged one, so we do it as an extra step from the outside.

Find the failed job here that did not have a core dump in the artifacts:
https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/11602/workflows/0ac9f7b9-8200-4c94-ae58-7edd648f90fc/jobs/2461257/steps

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
