### PR TITLE
Run benchmarks only in profiling PRs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -8,7 +8,7 @@ benchmarks:
   when: on_success
   only:
     changes:
-      - profiling/**
+      - profiling/**/*
       - .gitlab/benchmarks.yml
   tags: ["runner:apm-k8s-tweaked-metal"]
   needs: []

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -6,6 +6,10 @@ variables:
 benchmarks:
   stage: benchmarks
   when: on_success
+  only:
+    changes:
+      - profiling/**
+      - .gitlab/benchmarks.yml
   tags: ["runner:apm-k8s-tweaked-metal"]
   needs: []
   image:

--- a/tests/randomized/config/envs.php
+++ b/tests/randomized/config/envs.php
@@ -63,5 +63,5 @@ const ENVS = [
     'DD_TRACE_YII_ENABLED' => ['false'],
     'DD_TRACE_ZENDFRAMEWORK_ENABLED' => ['false'],
     'DD_PROFILING_ENABLED' => ['true'],
-    'DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED' => ['true'],
+    'DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED' => ['true'],
 ];


### PR DESCRIPTION
### Description

This will make sure the benchmarks are only run on changes in the profiler, as the tracer does not have benchmarks yet. Additionally it will add the timeline feature to the randomized tests.

We do not need the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` env variable anymore, as allocation profiling is enabled by default now.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
