### PR TITLE
refactor: rename zai_str_equals_ci_cstr to zai_str_eq_ci_cstr

### DIFF
--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -54,11 +54,11 @@ DD_CONFIGURATION
 
 static bool dd_parse_dbm_mode(zai_str value, zval *decoded_value, bool persistent) {
     UNUSED(persistent);
-    if (zai_str_equals_ci_cstr(value, "disabled")) {
+    if (zai_str_eq_ci_cstr(value, "disabled")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_DISABLED);
-    } else if (zai_str_equals_ci_cstr(value, "service")) {
+    } else if (zai_str_eq_ci_cstr(value, "service")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_SERVICE);
-    } else if (zai_str_equals_ci_cstr(value, "full")) {
+    } else if (zai_str_eq_ci_cstr(value, "full")) {
         ZVAL_LONG(decoded_value, DD_TRACE_DBM_PROPAGATION_FULL);
     } else {
         return false;

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -78,7 +78,7 @@ static inline bool zai_str_eq(zai_str a, zai_str b) {
     return a.len == b.len && (b.len == 0 || memcmp(a.ptr, b.ptr, b.len) == 0);
 }
 
-static inline bool zai_str_equals_ci_cstr(zai_str s, const char *str) {
+static inline bool zai_str_eq_ci_cstr(zai_str s, const char *str) {
     size_t len = strlen(str);
     return s.len == len && (len == 0 || strncasecmp(s.ptr, str, strlen(str)) == 0);
 }


### PR DESCRIPTION
### Description

Renames`zai_str_equals_ci_cstr` to `zai_str_eq_ci_cstr` to match `zai_str_eq`.

This is a follow-up from [code review](https://github.com/DataDog/dd-trace-php/pull/2203#pullrequestreview-1580538278) on a previous PR.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
