### PR TITLE
fix(profiling) neighboring extension handling in `gc_mem_caches()`

### DIFF
--- a/profiling/tests/phpt/gc_mem_caches_02.phpt
+++ b/profiling/tests/phpt/gc_mem_caches_02.phpt
@@ -1,0 +1,35 @@
+--TEST--
+[profiling] allocation profiling not crashing with system allocator in `gc_mem_caches()` call
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+if (PHP_VERSION_ID < 70400)
+    echo "skip: 'run-tests.php' in PHP older then 7.4.0 overwrites the `USE_ZEND_ALLOC` environment variable";
+?>
+--ENV--
+USE_ZEND_ALLOC=0
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=yes
+DD_PROFILING_ALLOCATION_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=off
+DD_SERVICE=datadog-profiling-phpt
+DD_ENV=dev
+DD_VERSION=13
+DD_AGENT_HOST=localh0st
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_AGENT_URL=http://datadog:8126
+--FILE--
+<?php
+
+$cleaned = gc_mem_caches();
+
+if ($cleaned !== 0) {
+    die('Cleaned '.$cleaned.' bytes, which is unexpected, maybe `USE_ZEND_ALLOC=0` was somehow overwritten?');
+}
+
+echo 'Done.';
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

In case there is another custom handler installed on the heap that we also hook into, we should not play with the `AG(heap)->use_custome_heap` flag anymore and we need to assume that the "other extension" takes care of this. This comes also into play when running PHP with `USE_ZEND_ALLOC=0` for ASAN which will point the allocation functions to the system allocator but also set the `use_custom_heap` flag.

PROF-8286

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
