### PR TITLE
doc(profiling): make `phpinfo()` output more helpful

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -702,7 +702,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Allocation Profiling Enabled\0".as_ptr(),
-                    b"Not available. The profiler was build without allocation profiling.\0"
+                    b"Not available. The profiler was built without allocation profiling.\0"
                 );
             }
         }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -667,9 +667,6 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
         let locals = cell.borrow();
         let yes: &[u8] = b"true\0";
         let no: &[u8] = b"false\0";
-        let na: &[u8] = b"Not available\0";
-        #[cfg(not(all(feature = "allocation_profiling", feature = "timeline")))]
-        let nc: &[u8] = b"Not compiled\0";
         zend::php_info_print_table_start();
         zend::php_info_print_table_row(2, b"Version\0".as_ptr(), module.version);
         zend::php_info_print_table_row(
@@ -696,7 +693,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                     if locals.profiling_allocation_enabled {
                         yes
                     } else if zend::ddog_php_jit_enabled() {
-                        na
+                        b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.\0"
                     } else {
                         no
                     }
@@ -705,7 +702,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Allocation Profiling Enabled\0".as_ptr(),
-                    nc
+                    b"Not available. The profiler was build without allocation profiling.\0"
                 );
             }
         }
@@ -725,7 +722,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Experimental Timeline Enabled\0".as_ptr(),
-                    nc
+                    b"Not available. The profiler was build without timeline support.\0"
                 );
             }
         }

--- a/profiling/tests/phpt/phpinfo_02.phpt
+++ b/profiling/tests/phpt/phpinfo_02.phpt
@@ -44,7 +44,7 @@ foreach ($lines as $line) {
 
 // Check exact values for this set
 $sections = [
-    ["Allocation Profiling Enabled", "Not available"],
+    ["Allocation Profiling Enabled", "Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information."],
 ];
 
 foreach ($sections as [$key, $expected]) {


### PR DESCRIPTION
### Description

This will add more helpful output the the `phpinfo()` output for the profiler.
Example:
```
$ php --ri datadog-profiling

datadog-profiling

Version => 0.89.0
Profiling Enabled => true
Experimental CPU Time Profiling Enabled => true
Allocation Profiling Enabled => Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.
Experimental Timeline Enabled => Not available. The profiler was build without timeline support.
Endpoint Collection Enabled => true
Platform's CPU Time API Works => true
Profiling Log Level => trace
Profiling Agent Endpoint => http://localhost:8126/
Application's Environment (DD_ENV) =>  
Application's Service (DD_SERVICE) => Standard input code
Application's Version (DD_VERSION) =>  
...
```

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
