### PR TITLE
Add a safeguard nullcheck for the sidecar into telemetry reporting

### DIFF
--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -15,7 +15,8 @@ static bool dd_check_for_composer_autoloader(zend_ulong invocation, zend_execute
     UNUSED(invocation, auxiliary, dynamic);
 
     ddog_CharSlice composer_path = dd_zend_string_to_CharSlice(execute_data->func->op_array.filename);
-    if (ddtrace_detect_composer_installed_json(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), composer_path)) {
+    if (!ddtrace_sidecar // if sidecar connection was broken, let's skip immediately
+     || ddtrace_detect_composer_installed_json(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), composer_path)) {
         zai_hook_remove(ZAI_STR_EMPTY, ZAI_STR_EMPTY, dd_composer_hook_id);
     }
     return true;


### PR DESCRIPTION
### Description

This may happen if the process tries to reconnect to the sidecar after the original sidecar was closed, but is then failing.
I've been seeing a suspicious stacktrace and I think that's the cause.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
