### PR TITLE
(Legacy OpenTracing API) Check if the active span has a parent

### DIFF
--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -129,8 +129,8 @@ final class ScopeManager implements ScopeManagerInterface
 
         $currentSpanId = $topScope->getSpan()->getSpanId();
         $newScopes = [];
-        for ($span = active_span(); $span->id != $currentSpanId; $span = $span->parent) {
-            $scope = new Scope($this, new Span($span, new SpanContext(trace_id(), $span->id, $span->parent->id)), true);
+        for ($span = active_span(); $span && ($span->id != $currentSpanId); $span = $span->parent) {
+            $scope = new Scope($this, new Span($span, new SpanContext(trace_id(), $span->id, $span->parent ? $span->parent->id : null)), true);
             $newScopes[] = $scope;
         }
         foreach (array_reverse($newScopes) as $scope) {

--- a/tests/Common/BaseTestCase.php
+++ b/tests/Common/BaseTestCase.php
@@ -13,7 +13,7 @@ use DDTrace\Util\Versions;
  * @method void assertEmpty(array $arr)
  * @method void assertFalse(boolean $value)
  * @method void assertNotEmpty(array $arr)
- * @method void assertSame(mixed $expected, array $value)
+ * @method void assertSame(mixed $expected, mixed $value)
  * @method void assertTrue(boolean $value)
  */
 abstract class BaseTestCase extends MultiPHPUnitVersionAdapter

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -276,12 +276,13 @@ final class TracerTest extends BaseTestCase
 
         $tracer = new Tracer(new DebugTransport());
         $tracer->startRootSpan('foo');
-        $tracer->getActiveSpan();
+        $foo = $tracer->getActiveSpan();
 
-        \DDTrace\start_trace_span();
-        $tracer->getActiveSpan();
+        $rootSpan = \DDTrace\start_trace_span();
+        $this->assertSame($tracer->getActiveSpan()->internalSpan, $rootSpan);
         \DDTrace\close_span();
 
+        $this->assertSame($foo, $tracer->getActiveSpan());
         $tracer->getActiveSpan()->finish();
 
         $this->assertSame(2, dd_trace_closed_spans_count());

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -271,9 +271,6 @@ final class TracerTest extends BaseTestCase
 
     public function testMixingOpenTracingAndModernAPI()
     {
-        self::putenv('DD_TRACE_GENERATE_ROOT_SPAN=0');
-        dd_trace_internal_fn('ddtrace_reload_config');
-
         $tracer = new Tracer(new DebugTransport());
         $tracer->startRootSpan('foo');
         $foo = $tracer->getActiveSpan();
@@ -288,8 +285,5 @@ final class TracerTest extends BaseTestCase
         $this->assertSame(2, dd_trace_closed_spans_count());
         $traces = \dd_trace_serialize_closed_spans();
         $this->assertCount(2, $traces);
-
-        self::putenv('DD_TRACE_GENERATE_ROOT_SPAN');
-        dd_trace_internal_fn('ddtrace_reload_config');
     }
 }


### PR DESCRIPTION
### Description

While experimenting with ways to reproduce #2172, I stumbled on an issue that would lead to the tracer crashing with the error message `Attempt to read property "id" on null`. The latter would happen when using `Tracer::getActiveSpan` after `start_root_span()` was called.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors, the reviewer is in charge of this task.
