### PR TITLE
fix(profiling) store customized heap

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -226,6 +226,9 @@ pub fn allocation_profiling_rshutdown() {
         }
         trace!("Memory allocation profiling shutdown gracefully.");
     }
+    unsafe {
+        HEAP = None;
+    }
 }
 
 pub fn allocation_profiling_startup() {


### PR DESCRIPTION
### Description

In case another extension is installing it's own heap into the ZendMM we start calling this instead of the one that we installed our custom handlers.
This PR will store the heap that we installed our custom handlers in and reuse it.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
