### PR TITLE
Fix ZAI config handling for .htaccess with php-fpm

### DIFF
--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -369,37 +369,40 @@ void zai_config_ini_rinit(void) {
 
     for (uint8_t i = 0; i < zai_config_memoized_entries_count; ++i) {
         zai_config_memoized_entry *memoized = &zai_config_memoized_entries[i];
-        if (memoized->ini_change == zai_config_system_ini_change || memoized->original_on_modify) {
+        if (memoized->ini_change == zai_config_system_ini_change) {
             continue;
         }
 
-        for (uint8_t name_index = 0; name_index < memoized->names_count; name_index++) {
-            zai_str name = ZAI_STR_NEW(memoized->names[name_index].ptr, memoized->names[name_index].len);
-            zai_env_result result = zai_getenv_ex(name, buf, false);
+        // makes only sense to update INIs once, avoid rereading env unnecessarily
+        if (!env_to_ini_name || !memoized->original_on_modify) {
+            for (uint8_t name_index = 0; name_index < memoized->names_count; name_index++) {
+                zai_str name = ZAI_STR_NEW(memoized->names[name_index].ptr, memoized->names[name_index].len);
+                zai_env_result result = zai_getenv_ex(name, buf, false);
 
-            if (result == ZAI_ENV_SUCCESS) {
-                /*
-                 * we unconditionally decode the value because we do not store the in-use encoded value
-                 * so we cannot compare the current environment value to the current configuration value
-                 * for the purposes of short circuiting decode
-                 */
-                if (env_to_ini_name) {
-                    zend_string *str = zend_string_init(buf.ptr, strlen(buf.ptr), in_startup);
+                if (result == ZAI_ENV_SUCCESS) {
+                    /*
+                     * we unconditionally decode the value because we do not store the in-use encoded value
+                     * so we cannot compare the current environment value to the current configuration value
+                     * for the purposes of short circuiting decode
+                     */
+                    if (env_to_ini_name) {
+                        zend_string *str = zend_string_init(buf.ptr, strlen(buf.ptr), in_startup);
 
-                    zend_ini_entry *ini = memoized->ini_entries[name_index];
-                    if (zend_alter_ini_entry_ex(ini->name, str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == SUCCESS) {
+                        zend_ini_entry *ini = memoized->ini_entries[name_index];
+                        if (zend_alter_ini_entry_ex(ini->name, str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == SUCCESS) {
+                            zend_string_release(str);
+                            goto next_entry;
+                        }
                         zend_string_release(str);
-                        goto next_entry;
-                    }
-                    zend_string_release(str);
-                } else {
-                    zai_str rte_value = ZAI_STR_FROM_CSTR(buf.ptr);
+                    } else {
+                        zai_str rte_value = ZAI_STR_FROM_CSTR(buf.ptr);
 
-                    zval new_zv;
-                    ZVAL_UNDEF(&new_zv);
-                    if (zai_config_decode_value(rte_value, memoized->type, memoized->parser, &new_zv, /* persistent */ false)) {
-                        zai_config_replace_runtime_config(i, &new_zv);
-                        zval_ptr_dtor(&new_zv);
+                        zval new_zv;
+                        ZVAL_UNDEF(&new_zv);
+                        if (zai_config_decode_value(rte_value, memoized->type, memoized->parser, &new_zv, /* persistent */ false)) {
+                            zai_config_replace_runtime_config(i, &new_zv);
+                            zval_ptr_dtor(&new_zv);
+                        }
                     }
                 }
             }

--- a/zend_abstract_interface/config/tests/ini.cc
+++ b/zend_abstract_interface/config/tests/ini.cc
@@ -539,3 +539,38 @@ TEST_INI("setting perdir INI setting for multiple ZAI config users", {
 
     REQUEST_END();
 })
+
+
+TEST_INI("setting an env value after memoization for multiple ZAI config users", {}, {
+    REQUIRE_SETENV("INI_FOO_STRING", "value");
+
+    REQUEST_BEGIN()
+
+    zval *value = zai_config_get_value(EXT_CFG_INI_FOO_STRING);
+
+    REQUIRE(value != NULL);
+    REQUIRE(Z_TYPE_P(value) == IS_STRING);
+    REQUIRE(zval_string_equals(value, "value"));
+
+    REQUEST_END()
+
+    REQUIRE_SETENV("INI_FOO_STRING", "value2");
+
+    // Something else inits zai config first
+    zai_config_rinit();
+    zai_config_rshutdown();
+
+    // now we init it
+    zai_config_memoized_entry *entry = &zai_config_memoized_entries[EXT_CFG_INI_FOO_STRING];
+    entry->original_on_modify = dummy;
+
+    REQUEST_BEGIN()
+
+    zval *value = zai_config_get_value(EXT_CFG_INI_FOO_STRING);
+
+    REQUIRE(value != NULL);
+    REQUIRE(Z_TYPE_P(value) == IS_STRING);
+    REQUIRE(zval_string_equals(value, "value2"));
+
+    REQUEST_END()
+})


### PR DESCRIPTION
When connecting .htaccess via php-fpm, apache will set true environment variables, a circumstance where the handling explicitly calling ZaiConfigOnUpdateIni was skipped, leading to non-updated configs.