### PR TITLE
Expand arrays and public properties of objects in meta into nested-tag format

### DIFF
--- a/ext/compat_string.c
+++ b/ext/compat_string.c
@@ -30,16 +30,16 @@ zend_string *ddtrace_convert_to_str(zval *op) {
 try_again:
     switch (Z_TYPE_P(op)) {
         case IS_UNDEF:
-            return zend_string_init("(undef)", sizeof("(undef)") - 1, 0);
+            return zend_string_init("undef", sizeof("undef") - 1, 0);
 
         case IS_NULL:
-            return zend_string_init("(null)", sizeof("(null)") - 1, 0);
+            return zend_string_init("null", sizeof("null") - 1, 0);
 
         case IS_FALSE:
-            return zend_string_init("(false)", sizeof("(false)") - 1, 0);
+            return zend_string_init("false", sizeof("false") - 1, 0);
 
         case IS_TRUE:
-            return zend_string_init("(true)", sizeof("(true)") - 1, 0);
+            return zend_string_init("true", sizeof("true") - 1, 0);
 
         case IS_RESOURCE:
             return strpprintf(0, "Resource id #" ZEND_LONG_FMT, (zend_long)Z_RES_HANDLE_P(op));

--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -121,9 +121,13 @@ static inline HashTable *zend_new_array(uint32_t nSize) {
     } while (0)
 #define ZVAL_EMPTY_ARRAY DD_ZVAL_EMPTY_ARRAY
 
-#define Z_IS_RECURSIVE_P(zv) (Z_OBJPROP_P(zv)->u.v.nApplyCount > 0)
-#define Z_PROTECT_RECURSION_P(zv) (++Z_OBJPROP_P(zv)->u.v.nApplyCount)
-#define Z_UNPROTECT_RECURSION_P(zv) (--Z_OBJPROP_P(zv)->u.v.nApplyCount)
+#define GC_IS_RECURSIVE(gc) ((gc)->u.v.nApplyCount > 0)
+#define GC_PROTECT_RECURSION(gc) (++(gc)->u.v.nApplyCount)
+#define GC_UNPROTECT_RECURSION(gc) (--(gc)->u.v.nApplyCount)
+
+#define Z_IS_RECURSIVE_P(zv) GC_IS_RECURSIVE(Z_OBJPROP_P(zv))
+#define Z_PROTECT_RECURSION_P(zv) GC_PROTECT_RECURSION(Z_OBJPROP_P(zv))
+#define Z_UNPROTECT_RECURSION_P(zv) GC_UNPROTECT_RECURSION(Z_OBJPROP_P(zv))
 
 #define ZEND_CLOSURE_OBJECT(op_array) \
     ((zend_object*)((char*)(op_array) - sizeof(zend_object)))

--- a/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
+++ b/tests/ext/sandbox/safe_to_string_metadata_drops_invalid_keys.phpt
@@ -27,5 +27,5 @@ array(2) {
   ["answer_to_universe"]=>
   string(2) "42"
   ["null_value"]=>
-  string(6) "(null)"
+  string(4) "null"
 }

--- a/tests/ext/sandbox/safe_to_string_properties.phpt
+++ b/tests/ext/sandbox/safe_to_string_properties.phpt
@@ -116,16 +116,16 @@ NULL
 'type' dropped
 
 bool(false)
-string(7) "(false)"
-string(7) "(false)"
-string(7) "(false)"
-string(7) "(false)"
+string(5) "false"
+string(5) "false"
+string(5) "false"
+string(5) "false"
 
 bool(true)
-string(6) "(true)"
-string(6) "(true)"
-string(6) "(true)"
-string(6) "(true)"
+string(4) "true"
+string(4) "true"
+string(4) "true"
+string(4) "true"
 
 float(4.2)
 string(3) "4.2"


### PR DESCRIPTION
### Description

This will be required for the display of OpenTelemetry array attributes. Note that this also removes the parenthesis from boolean/null values in order to be consistent with other languages, i.e. system-tests.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
