### PR TITLE
Fix tests: allocate less TLS space by putting uhook HashTables into module globals

### DIFF
--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -139,6 +139,9 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     char *cgroup_file;
     ddog_QueueId telemetry_queue_id;
     zend_string *last_flushed_root_service_name;
+
+    HashTable uhook_active_hooks;
+    HashTable uhook_closure_hooks;
 ZEND_END_MODULE_GLOBALS(ddtrace)
 // clang-format on
 

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1042,7 +1042,8 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     // handle dropped spans
     if (span->parent) {
         ddtrace_span_data *parent = span->parent;
-        while (ddtrace_span_is_dropped(parent)) {
+        // Ensure the parent id is the root span if everything else was dropped
+        while (parent->parent && ddtrace_span_is_dropped(parent)) {
             parent = parent->parent;
         }
         span->parent_id = parent->span_id;


### PR DESCRIPTION
### Description

And add a small safeguard in serialization with dropping parents (I'm not sure under which circumstances that happens, but apparently it happens, but CI should be happy I hope).

That should fix the CI issues encountered.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~ Fixes CI failures

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
