### PR TITLE
Explicitly drop dd.p.dm if provided in propagated tags when the incoming sampling priority is reject

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2622,8 +2622,12 @@ void ddtrace_read_distributed_tracing_ids(bool (*read_header)(zai_str, const cha
         }
         zval zv;
         if (reset_decision_maker) {
-            ZVAL_STRINGL(&zv, "-0", 2);
-            zend_hash_str_update(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.dm"), &zv);
+            if (priority_sampling > 0) {
+                ZVAL_STRINGL(&zv, "-0", 2);
+                zend_hash_str_update(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.dm"), &zv);
+            } else {
+                zend_hash_str_del(&DDTRACE_G(root_span_tags_preset), ZEND_STRL("_dd.p.dm"));
+            }
         }
         if (!DDTRACE_G(active_stack)->root_span) {
             DDTRACE_G(propagated_priority_sampling) = DDTRACE_G(default_priority_sampling) = priority_sampling;

--- a/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Explicitly drop dd.p.dm if provided in propagated tags when the incoming sampling priority is reject
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--INI--
+ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
+--ENV--
+DD_TRACE_DEBUG=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+HTTP_TRACEPARENT=00-12345678901234567890123456789012-1234567890123456-00
+HTTP_TRACESTATE=foo=1,dd=s:1;t.dm:-0;t.usr.id:baz64~~;t.url:http://localhost
+DD_PROPAGATION_STYLE=tracecontext,Datadog
+--FILE--
+<?php
+include 'curl_helper.inc';
+
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/headers';
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$response = curl_exec($ch);
+show_curl_error_on_fail($ch);
+curl_close($ch);
+
+include 'distributed_tracing.inc';
+$headers = dt_decode_headers_from_httpbin($response);
+dt_dump_headers_from_httpbin($headers, [
+    'x-datadog-trace-id',
+    'x-datadog-parent-id',
+    'x-datadog-origin',
+    'x-datadog-tags',
+    'b3',
+    'traceparent',
+    'tracestate',
+]);
+
+$spans = dd_trace_serialize_closed_spans();
+var_dump(isset($spans[0]["meta"]["_dd.propagation_error"]));
+
+echo 'Done.' . PHP_EOL;
+
+?>
+--EXPECTF--
+traceparent: 00-12345678901234567890123456789012-1234567890123456-00
+tracestate: dd=t.tid:1234567890123456;t.usr.id:baz64~~;t.url:http://localhost,foo=1,
+x-datadog-parent-id: 1311768467284833366
+x-datadog-tags: _dd.p.tid=1234567890123456,_dd.p.usr.id=baz64==,_dd.p.url=http://localhost
+x-datadog-trace-id: 8687463697196027922
+bool(false)
+Done.
+No finished traces to be sent to the agent


### PR DESCRIPTION
### Description

Beforehand, the tracer would pass _dd.p.dm unfiltered, if it was propagated and sampling priorities not changed. I do think this is the more reasonable behaviour, but complying with system tests here.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
