### PR TITLE
Set peer.service as dddbs when available

### DIFF
--- a/src/Integrations/Integrations/DatabaseIntegrationHelper.php
+++ b/src/Integrations/Integrations/DatabaseIntegrationHelper.php
@@ -43,8 +43,9 @@ class DatabaseIntegrationHelper
                 $propagationMode = \DDTrace\DBM_PROPAGATION_SERVICE;
             }
 
-            $databaseService = in_array("peer.service", $hook->span()->meta)
-                ? $hook->span->meta["peer.service"] : $hook->span()->service;
+            $databaseService = isset($hook->span()->meta['peer.service'])
+                ? $hook->span()->meta['peer.service']
+                : $hook->span()->service;
 
             $query = self::propagateViaSqlComments($hook->args[$argNum], $databaseService, $propagationMode);
             $hook->args[$argNum] = $query;

--- a/src/Integrations/Integrations/DatabaseIntegrationHelper.php
+++ b/src/Integrations/Integrations/DatabaseIntegrationHelper.php
@@ -43,7 +43,10 @@ class DatabaseIntegrationHelper
                 $propagationMode = \DDTrace\DBM_PROPAGATION_SERVICE;
             }
 
-            $query = self::propagateViaSqlComments($hook->args[$argNum], $hook->span()->service, $propagationMode);
+            $databaseService = in_array("peer.service", $hook->span()->meta)
+                ? $hook->span->meta["peer.service"] : $hook->span()->service;
+
+            $query = self::propagateViaSqlComments($hook->args[$argNum], $databaseService, $propagationMode);
             $hook->args[$argNum] = $query;
             $hook->overrideArguments($hook->args);
             $hook->span()->meta["_dd.dbm_trace_injected"] = "true";

--- a/src/Integrations/Integrations/DatabaseIntegrationHelper.php
+++ b/src/Integrations/Integrations/DatabaseIntegrationHelper.php
@@ -43,9 +43,8 @@ class DatabaseIntegrationHelper
                 $propagationMode = \DDTrace\DBM_PROPAGATION_SERVICE;
             }
 
-            $databaseService = isset($hook->span()->meta['peer.service'])
-                ? $hook->span()->meta['peer.service']
-                : $hook->span()->service;
+            $span = $hook->span();
+            $databaseService = $span->meta['peer.service'] ?? $span->service;
 
             $query = self::propagateViaSqlComments($hook->args[$argNum], $databaseService, $propagationMode);
             $hook->args[$argNum] = $query;


### PR DESCRIPTION
### Description

Prioritize `peer.service` as dddbs for SQL comments when available. Reasoning explained [in this task](https://datadoghq.atlassian.net/browse/AIT-8319).

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
