### PR TITLE
Add a check for ce->parent not being NULL in zai hook

### DIFF
--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -373,7 +373,8 @@ static void zai_hook_resolve_hooks_entry(zai_hooks_entry *hooks, zend_function *
 static inline zai_hooks_entry *zai_hook_resolved_ensure_hooks_entry(zend_function *resolved, zend_class_entry *ce);
 static inline void zai_hook_handle_internal_duplicate_function(zai_hooks_entry *hooks, zend_class_entry *ce, zend_function *function) {
     // Internal functions duplicated onto userland classes share their run_time_cache with their parent function
-    bool is_internal_duplicate = !ZEND_USER_CODE(function->type) && (function->common.fn_flags & ZEND_ACC_ARENA_ALLOCATED) && function->common.scope != ce;
+    // This may also happen for leaf functions without code, ignore it here
+    bool is_internal_duplicate = !ZEND_USER_CODE(function->type) && (function->common.fn_flags & ZEND_ACC_ARENA_ALLOCATED) && function->common.scope != ce && ce->parent;
     if (is_internal_duplicate) {
         // Hence we need to ensure that each top-level internal function is responsible for its run-time cache.
         // We achieve that by refcounting on top of the anyway checked nNumOfElements.


### PR DESCRIPTION
### Description

We've got a crash trace, and this PR aims to fix the issue observed by the crash:
```
#0  0x000055f305771273 in zend_hash_find ()
#1  0x00007fd2a709aaf8 in zend_hash_find_ptr (key=0x7fd2a21a3d48, ht=<optimized out>) at /usr/local/php-8.2.8/include/php/Zend/zend_hash.h:867
#2  zai_hook_handle_internal_duplicate_function (function=<optimized out>, ce=0x55f309965280, hooks=0x7fd2a2549c60) at /home/circleci/datadog/tmp/build_extension/zend_abstract_interface/hook/hook.c:381
#3  zai_hook_handle_internal_duplicate_function (function=0x55f3099654d8, ce=0x55f309965280, hooks=0x7fd2a2549c60) at /home/circleci/datadog/tmp/build_extension/zend_abstract_interface/hook/hook.c:374
#4  zai_hook_merge_inherited_hooks (hooks_entry=hooks_entry@entry=0x7fffe0232070, function=function@entry=0x55f3099654d8, proto=<optimized out>, ce=ce@entry=0x55f309965280)
at /home/circleci/datadog/tmp/build_extension/zend_abstract_interface/hook/hook.c:557
#5  0x00007fd2a709c198 in zai_hook_resolve_lookup_inherited (lcname=0x55f307843370, function=0x55f3099654d8, ce=0x55f309965280, hooks=0x0) at /home/circleci/datadog/tmp/build_extension/zend_abstract_interface/hook/hook.c:584
#6  zai_hook_resolve_class (ce=0x55f309965280, lcname=<optimized out>) at /home/circleci/datadog/tmp/build_extension/zend_abstract_interface/hook/hook.c:742
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
