### PR TITLE
Run profiling benchmarks in Gitlab only when changes are detected

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -7,7 +7,11 @@ benchmarks:
   stage: benchmarks
   rules:
     - changes:
-      - profiling/**/*
+        paths:
+          - profiling/**/*
+        compare_to: "master"
+      when: on_success
+    - when: manual
   tags: ["runner:apm-k8s-tweaked-metal"]
   needs: []
   image:


### PR DESCRIPTION
### Description

Fixes the the changes detection on Gitlab, so it starts working for new branches.

Gitlab has a known issue with changes detection, please see documentation for more info:
* https://docs.gitlab.com/ee/ci/jobs/job_control.html#jobs-or-pipelines-run-unexpectedly-when-using-changes
* https://gitlab.com/gitlab-org/gitlab/-/issues/11427

Gitlab ignores `changes` keyword when a new branch is pushed, unless merge request on Gitlab exists (which doesn't, since we use custom gitsync tooling). In order to mitigate the issue, [a keyword `compare_to` was introduced in Gitlab](https://docs.gitlab.com/ee/ci/yaml/#ruleschangescompare_to), so developers can specify a ref for changes detection.

This PR uses `compare_to` to enable automatic benchmark runs for branches that have changes in `/profiling` directory in comparison to `master` branch.

If no changes are detected, it is now possible to run benchmarks manually.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
