### PR TITLE
Fix #2232: Add Cargo.lock to pecl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 
 build_pecl_package:
 	BUILD_DIR='$(BUILD_DIR)/'; \
-	FILES="$(C_FILES) $(RUST_FILES) $(TEST_FILES) $(TEST_STUB_FILES) $(M4_FILES)"; \
+	FILES="$(C_FILES) $(RUST_FILES) $(TEST_FILES) $(TEST_STUB_FILES) $(M4_FILES) Cargo.lock"; \
 	tooling/bin/pecl-build $${FILES//$${BUILD_DIR}/}
 
 packages: .apk.x86_64 .apk.aarch64 .rpm.x86_64 .rpm.aarch64 .deb.x86_64 .deb.arm64 .tar.gz.x86_64 .tar.gz.aarch64 bundle.tar.gz

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Visit the [PHP tracer documentation](https://docs.datadoghq.com/tracing/language
 
 #### Installation from PECL (datadog_trace) or from source
 
-Compilation of the tracer and the profiler requires cargo to be installed. Ensure that cargo is minimum version 1.64.0, otherwise follow the [official instructions for installing cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+Compilation of the tracer and the profiler requires cargo to be installed. Ensure that cargo is minimum version 1.71.0, otherwise follow the [official instructions for installing cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 
 ### Advanced configuration
 


### PR DESCRIPTION
### Description

And bump the required rust version in the README.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- ~[ ] Tests added for this feature/bug.~

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
