### PR TITLE
Work around JITting when using HookData->overrideArguments

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -114,6 +114,7 @@ if test "$PHP_DDTRACE" != "no"; then
     EXTRA_ZAI_SOURCES="\
       zend_abstract_interface/interceptor/php8/interceptor.c \
       zend_abstract_interface/interceptor/php8/resolver$ZAI_RESOLVER_SUFFIX.c \
+      zend_abstract_interface/jit_utils/jit_blacklist.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \
     "
   fi
@@ -233,6 +234,7 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/interceptor])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/interceptor/php7])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/interceptor/php8])
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/jit_utils])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/json])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -19,6 +19,7 @@
 #else
 #include <interceptor/php8/interceptor.h>
 #endif
+#include <jit_utils/jit_blacklist.h>
 #include <php.h>
 #include <php_ini.h>
 #include <pthread.h>
@@ -647,6 +648,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     zai_uhook_minit(module_number);
 #if PHP_VERSION_ID >= 80000
     zai_interceptor_minit();
+#endif
+#if ZAI_JIT_BLACKLIST_ACTIVE
+    zai_jit_minit();
 #endif
 #if PHP_VERSION_ID >= 80100
     ddtrace_setup_fiber_observers();

--- a/package.xml
+++ b/package.xml
@@ -75,7 +75,7 @@ This release adds an enhanced WordPress integration, which can be enabled throug
 - (Legacy OpenTracing API) Check if the active span has a parent #2177
 - Handle killed workers and change root span initialization in the integrations #2176
 - fix: add Symfony command's exception to the root span #2194
-- Fix #2174: Can't pass less args to an untyped function than originally passed #2227
+- Fix #2174: Can't pass less args to an untyped function than originally passed #2227, #2243
 - Fix #2232: Add Cargo.lock to pecl #2233
 - fix: wrong service name on some laravel.event.handle spans #2235
 - fix: PHP7 compatibility in logs correlation #2236

--- a/tests/ext/sandbox/install_hook/override_argument_jit.phpt
+++ b/tests/ext/sandbox/install_hook/override_argument_jit.phpt
@@ -3,6 +3,7 @@ overrideArguments() works with JIT (Issue #2174)
 --SKIPIF--
 <?php if (!file_exists(ini_get("extension_dir") . "/opcache.so")) die('skip: opcache.so does not exist in extension_dir'); ?>
 <?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
+<?php if (PHP_VERSION_ID == 80000 && getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip: On php 8.0 we use heuristics to match the pointer. Valgrind does not have a pointer layout matching our assumptions and will gracefully fail the test.'); ?>
 --INI--
 opcache.enable=1
 opcache.enable_cli = 1
@@ -12,11 +13,14 @@ zend_extension=opcache.so
 --FILE--
 <?php
 
+global $val;
+$val = 123;
+
 DDTrace\install_hook('BaseClass::speak',
     function (\DDTrace\HookData $hook) {
         echo "hooked in BaseClass.\n";
         $hook->args[0] = 'goodbye';
-        $hook->args[1] = 'overrideDefault';
+        $hook->args[1] = "{$GLOBALS["val"]}"; // dynamic value
         $hook->overrideArguments($hook->args);
     }
 );
@@ -34,7 +38,7 @@ class BaseClass
 {
     public static function speak($message, $defArg = 'w/e')
     {
-        echo "BaseClass::speak: $message\n";
+        echo "BaseClass::speak: $message, $defArg\n";
     }
 }
 
@@ -53,10 +57,10 @@ for ($i = 0; $i < 2; $i++) {
 
 --EXPECTF--
 hooked in BaseClass.
-BaseClass::speak: goodbye
+BaseClass::speak: goodbye, 123
 hooked in ChildClass.
 hooked in BaseClass.
-BaseClass::speak: goodbye
+BaseClass::speak: goodbye, 123
 hooked in ChildClass.
 hooked in BaseClass.
-BaseClass::speak: goodbye
+BaseClass::speak: goodbye, 123

--- a/zend_abstract_interface/jit_utils/jit_blacklist.c
+++ b/zend_abstract_interface/jit_utils/jit_blacklist.c
@@ -1,0 +1,213 @@
+#include "jit_blacklist.h"
+#include "zend_extensions.h"
+#include <Zend/zend_types.h>
+#include <Zend/zend_ini.h>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#if PHP_VERSION_ID >= 80100
+#include <Zend/Optimizer/zend_call_graph.h>
+#else
+#define zend_func_info_rid zai_jit_func_info_rid
+static int zai_jit_func_info_rid = -2;
+
+typedef struct _zend_ssa_range {
+    zend_long              min;
+    zend_long              max;
+    bool              underflow;
+    bool              overflow;
+} zend_ssa_range;
+
+typedef struct _zend_ssa_var_info {
+    uint32_t               type; /* inferred type (see zend_inference.h) */
+    zend_ssa_range         range;
+    zend_class_entry      *ce;
+    unsigned int           has_range : 1;
+    unsigned int           is_instanceof : 1; /* 0 - class == "ce", 1 - may be child of "ce" */
+    unsigned int           recursive : 1;
+    unsigned int           use_as_double : 1;
+    unsigned int           delayed_fetch_this : 1;
+    unsigned int           avoid_refcounting : 1;
+    unsigned int           guarded_reference : 1;
+    unsigned int           indirect_reference : 1; /* IS_INDIRECT returned by FETCH_DIM_W/FETCH_OBJ_W */
+} zend_ssa_var_info;
+
+typedef struct _zend_cfg {
+    int               blocks_count;       /* number of basic blocks      */
+    int               edges_count;        /* number of edges             */
+    void *blocks;             /* array of basic blocks       */
+    int              *predecessors;
+    uint32_t         *map;
+    uint32_t          flags;
+} zend_cfg;
+
+typedef struct _zend_ssa {
+    zend_cfg               cfg;            /* control flow graph             */
+    int                    vars_count;     /* number of SSA variables        */
+    int                    sccs;           /* number of SCCs                 */
+    void        *blocks;         /* array of SSA blocks            */
+    void           *ops;            /* array of SSA instructions      */
+    void          *vars;           /* use/def chain of SSA variables */
+    zend_ssa_var_info     *var_info;
+} zend_ssa;
+
+typedef struct _zend_func_info {
+    int                     num;
+    uint32_t                flags;
+    zend_ssa                ssa;          /* Static Single Assignment Form  */
+    void         *caller_info;  /* where this function is called from */
+    void         *callee_info;  /* which functions are called from this one */
+    void        **call_map;     /* Call info associated with init/call/send opnum */
+    zend_ssa_var_info       return_info;
+} zend_func_info;
+#endif
+
+typedef struct _zend_jit_op_array_trace_extension {
+    zend_func_info func_info;
+    const zend_op_array *op_array;
+    size_t offset; /* offset from "zend_op" to corresponding "op_info" */
+} zend_jit_op_array_trace_extension;
+
+typedef union _zend_op_trace_info {
+    zend_op dummy; /* the size of this structure must be the same as zend_op */
+    struct {
+        const void *orig_handler;
+        const void *call_handler;
+        int16_t    *counter;
+        uint8_t     trace_flags;
+    };
+} zend_op_trace_info;
+
+#define ZEND_JIT_TRACE_BLACKLISTED  (1<<5)
+
+#define ZEND_OP_TRACE_INFO(opline, offset) \
+	((zend_op_trace_info*)(((char*)opline) + offset))
+
+#define ZEND_FUNC_INFO(op_array) \
+	((zend_func_info*)((op_array)->reserved[zend_func_info_rid]))
+
+static void *opcache_handle;
+static void zai_jit_find_opcache_handle(void *ext) {
+    zend_extension *extension = (zend_extension *)ext;
+    if (strcmp(extension->name, "Zend OPcache") == 0) {
+        opcache_handle = extension->handle;
+    }
+}
+
+// opcache startup NULLs its handle. MINIT is executed before extension startup.
+void zai_jit_minit(void) {
+    zend_llist_apply(&zend_extensions, zai_jit_find_opcache_handle);
+}
+
+void (*zai_jit_protect)(void), (*zai_jit_unprotect)(void);
+static void zai_jit_fetch_symbols(void) {
+    if (!zai_jit_protect) {
+        ZEND_ASSERT(opcache_handle); // assert the handle is there is zend_func_info_rid != -1
+
+        zai_jit_protect = DL_FETCH_SYMBOL(opcache_handle, "zend_jit_protect");
+        if (zai_jit_protect == NULL) {
+            zai_jit_protect = DL_FETCH_SYMBOL(opcache_handle, "_zend_jit_protect");
+        }
+
+        zai_jit_unprotect = DL_FETCH_SYMBOL(opcache_handle, "zend_jit_unprotect");
+        if (zai_jit_unprotect == NULL) {
+            zai_jit_unprotect = DL_FETCH_SYMBOL(opcache_handle, "_zend_jit_unprotect");
+        }
+    }
+}
+
+static inline bool zai_is_func_recv_opcode(zend_uchar opcode) {
+    return opcode == ZEND_RECV || opcode == ZEND_RECV_INIT || opcode == ZEND_RECV_VARIADIC;
+}
+
+#if PHP_VERSION_ID < 80100
+static inline bool check_pointer_near(void *a, void *b) {
+    const size_t prefix_size = 0xFFFFFFFF; // 4 GB
+    return (uintptr_t)a + prefix_size - (uintptr_t)b < prefix_size * 2;
+}
+#endif
+
+void zai_jit_blacklist_function_inlining(zend_op_array *op_array) {
+    if (zend_func_info_rid < 0) {
+#if PHP_VERSION_ID < 80100
+        if (zend_func_info_rid == -2) {
+            if (!opcache_handle) {
+                zai_jit_func_info_rid = -1;
+            } else {
+                // On PHP 8.0 we impossibly can get hold of zend_func_info_rid.
+                // We determine it on our own heuristically, assuming:
+                // a) The zend_func_info_rid is allocated in shared memory.
+                // b) The op_array data is also allocated in shared memory, and thus relatively near.
+                // c) The first matching pointer in op_array->reserved is the zend_func_info_rid.
+                // d) "Normal" memory, like the VM stack is far away
+
+                if (check_pointer_near(op_array->arg_info, EG(vm_stack))) {
+                    // This function does not seem JITted
+                    return;
+                }
+
+                for (int i = 0; i < ZEND_MAX_RESERVED_RESOURCES; ++i) {
+                    if (check_pointer_near(op_array->reserved, op_array->arg_info)) {
+                        zend_func_info_rid = i;
+                        break;
+                    }
+                }
+            }
+        }
+        if (zend_func_info_rid < 0) {
+            return;
+        }
+#else
+        return;
+#endif
+    }
+
+    zend_jit_op_array_trace_extension *jit_extension = (zend_jit_op_array_trace_extension *)ZEND_FUNC_INFO(op_array);
+    if (!jit_extension) {
+        return;
+    }
+
+    // First not-skipped op
+    zend_op *opline = op_array->opcodes;
+    while (zai_is_func_recv_opcode(opline->opcode)) {
+        ++opline;
+    }
+
+    size_t offset = jit_extension->offset;
+
+    if (!(ZEND_OP_TRACE_INFO(opline, offset)->trace_flags & ZEND_JIT_TRACE_BLACKLISTED)) {
+        bool is_protected_memory = false;
+        zend_string *protect_memory = zend_string_init(ZEND_STRL("opcache.protect_memory"), 0);
+        zend_string *protect_memory_ini = zend_ini_get_value(protect_memory);
+        zend_string_release(protect_memory);
+        if (protect_memory_ini) {
+            is_protected_memory = zend_ini_parse_bool(protect_memory_ini);
+        }
+
+        zai_jit_fetch_symbols();
+
+        uint8_t *trace_flags = &ZEND_OP_TRACE_INFO(opline, offset)->trace_flags;
+        const void **handler = &((zend_op*)opline)->handler;
+
+        size_t page_size = sysconf(_SC_PAGESIZE);
+        void *trace_flags_page = (void *) ((uintptr_t) trace_flags & ~page_size);
+        void *handler_page = (void *) ((uintptr_t) handler & ~page_size);
+        if (is_protected_memory) {
+            mprotect(trace_flags_page, page_size, PROT_READ | PROT_WRITE);
+            mprotect(handler_page, page_size, PROT_READ | PROT_WRITE);
+        }
+
+        zai_jit_unprotect();
+
+        *trace_flags |= ZEND_JIT_TRACE_BLACKLISTED;
+        *handler = ZEND_OP_TRACE_INFO(opline, offset)->orig_handler;
+
+        zai_jit_protect();
+
+        if (is_protected_memory) {
+            mprotect(handler_page, page_size, PROT_READ);
+            mprotect(trace_flags_page, page_size, PROT_READ);
+        }
+    }
+}

--- a/zend_abstract_interface/jit_utils/jit_blacklist.h
+++ b/zend_abstract_interface/jit_utils/jit_blacklist.h
@@ -1,0 +1,20 @@
+#ifndef ZAI_JIT_BLACKLIST_H
+#define ZAI_JIT_BLACKLIST_H
+
+#include <main/php_version.h>
+#include <Zend/zend_compile.h>
+
+#ifdef __x86_64__
+#define ZAI_JIT_BLACKLIST_ACTIVE PHP_VERSION_ID >= 80000
+#elif defined(__aarch64__)
+#define ZAI_JIT_BLACKLIST_ACTIVE PHP_VERSION_ID >= 80100
+#else
+#define ZAI_JIT_BLACKLIST_ACTIVE 0
+#endif
+
+#if ZAI_JIT_BLACKLIST_ACTIVE
+void zai_jit_minit(void);
+void zai_jit_blacklist_function_inlining(zend_op_array *op_array);
+#endif
+
+#endif // ZAI_JIT_BLACKLIST_H


### PR DESCRIPTION
### Description

This PR forcefully disallows inlining the hooked methods where overrideArguments is used.
I'll look at implementing a mechanism directly in php-src to avoid this issue.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
