### PR TITLE
Add `zai_option_str` and use it in config

### DIFF
--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -32,8 +32,11 @@ static void zai_config_lock_ini_copying(THREAD_T thread_id) {
 #endif
 
 // values retrieved here are assumed to be valid
-int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_count, zai_string_view *buf,
-                                        zai_string_view default_value, zai_config_id entry_id) {
+int16_t zai_config_initialize_ini_value(zend_ini_entry **entries,
+                                        int16_t ini_count,
+                                        zai_option_str *buf,
+                                        zai_string_view default_value,
+                                        zai_config_id entry_id) {
     if (!env_to_ini_name) return -1;
 
     zai_config_memoized_entry *memoized = &zai_config_memoized_entries[entry_id];
@@ -106,7 +109,7 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
             if (i > 0) {
                 zend_string_release(*target);
                 *target = zend_string_copy(entries[0]->modified ? entries[0]->orig_value : entries[0]->value);
-            } else if (buf->ptr != NULL) {
+            } else if (zai_option_str_is_some(*buf)) {
                 zend_string_release(*target);
                 *target = zend_string_init(buf->ptr, buf->len, 1);
             } else if (parsed_ini_value != NULL) {
@@ -133,7 +136,7 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_co
             buf->ptr = ZSTR_VAL(runtime_value);
             buf->len = ZSTR_LEN(runtime_value);
             zend_string_release(runtime_value);
-        } else if (parsed_ini_value && buf->ptr == NULL) {
+        } else if (parsed_ini_value && zai_option_str_is_none(*buf)) {
             buf->ptr = ZSTR_VAL(parsed_ini_value);
             buf->len = ZSTR_LEN(parsed_ini_value);
         }

--- a/zend_abstract_interface/config/config_ini.h
+++ b/zend_abstract_interface/config/config_ini.h
@@ -28,8 +28,11 @@ void zai_config_ini_mshutdown();
  * but these get applied before first time rinit. So we need to find the highest priority ini value
  * and apply these as runtime config to all other values
  */
-int16_t zai_config_initialize_ini_value(zend_ini_entry **entries, int16_t ini_count, zai_string_view *buf,
-                                        zai_string_view default_value, zai_config_id entry_id);
+int16_t zai_config_initialize_ini_value(zend_ini_entry **entries,
+                                        int16_t ini_count,
+                                        zai_option_str *buf,
+                                        zai_string_view default_value,
+                                        zai_config_id entry_id);
 
 typedef bool (*zai_config_apply_ini_change)(zval *old_value, zval *new_value);
 

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -29,4 +29,63 @@ static inline bool zai_string_equals_literal_ci(zai_string_view s, const char *s
     return s.len == strlen(str) && (strlen(str) == 0 || strncasecmp(s.ptr, str, strlen(str)) == 0);
 }
 
+/** Represents an optional string view. Please treat this as opaque. */
+typedef struct zai_option_str_s {
+    /* If null, this is a None. */
+    const char *ptr;
+
+    /* If ptr is null, this must be 0, use ZAI_OPTION_STR_NONE and
+     * zai_option_str_from_raw_parts to help manage it.
+     */
+    size_t len;
+} zai_option_str;
+
+/** Creates a zai_option_str which is empty. */
+#define ZAI_OPTION_STR_NONE \
+    (zai_option_str) {.ptr = NULL, .len = 0}
+
+/**
+ * Creates a zai_option_str from the given `ptr` and `len`. If `ptr` is null,
+ * then it will be a None.
+ */
+static inline
+zai_option_str zai_option_str_from_raw_parts(const char *ptr, size_t len) {
+    zai_option_str value = {.ptr = ptr, .len = len};
+    return ptr ? value : ZAI_OPTION_STR_NONE;
+}
+
+/**
+ * Creates a zai_option_str from the given `str`. The option always holds a
+ * value in this case.
+ */
+static inline
+zai_option_str zai_option_str_from_str(zai_string_view str) {
+    return (zai_option_str) {.ptr = str.len ? str.ptr : "", .len = str.len};
+}
+
+/** Returns true of the option holds a value. */
+static inline bool zai_option_str_is_some(zai_option_str self) {
+    return self.ptr != NULL;
+}
+
+/** Returns true of the option does not hold a value. */
+static inline bool zai_option_str_is_none(zai_option_str self) {
+    return self.ptr == NULL;
+}
+
+/**
+ * Creates a zai_string_view from the option and assigns it to `view`. If the
+ * option doesn't hold a value, then it will assign the empty string.
+ *
+ * Returns true if the option holds a value, false if it doesn't. This can be
+ * used to distinguish between an empty option vs a non-empty option holding an
+ * empty string.
+ */
+static inline
+bool zai_option_str_get(zai_option_str self, zai_string_view *view) {
+    zai_string_view value = {.len = self.len, .ptr = self.ptr};
+    *view = zai_option_str_is_some(self) ? value : ZAI_STRING_EMPTY;
+    return self.ptr;
+}
+
 #endif  // ZAI_STRING_H


### PR DESCRIPTION
### Description

Soon I hope to enforce that `zai_string_view`s never hold null pointers. While refactoring, I accidentally hit a case where `.ptr == null` was handled differently from `.ptr = ""`. I added `zai_option_str` to address this case.

This changes the signature of a possibly-public function `zai_config_initialize_ini_value`. The profiler does not use this function directly, but application security may--I haven't checked.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Existing tests are good.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
