### PR TITLE
build(profiling): bump bindgen to 0.66.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,15 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,24 +121,24 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
- "clap 2.34.0",
- "env_logger 0.9.3",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.18",
  "which",
 ]
 
@@ -162,6 +153,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitmaps"
@@ -202,7 +199,7 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
 dependencies = [
- "clap 3.2.25",
+ "clap",
  "heck",
  "indexmap 1.9.3",
  "log",
@@ -296,32 +293,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap 1.9.3",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -394,7 +376,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -542,7 +524,7 @@ dependencies = [
  "crossbeam-channel",
  "datadog-profiling",
  "ddcommon 2.2.0 (git+https://github.com/DataDog/libdatadog?tag=v2.2.0)",
- "env_logger 0.10.0",
+ "env_logger",
  "indexmap 2.0.0",
  "lazy_static",
  "libc 0.2.146",
@@ -790,19 +772,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1443,7 +1412,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc 0.2.146",
  "memoffset 0.6.5",
@@ -1671,7 +1640,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba1fd955270ca6f8bd8624ec0c4ee1a251dd3cc0cc18e1e2665ca8f5acb1501"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc 0.2.146",
  "mmap",
  "nom 4.2.3",
@@ -1795,6 +1764,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,7 +1888,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1949,7 +1928,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2029,7 +2008,7 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc 0.2.146",
@@ -2127,7 +2106,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc 0.2.146",
@@ -2283,12 +2262,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -2401,15 +2374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2716,12 +2680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,12 +2699,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3040,7 +2992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5be8cc34d017d8aabec95bc45a43d0f20e8b2a31a453cabc804fe996f8dca"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "csv",
  "phf",
  "phf_codegen",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -47,7 +47,7 @@ timeline = []
 stack_walking_tests = []
 
 [build-dependencies]
-bindgen = { version = "0.59" }
+bindgen = { version = "0.66.1" }
 cc = { version = "1.0" }
 
 # profiling release options in root Cargo.toml

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -189,7 +189,6 @@ fn generate_bindings(php_config_includes: &str) {
         .parse_callbacks(Box::new(ignored_macros))
         .clang_args(php_config_includes.split(' '))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .rustfmt_bindings(true)
         .layout_tests(false)
         // this prevents bindgen from copying C comments to Rust, as otherwise
         // rustdoc would look for tests and currently fail as it assumes

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -3,8 +3,7 @@ use crate::config;
 use crate::PROFILER;
 use crate::PROFILER_NAME;
 use crate::REQUEST_LOCALS;
-use libc::c_char;
-use libc::c_int;
+use libc::{c_char, c_int, c_void, size_t};
 use log::{debug, error, info};
 use once_cell::sync::OnceCell;
 use std::cell::RefCell;
@@ -54,7 +53,7 @@ impl AllocationProfilingStats {
             .sample(&mut rand::thread_rng()) as i64
     }
 
-    fn track_allocation(&mut self, len: u64) {
+    fn track_allocation(&mut self, len: size_t) {
         self.next_sample -= len as i64;
 
         if self.next_sample > 0 {
@@ -272,8 +271,8 @@ unsafe extern "C" fn alloc_profiling_gc_mem_caches(
     }
 }
 
-unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_ALLOC(len);
+unsafe extern "C" fn alloc_profiling_malloc(len: size_t) -> *mut c_void {
+    let ptr: *mut c_void = ALLOCATION_PROFILING_ALLOC(len);
 
     // during startup, minit, rinit, ... current_execute_data is null
     // we are only interested in allocations during userland operations
@@ -289,16 +288,16 @@ unsafe extern "C" fn alloc_profiling_malloc(len: u64) -> *mut ::libc::c_void {
     ptr
 }
 
-static mut ALLOCATION_PROFILING_ALLOC: unsafe fn(u64) -> *mut ::libc::c_void =
+static mut ALLOCATION_PROFILING_ALLOC: unsafe fn(size_t) -> *mut c_void =
     allocation_profiling_orig_alloc;
 
-unsafe fn allocation_profiling_prev_alloc(len: u64) -> *mut ::libc::c_void {
+unsafe fn allocation_profiling_prev_alloc(len: size_t) -> *mut c_void {
     let prev = PREV_CUSTOM_MM_ALLOC.unwrap();
     prev(len)
 }
 
-unsafe fn allocation_profiling_orig_alloc(len: u64) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void;
+unsafe fn allocation_profiling_orig_alloc(len: size_t) -> *mut c_void {
+    let ptr: *mut c_void;
     let heap = zend::zend_mm_get_heap();
     let custom_heap = prepare_zend_heap(heap);
     ptr = zend::_zend_mm_alloc(heap, len);
@@ -310,28 +309,24 @@ unsafe fn allocation_profiling_orig_alloc(len: u64) -> *mut ::libc::c_void {
 // to pass a pointer to a `free()` function as well, otherwise your custom handlers won't be
 // installed. We can not just point to the original `zend::_zend_mm_free()` as the function
 // definitions differ.
-unsafe extern "C" fn alloc_profiling_free(ptr: *mut ::libc::c_void) {
+unsafe extern "C" fn alloc_profiling_free(ptr: *mut c_void) {
     ALLOCATION_PROFILING_FREE(ptr);
 }
 
-static mut ALLOCATION_PROFILING_FREE: unsafe fn(*mut ::libc::c_void) =
-    allocation_profiling_orig_free;
+static mut ALLOCATION_PROFILING_FREE: unsafe fn(*mut c_void) = allocation_profiling_orig_free;
 
-unsafe fn allocation_profiling_prev_free(ptr: *mut ::libc::c_void) {
+unsafe fn allocation_profiling_prev_free(ptr: *mut c_void) {
     let prev = PREV_CUSTOM_MM_FREE.unwrap();
     prev(ptr);
 }
 
-unsafe fn allocation_profiling_orig_free(ptr: *mut ::libc::c_void) {
+unsafe fn allocation_profiling_orig_free(ptr: *mut c_void) {
     let heap = zend::zend_mm_get_heap();
     zend::_zend_mm_free(heap, ptr);
 }
 
-unsafe extern "C" fn alloc_profiling_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void = ALLOCATION_PROFILING_REALLOC(prev_ptr, len);
+unsafe extern "C" fn alloc_profiling_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    let ptr: *mut c_void = ALLOCATION_PROFILING_REALLOC(prev_ptr, len);
 
     // during startup, minit, rinit, ... current_execute_data is null
     // we are only interested in allocations during userland operations
@@ -347,24 +342,16 @@ unsafe extern "C" fn alloc_profiling_realloc(
     ptr
 }
 
-static mut ALLOCATION_PROFILING_REALLOC: unsafe fn(
-    *mut ::libc::c_void,
-    u64,
-) -> *mut ::libc::c_void = allocation_profiling_orig_realloc;
+static mut ALLOCATION_PROFILING_REALLOC: unsafe fn(*mut c_void, size_t) -> *mut c_void =
+    allocation_profiling_orig_realloc;
 
-unsafe fn allocation_profiling_prev_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
+unsafe fn allocation_profiling_prev_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
     let prev = PREV_CUSTOM_MM_REALLOC.unwrap();
     prev(prev_ptr, len)
 }
 
-unsafe fn allocation_profiling_orig_realloc(
-    prev_ptr: *mut ::libc::c_void,
-    len: u64,
-) -> *mut ::libc::c_void {
-    let ptr: *mut libc::c_void;
+unsafe fn allocation_profiling_orig_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    let ptr: *mut c_void;
     let heap = zend::zend_mm_get_heap();
     let custom_heap = prepare_zend_heap(heap);
     ptr = zend::_zend_mm_realloc(heap, prev_ptr, len);

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -14,11 +14,11 @@ pub type VmInterruptFn = unsafe extern "C" fn(execute_data: *mut zend_execute_da
 pub type VmGcCollectCyclesFn = unsafe extern "C" fn() -> i32;
 
 #[cfg(feature = "allocation_profiling")]
-pub type VmMmCustomAllocFn = unsafe extern "C" fn(u64) -> *mut libc::c_void;
+pub type VmMmCustomAllocFn = unsafe extern "C" fn(size_t) -> *mut c_void;
 #[cfg(feature = "allocation_profiling")]
-pub type VmMmCustomReallocFn = unsafe extern "C" fn(*mut libc::c_void, u64) -> *mut libc::c_void;
+pub type VmMmCustomReallocFn = unsafe extern "C" fn(*mut c_void, size_t) -> *mut c_void;
 #[cfg(feature = "allocation_profiling")]
-pub type VmMmCustomFreeFn = unsafe extern "C" fn(*mut libc::c_void);
+pub type VmMmCustomFreeFn = unsafe extern "C" fn(*mut c_void);
 
 // todo: this a lie on some PHP versions; is it a problem even though zend_bool
 //       was always supposed to be 0 or 1 anyway?


### PR DESCRIPTION
### Description

Bumps the bindgen dependency to 0.66.1:

- Had to fix some `u64`/`size_t` differences for allocation profiling.
- `rustfmt_bindings` is deprecated now and it's enabled by default.
- Removes unnecessary qualifications like `::libc::c_void`. Also imports things like `libc::c_void` if other `libc::` items were already being imported.

This is stacked on top of another PR; merge it first.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests are sufficient.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
