### PR TITLE
ci: fix relenv deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,20 +16,23 @@ include:
   - local: .gitlab/benchmarks.yml
 
 build:
+  extends: .ci_authenticated_job
   stage: build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/base:bionic
+  image: registry.ddbuild.io/images/ci_docker_base
   tags: [ "runner:main", "size:large" ]
   script:
     - |
       if [ -z "$LATEST_LIBRARY_x86_64_LINUX_GNU" ]; then
-        UPSTREAM_TRACER_VERSION=$(curl -L https://api.github.com/repos/DataDog/dd-trace-php/releases | grep -E '"tag_name"|"prerelease"' | paste -sd" \n" - | grep -v '"prerelease": true' | grep -Pom1 '"tag_name": "\K[^"]+')
-        LATEST_LIBRARY_x86_64_LINUX_GNU="https://github.com/DataDog/dd-trace-php/releases/download/${UPSTREAM_TRACER_VERSION}/dd-library-php-${UPSTREAM_TRACER_VERSION}-x86_64-linux-gnu.tar.gz"
+        source /download-binary-tracer.sh
+        get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-x86_64-linux-gnu.tar.gz" "dd-library-php-x86_64-linux-gnu.tar.gz"
+        get_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "datadog-setup.php" "datadog-setup.php"
+        echo "UPSTREAM_TRACER_VERSION=dev-master" >> upstream.env
       else
         UPSTREAM_TRACER_VERSION=$(echo "$LATEST_LIBRARY_x86_64_LINUX_GNU" | grep -Po '(?<=dd-library-php-).+(?=-x86_64-linux-gnu.tar.gz)')
+        echo "UPSTREAM_TRACER_VERSION=${UPSTREAM_TRACER_VERSION}" >> upstream.env
+        curl --fail --location --output 'dd-library-php-x86_64-linux-gnu.tar.gz' "$LATEST_LIBRARY_x86_64_LINUX_GNU"
+        curl --fail --location -O "$(dirname $LATEST_LIBRARY_x86_64_LINUX_GNU)/datadog-setup.php"
       fi
-    - echo "UPSTREAM_TRACER_VERSION=${UPSTREAM_TRACER_VERSION}" >> upstream.env
-    - curl --fail --location --output 'dd-library-php-x86_64-linux-gnu.tar.gz' "$LATEST_LIBRARY_x86_64_LINUX_GNU"
-    - curl --fail --location -O "$(dirname $LATEST_LIBRARY_x86_64_LINUX_GNU)/datadog-setup.php"
     - tar -cf 'datadog-setup-x86_64-linux-gnu.tar' 'datadog-setup.php' 'dd-library-php-x86_64-linux-gnu.tar.gz'
   artifacts:
     paths:


### PR DESCRIPTION
### Description

This PR will fix the reliability environment deployment by making sure that if no `LATEST_LIBRARY_x86_64_LINUX_GNU` is passed to the job, it fetches the latest artifact from CircleCI and not from GitHub.

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.

PROF-8281