### PR TITLE
fix: `datadog-setup.php` when INI file is a symlink

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -595,16 +595,21 @@ function install($options)
                 }
                 echo "Created INI file '$iniFilePath'\n";
             } else {
-                echo "Updating existing INI file '$iniFilePath'\n";
+                echo "Updating existing INI file '$iniFilePath'";
+                if (is_link($iniFilePath)) {
+                    $iniFilePath = readlink($iniFilePath);
+                    echo " which is a symlink to '$iniFilePath'";
+                }
+                echo "\n";
                 // phpcs:disable Generic.Files.LineLength.TooLong
                 execute_or_exit(
                     'Impossible to replace the deprecated ddtrace.request_init_hook parameter with the new name.',
-                    "sed -i --follow-symlinks 's|ddtrace.request_init_hook|datadog.trace.request_init_hook|g' "
+                    "sed -i 's|ddtrace.request_init_hook|datadog.trace.request_init_hook|g' "
                     . escapeshellarg($iniFilePath)
                 );
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@datadog\.trace\.request_init_hook \?= \?\(.*\)@datadog.trace.request_init_hook = '"
+                    "sed -i 's@datadog\.trace\.request_init_hook \?= \?\(.*\)@datadog.trace.request_init_hook = '"
                     . escapeshellarg($installDirWrapperPath)
                     . "'@g' " . escapeshellarg($iniFilePath)
                 );
@@ -616,7 +621,7 @@ function install($options)
                  */
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@ \?;\? \?extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
+                    "sed -i 's@ \?;\? \?extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -624,7 +629,7 @@ function install($options)
                 // Support upgrading from the C based zend_extension.
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@zend_extension \?= \?.*datadog-profiling.*\(.*\)@extension = datadog-profiling.so@g' "
+                    "sed -i 's@zend_extension \?= \?.*datadog-profiling.*\(.*\)@extension = datadog-profiling.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
             }
@@ -640,7 +645,7 @@ function install($options)
                 if ($shouldInstallProfiling) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i --follow-symlinks 's@ \?; \?extension \?= \?datadog-profiling.so@extension = datadog-profiling.so@g' "
+                        "sed -i 's@ \?; \?extension \?= \?datadog-profiling.so@extension = datadog-profiling.so@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 } else {
@@ -658,14 +663,14 @@ function install($options)
             if ($shouldInstallAppsec) {
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@ \?; \?extension \?= \?ddappsec.so@extension = ddappsec.so@g' "
+                    "sed -i 's@ \?; \?extension \?= \?ddappsec.so@extension = ddappsec.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
                 // Update helper path
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@datadog.appsec.helper_path \?= \?.*@datadog.appsec.helper_path = " . $appSecHelperPath . "@g' "
+                    "sed -i 's@datadog.appsec.helper_path \?= \?.*@datadog.appsec.helper_path = " . $appSecHelperPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -673,20 +678,20 @@ function install($options)
                 $rulesPathRegex = $options[OPT_INSTALL_DIR] . "/[0-9\.]*/etc/recommended.json";
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@^[ ;]*datadog.appsec.rules \?= \?" . $rulesPathRegex . "@;datadog.appsec.rules = " . $appSecRulesPath . "@g' "
+                    "sed -i 's@^[ ;]*datadog.appsec.rules \?= \?" . $rulesPathRegex . "@;datadog.appsec.rules = " . $appSecRulesPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
                 if (is_truthy($options[OPT_ENABLE_APPSEC])) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i --follow-symlinks 's@;\? \?datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
+                        "sed -i 's@;\? \?datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 } else {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i --follow-symlinks 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
+                        "sed -i 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 }
@@ -694,7 +699,7 @@ function install($options)
                 // Ensure AppSec isn't loaded if not compatible
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i --follow-symlinks 's@extension \?= \?ddappsec.so@;extension = ddappsec.so@g' "
+                    "sed -i 's@extension \?= \?ddappsec.so@;extension = ddappsec.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -908,14 +913,17 @@ function uninstall($options)
          *  2) remove ddtrace.so
          */
         foreach ($iniFilePaths as $iniFilePath) {
+            if (is_link($iniFilePath)) {
+                $iniFilePath = readlink($iniFilePath);
+            }
             if (file_exists($iniFilePath)) {
                 execute_or_exit(
                     "Impossible to disable PHP modules from '$iniFilePath'. You can disable them manually.",
-                    "sed -i --follow-symlinks 's@^extension \?=@;extension =@g' " . escapeshellarg($iniFilePath)
+                    "sed -i 's@^extension \?=@;extension =@g' " . escapeshellarg($iniFilePath)
                 );
                 execute_or_exit(
                     "Impossible to disable Zend modules from '$iniFilePath'. You can disable them manually.",
-                    "sed -i --follow-symlinks 's@^zend_extension \?=@;zend_extension =@g' " . escapeshellarg($iniFilePath)
+                    "sed -i 's@^zend_extension \?=@;zend_extension =@g' " . escapeshellarg($iniFilePath)
                 );
                 echo "Disabled all modules in INI file '$iniFilePath'. "
                     . "The file has not been removed to preserve custom settings.\n";

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -599,12 +599,12 @@ function install($options)
                 // phpcs:disable Generic.Files.LineLength.TooLong
                 execute_or_exit(
                     'Impossible to replace the deprecated ddtrace.request_init_hook parameter with the new name.',
-                    "sed -i 's|ddtrace.request_init_hook|datadog.trace.request_init_hook|g' "
+                    "sed -i --follow-symlinks 's|ddtrace.request_init_hook|datadog.trace.request_init_hook|g' "
                     . escapeshellarg($iniFilePath)
                 );
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@datadog\.trace\.request_init_hook \?= \?\(.*\)@datadog.trace.request_init_hook = '"
+                    "sed -i --follow-symlinks 's@datadog\.trace\.request_init_hook \?= \?\(.*\)@datadog.trace.request_init_hook = '"
                     . escapeshellarg($installDirWrapperPath)
                     . "'@g' " . escapeshellarg($iniFilePath)
                 );
@@ -616,7 +616,7 @@ function install($options)
                  */
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@ \?;\? \?extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
+                    "sed -i --follow-symlinks 's@ \?;\? \?extension \?= \?.*ddtrace.*\(.*\)@extension = ddtrace.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -624,7 +624,7 @@ function install($options)
                 // Support upgrading from the C based zend_extension.
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@zend_extension \?= \?.*datadog-profiling.*\(.*\)@extension = datadog-profiling.so@g' "
+                    "sed -i --follow-symlinks 's@zend_extension \?= \?.*datadog-profiling.*\(.*\)@extension = datadog-profiling.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
             }
@@ -640,7 +640,7 @@ function install($options)
                 if ($shouldInstallProfiling) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i 's@ \?; \?extension \?= \?datadog-profiling.so@extension = datadog-profiling.so@g' "
+                        "sed -i --follow-symlinks 's@ \?; \?extension \?= \?datadog-profiling.so@extension = datadog-profiling.so@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 } else {
@@ -658,14 +658,14 @@ function install($options)
             if ($shouldInstallAppsec) {
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@ \?; \?extension \?= \?ddappsec.so@extension = ddappsec.so@g' "
+                    "sed -i --follow-symlinks 's@ \?; \?extension \?= \?ddappsec.so@extension = ddappsec.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
                 // Update helper path
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@datadog.appsec.helper_path \?= \?.*@datadog.appsec.helper_path = " . $appSecHelperPath . "@g' "
+                    "sed -i --follow-symlinks 's@datadog.appsec.helper_path \?= \?.*@datadog.appsec.helper_path = " . $appSecHelperPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -673,20 +673,20 @@ function install($options)
                 $rulesPathRegex = $options[OPT_INSTALL_DIR] . "/[0-9\.]*/etc/recommended.json";
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@^[ ;]*datadog.appsec.rules \?= \?" . $rulesPathRegex . "@;datadog.appsec.rules = " . $appSecRulesPath . "@g' "
+                    "sed -i --follow-symlinks 's@^[ ;]*datadog.appsec.rules \?= \?" . $rulesPathRegex . "@;datadog.appsec.rules = " . $appSecRulesPath . "@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
                 if (is_truthy($options[OPT_ENABLE_APPSEC])) {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i 's@;\? \?datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
+                        "sed -i --follow-symlinks 's@;\? \?datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = On@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 } else {
                     execute_or_exit(
                         'Impossible to update the INI settings file.',
-                        "sed -i 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
+                        "sed -i --follow-symlinks 's@datadog.appsec.enabled \?=.*$\?@datadog.appsec.enabled = Off@g' "
                         . escapeshellarg($iniFilePath)
                     );
                 }
@@ -694,7 +694,7 @@ function install($options)
                 // Ensure AppSec isn't loaded if not compatible
                 execute_or_exit(
                     'Impossible to update the INI settings file.',
-                    "sed -i 's@extension \?= \?ddappsec.so@;extension = ddappsec.so@g' "
+                    "sed -i --follow-symlinks 's@extension \?= \?ddappsec.so@;extension = ddappsec.so@g' "
                     . escapeshellarg($iniFilePath)
                 );
 
@@ -911,11 +911,11 @@ function uninstall($options)
             if (file_exists($iniFilePath)) {
                 execute_or_exit(
                     "Impossible to disable PHP modules from '$iniFilePath'. You can disable them manually.",
-                    "sed -i 's@^extension \?=@;extension =@g' " . escapeshellarg($iniFilePath)
+                    "sed -i --follow-symlinks 's@^extension \?=@;extension =@g' " . escapeshellarg($iniFilePath)
                 );
                 execute_or_exit(
                     "Impossible to disable Zend modules from '$iniFilePath'. You can disable them manually.",
-                    "sed -i 's@^zend_extension \?=@;zend_extension =@g' " . escapeshellarg($iniFilePath)
+                    "sed -i --follow-symlinks 's@^zend_extension \?=@;zend_extension =@g' " . escapeshellarg($iniFilePath)
                 );
                 echo "Disabled all modules in INI file '$iniFilePath'. "
                     . "The file has not been removed to preserve custom settings.\n";

--- a/package.xml
+++ b/package.xml
@@ -80,6 +80,7 @@ This release adds an enhanced WordPress integration, which can be enabled throug
 - fix: wrong service name on some laravel.event.handle spans #2235
 - fix: PHP7 compatibility in logs correlation #2236
 - Store library_dependencies in memfd, referenced via /proc/self/fd/X DataDog/libdatadog#221
+- fix `datadog-setup.php` when INI file is a symlink #2242
 
 ### Internal Changes
 - Add log levels #2158


### PR DESCRIPTION
### Description

When the INI file found by `datadog-setup.php` is a symlink, the script wont update the INI file correctly.

We found out by a customer complaint. They where installing the tracer via a Debian Package which creates the `/usr/local/etc/php/conf.d/98-ddtrace.ini` as a symlink to `/opt/datadog-php/etc/ddtrace.ini`. Now `sed` is being used with `-i` to update some parts of the INI file, but `sed -i` destroys the symlink and creates a regular file instead which leads to none of the changes are making it to the INI file.

The workaround in that specific case is to not install the tracer via a Debian package, but only use the `datadog-setup.php`,  but still the INI file being a symlink should be supported.

PROF-8145

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
