### PR TITLE
feat(profiling): add arg0 to WordPress's do_action frame 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
 name = "ddtrace-php"
 version = "0.0.1"
 dependencies = [
+ "bitflags 2.3.3",
  "cbindgen",
  "cc_utils",
  "datadog-sidecar",

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -19,7 +19,7 @@ use config::AgentEndpoint;
 use datadog_profiling::exporter::{Tag, Uri};
 use ddcommon::cstr;
 use lazy_static::lazy_static;
-use libc::c_char;
+use libc::{c_char, c_short, c_ushort};
 use log::{debug, error, info, trace, warn, LevelFilter};
 use once_cell::sync::OnceCell;
 use profiling::{LocalRootSpanResourceMessage, Profiler, VmInterrupt};

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -19,7 +19,7 @@ use config::AgentEndpoint;
 use datadog_profiling::exporter::{Tag, Uri};
 use ddcommon::cstr;
 use lazy_static::lazy_static;
-use libc::{c_char, c_short, c_ushort};
+use libc::c_char;
 use log::{debug, error, info, trace, warn, LevelFilter};
 use once_cell::sync::OnceCell;
 use profiling::{LocalRootSpanResourceMessage, Profiler, VmInterrupt};

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -399,3 +399,19 @@ bool ddog_php_jit_enabled() {
     }
     return jit;
 }
+
+zval *ddog_php_prof_zend_call_arg(zend_execute_data const *ex, unsigned int n) {
+    uint32_t arg_count = ZEND_CALL_NUM_ARGS(ex);
+    if (n >= arg_count) {
+        return NULL;
+    }
+
+    uint32_t first_extra_arg = ex->func->op_array.num_args;
+    if (n >= first_extra_arg && (arg_count > first_extra_arg)) {
+        // Return NULL for now. We aren't using this case. I'm also not sure
+        // how stable it is.
+        return NULL;
+    }
+
+    return ZEND_CALL_ARG(ex, n + 1);
+}

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -129,3 +129,9 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data);
 
 void ddog_php_opcache_init_handle();
 bool ddog_php_jit_enabled();
+
+/**
+ * Gets arg `n` of the `ex` frame. Returns NULL on error.
+ * @see ZEND_FUNCTION(func_get_arg)
+ */
+zval *ddog_php_prof_zend_call_arg(zend_execute_data const *ex, unsigned int n);

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -760,7 +760,7 @@ impl Profiler {
         match self.send_sample(Profiler::prepare_sample_message(
             vec![ZendFrame {
                 function: "[eval]".into(),
-                file: Some(Cow::Owned(filename)),
+                file: Some(filename),
                 line,
             }],
             SampleValues {

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -144,8 +144,8 @@ unsafe fn interesting_arg0(
 
             match std::str::from_utf8(param0_name) {
                 Ok(HOOK_NAME) => return Some((method_name, HOOK_NAME)),
-                Ok(name) => log::debug!("'{method_name}' is likely not WordPress's: parameter 0 has name '{name}' instead of 'hook_name'"),
-                Err(err) => log::debug!("encountered invalid utf-8 string in parameter 0 of {method_name}: {err}"),
+                Ok(name) => log::trace!("'{method_name}' is likely not WordPress's: parameter 0 has name '{name}' instead of 'hook_name'"),
+                Err(err) => log::warn!("encountered invalid utf-8 string in parameter 0 of {method_name}: {err}"),
             }
         }
         _ => {}


### PR DESCRIPTION
### Description

Example: `do_action(hook_name: 'rest_api_init')`.

When looking at WordPress profiles, it's helpful to know what action is attached to the frame. For example, if I browse to the profile from the Code Hotspot  section from  a span `action` with tag `wp.hook` of `rest_api_init`, it's nice to know which of the 4 possible `do_action` frames is the one for `rest_api_init`.

We may also be able to use this info in a smart way when building the breakdown as well.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [ ] Milestone is set.
