### PR TITLE
Fix #2174: Can't pass less args to an untyped function than originally passed

### DIFF
--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -656,7 +656,7 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
         RETURN_FALSE;
     }
 
-    if (ZEND_USER_CODE(func->type) && hookData->execute_data->opline > func->op_array.opcodes + zend_hash_num_elements(args)) {
+    if (ZEND_USER_CODE(func->type) && MIN(func->common.num_args, passed_args) > zend_hash_num_elements(args)) {
         LOG_LINE_ONCE(Error, "Can't pass less args to an untyped function than originally passed (minus extra args)");
         RETURN_FALSE;
     }

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -656,6 +656,8 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
         RETURN_FALSE;
     }
 
+    // If we'd remove args, we'd need to re-evaluate potential RECV_INIT opcodes, to get their default values, or outright throw a TypeError
+    // Guard against that for now instead of manually re-evaluating RECV_INIT opcodes.
     if (ZEND_USER_CODE(func->type) && MIN(func->common.num_args, passed_args) > zend_hash_num_elements(args)) {
         LOG_LINE_ONCE(Error, "Can't pass less args to an untyped function than originally passed (minus extra args)");
         RETURN_FALSE;

--- a/tests/ext/sandbox/install_hook/override_argument_jit.phpt
+++ b/tests/ext/sandbox/install_hook/override_argument_jit.phpt
@@ -1,6 +1,7 @@
 --TEST--
 overrideArguments() works with JIT (Issue #2174)
 --SKIPIF--
+<?php if (!file_exists(ini_get("extension_dir") . "/opcache.so")) die('skip: opcache.so does not exist in extension_dir'); ?>
 <?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
 --INI--
 opcache.enable=1

--- a/tests/ext/sandbox/install_hook/override_argument_jit.phpt
+++ b/tests/ext/sandbox/install_hook/override_argument_jit.phpt
@@ -1,0 +1,63 @@
+--TEST--
+overrideArguments() works with JIT (Issue #2174)
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+<?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
+--INI--
+opcache.enable=1
+opcache.enable_cli = 1
+opcache.jit_buffer_size=512M
+opcache.jit=1255
+zend_extension=opcache.so
+--FILE--
+<?php
+
+DDTrace\install_hook('BaseClass::speak',
+    function (\DDTrace\HookData $hook) {
+        echo "hooked in BaseClass.\n";
+        $hook->args[0] = 'goodbye';
+        $hook->args[1] = 'overrideDefault';
+        $hook->overrideArguments($hook->args);
+    }
+);
+
+DDTrace\install_hook('ChildClass::speak',
+    function (\DDTrace\HookData $hook) {
+        echo "hooked in ChildClass.\n";
+        $hook->args[0] = 'goodbye';
+        $hook->args[1] = 'overrideDefault';
+        $hook->overrideArguments($hook->args);
+    }
+);
+
+class BaseClass
+{
+    public static function speak($message, $defArg = 'w/e')
+    {
+        echo "BaseClass::speak: $message\n";
+    }
+}
+
+BaseClass::speak('hello');
+
+// delay ChildClass invocation until runtime
+if (true) {
+    final class ChildClass extends BaseClass
+    {
+    }
+}
+
+for ($i = 0; $i < 2; $i++) {
+    ChildClass::speak('hello');
+}
+
+--EXPECTF--
+hooked in BaseClass.
+BaseClass::speak: goodbye
+hooked in ChildClass.
+hooked in BaseClass.
+BaseClass::speak: goodbye
+hooked in ChildClass.
+hooked in BaseClass.
+BaseClass::speak: goodbye

--- a/tests/ext/sandbox/install_hook/override_argument_jit.phpt
+++ b/tests/ext/sandbox/install_hook/override_argument_jit.phpt
@@ -1,8 +1,6 @@
 --TEST--
 overrideArguments() works with JIT (Issue #2174)
 --SKIPIF--
-<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
-<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
 <?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
 --INI--
 opcache.enable=1

--- a/tests/ext/sandbox/install_hook/replace_hook_args.phpt
+++ b/tests/ext/sandbox/install_hook/replace_hook_args.phpt
@@ -8,6 +8,13 @@ function foo($a, $b) {
 }
 
 $hook = DDTrace\install_hook("foo", function($hook) {
+    $hook->overrideArguments([9, 10]);
+});
+
+foo(1, 2); // exact args
+
+DDTrace\remove_hook($hook);
+$hook = DDTrace\install_hook("foo", function($hook) {
     $hook->overrideArguments([5, 6, 7, 8]);
 });
 
@@ -33,6 +40,11 @@ optArg(1, 2);
 
 ?>
 --EXPECTF--
+Array
+(
+    [0] => 9
+    [1] => 10
+)
 Array
 (
     [0] => 5

--- a/tests/ext/sandbox/internal_hook_jit.phpt
+++ b/tests/ext/sandbox/internal_hook_jit.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test internal functions are hooked within JIT
 --SKIPIF--
+<?php if (!file_exists(ini_get("extension_dir") . "/opcache.so")) die('skip: opcache.so does not exist in extension_dir'); ?>
 <?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
 <?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
 <?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>


### PR DESCRIPTION
### Description

Fixes an issue with JIT.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
