### PR TITLE
Add `horizon` as artisan queue command

### DIFF
--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -44,7 +44,8 @@ class LaravelIntegration extends Integration
 
         return !empty($artisanCommand)
             && (strpos($artisanCommand, 'horizon:work') !== false
-                || strpos($artisanCommand, 'queue:work') !== false);
+                || strpos($artisanCommand, 'queue:work') !== false
+                || $artisanCommand === 'horizon');
     }
 
     /**


### PR DESCRIPTION
### Description

The default horizon work command is `php artisan horizon`. Which doesn't get recognised right now.

I've chosen to do an exact match, because using `strpos()` will match on all Horizon subcommands.

I'm not familiar with the codebase, but I did some quick testing on the `$artisanCommand` variable locally and saw that it contains the command without any options. So this should work I think. I'm not sure why we aren't using an exact match (or `in_array()`) for all options. Is this speed related?

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
