### PR TITLE
feat(tracing): emit metrics for WordPress plugins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,8 +159,11 @@ services:
       - DD_APM_ENABLED=true
       - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
       - DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
+      - DD_DOGSTATSD_SOCKET=/var/run/datadog/dsd.socket
+      - DD_DOGSTATSD_ORIGIN_DETECTION=true
     ports:
       - "8126:8126"
+      - "8125:8125/udp"
 
   packager:
     image: datadog/docker-library:ddtrace_php_fpm_packaging


### PR DESCRIPTION
### Description

Tracks the loading of WordPress plugins in WP 6. I have not checked if this will work for older versions. When plugins install actions and filters, register them and emit their overhead as metrics. The plan is for these metrics to be billed as part of APM and not separately (aka unbilled) and to create an out-of-the-box dashboard which can show this information to users.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
