### PR TITLE
Subclass SpanData with RootSpanData

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -61,6 +61,9 @@ if test "$PHP_DDTRACE" != "no"; then
     EXTRA_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
   fi
 
+  CFLAGS="$CFLAGS -fms-extensions"
+  EXTRA_CFLAGS="$EXTRA_CFLAGS -fms-extensions"
+
   DD_TRACE_VENDOR_SOURCES="\
     ext/vendor/mpack/mpack.c \
     ext/vendor/mt19937/mt19937-64.c \

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -218,16 +218,16 @@ bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value) 
 static inline bool dd_alter_meta_var(const char *tag, zval *old_value, zval *new_value) {
     UNUSED(old_value);
 
-    ddtrace_span_data *span = ddtrace_active_span();
-    while (span) {
-        zend_array *meta = ddtrace_spandata_property_meta(span);
+    ddtrace_span_properties *pspan = ddtrace_active_span_props();
+    while (pspan) {
+        zend_array *meta = ddtrace_property_array(&pspan->property_meta);
         if (Z_STRLEN_P(new_value) == 0) {
             zend_hash_str_del(meta, tag, strlen(tag));
         } else {
             Z_TRY_ADDREF_P(new_value);
             zend_hash_str_update(meta, tag, strlen(tag), new_value);
         }
-        span = span->parent;
+        pspan = pspan->parent;
     }
 
     return true;
@@ -387,26 +387,40 @@ PHP_METHOD(DDTrace_SpanLink, jsonSerialize) {
 
 /* DDTrace\SpanData */
 zend_class_entry *ddtrace_ce_span_data;
+zend_class_entry *ddtrace_ce_root_span_data;
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80100
+HashTable dd_root_span_data_duplicated_properties_table;
+#endif
 zend_class_entry *ddtrace_ce_span_stack;
 zend_object_handlers ddtrace_span_data_handlers;
+zend_object_handlers ddtrace_root_span_data_handlers;
 zend_object_handlers ddtrace_span_stack_handlers;
 
-static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
-    ddtrace_span_data *span = ecalloc(1, sizeof(*span));
+static zend_object *dd_init_span_data_object(zend_class_entry *class_type, ddtrace_span_data *span, zend_object_handlers *handlers) {
     zend_object_std_init(&span->std, class_type);
-    span->std.handlers = &ddtrace_span_data_handlers;
+    span->std.handlers = handlers;
     object_properties_init(&span->std, class_type);
 #if PHP_VERSION_ID < 80000
     // Not handled in arginfo on these old versions
-    array_init(ddtrace_spandata_property_meta_zval(span));
-    array_init(ddtrace_spandata_property_metrics_zval(span));
-    array_init(ddtrace_spandata_property_links_zval(span));
-    array_init(ddtrace_spandata_property_peerServiceSources_zval(span));
+    array_init(&span->property_meta);
+    array_init(&span->property_metrics);
+    array_init(&span->property_links);
+    array_init(&span->property_peer_service_sources);
 #endif
     // Explicitly assign property-mapped NULLs
     span->stack = NULL;
     span->parent = NULL;
     return &span->std;
+}
+
+static zend_object *ddtrace_span_data_create(zend_class_entry *class_type) {
+    ddtrace_span_data *span = ecalloc(1, sizeof(*span));
+    return dd_init_span_data_object(class_type, span, &ddtrace_span_data_handlers);
+}
+
+static zend_object *ddtrace_root_span_data_create(zend_class_entry *class_type) {
+    ddtrace_root_span_data *span = ecalloc(1, sizeof(*span));
+    return dd_init_span_data_object(class_type, &span->span, &ddtrace_root_span_data_handlers);
 }
 
 static zend_object *ddtrace_span_stack_create(zend_class_entry *class_type) {
@@ -423,7 +437,7 @@ static zend_object *ddtrace_span_stack_create(zend_class_entry *class_type) {
 
 // Init with empty span stack if directly allocated via new()
 static zend_function *ddtrace_span_data_get_constructor(zend_object *object) {
-    object_init_ex(&((ddtrace_span_data *)object)->property_stack, ddtrace_ce_span_stack);
+    object_init_ex(&OBJ_SPANDATA(object)->property_stack, ddtrace_ce_span_stack);
     return NULL;
 }
 
@@ -436,7 +450,7 @@ static void ddtrace_span_stack_dtor_obj(zend_object *object) {
 
     ddtrace_span_stack *stack = (ddtrace_span_stack *)object;
     ddtrace_span_data *top;
-    while ((top = stack->active) && top->stack == stack) {
+    while (stack->active && (top = SPANDATA(stack->active)) && top->stack == stack) {
         dd_trace_stop_span_time(top);
         // let's not stack swap to a) avoid side effects in destructors and b) avoid a crash on PHP 7.3 and older
         ddtrace_close_top_span_without_stack_swap(top);
@@ -468,13 +482,13 @@ static zend_object *ddtrace_span_stack_clone_obj(zend_object *old_obj) {
         stack->root_stack = stack;
     }
 
-    ddtrace_span_data *span = stack->active;
+    ddtrace_span_properties *pspan = stack->active;
     zval_ptr_dtor(&stack->property_active);
-    while (span && span->stack == oldstack) {
-        span = span->parent;
+    while (pspan && pspan->stack == oldstack) {
+        pspan = pspan->parent;
     }
-    if (span) {
-        ZVAL_OBJ_COPY(&stack->property_active, &span->std);
+    if (pspan) {
+        ZVAL_OBJ_COPY(&stack->property_active, &pspan->std);
     } else {
         if (oldstack->root_span && oldstack->root_span->stack == oldstack) {
             stack->root_span = NULL;
@@ -489,7 +503,7 @@ static zend_object *ddtrace_span_stack_clone_obj(zend_object *old_obj) {
 static void ddtrace_span_data_free_storage(zend_object *object) {
     zend_object_std_dtor(object);
     // Prevent use after free after zend_objects_store_free_object_storage is called (e.g. preloading) [PHP < 8.1]
-    memset(object->properties_table, 0, sizeof(zval) + sizeof(((ddtrace_span_data *)NULL)->properties_table_placeholder));
+    memset(object->properties_table, 0, sizeof(ddtrace_span_data) - XtOffsetOf(ddtrace_span_data, std.properties_table));
 }
 
 #if PHP_VERSION_ID < 80000
@@ -499,6 +513,17 @@ static zend_object *ddtrace_span_data_clone_obj(zval *old_zv) {
 static zend_object *ddtrace_span_data_clone_obj(zend_object *old_obj) {
 #endif
     zend_object *new_obj = ddtrace_span_data_create(old_obj->ce);
+    zend_objects_clone_members(new_obj, old_obj);
+    return new_obj;
+}
+
+#if PHP_VERSION_ID < 80000
+static zend_object *ddtrace_root_span_data_clone_obj(zval *old_zv) {
+    zend_object *old_obj = Z_OBJ_P(old_zv);
+#else
+static zend_object *ddtrace_root_span_data_clone_obj(zend_object *old_obj) {
+#endif
+    zend_object *new_obj = ddtrace_root_span_data_create(old_obj->ce);
     zend_objects_clone_members(new_obj, old_obj);
     return new_obj;
 }
@@ -563,17 +588,17 @@ static zval *ddtrace_span_stack_readonly(zend_object *object, zend_string *membe
 }
 
 PHP_METHOD(DDTrace_SpanData, getDuration) {
-    ddtrace_span_data *span = (ddtrace_span_data *)Z_OBJ_P(ZEND_THIS);
+    ddtrace_span_data *span = OBJ_SPANDATA(Z_OBJ_P(ZEND_THIS));
     RETURN_LONG(span->duration);
 }
 
 PHP_METHOD(DDTrace_SpanData, getStartTime) {
-    ddtrace_span_data *span = (ddtrace_span_data *)Z_OBJ_P(ZEND_THIS);
+    ddtrace_span_data *span = OBJ_SPANDATA(Z_OBJ_P(ZEND_THIS));
     RETURN_LONG(span->start);
 }
 
 PHP_METHOD(DDTrace_SpanData, getLink) {
-    ddtrace_span_data *span = (ddtrace_span_data *)Z_OBJ_P(ZEND_THIS);
+    ddtrace_span_data *span = OBJ_SPANDATA(Z_OBJ_P(ZEND_THIS));
 
     zval fci_zv;
     object_init_ex(&fci_zv, ddtrace_ce_span_link);
@@ -586,15 +611,38 @@ PHP_METHOD(DDTrace_SpanData, getLink) {
 }
 
 static void dd_register_span_data_ce(void) {
+    ddtrace_ce_span_data = register_class_DDTrace_SpanData();
+    ddtrace_ce_span_data->create_object = ddtrace_span_data_create;
+
     memcpy(&ddtrace_span_data_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    ddtrace_span_data_handlers.offset = XtOffsetOf(ddtrace_span_data, std);
     ddtrace_span_data_handlers.clone_obj = ddtrace_span_data_clone_obj;
     ddtrace_span_data_handlers.free_obj = ddtrace_span_data_free_storage;
     ddtrace_span_data_handlers.write_property = ddtrace_span_data_readonly;
     ddtrace_span_data_handlers.get_constructor = ddtrace_span_data_get_constructor;
-    ddtrace_ce_span_data = register_class_DDTrace_SpanData();
-    ddtrace_ce_span_data->create_object = ddtrace_span_data_create;
+
+    ddtrace_ce_root_span_data = register_class_DDTrace_RootSpanData(ddtrace_ce_span_data);
+    ddtrace_ce_root_span_data->create_object = ddtrace_root_span_data_create;
+
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80100
+    // Work around wrong reference source for typed internal properties by preventing duplication of them
+    // php -d extension=zend_test -r '$c = new _ZendTestChildClass; $i = &$c->intProp;'
+    // php: /usr/local/src/php/Zend/zend_execute.c:3390: zend_ref_del_type_source: Assertion `source_list->ptr == prop' failed.
+    zend_hash_init(&dd_root_span_data_duplicated_properties_table, zend_hash_num_elements(&ddtrace_ce_span_data->properties_info), NULL, NULL, true);
+    for (uint32_t i = 0; i < zend_hash_num_elements(&ddtrace_ce_span_data->properties_info); ++i) {
+        Bucket *bucket = &ddtrace_ce_root_span_data->properties_info.arData[i];
+        zend_hash_add_ptr(&dd_root_span_data_duplicated_properties_table, bucket->key, Z_PTR(bucket->val));
+        Z_PTR(bucket->val) = ddtrace_ce_root_span_data->properties_info_table[i] = Z_PTR(ddtrace_ce_span_data->properties_info.arData[i].val);
+    }
+#endif
+
+    memcpy(&ddtrace_root_span_data_handlers, &ddtrace_span_data_handlers, sizeof(zend_object_handlers));
+    ddtrace_root_span_data_handlers.offset = XtOffsetOf(ddtrace_root_span_data, std);
+    ddtrace_root_span_data_handlers.clone_obj = ddtrace_root_span_data_clone_obj;
+
     ddtrace_ce_span_stack = register_class_DDTrace_SpanStack();
     ddtrace_ce_span_stack->create_object = ddtrace_span_stack_create;
+
     memcpy(&ddtrace_span_stack_handlers, &std_object_handlers, sizeof(zend_object_handlers));
     ddtrace_span_stack_handlers.clone_obj = ddtrace_span_stack_clone_obj;
     ddtrace_span_stack_handlers.dtor_obj = ddtrace_span_stack_dtor_obj;
@@ -758,6 +806,15 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     zai_config_mshutdown();
 
     ddtrace_sidecar_shutdown();
+
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 80100
+    // See dd_register_span_data_ce for explanation
+    zend_string *key;
+    void *prop_info;
+    ZEND_HASH_FOREACH_STR_KEY_PTR(&dd_root_span_data_duplicated_properties_table, key, prop_info) {
+        ZVAL_PTR(zend_hash_find(&ddtrace_ce_root_span_data->properties_info, key), prop_info); // no update to avoid dtor
+    } ZEND_HASH_FOREACH_END();
+#endif
 
     return SUCCESS;
 }
@@ -1138,7 +1195,7 @@ PHP_FUNCTION(DDTrace_add_distributed_tag) {
 
     zend_array *target_table;
     if (DDTRACE_G(active_stack)->root_span) {
-        target_table = ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span);
+        target_table = ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta);
     } else {
         target_table = &DDTRACE_G(root_span_tags_preset);
     }
@@ -1175,7 +1232,7 @@ PHP_FUNCTION(DDTrace_set_user) {
 
     zend_array *target_table;
     if (DDTRACE_G(active_stack)->root_span) {
-        target_table = ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span);
+        target_table = ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta);
     } else {
         target_table = &DDTRACE_G(root_span_tags_preset);
     }
@@ -1636,7 +1693,7 @@ PHP_FUNCTION(DDTrace_close_spans_until) {
         RETURN_FALSE;
     }
 
-    int closed_spans = ddtrace_close_userland_spans_until(untilzv ? (ddtrace_span_data *)Z_OBJ_P(untilzv) : NULL);
+    int closed_spans = ddtrace_close_userland_spans_until(untilzv ? OBJ_SPANDATA(Z_OBJ_P(untilzv)) : NULL);
 
     if (closed_spans == -1) {
         RETURN_FALSE;
@@ -1753,7 +1810,7 @@ PHP_FUNCTION(DDTrace_root_span) {
         RETURN_NULL();
     }
     dd_ensure_root_span();
-    ddtrace_span_data *span = DDTRACE_G(active_stack)->root_span;
+    ddtrace_root_span_data *span = DDTRACE_G(active_stack)->root_span;
     if (span) {
         RETURN_OBJ_COPY(&span->std);
     }
@@ -1770,8 +1827,7 @@ static inline void dd_start_span(INTERNAL_FUNCTION_PARAMETERS) {
     ddtrace_span_data *span;
 
     if (get_DD_TRACE_ENABLED()) {
-        span = ddtrace_init_span(DDTRACE_USER_SPAN);
-        ddtrace_open_span(span);
+        span = ddtrace_open_span(DDTRACE_USER_SPAN);
     } else {
         span = ddtrace_init_dummy_span();
     }
@@ -1860,10 +1916,10 @@ PHP_FUNCTION(DDTrace_switch_stack) {
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
         DD_PARAM_PROLOGUE(0, 0);
-        if (Z_TYPE_P(_arg) == IS_OBJECT && (Z_OBJCE_P(_arg) == ddtrace_ce_span_data || Z_OBJCE_P(_arg) == ddtrace_ce_span_stack)) {
+        if (Z_TYPE_P(_arg) == IS_OBJECT && (instanceof_function(Z_OBJCE_P(_arg), ddtrace_ce_span_data) || Z_OBJCE_P(_arg) == ddtrace_ce_span_stack)) {
             stack = (ddtrace_span_stack *) Z_OBJ_P(_arg);
-            if (Z_OBJCE_P(_arg) == ddtrace_ce_span_data) {
-                stack = ((ddtrace_span_data *)stack)->stack;
+            if (instanceof_function(Z_OBJCE_P(_arg), ddtrace_ce_span_data)) {
+                stack = OBJ_SPANDATA(Z_OBJ_P(_arg))->stack;
             }
         } else {
             zend_argument_type_error(1, "must be of type DDTrace\\SpanData|DDTrace\\SpanStack, %s given", zend_zval_value_name(_arg));
@@ -1980,16 +2036,17 @@ PHP_FUNCTION(DDTrace_current_context) {
 static void dd_clear_propagated_tags_from_root_span(void) {
     if (DDTRACE_G(active_stack)->root_span) {
         zend_string *tagname;
-        zend_array *meta = ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span);
+        zend_array *meta = ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta);
         ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) { zend_hash_del(meta, tagname); }
         ZEND_HASH_FOREACH_END();
     }
 }
 
 static void dd_apply_propagated_values_to_existing_spans(void) {
-    ddtrace_span_data *span = ddtrace_active_span();
-    while (span) {
-        zend_array *meta = ddtrace_spandata_property_meta(span);
+    ddtrace_span_properties *pspan = ddtrace_active_span_props();
+    while (pspan) {
+        ddtrace_span_data *span = SPANDATA(pspan);
+        zend_array *meta = ddtrace_property_array(&span->property_meta);
         if (!DDTRACE_G(distributed_trace_id).low && !DDTRACE_G(distributed_trace_id).high) {
             span->trace_id = (ddtrace_trace_id) {
                 .low = span->root->span_id,
@@ -2007,7 +2064,7 @@ static void dd_apply_propagated_values_to_existing_spans(void) {
             zend_hash_str_del(meta, ZEND_STRL("_dd.origin"));
         }
 
-        span = span->parent;
+        pspan = pspan->parent;
     }
 
     if (DDTRACE_G(active_stack)->root_span) {
@@ -2070,7 +2127,7 @@ PHP_FUNCTION(DDTrace_set_distributed_tracing_context) {
         }
 
         if (DDTRACE_G(active_stack)->root_span) {
-            ddtrace_get_propagated_tags(ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span));
+            ddtrace_get_propagated_tags(ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta));
         }
     }
 
@@ -2168,7 +2225,7 @@ PHP_FUNCTION(DDTrace_consume_distributed_tracing_headers) {
     }
 
     if (DDTRACE_G(active_stack)->root_span) {
-        ddtrace_get_propagated_tags(ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span));
+        ddtrace_get_propagated_tags(ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta));
     }
     dd_apply_propagated_values_to_existing_spans();
 
@@ -2630,7 +2687,7 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_str, const cha
         } else {
             if (reset_decision_maker) {
                 Z_ADDREF_P(&zv);
-                zend_hash_str_update(ddtrace_spandata_property_meta(DDTRACE_G(active_stack)->root_span), ZEND_STRL("_dd.p.dm"), &zv);
+                zend_hash_str_update(ddtrace_property_array(&DDTRACE_G(active_stack)->root_span->property_meta), ZEND_STRL("_dd.p.dm"), &zv);
             }
             ddtrace_set_prioritySampling_on_root(priority_sampling, DD_MECHANISM_DEFAULT);
         }

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -10,30 +10,18 @@
 
 extern zend_module_entry ddtrace_module_entry;
 extern zend_class_entry *ddtrace_ce_span_data;
+extern zend_class_entry *ddtrace_ce_root_span_data;
 extern zend_class_entry *ddtrace_ce_span_stack;
 extern zend_class_entry *ddtrace_ce_fatal_error;
 extern zend_class_entry *ddtrace_ce_span_link;
 
 typedef struct ddtrace_span_ids_t ddtrace_span_ids_t;
 typedef struct ddtrace_span_data ddtrace_span_data;
+typedef struct ddtrace_root_span_data ddtrace_root_span_data;
 typedef struct ddtrace_span_stack ddtrace_span_stack;
 typedef struct ddtrace_span_link ddtrace_span_link;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"  // useful compiler does not like the struct hack
-static inline zval *ddtrace_spandata_property_name(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 0);
-}
-static inline zval *ddtrace_spandata_property_resource(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 1);
-}
-static inline zval *ddtrace_spandata_property_service(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 2);
-}
-static inline zval *ddtrace_spandata_property_type(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 3);
-}
-static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
+static inline zend_array *ddtrace_property_array(zval *zv) {
     ZVAL_DEREF(zv);
     if (Z_TYPE_P(zv) != IS_ARRAY) {
         zval garbage;
@@ -44,37 +32,6 @@ static inline zend_array *ddtrace_spandata_property_force_array(zval *zv) {
     SEPARATE_ARRAY(zv);
     return Z_ARR_P(zv);
 }
-static inline zval *ddtrace_spandata_property_meta_zval(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 4);
-}
-static inline zend_array *ddtrace_spandata_property_meta(ddtrace_span_data *span) {
-    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_meta_zval(span));
-}
-static inline zval *ddtrace_spandata_property_metrics_zval(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 5);
-}
-static inline zend_array *ddtrace_spandata_property_metrics(ddtrace_span_data *span) {
-    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_metrics_zval(span));
-}
-static inline zval *ddtrace_spandata_property_exception(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 6);
-}
-static inline zval *ddtrace_spandata_property_id(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 7);
-}
-static inline zval *ddtrace_spandata_property_links_zval(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 8);
-}
-static inline zend_array *ddtrace_spandata_property_links(ddtrace_span_data *span) {
-    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_links_zval(span));
-}
-static inline zval *ddtrace_spandata_property_peerServiceSources_zval(ddtrace_span_data *span) {
-    return OBJ_PROP_NUM((zend_object *)span, 9);
-}
-static inline zend_array *ddtrace_spandata_property_peer_service_sources(ddtrace_span_data *span) {
-    return ddtrace_spandata_property_force_array(ddtrace_spandata_property_peerServiceSources_zval(span));
-}
-#pragma GCC diagnostic pop
 
 bool ddtrace_tracer_is_limited(void);
 // prepare the tracer state to start handling a new trace

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -138,6 +138,9 @@ namespace DDTrace {
         public function getLink(): SpanLink {}
     }
 
+    class RootSpanData extends SpanData {
+    }
+
     /**
      * The SpanStack class allows context transfer between spans.
      *

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 414789fb27e3a704af44a6c25ae021ce97c85b43 */
+ * Stub hash: 80693b89dadb1c051e428e472dd5a3cd8c0d8d57 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -411,6 +411,11 @@ static const zend_function_entry class_DDTrace_SpanData_methods[] = {
 };
 
 
+static const zend_function_entry class_DDTrace_RootSpanData_methods[] = {
+	ZEND_FE_END
+};
+
+
 static const zend_function_entry class_DDTrace_SpanStack_methods[] = {
 	ZEND_FE_END
 };
@@ -551,6 +556,16 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	zend_string *property_stack_class_DDTrace_SpanStack = zend_string_init("DDTrace\\SpanStack", sizeof("DDTrace\\SpanStack")-1, 1);
 	zend_declare_typed_property(class_entry, property_stack_name, &property_stack_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_stack_class_DDTrace_SpanStack, 0, 0));
 	zend_string_release(property_stack_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_DDTrace_RootSpanData(zend_class_entry *class_entry_DDTrace_SpanData)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "RootSpanData", class_DDTrace_RootSpanData_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_DDTrace_SpanData);
 
 	return class_entry;
 }

--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -32,7 +32,7 @@ static void dd_check_exception_in_header(int old_response_code) {
         return;
     }
 
-    ddtrace_span_data *root_span = DDTRACE_G(active_stack)->root_span;
+    ddtrace_root_span_data *root_span = DDTRACE_G(active_stack)->root_span;
     if (!root_span) {
         return;
     }
@@ -43,7 +43,7 @@ static void dd_check_exception_in_header(int old_response_code) {
 
     ddtrace_save_active_error_to_metadata();
 
-    zval *root_exception = ddtrace_spandata_property_exception(root_span);
+    zval *root_exception = &root_span->property_exception;
     if (Z_TYPE_P(root_exception) > IS_FALSE) {
         return;
     }
@@ -266,7 +266,7 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
 
         DDTRACE_G(active_error).type = 0;
     } else {
-        ddtrace_span_data *volatile root_span = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->root_span : NULL;
+        ddtrace_root_span_data *volatile root_span = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->root_span : NULL;
         zend_object *volatile exception;
         zval *volatile span_exception;
         volatile zval old_exception = {0};
@@ -279,7 +279,7 @@ static PHP_METHOD(DDTrace_ExceptionOrErrorHandler, execute) {
 
         // Assign early so that exceptions thrown inside the exception handler won't gain priority
         if (root_span) {
-            span_exception = ddtrace_spandata_property_exception(root_span);
+            span_exception = &root_span->property_exception;
             ZVAL_COPY_VALUE((zval *)&old_exception, span_exception);
             ZVAL_OBJ_COPY(span_exception, exception);
         }

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -258,7 +258,7 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
 
     ddtrace_span_data *span = dyn->hook_data->span;
     if (span && span->duration != DDTRACE_DROPPED_SPAN && span->duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
-        zval *exception_zv = ddtrace_spandata_property_exception(span);
+        zval *exception_zv = &span->property_exception;
         if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
             ZVAL_OBJ_COPY(exception_zv, EG(exception));
         }
@@ -574,10 +574,10 @@ void dd_uhook_span(INTERNAL_FUNCTION_PARAMETERS, bool unlimited) {
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
         DD_PARAM_PROLOGUE(0, 0);
-        if (Z_TYPE_P(_arg) == IS_OBJECT && (Z_OBJCE_P(_arg) == ddtrace_ce_span_data || Z_OBJCE_P(_arg) == ddtrace_ce_span_stack)) {
+        if (Z_TYPE_P(_arg) == IS_OBJECT && (instanceof_function(Z_OBJCE_P(_arg), ddtrace_ce_span_data) || Z_OBJCE_P(_arg) == ddtrace_ce_span_stack)) {
             stack = (ddtrace_span_stack *) Z_OBJ_P(_arg);
-            if (Z_OBJCE_P(_arg) == ddtrace_ce_span_data) {
-                stack = ((ddtrace_span_data *)stack)->stack;
+            if (instanceof_function(Z_OBJCE_P(_arg), ddtrace_ce_span_data)) {
+                stack = OBJ_SPANDATA(Z_OBJ_P(_arg))->stack;
             }
         } else {
             zend_argument_type_error(1, "must be of type DDTrace\\SpanData|DDTrace\\SpanStack, %s given", zend_zval_value_name(_arg));

--- a/ext/hook/uhook_legacy.c
+++ b/ext/hook/uhook_legacy.c
@@ -165,7 +165,7 @@ static void dd_uhook_generator_yield(zend_ulong invocation, zend_execute_data *e
                 LOG_ONCE(Error, "Cannot run tracing closure for %s(); spans out of sync", ZSTR_VAL(EX(func)->common.function_name));
             }
         } else if (dyn->span->duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
-            zval *exception_zv = ddtrace_spandata_property_exception(dyn->span);
+            zval *exception_zv = &dyn->span->property_exception;
             if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
                 ZVAL_OBJ_COPY(exception_zv, EG(exception));
             }
@@ -201,7 +201,7 @@ static void dd_uhook_end(zend_ulong invocation, zend_execute_data *execute_data,
                 LOG_ONCE(Error, "Cannot run tracing closure for %s(); spans out of sync", ZSTR_VAL(EX(func)->common.function_name));
             }
         } else if (dyn->span->duration != DDTRACE_SILENTLY_DROPPED_SPAN) {
-            zval *exception_zv = ddtrace_spandata_property_exception(dyn->span);
+            zval *exception_zv = &dyn->span->property_exception;
             if (EG(exception) && Z_TYPE_P(exception_zv) <= IS_FALSE) {
                 ZVAL_OBJ_COPY(exception_zv, EG(exception));
             }

--- a/ext/priority_sampling/priority_sampling.h
+++ b/ext/priority_sampling/priority_sampling.h
@@ -20,7 +20,7 @@ enum dd_sampling_mechanism {
 };
 
 void ddtrace_set_prioritySampling_on_root(zend_long priority, enum dd_sampling_mechanism mechanism);
-zend_long ddtrace_fetch_prioritySampling_from_span(ddtrace_span_data *root_span);
+zend_long ddtrace_fetch_prioritySampling_from_span(ddtrace_root_span_data *root_span);
 zend_long ddtrace_fetch_prioritySampling_from_root(void);
 
 void ddtrace_try_read_agent_rate(void);

--- a/ext/random.c
+++ b/ext/random.c
@@ -98,13 +98,13 @@ uint64_t ddtrace_parse_hex_span_id(zval *zid) {
 uint64_t ddtrace_generate_span_id(void) { return (uint64_t)genrand64_int64(); }
 
 uint64_t ddtrace_peek_span_id(void) {
-    ddtrace_span_data *span = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->active : NULL;
-    return span ? span->span_id : DDTRACE_G(distributed_parent_trace_id);
+    ddtrace_span_properties *pspan = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->active : NULL;
+    return pspan ? SPANDATA(pspan)->span_id : DDTRACE_G(distributed_parent_trace_id);
 }
 
 ddtrace_trace_id ddtrace_peek_trace_id(void) {
-    ddtrace_span_data *span = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->active : NULL;
-    return span ? span->trace_id : DDTRACE_G(distributed_trace_id);
+    ddtrace_span_properties *pspan = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->active : NULL;
+    return pspan ? SPANDATA(pspan)->trace_id : DDTRACE_G(distributed_trace_id);
 }
 
 int ddtrace_conv10_trace_id(ddtrace_trace_id id, uint8_t reverse[DD_TRACE_MAX_ID_LEN]) {

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -515,7 +515,7 @@ static void dd_add_post_fields_to_meta_recursive(zend_array *meta, const char *t
 }
 
 void ddtrace_set_global_span_properties(ddtrace_span_data *span) {
-    zend_array *meta = ddtrace_spandata_property_meta(span);
+    zend_array *meta = ddtrace_property_array(&span->property_meta);
 
     zend_array *global_tags = get_DD_TAGS();
     zend_string *global_key;
@@ -536,9 +536,8 @@ void ddtrace_set_global_span_properties(ddtrace_span_data *span) {
     }
     ZEND_HASH_FOREACH_END();
 
-    zval *prop_id = ddtrace_spandata_property_id(span);
-    zval_ptr_dtor(prop_id);
-    ZVAL_STR(prop_id, ddtrace_span_id_as_string(span->span_id));
+    zval_ptr_dtor(&span->property_id);
+    ZVAL_STR(&span->property_id, ddtrace_span_id_as_string(span->span_id));
 }
 
 static const char *dd_get_req_uri() {
@@ -641,7 +640,7 @@ static bool dd_set_mapped_peer_service(zval *meta, zend_string *peer_service) {
 }
 
 void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
-    zend_array *meta = ddtrace_spandata_property_meta(span);
+    zend_array *meta = ddtrace_property_array(&span->property_meta);
 
     zend_hash_copy(meta, &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
 
@@ -671,7 +670,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
 
         if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED()) {
             const char *uri = dd_get_req_uri();
-            zval *prop_resource = ddtrace_spandata_property_resource(span);
+            zval *prop_resource = &span->property_resource;
             zval_ptr_dtor(prop_resource);
             if (uri) {
                 zend_string *path = zend_string_init(uri, strlen(uri), 0);
@@ -710,8 +709,8 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
         zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
     }
 
-    zval *prop_type = ddtrace_spandata_property_type(span);
-    zval *prop_name = ddtrace_spandata_property_name(span);
+    zval *prop_type = &span->property_type;
+    zval *prop_name = &span->property_name;
     if (strcmp(sapi_module.name, "cli") == 0) {
         zval_ptr_dtor(prop_type);
         ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("cli"), 0));
@@ -727,7 +726,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
         zval_ptr_dtor(prop_name);
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
     }
-    zval *prop_service = ddtrace_spandata_property_service(span);
+    zval *prop_service = &span->property_service;
     zval_ptr_dtor(prop_service);
     ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 
@@ -799,7 +798,7 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
     }
 
     ddtrace_integration *web_integration = &ddtrace_integrations[DDTRACE_INTEGRATION_WEB];
-    zend_array *metrics = ddtrace_spandata_property_metrics(span);
+    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
     if (get_DD_TRACE_ANALYTICS_ENABLED() || web_integration->is_analytics_enabled()) {
         zval sample_rate;
         ZVAL_DOUBLE(&sample_rate, web_integration->get_sample_rate());
@@ -821,7 +820,7 @@ static void _dd_serialize_json(zend_array *arr, smart_str *buf, int options) {
 static void _serialize_meta(zval *el, ddtrace_span_data *span) {
     bool is_top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
     bool is_local_root_span = span->parent_id == 0 || is_top_level_span;
-    zval meta_zv, *meta = ddtrace_spandata_property_meta_zval(span);
+    zval meta_zv, *meta = &span->property_meta;
     bool ignore_error = false;
 
     array_init(&meta_zv);
@@ -844,7 +843,7 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
     }
     meta = &meta_zv;
 
-    zval *exception_zv = ddtrace_spandata_property_exception(span);
+    zval *exception_zv = &span->property_exception;
     if (Z_TYPE_P(exception_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(exception_zv), zend_ce_throwable)) {
         ignore_error = false;
         enum dd_exception exception_type = DD_EXCEPTION_THROWN;
@@ -854,7 +853,7 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
         ddtrace_exception_to_meta(Z_OBJ_P(exception_zv), meta, dd_add_meta_array, exception_type);
     }
 
-    zend_array *span_links = ddtrace_spandata_property_links(span);
+    zend_array *span_links = ddtrace_property_array(&span->property_links);
     if (zend_hash_num_elements(span_links) > 0) {
         smart_str buf = {0};
         _dd_serialize_json(span_links, &buf, 0);
@@ -862,7 +861,7 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
     }
 
     if (get_DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED()) { // opt-in
-        zend_array *peer_service_sources = ddtrace_spandata_property_peer_service_sources(span);
+        zend_array *peer_service_sources = ddtrace_property_array(&span->property_peer_service_sources);
         if (zend_hash_str_exists(Z_ARRVAL_P(meta), ZEND_STRL("peer.service"))) { // peer.service is already set by the user, honor it
             add_assoc_str(meta, "_dd.peer.service.source", zend_string_init(ZEND_STRL("peer.service"), 0));
 
@@ -1057,10 +1056,10 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
 
     // handle dropped spans
     if (span->parent) {
-        ddtrace_span_data *parent = span->parent;
+        ddtrace_span_data *parent = SPANDATA(span->parent);
         // Ensure the parent id is the root span if everything else was dropped
         while (parent->parent && ddtrace_span_is_dropped(parent)) {
-            parent = parent->parent;
+            parent = SPANDATA(parent->parent);
         }
         span->parent_id = parent->span_id;
     }
@@ -1072,7 +1071,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     add_assoc_long(el, "duration", span->duration);
 
     // SpanData::$name defaults to fully qualified called name (set at span close)
-    zval *prop_name = ddtrace_spandata_property_name(span);
+    zval *prop_name = &span->property_name;
     ZVAL_DEREF(prop_name);
     if (Z_TYPE_P(prop_name) > IS_NULL) {
         zval prop_name_as_string;
@@ -1081,7 +1080,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     }
 
     // SpanData::$resource defaults to SpanData::$name
-    zval *prop_resource = ddtrace_spandata_property_resource(span);
+    zval *prop_resource = &span->property_resource;
     ZVAL_DEREF(prop_resource);
     zval prop_resource_as_string;
     ZVAL_UNDEF(&prop_resource_as_string);
@@ -1096,7 +1095,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     }
 
     // TODO: SpanData::$service defaults to parent SpanData::$service or DD_SERVICE if root span
-    zval *prop_service = ddtrace_spandata_property_service(span);
+    zval *prop_service = &span->property_service;
     ZVAL_DEREF(prop_service);
     zval prop_service_as_string;
     if (Z_TYPE_P(prop_service) > IS_NULL) {
@@ -1120,7 +1119,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     }
 
     // SpanData::$type is optional and defaults to 'custom' at the Agent level
-    zval *prop_type = ddtrace_spandata_property_type(span);
+    zval *prop_type = &span->property_type;
     ZVAL_DEREF(prop_type);
     zval prop_type_as_string;
     ZVAL_UNDEF(&prop_type_as_string);
@@ -1247,7 +1246,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
                 }
             }
 
-            zend_array *metrics = ddtrace_spandata_property_metrics(span);
+            zend_array *metrics = ddtrace_property_array(&span->property_metrics);
 
             zval mechanism;
             ZVAL_LONG(&mechanism, 8);
@@ -1270,7 +1269,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
 
     _serialize_meta(el, span);
 
-    zval *metrics = ddtrace_spandata_property_metrics_zval(span);
+    zval *metrics = &span->property_metrics;
     ZVAL_DEREF(metrics);
     if (Z_TYPE_P(metrics) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(metrics))) {
         zval metrics_zv;
@@ -1325,12 +1324,12 @@ void ddtrace_save_active_error_to_metadata(void) {
         .msg = zend_string_copy(DDTRACE_G(active_error).message),
         .stack = dd_fatal_error_stack(),
     };
-    for (ddtrace_span_data *span = ddtrace_active_span(); span; span = span->parent) {
-        if (Z_TYPE_P(ddtrace_spandata_property_exception(span)) == IS_OBJECT) {  // exceptions take priority
+    for (ddtrace_span_properties *pspan = ddtrace_active_span_props(); pspan; pspan = pspan->parent) {
+        if (Z_TYPE(pspan->property_exception) == IS_OBJECT) {  // exceptions take priority
             continue;
         }
 
-        dd_fatal_error_to_meta(ddtrace_spandata_property_meta(span), error);
+        dd_fatal_error_to_meta(ddtrace_property_array(&pspan->property_meta), error);
     }
     zend_string_release(error.type);
     zend_string_release(error.msg);
@@ -1415,13 +1414,13 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
 #if PHP_VERSION_ID < 80000
             zend_string_release(message);
 #endif
-            ddtrace_span_data *span;
-            for (span = DDTRACE_G(active_stack)->active; span; span = span->parent) {
-                if (Z_TYPE_P(ddtrace_spandata_property_exception(span)) > IS_FALSE) {
+            ddtrace_span_properties *pspan;
+            for (pspan = DDTRACE_G(active_stack)->active; pspan; pspan = pspan->parent) {
+                if (Z_TYPE(pspan->property_exception) > IS_FALSE) {
                     continue;
                 }
 
-                dd_fatal_error_to_meta(ddtrace_spandata_property_meta(span), error);
+                dd_fatal_error_to_meta(ddtrace_property_array(&pspan->property_meta), error);
             }
             zend_string_release(error.type);
             zend_string_release(error.msg);

--- a/ext/span.h
+++ b/ext/span.h
@@ -22,6 +22,34 @@ enum ddtrace_span_dataype {
     DDTRACE_SPAN_CLOSED,
 };
 
+typedef union ddtrace_span_properties {
+    zend_object std;
+    struct {
+        char object_placeholder[sizeof(zend_object) - sizeof(zval)];
+        zval property_name;
+        zval property_resource;
+        zval property_service;
+        zval property_type;
+        zval property_meta;
+        zval property_metrics;
+        zval property_exception;
+        union {
+            zend_string *string_id;
+            zval property_id;
+        };
+        zval property_links;
+        zval property_peer_service_sources;
+        union {
+            union ddtrace_span_properties *parent;
+            zval property_parent;
+        };
+        union {
+            struct ddtrace_span_stack *stack;
+            zval property_stack;
+        };
+    };
+} ddtrace_span_properties;
+
 // Refcounting:
 // Only internal/autoroot spans retain a ref on their own
 // Non-flushed closed spans also have a ref on their own
@@ -29,16 +57,6 @@ enum ddtrace_span_dataype {
 // Spans keep a ref to their parents (parent span property)
 // Open spans as well as flushed spans keep a reference to the span stack
 struct ddtrace_span_data {
-    zend_object std;
-    zval properties_table_placeholder[9];
-    union {
-        struct ddtrace_span_data *parent;
-        zval property_parent;
-    };
-    union {
-        struct ddtrace_span_stack *stack;
-        zval property_stack;
-    };
     ddtrace_trace_id trace_id;
     uint64_t parent_id;
     uint64_t span_id;
@@ -47,8 +65,32 @@ struct ddtrace_span_data {
     uint64_t duration;
     enum ddtrace_span_dataype type;
     struct ddtrace_span_data *next;
-    struct ddtrace_span_data *root;
+    struct ddtrace_root_span_data *root;
+
+    union {
+        ddtrace_span_properties;
+        ddtrace_span_properties props;
+    };
 };
+
+static inline ddtrace_span_data *OBJ_SPANDATA(zend_object *obj) {
+    return (ddtrace_span_data *)((char *)(obj) - XtOffsetOf(ddtrace_span_data, std));
+}
+
+static inline ddtrace_span_data *SPANDATA(ddtrace_span_properties *obj) {
+    return OBJ_SPANDATA(&obj->std);
+}
+
+struct ddtrace_root_span_data {
+    union {
+        ddtrace_span_data;
+        ddtrace_span_data span;
+    };
+};
+
+static inline ddtrace_root_span_data *ROOTSPANDATA(zend_object *obj) {
+    return (ddtrace_root_span_data *)((char *)(obj) - XtOffsetOf(ddtrace_root_span_data, std));
+}
 
 struct ddtrace_span_stack {
     union {
@@ -61,11 +103,11 @@ struct ddtrace_span_stack {
             };
             union {
                 zval property_active;
-                struct ddtrace_span_data *active;
+                ddtrace_span_properties *active;
             };
         };
     };
-    struct ddtrace_span_data *root_span;
+    struct ddtrace_root_span_data *root_span;
     struct ddtrace_span_stack *root_stack;
     union {
         struct ddtrace_span_stack *next; // closed chunk chain
@@ -76,10 +118,10 @@ struct ddtrace_span_stack {
 #endif
         };
     };
-    struct ddtrace_span_stack *top_closed_stack;
+    ddtrace_span_stack *top_closed_stack;
     // closed ring: linked list where the last element links to the first. The last inserted element is always reachable via closed_ring->next.
-    struct ddtrace_span_data *closed_ring;
-    struct ddtrace_span_data *closed_ring_flush;
+    ddtrace_span_data *closed_ring;
+    ddtrace_span_data *closed_ring_flush;
 };
 
 struct ddtrace_span_link {
@@ -100,14 +142,17 @@ void ddtrace_init_span_stacks(void);
 void ddtrace_free_span_stacks(bool silent);
 void ddtrace_switch_span_stack(ddtrace_span_stack *target_stack);
 
-void ddtrace_open_span(ddtrace_span_data *span);
-ddtrace_span_data *ddtrace_init_span(enum ddtrace_span_dataype type);
+ddtrace_span_data *ddtrace_open_span(enum ddtrace_span_dataype type);
 ddtrace_span_data *ddtrace_init_dummy_span(void);
 ddtrace_span_stack *ddtrace_init_span_stack(void);
 ddtrace_span_stack *ddtrace_init_root_span_stack(void);
 void ddtrace_push_root_span(void);
 
 ddtrace_span_data *ddtrace_active_span(void);
+static inline ddtrace_span_properties *ddtrace_active_span_props(void) {
+    ddtrace_span_data *span = ddtrace_active_span();
+    return span ? &span->props : NULL;
+}
 
 ddtrace_span_data *ddtrace_alloc_execute_data_span(zend_ulong invocation, zend_execute_data *execute_data);
 void ddtrace_clear_execute_data_span(zend_ulong invocation, bool keep);

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.c
@@ -25,9 +25,9 @@ void ddtrace_add_tracer_tags_from_header(zend_string *headerstr) {
     char *header = ZSTR_VAL(headerstr), *headerend = header + ZSTR_LEN(headerstr);
 
     zend_array *tags = &DDTRACE_G(root_span_tags_preset);
-    ddtrace_span_data *span = DDTRACE_G(active_stack)->root_span;
+    ddtrace_root_span_data *span = DDTRACE_G(active_stack)->root_span;
     if (span) {
-        tags = ddtrace_spandata_property_meta(span);
+        tags = ddtrace_property_array(&span->property_meta);
     }
 
     if (ZSTR_LEN(headerstr) > 512) {
@@ -107,9 +107,9 @@ zend_string *ddtrace_format_propagated_tags(void) {
     zend_hash_str_add_empty_element(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.dm"));
 
     zend_array *tags = &DDTRACE_G(root_span_tags_preset);
-    ddtrace_span_data *span = DDTRACE_G(active_stack)->root_span;
+    ddtrace_root_span_data *span = DDTRACE_G(active_stack)->root_span;
     if (span) {
-        tags = ddtrace_spandata_property_meta(span);
+        tags = ddtrace_property_array(&span->property_meta);
     }
 
     smart_str taglist = {0};

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -26,7 +26,7 @@ var_dump(DDTrace\active_span() == DDTrace\active_span());
 Hello, Datadog.
 greet tracer.
 bool(true)
-object(DDTrace\SpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (12) {
   ["name"]=>
   string(15) "active_span.php"
   ["resource"]=>

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -22,7 +22,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-object(DDTrace\SpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (12) {
   ["name"]=>
   string(3) "foo"
   ["resource"]=>
@@ -66,7 +66,7 @@ object(DDTrace\SpanData)#%d (12) {
     *RECURSION*
   }
 }
-object(DDTrace\SpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (12) {
   ["name"]=>
   string(5) "dummy"
   ["resource"]=>
@@ -107,7 +107,7 @@ object(DDTrace\SpanData)#%d (12) {
       NULL
     }
     ["active"]=>
-    object(DDTrace\SpanData)#%d (12) {
+    object(DDTrace\RootSpanData)#%d (12) {
       ["name"]=>
       string(3) "foo"
       ["resource"]=>


### PR DESCRIPTION
### Description

This allows setting specific data on RootSpans.
Further, since properties are always at the end of the zend_object, if RootSpanData has properties, they would conflict with the trailing SpanData members. Hence, they need to be moved in front.

This is preparatory work for adding more properties to RootSpanData.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
