### PR TITLE
fix(profiling) detect an uninitialized runtime cache

### DIFF
--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -211,7 +211,7 @@ static bool has_invalid_run_time_cache(zend_function const *func) {
     // persisting the compiled file and puts a fake frame on the stack where the
     // runtime cache is not yet initialized.
 #if PHP_VERSION_ID < 80200
-    bool is_file_compile = func->op_array.run_time_cache__ptr == NULL;
+    bool is_file_compile = ZEND_MAP_PTR(func->op_array.run_time_cache) == NULL;
 #else
     bool is_file_compile = func->common.run_time_cache__ptr == NULL;
 #endif

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -213,7 +213,7 @@ static bool has_invalid_run_time_cache(zend_function const *func) {
 #if PHP_VERSION_ID < 80200
     bool is_file_compile = ZEND_MAP_PTR(func->op_array.run_time_cache) == NULL;
 #else
-    bool is_file_compile = func->common.run_time_cache__ptr == NULL;
+    bool is_file_compile = ZEND_MAP_PTR(func->common.run_time_cache) == NULL;
 #endif
 
     // Trampolines use the extension slot for internal things.


### PR DESCRIPTION
### Description

One of our randomized tests surfaced a segfault in allocation profiling, here is how you may reproduce the bug:
- create a PHP file that includes another PHP file (besides that, those files can be emtpy)
- make sure to collect every allocation (set `ALLOCATION_PROFILING_INTERVAL` in `src/allocation.rs` to `1.0`)
- comment out ignoring runtime cache on CLI SAPI in [src/php_ffi.c](https://github.com/DataDog/dd-trace-php/blob/5f38251b568fc028f6d1ef44dcb32f0c67c8dd10/profiling/src/php_ffi.c#L81)
- execute the script with loaded profiler and activated OPcache and see it segfault

What is happening is that after file compilation, the OPcache tries to persist the currently compiled PHP file into the OPcache, creating a fake stack frame and pushing that onto the stack in [ext/opcache/zend_persist.c](https://heap.space/xref/PHP-8.1/ext/opcache/zend_persist.c?r=7202fe16#385-395).
This leads to `func->common->run_time_cache__ptr` being `NULL`.
The `RUN_TIME_CACHE` macro dereferences this, so we can not just check for `NULL` a view lines later in `uintptr_t *cache_addr = RUN_TIME_CACHE(&func->common);` as this already segfaults.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

Tested manually, but we should make the sampling distance for allocation profiling configurable (and also the fact that we currently ignore the runtime cache on CLI) and then we could create a PHPT test for this.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
