### PR TITLE
Add `zai_string` and use it in `zai_config`

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -169,6 +169,7 @@ if test "$PHP_DDTRACE" != "no"; then
     zend_abstract_interface/symbols/lookup.c \
     zend_abstract_interface/symbols/call.c \
     zend_abstract_interface/uri_normalization/uri_normalization.c \
+    zend_abstract_interface/zai_string/string.c \
   "
 
   PHP_NEW_EXTENSION(ddtrace, $DD_TRACE_COMPONENT_SOURCES $ZAI_SOURCES $DD_TRACE_VENDOR_SOURCES $DD_TRACE_PHP_SOURCES, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Wall -std=gnu11)

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -98,6 +98,7 @@ fn build_zend_php_ffis(
         "../zend_abstract_interface/config/config_runtime.c",
         "../zend_abstract_interface/env/env.c",
         "../zend_abstract_interface/json/json.c",
+        "../zend_abstract_interface/zai_string/string.c",
     ];
 
     for file in zai_c_files.iter().chain(ZAI_H_FILES.iter()) {

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -84,12 +84,11 @@ impl _zend_function {
     /// Returns a slice to the zend_string's data if it's present and not
     /// empty; otherwise returns None.
     fn zend_string_to_optional_bytes(zstr: Option<&mut zend_string>) -> Option<&[u8]> {
-        /* Safety: ddog_php_prof_zend_string_view can be called with
-         * any valid zend_string pointer, and the tailing .into_bytes() will
-         * be safe as the former will always return a view with a non-null
-         * pointer.
+        /* Safety: zai_str_from_zstr can be called with any valid zend_string
+         * pointer, and the tailing .into_bytes() will be safe as the former
+         * will always return a view with a non-null pointer.
          */
-        let bytes = unsafe { ddog_php_prof_zend_string_view(zstr).into_bytes() };
+        let bytes = unsafe { zai_str_from_zstr(zstr) }.into_bytes();
         if bytes.is_empty() {
             None
         } else {
@@ -290,7 +289,7 @@ extern "C" {
     /// Converts the `zstr` into a `zai_str`. A None as well as empty
     /// strings will be converted into a string view to a static empty string
     /// (single byte of null, len of 0).
-    pub fn ddog_php_prof_zend_string_view(zstr: Option<&mut zend_string>) -> zai_str;
+    pub fn zai_str_from_zstr(zstr: Option<&mut zend_string>) -> zai_str;
 
     /// Registers the run_time_cache slot with the engine. Must be done in
     /// module init or extension startup.
@@ -439,8 +438,7 @@ impl TryFrom<&mut zval> for String {
             }
 
             // Safety: checked the pointer wasn't null above.
-            let str =
-                unsafe { ddog_php_prof_zend_string_view(zval.value.str_.as_mut()).into_string() };
+            let str = unsafe { zai_str_from_zstr(zval.value.str_.as_mut()) }.into_string();
             Ok(str)
         } else {
             Err(StringError::Type(r#type))

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -3,7 +3,6 @@
 
 use crate::bindings::{zend_execute_data, ZaiStr};
 use crate::runtime_id;
-use std::borrow::Cow;
 
 #[no_mangle]
 pub extern "C" fn datadog_profiling_notify_trace_finished(
@@ -69,6 +68,7 @@ pub extern "C" fn datadog_profiling_interrupt_function(execute_data: *mut zend_e
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
 
     #[test]
     fn test_string_view() {

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -145,17 +145,6 @@ void ddog_php_prof_copy_long_into_zval(zval *dest, long num) {
     return;
 }
 
-/**
- * Converts the zend_string pointer into a string view. Null pointers and
- * empty strings will be converted into a string view to a static empty
- * string (single byte of null, len of 0).
- */
-zai_str ddog_php_prof_zend_string_view(zend_string *zstr) {
-    return (!zstr || ZSTR_LEN(zstr) == 0)
-        ? ZAI_STR_EMPTY
-        : ZAI_STR_FROM_ZSTR(zstr);
-}
-
 void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
                                                void* (*_malloc)(size_t),
                                                void  (*_free)(void*),

--- a/profiling/src/profiling/stalk_walking.rs
+++ b/profiling/src/profiling/stalk_walking.rs
@@ -1,6 +1,4 @@
-use crate::bindings::{
-    ddog_php_prof_zend_string_view, zend_execute_data, zend_function, ZEND_USER_FUNCTION,
-};
+use crate::bindings::{zai_str_from_zstr, zend_execute_data, zend_function, ZEND_USER_FUNCTION};
 use crate::string_table::StringTable;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -113,7 +111,7 @@ unsafe fn handle_file_cache_slot_helper(
             return None;
         };
 
-        let file = ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).into_string();
+        let file = zai_str_from_zstr(func.op_array.filename.as_mut()).into_string();
         let offset = string_table.insert(file.as_ref());
         cache_slots[1] = offset as usize;
         file
@@ -163,9 +161,8 @@ unsafe fn extract_file_and_line(execute_data: &zend_execute_data) -> (Option<Str
     // This should be Some, just being cautious.
     match execute_data.func.as_ref() {
         Some(func) if func.type_ == ZEND_USER_FUNCTION as u8 => {
-            // Safety: ddog_php_prof_zend_string_view will return a valid ZaiStr.
-            let file =
-                ddog_php_prof_zend_string_view(func.op_array.filename.as_mut()).into_string();
+            // Safety: zai_str_from_zstr will return a valid ZaiStr.
+            let file = zai_str_from_zstr(func.op_array.filename.as_mut()).into_string();
             let lineno = match execute_data.opline.as_ref() {
                 Some(opline) => opline.lineno,
                 None => 0,

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -1,5 +1,5 @@
 use crate::bindings as zend;
-use crate::zend::{ddog_php_prof_zend_string_view, zend_get_executed_filename_ex};
+use crate::zend::{zai_str_from_zstr, zend_get_executed_filename_ex};
 use crate::{PROFILER, REQUEST_LOCALS};
 use libc::c_char;
 use log::{error, trace};
@@ -74,8 +74,7 @@ unsafe extern "C" fn ddog_php_prof_compile_string(
             return op_array;
         }
 
-        let filename =
-            ddog_php_prof_zend_string_view(zend_get_executed_filename_ex().as_mut()).into_string();
+        let filename = zai_str_from_zstr(zend_get_executed_filename_ex().as_mut()).into_string();
 
         let line = zend::zend_get_executed_lineno();
 
@@ -148,7 +147,7 @@ unsafe extern "C" fn ddog_php_prof_compile_file(
         // for example "/var/www/html/../vendor/foo/bar.php" while during stack walking we get
         // "/var/html/vendor/foo/bar.php". This makes sure it is the exact same string we'd
         // collect in stack walking and therefore we are fully utilizing the pprof string table
-        let filename = ddog_php_prof_zend_string_view((*op_array).filename.as_mut()).into_string();
+        let filename = zai_str_from_zstr((*op_array).filename.as_mut()).into_string();
 
         trace!(
             "Compile file \"{filename}\" with include type \"{include_type}\" took {} nanoseconds",

--- a/zend_abstract_interface/config/CMakeLists.txt
+++ b/zend_abstract_interface/config/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(
 
 target_compile_features(zai_config PUBLIC c_std_99)
 
-target_link_libraries(zai_config PUBLIC Tea::Php Zai::Json Zai::Env)
+target_link_libraries(zai_config PUBLIC Tea::Php Zai::Json Zai::Env Zai::String)
 
 set_target_properties(zai_config PROPERTIES EXPORT_NAME Config
                                             VERSION ${PROJECT_VERSION})

--- a/zend_abstract_interface/env/CMakeLists.txt
+++ b/zend_abstract_interface/env/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(
 
 target_compile_features(zai_env PUBLIC c_std_99)
 
-target_link_libraries(zai_env PUBLIC Tea::Tea Tea::Php)
+target_link_libraries(zai_env PUBLIC Tea::Tea Tea::Php Zai::String)
 
 set_target_properties(zai_env PROPERTIES EXPORT_NAME Env VERSION
                                                          ${PROJECT_VERSION})

--- a/zend_abstract_interface/env/env.h
+++ b/zend_abstract_interface/env/env.h
@@ -1,9 +1,10 @@
 #ifndef ZAI_ENV_H
 #define ZAI_ENV_H
 
+#include <zai_string/string.h>
+
 #include <stdbool.h>
 #include <stddef.h>
-#include <zai_string/string.h>
 
 /* The upper-bounds limit on the buffer size to hold the value of an arbitrary
  * environment variable.

--- a/zend_abstract_interface/headers/CMakeLists.txt
+++ b/zend_abstract_interface/headers/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(zai_headers PUBLIC
 
 target_compile_features(zai_headers PUBLIC c_std_99)
 
-target_link_libraries(zai_headers PUBLIC Tea::Php)
+target_link_libraries(zai_headers PUBLIC Tea::Php Zai::String)
 
 set_target_properties(zai_headers PROPERTIES
                                   EXPORT_NAME headers

--- a/zend_abstract_interface/symbols/CMakeLists.txt
+++ b/zend_abstract_interface/symbols/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(
   zai_symbols PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(zai_symbols PUBLIC Tea::Php Zai::Sandbox)
+target_link_libraries(zai_symbols PUBLIC Tea::Php Zai::Sandbox Zai::String)
 
 target_compile_features(zai_symbols PUBLIC c_std_99)
 

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -122,7 +122,7 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
         case ZAI_SYMBOL_SCOPE_NAMESPACE: {
             zai_string key = zai_symbol_lookup_key(scope, name, true);
             result = zai_symbol_lookup_table(EG(class_table),zai_string_as_str(&key),false, true);
-            zai_string_dtor(&key);
+            zai_string_destroy(&key);
         } break;
 
         default:
@@ -165,7 +165,7 @@ static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t 
         key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         scope_type != ZAI_SYMBOL_SCOPE_NAMESPACE, true);
 
-    zai_string_dtor(&tmpkey);
+    zai_string_destroy(&tmpkey);
 
     return function;
 }
@@ -184,7 +184,7 @@ static inline zval* lookup_constant_global(zai_symbol_scope_t scope_type, void *
         key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         false, true);
 
-    zai_string_dtor(&tmpkey);
+    zai_string_destroy(&tmpkey);
 
     if (!constant) {
         return NULL;

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -77,41 +77,19 @@ static inline zai_str zai_symbol_lookup_clean(zai_str view) {
     return ZAI_STR_NEW(view.ptr + 1, view.len - 1);
 }
 
-static inline zai_str zai_symbol_lookup_key(zai_str *namespace, zai_str *name, bool lower) {
-    zai_str rv;
-    zai_str vns     = zai_symbol_lookup_clean(*namespace);
-    zai_str vn      = zai_symbol_lookup_clean(*name);
+static zai_string zai_symbol_lookup_key(zai_str *namespace, zai_str *name, bool lower) {
+    zai_str vns         = zai_symbol_lookup_clean(*namespace);
+    zai_str separator   = vns.len ? ZAI_STRL("\\") : ZAI_STR_EMPTY;
+    zai_str vn          = zai_symbol_lookup_clean(*name);
+    zai_string rv       = zai_string_concat3(vns, separator, vn);
 
-    char *result = NULL;
-#define CHAR_AT(n) (result[n])
-    if (vns.len) {
-        rv.len = vns.len + vn.len + 1;
-        result = pemalloc(rv.len + 1, 1);
-
-        memcpy(&CHAR_AT(0), vns.ptr, vns.len);
-
-        for (uint32_t c = 0; c < vns.len; c++) {
-            CHAR_AT(c) = tolower(CHAR_AT(c));
-        }
-
-        CHAR_AT(vns.len) = '\\';
-        memcpy(&CHAR_AT(vns.len + 1), vn.ptr, vn.len);
-    } else {
-        rv.len = vn.len;
-        result = pemalloc(rv.len + 1, 1);
-
-        memcpy(&CHAR_AT(0), vn.ptr, vn.len);
+    // Namespaces are never case-sensitive, so they are always lowered, even
+    // if `lower == false`, but do not lowercase the name segment unless
+    // `lower == true`.
+    size_t len = vns.len + separator.len + (lower ? vn.len : 0);
+    for (size_t c = 0; c < len; c++) {
+        rv.ptr[c] = tolower(rv.ptr[c]);
     }
-
-    if (lower) {
-        for (uint32_t c = vns.len; c < rv.len; c++) {
-            CHAR_AT(c) = tolower(CHAR_AT(c));
-        }
-    }
-
-    CHAR_AT(rv.len) = 0;
-#undef CHAR_AT
-    rv.ptr = result;
 
     return rv;
 }
@@ -142,16 +120,16 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
         } break;
 
         case ZAI_SYMBOL_SCOPE_NAMESPACE: {
-            zai_str key = zai_symbol_lookup_key(scope, name, true);
+            zai_string key = zai_symbol_lookup_key(scope, name, true);
 
-            if (key.ptr) {
+            if (key.len > 0) {
                 result = zai_symbol_lookup_table(
                     EG(class_table),
-                    key,
+                    zai_string_as_str(&key),
                     false, true);
-
-                pefree((char*) key.ptr, 1);
             }
+
+            zai_string_dtor(&key);
         } break;
 
         default:
@@ -164,6 +142,7 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
 static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t scope_type, void *scope, zai_str *name) {
     HashTable *table = NULL;
     zai_str key = *name;
+    zai_string tmpkey = ZAI_STRING_EMPTY;
 
     switch (scope_type) {
         case ZAI_SYMBOL_SCOPE_CLASS:
@@ -175,7 +154,8 @@ static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t 
             break;
 
         case ZAI_SYMBOL_SCOPE_NAMESPACE:
-            key = zai_symbol_lookup_key(scope, name, true);
+            tmpkey = zai_symbol_lookup_key(scope, name, true);
+            key = zai_string_as_str(&tmpkey);
             /* intentional fall through */
 
         case ZAI_SYMBOL_SCOPE_GLOBAL:
@@ -192,18 +172,18 @@ static inline zend_function *zai_symbol_lookup_function_impl(zai_symbol_scope_t 
         key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         scope_type != ZAI_SYMBOL_SCOPE_NAMESPACE, true);
 
-    if (key.ptr != name->ptr) {
-        pefree((char*) key.ptr, 1);
-    }
+    zai_string_dtor(&tmpkey);
 
     return function;
 }
 
 static inline zval* lookup_constant_global(zai_symbol_scope_t scope_type, void *scope, zai_str *name) {
     zai_str key = *name;
+    zai_string tmpkey = ZAI_STRING_EMPTY;
 
     if (scope_type == ZAI_SYMBOL_SCOPE_NAMESPACE) {
-        key = zai_symbol_lookup_key(scope, name, false);
+        tmpkey = zai_symbol_lookup_key(scope, name, false);
+        key = zai_string_as_str(&tmpkey);
     }
 
     zend_constant *constant = zai_symbol_lookup_table(
@@ -211,9 +191,7 @@ static inline zval* lookup_constant_global(zai_symbol_scope_t scope_type, void *
         key.ptr == name->ptr ? zai_symbol_lookup_clean(key) : key,
         false, true);
 
-    if (key.ptr != name->ptr) {
-        pefree((char*) key.ptr, 1);
-    }
+    zai_string_dtor(&tmpkey);
 
     if (!constant) {
         return NULL;

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -121,14 +121,7 @@ static inline zend_class_entry *zai_symbol_lookup_class_impl(zai_symbol_scope_t 
 
         case ZAI_SYMBOL_SCOPE_NAMESPACE: {
             zai_string key = zai_symbol_lookup_key(scope, name, true);
-
-            if (key.len > 0) {
-                result = zai_symbol_lookup_table(
-                    EG(class_table),
-                    zai_string_as_str(&key),
-                    false, true);
-            }
-
+            result = zai_symbol_lookup_table(EG(class_table),zai_string_as_str(&key),false, true);
             zai_string_dtor(&key);
         } break;
 

--- a/zend_abstract_interface/zai_string/CMakeLists.txt
+++ b/zend_abstract_interface/zai_string/CMakeLists.txt
@@ -1,14 +1,18 @@
-add_library(zai_string INTERFACE)
+add_library(zai_string string.c)
 
-target_include_directories(zai_string INTERFACE
-                                      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                      $<INSTALL_INTERFACE:include>)
+target_include_directories(
+  zai_string PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                    $<INSTALL_INTERFACE:include>)
 
-target_compile_features(zai_string INTERFACE c_std_99)
+target_compile_features(zai_string PUBLIC c_std_99)
 
-target_link_libraries(zai_string INTERFACE Tea::Php Zai::Assert)
+target_link_libraries(zai_string PUBLIC Tea::Php Zai::Assert)
 
-add_library(Zai::string ALIAS zai_string)
+add_library(Zai::String ALIAS zai_string)
+
+if (${BUILD_ZAI_TESTING})
+    add_subdirectory(tests)
+endif()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string.h

--- a/zend_abstract_interface/zai_string/string.c
+++ b/zend_abstract_interface/zai_string/string.c
@@ -1,0 +1,5 @@
+#include "string.h"
+
+char *ZAI_STRING_EMPTY_PTR = "";
+
+extern inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str third);

--- a/zend_abstract_interface/zai_string/string.c
+++ b/zend_abstract_interface/zai_string/string.c
@@ -2,4 +2,6 @@
 
 char *ZAI_STRING_EMPTY_PTR = "";
 
+extern inline zai_str zai_str_from_zstr(zend_string *zstr);
+
 extern inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str third);

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -213,7 +213,7 @@ static inline zai_string zai_string_ctor(zai_str str) {
     }
 
     // plus 1 for the null byte
-    char *bytes = (char *)__zend_malloc(str.len + 1);
+    char *bytes = (char *)pemalloc(str.len + 1, true);
     memcpy(bytes, str.ptr, str.len);
     bytes[str.len] = '\0';
     return (zai_string) {.ptr = bytes, .len = str.len};
@@ -227,7 +227,7 @@ inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str thir
     }
 
     // plus 1 for the null byte
-    char *bytes = (char *)pemalloc(len + 1, 1);
+    char *bytes = (char *)pemalloc(len + 1, true);
 
     memcpy(bytes, first.ptr, first.len);
     memcpy(bytes + first.len, second.ptr, second.len);
@@ -243,7 +243,7 @@ inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str thir
  */
 static inline void zai_string_dtor(zai_string *string) {
     if (EXPECTED(string->ptr != ZAI_STRING_EMPTY_PTR)) {
-        pefree(string->ptr, 1);
+        pefree(string->ptr, true);
         // Because this project runs asan builds, we don't re-assign the
         // pointer to ZAI_STRING_EMPTY_PTR or similar because we want the
         // analyzer to complain if this gets used in some way after free.

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -241,7 +241,7 @@ inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str thir
  * Destroys the contents of the string. It is considered to be uninitialized
  * after this call.
  */
-static inline void zai_string_dtor(zai_string *string) {
+static inline void zai_string_destroy(zai_string *string) {
     if (EXPECTED(string->ptr != ZAI_STRING_EMPTY_PTR)) {
         pefree(string->ptr, true);
         // Because this project runs asan builds, we don't re-assign the

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -11,6 +11,8 @@
 #include <stddef.h>
 #include <string.h>
 
+extern char *ZAI_STRING_EMPTY_PTR;
+
 /**
  * Represents a non-owning view of a string.
  *
@@ -44,7 +46,7 @@ typedef struct zai_str_s {
     ZAI_STR_FROM_RAW_PARTS("" literal, sizeof(literal) - 1)
 
 #define ZAI_STR_EMPTY \
-    ZAI_STR_FROM_RAW_PARTS("", 0)
+    ZAI_STR_FROM_RAW_PARTS(ZAI_STRING_EMPTY_PTR, 0)
 
 /** Use if cstr is known to be non-null, use zai_str_from_cstr otherwise. */
 #define ZAI_STR_FROM_CSTR(cstr)  \
@@ -100,7 +102,7 @@ static inline bool zai_str_eq_ci_cstr(zai_str s, const char *str) {
     ZEND_ASSERT(s.ptr != NULL);
     ZEND_ASSERT(str != NULL);
     size_t len = strlen(str);
-    return s.len == len && strncasecmp(s.ptr, str, len) == 0;
+    return s.len == len && zend_binary_strncasecmp(s.ptr, s.len, str, len, len) == 0;
 }
 
 /** Represents an optional string view. Please treat this as opaque. */
@@ -134,7 +136,10 @@ zai_option_str zai_option_str_from_raw_parts(const char *ptr, size_t len) {
  */
 static inline
 zai_option_str zai_option_str_from_str(zai_str str) {
-    return (zai_option_str) {.ptr = str.len ? str.ptr : "", .len = str.len};
+    return (zai_option_str) {
+        .ptr = str.len ? str.ptr : ZAI_STRING_EMPTY_PTR,
+        .len = str.len,
+    };
 }
 
 /** Returns true if the option holds a value. */
@@ -165,6 +170,84 @@ bool zai_option_str_get(zai_option_str self, zai_str *view) {
     *view = zai_option_str_is_some(self) ? value : ZAI_STR_EMPTY;
     ZEND_ASSERT(view->ptr != NULL);
     return self.ptr;
+}
+
+/**
+ * Represents a owned string.
+ *
+ * When initializing the struct, use one of the initialization macros or
+ * functions. Do not initialize the struct directly.
+ *
+ * It is currently guaranteed that zai_string has the same layout as zai_str.
+ * This makes it safe to memcpy a zai_string into a zai_str. However, you
+ * shouldn't re-interpret a zai_string as a zai_str, because you are likely to
+ * commit an aliasing violation.
+ */
+typedef struct zai_string_s {
+    /**
+     * Guaranteed to hold .len + 1 bytes. The byte at self.ptr[self.len] is
+     * guaranteed to be a null character, but after initialization, this last
+     * byte must only be read, never written.
+     */
+    char *ptr;
+    size_t len;
+} zai_string;
+
+#define ZAI_STRING_EMPTY \
+    (zai_string) {.ptr = ZAI_STRING_EMPTY_PTR, .len = 0}
+
+/**
+ * Creates a zai_str view of the zai_string. Make sure the zai_str does not
+ * outlive the zai_string.
+ */
+__attribute__((pure))
+static inline zai_str zai_string_as_str(const zai_string *string) {
+    zai_str str;
+    memcpy(&str, string, sizeof(zai_str));
+    return str;
+}
+
+static inline zai_string zai_string_ctor(zai_str str) {
+    if (str.len == 0) {
+        return ZAI_STRING_EMPTY;
+    }
+
+    // plus 1 for the null byte
+    char *bytes = (char *)__zend_malloc(str.len + 1);
+    memcpy(bytes, str.ptr, str.len);
+    bytes[str.len] = '\0';
+    return (zai_string) {.ptr = bytes, .len = str.len};
+}
+
+inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str third) {
+    size_t len = first.len + second.len + third.len;
+
+    if (len == 0) {
+        return ZAI_STRING_EMPTY;
+    }
+
+    // plus 1 for the null byte
+    char *bytes = (char *)pemalloc(len + 1, 1);
+
+    memcpy(bytes, first.ptr, first.len);
+    memcpy(bytes + first.len, second.ptr, second.len);
+    memcpy(bytes + first.len + second.len, third.ptr, third.len);
+
+    bytes[len] = '\0';
+    return (zai_string) {.ptr = bytes, .len = len};
+}
+
+/**
+ * Destroys the contents of the string. It is considered to be uninitialized
+ * after this call.
+ */
+static inline void zai_string_dtor(zai_string *string) {
+    if (EXPECTED(string->ptr != ZAI_STRING_EMPTY_PTR)) {
+        pefree(string->ptr, 1);
+        // Because this project runs asan builds, we don't re-assign the
+        // pointer to ZAI_STRING_EMPTY_PTR or similar because we want the
+        // analyzer to complain if this gets used in some way after free.
+    }
 }
 
 #endif  // ZAI_STRING_H

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -207,7 +207,7 @@ static inline zai_str zai_string_as_str(const zai_string *string) {
     return str;
 }
 
-static inline zai_string zai_string_ctor(zai_str str) {
+static inline zai_string zai_string_from_str(zai_str str) {
     if (str.len == 0) {
         return ZAI_STRING_EMPTY;
     }

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -82,7 +82,7 @@ static inline zai_str zai_str_from_cstr(const char *cstr) {
  *
  * If the pointer is known to be non-null, use ZAI_STR_FROM_ZSTR directly.
  */
-static inline zai_str zai_str_from_zstr(zend_string *zstr) {
+inline zai_str zai_str_from_zstr(zend_string *zstr) {
     return zstr ? ZAI_STR_FROM_ZSTR(zstr) : ZAI_STR_EMPTY;
 }
 

--- a/zend_abstract_interface/zai_string/tests/CMakeLists.txt
+++ b/zend_abstract_interface/zai_string/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(strings strings.cc)
+
+target_link_libraries(strings PUBLIC catch2_main Tea::Tea Zai::String)
+
+catch_discover_tests(strings)

--- a/zend_abstract_interface/zai_string/tests/strings.cc
+++ b/zend_abstract_interface/zai_string/tests/strings.cc
@@ -44,7 +44,7 @@ TEA_TEST_CASE("zai_string/strings", "zai_string_concat3 empty first and second",
 
     REQUIRE(zai_str_eq(third, zai_string_as_str(&result)));
 
-    zai_string_dtor(&result);
+    zai_string_destroy(&result);
 })
 
 TEA_TEST_CASE("zai_string/strings", "zai_string_concat3 all full", {
@@ -57,5 +57,5 @@ TEA_TEST_CASE("zai_string/strings", "zai_string_concat3 all full", {
     zai_str expected = ZAI_STRL("Datadog\\Test\\str");
     REQUIRE(zai_str_eq(expected, zai_string_as_str(&result)));
 
-    zai_string_dtor(&result);
+    zai_string_destroy(&result);
 })

--- a/zend_abstract_interface/zai_string/tests/strings.cc
+++ b/zend_abstract_interface/zai_string/tests/strings.cc
@@ -1,0 +1,61 @@
+extern "C" {
+#include "zai_string/string.h"
+}
+
+#include "tea/testing/catch2.hpp"
+
+TEA_TEST_CASE("zai_string/strings", "zai_str_eq empty string", {
+    zai_str a = ZAI_STR_EMPTY;
+    zai_str b = ZAI_STR_EMPTY;
+    zai_str c = ZAI_STRL("datadog");
+
+    REQUIRE(zai_str_eq(a, b));
+    REQUIRE(zai_str_eq(b, a));
+
+    REQUIRE(!zai_str_eq(a, c));
+    REQUIRE(!zai_str_eq(c, b));
+})
+
+TEA_TEST_CASE("zai_string/strings", "zai_str_eq non-empty string", {
+    zai_str a = ZAI_STRL("datadog");
+    zai_str b = ZAI_STRL("datadog");
+    zai_str c = ZAI_STRL("datadoge");
+    zai_str d = ZAI_STRL("datad0g");
+
+    REQUIRE(zai_str_eq(a, b));
+    REQUIRE(zai_str_eq(b, a));
+
+    REQUIRE(!zai_str_eq(a, c));
+    REQUIRE(!zai_str_eq(c, a));
+
+    REQUIRE(!zai_str_eq(a, d));
+    REQUIRE(!zai_str_eq(d, a));
+
+    REQUIRE(!zai_str_eq(c, d));
+    REQUIRE(!zai_str_eq(d, c));
+})
+
+TEA_TEST_CASE("zai_string/strings", "zai_string_concat3 empty first and second", {
+    // this models namespace lookups
+    zai_str first   = ZAI_STR_EMPTY;
+    zai_str second  = ZAI_STR_EMPTY;
+    zai_str third   = ZAI_STRL("datadog");
+    zai_string result = zai_string_concat3(first, second, third);
+
+    REQUIRE(zai_str_eq(third, zai_string_as_str(&result)));
+
+    zai_string_dtor(&result);
+})
+
+TEA_TEST_CASE("zai_string/strings", "zai_string_concat3 all full", {
+    // this models namespace lookups
+    zai_str first   = ZAI_STRL("Datadog\\Test");
+    zai_str second  = ZAI_STRL("\\");
+    zai_str third   = ZAI_STRL("str");
+    zai_string result = zai_string_concat3(first, second, third);
+
+    zai_str expected = ZAI_STRL("Datadog\\Test\\str");
+    REQUIRE(zai_str_eq(expected, zai_string_as_str(&result)));
+
+    zai_string_dtor(&result);
+})


### PR DESCRIPTION
### Description

This adds a `zai_string` struct and associated methods. Part of the `zai_config` code was storing owned pointers inside `zai_str`s, and since it did it more than once, I figured adding a dedicated struct with methods seemed prudent.

A few notes:
 - We don't want to allocate for empty strings. There is some effort made to return a canonical empty string `ZAI_STRING_EMPTY` which always uses `ZAI_STRING_EMPTY_PTR` for the pointer value. This pointer is not freed in `zai_string_dtor`.
 - There are tests for some `zai_string` and `zai_str` functions now.

This also uses the `zai_str_from_zstr` function in the profiler instead of rolling its own `ddog_php_prof_zend_string_view`. This means that at least for now, `zai_str_from_zstr` cannot be purely `static inline`. So I use the standardized C99 `inline` + `extern inline` instead. This probably should have been in its own PR, sorry.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
