### PR TITLE
feat(profiling): Do not disable allocation profiling on fixed PHP version with active JIT

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -1,3 +1,4 @@
+use bindgen::callbacks::IntKind;
 use std::collections::HashSet;
 use std::env;
 use std::path::Path;
@@ -154,6 +155,18 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
             bindgen::callbacks::MacroParsingBehavior::Ignore
         } else {
             bindgen::callbacks::MacroParsingBehavior::Default
+        }
+    }
+
+    fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
+        match name {
+            "IS_UNDEF" | "IS_NULL" | "IS_FALSE" | "IS_TRUE" | "IS_LONG" | "IS_DOUBLE"
+            | "IS_STRING" | "IS_ARRAY" | "IS_OBJECT" | "IS_RESOURCE" | "IS_REFERENCE"
+            | "_IS_BOOL" => Some(IntKind::U8),
+
+            // None means whatever it would have been without this hook
+            // (likely u32).
+            _ => None,
         }
     }
 }

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -287,6 +287,7 @@ fn cfg_php_feature_flags(vernum: u64) {
     }
     if vernum >= 80300 {
         println!("cargo:rustc-cfg=php_gc_status_extended");
+        println!("cargo:rustc-cfg=php_has_php_version_id_fn");
     }
 }
 

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -88,7 +88,7 @@ const NEEDS_RUN_TIME_CHECK_FOR_ENABLED_JIT: bool =
 
 fn allocation_profiling_needs_disabled_for_jit(version: u32) -> bool {
     // see https://github.com/php/php-src/pull/11380
-    (version >= 80000 && version < 80121) || (version >= 80200 && version < 80208)
+    (80000..80121).contains(&version) || (80200..80208).contains(&version)
 }
 
 lazy_static! {
@@ -372,5 +372,28 @@ fn is_zend_mm() -> bool {
     #[cfg(php8)]
     {
         unsafe { zend::is_zend_mm() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_versions_that_allocation_profiling_needs_disabled_with_active_jit() {
+        // versions that need disabled allocation profiling with active jit
+        assert!(allocation_profiling_needs_disabled_for_jit(80000));
+        assert!(allocation_profiling_needs_disabled_for_jit(80100));
+        assert!(allocation_profiling_needs_disabled_for_jit(80120));
+        assert!(allocation_profiling_needs_disabled_for_jit(80200));
+        assert!(allocation_profiling_needs_disabled_for_jit(80207));
+
+        // versions that DO NOT need disabled allocation profiling with active jit
+        assert!(!allocation_profiling_needs_disabled_for_jit(70421));
+        assert!(!allocation_profiling_needs_disabled_for_jit(80121));
+        assert!(!allocation_profiling_needs_disabled_for_jit(80122));
+        assert!(!allocation_profiling_needs_disabled_for_jit(80208));
+        assert!(!allocation_profiling_needs_disabled_for_jit(80209));
+        assert!(!allocation_profiling_needs_disabled_for_jit(80300));
     }
 }

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -1,5 +1,5 @@
 use crate::bindings as zend;
-use crate::PHP_VERSION_STRUCTURED;
+use crate::PHP_VERSION_ID;
 use crate::PROFILER;
 use crate::PROFILER_NAME;
 use crate::REQUEST_LOCALS;
@@ -94,8 +94,8 @@ lazy_static! {
     /// A fix was introduced in PHP Version 8.1.21 and 8.2.8 with
     /// https://github.com/php/php-src/pull/11380
     static ref CHECK_FOR_ENABLED_JIT: bool = {
-        if let Some((major, minor, patch)) = *PHP_VERSION_STRUCTURED {
-            if major == 8 && ((minor == 0) || (minor == 1 && patch < 21) || (minor == 2 && patch < 8)) {
+        if let Some(version) = *PHP_VERSION_ID {
+            if (version >= 80000 && version <= 80099) || (version >= 80100 && version < 80121) || (version >= 80200 && version < 80208) {
                 return true;
             }
         }

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -375,7 +375,7 @@ impl<'a> TryFrom<&'a mut zval> for &'a mut zend_long {
 
     fn try_from(zval: &'a mut zval) -> Result<Self, Self::Error> {
         let r#type = unsafe { zval.u1.v.type_ };
-        if r#type as u32 == IS_LONG {
+        if r#type == IS_LONG {
             Ok(unsafe { &mut zval.value.lval })
         } else {
             Err(r#type)
@@ -388,7 +388,7 @@ impl TryFrom<&mut zval> for zend_long {
 
     fn try_from(zval: &mut zval) -> Result<Self, Self::Error> {
         let r#type = unsafe { zval.u1.v.type_ };
-        if r#type as u32 == IS_LONG {
+        if r#type == IS_LONG {
             Ok(unsafe { zval.value.lval })
         } else {
             Err(r#type)
@@ -409,9 +409,9 @@ impl TryFrom<&mut zval> for bool {
 
     fn try_from(zval: &mut zval) -> Result<Self, Self::Error> {
         let r#type = unsafe { zval.u1.v.type_ };
-        if r#type == (IS_FALSE as u8) {
+        if r#type == IS_FALSE {
             Ok(false)
-        } else if r#type == (IS_TRUE as u8) {
+        } else if r#type == IS_TRUE {
             Ok(true)
         } else {
             Err(r#type)
@@ -424,14 +424,13 @@ pub enum StringError {
     Type(u8), // Type didn't match.
 }
 
-/// Until we have safely abstracted zend_string*'s in Rust, we need to copy
-/// the String. This also means we can ensure UTF-8 through lossy conversion.
+/// Since we're making a String, do lossy-conversion as necessary.
 impl TryFrom<&mut zval> for String {
     type Error = StringError;
 
     fn try_from(zval: &mut zval) -> Result<Self, Self::Error> {
         let r#type = unsafe { zval.u1.v.type_ };
-        if r#type == (IS_STRING as u8) {
+        if r#type == IS_STRING {
             // This shouldn't happen, very bad, something screwed up.
             if unsafe { zval.value.str_.is_null() } {
                 return Err(StringError::Null);

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -83,6 +83,21 @@ lazy_static! {
             .expect("Reflection's zend_module_entry to be found and contain a valid string")
     };
 
+    static ref PHP_VERSION_STRUCTURED: Option<(u32, u32, u32)> = {
+        let mut iter = PHP_VERSION.split('.').fuse();
+
+        let major = iter.next()?.parse().ok()?;
+        let minor = iter.next()?.parse().ok()?;
+        let patch = iter
+            .next()?
+            .split(|c: char| !c.is_numeric())
+            .next()?
+            .parse()
+            .ok()?;
+
+        Some((major, minor, patch))
+    };
+
     /// The Server API the profiler is running under.
     static ref SAPI: Sapi = {
         // Safety: sapi_module is initialized before minit and there should be

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -14,8 +14,11 @@ mod allocation;
 #[cfg(feature = "timeline")]
 mod timeline;
 
+#[cfg(not(php_has_php_version_id_fn))]
+use bindings::zend_long;
+
 use bindings as zend;
-use bindings::{sapi_globals, zend_long, ZendExtension, ZendResult};
+use bindings::{sapi_globals, ZendExtension, ZendResult};
 use clocks::*;
 use config::AgentEndpoint;
 use datadog_profiling::exporter::{Tag, Uri};
@@ -186,6 +189,7 @@ unsafe fn set_run_time_php_version_id() -> anyhow::Result<()> {
     cfg_if::cfg_if! {
         if #[cfg(php_has_php_version_id_fn)] {
             PHP_VERSION_ID = zend::php_version_id();
+            Ok(())
         } else {
             let vernum = b"PHP_VERSION_ID";
             let vernum_zvp = zend::zend_get_constant_str(

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -371,7 +371,7 @@ void ddog_php_opcache_init_handle() {
 
 // This checks if the JIT actually has a buffer, if so, JIT is active, otherwise
 // JIT is inactive. This will only work after OPcache was initialized (after it
-// assigned its PHP.INI settings), so make sure to call this in RINIT.a
+// assigned its PHP.INI settings), so make sure to call this in RINIT.
 //
 // Attention: this will check for the `opcache.jit_buffer_size` setting as this
 // one is a PHP_INI_SYSTEM (can not be changed on a per directory basis). This

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -7,6 +7,7 @@
 #include <Zend/zend_globals_macros.h>
 #include <Zend/zend_modules.h>
 #include <Zend/zend_alloc.h>
+#include <main/php_main.h>
 #include <php.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/profiling/tests/phpt/jit_02.phpt
+++ b/profiling/tests/phpt/jit_02.phpt
@@ -1,13 +1,12 @@
 --TEST--
-[profiling] Allocation profiling should be disabled when JIT is active
+[profiling] Allocation profiling should be enabled when JIT is active on fixed PHP version
 --DESCRIPTION--
 We did find a crash in PHP when collecting a stack sample in allocation
-profiling when JIT is activated in a `ZEND_GENERATOR_RETURN`. For the time being
-we make sure to disable allocation profiling when we detect the JIT is enabled.
+profiling when JIT is activated in a `ZEND_GENERATOR_RETURN` on PHP 8.0, 8.1.0-8.1.20 and 8.2.0-8.2.7.
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID >= 80208 || PHP_VERSION_ID >= 80121 && PHP_VERSION_ID < 80200)
-    echo "skip: PHP Version >= 8.1.21 and >= 8.2.8 have a fix for this";
+if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207)
+    echo "skip: unpatched PHP version, so JIT should be inactive";
 if (PHP_VERSION_ID < 80000)
     echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
@@ -18,7 +17,7 @@ if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
 ?>
 --INI--
 datadog.profiling.enabled=yes
-datadog.profiling.log_level=debug
+datadog.profiling.log_level=trace
 datadog.profiling.allocation_enabled=yes
 datadog.profiling.experimental_cpu_time_enabled=no
 zend_extension=opcache
@@ -30,6 +29,6 @@ opcache.jit_buffer_size=4M
 echo "Done.", PHP_EOL;
 ?>
 --EXPECTREGEX--
-.*Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https:\/\/github.com\/DataDog\/dd-trace-php\/pull\/2088
+.*Memory allocation profiling enabled.
 .*Done.
 .*

--- a/profiling/tests/phpt/phpinfo_01.phpt
+++ b/profiling/tests/phpt/phpinfo_01.phpt
@@ -1,5 +1,5 @@
 --TEST--
-[profiling] test profiler's extension info
+[profiling] test profiler's extension info with disabled profiling
 --DESCRIPTION--
 The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.

--- a/profiling/tests/phpt/phpinfo_02.phpt
+++ b/profiling/tests/phpt/phpinfo_02.phpt
@@ -5,6 +5,8 @@ The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID >= 80208 || PHP_VERSION_ID >= 80121 && PHP_VERSION_ID < 80200)
+    echo "skip: PHP Version >= 8.1.21 and >= 8.2.8 have a fix for this";
 if (PHP_VERSION_ID < 80000)
     echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))

--- a/profiling/tests/phpt/phpinfo_03.phpt
+++ b/profiling/tests/phpt/phpinfo_03.phpt
@@ -1,27 +1,31 @@
 --TEST--
-[profiling] test profiler's extension info
+[profiling] test profiler's extension info with active JIT on patched version
 --DESCRIPTION--
 The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207)
+    echo "skip: unpatched PHP version, so JIT should be inactive";
+if (PHP_VERSION_ID < 80000)
+    echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
-    echo "skip: test requires Datadog Continuous Profiler\n";
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+$arch = php_uname('m');
+if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
+    echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
 ?>
 --ENV--
 DD_PROFILING_ENABLED=yes
 DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
-DD_PROFILING_ALLOCATION_ENABLED=no
-DD_SERVICE=datadog-profiling-phpt
-DD_ENV=dev
-DD_VERSION=13
-DD_AGENT_HOST=localh0st
-DD_TRACE_AGENT_PORT=80
-DD_TRACE_AGENT_URL=http://datadog:8126
+DD_PROFILING_ALLOCATION_ENABLED=yes
 --INI--
 assert.exception=1
-opcache.jit=off
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
 --FILE--
 <?php
 
@@ -40,20 +44,9 @@ foreach ($lines as $line) {
     $values[trim($pair[0])] = trim($pair[1]);
 }
 
-// Check that Version exists, but not its value
-assert(isset($values["Version"]));
-
 // Check exact values for this set
 $sections = [
-    ["Profiling Enabled", "true"],
-    ["Experimental CPU Time Profiling Enabled", "false"],
-    ["Allocation Profiling Enabled", "false"],
-    ["Endpoint Collection Enabled", "true"],
-    ["Profiling Log Level", "off"],
-    ["Profiling Agent Endpoint", "http://datadog:8126/"],
-    ["Application's Environment (DD_ENV)", "dev"],
-    ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],
-    ["Application's Version (DD_VERSION)", "13"],
+    ["Allocation Profiling Enabled", "true"],
 ];
 
 foreach ($sections as [$key, $expected]) {
@@ -63,7 +56,7 @@ foreach ($sections as [$key, $expected]) {
     );
 }
 
-echo "Done.", PHP_EOL;
+echo "Done.";
 
 ?>
 --EXPECT--

--- a/profiling/tests/phpt/phpinfo_04.phpt
+++ b/profiling/tests/phpt/phpinfo_04.phpt
@@ -1,27 +1,31 @@
 --TEST--
-[profiling] test profiler's extension info
+[profiling] test profiler's extension info with active JIT on patched version
 --DESCRIPTION--
 The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207)
+    echo "skip: unpatched PHP version, so JIT should be inactive";
+if (PHP_VERSION_ID < 80000)
+    echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
-    echo "skip: test requires Datadog Continuous Profiler\n";
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+$arch = php_uname('m');
+if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
+    echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
 ?>
 --ENV--
 DD_PROFILING_ENABLED=yes
 DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
-DD_PROFILING_ALLOCATION_ENABLED=no
-DD_SERVICE=datadog-profiling-phpt
-DD_ENV=dev
-DD_VERSION=13
-DD_AGENT_HOST=localh0st
-DD_TRACE_AGENT_PORT=80
-DD_TRACE_AGENT_URL=http://datadog:8126
+DD_PROFILING_ALLOCATION_ENABLED=yes
 --INI--
 assert.exception=1
-opcache.jit=off
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
 --FILE--
 <?php
 
@@ -40,20 +44,9 @@ foreach ($lines as $line) {
     $values[trim($pair[0])] = trim($pair[1]);
 }
 
-// Check that Version exists, but not its value
-assert(isset($values["Version"]));
-
 // Check exact values for this set
 $sections = [
-    ["Profiling Enabled", "true"],
-    ["Experimental CPU Time Profiling Enabled", "false"],
-    ["Allocation Profiling Enabled", "false"],
-    ["Endpoint Collection Enabled", "true"],
-    ["Profiling Log Level", "off"],
-    ["Profiling Agent Endpoint", "http://datadog:8126/"],
-    ["Application's Environment (DD_ENV)", "dev"],
-    ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],
-    ["Application's Version (DD_VERSION)", "13"],
+    ["Allocation Profiling Enabled", "true"],
 ];
 
 foreach ($sections as [$key, $expected]) {
@@ -63,7 +56,7 @@ foreach ($sections as [$key, $expected]) {
     );
 }
 
-echo "Done.", PHP_EOL;
+echo "Done.";
 
 ?>
 --EXPECT--


### PR DESCRIPTION
### Description

In #2088 we disabled allocation profiling on PHP Version >= 8.0.0 when an active JIT is detected. This PR will incorporate the fact that PHP 8.1.21 and 8.2.8 have a fix for this bug, so we will now disable allocation profiling only when JIT is active on PHP 8.0, 8.1.0 - 8.1.20 and 8.2.0 - 8.2.7.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
