### PR TITLE
Refactor zai_string_view APIs and use them more

### DIFF
--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -54,11 +54,11 @@ DD_CONFIGURATION
 
 static bool dd_parse_dbm_mode(zai_string_view value, zval *decoded_value, bool persistent) {
     UNUSED(persistent);
-    if (zai_string_equals_ci_cstr(value, "disabled")) {
+    if (zai_str_equals_ci_cstr(value, "disabled")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_DISABLED);
-    } else if (zai_string_equals_ci_cstr(value, "service")) {
+    } else if (zai_str_equals_ci_cstr(value, "service")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_SERVICE);
-    } else if (zai_string_equals_ci_cstr(value, "full")) {
+    } else if (zai_str_equals_ci_cstr(value, "full")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_FULL);
     } else {
         return false;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -54,11 +54,11 @@ DD_CONFIGURATION
 
 static bool dd_parse_dbm_mode(zai_string_view value, zval *decoded_value, bool persistent) {
     UNUSED(persistent);
-    if (zai_string_equals_literal_ci(value, "disabled")) {
+    if (zai_string_equals_ci_cstr(value, "disabled")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_DISABLED);
-    } else if (zai_string_equals_literal_ci(value, "service")) {
+    } else if (zai_string_equals_ci_cstr(value, "service")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_SERVICE);
-    } else if (zai_string_equals_literal_ci(value, "full")) {
+    } else if (zai_string_equals_ci_cstr(value, "full")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_FULL);
     } else {
         return false;

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1213,7 +1213,7 @@ PHP_FUNCTION(dd_trace_env_config) {
     }
 
     zai_config_id id;
-    if (zai_config_get_id_by_name((zai_string_view){.ptr = ZSTR_VAL(env_name), .len = ZSTR_LEN(env_name)}, &id)) {
+    if (zai_config_get_id_by_name(ZAI_STRING_FROM_ZSTR(env_name), &id)) {
         RETURN_COPY(zai_config_get_value(id));
     } else {
         RETURN_NULL();

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -557,7 +557,7 @@ PHP_FUNCTION(DDTrace_remove_hook) {
     dd_uhook_def *def;
     if ((def = zend_hash_index_find_ptr(&dd_active_hooks, (zend_ulong)id))) {
         if (def->function) {
-            zai_string_view scope = zai_string_from_zstr(def->scope);
+            zai_string_view scope = zai_str_from_zstr(def->scope);
             zai_string_view function = ZAI_STRING_FROM_ZSTR(def->function);
             zai_hook_remove(scope, function, id);
         } else {

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -485,13 +485,13 @@ type_error:
         }
     } else {
         const char *colon = strchr(ZSTR_VAL(name), ':');
-        zai_string_view scope = ZAI_STRING_EMPTY, function = {.ptr = ZSTR_VAL(name), .len = ZSTR_LEN(name)};
+        zai_string_view scope = ZAI_STRING_EMPTY, function = ZAI_STRING_FROM_ZSTR(name);
         if (colon) {
             def->scope = zend_string_init(function.ptr, colon - ZSTR_VAL(name), 0);
             do ++colon; while (*colon == ':');
             def->function = zend_string_init(colon, ZSTR_VAL(name) + ZSTR_LEN(name) - colon, 0);
-            scope = (zai_string_view) {.ptr = ZSTR_VAL(def->scope), .len = ZSTR_LEN(def->scope)};
-            function = (zai_string_view) {.ptr = ZSTR_VAL(def->function), .len = ZSTR_LEN(def->function)};
+            scope = ZAI_STRING_FROM_ZSTR(def->scope);
+            function = ZAI_STRING_FROM_ZSTR(def->function);
         } else {
             def->scope = NULL;
             if (ZSTR_LEN(name) == 0 || strchr(ZSTR_VAL(name), '.')) {
@@ -557,10 +557,8 @@ PHP_FUNCTION(DDTrace_remove_hook) {
     dd_uhook_def *def;
     if ((def = zend_hash_index_find_ptr(&dd_active_hooks, (zend_ulong)id))) {
         if (def->function) {
-            zai_string_view scope = ZAI_STRING_EMPTY, function = { .ptr = ZSTR_VAL(def->function), .len = ZSTR_LEN(def->function) };
-            if (def->scope) {
-                scope = (zai_string_view){ .ptr = ZSTR_VAL(def->scope), .len = ZSTR_LEN(def->scope) };
-            }
+            zai_string_view scope = zai_string_from_zstr(def->scope);
+            zai_string_view function = ZAI_STRING_FROM_ZSTR(def->function);
             zai_hook_remove(scope, function, id);
         } else {
             zai_hook_remove_resolved(def->install_address, id);

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -75,9 +75,9 @@ static void dd_invoke_integration_loader_and_unhook_posthook(zend_ulong invocati
         bool success;
         zval *thisp = getThis();
         if (thisp) {
-            success = zai_symbol_call_literal(ZEND_STRL("ddtrace\\integrations\\load_deferred_integration"), &rv, 2, &integration, thisp);
+            success = zai_symbol_call_global(ZAI_STRL_VIEW("ddtrace\\integrations\\load_deferred_integration"), &rv, 2, &integration, thisp);
         } else {
-            success = zai_symbol_call_literal(ZEND_STRL("ddtrace\\integrations\\load_deferred_integration"), &rv, 1, &integration);
+            success = zai_symbol_call_global(ZAI_STRL_VIEW("ddtrace\\integrations\\load_deferred_integration"), &rv, 1, &integration);
         }
 
         if (UNEXPECTED(!success)) {

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -581,7 +581,7 @@ static zend_string *dd_build_req_url() {
     if (question_mark) {
         uri_len = question_mark - uri;
         query_string = zai_filter_query_string(
-            ZAI_STRING_VIEW_NEW(question_mark + 1, strlen(uri) - uri_len - 1),
+            ZAI_STR_NEW(question_mark + 1, strlen(uri) - uri_len - 1),
             get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
     } else {
         uri_len = strlen(uri);
@@ -664,7 +664,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
                 const char *query_str = dd_get_query_string();
                 if (query_str) {
                     query_string =
-                        zai_filter_query_string(ZAI_STRING_FROM_CSTR(query_str),
+                        zai_filter_query_string(ZAI_STR_FROM_CSTR(query_str),
                                                 get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
                                                 get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                 }

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -581,7 +581,7 @@ static zend_string *dd_build_req_url() {
     if (question_mark) {
         uri_len = question_mark - uri;
         query_string = zai_filter_query_string(
-            (zai_string_view){.len = strlen(uri) - uri_len - 1, .ptr = question_mark + 1},
+            ZAI_STRING_VIEW_NEW(question_mark + 1, strlen(uri) - uri_len - 1),
             get_DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED(), get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
     } else {
         uri_len = strlen(uri);
@@ -664,7 +664,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
                 const char *query_str = dd_get_query_string();
                 if (query_str) {
                     query_string =
-                        zai_filter_query_string((zai_string_view){.len = strlen(query_str), .ptr = query_str},
+                        zai_filter_query_string(ZAI_STRING_FROM_CSTR(query_str),
                                                 get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
                                                 get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                 }

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -34,7 +34,7 @@ static void zai_config_find_and_set_value(zai_config_memoized_entry *memoized, z
     for (; name_index < memoized->names_count; name_index++) {
         zai_string_view name = {.len = memoized->names[name_index].len, .ptr = memoized->names[name_index].ptr};
         if (zai_config_get_env_value(name, buf)) {
-            zai_string_view env_value = {.len = strlen(buf.ptr), .ptr = buf.ptr};
+            zai_string_view env_value = ZAI_STRING_FROM_CSTR(buf.ptr);
             if (!zai_config_decode_value(env_value, memoized->type, memoized->parser, &tmp, /* persistent */ true)) {
                 // TODO Log decoding error
             } else {

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -34,7 +34,7 @@ static void zai_config_find_and_set_value(zai_config_memoized_entry *memoized, z
     for (; name_index < memoized->names_count; name_index++) {
         zai_string_view name = {.len = memoized->names[name_index].len, .ptr = memoized->names[name_index].ptr};
         if (zai_config_get_env_value(name, buf)) {
-            zai_string_view env_value = ZAI_STRING_FROM_CSTR(buf.ptr);
+            zai_string_view env_value = ZAI_STR_FROM_CSTR(buf.ptr);
             if (!zai_config_decode_value(env_value, memoized->type, memoized->parser, &tmp, /* persistent */ true)) {
                 // TODO Log decoding error
             } else {

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -235,7 +235,7 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
     }
 
     zai_config_id duplicate;
-    if (zai_config_get_id_by_name(ZAI_STRING_VIEW_NEW(ini_name->ptr, ini_name->len), &duplicate)) {
+    if (zai_config_get_id_by_name(ZAI_STR_NEW(ini_name->ptr, ini_name->len), &duplicate)) {
         return;
     }
 
@@ -246,7 +246,7 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
         memoized->original_on_modify = existing->on_modify;
         zai_string_view current_value = memoized->default_encoded_value;
         zai_string_view value_view = ZAI_STRING_FROM_ZSTR(existing->value);
-        if (!zai_string_view_eq(current_value, value_view)) {
+        if (!zai_str_eq(current_value, value_view)) {
             zval decoded;
             // This should never fail, ideally, as all usages should validate the same way, but at least not crash, just don't accept the value then
             if (zai_config_decode_value(value_view, memoized->type, memoized->parser, &decoded, 1)) {

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -32,8 +32,11 @@ static void zai_config_lock_ini_copying(THREAD_T thread_id) {
 #endif
 
 // values retrieved here are assumed to be valid
-int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_count, zai_string_view *buf,
-                                        zai_string_view default_value, zai_config_id entry_id) {
+int16_t zai_config_initialize_ini_value(zend_ini_entry **entries,
+                                        int16_t ini_count,
+                                        zai_option_str *buf,
+                                        zai_string_view default_value,
+                                        zai_config_id entry_id) {
     if (!env_to_ini_name) return -1;
 
     zai_config_memoized_entry *memoized = &zai_config_memoized_entries[entry_id];
@@ -106,7 +109,7 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
             if (i > 0) {
                 zend_string_release(*target);
                 *target = zend_string_copy(entries[0]->modified ? entries[0]->orig_value : entries[0]->value);
-            } else if (buf->ptr != NULL) {
+            } else if (zai_option_str_is_some(*buf)) {
                 zend_string_release(*target);
                 *target = zend_string_init(buf->ptr, buf->len, 1);
             } else if (parsed_ini_value != NULL) {
@@ -133,7 +136,7 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
             buf->ptr = ZSTR_VAL(runtime_value);
             buf->len = ZSTR_LEN(runtime_value);
             zend_string_release(runtime_value);
-        } else if (parsed_ini_value && buf->ptr == NULL) {
+        } else if (parsed_ini_value && zai_option_str_is_none(*buf)) {
             buf->ptr = ZSTR_VAL(parsed_ini_value);
             buf->len = ZSTR_LEN(parsed_ini_value);
         }

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -235,7 +235,7 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
     }
 
     zai_config_id duplicate;
-    if (zai_config_get_id_by_name((zai_string_view){.ptr = ini_name->ptr, .len = ini_name->len}, &duplicate)) {
+    if (zai_config_get_id_by_name(ZAI_STRING_VIEW_NEW(ini_name->ptr, ini_name->len), &duplicate)) {
         return;
     }
 
@@ -245,8 +245,8 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
     if ((existing = zend_hash_str_find_ptr(EG(ini_directives), ini_name->ptr, ini_name->len))) {
         memoized->original_on_modify = existing->on_modify;
         zai_string_view current_value = memoized->default_encoded_value;
-        if (ZSTR_LEN(existing->value) != current_value.len || memcmp(current_value.ptr, ZSTR_VAL(existing->value), ZSTR_LEN(existing->value)) != 0) {
-            zai_string_view value_view = (zai_string_view){ .ptr = existing->value->val, .len = existing->value->len };
+        zai_string_view value_view = ZAI_STRING_FROM_ZSTR(existing->value);
+        if (!zai_string_view_eq(current_value, value_view)) {
             zval decoded;
             // This should never fail, ideally, as all usages should validate the same way, but at least not crash, just don't accept the value then
             if (zai_config_decode_value(value_view, memoized->type, memoized->parser, &decoded, 1)) {

--- a/zend_abstract_interface/config/config_ini.h
+++ b/zend_abstract_interface/config/config_ini.h
@@ -28,8 +28,11 @@ void zai_config_ini_mshutdown();
  * but these get applied before first time rinit. So we need to find the highest priority ini value
  * and apply these as runtime config to all other values
  */
-int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_count, zai_string_view *buf,
-                                        zai_string_view default_value, zai_config_id entry_id);
+int16_t zai_config_initialize_ini_value(zend_ini_entry **entries,
+                                        int16_t ini_count,
+                                        zai_option_str *buf,
+                                        zai_string_view default_value,
+                                        zai_config_id entry_id);
 
 typedef bool (*zai_config_apply_ini_change)(zval *old_value, zval *new_value);
 

--- a/zend_abstract_interface/config/config_runtime.c
+++ b/zend_abstract_interface/config/config_runtime.c
@@ -57,7 +57,7 @@ void zai_config_register_config_id(zai_config_name *name, zai_config_id id) {
 
 bool zai_config_get_id_by_name(zai_string_view name, zai_config_id *id) {
     if (!zai_config_name_map.nTableSize) return false;
-    if (!zai_string_stuffed(name) || !id) return false;
+    if (zai_str_is_empty(name) || !id) return false;
 
     assert(name.ptr && name.len && id);
     if (!zai_config_name_map.nTableSize) {

--- a/zend_abstract_interface/env/env.c
+++ b/zend_abstract_interface/env/env.c
@@ -15,7 +15,7 @@ zai_env_result zai_getenv_ex(zai_string_view name, zai_env_buffer buf, bool pre_
 
     buf.ptr[0] = '\0';
 
-    if (!zai_string_stuffed(name)) return ZAI_ENV_ERROR;
+    if (zai_str_is_empty(name)) return ZAI_ENV_ERROR;
 
     if (buf.len > ZAI_ENV_MAX_BUFSIZ) return ZAI_ENV_BUFFER_TOO_BIG;
 

--- a/zend_abstract_interface/exceptions/exceptions.h
+++ b/zend_abstract_interface/exceptions/exceptions.h
@@ -20,7 +20,7 @@ static inline zval *zai_exception_read_property(zend_object *object, const char 
 
     ZVAL_OBJ(&zv, object);
 
-    zval *property = zai_symbol_lookup_property(ZAI_SYMBOL_SCOPE_OBJECT, &zv, ZAI_STRING_VIEW_NEW(pn, pnl));
+    zval *property = zai_symbol_lookup_property(ZAI_SYMBOL_SCOPE_OBJECT, &zv, ZAI_STR_NEW(pn, pnl));
 
     if (!property) {
         return &EG(uninitialized_zval);

--- a/zend_abstract_interface/exceptions/exceptions.h
+++ b/zend_abstract_interface/exceptions/exceptions.h
@@ -5,6 +5,7 @@
 // dummy comment here to prevent clang format fixer from reordering includes here
 #include <Zend/zend_exceptions.h>
 #include <symbols/symbols.h>
+#include <zai_string/string.h>
 
 static inline zend_class_entry *zai_get_exception_base(zend_object *object) {
     assert(instanceof_function(object->ce, zend_ce_throwable));
@@ -19,7 +20,7 @@ static inline zval *zai_exception_read_property(zend_object *object, const char 
 
     ZVAL_OBJ(&zv, object);
 
-    zval *property = zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_OBJECT, &zv, pn, pnl);
+    zval *property = zai_symbol_lookup_property(ZAI_SYMBOL_SCOPE_OBJECT, &zv, ZAI_STRING_VIEW_NEW(pn, pnl));
 
     if (!property) {
         return &EG(uninitialized_zval);
@@ -34,7 +35,7 @@ static inline zval *zai_exception_read_property(zend_object *object, zend_string
 
     ZVAL_OBJ(&zv, object);
 
-    zval *property = zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_OBJECT, &zv, ZSTR_VAL(name), ZSTR_LEN(name));
+    zval *property = zai_symbol_lookup_property(ZAI_SYMBOL_SCOPE_OBJECT, &zv, ZAI_STRING_FROM_ZSTR(name));
 
     if (!property) {
         return &EG(uninitialized_zval);

--- a/zend_abstract_interface/exceptions/tests/exceptions.cc
+++ b/zend_abstract_interface/exceptions/tests/exceptions.cc
@@ -9,7 +9,7 @@ extern "C" {
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading message with non-string type returns a non-empty string", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\broken_exception"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\broken_exception"), &ex, 0);
 
     zend_string *str = zai_exception_message(Z_OBJ(ex));
     REQUIRE(ZSTR_LEN(str) > 0);
@@ -20,7 +20,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading message with non-string type retu
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from exception", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\legitimate_exception"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\legitimate_exception"), &ex, 0);
 
     zend_string *str = zai_exception_message(Z_OBJ(ex));
     REQUIRE(zend_string_equals_literal(str, "msg"));
@@ -31,7 +31,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from exception", "./stubs
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from exception subclass", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\child_exception"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\child_exception"), &ex, 0);
 
     zend_string *str = zai_exception_message(Z_OBJ(ex));
     REQUIRE(zend_string_equals_literal(str, "msg"));
@@ -42,7 +42,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from exception subclass",
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from error", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\legitimate_error"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\legitimate_error"), &ex, 0);
 
     zend_string *str = zai_exception_message(Z_OBJ(ex));
     REQUIRE(zend_string_equals_literal(str, "msg"));
@@ -53,7 +53,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from error", "./stubs/fun
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from error subclass", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\child_error"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\child_error"), &ex, 0);
 
     zend_string *str = zai_exception_message(Z_OBJ(ex));
     REQUIRE(zend_string_equals_literal(str, "msg"));
@@ -64,7 +64,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading message from error subclass", "./
 TEA_TEST_CASE_WITH_STUB("exceptions", "reading trace from exception", "./stubs/functions.php", {
     zval ex;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\legitimate_exception"), &ex, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\legitimate_exception"), &ex, 0);
 
     zend_string *str = zai_get_trace_without_args_from_exception(Z_OBJ(ex));
     REQUIRE(zend_string_equals_literal(str, "#0 [internal function]: zai\\exceptions\\test\\legitimate_exception()\n"
@@ -77,7 +77,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "reading trace from exception", "./stubs/f
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid frame", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\trace_with_bad_frame"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\trace_with_bad_frame"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));
@@ -92,7 +92,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid frame", ".
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing valid trace", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\good_trace_with_all_values"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\good_trace_with_all_values"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));
@@ -106,7 +106,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "serializing valid trace", "./stubs/functi
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid filename", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\trace_with_invalid_filename"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\trace_with_invalid_filename"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));
@@ -120,7 +120,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid filename",
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace without line number", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\trace_without_line_number"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\trace_without_line_number"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));
@@ -134,7 +134,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace without line number", "
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid line number", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\trace_with_invalid_line_number"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\trace_with_invalid_line_number"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));
@@ -148,7 +148,7 @@ TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid line numbe
 TEA_TEST_CASE_WITH_STUB("exceptions", "serializing trace with invalid class, type and function", "./stubs/functions.php", {
     zval trace;
 
-    zai_symbol_call_literal(ZEND_STRL("zai\\exceptions\\test\\trace_with_invalid_class_type_function"), &trace, 0);
+    zai_symbol_call_global(ZAI_STRL_VIEW("zai\\exceptions\\test\\trace_with_invalid_class_type_function"), &trace, 0);
 
     zend_string *str = zai_get_trace_without_args(Z_ARR(trace));
     printf("%s", ZSTR_VAL(str));

--- a/zend_abstract_interface/headers/headers.c
+++ b/zend_abstract_interface/headers/headers.c
@@ -4,7 +4,7 @@
 #include <zai_assert/zai_assert.h>
 
 zai_header_result zai_read_header(zai_string_view uppercase_header_name, zend_string **header_value) {
-    if (!zai_string_stuffed(uppercase_header_name) || !header_value) return ZAI_HEADER_ERROR;
+    if (zai_str_is_empty(uppercase_header_name) || !header_value) return ZAI_HEADER_ERROR;
 
     zai_assert_is_upper(uppercase_header_name.ptr, "Header names must be uppercase.");
 

--- a/zend_abstract_interface/interceptor/tests/resolver.cc
+++ b/zend_abstract_interface/interceptor/tests/resolver.cc
@@ -121,11 +121,11 @@ TEA_TEST_CASE_WITH_PROLOGUE("interceptor", "runtime top-level resolving", init_i
     REQUIRE(stub);
 
     {
-        zend_function *fn = zai_symbol_lookup_function_literal(ZEND_STRL("doAlias"));
+        zend_function *fn = zai_symbol_lookup_function_global(ZAI_STRL_VIEW("doAlias"));
         CHECK(hook_is_installed(&fn->op_array));
     }
     {
-        zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("TopLevel"));
+        zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("TopLevel"));
         zai_string_view name = ZAI_STRL_VIEW("foo");
         zend_function *classfn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
         CHECK(hook_is_installed(&classfn->op_array));
@@ -135,21 +135,21 @@ TEA_TEST_CASE_WITH_PROLOGUE("interceptor", "runtime top-level resolving", init_i
 INTERCEPTOR_TEST_CASE("runtime eval resolving", {
     INSTALL_HOOK("dynamicFunction");
     CALL_FN("doEval");
-    zend_function *fn = zai_symbol_lookup_function_literal(ZEND_STRL("dynamicFunction"));
+    zend_function *fn = zai_symbol_lookup_function_global(ZAI_STRL_VIEW("dynamicFunction"));
     REQUIRE(hook_is_installed(&fn->op_array));
 });
 
 INTERCEPTOR_TEST_CASE("runtime function resolving", {
     INSTALL_HOOK("aFunction");
     CALL_FN("defineFunc");
-    zend_function *fn = zai_symbol_lookup_function_literal(ZEND_STRL("aFunction"));
+    zend_function *fn = zai_symbol_lookup_function_global(ZAI_STRL_VIEW("aFunction"));
     REQUIRE(hook_is_installed(&fn->op_array));
 });
 
 INTERCEPTOR_TEST_CASE("runtime simple class resolving", {
     INSTALL_CLASS_HOOK("Normal", "foo");
     CALL_FN("defineNormal");
-    zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("Normal"));
+    zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("Normal"));
     zai_string_view name = ZAI_STRL_VIEW("foo");
     zend_function *fn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
     REQUIRE(hook_is_installed(&fn->op_array));
@@ -158,7 +158,7 @@ INTERCEPTOR_TEST_CASE("runtime simple class resolving", {
 INTERCEPTOR_TEST_CASE("runtime inherited class resolving", {
     INSTALL_CLASS_HOOK("Inherited", "bar");
     CALL_FN("defineInherited");
-    zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("Inherited"));
+    zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("Inherited"));
     zai_string_view name = ZAI_STRL_VIEW("bar");
     zend_function *fn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
     REQUIRE(hook_is_installed(&fn->op_array));
@@ -168,7 +168,7 @@ INTERCEPTOR_TEST_CASE("runtime inherited delayed class resolving", {
     INSTALL_CLASS_HOOK("Inherited", "bar");
     CALL_FN("defineNormal");
     CALL_FN("defineDelayedInherited");
-    zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("Inherited"));
+    zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("Inherited"));
     zai_string_view name = ZAI_STRL_VIEW("bar");
     zend_function *fn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
     REQUIRE(hook_is_installed(&fn->op_array));
@@ -177,7 +177,7 @@ INTERCEPTOR_TEST_CASE("runtime inherited delayed class resolving", {
 INTERCEPTOR_TEST_CASE("runtime trait using class resolving", {
     INSTALL_CLASS_HOOK("TraitImport", "bar");
     CALL_FN("defineTraitUser");
-    zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("TraitImport"));
+    zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("TraitImport"));
     zai_string_view name = ZAI_STRL_VIEW("bar");
     zend_function *fn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
     REQUIRE(hook_is_installed(&fn->op_array));
@@ -186,7 +186,7 @@ INTERCEPTOR_TEST_CASE("runtime trait using class resolving", {
 INTERCEPTOR_TEST_CASE("runtime class_alias resolving", {
     INSTALL_CLASS_HOOK("Aliased", "foo");
     CALL_FN("doAlias");
-    zend_class_entry *ce = zai_symbol_lookup_class_literal(ZEND_STRL("Aliased"));
+    zend_class_entry *ce = zai_symbol_lookup_class_global(ZAI_STRL_VIEW("Aliased"));
     zai_string_view name = ZAI_STRL_VIEW("foo");
     zend_function *fn = zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_CLASS, ce, &name);
     REQUIRE(hook_is_installed(&fn->op_array));

--- a/zend_abstract_interface/symbols/api/call.h
+++ b/zend_abstract_interface/symbols/api/call.h
@@ -1,6 +1,6 @@
 #ifndef HAVE_ZAI_SYMBOLS_API_CALL_H
 #define HAVE_ZAI_SYMBOLS_API_CALL_H
-// clang-format off
+
 static inline bool zai_symbol_call(
                         zai_symbol_scope_t scope_type, void *scope,
                         zai_symbol_function_t function_type, void *function,
@@ -48,67 +48,21 @@ static inline bool zai_symbol_call_named(
     return result;
 }
 
-static inline bool zai_symbol_call_static(zend_class_entry *scope, zai_string_view *function, zval *rv, uint32_t argc, ...) {
+static inline bool zai_symbol_call_static(zend_class_entry *scope, zai_string_view function, zval *rv, uint32_t argc, ...) {
     bool result;
 
     va_list args;
     va_start(args, argc);
     result =
-        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_CLASS, scope, ZAI_SYMBOL_FUNCTION_NAMED, function, rv, argc, &args);
+        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_CLASS, scope, ZAI_SYMBOL_FUNCTION_NAMED, &function, rv, argc, &args);
     va_end(args);
 
     return result;
 }
 
-static inline bool zai_symbol_call_static_literal(zend_class_entry *scope,
-                                                  const char *fn, size_t fnl,
-                                                  zval *rv,
-                                                  uint32_t argc, ...) {
-    zai_string_view vfn =
-        (zai_string_view) {fnl, fn};
-    bool result;
-
-    va_list args;
-    va_start(args, argc);
-    result =
-        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_CLASS, scope, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv, argc, &args);
-    va_end(args);
-
-    return result;
-}
-
-static inline bool zai_symbol_call_method(zval *zv, zai_string_view *function, zval *rv, uint32_t argc, ...) {
-    bool result;
-
-    va_list args;
-    va_start(args, argc);
-    result =
-        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_OBJECT, zv, ZAI_SYMBOL_FUNCTION_NAMED, function, rv, argc, &args);
-    va_end(args);
-
-    return result;
-}
-
-static inline bool zai_symbol_call_method_literal(zval *zv, const char *fn, size_t fnl, zval *rv, uint32_t argc, ...) {
-    zai_string_view vfn =
-        (zai_string_view) {fnl, fn};
-    bool result;
-
-    va_list args;
-    va_start(args, argc);
-    result =
-        zai_symbol_call_impl(ZAI_SYMBOL_SCOPE_OBJECT, zv, ZAI_SYMBOL_FUNCTION_NAMED, &vfn, rv, argc, &args);
-    va_end(args);
-
-    return result;
-}
-
-static inline bool zai_symbol_call_literal(
-                    const char *fn, size_t fnl,
-                    zval *rv,
-                    uint32_t argc, ...) {
-    zai_string_view vfn =
-        (zai_string_view) {fnl, fn};
+static inline bool zai_symbol_call_global(zai_string_view vfn,
+                                           zval *rv,
+                                           uint32_t argc, ...) {
     bool result;
 
     va_list args;
@@ -120,15 +74,11 @@ static inline bool zai_symbol_call_literal(
     return result;
 }
 
-static inline bool zai_symbol_call_literal_ns(
-                    const char *ns, size_t nsl,
-                    const char *fn, size_t fnl,
-                    zval *rv	,
-                    uint32_t argc, ...) {
-    zai_string_view vns =
-        (zai_string_view) {nsl, ns};
-    zai_string_view vfn =
-        (zai_string_view) {fnl, fn};
+static inline bool zai_symbol_call_ns(
+    zai_string_view vns,
+    zai_string_view vfn,
+    zval *rv,
+    uint32_t argc, ...) {
     bool result;
 
     va_list args;
@@ -139,5 +89,5 @@ static inline bool zai_symbol_call_literal_ns(
 
     return result;
 }
-// clang-format on
+
 #endif

--- a/zend_abstract_interface/symbols/api/class.h
+++ b/zend_abstract_interface/symbols/api/class.h
@@ -1,27 +1,20 @@
 #ifndef HAVE_ZAI_SYMBOLS_API_CLASS_H
 #define HAVE_ZAI_SYMBOLS_API_CLASS_H
-// clang-format off
-static inline zend_class_entry *zai_symbol_lookup_class(
-                                    zai_symbol_scope_t scope_type, void *scope,
-                                    zai_string_view *name	) {
-    return (zend_class_entry *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, scope_type, scope, name	);
+
+static inline
+zend_class_entry *zai_symbol_lookup_class(zai_symbol_scope_t scope_type,
+                                          void *scope,
+                                          zai_string_view *name) {
+    return (zend_class_entry *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CLASS, scope_type, scope, name);
 }
 
-static inline zend_class_entry *zai_symbol_lookup_class_literal(const char *cn, size_t cnl	) {
-    zai_string_view vcn =
-        (zai_string_view){cnl, cn};
-
-    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vcn	);
+static inline zend_class_entry *zai_symbol_lookup_class_global(zai_string_view vcn) {
+    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vcn);
 }
 
-static inline zend_class_entry *zai_symbol_lookup_class_literal_ns(const char *ns, size_t nsl,
-                                                                   const char *cn, size_t cnl	) {
-    zai_string_view vns =
-        (zai_string_view){nsl, ns};
-    zai_string_view vcn =
-        (zai_string_view){cnl, cn};
-
-    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vcn	);
+static inline zend_class_entry *zai_symbol_lookup_class_ns(zai_string_view vns,
+                                                           zai_string_view vcn) {
+    return zai_symbol_lookup_class(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vcn);
 }
-// clang-format on
+
 #endif

--- a/zend_abstract_interface/symbols/api/constant.h
+++ b/zend_abstract_interface/symbols/api/constant.h
@@ -1,27 +1,20 @@
 #ifndef HAVE_ZAI_SYMBOLS_API_CONSTANT_H
 #define HAVE_ZAI_SYMBOLS_API_CONSTANT_H
-// clang-format off
-static inline zval *zai_symbol_lookup_constant(
-                        zai_symbol_scope_t scope_type, void *scope,
-                        zai_string_view *name	) {
-    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, scope_type, scope, name	);
+
+static inline
+zval *zai_symbol_lookup_constant(zai_symbol_scope_t scope_type,
+                                 void *scope,
+                                 zai_string_view name) {
+    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_CONSTANT, scope_type, scope, &name);
 }
 
-static inline zval *zai_symbol_lookup_constant_literal(const char *cn, size_t cnl	) {
-    zai_string_view vcn =
-        (zai_string_view){cnl, cn};
-
-    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vcn	);
+static inline zval *zai_symbol_lookup_constant_global(zai_string_view vcn) {
+    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, vcn);
 }
 
-static inline zval *zai_symbol_lookup_constant_literal_ns(const char *ns, size_t nsl,
-                                                          const char *cn, size_t cnl	) {
-    zai_string_view vns =
-        (zai_string_view){nsl, ns};
-    zai_string_view vcn =
-        (zai_string_view){cnl, cn};
-
-    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vcn	);
+static inline
+zval *zai_symbol_lookup_constant_ns(zai_string_view vns, zai_string_view vcn) {
+    return zai_symbol_lookup_constant(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, vcn);
 }
-// clang-format on
+
 #endif

--- a/zend_abstract_interface/symbols/api/function.h
+++ b/zend_abstract_interface/symbols/api/function.h
@@ -1,27 +1,20 @@
 #ifndef HAVE_ZAI_SYMBOLS_API_FUNCTION_H
 #define HAVE_ZAI_SYMBOLS_API_FUNCTION_H
-// clang-format off
-static inline zend_function *zai_symbol_lookup_function(
-                                zai_symbol_scope_t scope_type, void *scope,
-                                zai_string_view *name	) {
+
+static inline
+zend_function *zai_symbol_lookup_function(zai_symbol_scope_t scope_type,
+                                          void *scope,
+                                          zai_string_view *name) {
     return (zend_function *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_FUNCTION, scope_type, scope, name	);
 }
 
-static inline zend_function *zai_symbol_lookup_function_literal(const char *fn, size_t fnl	) {
-    zai_string_view vfn =
-        (zai_string_view){fnl, fn};
-
-    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vfn	);
+static inline zend_function *zai_symbol_lookup_function_global(zai_string_view vfn) {
+    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_GLOBAL, NULL, &vfn);
 }
 
-static inline zend_function *zai_symbol_lookup_function_literal_ns(const char *ns, size_t nsl,
-                                                                   const char *fn, size_t fnl	) {
-    zai_string_view vns =
-        (zai_string_view){nsl, ns};
-    zai_string_view vfn =
-        (zai_string_view){fnl, fn};
-
-    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vfn	);
+static inline
+zend_function *zai_symbol_lookup_function_ns(zai_string_view vns, zai_string_view vfn) {
+    return zai_symbol_lookup_function(ZAI_SYMBOL_SCOPE_NAMESPACE, &vns, &vfn);
 }
-// clang-format on
+
 #endif

--- a/zend_abstract_interface/symbols/api/property.h
+++ b/zend_abstract_interface/symbols/api/property.h
@@ -1,16 +1,11 @@
 #ifndef HAVE_ZAI_SYMBOLS_API_PROPERTY_H
 #define HAVE_ZAI_SYMBOLS_API_PROPERTY_H
-// clang-format off
-static inline zval *zai_symbol_lookup_property(
-                        zai_symbol_scope_t scope_type, void *scope,
-                        zai_string_view *name	) {
-    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, scope_type, scope, name	);
+
+static inline
+zval *zai_symbol_lookup_property(zai_symbol_scope_t scope_type,
+                                 void *scope,
+                                 zai_string_view name) {
+    return (zval *)zai_symbol_lookup(ZAI_SYMBOL_TYPE_PROPERTY, scope_type, scope, &name);
 }
 
-static inline zval *zai_symbol_lookup_property_literal(zai_symbol_scope_t scope_type, void *scope, const char *pn, size_t pnl	) {
-    zai_string_view vpn =
-        (zai_string_view) {pnl, pn};
-    return zai_symbol_lookup_property(scope_type, scope, &vpn	);
-}
-// clang-format on
 #endif

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -74,7 +74,7 @@ static inline zai_string_view zai_symbol_lookup_clean(zai_string_view view) {
     if (!view.len || *view.ptr != '\\') {
         return view;
     }
-    return (zai_string_view){ .ptr = view.ptr + 1, .len = view.len - 1 };
+    return ZAI_STRING_VIEW_NEW(view.ptr + 1, view.len - 1);
 }
 
 static inline zai_string_view zai_symbol_lookup_key(zai_string_view *namespace, zai_string_view *name, bool lower) {
@@ -199,7 +199,7 @@ static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t 
     return function;
 }
 
-static inline zval* zai_symbol_lookup_constant_global(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name) {
+static inline zval* lookup_constant_global(zai_symbol_scope_t scope_type, void *scope, zai_string_view *name) {
     zai_string_view key = *name;
 
     if (scope_type == ZAI_SYMBOL_SCOPE_NAMESPACE) {
@@ -266,7 +266,7 @@ static inline zval* zai_symbol_lookup_constant_impl(
     switch (scope_type) {
         case ZAI_SYMBOL_SCOPE_GLOBAL:
         case ZAI_SYMBOL_SCOPE_NAMESPACE:
-            return zai_symbol_lookup_constant_global(scope_type, scope, name	);
+            return lookup_constant_global(scope_type, scope, name	);
 
         case ZAI_SYMBOL_SCOPE_CLASS:
         case ZAI_SYMBOL_SCOPE_OBJECT:

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -74,7 +74,7 @@ static inline zai_string_view zai_symbol_lookup_clean(zai_string_view view) {
     if (!view.len || *view.ptr != '\\') {
         return view;
     }
-    return ZAI_STRING_VIEW_NEW(view.ptr + 1, view.len - 1);
+    return ZAI_STR_NEW(view.ptr + 1, view.len - 1);
 }
 
 static inline zai_string_view zai_symbol_lookup_key(zai_string_view *namespace, zai_string_view *name, bool lower) {

--- a/zend_abstract_interface/symbols/tests/api/call.cc
+++ b/zend_abstract_interface/symbols/tests/api/call.cc
@@ -7,7 +7,7 @@ extern "C" {
 TEA_TEST_CASE("symbol/api/call", "literal", {
     zval result;
 
-    CHECK(zai_symbol_call_literal(ZEND_STRL("phpversion"), &result, 0));
+    CHECK(zai_symbol_call_global(ZAI_STRL_VIEW("phpversion"), &result, 0));
 
     zval_ptr_dtor(&result);
 })
@@ -15,28 +15,27 @@ TEA_TEST_CASE("symbol/api/call", "literal", {
 TEA_TEST_CASE_WITH_STUB("symbol/api/call", "literal ns", "./stubs/call/user/Stub.php", {
     zval result;
 
-    CHECK(zai_symbol_call_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("noargs"), &result, 0));
+    CHECK(zai_symbol_call_ns(ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("noargs"), &result, 0));
 
     zval_ptr_dtor(&result);
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/call", "static", "./stubs/call/user/Stub.php", {
     zval result;
-    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub"));
-    zai_string_view vfn = ZAI_STRL_VIEW("staticPublicFunction");
+    zend_class_entry *ce = zai_symbol_lookup_class_ns(
+        ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("Stub"));
 
-    CHECK(zai_symbol_call_static(ce, &vfn, &result, 0));
+    CHECK(zai_symbol_call_static(ce, ZAI_STRL_VIEW("staticPublicFunction"), &result, 0));
 
     zval_ptr_dtor(&result);
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/call", "static literal", "./stubs/call/user/Stub.php", {
     zval result;
-    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub"));
+    zend_class_entry *ce = zai_symbol_lookup_class_ns(
+        ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("Stub"));
 
-    CHECK(zai_symbol_call_static_literal(ce, ZEND_STRL("staticPublicFunction"), &result, 0));
+    CHECK(zai_symbol_call_static(ce, ZAI_STRL_VIEW("staticPublicFunction"), &result, 0));
 
     zval_ptr_dtor(&result);
 })

--- a/zend_abstract_interface/symbols/tests/api/class.cc
+++ b/zend_abstract_interface/symbols/tests/api/class.cc
@@ -5,9 +5,9 @@ extern "C" {
 #include "tea/testing/catch2.hpp"
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/class", "literal, exists", "./stubs/lookup/class/Stub.php", {
-    REQUIRE(zai_symbol_lookup_class_literal(ZEND_STRL("\\DDTraceTesting\\Stub")));
+    REQUIRE(zai_symbol_lookup_class_global(ZAI_STRL_VIEW("\\DDTraceTesting\\Stub")));
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/class", "literal ns, exists", "./stubs/lookup/class/Stub.php", {
-    REQUIRE(zai_symbol_lookup_class_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub")));
+    REQUIRE(zai_symbol_lookup_class_ns(ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("Stub")));
 })

--- a/zend_abstract_interface/symbols/tests/api/constant.cc
+++ b/zend_abstract_interface/symbols/tests/api/constant.cc
@@ -5,9 +5,9 @@ extern "C" {
 #include "tea/testing/catch2.hpp"
 
 TEA_TEST_CASE("symbol/api/constant", "literal, exists", {
-    REQUIRE(zai_symbol_lookup_constant_literal(ZEND_STRL("PHP_VERSION")));
+    REQUIRE(zai_symbol_lookup_constant_global(ZAI_STRL_VIEW("PHP_VERSION")));
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/constant", "literal ns, exists", "./stubs/lookup/constant/Stub.php", {
-    REQUIRE(zai_symbol_lookup_constant_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("DD_TRACE_TESTING")));
+    REQUIRE(zai_symbol_lookup_constant_ns(ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("DD_TRACE_TESTING")));
 })

--- a/zend_abstract_interface/symbols/tests/api/function.cc
+++ b/zend_abstract_interface/symbols/tests/api/function.cc
@@ -5,9 +5,9 @@ extern "C" {
 #include "tea/testing/catch2.hpp"
 
 TEA_TEST_CASE("symbol/api/function", "literal, exists", {
-    REQUIRE(zai_symbol_lookup_function_literal(ZEND_STRL("strlen")));
+    REQUIRE(zai_symbol_lookup_function_global(ZAI_STRL_VIEW("strlen")));
 })
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/function", "literal ns, exists", "./stubs/lookup/function/Stub.php", {
-    REQUIRE(zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), ZEND_STRL("StubFunction")));
+    REQUIRE(zai_symbol_lookup_function_ns(ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("StubFunction")));
 })

--- a/zend_abstract_interface/symbols/tests/api/property.cc
+++ b/zend_abstract_interface/symbols/tests/api/property.cc
@@ -5,10 +5,10 @@ extern "C" {
 #include "tea/testing/catch2.hpp"
 
 TEA_TEST_CASE_WITH_STUB("symbol/api/property", "literal", "./stubs/lookup/property/Stub.php", {
-    zend_class_entry *ce = zai_symbol_lookup_class_literal_ns(
-        ZEND_STRL("DDTraceTesting"), ZEND_STRL("Stub"));
+    zend_class_entry *ce = zai_symbol_lookup_class_ns(
+        ZAI_STRL_VIEW("DDTraceTesting"), ZAI_STRL_VIEW("Stub"));
 
     REQUIRE(ce);
 
-    REQUIRE(zai_symbol_lookup_property_literal(ZAI_SYMBOL_SCOPE_CLASS, ce, ZEND_STRL("publicStatic")));
+    REQUIRE(zai_symbol_lookup_property(ZAI_SYMBOL_SCOPE_CLASS, ce, ZAI_STRL_VIEW("publicStatic")));
 })

--- a/zend_abstract_interface/symbols/tests/call/closure.cc
+++ b/zend_abstract_interface/symbols/tests/call/closure.cc
@@ -32,8 +32,8 @@ const zend_function_entry ddtrace_testing_closure_functions[] = {
 #include <cstdlib>
 #include <cstring>
 
-static bool zai_symbol_call_closure_test(const char *fn, size_t fnl) {
-    zend_function *function = zai_symbol_lookup_function_literal_ns(ZEND_STRL("DDTraceTesting"), fn, fnl);
+static bool zai_symbol_call_closure_test(zai_string_view vfn) {
+    zend_function *function = zai_symbol_lookup_function_ns(ZAI_STRL_VIEW("DDTraceTesting"), vfn);
 
     if (!function) {
         return false;
@@ -53,7 +53,7 @@ static bool zai_symbol_call_closure_test(const char *fn, size_t fnl) {
 TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/call/closure", "closure bound", "./stubs/call/closure/Stub.php", {
     tea_extension_functions(ddtrace_testing_closure_functions);
 },{
-    REQUIRE(zai_symbol_call_closure_test(ZEND_STRL("closureTestBinding")));
+    REQUIRE(zai_symbol_call_closure_test(ZAI_STRL_VIEW("closureTestBinding")));
 
     zval result;
 
@@ -71,7 +71,7 @@ zval_ptr_dtor(&ddtrace_testing_closure_object);
 TEA_TEST_CASE_WITH_STUB_WITH_PROLOGUE("symbol/call/closure", "closure rebound", "./stubs/call/closure/Stub.php", {
     tea_extension_functions(ddtrace_testing_closure_functions);
 },{
-    REQUIRE(zai_symbol_call_closure_test(ZEND_STRL("closureTestRebinding")));
+    REQUIRE(zai_symbol_call_closure_test(ZAI_STRL_VIEW("closureTestRebinding")));
 
     zval result;
 

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -69,7 +69,10 @@ static inline zai_string_view zai_string_from_zstr(zend_string *zstr) {
     return zstr ? ZAI_STRING_FROM_ZSTR(zstr) : ZAI_STRING_EMPTY;
 }
 
-static inline bool zai_string_stuffed(zai_string_view s) { return s.ptr && s.len; }
+/** Returns whether the string is empty. */
+static inline bool zai_str_is_empty(zai_string_view self) {
+    return self.len == 0 || self.ptr == NULL;
+}
 
 static inline
 bool zai_string_view_eq(zai_string_view a, zai_string_view b) {

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -22,41 +22,41 @@ typedef struct zai_string_view_s {
 } zai_string_view;
 
 /** Use if data is known to be non-null, use zai_string_view_new otherwise. */
-#define ZAI_STRING_VIEW_NEW(data, size)   \
+#define ZAI_STR_NEW(data, size)   \
     (zai_string_view) {.len = (size), .ptr = (data)}
 
 #define ZAI_STRL_VIEW(literal) \
-    ZAI_STRING_VIEW_NEW("" literal, sizeof(literal) - 1) \
+    ZAI_STR_NEW("" literal, sizeof(literal) - 1) \
 
 #define ZAI_STRING_EMPTY \
-    ZAI_STRING_VIEW_NEW("", 0)
+    ZAI_STR_NEW("", 0)
 
-/** Use if cstr is known to be non-null, use zai_string_from_cstr otherwise. */
-#define ZAI_STRING_FROM_CSTR(cstr)  \
-    ZAI_STRING_VIEW_NEW((cstr), strlen(cstr))
+/** Use if cstr is known to be non-null, use zai_str_from_cstr otherwise. */
+#define ZAI_STR_FROM_CSTR(cstr)  \
+    ZAI_STR_NEW((cstr), strlen(cstr))
 
-/** Use if zstr is known to be non-null, use zai_string_from_zstr otherwise. */
+/** Use if zstr is known to be non-null, use zai_str_from_zstr otherwise. */
 #define ZAI_STRING_FROM_ZSTR(zstr)  \
-    ZAI_STRING_VIEW_NEW(ZSTR_VAL(zstr), ZSTR_LEN(zstr))
+    ZAI_STR_NEW(ZSTR_VAL(zstr), ZSTR_LEN(zstr))
 
 /**
  * Creates a zai_string_view from the given pointer and length. If the pointer
  * is null, then ZAI_STRING_EMPTY will be returned.
  *
- * If the pointer is known to be non-null, use ZAI_STRING_VIEW_NEW directly.
+ * If the pointer is known to be non-null, use ZAI_STR_NEW directly.
  */
 static inline zai_string_view zai_string_view_new(const char *ptr, size_t len) {
-    return ptr ? ZAI_STRING_VIEW_NEW(ptr, len) : ZAI_STRING_EMPTY;
+    return ptr ? ZAI_STR_NEW(ptr, len) : ZAI_STRING_EMPTY;
 }
 
 /**
  * Creates a zai_string_view from a possibly-null C-string. Returns
  * ZAI_STRING_EMPTY if the pointer is null.
  *
- * If the pointer is known to be non-null, use ZAI_STRING_FROM_CSTR directly.
+ * If the pointer is known to be non-null, use ZAI_STR_FROM_CSTR directly.
  */
-static inline zai_string_view zai_string_from_cstr(const char *cstr) {
-    return cstr ? ZAI_STRING_FROM_CSTR(cstr) : ZAI_STRING_EMPTY;
+static inline zai_string_view zai_str_from_cstr(const char *cstr) {
+    return cstr ? ZAI_STR_FROM_CSTR(cstr) : ZAI_STRING_EMPTY;
 }
 
 /**
@@ -65,7 +65,7 @@ static inline zai_string_view zai_string_from_cstr(const char *cstr) {
  *
  * If the pointer is known to be non-null, use ZAI_STRING_FROM_ZSTR directly.
  */
-static inline zai_string_view zai_string_from_zstr(zend_string *zstr) {
+static inline zai_string_view zai_str_from_zstr(zend_string *zstr) {
     return zstr ? ZAI_STRING_FROM_ZSTR(zstr) : ZAI_STRING_EMPTY;
 }
 
@@ -74,12 +74,11 @@ static inline bool zai_str_is_empty(zai_string_view self) {
     return self.len == 0 || self.ptr == NULL;
 }
 
-static inline
-bool zai_string_view_eq(zai_string_view a, zai_string_view b) {
+static inline bool zai_str_eq(zai_string_view a, zai_string_view b) {
     return a.len == b.len && (b.len == 0 || memcmp(a.ptr, b.ptr, b.len) == 0);
 }
 
-static inline bool zai_string_equals_ci_cstr(zai_string_view s, const char *str) {
+static inline bool zai_str_equals_ci_cstr(zai_string_view s, const char *str) {
     size_t len = strlen(str);
     return s.len == len && (len == 0 || strncasecmp(s.ptr, str, strlen(str)) == 0);
 }

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -29,4 +29,63 @@ static inline bool zai_string_equals_literal_ci(zai_string_view s, const char *s
     return s.len == strlen(str) && (strlen(str) == 0 || strncasecmp(s.ptr, str, strlen(str)) == 0);
 }
 
+/** Represents an optional string view. Please treat this as opaque. */
+typedef struct zai_option_str_s {
+    /* If null, this is a None. */
+    const char *ptr;
+
+    /* If ptr is null, this must be 0, use ZAI_OPTION_STR_NONE and
+     * zai_option_str_from_raw_parts to help manage it.
+     */
+    size_t len;
+} zai_option_str;
+
+/** Creates a zai_option_str which is empty. */
+#define ZAI_OPTION_STR_NONE \
+    (zai_option_str) {.ptr = NULL, .len = 0}
+
+/**
+ * Creates a zai_option_str from the given `ptr` and `len`. If `ptr` is null,
+ * then it will be a None.
+ */
+static inline
+zai_option_str zai_option_str_from_raw_parts(const char *ptr, size_t len) {
+    zai_option_str value = {.ptr = ptr, .len = len};
+    return ptr ? value : ZAI_OPTION_STR_NONE;
+}
+
+/**
+ * Creates a zai_option_str from the given `str`. The option always holds a
+ * value in this case.
+ */
+static inline
+zai_option_str zai_option_str_from_str(zai_string_view str) {
+    return (zai_option_str) {.ptr = str.len ? str.ptr : "", .len = str.len};
+}
+
+/** Returns true of the option holds a value. */
+static inline bool zai_option_str_is_some(zai_option_str self) {
+    return self.ptr != NULL;
+}
+
+/** Returns true of the option does not hold a value. */
+static inline bool zai_option_str_is_none(zai_option_str self) {
+    return self.ptr == NULL;
+}
+
+/**
+ * Creates a zai_string_view from the option and assigns it to `view`. If the
+ * option doesn't hold a value, then it will assign the empty string.
+ *
+ * Returns true if the option holds a value, false if it doesn't. This can be
+ * used to distinguish between an empty option vs a non-empty option holding an
+ * empty string.
+ */
+static inline
+bool zai_option_str_get(zai_option_str self, zai_string_view *view) {
+    zai_string_view value = {.len = self.len, .ptr = self.ptr};
+    *view = zai_option_str_is_some(self) ? value : ZAI_STRING_EMPTY;
+    return self.ptr;
+}
+
 #endif  // ZAI_STRING_H

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -118,12 +118,12 @@ zai_option_str zai_option_str_from_str(zai_string_view str) {
     return (zai_option_str) {.ptr = str.len ? str.ptr : "", .len = str.len};
 }
 
-/** Returns true of the option holds a value. */
+/** Returns true if the option holds a value. */
 static inline bool zai_option_str_is_some(zai_option_str self) {
     return self.ptr != NULL;
 }
 
-/** Returns true of the option does not hold a value. */
+/** Returns true if the option does not hold a value. */
 static inline bool zai_option_str_is_none(zai_option_str self) {
     return self.ptr == NULL;
 }


### PR DESCRIPTION
### Description

This adds new macros and functions for working with zai_string_view. They are prefixed with `zai_str_` or `ZAI_STR_` in preparation for renaming `zai_string_view` to simply `zai_str`. By naming these with the new prefix, it will reduce the size of the review for that PR.

This changes the signatures of many functions taking pairs of pointers and lengths to using zai_string_views instead, and the functions were renamed because they had `literal` in their names which didn't apply anymore. A small number of these already had versions that took views, so the versions with literals were outright removed.

### Readiness checklist
- [x]  Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests are sufficient.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
