### PR TITLE
build(profiling): enable cross-language link-time optimization

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -534,7 +534,7 @@ commands:
             command -v switch-php && switch-php "${PHP_VERSION}"
             cd profiling
             echo "${CARGO_TARGET_DIR}"
-            cargo build --release
+            ./build-linux-lto.sh
             cd -
             cp -v "${CARGO_TARGET_DIR}/release/libdatadog_php_profiling.so" "${prefix}/datadog-profiling.so"
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -534,7 +534,7 @@ commands:
             command -v switch-php && switch-php "${PHP_VERSION}"
             cd profiling
             echo "${CARGO_TARGET_DIR}"
-            ./build-linux-lto.sh
+            ./cargo-lto.sh build --release -vv
             cd -
             cp -v "${CARGO_TARGET_DIR}/release/libdatadog_php_profiling.so" "${prefix}/datadog-profiling.so"
 

--- a/benchmark/runall.sh
+++ b/benchmark/runall.sh
@@ -5,4 +5,7 @@ set -ex
 cd ../profiling/
 sed -i -e "s/crate-type.*$/crate-type = [\"rlib\"]/g" Cargo.toml
 
-cargo bench --features stack_walking_tests -- --noplot
+# Symlink clang-16 to clang so we can use the lto helper
+ln -s "$(command -v clang-16)" /usr/local/bin/clang
+
+../profiling/cargo-lto.sh bench --features stack_walking_tests -- --noplot

--- a/profiling/build-linux-lto.sh
+++ b/profiling/build-linux-lto.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+# These are needed for cross-language LTO
+AR="$(command -v llvm-ar)"
+CC="$(command -v clang)"
+RANLIB="$(command -v llvm-ranlib)"
+export AR
+export CC
+export CFLAGS="-flto=thin"
+export RANLIB
+
+RUSTFLAGS="-Clinker-plugin-lto -C linker=clang -C link-arg=-fuse-ld=lld" \
+    cargo build --release -vv

--- a/profiling/cargo-lto.sh
+++ b/profiling/cargo-lto.sh
@@ -11,5 +11,4 @@ export CC
 export CFLAGS="-flto=thin"
 export RANLIB
 
-RUSTFLAGS="-Clinker-plugin-lto -C linker=clang -C link-arg=-fuse-ld=lld" \
-    cargo build --release -vv
+RUSTFLAGS="-Clinker-plugin-lto -C linker=clang -C link-arg=-fuse-ld=lld" cargo "$@"


### PR DESCRIPTION
### Description

The profiler is mostly written in Rust and has a few small bits in C. Most of these functions in C would be inlined if they were written in the same language. This PR enables cross-language link-time optimization (LTO) for the versions shipped in 
"package extension" job.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
