### PR TITLE
Fix toggling datadog.trace.enabled with perdir configuation

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -970,6 +970,10 @@ bool ddtrace_alter_dd_trace_disabled_config(zval *old_value, zval *new_value) {
         return Z_TYPE_P(new_value) == IS_FALSE;  // no changing to enabled allowed if globally disabled
     }
 
+    if (!DDTRACE_G(active_stack)) {
+        return true; // We must not do anything early in RINIT before the necessary structures are initialized at all
+    }
+
     if (Z_TYPE_P(old_value) == IS_FALSE) {
         dd_initialize_request();
     } else if (!DDTRACE_G(disable)) {  // if this is true, the request has not been initialized at all

--- a/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/.htaccess
+++ b/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/.htaccess
@@ -1,0 +1,1 @@
+php_value datadog.trace.enabled "Off"

--- a/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/.user.ini
+++ b/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/.user.ini
@@ -1,0 +1,1 @@
+datadog.trace.enabled = 0

--- a/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/test.php
+++ b/tests/Frameworks/Custom/Version_Not_Autoloaded/per-dir-disabled/test.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "Tracing enabled: " . (int)dd_trace_env_config("DD_TRACE_ENABLED");

--- a/tests/Integrations/Custom/NotAutoloaded/EarlyDisableTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/EarlyDisableTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Custom\NotAutoloaded;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+final class EarlyDisableTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Custom/Version_Not_Autoloaded/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'APP_NAME' => 'custom_no_autoloaded_app',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+        ]);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTracingDisabledByPerdirConfig()
+    {
+        $sapi = \getenv('DD_TRACE_TEST_SAPI');
+        if ($sapi != 'fpm-fcgi' && $sapi != "apache2handler") {
+            $this->markTestSkipped('Only run under apache and fpm-fcgi SAPI');
+        }
+
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('A web request to a disabled endpoint', '/per-dir-disabled/test.php'));
+            $this->assertSame("Tracing enabled: 0", $response);
+        });
+
+        $this->assertSpans($traces, []);
+    }
+}


### PR DESCRIPTION
### Description

And ensure in ZAI config that perdir configuration is handled the same with fpm and apache. Fixes #2266.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
