### PR TITLE
Fix getting fpm php_values in appsec and profiler

### DIFF
--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -131,15 +131,15 @@ int16_t zai_config_initialize_ini_value(zend_ini_entry **entries,
                 entries[i]->value = zend_string_copy(runtime_value);
             }
         }
+    }
 
-        if (runtime_value) {
-            buf->ptr = ZSTR_VAL(runtime_value);
-            buf->len = ZSTR_LEN(runtime_value);
-            zend_string_release(runtime_value);
-        } else if (parsed_ini_value && zai_option_str_is_none(*buf)) {
-            buf->ptr = ZSTR_VAL(parsed_ini_value);
-            buf->len = ZSTR_LEN(parsed_ini_value);
-        }
+    if (runtime_value) {
+        buf->ptr = ZSTR_VAL(runtime_value);
+        buf->len = ZSTR_LEN(runtime_value);
+        zend_string_release(runtime_value);
+    } else if (parsed_ini_value && zai_option_str_is_none(*buf)) {
+        buf->ptr = ZSTR_VAL(parsed_ini_value);
+        buf->len = ZSTR_LEN(parsed_ini_value);
     }
 
     if (parsed_ini_value) {

--- a/zend_abstract_interface/config/tests/ini.cc
+++ b/zend_abstract_interface/config/tests/ini.cc
@@ -518,3 +518,24 @@ TEST_INI("change before request startup", {
     REQUIRE(Z_LVAL_P(value) == 3);
     REQUEST_END();
 })
+
+static ZEND_INI_MH(dummy) {
+    return SUCCESS;
+}
+TEST_INI("setting perdir INI setting for multiple ZAI config users", {
+    REQUIRE(tea_sapi_append_system_ini_entry("zai_config.INI_FOO_STRING", "another"));
+}, {
+    zai_config_memoized_entry *entry = &zai_config_memoized_entries[EXT_CFG_INI_FOO_STRING];
+    entry->original_on_modify = dummy;
+
+    zai_config_first_time_rinit();
+    REQUEST_BEGIN();
+
+    zval *value = zai_config_get_value(EXT_CFG_INI_FOO_STRING);
+
+    REQUIRE(value != NULL);
+    REQUIRE(Z_TYPE_P(value) == IS_STRING);
+    REQUIRE(zval_string_equals(value, "another"));
+
+    REQUEST_END();
+})


### PR DESCRIPTION
### Description

It was reported that when using `php_value` on `php-fpm` configuration to set values to datadog inis shared between `ddtrace` and `ddappsec` , the values were not getting picked by `ddappsec`. It was getting defaults or values ono `.ini` files


### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
