### PR TITLE
fix: PHP7 compatibility in logs correlation

### DIFF
--- a/src/Integrations/Integrations/Logs/LogsIntegration.php
+++ b/src/Integrations/Integrations/Logs/LogsIntegration.php
@@ -82,7 +82,7 @@ class LogsIntegration extends Integration
         $placeholders = LogsIntegration::getPlaceholders();
 
         foreach ($placeholders as $placeholder => $value) {
-            if (empty(strpos($message, $placeholder) !== false)) {
+            if (strpos($message, $placeholder) !== false) {
                 return true;
             }
         }

--- a/src/Integrations/Integrations/Logs/LogsIntegration.php
+++ b/src/Integrations/Integrations/Logs/LogsIntegration.php
@@ -82,7 +82,7 @@ class LogsIntegration extends Integration
         $placeholders = LogsIntegration::getPlaceholders();
 
         foreach ($placeholders as $placeholder => $value) {
-            if (str_contains($message, $placeholder)) {
+            if (empty(strpos($message, $placeholder) !== false)) {
                 return true;
             }
         }


### PR DESCRIPTION
### Description

`str_contains` does not exist in PHP7. The tests missed this because of the tests' polyfill (`symfony/polyfill-php80`). 

This may address the issue mentioned in #2231 (TBD).

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors, the reviewer is in charge of this task.
