### PR TITLE
Not run syslog tests on outdated libsasl2-2.1.27

### DIFF
--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -149,6 +149,8 @@ ext/standard/tests/math/bindec_variation1_64bit.phpt
 ext/standard/tests/math/hexdec_variation1_64bit.phpt
 ext/standard/tests/math/octdec_variation1.phpt
 ext/standard/tests/network/bug80067.phpt
+ext/standard/tests/network/syslog_new_line.phpt
+ext/standard/tests/network/syslog_null_byte.phpt
 ext/standard/tests/serialize/005.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -146,6 +146,8 @@ ext/standard/tests/math/bindec_variation1_64bit.phpt
 ext/standard/tests/math/hexdec_variation1_64bit.phpt
 ext/standard/tests/math/octdec_variation1.phpt
 ext/standard/tests/network/bug80067.phpt
+ext/standard/tests/network/syslog_new_line.phpt
+ext/standard/tests/network/syslog_null_byte.phpt
 ext/standard/tests/serialize/005.phpt
 ext/standard/tests/streams/bug78902.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -161,6 +161,12 @@ ddtrace affects the order of destructor execution due to creating span stacks et
 
 Observer tests trace all functions, including dd setup. Exclude these from being observed.
 
+## `ext/standard/tests/network/syslog_null_byte.phpt`, `ext/standard/tests/network/syslog_new_line.phpt`
+
+Both of them have a additional `PHPT: DIGEST-MD5 common mech free` in the output which is not expected in the test. This line originates from `libdigestmd5.so` which is shipped as part of `libsasl2-modules` in Debian. We are currently running those tests on Debian Buster which is stuck on Version 2.1.27 of that package, while the "fix" is in 2.1.28 version of the Debian package.
+
+See also: https://github.com/DataDog/dd-trace-php/pull/2218
+
 ## SKIP\_ONLINE\_TESTS
 
 The env var `SKIP_ONLINE_TESTS` is set so that in newer PHP versions, we skip


### PR DESCRIPTION
### Description

There are two tests failing since #2208:
- `ext/standard/tests/network/syslog_null_byte.phpt`
- `ext/standard/tests/network/syslog_new_line.phpt`

Both of them have a additional `PHPT: DIGEST-MD5 common mech free` in the output which is not expected in the test. This line originates from `libdigestmd5.so` which is shipped as part of `libsasl2-modules` in Debian. We are currently running those tests on Debian Buster which is stuck on Version 2.1.27 of that package, while the ["fix" is in 2.1.28 version of the Debian package](https://git.launchpad.net/ubuntu/+source/cyrus-sasl2/tree/debian/patches/0001-plugins-digestmd5-Remove-debug-log-mech-free.patch).

For the time being we'll just allow those tests to fail. We'll have to revisit once we run the tests not on Debian Buster anymore.

More about this: https://bugs.launchpad.net/ubuntu/+source/cyrus-sasl2/+bug/827151

#### Why does `closelog()` not solve the problem?
I am not 100% sure, but on our Debian Buster container we do not have a syslogd running, so it looks like `libdigestmd5.so` falls back to just `fprintf(stderr, ...)`, but the test calling `openlog()` definitely triggers this, which is something we might investigate in the future. That being said: Debian Buster is on LTS till June 30th, 2024, so we might as well not have another look and let the problem solve itself 😉 

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
