### PR TITLE
fix(profiling) allocation profiling shutdown with `USE_ZEND_ALLOC=0` crashing

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -176,6 +176,16 @@ pub fn allocation_profiling_rinit() {
 }
 
 pub fn allocation_profiling_rshutdown() {
+    let allocation_profiling = REQUEST_LOCALS.with(|cell| {
+        cell.try_borrow()
+            .map(|locals| locals.profiling_allocation_enabled)
+            .unwrap_or(false)
+    });
+
+    if !allocation_profiling {
+        return;
+    }
+
     // If `is_zend_mm()` is true, the custom handlers have been reset to `None`
     // already. This is unexpected, therefore we will not touch the ZendMM handlers
     // anymore as resetting to prev handlers might result in segfaults and other

--- a/profiling/tests/phpt/allocation_jit_01.phpt
+++ b/profiling/tests/phpt/allocation_jit_01.phpt
@@ -1,0 +1,33 @@
+--TEST--
+[profiling] Allocation profiling should not crash when run with `USE_ZEND_ALLOC=0`
+--DESCRIPTION--
+When running PHP with `USE_ZEND_ALLOC=0` and disabled allocation profiling
+(either explicit disabled or due to the JIT bug), PHP will install the system
+allocator in https://heap.space/xref/PHP-8.2/Zend/zend_alloc.c?r=4553258d#2895-2918
+and set the `AG(heap)->use_custom_heap` to `ZEND_MM_CUSTOM_HEAP_STD` (which is 1),
+so future calls to `is_zend_mm()` will return false which might lead to a situation
+where we assume we are hooked into, while we are not.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+?>
+--ENV--
+USE_ZEND_ALLOC=0
+--INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+datadog.profiling.allocation_enabled=yes
+datadog.profiling.experimental_cpu_time_enabled=no
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
+--FILE--
+<?php
+echo "Done.", PHP_EOL;
+?>
+--EXPECTREGEX--
+.*Done.
+.*Stopping profiler.
+.*


### PR DESCRIPTION
### Description

When running PHP with `USE_ZEND_ALLOC=0` and allocation profiling being disabled, in `RSHUTDOWN` we were crashing. This is due to `is_zend_mm()` returning false in that case and we wrongly assumed this would also mean allocation profiling is installed.

Technical background: `USE_ZEND_ALLOC=0` installs the system allocator and sets the `AG(heap)->use_custom_heap` to 1 in https://heap.space/xref/PHP-8.2/Zend/zend_alloc.c?r=4553258d#2895-2918

The `ci/circleci: PHP 82 Xdebug tests` failing is due to the container already being upgraded to run xdebug 3.2.2 and not the 3.2.0RC1 anymore. The fix for this is in https://github.com/DataDog/dd-trace-php/pull/2098

PROF-8286

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
