### PR TITLE
ci: skip online tests due to flakiness

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1050,6 +1050,7 @@ jobs:
     environment:
       DDAGENT_HOSTNAME: 127.0.0.1
       DD_AGENT_HOST: 127.0.0.1
+      SKIP_ONLINE_TESTS: 1 # too flaky
     executor:
       name: with_agent
       docker_image: << parameters.docker_image >>

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -194,6 +194,7 @@ ext/simplexml/tests/simplexml_load_file.phpt
 ext/sockets/tests/socket_connect_params.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
+ext/sockets/tests/socket_shutdown.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt
 ext/spl/tests/ArrayObject_dump_during_sort.phpt
 ext/spl/tests/ArrayObject_exchange_array_during_sorting.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -160,3 +160,13 @@ ddtrace affects the order of destructor execution due to creating span stacks et
 ## `ext/zend_test/tests/`, `Zend/tests/gh10346.phpt`
 
 Observer tests trace all functions, including dd setup. Exclude these from being observed.
+
+## SKIP\_ONLINE\_TESTS
+
+The env var `SKIP_ONLINE_TESTS` is set so that in newer PHP versions, we skip
+any test which checks this env var. Online tests are too flaky for CI.
+
+The exact PHP version that a given test checks this env var varies, but these
+are some tests which are skipped for older versions which don't check it:
+
+ - `ext/sockets/tests/socket_shutdown.phpt`


### PR DESCRIPTION
### Description

The language tests are sometimes flaky with network related tests. Although we've added many to our xfail lists, new ones get added from time to time when we update PHP versions used in the tests. This seems a bit more robust than explicitly listing all of them in the xfail lists.

Some online tests like `ext/sockets/tests/socket_shutdown.phpt` exist on versions which don't check `SKIP_ONLINE_TESTS`, so they are added to the xfail lists for the relevant versions.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ This skips tests ^_^

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
