### PR TITLE
Handle UnwindExit in sandbox error reporting

### DIFF
--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -141,9 +141,9 @@ void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object 
         zend_object *ex = EG(exception);
         if (ex) {
             const char *type = ZSTR_VAL(ex->ce->name);
-            zend_string *msg = zai_exception_message(ex);
+            const char *msg = instanceof_function(ex->ce, zend_ce_throwable) ? ZSTR_VAL(zai_exception_message(ex)): "<exit>";
             log("%s thrown in ddtrace's closure defined at %s:%d for %s%s%s(): %s",
-                             type, deffile, defline, scope, colon, name, ZSTR_VAL(msg));
+                             type, deffile, defline, scope, colon, name, msg);
         } else if (PG(last_error_message)) {
 #if PHP_VERSION_ID < 80000
             char *error = PG(last_error_message);

--- a/ext/request_hooks.c
+++ b/ext/request_hooks.c
@@ -117,8 +117,8 @@ int dd_execute_php_file(const char *filename) {
                     zend_object *ex = EG(exception);
 
                     const char *type = ex->ce->name->val;
-                    zend_string *msg = zai_exception_message(ex);
-                    log("%s thrown in request init hook: %s", type, ZSTR_VAL(msg));
+                    const char *msg = instanceof_function(ex->ce, zend_ce_throwable) ? ZSTR_VAL(zai_exception_message(ex)): "<exit>";
+                    log("%s thrown in request init hook: %s", type, msg);
                 })
             }
             ddtrace_maybe_clear_exception();

--- a/tests/ext/sandbox/die_in_sandbox.phpt
+++ b/tests/ext/sandbox/die_in_sandbox.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Die()'ing in the sandbox is properly caught
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: UnwindExit does not exist on PHP 7'); ?>
+--INI--
+datadog.trace.debug=1
+--FILE--
+<?php
+
+function x() {
+    die();
+}
+\DDTrace\trace_function("x", function($s) { die(); });
+x();
+
+?>
+--EXPECTF--
+UnwindExit thrown in ddtrace's closure defined at %s:%d for x(): <exit>
+Flushing trace of size 2 to send-queue for %s

--- a/zend_abstract_interface/exceptions/exceptions.c
+++ b/zend_abstract_interface/exceptions/exceptions.c
@@ -25,7 +25,7 @@
 #endif
 
 zend_string *zai_exception_message(zend_object *ex) {
-    if (!ex) {
+    if (!ex || !instanceof_function(ex->ce, zend_ce_throwable)) {
         // should never happen; TODO: fail in CI
         return zend_string_init_interned(ZEND_STRL("(internal error retrieving exception for message)"), 1);
     }


### PR DESCRIPTION
### Description

Just a small crash with DD_TRACE_DEBUG=1 active, including a safeguard in zai_exception_message.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
