### PR TITLE
fix(profilier) Add missing `end_timestamp_ns` to string compilation event

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -707,6 +707,7 @@ impl Profiler {
     #[cfg(feature = "timeline")]
     pub fn collect_compile_string(
         &self,
+        now: i64,
         duration: i64,
         filename: String,
         line: u32,
@@ -722,6 +723,10 @@ impl Profiler {
         }
 
         labels.extend_from_slice(&TIMELINE_COMPILE_FILE_LABELS);
+        labels.push(Label {
+            key: "end_timestamp_ns",
+            value: LabelValue::Num(now, None),
+        });
         let n_labels = labels.len();
 
         match self.send_sample(Profiler::prepare_sample_message(

--- a/profiling/tests/correctness/timeline.json
+++ b/profiling/tests/correctness/timeline.json
@@ -48,6 +48,19 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "regular_expression": "^\\[eval\\]$",
+                    "percent": 100,
+                    "error_margin": 100,
+                    "labels": [
+                        {
+                            "key": "event",
+                            "values": [
+                                "compilation"
+                            ]
+                        }
+                    ]
                 }
             ]
         }

--- a/profiling/tests/correctness/timeline.php
+++ b/profiling/tests/correctness/timeline.php
@@ -5,3 +5,5 @@ function foobar () {
 }
 
 include(__DIR__.'/timeline_call.php');
+
+eval('usleep(1);');


### PR DESCRIPTION
### Description

String compilation events (`eval()`) where missing an `end_timestamp_ns` label, so they did not show up in the profiling timeline. This PR adds the missing label

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

It is currently not testing, that there is a `end_timestamp_ns` label onyl that there is an `eval()` call observed, as I would have to add a value, but that value is unpredictable. This would need a change in https://github.com/DataDog/prof-correctness/

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
