### PR TITLE
Require `zai_str.ptr` to not be null

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -69,6 +69,7 @@ fn php_config_vernum() -> u64 {
 }
 
 const ZAI_H_FILES: &[&str] = &[
+    "../zend_abstract_interface/zai_assert/zai_assert.h",
     "../zend_abstract_interface/zai_string/string.h",
     "../zend_abstract_interface/config/config.h",
     "../zend_abstract_interface/config/config_decode.h",

--- a/profiling/src/bindings/ffi.rs
+++ b/profiling/src/bindings/ffi.rs
@@ -4,12 +4,12 @@
 
 use crate::bindings::{
     _zend_module_entry, zend_bool, zend_extension, zend_module_entry, zend_result, ZaiConfigEntry,
-    ZaiConfigMemoizedEntry, ZaiStringView, ZendString,
+    ZaiConfigMemoizedEntry, ZaiStr, ZendString,
 };
 
 pub type _zend_string = ZendString;
 
-pub type zai_str_s<'a> = ZaiStringView<'a>;
+pub type zai_str_s<'a> = ZaiStr<'a>;
 pub type zai_str<'a> = zai_str_s<'a>;
 
 pub type zai_config_entry_s = ZaiConfigEntry;

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -451,7 +451,7 @@ impl TryFrom<&mut zval> for String {
 /// A non-owning, not necessarily null terminated, not necessarily utf-8
 /// encoded, borrowed string.
 /// It must satisfy the requirements of [core::slice::from_raw_parts], notably
-/// it must not use the nul pointer even when the length is 0.
+/// it must not use the null pointer even when the length is 0.
 /// Keep this representation in sync with zai_str.
 #[repr(C)]
 pub struct ZaiStr<'a> {

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -1,57 +1,15 @@
 //! Definitions for interacting with the profiler from a C API, such as the
 //! ddtrace extension.
 
-use crate::bindings::zend_execute_data;
+use crate::bindings::{zend_execute_data, ZaiStr};
 use crate::runtime_id;
 use std::borrow::Cow;
-use std::fmt::{Display, Formatter};
-use std::marker::PhantomData;
-
-/// A non-owning, not necessarily null terminated, not utf-8 encoded, borrowed
-/// string. Must satisfy the requirements of [core::slice::from_raw_parts],
-/// notably it must not use the nul pointer even when the length is 0.
-/// Keep this representation in sync with zai_str.
-#[repr(C)]
-pub struct StringView<'a> {
-    len: libc::size_t,
-    ptr: *const libc::c_char,
-    // The PhantomData says this acts like a reference to a [u8], even though
-    // it doesn't actually have one.
-    _marker: PhantomData<&'a [u8]>,
-}
-
-impl<'a> From<&'a [u8]> for StringView<'a> {
-    fn from(value: &'a [u8]) -> Self {
-        Self {
-            len: value.len(),
-            ptr: value.as_ptr() as *const libc::c_char,
-            _marker: Default::default(),
-        }
-    }
-}
-
-impl<'a> StringView<'a> {
-    pub fn as_slice(&self) -> &'a [u8] {
-        // Safety: StringView's are required to uphold these invariants.
-        unsafe { core::slice::from_raw_parts(self.ptr as *const u8, self.len) }
-    }
-
-    pub fn to_string_lossy(&self) -> Cow<'a, str> {
-        String::from_utf8_lossy(self.as_slice())
-    }
-}
-
-impl<'a> Display for StringView<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.to_string_lossy())
-    }
-}
 
 #[no_mangle]
 pub extern "C" fn datadog_profiling_notify_trace_finished(
     local_root_span_id: u64,
-    span_type: StringView,
-    resource: StringView,
+    span_type: ZaiStr,
+    resource: ZaiStr,
 ) {
     crate::notify_trace_finished(
         local_root_span_id,
@@ -115,8 +73,8 @@ mod tests {
     #[test]
     fn test_string_view() {
         let slice: &[u8] = b"datadog \xF0\x9F\x90\xB6";
-        let string_view: StringView = StringView::from(slice);
-        assert_eq!(slice, string_view.as_slice());
+        let string_view = ZaiStr::from(slice);
+        assert_eq!(slice, string_view.as_bytes());
 
         let expected = "datadog 🐶";
         let actual = string_view.to_string_lossy();
@@ -125,7 +83,7 @@ mod tests {
             _ => panic!("Expected a borrowed string, got: {:?}", actual),
         };
 
-        let actual = string_view.to_string();
+        let actual = string_view.into_string();
         assert_eq!(expected, actual)
     }
 }

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -113,7 +113,7 @@ unsafe fn handle_file_cache_slot_helper(
             return None;
         };
 
-        let file = ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).to_string();
+        let file = ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).into_string();
         let offset = string_table.insert(file.as_ref());
         cache_slots[1] = offset as usize;
         file
@@ -163,8 +163,9 @@ unsafe fn extract_file_and_line(execute_data: &zend_execute_data) -> (Option<Str
     // This should be Some, just being cautious.
     match execute_data.func.as_ref() {
         Some(func) if func.type_ == ZEND_USER_FUNCTION as u8 => {
-            // Safety: ddog_php_prof_zend_string_view will return a valid ZaiStringView.
-            let file = ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).to_string();
+            // Safety: ddog_php_prof_zend_string_view will return a valid ZaiStr.
+            let file =
+                ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).into_string();
             let lineno = match execute_data.opline.as_ref() {
                 Some(opline) => opline.lineno,
                 None => 0,

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -75,7 +75,7 @@ unsafe extern "C" fn ddog_php_prof_compile_string(
         }
 
         let filename =
-            ddog_php_prof_zend_string_view(zend_get_executed_filename_ex().as_mut()).to_string();
+            ddog_php_prof_zend_string_view(zend_get_executed_filename_ex().as_mut()).into_string();
 
         let line = zend::zend_get_executed_lineno();
 
@@ -148,7 +148,7 @@ unsafe extern "C" fn ddog_php_prof_compile_file(
         // for example "/var/www/html/../vendor/foo/bar.php" while during stack walking we get
         // "/var/html/vendor/foo/bar.php". This makes sure it is the exact same string we'd
         // collect in stack walking and therefore we are fully utilizing the pprof string table
-        let filename = ddog_php_prof_zend_string_view((*op_array).filename.as_mut()).to_string();
+        let filename = ddog_php_prof_zend_string_view((*op_array).filename.as_mut()).into_string();
 
         trace!(
             "Compile file \"{filename}\" with include type \"{include_type}\" took {} nanoseconds",

--- a/tea/include/common.h
+++ b/tea/include/common.h
@@ -1,8 +1,12 @@
 #ifndef HAVE_TEA_COMMON_H
 #define HAVE_TEA_COMMON_H
 
-#include <assert.h>
+// Include very first, as it defines things like _GNU_SOURCE. Without it, there
+// are warnings like this:
+// warning: implicit declaration of function ‘memrchr’; did you mean ‘memchr’?
 #include <main/php.h>
+
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/zend_abstract_interface/config/tests/id.cc
+++ b/zend_abstract_interface/config/tests/id.cc
@@ -46,19 +46,6 @@ TEST_ID("unknown", {
     REQUEST_END()
 })
 
-TEST_ID("null name", {
-    REQUEST_BEGIN()
-
-    zai_config_id id;
-    zai_str name = ZAI_STRL("FOO_BOOL");
-    name.ptr = NULL;
-    bool res = zai_config_get_id_by_name(name, &id);
-
-    REQUIRE(res == false);
-
-    REQUEST_END()
-})
-
 TEST_ID("null id", {
     REQUEST_BEGIN()
 

--- a/zend_abstract_interface/env/tests/error.cc
+++ b/zend_abstract_interface/env/tests/error.cc
@@ -6,20 +6,6 @@ extern "C" {
 
 #include "zai_tests_common.hpp"
 
-TEA_TEST_CASE_WITH_PROLOGUE("env/error", "NULL name", {
-    REQUIRE(tea_sapi_module.getenv == NULL);
-},{
-    REQUIRE_UNSETENV("FOO");
-
-    ZAI_ENV_BUFFER_INIT(buf, 64);
-    zai_str name = ZAI_STRL("FOO");
-    name.ptr = NULL;
-    zai_env_result res = zai_getenv(name, buf);
-
-    REQUIRE(res == ZAI_ENV_ERROR);
-    REQUIRE_BUF_EQ("", buf);
-})
-
 TEA_TEST_CASE_WITH_PROLOGUE("env/error", "zero name len", {
     REQUIRE(tea_sapi_module.getenv == NULL);
 },{

--- a/zend_abstract_interface/headers/tests/headers.cc
+++ b/zend_abstract_interface/headers/tests/headers.cc
@@ -41,8 +41,7 @@ TEA_TEST_CASE_WITH_PROLOGUE("headers", "reading undefined header value", {
 
 TEA_TEST_CASE("headers", "erroneous read_header input", {
     zend_string *header;
-    REQUIRE(zai_read_header({ 1, nullptr }, &header) == ZAI_HEADER_ERROR);
-    REQUIRE(zai_read_header({ 0, "" }, &header) == ZAI_HEADER_ERROR);
+    REQUIRE(zai_read_header(ZAI_STR_EMPTY, &header) == ZAI_HEADER_ERROR);
     REQUIRE(zai_read_header_literal("abc", nullptr) == ZAI_HEADER_ERROR);
 })
 

--- a/zend_abstract_interface/hook/tests/internal/request.cc
+++ b/zend_abstract_interface/hook/tests/internal/request.cc
@@ -21,7 +21,7 @@ extern "C" {
         uint32_t u;
     } zai_hook_test_fixed_t;
 
-    zai_str zai_hook_test_nonexistent = {.len = sizeof("zai_hook_test_nonexistent")-1, .ptr = "zai_hook_test_nonexistent"};
+    zai_str zai_hook_test_nonexistent = ZAI_STRL("zai_hook_test_nonexistent");
 
     static zai_hook_test_fixed_t zai_hook_test_fixed_first = {42};
     static zai_hook_test_fixed_t zai_hook_test_fixed_second = {42};

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -36,6 +36,13 @@ zend_result zend_call_function_wrapper(zend_fcall_info *fci, zend_fcall_info_cac
 #define ZEND_OBSERVER_NOT_OBSERVED ((void *) 2)
 
 static zend_execute_data *zai_set_observed_frame(zend_execute_data *execute_data) {
+    // Although the tracer being present should always cause an observer to be
+    // present, if zai is used from another extension, like say the profiler,
+    // then this may not be set.
+    if (zend_observer_fcall_op_array_extension < 0) {
+        return NULL;
+    }
+
     zend_execute_data fake_ex[2]; // 2 to have some space for observer temps
     zend_function dummy_observable_func;
     dummy_observable_func.type = ZEND_INTERNAL_FUNCTION;

--- a/zend_abstract_interface/zai_assert/zai_assert.h
+++ b/zend_abstract_interface/zai_assert/zai_assert.h
@@ -37,11 +37,13 @@
 
 // __has_builtin will get defined by zend_portability.h if it doesn't exist.
 #if __has_builtin(__builtin_assume)
+// At the time of writing, this is clang-only.
 #define ZAI_ASSUME(cond) __builtin_assume(cond)
+#elif defined(__GCC__)
+// GCC has had these builtins a long, long time. Not guarding them.
+#define ZAI_ASSUME(cond) \
+    (__builtin_expect(!(cond), 0) ? __builtin_unreachable() : true)
 #else
-// __builtin_assume is not on GCC. We could make this work with other tricks,
-// but the easiest ones are statements, not expressions, so they don't work
-// here, as we need to evaluate to an expression.
 #define ZAI_ASSUME(cond) true
 #endif
 

--- a/zend_abstract_interface/zai_assert/zai_assert.h
+++ b/zend_abstract_interface/zai_assert/zai_assert.h
@@ -2,6 +2,7 @@
 #define ZAI_ASSERT_H
 
 #include <main/php.h>
+#include <Zend/zend_portability.h>
 
 #ifndef NDEBUG
 #include <assert.h>
@@ -32,6 +33,26 @@
 #else
 #define zai_assert_is_lower(str, message)
 #define zai_assert_is_upper(str, message)
+#endif
+
+// __has_builtin will get defined by zend_portability.h if it doesn't exist.
+#if __has_builtin(__builtin_assume)
+#define ZAI_ASSUME(cond) __builtin_assume(cond)
+#else
+// __builtin_assume is not on GCC. We could make this work with other tricks,
+// but the easiest ones are statements, not expressions, so they don't work
+// here, as we need to evaluate to an expression.
+#define ZAI_ASSUME(cond) true
+#endif
+
+/**
+ * ZAI_ASSERT is like ZEND_ASSERT and C assert that it will expand into a valid
+ * expression which returns true (if it fails, it will not return at all).
+ */
+#if ZEND_DEBUG
+#define ZAI_ASSERT(cond) (assert(cond), true)
+#else
+#define ZAI_ASSERT(cond) (ZAI_ASSUME(cond), true)
 #endif
 
 #endif  // ZAI_ASSERT_H

--- a/zend_abstract_interface/zai_string/CMakeLists.txt
+++ b/zend_abstract_interface/zai_string/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(zai_string INTERFACE
 
 target_compile_features(zai_string INTERFACE c_std_99)
 
-target_link_libraries(zai_string INTERFACE "${PHP_LIB}")
+target_link_libraries(zai_string INTERFACE "${PHP_LIB}" Zai::Assert)
 
 add_library(Zai::string ALIAS zai_string)
 

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -1,35 +1,53 @@
 #ifndef ZAI_STRING_H
 #define ZAI_STRING_H
 
+// Include this before standard headers, or you may get strange errors like:
+// error: unknown type name 'siginfo_t'
+#include <Zend/zend.h>
+
+#include <zai_assert/zai_assert.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
-#include <Zend/zend.h>
+// never write, only read
+extern char *ZAI_STRING_EMPTY_PTR;
 
 /**
  * Represents a non-owning view of a string.
  *
  * When initializing the struct, use one of the initialization macros or
- * functions. Do not initialize the struct directly e.g. `{0, null}`.
- *
- * todo: move .ptr to come before .len to match ddtrace_string and Rust and
- *       ensure it's never null.
+ * functions. Do not initialize the struct directly e.g. `{"", 0}`.
  */
 typedef struct zai_str_s {
-    size_t len;
     const char *ptr;
+    size_t len;
 } zai_str;
 
-/** Use if data is known to be non-null, use zai_str_new otherwise. */
-#define ZAI_STR_NEW(data, size)   \
-    (zai_str) {.len = (size), .ptr = (data)}
+/** Private, you probably want to use ZAI_STR_NEW or zai_str_new. */
+#define ZAI_STR_FROM_RAW_PARTS(data, size) \
+    (zai_str) {.ptr = (data), .len = (size)}
+
+/**
+ * ZAI_STR_NEW creates a zai_str from the given pointer and length. Use if the
+ * pointer is known to be non-null, use zai_str_new otherwise.
+ */
+#if ZEND_DEBUG
+#define ZAI_STR_NEW(data, size) \
+    ZAI_STR_FROM_RAW_PARTS( \
+        ZAI_ASSERT((data) != NULL) ? (data) : NULL, \
+        (size))
+#else
+#define ZAI_STR_NEW(data, size) \
+    ZAI_STR_FROM_RAW_PARTS((data), (size))
+#endif
 
 #define ZAI_STRL(literal) \
-    ZAI_STR_NEW("" literal, sizeof(literal) - 1) \
+    ZAI_STR_FROM_RAW_PARTS("" literal, sizeof(literal) - 1)
 
 #define ZAI_STR_EMPTY \
-    ZAI_STR_NEW("", 0)
+    ZAI_STR_FROM_RAW_PARTS("", 0)
 
 /** Use if cstr is known to be non-null, use zai_str_from_cstr otherwise. */
 #define ZAI_STR_FROM_CSTR(cstr)  \
@@ -46,7 +64,7 @@ typedef struct zai_str_s {
  * If the pointer is known to be non-null, use ZAI_STR_NEW directly.
  */
 static inline zai_str zai_str_new(const char *ptr, size_t len) {
-    return ptr ? ZAI_STR_NEW(ptr, len) : ZAI_STR_EMPTY;
+    return ptr ? ZAI_STR_FROM_RAW_PARTS(ptr, len) : ZAI_STR_EMPTY;
 }
 
 /**
@@ -71,16 +89,21 @@ static inline zai_str zai_str_from_zstr(zend_string *zstr) {
 
 /** Returns whether the string is empty. */
 static inline bool zai_str_is_empty(zai_str self) {
-    return self.len == 0 || self.ptr == NULL;
+    ZEND_ASSERT(self.ptr != NULL);
+    return self.len == 0;
 }
 
 static inline bool zai_str_eq(zai_str a, zai_str b) {
-    return a.len == b.len && (b.len == 0 || memcmp(a.ptr, b.ptr, b.len) == 0);
+    ZEND_ASSERT(a.ptr != NULL);
+    ZEND_ASSERT(b.ptr != NULL);
+    return a.len == b.len && memcmp(a.ptr, b.ptr, b.len) == 0;
 }
 
 static inline bool zai_str_eq_ci_cstr(zai_str s, const char *str) {
+    ZEND_ASSERT(s.ptr != NULL);
+    ZEND_ASSERT(str != NULL);
     size_t len = strlen(str);
-    return s.len == len && (len == 0 || strncasecmp(s.ptr, str, strlen(str)) == 0);
+    return s.len == len && strncasecmp(s.ptr, str, len) == 0;
 }
 
 /** Represents an optional string view. Please treat this as opaque. */
@@ -137,8 +160,13 @@ static inline bool zai_option_str_is_none(zai_option_str self) {
  */
 static inline
 bool zai_option_str_get(zai_option_str self, zai_str *view) {
-    zai_str value = {.len = self.len, .ptr = self.ptr};
+    // The .ptr may be null here, but if it is, then zai_option_str_is_some()
+    // will return false, and the ill-formed zai_str won't be assigned.
+    // Doing it in this order made slightly better assembly, and a ZEND_ASSERT
+    // guards this on debug builds in case of a mistake.
+    zai_str value = ZAI_STR_FROM_RAW_PARTS(self.ptr, self.len);
     *view = zai_option_str_is_some(self) ? value : ZAI_STR_EMPTY;
+    ZEND_ASSERT(view->ptr != NULL);
     return self.ptr;
 }
 

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -11,9 +11,6 @@
 #include <stddef.h>
 #include <string.h>
 
-// never write, only read
-extern char *ZAI_STRING_EMPTY_PTR;
-
 /**
  * Represents a non-owning view of a string.
  *


### PR DESCRIPTION
### Description

Requires `zai_str.ptr` to not be null and also moves the `.ptr` to be first. This matches Rust's slice layout, as well as `struct iovec` on most platforms. Reordering also helped find some C++ locations which were using designated initializers, as that feature in C++ requires fields to be initialized in the same order as the source, and were thereby broken by the re-ordering.

This also fixes the profiler's equivalent structs (there were two of them 🤦🏻). It combines them into one struct since they had to be updated anyway.

This also fixes a potential heap-buffer-overflow when zai is used without an observer. I think only the tracer was using the particular set of functions which could have hit this, and the tracer is an observer, so in practice I don't think it could have been triggered by users. I hit this when running asan builds locally. I couldn't determine why the CI doesn't hit this case.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
