### PR TITLE
fix: generate runtime-id on first request

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -214,6 +214,7 @@ bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value) 
 
 static void dd_activate_once(void) {
     ddtrace_config_first_rinit();
+    ddtrace_generate_runtime_id();
 
     // must run before the first zai_hook_activate as ddtrace_telemetry_setup installs a global hook
     if (!DDTRACE_G(disable) && get_global_DD_TRACE_TELEMETRY_ENABLED()) {
@@ -655,7 +656,6 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     }
 
     ddtrace_set_coredumpfilter();
-    ddtrace_generate_runtime_id();
 
     ddtrace_initialize_span_sampling_limiter();
     ddtrace_limiter_create();


### PR DESCRIPTION
### Description

Without this, in SAPIs which fork after MINIT, the runtime id will be shared by multiple processes. This issue was introduced in #2029 in v0.88.0 when the tracer took over runtime generation. Previously the profiler was in charge of generating the runtime id.

This affects cross-product features such as Code Hotspots in the profiler.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
