### PR TITLE
fix(profiling): `end_timestamp_ns` usage in profiler

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -632,7 +632,7 @@ impl Profiler {
                     if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
                         labels.push(Label {
                             key: "end_timestamp_ns",
-                            value: LabelValue::Num(now.as_nanos() as i64, Some("nanoseconds")),
+                            value: LabelValue::Num(now.as_nanos() as i64, None),
                         });
                     }
                 }
@@ -773,7 +773,7 @@ impl Profiler {
         });
         labels.push(Label {
             key: "end_timestamp_ns",
-            value: LabelValue::Num(now, Some("nanoseconds")),
+            value: LabelValue::Num(now, None),
         });
 
         let n_labels = labels.len();
@@ -830,7 +830,7 @@ impl Profiler {
         });
         labels.push(Label {
             key: "end_timestamp_ns",
-            value: LabelValue::Num(now, Some("nanoseconds")),
+            value: LabelValue::Num(now, None),
         });
 
         #[cfg(php_gc_status)]
@@ -1130,5 +1130,31 @@ mod tests {
             ]
         );
         assert_eq!(message.value.sample_values, vec![10, 20, 30, 40, 50]);
+    }
+
+    #[test]
+    #[cfg(feature = "timeline")]
+    fn profiler_prepare_sample_message_works_cpu_time_and_timeline() {
+        let frames = get_frames();
+        let samples = get_samples();
+        let labels = Profiler::message_labels();
+        let mut locals = get_request_locals();
+        locals.profiling_enabled = true;
+        locals.profiling_experimental_cpu_time_enabled = true;
+        locals.profiling_experimental_timeline_enabled = true;
+
+        let message: SampleMessage =
+            Profiler::prepare_sample_message(frames, samples, labels, &locals);
+
+        assert_eq!(
+            message.key.sample_types,
+            vec![
+                ValueType::new("sample", "count"),
+                ValueType::new("wall-time", "nanoseconds"),
+                ValueType::new("cpu-time", "nanoseconds"),
+                ValueType::new("timeline", "nanoseconds"),
+            ]
+        );
+        assert_eq!(message.value.sample_values, vec![10, 20, 30, 60]);
     }
 }


### PR DESCRIPTION
### Description

With the update to `libdatadog` version `4.0.0` https://github.com/DataDog/libdatadog/pull/205 came and `libdatadog` now rejects the `end_timestamp_ns` label if it has a `unit` specified with this error message:

> Failed to add sample to the profile: Timestamps with label 'end_timestamp_ns' are always nanoseconds and do not take a unit: found 'nanoseconds'

This leads to empty pprofs (besides allocations, as they are not labeld with timestamps) when the timeline feature is enabled.

This PR fixes this

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

Test is to be found here: https://github.com/DataDog/dd-trace-php/pull/2192

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
