### PR TITLE
ci: Add some php extensions to the buster images

### DIFF
--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -16,14 +16,20 @@ ENV DEVLIBS \
     libcurl4-openssl-dev \
     libedit-dev \
     libffi-dev \
+    libfreetype6-dev \
+    libicu-dev \
+    libjpeg-dev \
     libmcrypt-dev \
     libmemcached-dev \
     libonig-dev \
     libpq-dev \
+    libpng-dev \
     libsodium-dev \
     libsqlite3-dev \
     libssl-dev \
+    libwebp-dev \
     libxml2-dev \
+    libxslt1-dev \
     libzip-dev \
     zlib1g-dev \
     libasan5 \

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -107,7 +107,8 @@ else
   yes 'no' | pecl install memcached; echo "extension=memcached.so" >> ${iniDir}/memcached.ini;
   yes '' | pecl install memcache$MEMCACHE_VERSION; echo "extension=memcache.so" >> ${iniDir}/memcache.ini;
   pecl install mongodb$MONGODB_VERSION; echo "extension=mongodb.so" >> ${iniDir}/mongodb.ini;
-  pecl install redis; echo "extension=redis.so" >> ${iniDir}/redis.ini;
+  # Redis 6.0.0 dropped support for PHP 7.1 and below
+  pecl install redis$(if [[ $PHP_VERSION_ID -le 71 ]]; then echo -5.3.7; fi); echo "extension=redis.so" >> ${iniDir}/redis.ini;
   pecl install sqlsrv$SQLSRV_VERSION; echo "extension=sqlsrv.so" >> ${iniDir}/sqlsrv.ini;
   # Xdebug is disabled by default
   for VERSION in "${XDEBUG_VERSIONS[@]}"; do

--- a/dockerfiles/ci/buster/build-php.sh
+++ b/dockerfiles/ci/buster/build-php.sh
@@ -36,13 +36,20 @@ ${PHP_SRC_DIR}/configure \
         --without-pear \
     ; else echo \
         --disable-phpdbg \
+        --enable-bcmath \
         --enable-ftp \
+        $(if [[ ${PHP_VERSION_ID} -ge 71 ]]; then echo --enable-intl; fi) \
         --enable-mbstring \
         --enable-opcache \
         $(if [[ ${PHP_VERSION_ID} -ge 80 ]]; then echo --enable-zend-test=shared; fi) \
         --enable-pcntl \
+        --enable-soap \
         --enable-sockets \
         $(if [[ ${PHP_VERSION_ID} -le 73 ]]; then echo --enable-zip; fi) \
+        $(if [[ ${PHP_VERSION_ID} -ge 74 ]];
+          then echo --enable-gd --with-jpeg --with-freetype --with-webp;
+          else echo --with-gd --with-png-dir --with-jpeg-dir=/usr/include/;
+        fi) \
         --with-curl \
         $(if [[ ${PHP_VERSION_ID} -ge 74 ]]; then echo --with-ffi; fi) \
         --with-libedit \
@@ -55,6 +62,8 @@ ${PHP_SRC_DIR}/configure \
         --with-pdo-sqlite \
         --with-pear \
         --with-readline \
+        $(if [[ ${PHP_VERSION_ID} -ge 72 ]]; then echo --with-sodium; fi) \
+        --with-xsl \
         $(if [[ ${PHP_VERSION_ID} -ge 74 ]]; then echo --with-zip; fi) \
         --with-zlib \
     ; fi) \

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -109,6 +109,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/ftp/tests
+ext/gd/tests/bug70976.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt

--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -191,6 +191,7 @@ ext/simplexml/tests/bug69491.phpt
 ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
+ext/soap/tests/bugs/bug28751.phpt
 ext/sockets/tests/socket_connect_params.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
@@ -326,6 +327,7 @@ ext/standard/tests/serialize/bug70219_1.phpt
 ext/standard/tests/serialize/serialization_objects_007.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt
 ext/standard/tests/strings/implode1.phpt
+ext/xsl/tests/bug33853.phpt
 ext/zip/tests/bug38943.phpt
 ext/zip/tests/bug38943_2.phpt
 sapi/cli/tests/upload_2G.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -119,6 +119,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/ftp/tests
+ext/gd/tests/bug70976.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/pass001.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt
@@ -204,6 +205,8 @@ ext/simplexml/tests/bug69491.phpt
 ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
+ext/soap/tests/bugs/bug28751.phpt
+ext/soap/tests/bugs/bug76348.phpt
 ext/sockets/tests/socket_connect_params.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt
@@ -340,6 +343,7 @@ ext/standard/tests/serialize/serialization_objects_007.phpt
 ext/standard/tests/streams/proc_open_bug69900.phpt
 ext/standard/tests/streams/stream_context_tcp_nodelay_fopen.phpt
 ext/standard/tests/strings/implode1.phpt
+ext/xsl/tests/bug33853.phpt
 ext/zip/tests/bug38943.phpt
 ext/zip/tests/bug38943_2.phpt
 sapi/cli/tests/upload_2G.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -103,6 +103,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/ftp/tests
+ext/gd/tests/bug70976.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/pass001.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -110,6 +110,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/ftp/tests
+ext/gd/tests/bug70976.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/json_decode_exceptions.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -162,6 +162,7 @@ ext/date/tests/date_timestamp_set_nullparam2.phpt
 ext/date/tests/test-parse-from-format.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/ftp/tests
+ext/gd/tests/bug70976.phpt
 ext/json/tests/bug45791.phpt
 ext/json/tests/bug77843.phpt
 ext/json/tests/json_decode_exceptions.phpt


### PR DESCRIPTION
### Description

The buster images (7.0->8.2) were rebuilt to add the following extensions to the buster images for the Magento test frameworks to be installable:
- bcmath
- gd
- intl (PHP 7.1+)
- soap
- sodium
- xsl

(non-impactful) Redis 6.0.0 dropped support for PHP 7.1 and below, hence 5.3.7 is explicitly used for these anterior versions.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
