### PR TITLE
fix: keep doctrine/dbal to major version 2 in symfony 5.2 tests

### DIFF
--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -8,6 +8,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/annotations": "^1.12",
+        "doctrine/dbal": "^2.13.1",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/doctrine-migrations-bundle": "^3.1",
         "doctrine/orm": "^2.15",


### PR DESCRIPTION
### Description

This PR explicitly sets the version of `doctrine/dbal` to `^2.13`

**Reasons** 👇 

The Symfony 5.2 tests started failing and were characterized by the following exception on the framework side:
```
[critical] Uncaught Error: Undefined constant Doctrine\DBAL\Types\Types::JSON_ARRAY
```

![image](https://github.com/DataDog/dd-trace-php/assets/42672104/5c1a6416-8fad-455a-978e-f3be2af770a5)

As shown in the screenshot above, the composer started updating the `doctrine/dbal` dependency from major version 2 to major version 3. However, `Doctrine\DBAL\Types\Types::JSON_ARRAY` was [deprecated](https://github.com/doctrine/dbal/blob/c480849ca3ad6706a39c970cdfe6888fa8a058b8/lib/Doctrine/DBAL/Types/Types.php#L38) and [removed](https://github.com/doctrine/dbal/blob/3.0.0/src/Types/Types.php) in version 3.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors, the reviewer is in charge of this task.
