### PR TITLE
Reflect changes to datadog.version and datadog.env in existing spans

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -70,7 +70,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                               \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                  \
-    CONFIG(STRING, DD_ENV, "")                                                                                 \
+    CONFIG(STRING, DD_ENV, "", .ini_change = ddtrace_alter_dd_env)                                             \
     CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                 \
     CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                               \
     CONFIG(BOOL, DD_HTTP_SERVER_ROUTE_BASED_NAMING, "true")                                                    \
@@ -145,7 +145,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(INT, DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT, "80", .ini_change = zai_config_system_ini_change)  \
     CONFIG(BOOL, DD_TRACE_WARN_LEGACY_DD_TRACE, "true")                                                        \
     CONFIG(BOOL, DD_TRACE_RETAIN_THREAD_CAPABILITIES, "false", .ini_change = zai_config_system_ini_change)     \
-    CONFIG(STRING, DD_VERSION, "")                                                                             \
+    CONFIG(STRING, DD_VERSION, "", .ini_change = ddtrace_alter_dd_version)                                     \
     CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_ENABLED, "false")                                                          \
     CONFIG(STRING, DD_TRACE_CLIENT_IP_HEADER, "")                                                              \

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -83,6 +83,8 @@ void ddtrace_disable_tracing_in_current_request(void);
 bool ddtrace_alter_dd_trace_disabled_config(zval *old_value, zval *new_value);
 bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value);
 bool ddtrace_alter_default_propagation_style(zval *old_value, zval *new_value);
+bool ddtrace_alter_dd_env(zval *old_value, zval *new_value);
+bool ddtrace_alter_dd_version(zval *old_value, zval *new_value);
 void dd_force_shutdown_tracing(void);
 
 typedef struct {

--- a/tests/ext/runtime_ini_env_version_change.phpt
+++ b/tests/ext/runtime_ini_env_version_change.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Change the env and version INIs at runtime
+--FILE--
+<?php
+
+var_dump(isset(\DDTrace\root_span()->meta["env"]), isset(\DDTrace\root_span()->meta["version"]));
+
+ini_set("datadog.env", "test");
+ini_set("datadog.version", "1.0.0");
+
+echo "New env: ", \DDTrace\root_span()->meta["env"], "\n";
+echo "New version: ", \DDTrace\root_span()->meta["version"], "\n";
+
+?>
+--EXPECT--
+bool(false)
+bool(false)
+New env: test
+New version: 1.0.0


### PR DESCRIPTION
### Description

Generally, users have been trying to change datadog.version or datadog.env at runtime (because it fits their setup easier) and were disappointed it to not affect the root span.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
