### PR TITLE
build(profiling): bump indexmap to v2.0.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Default owners
 * @DataDog/apm-php
+Cargo.lock @DataDog/apm-php @DataDog/profiling-php
 
 # Profiling team
 /profiling/ @DataDog/profiling-php

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
 dependencies = [
  "clap 3.2.25",
  "heck",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "proc-macro2",
  "quote",
@@ -318,7 +318,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
@@ -543,7 +543,7 @@ dependencies = [
  "datadog-profiling",
  "ddcommon 2.2.0 (git+https://github.com/DataDog/libdatadog?tag=v2.2.0)",
  "env_logger 0.10.0",
- "indexmap",
+ "indexmap 2.0.0",
  "lazy_static",
  "libc 0.2.146",
  "log",
@@ -572,7 +572,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-multipart-rfc7578",
- "indexmap",
+ "indexmap 1.9.3",
  "libc 0.2.146",
  "lz4_flex",
  "mime",
@@ -595,7 +595,7 @@ dependencies = [
  "ddcommon 2.2.0",
  "ddtelemetry",
  "futures",
- "hashbrown",
+ "hashbrown 0.12.3",
  "http",
  "hyper",
  "io-lifetimes",
@@ -644,7 +644,7 @@ dependencies = [
  "hex",
  "hyper",
  "hyper-rustls",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "log",
  "maplit",
@@ -695,7 +695,7 @@ dependencies = [
  "anyhow",
  "ddcommon 2.2.0",
  "futures",
- "hashbrown",
+ "hashbrown 0.12.3",
  "http",
  "hyper",
  "io-lifetimes",
@@ -817,6 +817,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "errno"
@@ -1009,6 +1015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,7 +1176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -19,7 +19,7 @@ cpu-time = { version = "1.0" }
 datadog-profiling = { git = "https://github.com/DataDog/libdatadog", tag = "v2.2.0" }
 ddcommon = { git = "https://github.com/DataDog/libdatadog", tag = "v2.2.0" }
 env_logger = { version = "0.10" }
-indexmap = { version = "1.8" }
+indexmap = { version = "2.0.0" }
 lazy_static = { version = "1.4" }
 libc = "0.2"
 # TRACE set to max to support runtime configuration.


### PR DESCRIPTION
### Description

Fortunately, we are not affected by any breaking changes. Also attempts to make `Cargo.lock` approvable by profiling or tracing.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests are sufficient.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
