### PR TITLE
Improve cargo build a bit

### DIFF
--- a/.cargo-registry/.gitignore
+++ b/.cargo-registry/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/components-rs/build.rs
+++ b/components-rs/build.rs
@@ -21,9 +21,15 @@ fn main() {
             let object_paths: Vec<_> = split_vec.iter().skip(1).map(Path::new).collect();
             match generate_mock_symbols(binary_path, object_paths.as_slice()) {
                 Ok(mock_symbols) => {
-                    if let Err(err) = fs::write("mock_php.c", mock_symbols) {
-                        eprintln!("Failed generating mock_php.c: {}", err);
-                        process::exit(1);
+                    if fs::read("mock_php.c")
+                        .ok()
+                        .map(|contents| contents == mock_symbols.as_str().as_bytes())
+                        != Some(true)
+                    {
+                        if let Err(err) = fs::write("mock_php.c", mock_symbols) {
+                            eprintln!("Failed generating mock_php.c: {}", err);
+                            process::exit(1);
+                        }
                     }
                 }
                 Err(err) => {

--- a/config.m4
+++ b/config.m4
@@ -276,7 +276,7 @@ if test "$PHP_DDTRACE" != "no"; then
   fi
 
   cat <<EOT >> Makefile.fragments
-\$(builddir)/target/$ddtrace_cargo_profile/libddtrace_php.a: $( (find "$ext_srcdir/components-rs" -name "*.c" -o -name "*.rs" -o -name "Cargo.toml"; find "$ext_srcdir/../../libdatadog" -name "*.rs" -exclude "target"; find "$ext_srcdir/libdatadog" -name "*.rs" -exclude "target"; echo "$all_object_files" ) | xargs )
+\$(builddir)/target/$ddtrace_cargo_profile/libddtrace_php.a: $( (find "$ext_srcdir/components-rs" -name "*.c" -o -name "*.rs" -o -name "Cargo.toml"; find "$ext_srcdir/../../libdatadog" -name "*.rs" -not -path "*/target/*"; find "$ext_srcdir/libdatadog" -name "*.rs" -not -path "*/target/*"; echo "$all_object_files" ) 2>/dev/null | xargs )
 	(cd "$ext_srcdir/components-rs"; $ddtrace_mock_sources CARGO_TARGET_DIR=\$(builddir)/target/ \$(DDTRACE_CARGO) build $(test "$ddtrace_cargo_profile" == debug || echo --profile tracer-release) && test "$PHP_DDTRACE_RUST_SYMBOLS" == yes || strip -d \$(builddir)/target/$ddtrace_cargo_profile/libddtrace_php.a)
 EOT
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-aliases:
         - .composer:/home/circleci/.composer
         - .scenarios.lock:/home/circleci/app/.scenarios.lock
         - agent-socket:/var/run/datadog
+        - .cargo-registry:/rust/cargo/registry
       tmpfs: [ '/home/circleci/app/tmp:uid=3434,gid=3434,exec', '/home/circleci/app/tests/vendor:uid=3434,gid=3434,exec' ]
       depends_on:
         - agent


### PR DESCRIPTION
### Description

- Use a shared cache of dependencies
- Ensure that cargo doesn't always need to recompile when tracer files change
- Fix tracking of rust dependencies in Makefile

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
