### PR TITLE
fix(profiling) panic after shutdown of forked child when `USE_ZEND_ALLOC=0`

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -383,27 +383,46 @@ pub struct RequestLocals {
     pub vm_interrupt_addr: *const AtomicBool,
 }
 
+impl RequestLocals {
+    pub fn disable(&mut self) {
+        self.profiling_enabled = false;
+        self.profiling_endpoint_collection_enabled = false;
+        self.profiling_experimental_cpu_time_enabled = false;
+        self.profiling_allocation_enabled = false;
+        self.profiling_experimental_timeline_enabled = false;
+        self.profiling_experimental_exception_enabled = false;
+    }
+}
+
+impl Default for RequestLocals {
+    fn default() -> RequestLocals {
+        RequestLocals {
+            env: None,
+            interrupt_count: AtomicU32::new(0),
+            profiling_enabled: false,
+            profiling_endpoint_collection_enabled: true,
+            profiling_experimental_cpu_time_enabled: true,
+            profiling_allocation_enabled: true,
+            profiling_experimental_timeline_enabled: true,
+            profiling_experimental_exception_enabled: false,
+            profiling_experimental_exception_sampling_distance: 100,
+            profiling_log_level: LevelFilter::Off,
+            service: None,
+            uri: Box::<AgentEndpoint>::default(),
+            version: None,
+            vm_interrupt_addr: std::ptr::null_mut(),
+        }
+    }
+}
+
 thread_local! {
     static CLOCKS: RefCell<Clocks> = RefCell::new(Clocks {
         cpu_time: None,
         wall_time: Instant::now(),
     });
 
-    static REQUEST_LOCALS: RefCell<RequestLocals> = RefCell::new(RequestLocals {
-        env: None,
-        interrupt_count: AtomicU32::new(0),
-        profiling_enabled: false,
-        profiling_endpoint_collection_enabled: true,
-        profiling_experimental_cpu_time_enabled: true,
-        profiling_allocation_enabled: true,
-        profiling_experimental_timeline_enabled: true,
-        profiling_experimental_exception_enabled: false,
-        profiling_experimental_exception_sampling_distance: 100,
-        profiling_log_level: LevelFilter::Off,
-        service: None,
-        uri: Box::<AgentEndpoint>::default(),
-        version: None,
-        vm_interrupt_addr: std::ptr::null_mut(),
+    static REQUEST_LOCALS: RefCell<RequestLocals> = RefCell::new(RequestLocals{
+        ..Default::default()
     });
 
     /// The tags for this thread/request. These get sent to other threads,

--- a/profiling/src/pcntl.rs
+++ b/profiling/src/pcntl.rs
@@ -7,7 +7,6 @@ use crate::{Profiler, PROFILER, REQUEST_LOCALS};
 use log::{error, warn};
 use std::ffi::CStr;
 use std::mem::{forget, swap};
-use std::sync::atomic::Ordering;
 
 static mut PCNTL_FORK_HANDLER: InternalFunctionHandler = None;
 static mut PCNTL_RFORK_HANDLER: InternalFunctionHandler = None;
@@ -102,8 +101,7 @@ fn stop_and_forget_profiling(maybe_profiler: &mut Option<Profiler>) {
      */
     REQUEST_LOCALS.with(|cell| {
         let mut locals = cell.borrow_mut();
-        locals.profiling_enabled = false;
-        locals.interrupt_count.store(0, Ordering::SeqCst);
+        locals.disable();
     });
 }
 

--- a/profiling/tests/phpt/gc_mem_caches_01.phpt
+++ b/profiling/tests/phpt/gc_mem_caches_01.phpt
@@ -7,6 +7,8 @@ anything and return `int(0)`. As we do prepare the heap for this call, the
 function should actually cleanup some memory and return the amount in bytes.
 --SKIPIF--
 <?php
+if (getenv('USE_ZEND_ALLOC') === '0')
+    die("skip requires ZendMM");
 if (!extension_loaded('datadog-profiling'))
     echo "skip: test requires Datadog Continuous Profiler\n";
 ?>


### PR DESCRIPTION
### Description

So this PR brings multiple things:

The `tests/phpt/gc_mem_caches_01.phpt` test should not run when `USE_ZEND_ALLOC=0` as the expectation would fail. We might be able to combine this and the `gc_mem_caches_02.phpt`, but I'd rather have both tests to make sure we have a version that explicitly tests the `USE_ZEND_ALLOC=0` case.

Implement a `reset()` function on the `RequestLocals` struct and call this after forking instead of setting values directly. This, and the fact that the `reset()` function resets not only `profiling_enabled` to `false` but all other profiling types as well solves a panic in `allocation_profiling_shutdown()` when PHP was run with `USE_ZEND_ALLOC=0`. What happened was that after forking we call the `allocation_profiling_shutdown()` function and reset the `HEAP` to `None`. When the child then exits, PHP will call the `allocation_profiling_shutdown()` again in `RSHUTDOWN` phase and will panic at the `HEAP.unwrap()`.

Additionally it implements a `Default` for the `RequestLocals`, combined with the `reset()` function this makes the `RequestLocals` struct more self contained.

PROF-8286

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
