### PR TITLE
Automated user events tracking symfony 5.2

### DIFF
--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -348,7 +348,11 @@ class LaravelIntegration extends Integration
                if (isset($args[0]['email'])) {
                    $metadata['email'] = $args[0]['email'];
                }
-               \datadog\appsec\track_user_login_success_event($args[0]->getAuthIdentifier(), $metadata, true);
+               \datadog\appsec\track_user_login_success_event(
+                    \method_exists($args[0], 'getAuthIdentifier') ? $args[0]->getAuthIdentifier(): '',
+                    $metadata,
+                    true
+               );
             }
         );
 
@@ -375,7 +379,11 @@ class LaravelIntegration extends Integration
                     $metadata['email'] = $args[0]['email'];
                 }
 
-                \datadog\appsec\track_user_login_success_event($args[0]->getAuthIdentifier(), $metadata, true);
+                \datadog\appsec\track_user_login_success_event(
+                    \method_exists($args[0], 'getAuthIdentifier') ? $args[0]->getAuthIdentifier(): '',
+                    $metadata,
+                    true
+                );
             }
         );
 
@@ -407,7 +415,11 @@ class LaravelIntegration extends Integration
                 ) {
                     return;
                 }
-                \datadog\appsec\track_user_signup_event($args[0]->getAuthIdentifier(), [], true);
+                \datadog\appsec\track_user_signup_event(
+                    \method_exists($args[0], 'getAuthIdentifier') ? $args[0]->getAuthIdentifier(): '',
+                    [],
+                    true
+                );
             }
         );
 

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -86,6 +86,10 @@ class SymfonyIntegration extends Integration
             'Doctrine\ORM\UnitOfWork',
             'executeInserts',
             function ($This, $scope, $args) {
+                  if (!function_exists('\datadog\appsec\track_user_signup_event'))
+                  {
+                    return;
+                  }
                   $metadataClass = 'Doctrine\ORM\Mapping\ClassMetadata';
                   if (
                        !$args ||

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -112,7 +112,11 @@ class SymfonyIntegration extends Integration
                     return;
                   }
 
-                  \datadog\appsec\track_user_signup_event($userEntity->getUsername(), [], true);
+                  \datadog\appsec\track_user_signup_event(
+                    \method_exists($userEntity, 'getUsername') ? $userEntity->getUsername() : '',
+                    [],
+                    true
+                  );
 
             }
         );
@@ -149,7 +153,11 @@ class SymfonyIntegration extends Integration
 
                 $metadata = [];
 
-                \datadog\appsec\track_user_login_success_event($token->getUsername(), $metadata, true);
+                \datadog\appsec\track_user_login_success_event(
+                    \method_exists($token, 'getUsername') ? $token->getUsername(): '',
+                    $metadata,
+                    true
+                );
             }
         );
 

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -96,7 +96,9 @@ class SymfonyIntegration extends Integration
                        return;
                   }
 
-                  $entities = $This->getScheduledEntityInsertions();
+                  $entities = \method_exists($This, 'getScheduledEntityInsertions') ?
+                    $This->getScheduledEntityInsertions():
+                    [];
                   $userInterface = 'Symfony\Component\Security\Core\User\UserInterface';
                   $found = 0;
                   $userEntity = null;

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -106,7 +106,7 @@ class SymfonyIntegration extends Integration
                     return;
                 }
                 $token = $args[1];
-                $authClass = 'Symfony\Component\Security\Core\Authentication\Token\TokenInterface';
+                $authClass = '\Symfony\Component\Security\Core\Authentication\Token\TokenInterface';
                 if (!$token || !($token instanceof $authClass)) {
                     return;
                 }

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -135,13 +135,14 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      * @param RequestSpec $spec
      * @return mixed|null
      */
-    protected function call(RequestSpec $spec)
+    protected function call(RequestSpec $spec, $options = [])
     {
         $response = $this->sendRequest(
             $spec->getMethod(),
             self::HOST . ':' . self::PORT . $spec->getPath(),
             $spec->getHeaders(),
-            $spec->getBody()
+            $spec->getBody(),
+            $options
         );
         return $response;
     }
@@ -155,13 +156,22 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      * @param array|string $body
      * @return mixed|null
      */
-    protected function sendRequest($method, $url, $headers = [], $body = [])
+    protected function sendRequest($method, $url, $headers = [], $body = [], $changedOptions = [])
     {
+        $options = [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+        ];
+
+        foreach ($changedOptions as $key => $value) {
+            $options[$key] = $value;
+        }
+
         for ($i = 0; $i < 10; ++$i) {
             $ch = curl_init($url);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, $options[CURLOPT_RETURNTRANSFER]);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, $options[CURLOPT_FOLLOWLOCATION]);
             if ($method === 'POST') {
                 curl_setopt($ch, CURLOPT_POST, true);
                 curl_setopt($ch, CURLOPT_POSTFIELDS, is_array($body) ? json_encode($body) : $body);

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -160,7 +160,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     {
         $options = [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_FOLLOWLOCATION => true,
         ];
 
         foreach ($changedOptions as $key => $value) {

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -8,10 +8,14 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/annotations": "^1.12",
+        "doctrine/doctrine-bundle": "^2.7",
+        "doctrine/doctrine-migrations-bundle": "^3.1",
+        "doctrine/orm": "^2.15",
         "symfony/console": "5.2.*",
         "symfony/dotenv": "5.2.*",
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "5.2.*",
+        "symfony/security-bundle": "5.2.*",
         "symfony/twig-bundle": "5.2.*",
         "symfony/yaml": "5.2.*"
     },
@@ -33,7 +37,8 @@
     "autoload-dev": {
         "psr-4": {
             "App\\Tests\\": "tests/"
-        }
+        },
+        "files": ["../../../Appsec/Mock.php"]
     },
     "replace": {
         "symfony/polyfill-ctype": "*",
@@ -60,5 +65,8 @@
             "allow-contrib": false,
             "require": "5.2.*"
         }
+    },
+    "require-dev": {
+        "symfony/maker-bundle": "*"
     }
 }

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -14,9 +14,11 @@
         "symfony/console": "5.2.*",
         "symfony/dotenv": "5.2.*",
         "symfony/flex": "^1.3.1",
+        "symfony/form": "5.2.*",
         "symfony/framework-bundle": "5.2.*",
         "symfony/security-bundle": "5.2.*",
         "symfony/twig-bundle": "5.2.*",
+        "symfony/validator": "5.2.*",
         "symfony/yaml": "5.2.*"
     },
     "config": {

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -55,6 +55,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
+        ],
+        "post-autoload-dump": [
+            "@php bin/console doctrine:migrations:migrate -n"
         ]
     },
     "conflict": {

--- a/tests/Frameworks/Symfony/Version_5_2/config/bundles.php
+++ b/tests/Frameworks/Symfony/Version_5_2/config/bundles.php
@@ -3,4 +3,8 @@
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
 ];

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine.yaml
@@ -1,0 +1,18 @@
+doctrine:
+    dbal:
+        url: 'mysql://test:test@mysql_integration:3306/test?serverVersion=8&charset=utf8mb4'
+
+        # IMPORTANT: You MUST configure your server version,
+        # either here or in the DATABASE_URL env var (see .env file)
+        #server_version: '15'
+    orm:
+        auto_generate_proxy_classes: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        auto_mapping: true
+        mappings:
+            App:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity'
+                prefix: 'App\Entity'
+                alias: App

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine.yaml
@@ -1,10 +1,10 @@
 doctrine:
     dbal:
-        url: 'mysql://test:test@mysql_integration:3306/test?serverVersion=8&charset=utf8mb4'
+        url: 'mysql://test:test@mysql_integration:3306/test?serverVersion=5&charset=utf8mb4'
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '15'
+        server_version: '5'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine_migrations.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,6 @@
+doctrine_migrations:
+    migrations_paths:
+        # namespace is arbitrary but should be different from App\Migrations
+        # as migrations classes should NOT be autoloaded
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    enable_profiler: false

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/prod/doctrine.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/prod/doctrine.yaml
@@ -1,0 +1,17 @@
+doctrine:
+    orm:
+        auto_generate_proxy_classes: false
+        query_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
+        result_cache_driver:
+            type: pool
+            pool: doctrine.result_cache_pool
+
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/security.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/security.yaml
@@ -1,0 +1,35 @@
+security:
+    encoders:
+        App\Entity\User:
+            algorithm: auto
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        # used to reload user from session & other features (e.g. switch_user)
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+            lazy: true
+            provider: app_user_provider
+            form_login:
+                login_path: login
+                check_path: login
+
+            # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#firewalls-authentication
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/test/doctrine.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/test/doctrine.yaml
@@ -1,0 +1,4 @@
+doctrine:
+    dbal:
+        # "TEST_TOKEN" is typically set by ParaTest
+        dbname: 'main_test%env(default::TEST_TOKEN)%'

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/test/validator.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/test/validator.yaml
@@ -1,0 +1,3 @@
+framework:
+    validation:
+        not_compromised_password: false

--- a/tests/Frameworks/Symfony/Version_5_2/config/packages/validator.yaml
+++ b/tests/Frameworks/Symfony/Version_5_2/config/packages/validator.yaml
@@ -1,0 +1,8 @@
+framework:
+    validation:
+        email_validation_mode: html5
+
+        # Enables validator auto-mapping support.
+        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
+        #auto_mapping:
+        #    App\Entity\: []

--- a/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230627152626.php
+++ b/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230627152626.php
@@ -13,7 +13,7 @@ use Doctrine\Migrations\AbstractMigration;
 final class Version20230627152626 extends AbstractMigration
 {
     public function getDescription(): string
-    {\
+    {
         return '';
     }
 

--- a/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230627152626.php
+++ b/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230627152626.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230627152626 extends AbstractMigration
+{
+    public function getDescription(): string
+    {\
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE `user` (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE `user`');
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230630141414.php
+++ b/tests/Frameworks/Symfony/Version_5_2/migrations/Version20230630141414.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20230627152626 extends AbstractMigration
+final class Version20230630141414 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -20,12 +20,12 @@ final class Version20230627152626 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE `user` (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE user (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\', password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE `user`');
+        $this->addSql('DROP TABLE user');
     }
 }

--- a/tests/Frameworks/Symfony/Version_5_2/src/Controller/RegistrationController.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Controller/RegistrationController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\RegistrationFormType;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+
+class RegistrationController extends AbstractController
+{
+    /**
+     * @Route("/register", name="app_register")
+     */
+    public function register(Request $request, UserPasswordEncoderInterface $userPasswordEncoder, EntityManagerInterface $entityManager): Response
+    {
+        $user = new User();
+        $form = $this->createForm(RegistrationFormType::class, $user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // encode the plain password
+            $user->setPassword(
+            $userPasswordEncoder->encodePassword(
+                    $user,
+                    $form->get('plainPassword')->getData()
+                )
+            );
+
+            $entityManager->persist($user);
+            $entityManager->flush();
+            // do anything else you need here, like send an email
+
+            return $this->redirectToRoute('simple');
+        }
+
+        return $this->render('registration/register.html.twig', [
+            'registrationForm' => $form->createView(),
+        ]);
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/src/Controller/SecurityController.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Controller/SecurityController.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\ParameterBagUtils;
+
+class SecurityController extends AbstractController
+{
+    /**
+     * @Route("/login", name="login", methods={"GET", "POST"})
+     */
+    public function login(AuthenticationUtils $authenticationUtils): Response
+    {
+        // get the login error if there is one
+        $error = $authenticationUtils->getLastAuthenticationError();
+
+        // last username entered by the user
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', [
+            'last_username' => $lastUsername,
+            'error'         => $error,
+        ]);
+    }
+
+    /**
+         * @Route("/dumper", name="dumper", methods={"GET", "POST"})
+         */
+        public function dump(Request $request): Response
+        {
+          $username = ParameterBagUtils::getParameterBagValue($request->request, '_username');
+          $password = ParameterBagUtils::getParameterBagValue($request->request, '_password');
+          var_dump($username, $password);
+          return new Response(
+                      'Hi!'
+                  );
+        }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UserRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @ORM\Entity(repositoryClass=UserRepository::class)
+ * @ORM\Table(name="`user`")
+ */
+class User implements UserInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
+    private $email;
+
+    /**
+     * @ORM\Column(type="json")
+     */
+    private $roles = [];
+
+    /**
+     * @var string The hashed password
+     * @ORM\Column(type="string")
+     */
+    private $password;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * A visual identifier that represents this user.
+     *
+     * @see UserInterface
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->email;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        // guarantee every user at least has ROLE_USER
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
+     * @see UserInterface
+     */
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function eraseCredentials()
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+        // $this->plainPassword = null;
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
@@ -4,10 +4,12 @@ namespace App\Entity;
 
 use App\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity(repositoryClass=UserRepository::class)
+ * @UniqueEntity(fields={"email"}, message="There is already an account with this email")
  */
 class User implements UserInterface
 {

--- a/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Entity/User.php
@@ -8,7 +8,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity(repositoryClass=UserRepository::class)
- * @ORM\Table(name="`user`")
  */
 class User implements UserInterface
 {

--- a/tests/Frameworks/Symfony/Version_5_2/src/Form/RegistrationFormType.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Form/RegistrationFormType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class RegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email')
+            ->add('agreeTerms', CheckboxType::class, [
+                'mapped' => false,
+                'constraints' => [
+                    new IsTrue([
+                        'message' => 'You should agree to our terms.',
+                    ]),
+                ],
+            ])
+            ->add('plainPassword', PasswordType::class, [
+                // instead of being set onto the object directly,
+                // this is read and encoded in the controller
+                'mapped' => false,
+                'attr' => ['autocomplete' => 'new-password'],
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter a password',
+                    ]),
+                    new Length([
+                        'min' => 6,
+                        'minMessage' => 'Your password should be at least {{ limit }} characters',
+                        // max length allowed by Symfony for security reasons
+                        'max' => 4096,
+                    ]),
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+            'csrf_protection' => false,
+        ]);
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/src/Repository/UserRepository.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Repository/UserRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ *
+ * @method User|null find($id, $lockMode = null, $lockVersion = null)
+ * @method User|null findOneBy(array $criteria, array $orderBy = null)
+ * @method User[]    findAll()
+ * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function add(User $entity, bool $flush = true): void
+    {
+        $this->_em->persist($entity);
+        if ($flush) {
+            $this->_em->flush();
+        }
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function remove(User $entity, bool $flush = true): void
+    {
+        $this->_em->remove($entity);
+        if ($flush) {
+            $this->_em->flush();
+        }
+    }
+
+    /**
+     * Used to upgrade (rehash) the user's password automatically over time.
+     */
+    public function upgradePassword(UserInterface $user, string $newHashedPassword): void
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        $user->setPassword($newHashedPassword);
+        $this->_em->persist($user);
+        $this->_em->flush();
+    }
+
+    // /**
+    //  * @return User[] Returns an array of User objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('u.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?User
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/tests/Frameworks/Symfony/Version_5_2/templates/registration/register.html.twig
+++ b/tests/Frameworks/Symfony/Version_5_2/templates/registration/register.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Register{% endblock %}
+
+{% block body %}
+    <h1>Register</h1>
+
+    {{ form_start(registrationForm) }}
+        {{ form_row(registrationForm.email) }}
+        {{ form_row(registrationForm.plainPassword, {
+            label: 'Password'
+        }) }}
+        {{ form_row(registrationForm.agreeTerms) }}
+
+        <button type="submit" class="btn">Register</button>
+    {{ form_end(registrationForm) }}
+{% endblock %}

--- a/tests/Frameworks/Symfony/Version_5_2/templates/security/login.html.twig
+++ b/tests/Frameworks/Symfony/Version_5_2/templates/security/login.html.twig
@@ -1,0 +1,23 @@
+{% extends "../base.html" %}
+
+{% block body %}
+{% if error %}
+    <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+{% endif %}
+
+<form action="{{ path('login') }}" method="post">
+    <label for="username">Username:</label>
+    <input type="text" id="username" name="_username" value="{{ last_username }}"/>
+
+    <label for="password">Password:</label>
+    <input type="password" id="password" name="_password"/>
+
+    {#
+        If you want to control the URL the user
+        is redirected to on success (more details below)
+        <input type="hidden" name="_target_path" value="/account"/>
+    #}
+
+    <button type="submit">login</button>
+</form>
+{% endblock %}

--- a/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
@@ -42,7 +42,7 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
         $email = 'test-user@email.com';
         $password = 'test';
         //Password is password
-        $this->connection()->exec('insert into user (roles, email, password) VALUES ("{}", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
+        $this->connection()->exec('insert into user (roles, email, password) VALUES ("", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
 
          $spec = PostSpec::create('request', '/login', [
                         'Content-Type: application/x-www-form-urlencoded'

--- a/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony\V5_2;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
+use datadog\appsec\AppsecStatus;
+
+class AutomatedLoginEventsTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/public/index.php';
+    }
+
+    protected function connection()
+    {
+        return new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
+    }
+
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from user where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    public static function ddSetUpBeforeClass()
+    {
+        parent::ddSetUpBeforeClass();
+        AppsecStatus::getInstance()->init();
+    }
+
+    public static function ddTearDownAfterClass()
+    {
+        AppsecStatus::getInstance()->destroy();
+        parent::ddTearDownAfterClass();
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $email = 'test-user@email.com';
+        $password = 'test';
+        //Password is password
+        $this->connection()->exec('insert into user (roles, email, password) VALUES ("{}", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
+
+         $spec = PostSpec::create('request', '/login', [
+                        'Content-Type: application/x-www-form-urlencoded'
+                    ], "_username=$email&_password=$password");
+
+         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+         $events = AppsecStatus::getInstance()->getEvents();
+         $this->assertEquals(1, count($events));
+         $this->assertEquals($email, $events[0]['userId']);
+         $this->assertEmpty($events[0]['metadata']);
+         $this->assertTrue($events[0]['automated']);
+         $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
+    }
+
+    public function testUserLoginFailureEvent()
+    {
+        $email = 'non-existing@email.com';
+        $password = 'some password';
+         $spec = PostSpec::create('request', '/login', [
+                        'Content-Type: application/x-www-form-urlencoded'
+                    ], "_username=$email&_password=$password");
+
+         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+         $events = AppsecStatus::getInstance()->getEvents();
+         $this->assertEquals(1, count($events));
+         $this->assertEmpty($events[0]['userId']);
+         $this->assertEmpty($events[0]['metadata']);
+         $this->assertTrue($events[0]['automated']);
+         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
+    }
+}

--- a/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
@@ -62,7 +62,7 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
     {
         $email = 'non-existing@email.com';
         $password = 'some password';
-         $spec = PostSpec::create('request', '/login', [
+        $spec = PostSpec::create('request', '/login', [
                         'Content-Type: application/x-www-form-urlencoded'
                     ], "_username=$email&_password=$password");
 
@@ -74,5 +74,31 @@ class AutomatedLoginEventsTest extends WebFrameworkTestCase
          $this->assertEmpty($events[0]['metadata']);
          $this->assertTrue($events[0]['automated']);
          $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
+    }
+
+    public function testUserSignUp()
+    {
+       $email = 'test-user@email.com';
+       $password = 'some password';
+       $spec = PostSpec::create('Signup', '/register', [
+                       'Content-Type: application/x-www-form-urlencoded'
+                   ], "registration_form[email]=$email&registration_form[plainPassword]=$password&registration_form[agreeTerms]=1");
+
+       $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+       $users = $this->connection()->query("SELECT * FROM user where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = null;
+        foreach(AppsecStatus::getInstance()->getEvents() as $event)
+        {
+            if ($event['eventName'] == 'track_user_signup_event') {
+                $signUpEvent = $event;
+            }
+        }
+
+        $this->assertTrue($signUpEvent['automated']);
+        $this->assertEquals($email, $signUpEvent['userId']);
     }
 }


### PR DESCRIPTION
### Description

ATO support for Symfony: login success, login failure, and signup events.

Same event model as [#2100](https://github.com/DataDog/dd-trace-php/pull/2100) (Laravel). Symfony uses a different authentication architecture (Security component, event listeners) so the instrumentation approach differs, but the output is identical from AppSec's perspective.

Methods wrapped:
- `Doctrine\ORM\UnitOfWork::executeInserts`: This method will trigger the appsec event signup
- `Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener::onFailure`:  This method will trigger the appsec event login attempt failure
- `Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener::onSuccess`: This method will trigger the appsec event login succesful

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
