### PR TITLE
Refactor tightly coupled extraction state

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -133,6 +133,7 @@ if test "$PHP_DDTRACE" != "no"; then
     ext/coms.c \
     ext/configuration.c \
     ext/ddshared.c \
+    ext/distributed_tracing_headers.c \
     ext/dogstatsd_client.c \
     ext/engine_api.c \
     ext/engine_hooks.c \

--- a/ddtrace.sym
+++ b/ddtrace.sym
@@ -1,5 +1,6 @@
 ddtrace_close_all_spans_and_flush
 ddtrace_get_profiling_context
+ddtrace_set_priority_sampling_on_root
 ddtrace_root_span_get_meta
 ddtrace_root_span_get_metrics
 ddtrace_runtime_id

--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -49,6 +49,14 @@
 #define ZVAL_VARARG_PARAM(list, arg_num) (&(((zval *)list)[arg_num]))
 #define IS_TRUE_P(x) (Z_TYPE_P(x) == IS_TRUE)
 
+static inline zval *ddtrace_assign_variable(zval *variable_ptr, zval *value) {
+#if PHP_VERSION_ID < 70400
+    return zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR);
+#else
+    return zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, false);
+#endif
+}
+
 #if PHP_VERSION_ID < 70100
 #define IS_VOID 0
 #define MAY_BE_NULL 0

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 80693b89dadb1c051e428e472dd5a3cd8c0d8d57 */
+ * Stub hash: a7d10bf6cca1521fbf2d8ab00d086c3de6c3c3e1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -241,12 +241,18 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DDTrace_SpanLink_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_SpanLink_fromHeaders, 0, 1, DDTrace\\SpanLink, 0)
+	ZEND_ARG_TYPE_MASK(0, headersOrCallback, MAY_BE_ARRAY|MAY_BE_CALLABLE, NULL)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_DDTrace_SpanData_getDuration arginfo_dd_trace_dd_get_memory_limit
 
 #define arginfo_class_DDTrace_SpanData_getStartTime arginfo_dd_trace_dd_get_memory_limit
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_SpanData_getLink, 0, 0, DDTrace\\SpanLink, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_DDTrace_SpanData_hexId arginfo_DDTrace_startup_logs
 
 
 ZEND_FUNCTION(DDTrace_trace_method);
@@ -318,9 +324,11 @@ ZEND_FUNCTION(dd_trace_push_span_id);
 ZEND_FUNCTION(dd_trace_pop_span_id);
 ZEND_FUNCTION(additional_trace_meta);
 ZEND_METHOD(DDTrace_SpanLink, jsonSerialize);
+ZEND_METHOD(DDTrace_SpanLink, fromHeaders);
 ZEND_METHOD(DDTrace_SpanData, getDuration);
 ZEND_METHOD(DDTrace_SpanData, getStartTime);
 ZEND_METHOD(DDTrace_SpanData, getLink);
+ZEND_METHOD(DDTrace_SpanData, hexId);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -399,6 +407,7 @@ static const zend_function_entry ext_functions[] = {
 
 static const zend_function_entry class_DDTrace_SpanLink_methods[] = {
 	ZEND_ME(DDTrace_SpanLink, jsonSerialize, arginfo_class_DDTrace_SpanLink_jsonSerialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(DDTrace_SpanLink, fromHeaders, arginfo_class_DDTrace_SpanLink_fromHeaders, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };
 
@@ -407,6 +416,7 @@ static const zend_function_entry class_DDTrace_SpanData_methods[] = {
 	ZEND_ME(DDTrace_SpanData, getDuration, arginfo_class_DDTrace_SpanData_getDuration, ZEND_ACC_PUBLIC)
 	ZEND_ME(DDTrace_SpanData, getStartTime, arginfo_class_DDTrace_SpanData_getStartTime, ZEND_ACC_PUBLIC)
 	ZEND_ME(DDTrace_SpanData, getLink, arginfo_class_DDTrace_SpanData_getLink, ZEND_ACC_PUBLIC)
+	ZEND_ME(DDTrace_SpanData, hexId, arginfo_class_DDTrace_SpanData_hexId, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -566,6 +576,54 @@ static zend_class_entry *register_class_DDTrace_RootSpanData(zend_class_entry *c
 
 	INIT_NS_CLASS_ENTRY(ce, "DDTrace", "RootSpanData", class_DDTrace_RootSpanData_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DDTrace_SpanData);
+
+	zval property_origin_default_value;
+	ZVAL_UNDEF(&property_origin_default_value);
+	zend_string *property_origin_name = zend_string_init("origin", sizeof("origin") - 1, 1);
+	zend_declare_typed_property(class_entry, property_origin_name, &property_origin_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_origin_name);
+
+	zval property_propagatedTags_default_value;
+	ZVAL_EMPTY_ARRAY(&property_propagatedTags_default_value);
+	zend_string *property_propagatedTags_name = zend_string_init("propagatedTags", sizeof("propagatedTags") - 1, 1);
+	zend_declare_typed_property(class_entry, property_propagatedTags_name, &property_propagatedTags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_propagatedTags_name);
+
+	zval property_samplingPriority_default_value;
+	ZVAL_LONG(&property_samplingPriority_default_value, DDTRACE_PRIORITY_SAMPLING_UNKNOWN);
+	zend_string *property_samplingPriority_name = zend_string_init("samplingPriority", sizeof("samplingPriority") - 1, 1);
+	zend_declare_typed_property(class_entry, property_samplingPriority_name, &property_samplingPriority_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_samplingPriority_name);
+
+	zval property_propagatedSamplingPriority_default_value;
+	ZVAL_UNDEF(&property_propagatedSamplingPriority_default_value);
+	zend_string *property_propagatedSamplingPriority_name = zend_string_init("propagatedSamplingPriority", sizeof("propagatedSamplingPriority") - 1, 1);
+	zend_declare_typed_property(class_entry, property_propagatedSamplingPriority_name, &property_propagatedSamplingPriority_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_propagatedSamplingPriority_name);
+
+	zval property_tracestate_default_value;
+	ZVAL_UNDEF(&property_tracestate_default_value);
+	zend_string *property_tracestate_name = zend_string_init("tracestate", sizeof("tracestate") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tracestate_name, &property_tracestate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_tracestate_name);
+
+	zval property_tracestateTags_default_value;
+	ZVAL_EMPTY_ARRAY(&property_tracestateTags_default_value);
+	zend_string *property_tracestateTags_name = zend_string_init("tracestateTags", sizeof("tracestateTags") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tracestateTags_name, &property_tracestateTags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_tracestateTags_name);
+
+	zval property_parentId_default_value;
+	ZVAL_UNDEF(&property_parentId_default_value);
+	zend_string *property_parentId_name = zend_string_init("parentId", sizeof("parentId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_parentId_name, &property_parentId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_parentId_name);
+
+	zval property_traceId_default_value;
+	ZVAL_EMPTY_STRING(&property_traceId_default_value);
+	zend_string *property_traceId_name = zend_string_init("traceId", sizeof("traceId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_traceId_name, &property_traceId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_traceId_name);
 
 	return class_entry;
 }

--- a/ext/distributed_tracing_headers.c
+++ b/ext/distributed_tracing_headers.c
@@ -1,0 +1,400 @@
+#include "distributed_tracing_headers.h"
+#include "configuration.h"
+#include "tracer_tag_propagation/tracer_tag_propagation.h"
+#include "serializer.h"
+#include <config/config_ini.h>
+#include <headers/headers.h>
+
+ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
+
+static ddtrace_trace_id dd_parse_b3_trace_id(char *trace_id, ssize_t trace_id_len) {
+    return (ddtrace_trace_id){
+        .high = trace_id_len > 16 ? ddtrace_parse_hex_span_id_str(trace_id, MIN(16, trace_id_len - 16)) : 0,
+        .low = ddtrace_parse_hex_span_id_str(trace_id + MAX(0, trace_id_len - 16), MIN(16, trace_id_len)),
+    };
+}
+
+static inline bool dd_is_hex_char(char chr) {
+    return (chr >= '0' && chr <= '9') || (chr >= 'a' && chr <= 'f');
+}
+
+
+ddtrace_distributed_tracing_result ddtrace_read_distributed_tracing_ids(ddtrace_read_header *read_header, void *data) {
+    zend_string *trace_id_str, *parent_id_str, *priority_str, *propagated_tags, *b3_header_str, *traceparent, *tracestate;
+
+    ddtrace_distributed_tracing_result result = {0};
+    result.priority_sampling = DDTRACE_PRIORITY_SAMPLING_UNKNOWN;
+    zend_hash_init(&result.tracestate_unknown_dd_keys, 8, unused, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&result.propagated_tags, 8, unused, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&result.meta_tags, 8, unused, ZVAL_PTR_DTOR, 0);
+
+    zend_array *extract = zai_config_is_modified(DDTRACE_CONFIG_DD_TRACE_PROPAGATION_STYLE)
+                          && !zai_config_is_modified(DDTRACE_CONFIG_DD_TRACE_PROPAGATION_STYLE_EXTRACT)
+                          ? get_DD_TRACE_PROPAGATION_STYLE() : get_DD_TRACE_PROPAGATION_STYLE_EXTRACT();
+    bool parse_datadog = zend_hash_str_exists(extract, ZEND_STRL("datadog"));
+    bool parse_tracestate = zend_hash_str_exists(extract, ZEND_STRL("tracecontext"));
+    bool parse_b3 = zend_hash_str_exists(extract, ZEND_STRL("b3")) || zend_hash_str_exists(extract, ZEND_STRL("b3multi"));
+    bool parse_b3_single = zend_hash_str_exists(extract, ZEND_STRL("b3 single header"));
+    bool parse_datadog_meta_headers = parse_datadog || parse_b3 || parse_b3_single;
+
+    if (parse_b3_single && read_header(ZAI_STRL("B3"), "b3", &b3_header_str, data)) {
+        char *b3_ptr = ZSTR_VAL(b3_header_str), *b3_end = b3_ptr + ZSTR_LEN(b3_header_str);
+        char *b3_traceid = b3_ptr;
+        while (b3_ptr < b3_end && *b3_ptr != '-') {
+            ++b3_ptr;
+        }
+
+        result.trace_id = dd_parse_b3_trace_id(b3_traceid, b3_ptr - b3_traceid);
+
+        char *b3_spanid = ++b3_ptr;
+        while (b3_ptr < b3_end && *b3_ptr != '-') {
+            ++b3_ptr;
+        }
+
+        result.parent_id = ddtrace_parse_hex_span_id_str(b3_spanid, b3_ptr - b3_spanid);
+
+        char *b3_sampling = ++b3_ptr;
+        while (b3_ptr < b3_end && *b3_ptr != '-') {
+            ++b3_ptr;
+        }
+
+        if (b3_ptr - b3_sampling == 1) {
+            if (*b3_sampling == '0') {
+                result.priority_sampling = 0;
+            } else if (*b3_sampling == '1') {
+                result.priority_sampling = 1;
+            } else if (*b3_sampling == 'd') {
+                result.priority_sampling = PRIORITY_SAMPLING_USER_KEEP;
+            }
+        } else if (b3_ptr - b3_sampling == 4 && strncmp(b3_sampling, "true", 4) == 0) {
+            result.priority_sampling = 1;
+        } else if (b3_ptr - b3_sampling == 5 && strncmp(b3_sampling, "false", 5) == 0) {
+            result.priority_sampling = 0;
+        }
+        zend_string_release(b3_header_str);
+    }
+
+    if (parse_datadog_meta_headers) {
+        read_header(ZAI_STRL("X_DATADOG_ORIGIN"), "x-datadog-origin", &result.origin, data);
+    }
+
+    if (parse_datadog && read_header(ZAI_STRL("X_DATADOG_TRACE_ID"), "x-datadog-trace-id", &trace_id_str, data)) {
+        zval trace_zv;
+        ZVAL_STR(&trace_zv, trace_id_str);
+        result.trace_id = (ddtrace_trace_id){ .low = ddtrace_parse_userland_span_id(&trace_zv) };
+        zend_string_release(trace_id_str);
+    } else if (parse_b3 && read_header(ZAI_STRL("X_B3_TRACEID"), "x-b3-traceid", &trace_id_str, data)) {
+        result.trace_id = dd_parse_b3_trace_id(ZSTR_VAL(trace_id_str), ZSTR_LEN(trace_id_str));
+        zend_string_release(trace_id_str);
+    }
+
+    if (result.trace_id.low || result.trace_id.high) {
+        if (parse_datadog && read_header(ZAI_STRL("X_DATADOG_PARENT_ID"), "x-datadog-parent-id", &parent_id_str, data)) {
+            zval parent_zv;
+            ZVAL_STR(&parent_zv, parent_id_str);
+            result.parent_id = ddtrace_parse_userland_span_id(&parent_zv);
+            zend_string_release(parent_id_str);
+        } else if (parse_b3 && read_header(ZAI_STRL("X_B3_SPANID"), "x-b3-spanid", &parent_id_str, data)) {
+            zval parent_zv;
+            ZVAL_STR(&parent_zv, parent_id_str);
+            result.parent_id = ddtrace_parse_hex_span_id(&parent_zv);
+            zend_string_release(parent_id_str);
+        }
+    } else {
+        // skip, if no valid trace is present
+        parse_datadog_meta_headers = 0;
+        parse_datadog = 0;
+    }
+
+    if (parse_datadog && read_header(ZAI_STRL("X_DATADOG_SAMPLING_PRIORITY"), "x-datadog-sampling-priority", &priority_str, data)) {
+        result.priority_sampling = strtol(ZSTR_VAL(priority_str), NULL, 10);
+        zend_string_release(priority_str);
+    } else if (parse_b3 && read_header(ZAI_STRL("X_B3_SAMPLED"), "x-b3-sampled", &priority_str, data)) {
+        if (ZSTR_LEN(priority_str) == 1) {
+            if (ZSTR_VAL(priority_str)[0] == '0') {
+                result.priority_sampling = 0;
+            } else if (ZSTR_VAL(priority_str)[0] == '1') {
+                result.priority_sampling = 1;
+            }
+        } else if (zend_string_equals_literal(priority_str, "true")) {
+            result.priority_sampling = 1;
+        } else if (zend_string_equals_literal(priority_str, "false")) {
+            result.priority_sampling = 0;
+        }
+        zend_string_release(priority_str);
+    } else if (parse_b3 && read_header(ZAI_STRL("X_B3_FLAGS"), "x-b3-flags", &priority_str, data)) {
+        if (ZSTR_LEN(priority_str) == 1 && ZSTR_VAL(priority_str)[1] == '1') {
+            result.priority_sampling = PRIORITY_SAMPLING_USER_KEEP;
+        }
+        zend_string_release(priority_str);
+    }
+
+    if (parse_datadog_meta_headers && read_header(ZAI_STRL("X_DATADOG_TAGS"), "x-datadog-tags", &propagated_tags, data)) {
+        ddtrace_add_tracer_tags_from_header(propagated_tags, &result.meta_tags, &result.propagated_tags);
+        zend_string_release(propagated_tags);
+    }
+
+    // "{version:2}-{trace-id:32}-{parent-id:16}-{trace-flags:2}"
+    if (parse_tracestate && read_header(ZAI_STRL("TRACEPARENT"), "traceparent", &traceparent, data)) {
+        do {
+            // skip whitespace
+            char *ws = ZSTR_VAL(traceparent), *wsend = ws + ZSTR_LEN(traceparent);
+            while (ws < wsend && isspace(*ws)) {
+                ++ws;
+            }
+            if (ws == wsend) {
+                break;
+            }
+            while (isspace(*--wsend));
+
+            size_t tracedata_len = wsend + 1 - ws;
+            struct {
+                char version[2];
+                char version_hyphen;
+                char trace_id[32];
+                char trace_id_hyphen;
+                char parent_id[16];
+                char parent_id_hyphen;
+                char trace_flags[2];
+                char trailing_data[];
+            } *tracedata = (void *)ws;
+
+            if (tracedata_len < sizeof(*tracedata)
+                || !dd_is_hex_char(tracedata->version[0]) || !dd_is_hex_char(tracedata->version[1])
+                || *(uint16_t *)tracedata->version == ('f' << 8) + 'f' // 0xFF is invalid version
+                || tracedata->version_hyphen != '-'
+                || tracedata->trace_id_hyphen != '-'
+                || tracedata->parent_id_hyphen != '-'
+                || !dd_is_hex_char(tracedata->trace_flags[0]) || !dd_is_hex_char(tracedata->trace_flags[1])
+                || (tracedata_len > sizeof(*tracedata)
+                    && ((tracedata->version[0] == '0' && tracedata->version[1] == '0') || tracedata->trailing_data[0] != '-'))
+                    ) {
+                parse_tracestate = 0;
+                break;
+            }
+
+            ddtrace_trace_id trace_id = {
+                    .high = ddtrace_parse_hex_span_id_str(tracedata->trace_id, 16),
+                    .low = ddtrace_parse_hex_span_id_str(&tracedata->trace_id[16], 16)
+            };
+            uint64_t parent_id = ddtrace_parse_hex_span_id_str(tracedata->parent_id, 16);
+
+            if ((!trace_id.low && !trace_id.high) || !parent_id) {
+                parse_tracestate = 0;
+                break;
+            }
+
+            result.trace_id = trace_id;
+            result.parent_id = parent_id;
+            result.priority_sampling = (tracedata->trace_flags[1] & 1) == (tracedata->trace_flags[1] <= '9'); // ('a' & 1) == 1
+        } while (0);
+        zend_string_release(traceparent);
+
+        // header format: "[*,]dd=s:1;o:rum;t.dm:-4;t.usr.id:12345[,*]"
+        if (parse_tracestate && read_header(ZAI_STRL("TRACESTATE"), "tracestate", &tracestate, data)) {
+            bool last_comma = true;
+            result.tracestate = zend_string_alloc(ZSTR_LEN(tracestate), 0);
+            char *persist = ZSTR_VAL(result.tracestate);
+            int commas = 0;
+            for (char *ptr = ZSTR_VAL(tracestate), *end = ptr + ZSTR_LEN(tracestate); ptr < end; ++ptr) {
+                // dd member
+                if (last_comma && ptr + 2 < end && ptr[0] == 'd' && ptr[1] == 'd' && (ptr[2] == '=' || ptr[2] == '\t' || ptr[2] == ' ')) {
+                    // If there's dd= members, ignore x-datadog-tags fully
+                    zend_hash_clean(&result.meta_tags);
+                    zend_hash_clean(&result.propagated_tags);
+
+                    while (ptr < end && *ptr != '=') {
+                        ++ptr;
+                    }
+
+                    do {
+                        char *keystart = ++ptr;
+                        while (ptr < end && *ptr != ';' && *ptr != ',' && *ptr != ':') {
+                            ++ptr;
+                        }
+                        size_t keylen = ptr - keystart;
+                        if (ptr >= end) {
+                            break;
+                        }
+                        char *valuestart = ++ptr;
+                        while (ptr < end && *ptr != ';' && *ptr != ',') {
+                            ++ptr;
+                        }
+                        char *valueend = ptr;
+                        while (*valueend == ' ' || *valueend == '\t') {
+                            --valueend;
+                        }
+                        size_t valuelen = valueend - valuestart;
+
+                        if (keylen == 1 && keystart[0] == 's') {
+                            int extraced_priority = strtol(valuestart, NULL, 10);
+                            if ((result.priority_sampling > 0) == (extraced_priority > 0)) {
+                                result.priority_sampling = extraced_priority;
+                            } else {
+                                result.conflicting_sampling_priority = true;
+                            }
+                        } else if (keylen == 1 && keystart[0] == 'o') {
+                            if (result.origin) {
+                                zend_string_release(result.origin);
+                            }
+                            result.origin = zend_string_init(valuestart, valuelen, 0);
+                            for (char *valptr = ZSTR_VAL(result.origin), *valend = valptr + valuelen; valptr < valend; ++valptr) {
+                                if (*valptr == '~') {
+                                    *valptr = '=';
+                                }
+                            }
+                        } else if (keylen > 2 && keystart[0] == 't' && keystart[1] == '.') {
+                            zend_string *tag_name = zend_strpprintf(0, "_dd.p.%.*s", (int) keylen - 2, keystart + 2);
+                            zval zv;
+                            ZVAL_STRINGL(&zv, valuestart, valuelen);
+                            for (char *valptr = Z_STRVAL(zv), *valend = valptr + valuelen; valptr < valend; ++valptr) {
+                                if (*valptr == '~') {
+                                    *valptr = '=';
+                                }
+                            }
+                            zend_hash_update(&result.meta_tags, tag_name, &zv);
+                            zend_hash_add_empty_element(&result.propagated_tags, tag_name);
+                            zend_string_release(tag_name);
+                        } else {
+                            zval zv;
+                            ZVAL_STRINGL(&zv, valuestart, valuelen);
+                            zend_hash_str_update(&result.tracestate_unknown_dd_keys, keystart, keylen, &zv);
+                        }
+                    } while (*ptr == ';');
+
+                    continue;
+                }
+                *(persist++) = *ptr;
+
+                if (*ptr == ' ' || *ptr == '\t') {
+                    continue;
+                }
+
+                last_comma = *ptr == ',';
+                // preserve only up to 31 vendor specific values, excluding our own
+                if (last_comma && ++commas == 30) {
+                    --persist;
+                    break;
+                }
+            }
+            *persist = 0; // and zero-terminate it
+            ZSTR_LEN(result.tracestate) = persist - ZSTR_VAL(result.tracestate);
+            zend_string_release(tracestate);
+        }
+    }
+
+    zval *tidzv = zend_hash_str_find(&result.meta_tags, ZEND_STRL("_dd.p.tid"));
+    if (tidzv && result.trace_id.low) {
+        uint64_t tid = ddtrace_parse_hex_span_id(tidzv);
+        uint64_t cur_high = result.trace_id.high;
+        if (tid && Z_TYPE_P(tidzv) == IS_STRING && Z_STRLEN_P(tidzv) == 16) {
+            if (!cur_high || tid == cur_high) {
+                result.trace_id.high = tid;
+            } else {
+                zval error;
+                ZVAL_STR(&error, zend_strpprintf(0, "inconsistent_tid %s", Z_STRVAL_P(tidzv)));
+                zend_hash_str_update(&result.meta_tags, ZEND_STRL("_dd.propagation_error"), &error);
+            }
+        } else if (Z_TYPE_P(tidzv) == IS_STRING && strcmp(Z_STRVAL_P(tidzv), "0") != 0) {
+            zval error;
+            ZVAL_STR(&error, zend_strpprintf(0, "malformed_tid %s", Z_STRVAL_P(tidzv)));
+            zend_hash_str_update(&result.meta_tags, ZEND_STRL("_dd.propagation_error"), &error);
+        }
+        zend_hash_str_del(&result.meta_tags, ZEND_STRL("_dd.p.tid"));
+    }
+
+    return result;
+}
+
+void ddtrace_apply_distributed_tracing_result(ddtrace_distributed_tracing_result *result, ddtrace_root_span_data *span) {
+    zval zv;
+
+    zend_array *root_meta = span ? ddtrace_property_array(&span->property_meta) : &DDTRACE_G(root_span_tags_preset);
+    if (span) {
+        zend_string *tagname;
+        ZEND_HASH_FOREACH_STR_KEY(ddtrace_property_array(&span->property_propagated_tags), tagname) {
+            zend_hash_del(root_meta, tagname);
+        } ZEND_HASH_FOREACH_END();
+
+        ZVAL_ARR(&zv, emalloc(sizeof(HashTable)));
+        *Z_ARR(zv) = result->propagated_tags;
+        ddtrace_assign_variable(&span->property_propagated_tags, &zv);
+
+        zend_hash_copy(root_meta, &result->meta_tags, NULL);
+
+        if (result->origin) {
+            ZVAL_STR(&zv, result->origin);
+            ddtrace_assign_variable(&span->property_origin, &zv);
+        }
+
+        if (result->tracestate) {
+            ZVAL_STR(&zv, result->tracestate);
+            ddtrace_assign_variable(&span->property_tracestate, &zv);
+        }
+
+        ZVAL_ARR(&zv, emalloc(sizeof(HashTable)));
+        *Z_ARR(zv) = result->tracestate_unknown_dd_keys;
+        ddtrace_assign_variable(&span->property_tracestate_tags, &zv);
+
+        if (result->trace_id.low || result->trace_id.high) {
+            span->trace_id = result->trace_id;
+            span->parent_id = result->parent_id;
+            ddtrace_update_root_id_properties(span);
+        }
+    } else {
+        zend_hash_destroy(&DDTRACE_G(propagated_root_span_tags));
+        DDTRACE_G(propagated_root_span_tags) = result->propagated_tags;
+        zend_hash_destroy(&DDTRACE_G(tracestate_unknown_dd_keys));
+        DDTRACE_G(tracestate_unknown_dd_keys) = result->tracestate_unknown_dd_keys;
+        zend_hash_copy(&DDTRACE_G(root_span_tags_preset), &result->meta_tags, NULL);
+        if (DDTRACE_G(dd_origin)) {
+            zend_string_release(DDTRACE_G(dd_origin));
+        }
+        DDTRACE_G(dd_origin) = result->origin;
+        if (DDTRACE_G(tracestate)) {
+            zend_string_release(DDTRACE_G(tracestate));
+        }
+        DDTRACE_G(tracestate) = result->tracestate;
+
+        if (result->trace_id.low || result->trace_id.high) {
+            DDTRACE_G(distributed_trace_id) = result->trace_id;
+            DDTRACE_G(distributed_parent_trace_id) = result->parent_id;
+        }
+    }
+
+    result->meta_tags.pDestructor = NULL; // we moved values directly
+    zend_hash_destroy(&result->meta_tags);
+
+    if (result->priority_sampling != DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
+        bool reset_decision_maker = result->conflicting_sampling_priority || !zend_hash_str_exists(root_meta, ZEND_STRL("_dd.p.dm"));
+        if (reset_decision_maker) {
+            if (result->priority_sampling > 0) {
+                ZVAL_STRINGL(&zv, "-0", 2);
+                zend_hash_str_update(root_meta, ZEND_STRL("_dd.p.dm"), &zv);
+            } else {
+                zend_hash_str_del(root_meta, ZEND_STRL("_dd.p.dm"));
+            }
+        }
+        if (!span) {
+            DDTRACE_G(propagated_priority_sampling) = DDTRACE_G(default_priority_sampling) = result->priority_sampling;
+        } else {
+            ddtrace_set_priority_sampling_on_span(span, result->priority_sampling, DD_MECHANISM_DEFAULT);
+
+            if (result->priority_sampling == DDTRACE_PRIORITY_SAMPLING_UNSET) {
+                ZVAL_UNDEF(&zv);
+            } else {
+                ZVAL_LONG(&zv, result->priority_sampling);
+            }
+            ddtrace_assign_variable(&span->property_propagated_sampling_priority, &zv);
+        }
+    }
+}
+
+bool ddtrace_read_zai_header(zai_str zai_header, const char *lowercase_header, zend_string **header_value, void *data) {
+    UNUSED(lowercase_header, data);
+    if (zai_read_header(zai_header, header_value) != ZAI_HEADER_SUCCESS) {
+        return false;
+    }
+    *header_value = zend_string_copy(*header_value);
+    return true;
+}

--- a/ext/distributed_tracing_headers.h
+++ b/ext/distributed_tracing_headers.h
@@ -1,0 +1,26 @@
+#ifndef DD_DISTRIBUTED_TRACING_HEADERS_H
+#define DD_DISTRIBUTED_TRACING_HEADERS_H
+
+#include "ddtrace.h"
+#include "priority_sampling/priority_sampling.h"
+#include <zai_string/string.h>
+
+typedef struct {
+    ddtrace_trace_id trace_id;
+    uint64_t parent_id;
+    zend_string *origin;
+    zend_string *tracestate;
+    HashTable tracestate_unknown_dd_keys;
+    HashTable propagated_tags;
+    HashTable meta_tags;
+    int priority_sampling;
+    enum dd_sampling_mechanism sampling_mechanism;
+    bool conflicting_sampling_priority; // propagated priorty does not match tracestate priority
+} ddtrace_distributed_tracing_result;
+
+typedef bool (ddtrace_read_header)(zai_str zai_header, const char *lowercase_header, zend_string **header_value, void *data);
+ddtrace_distributed_tracing_result ddtrace_read_distributed_tracing_ids(ddtrace_read_header *read_header, void *data);
+void ddtrace_apply_distributed_tracing_result(ddtrace_distributed_tracing_result *result, ddtrace_root_span_data *span);
+bool ddtrace_read_zai_header(zai_str zai_header, const char *lowercase_header, zend_string **header_value, void *data);
+
+#endif // DD_DISTRIBUTED_TRACING_HEADERS_H

--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -7,7 +7,101 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
+static inline zend_string *ddtrace_format_tracestate(zend_string *tracestate, zend_string *origin, zend_long sampling_priority, zend_string *propagated_tags, zend_array *tracestate_unknown_dd_keys) {
+    smart_str str = {0};
+
+    if (origin) {
+        smart_str_appends(&str, "o:");
+        signed char *cur = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s);
+        smart_str_append(&str, origin);
+        for (signed char *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s); cur < end; ++cur) {
+            if (*cur == '=') {
+                *cur = '~';
+            } else if (*cur < 0x20 || *cur == ',' || *cur == ';' || *cur == '~') {
+                *cur = '_';
+            }
+        }
+    }
+
+    if (sampling_priority != DDTRACE_PRIORITY_SAMPLING_UNKNOWN && sampling_priority != 0 && sampling_priority != 1) {
+        if (str.s) {
+            smart_str_appendc(&str, ';');
+        }
+        smart_str_append_printf(&str, "s:" ZEND_LONG_FMT, sampling_priority);
+    }
+
+    if (propagated_tags) {
+        if (str.s) {
+            smart_str_appendc(&str, ';');
+        }
+        int last_separator = true;
+        char next_equals;
+        for (char *cur = ZSTR_VAL(propagated_tags), *end = cur + ZSTR_LEN(propagated_tags); cur < end; ++cur) {
+            if (last_separator) {
+                next_equals = ':';
+                cur += strlen("_dd.p");
+                smart_str_appendc(&str, 't');
+            }
+            signed char chr = *cur;
+            if (chr < 0x20  || chr == ';' || chr == '~') {
+                chr = '_';
+            } else if (chr == ',') {
+                chr = ';';
+            } else if (chr == '=') {
+                chr = next_equals;
+                next_equals = '~';
+            }
+            smart_str_appendc(&str, chr);
+            last_separator = chr == ';';
+        }
+    }
+
+    zend_string *unknown_key;
+    zval *unknown_val;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(tracestate_unknown_dd_keys, unknown_key, unknown_val) {
+        if (str.s) {
+            smart_str_appendc(&str, ';');
+        }
+        smart_str_append(&str, unknown_key);
+        smart_str_appendc(&str, ':');
+        smart_str_append(&str, Z_STR_P(unknown_val));
+    } ZEND_HASH_FOREACH_END();
+
+    bool hasdd = str.s != NULL;
+    if (tracestate && ZSTR_LEN(tracestate) > 0) {
+        if (str.s) {
+            smart_str_appendc(&str, ',');
+        }
+        smart_str_append(&str, tracestate);
+    }
+
+    if (str.s) {
+        zend_string *full_tracestate = zend_strpprintf(0, "%s%.*s", hasdd ? "dd=" : "", (int)ZSTR_LEN(str.s), ZSTR_VAL(str.s));
+        smart_str_free(&str);
+        return full_tracestate;
+    }
+    return NULL;
+}
+
 static inline void ddtrace_inject_distributed_headers_config(zend_array *array, bool key_value_pairs, zend_array *inject) {
+    ddtrace_root_span_data *root = DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->active ? SPANDATA(DDTRACE_G(active_stack)->active)->root : NULL;
+    zend_string *origin = DDTRACE_G(dd_origin);
+    zend_array *tracestate_unknown_dd_keys = &DDTRACE_G(tracestate_unknown_dd_keys);
+    zend_string *tracestate = DDTRACE_G(tracestate);
+    if (root) {
+        if (Z_TYPE(root->property_origin) == IS_STRING && Z_STRLEN(root->property_origin)) {
+            origin = Z_STR(root->property_origin);
+        } else {
+            origin = NULL;
+        }
+        if (Z_TYPE(root->property_tracestate) == IS_STRING && Z_STRLEN(root->property_tracestate)) {
+            tracestate = Z_STR(root->property_tracestate);
+        } else {
+            tracestate = NULL;
+        }
+        tracestate_unknown_dd_keys = ddtrace_property_array(&root->property_tracestate_tags);
+    }
+
     zval headers;
     ZVAL_ARR(&headers, array);
 
@@ -23,7 +117,7 @@ static inline void ddtrace_inject_distributed_headers_config(zend_array *array, 
     bool send_b3 = zend_hash_str_exists(inject, ZEND_STRL("b3")) || zend_hash_str_exists(inject, ZEND_STRL("b3multi"));
     bool send_b3single = zend_hash_str_exists(inject, ZEND_STRL("b3 single header"));
 
-    zend_long sampling_priority = ddtrace_fetch_prioritySampling_from_root();
+    zend_long sampling_priority = ddtrace_fetch_priority_sampling_from_root();
     if (sampling_priority != DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
         if (send_datadog) {
             ADD_HEADER("x-datadog-sampling-priority", ZEND_LONG_FMT, sampling_priority);
@@ -38,13 +132,13 @@ static inline void ddtrace_inject_distributed_headers_config(zend_array *array, 
             }
         }
     }
-    zend_string *propagated_tags = ddtrace_format_propagated_tags();
+    zend_string *propagated_tags = ddtrace_format_root_propagated_tags();
     if (send_datadog || send_b3 || send_b3single) {
         if (propagated_tags) {
             ADD_HEADER("x-datadog-tags", "%s", ZSTR_VAL(propagated_tags));
         }
-        if (DDTRACE_G(dd_origin)) {
-            ADD_HEADER("x-datadog-origin", "%s", ZSTR_VAL(DDTRACE_G(dd_origin)));
+        if (origin) {
+            ADD_HEADER("x-datadog-origin", "%s", ZSTR_VAL(origin));
         }
     }
     ddtrace_trace_id trace_id = ddtrace_peek_trace_id();
@@ -74,76 +168,10 @@ static inline void ddtrace_inject_distributed_headers_config(zend_array *array, 
                            span_id,
                            sampling_priority > 0);
 
-                smart_str str = {0};
-
-                if (DDTRACE_G(dd_origin)) {
-                    smart_str_appends(&str, "o:");
-                    signed char *cur = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s);
-                    smart_str_append(&str, DDTRACE_G(dd_origin));
-                    for (signed char *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s); cur < end; ++cur) {
-                        if (*cur == '=') {
-                            *cur = '~';
-                        } else if (*cur < 0x20 || *cur == ',' || *cur == ';' || *cur == '~') {
-                            *cur = '_';
-                        }
-                    }
-                }
-
-                if (sampling_priority != DDTRACE_PRIORITY_SAMPLING_UNKNOWN && sampling_priority != 0 && sampling_priority != 1) {
-                    if (str.s) {
-                        smart_str_appendc(&str, ';');
-                    }
-                    smart_str_append_printf(&str, "s:" ZEND_LONG_FMT, sampling_priority);
-                }
-
-                if (propagated_tags) {
-                    if (str.s) {
-                        smart_str_appendc(&str, ';');
-                    }
-                    int last_separator = true;
-                    char next_equals;
-                    for (char *cur = ZSTR_VAL(propagated_tags), *end = cur + ZSTR_LEN(propagated_tags); cur < end; ++cur) {
-                        if (last_separator) {
-                            next_equals = ':';
-                            cur += strlen("_dd.p");
-                            smart_str_appendc(&str, 't');
-                        }
-                        signed char chr = *cur;
-                        if (chr < 0x20  || chr == ';' || chr == '~') {
-                            chr = '_';
-                        } else if (chr == ',') {
-                            chr = ';';
-                        } else if (chr == '=') {
-                            chr = next_equals;
-                            next_equals = '~';
-                        }
-                        smart_str_appendc(&str, chr);
-                        last_separator = chr == ';';
-                    }
-                }
-
-                zend_string *unknown_key;
-                zval *unknown_val;
-                ZEND_HASH_FOREACH_STR_KEY_VAL(&DDTRACE_G(tracestate_unknown_dd_keys), unknown_key, unknown_val) {
-                    if (str.s) {
-                        smart_str_appendc(&str, ';');
-                    }
-                    smart_str_append(&str, unknown_key);
-                    smart_str_appendc(&str, ':');
-                    smart_str_append(&str, Z_STR_P(unknown_val));
-                } ZEND_HASH_FOREACH_END();
-
-                bool hasdd = str.s != NULL;
-                if (DDTRACE_G(tracestate) && ZSTR_LEN(DDTRACE_G(tracestate)) > 0) {
-                    if (str.s) {
-                        smart_str_appendc(&str, ',');
-                    }
-                    smart_str_append(&str, DDTRACE_G(tracestate));
-                }
-
-                if (str.s) {
-                    ADD_HEADER("tracestate", "%s%.*s", hasdd ? "dd=" : "", (int)ZSTR_LEN(str.s), ZSTR_VAL(str.s));
-                    smart_str_free(&str);
+                zend_string *full_tracestate = ddtrace_format_tracestate(tracestate, origin, sampling_priority, propagated_tags, tracestate_unknown_dd_keys);
+                if (full_tracestate) {
+                    ADD_HEADER("tracestate", "%.*s", (int)ZSTR_LEN(full_tracestate), ZSTR_VAL(full_tracestate));
+                    zend_string_release(full_tracestate);
                 }
             }
         }

--- a/ext/priority_sampling/priority_sampling.h
+++ b/ext/priority_sampling/priority_sampling.h
@@ -2,6 +2,7 @@
 #define DDTRACE_PRIORITY_SAMPLING_H
 
 #include "../ddtrace.h"
+#include "../ddtrace_export.h"
 
 #define DDTRACE_PRIORITY_SAMPLING_UNKNOWN (1 << 30)
 #define DDTRACE_PRIORITY_SAMPLING_UNSET ((1 << 30) + 1)
@@ -19,9 +20,10 @@ enum dd_sampling_mechanism {
     DD_MECHANISM_MANUAL = 4,
 };
 
-void ddtrace_set_prioritySampling_on_root(zend_long priority, enum dd_sampling_mechanism mechanism);
-zend_long ddtrace_fetch_prioritySampling_from_span(ddtrace_root_span_data *root_span);
-zend_long ddtrace_fetch_prioritySampling_from_root(void);
+DDTRACE_PUBLIC void ddtrace_set_priority_sampling_on_root(zend_long priority, enum dd_sampling_mechanism mechanism);
+void ddtrace_set_priority_sampling_on_span(ddtrace_root_span_data *root_span, zend_long priority, enum dd_sampling_mechanism mechanism);
+zend_long ddtrace_fetch_priority_sampling_from_span(ddtrace_root_span_data *root_span);
+zend_long ddtrace_fetch_priority_sampling_from_root(void);
 
 void ddtrace_try_read_agent_rate(void);
 

--- a/ext/random.c
+++ b/ext/random.c
@@ -104,7 +104,7 @@ uint64_t ddtrace_peek_span_id(void) {
 
 ddtrace_trace_id ddtrace_peek_trace_id(void) {
     ddtrace_span_properties *pspan = DDTRACE_G(active_stack) ? DDTRACE_G(active_stack)->active : NULL;
-    return pspan ? SPANDATA(pspan)->trace_id : DDTRACE_G(distributed_trace_id);
+    return pspan ? SPANDATA(pspan)->root->trace_id : DDTRACE_G(distributed_trace_id);
 }
 
 int ddtrace_conv10_trace_id(ddtrace_trace_id id, uint8_t reverse[DD_TRACE_MAX_ID_LEN]) {

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -639,7 +639,21 @@ static bool dd_set_mapped_peer_service(zval *meta, zend_string *peer_service) {
     return false;
 }
 
-void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
+void ddtrace_update_root_id_properties(ddtrace_root_span_data *span) {
+    zval zv;
+    ZVAL_STR(&zv, ddtrace_trace_id_as_hex_string(span->trace_id));
+    ddtrace_assign_variable(&span->property_trace_id, &zv);
+    if (span->parent_id) {
+        ZVAL_STR(&zv, ddtrace_span_id_as_string(span->parent_id));
+    } else {
+        ZVAL_UNDEF(&zv);
+    }
+    ddtrace_assign_variable(&span->property_parent_id, &zv);
+}
+
+void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
+    ddtrace_update_root_id_properties(span);
+
     zend_array *meta = ddtrace_property_array(&span->property_meta);
 
     zend_hash_copy(meta, &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
@@ -656,110 +670,90 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
     ZVAL_STR(&zv, encoded_id);
     zend_hash_str_add_new(meta, ZEND_STRL("runtime-id"), &zv);
 
-    zval http_url;
-    ZVAL_STR(&http_url, dd_build_req_url());
-    if (Z_STRLEN(http_url)) {
-        zend_hash_str_add_new(meta, ZEND_STRL("http.url"), &http_url);
-    }
-
-    const char *method = SG(request_info).request_method;
-    if (method) {
-        zval http_method;
-        ZVAL_STR(&http_method, zend_string_init(method, strlen(method), 0));
-        zend_hash_str_add_new(meta, ZEND_STRL("http.method"), &http_method);
-
-        if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED()) {
-            const char *uri = dd_get_req_uri();
-            zval *prop_resource = &span->property_resource;
-            zval_ptr_dtor(prop_resource);
-            if (uri) {
-                zend_string *path = zend_string_init(uri, strlen(uri), 0);
-                zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
-                zend_string *query_string = ZSTR_EMPTY_ALLOC();
-                const char *query_str = dd_get_query_string();
-                if (query_str) {
-                    query_string =
-                        zai_filter_query_string(ZAI_STR_FROM_CSTR(query_str),
-                                                get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
-                                                get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
-                }
-
-                ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),
-                                                        ZSTR_LEN(query_string) ? "?" : "", (int)ZSTR_LEN(query_string),
-                                                        ZSTR_VAL(query_string)));
-                zend_string_release(query_string);
-                zend_string_release(normalized);
-                zend_string_release(path);
-            } else {
-                ZVAL_COPY(prop_resource, &http_method);
-            }
+    if (ddtrace_span_is_entrypoint_root(&span->span)) {
+        zval http_url;
+        ZVAL_STR(&http_url, dd_build_req_url());
+        if (Z_STRLEN(http_url)) {
+            zend_hash_str_add_new(meta, ZEND_STRL("http.url"), &http_url);
         }
-    }
 
-    if (get_DD_TRACE_CLIENT_IP_ENABLED()) {
-        if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
-            ddtrace_extract_ip_from_headers(&PG(http_globals)[TRACK_VARS_SERVER], meta);
-        }
-    }
+        const char *method = SG(request_info).request_method;
+        if (method) {
+            zval http_method;
+            ZVAL_STR(&http_method, zend_string_init(method, strlen(method), 0));
+            zend_hash_str_add_new(meta, ZEND_STRL("http.method"), &http_method);
 
-    zend_string *user_agent = dd_get_user_agent();
-    if (user_agent && ZSTR_LEN(user_agent) > 0) {
-        zval http_useragent;
-        ZVAL_STR_COPY(&http_useragent, user_agent);
-        zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
-    }
-
-    zval *prop_type = &span->property_type;
-    zval *prop_name = &span->property_name;
-    if (strcmp(sapi_module.name, "cli") == 0) {
-        zval_ptr_dtor(prop_type);
-        ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("cli"), 0));
-        const char *script_name;
-        zval_ptr_dtor(prop_name);
-        ZVAL_STR(prop_name,
-            (SG(request_info).argc > 0 && (script_name = SG(request_info).argv[0]) && script_name[0] != '\0')
-                ? php_basename(script_name, strlen(script_name), NULL, 0)
-                : zend_string_init(ZEND_STRL("cli.command"), 0));
-    } else {
-        zval_ptr_dtor(prop_type);
-        ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("web"), 0));
-        zval_ptr_dtor(prop_name);
-        ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
-    }
-    zval *prop_service = &span->property_service;
-    zval_ptr_dtor(prop_service);
-    ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
-
-    if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
-        zend_string *headername;
-        zval *headerval;
-        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), headername, headerval) {
-            ZVAL_DEREF(headerval);
-            if (Z_TYPE_P(headerval) == IS_STRING && headername && ZSTR_LEN(headername) > 5 &&
-                memcmp(ZSTR_VAL(headername), "HTTP_", 5) == 0) {
-                zend_string *lowerheader = zend_string_init(ZSTR_VAL(headername) + 5, ZSTR_LEN(headername) - 5, 0);
-                for (char *ptr = ZSTR_VAL(lowerheader); *ptr; ++ptr) {
-                    if (*ptr >= 'A' && *ptr <= 'Z') {
-                        *ptr -= 'A' - 'a';
-                    } else if (*ptr == '_') {
-                        *ptr = '-';
+            if (get_DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED()) {
+                const char *uri = dd_get_req_uri();
+                zval *prop_resource = &span->property_resource;
+                zval_ptr_dtor(prop_resource);
+                if (uri) {
+                    zend_string *path = zend_string_init(uri, strlen(uri), 0);
+                    zend_string *normalized = ddtrace_uri_normalize_incoming_path(path);
+                    zend_string *query_string = ZSTR_EMPTY_ALLOC();
+                    const char *query_str = dd_get_query_string();
+                    if (query_str) {
+                        query_string =
+                                zai_filter_query_string(ZAI_STR_FROM_CSTR(query_str),
+                                                        get_DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED(),
+                                                        get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                     }
-                }
 
-                dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));
-                zend_string_release(lowerheader);
+                    ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),
+                                                            ZSTR_LEN(query_string) ? "?" : "", (int) ZSTR_LEN(query_string),
+                                                            ZSTR_VAL(query_string)));
+                    zend_string_release(query_string);
+                    zend_string_release(normalized);
+                    zend_string_release(path);
+                } else {
+                    ZVAL_COPY(prop_resource, &http_method);
+                }
             }
         }
-        ZEND_HASH_FOREACH_END();
-    }
 
-    if (zend_hash_num_elements(get_DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED())
-        && (Z_TYPE(PG(http_globals)[TRACK_VARS_POST]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_POST")))) {
-        zval *post = &PG(http_globals)[TRACK_VARS_POST];
-        zend_string *empty = ZSTR_EMPTY_ALLOC();
-        dd_add_post_fields_to_meta_recursive(meta, "request", empty, post,
-                                             get_DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED(),false);
-        zend_string_release(empty);
+        if (get_DD_TRACE_CLIENT_IP_ENABLED()) {
+            if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+                ddtrace_extract_ip_from_headers(&PG(http_globals)[TRACK_VARS_SERVER], meta);
+            }
+        }
+
+        zend_string *user_agent = dd_get_user_agent();
+        if (user_agent && ZSTR_LEN(user_agent) > 0) {
+            zval http_useragent;
+            ZVAL_STR_COPY(&http_useragent, user_agent);
+            zend_hash_str_add_new(meta, ZEND_STRL("http.useragent"), &http_useragent);
+        }
+
+        if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_SERVER"))) {
+            zend_string *headername;
+            zval *headerval;
+            ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR(PG(http_globals)[TRACK_VARS_SERVER]), headername, headerval) {
+                ZVAL_DEREF(headerval);
+                if (Z_TYPE_P(headerval) == IS_STRING && headername && ZSTR_LEN(headername) > 5 &&
+                    memcmp(ZSTR_VAL(headername), "HTTP_", 5) == 0) {
+                    zend_string *lowerheader = zend_string_init(ZSTR_VAL(headername) + 5, ZSTR_LEN(headername) - 5, 0);
+                    for (char *ptr = ZSTR_VAL(lowerheader); *ptr; ++ptr) {
+                        if (*ptr >= 'A' && *ptr <= 'Z') {
+                            *ptr -= 'A' - 'a';
+                        } else if (*ptr == '_') {
+                            *ptr = '-';
+                        }
+                    }
+
+                    dd_add_header_to_meta(meta, "request", lowerheader, Z_STR_P(headerval));
+                    zend_string_release(lowerheader);
+                }
+            } ZEND_HASH_FOREACH_END();
+        }
+
+        if (zend_hash_num_elements(get_DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED())
+            && (Z_TYPE(PG(http_globals)[TRACK_VARS_POST]) == IS_ARRAY || zend_is_auto_global_str(ZEND_STRL("_POST")))) {
+            zval *post = &PG(http_globals)[TRACK_VARS_POST];
+            zend_string *empty = ZSTR_EMPTY_ALLOC();
+            dd_add_post_fields_to_meta_recursive(meta, "request", empty, post,
+                                                 get_DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED(),false);
+            zend_string_release(empty);
+        }
     }
 
     if (get_DD_TRACE_REPORT_HOSTNAME()) {
@@ -778,31 +772,89 @@ void ddtrace_set_root_span_properties(ddtrace_span_data *span) {
         }
     }
 
+    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
+    zval *prop_type = &span->property_type;
+    zval *prop_name = &span->property_name;
+    zval *prop_service = &span->property_service;
     zval value;
 
-    zend_string *version = get_DD_VERSION();
-    if (ZSTR_LEN(version) > 0) {  // non-empty
-        ZVAL_STR_COPY(&value, version);
-        zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
-    }
+    ddtrace_root_span_data *parent_root = span->stack->parent_stack->root_span;
+    if (parent_root) {
+        zval_ptr_dtor(prop_type);
+        ZVAL_COPY(prop_type, &parent_root->property_type);
+        zval_ptr_dtor(prop_service);
+        ZVAL_COPY(prop_service, &parent_root->property_service);
 
-    zend_string *env = get_DD_ENV();
-    if (ZSTR_LEN(env) > 0) {  // non-empty
-        ZVAL_STR_COPY(&value, env);
-        zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
-    }
+        zend_array *parent_meta = ddtrace_property_array(&parent_root->property_meta);
 
-    if (DDTRACE_G(dd_origin)) {
-        ZVAL_STR_COPY(&value, DDTRACE_G(dd_origin));
-        zend_hash_str_add_new(meta, ZEND_STRL("_dd.origin"), &value);
-    }
+        zval *version = zend_hash_str_find(parent_meta, ZEND_STRL("version"));
+        if (version) {
+            Z_TRY_ADDREF_P(version);
+            zend_hash_str_add_new(meta, ZEND_STRL("version"), version);
+        }
 
-    ddtrace_integration *web_integration = &ddtrace_integrations[DDTRACE_INTEGRATION_WEB];
-    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
-    if (get_DD_TRACE_ANALYTICS_ENABLED() || web_integration->is_analytics_enabled()) {
-        zval sample_rate;
-        ZVAL_DOUBLE(&sample_rate, web_integration->get_sample_rate());
-        zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &sample_rate);
+        zval *env = zend_hash_str_find(parent_meta, ZEND_STRL("env"));
+        if (env) {
+            Z_TRY_ADDREF_P(env);
+            zend_hash_str_add_new(meta, ZEND_STRL("env"), env);
+        }
+
+        ZVAL_COPY(&span->property_origin, &parent_root->property_origin);
+    } else {
+        if (strcmp(sapi_module.name, "cli") == 0) {
+            zval_ptr_dtor(prop_type);
+            ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("cli"), 0));
+            const char *script_name;
+            zval_ptr_dtor(prop_name);
+            ZVAL_STR(prop_name,
+                     (SG(request_info).argc > 0 && (script_name = SG(request_info).argv[0]) && script_name[0] != '\0')
+                     ? php_basename(script_name, strlen(script_name), NULL, 0)
+                     : zend_string_init(ZEND_STRL("cli.command"), 0));
+        } else {
+            zval_ptr_dtor(prop_type);
+            ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("web"), 0));
+            zval_ptr_dtor(prop_name);
+            ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
+        }
+        zval_ptr_dtor(prop_service);
+        ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
+
+        zend_string *version = get_DD_VERSION();
+        if (ZSTR_LEN(version) > 0) {  // non-empty
+            ZVAL_STR_COPY(&value, version);
+            zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
+        }
+
+        zend_string *env = get_DD_ENV();
+        if (ZSTR_LEN(env) > 0) {  // non-empty
+            ZVAL_STR_COPY(&value, env);
+            zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
+        }
+
+        if (DDTRACE_G(dd_origin)) {
+            ZVAL_STR_COPY(&span->property_origin, DDTRACE_G(dd_origin));
+        }
+        if (DDTRACE_G(tracestate)) {
+            ZVAL_STR_COPY(&span->property_tracestate, DDTRACE_G(tracestate));
+        }
+
+        SEPARATE_ARRAY(&span->property_propagated_tags);
+        zend_hash_copy(Z_ARR(span->property_propagated_tags), &DDTRACE_G(propagated_root_span_tags), zval_add_ref);
+        SEPARATE_ARRAY(&span->property_tracestate_tags);
+        zend_hash_copy(Z_ARR(span->property_tracestate_tags), &DDTRACE_G(tracestate_unknown_dd_keys), zval_add_ref);
+        if (DDTRACE_G(propagated_priority_sampling) != DDTRACE_PRIORITY_SAMPLING_UNSET) {
+            ZVAL_LONG(&span->property_propagated_sampling_priority, DDTRACE_G(propagated_priority_sampling));
+        }
+        if (DDTRACE_G(default_priority_sampling) != DDTRACE_PRIORITY_SAMPLING_UNSET) {
+            ZVAL_LONG(&span->property_sampling_priority, DDTRACE_G(default_priority_sampling));
+        }
+
+        ddtrace_integration *web_integration = &ddtrace_integrations[DDTRACE_INTEGRATION_WEB];
+        if (get_DD_TRACE_ANALYTICS_ENABLED() || web_integration->is_analytics_enabled()) {
+            zval sample_rate;
+            ZVAL_DOUBLE(&sample_rate, web_integration->get_sample_rate());
+            zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &sample_rate);
+        }
     }
 
     zval pid;
@@ -871,8 +923,7 @@ static void dd_serialize_array_meta_recursively(zend_array *target, zend_string 
 }
 
 static void _serialize_meta(zval *el, ddtrace_span_data *span) {
-    bool is_top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
-    bool is_local_root_span = span->parent_id == 0 || is_top_level_span;
+    bool is_root_span = span->std.ce == ddtrace_ce_root_span_data;
     zval meta_zv, *meta = &span->property_meta;
     bool ignore_error = false;
 
@@ -906,7 +957,7 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
     if (Z_TYPE_P(exception_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(exception_zv), zend_ce_throwable)) {
         ignore_error = false;
         enum dd_exception exception_type = DD_EXCEPTION_THROWN;
-        if (is_local_root_span) {
+        if (is_root_span) {
             exception_type = Z_PROP_FLAG_P(exception_zv) == 2 ? DD_EXCEPTION_CAUGHT : DD_EXCEPTION_UNCAUGHT;
         }
         ddtrace_exception_to_meta(Z_OBJ_P(exception_zv), meta, dd_add_meta_array, exception_type);
@@ -950,7 +1001,7 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
         }
     }
 
-    if (is_top_level_span) {
+    if (ddtrace_span_is_entrypoint_root(span)) {
         if (SG(sapi_headers).http_response_code) {
             add_assoc_str(meta, "http.status_code", zend_long_to_str(SG(sapi_headers).http_response_code));
             if (SG(sapi_headers).http_response_code >= 500 && !ignore_error) {
@@ -1003,14 +1054,21 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
         }
     }
 
+    zval *origin = &span->root->property_origin;
+    if (Z_TYPE_P(origin) > IS_NULL && (Z_TYPE_P(origin) != IS_STRING || Z_STRLEN_P(origin))) {
+        if (zend_hash_str_add(Z_ARR_P(meta), ZEND_STRL("_dd.origin"), origin)) {
+            Z_TRY_ADDREF_P(origin);
+        }
+    }
+
     zend_bool error = ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.message")) ||
                       ddtrace_hash_find_ptr(Z_ARR_P(meta), ZEND_STRL("error.type"));
     if (error && !ignore_error) {
         add_assoc_long(el, "error", 1);
     }
 
-    if (span->trace_id.high && is_local_root_span) {
-        add_assoc_str(meta, "_dd.p.tid", zend_strpprintf(0, "%" PRIx64, span->trace_id.high));
+    if (span->root->trace_id.high && is_root_span) {
+        add_assoc_str(meta, "_dd.p.tid", zend_strpprintf(0, "%" PRIx64, span->root->trace_id.high));
     }
 
     if (zend_array_count(Z_ARRVAL_P(meta))) {
@@ -1104,14 +1162,15 @@ void ddtrace_shutdown_span_sampling_limiter(void) {
 }
 
 void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
-    bool top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
+    bool is_root_span = span->std.ce == ddtrace_ce_root_span_data;
+
     zval *el;
     zval zv;
     el = &zv;
     array_init(el);
 
-    add_assoc_str(el, KEY_TRACE_ID, ddtrace_span_id_as_string(span->trace_id.low));
-    add_assoc_str(el, KEY_SPAN_ID, ddtrace_span_id_as_string(span->span_id));
+    add_assoc_str(el, KEY_TRACE_ID, ddtrace_span_id_as_string(span->root->trace_id.low));
+    add_assoc_str(el, KEY_SPAN_ID, zend_string_copy(span->string_id));
 
     // handle dropped spans
     if (span->parent) {
@@ -1120,11 +1179,14 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
         while (parent->parent && ddtrace_span_is_dropped(parent)) {
             parent = SPANDATA(parent->parent);
         }
-        span->parent_id = parent->span_id;
-    }
-
-    if (span->parent_id > 0) {
-        add_assoc_str(el, KEY_PARENT_ID, ddtrace_span_id_as_string(span->parent_id));
+        if (parent) {
+            add_assoc_str(el, KEY_PARENT_ID, zend_string_copy(parent->string_id));
+        }
+    } else if (is_root_span) {
+        zval *parent_id = &ROOTSPANDATA(&span->std)->property_parent_id;
+        if (Z_TYPE_P(parent_id) == IS_STRING) {
+            add_assoc_str(el, KEY_PARENT_ID, zend_string_copy(Z_STR_P(parent_id)));
+        }
     }
     add_assoc_long(el, "start", span->start);
     add_assoc_long(el, "duration", span->duration);
@@ -1188,7 +1250,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     }
 
     // Notify profiling for Endpoint Profiling.
-    if (profiling_notify_trace_finished && top_level_span && Z_TYPE(prop_resource_as_string) == IS_STRING) {
+    if (profiling_notify_trace_finished && ddtrace_span_is_entrypoint_root(span) && Z_TYPE(prop_resource_as_string) == IS_STRING) {
         zai_str type = Z_TYPE(prop_type_as_string) == IS_STRING
                                ? ZAI_STR_FROM_ZSTR(Z_STR(prop_type_as_string))
                                : ZAI_STRL("custom");
@@ -1200,7 +1262,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     zval_ptr_dtor(&prop_type_as_string);
     zval_ptr_dtor(&prop_resource_as_string);
 
-    if (ddtrace_fetch_prioritySampling_from_span(span->root) <= 0) {
+    if (ddtrace_fetch_priority_sampling_from_span(span->root) <= 0) {
         zval *rule;
         ZEND_HASH_FOREACH_VAL(get_DD_SPAN_SAMPLING_RULES(), rule) {
             if (Z_TYPE_P(rule) != IS_ARRAY) {
@@ -1328,31 +1390,32 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
 
     _serialize_meta(el, span);
 
-    zval *metrics = &span->property_metrics;
-    ZVAL_DEREF(metrics);
-    if (Z_TYPE_P(metrics) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(metrics))) {
-        zval metrics_zv;
-        array_init(&metrics_zv);
-        zend_string *str_key;
-        zval *val;
-        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR_P(metrics), str_key, val) {
-            if (str_key) {
-                add_assoc_double(&metrics_zv, ZSTR_VAL(str_key), zval_get_double(val));
-            }
+
+    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
+    zval metrics_zv;
+    array_init(&metrics_zv);
+    zend_string *str_key;
+    zval *val;
+    ZEND_HASH_FOREACH_STR_KEY_VAL_IND(metrics, str_key, val) {
+        if (str_key) {
+            add_assoc_double(&metrics_zv, ZSTR_VAL(str_key), zval_get_double(val));
         }
-        ZEND_HASH_FOREACH_END();
-        metrics = zend_hash_str_add_new(Z_ARR_P(el), ZEND_STRL("metrics"), &metrics_zv);
-    } else {
-        metrics = NULL;
+    } ZEND_HASH_FOREACH_END();
+
+    if (is_root_span) {
+        if (Z_TYPE_P(&span->root->property_sampling_priority) != IS_UNDEF) {
+            add_assoc_double(&metrics_zv, "_sampling_priority_v1", zval_get_long(&span->root->property_sampling_priority));
+        }
     }
 
-    if (top_level_span && get_DD_TRACE_MEASURE_COMPILE_TIME()) {
-        if (!metrics) {
-            zval metrics_array;
-            array_init(&metrics_array);
-            metrics = zend_hash_str_add_new(Z_ARR_P(el), ZEND_STRL("metrics"), &metrics_array);
-        }
-        add_assoc_double(metrics, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+    if (ddtrace_span_is_entrypoint_root(span) && get_DD_TRACE_MEASURE_COMPILE_TIME()) {
+        add_assoc_double(&metrics_zv, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+    }
+
+    if (zend_hash_num_elements(Z_ARR(metrics_zv))) {
+        zend_hash_str_add_new(Z_ARR_P(el), ZEND_STRL("metrics"), &metrics_zv);
+    } else {
+        zend_array_destroy(Z_ARR(metrics_zv));
     }
 
     add_next_index_zval(array, el);

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -10,7 +10,8 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array);
 
 void ddtrace_save_active_error_to_metadata(void);
 void ddtrace_set_global_span_properties(ddtrace_span_data *span);
-void ddtrace_set_root_span_properties(ddtrace_span_data *span);
+void ddtrace_set_root_span_properties(ddtrace_root_span_data *span);
+void ddtrace_update_root_id_properties(ddtrace_root_span_data *span);
 
 void ddtrace_initialize_span_sampling_limiter(void);
 void ddtrace_shutdown_span_sampling_limiter(void);

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.c
@@ -10,17 +10,16 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
-void ddtrace_clean_tracer_tags(zend_array *root_meta) {
+void ddtrace_clean_tracer_tags(zend_array *root_meta, zend_array *propagated_tags) {
     zend_string *tagname;
-    ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
+    ZEND_HASH_FOREACH_STR_KEY(propagated_tags, tagname) {
         zend_hash_del(root_meta, tagname);
-    }
-    ZEND_HASH_FOREACH_END();
-    zend_hash_clean(&DDTRACE_G(propagated_root_span_tags));
+    } ZEND_HASH_FOREACH_END();
+    zend_hash_clean(propagated_tags);
 }
 
-void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *root_meta) {
-    ddtrace_clean_tracer_tags(root_meta);
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *root_meta, zend_array *propagated_tags) {
+    ddtrace_clean_tracer_tags(root_meta, propagated_tags);
 
     char *header = ZSTR_VAL(headerstr), *headerend = header + ZSTR_LEN(headerstr);
 
@@ -47,7 +46,7 @@ void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *roo
                 zval zv;
                 ZVAL_STRINGL(&zv, valuestart, header - valuestart);
                 zend_hash_update(root_meta, tag_name, &zv);
-                zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), tag_name);
+                zend_hash_add_empty_element(propagated_tags, tag_name);
             }
             zend_string_release(tag_name);
 
@@ -65,8 +64,8 @@ void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *roo
     }
 }
 
-void ddtrace_add_tracer_tags_from_array(zend_array *array, zend_array *root_meta) {
-    ddtrace_clean_tracer_tags(root_meta);
+void ddtrace_add_tracer_tags_from_array(zend_array *array, zend_array *root_meta, zend_array *propagated_tags) {
+    ddtrace_clean_tracer_tags(root_meta, propagated_tags);
 
     zend_string *tagname;
     zval *tag;
@@ -75,21 +74,23 @@ void ddtrace_add_tracer_tags_from_array(zend_array *array, zend_array *root_meta
             zval tagstr;
             ddtrace_convert_to_string(&tagstr, tag);
             zend_hash_update(root_meta, tagname, &tagstr);
-            zend_hash_add_empty_element(&DDTRACE_G(propagated_root_span_tags), tagname);
+            zend_hash_add_empty_element(propagated_tags, tagname);
         }
     }
     ZEND_HASH_FOREACH_END();
 }
 
 void ddtrace_get_propagated_tags(zend_array *tags) {
+    zend_array *propagated = &DDTRACE_G(propagated_root_span_tags);
     zend_array *root_meta = &DDTRACE_G(root_span_tags_preset);
     ddtrace_root_span_data *root_span = DDTRACE_G(active_stack)->root_span;
     if (root_span) {
         root_meta = ddtrace_property_array(&root_span->property_meta);
+        propagated = ddtrace_property_array(&root_span->property_propagated_tags);
     }
 
     zend_string *tagname;
-    ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
+    ZEND_HASH_FOREACH_STR_KEY(propagated, tagname) {
         zval *tag;
         if ((tag = zend_hash_find(root_meta, tagname))) {
             Z_TRY_ADDREF_P(tag);
@@ -99,18 +100,24 @@ void ddtrace_get_propagated_tags(zend_array *tags) {
     ZEND_HASH_FOREACH_END();
 }
 
-zend_string *ddtrace_format_propagated_tags(void) {
-    // we propagate all tags on the current root span which were originally propagated, including the explicitly
-    // defined tags here
-    zend_hash_str_del(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.upstream_services"));
-    zend_hash_str_del(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.tid"));
-    zend_hash_str_add_empty_element(&DDTRACE_G(propagated_root_span_tags), ZEND_STRL("_dd.p.dm"));
-
+zend_string *ddtrace_format_root_propagated_tags(void) {
+    zend_array *propagated = &DDTRACE_G(propagated_root_span_tags);
     zend_array *tags = &DDTRACE_G(root_span_tags_preset);
     ddtrace_root_span_data *span = DDTRACE_G(active_stack)->root_span;
     if (span) {
         tags = ddtrace_property_array(&span->property_meta);
+        propagated = ddtrace_property_array(&span->property_propagated_tags);
     }
+
+    return ddtrace_format_propagated_tags(propagated, tags);
+}
+
+zend_string *ddtrace_format_propagated_tags(zend_array *propagated, zend_array *tags) {
+    // we propagate all tags on the current root span which were originally propagated, including the explicitly
+    // defined tags here
+    zend_hash_str_del(propagated, ZEND_STRL("_dd.p.upstream_services"));
+    zend_hash_str_del(propagated, ZEND_STRL("_dd.p.tid"));
+    zend_hash_str_add_empty_element(propagated, ZEND_STRL("_dd.p.dm"));
 
     smart_str taglist = {0};
 
@@ -120,7 +127,7 @@ zend_string *ddtrace_format_propagated_tags(void) {
     }
 
     zend_string *tagname;
-    ZEND_HASH_FOREACH_STR_KEY(&DDTRACE_G(propagated_root_span_tags), tagname) {
+    ZEND_HASH_FOREACH_STR_KEY(propagated, tagname) {
         zval *tag = zend_hash_find(tags, tagname), error_zv = {0};
         if (tag) {
             zend_string *str = ddtrace_convert_to_str(tag);

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.h
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.h
@@ -3,11 +3,12 @@
 
 #include <php.h>
 
-void ddtrace_clean_tracer_tags(zend_array *root_meta);
-void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *root_meta);
-void ddtrace_add_tracer_tags_from_array(zend_array *array, zend_array *root_meta);
+void ddtrace_clean_tracer_tags(zend_array *root_meta, zend_array *propagated_tags);
+void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *root_meta, zend_array *propagated_tags);
+void ddtrace_add_tracer_tags_from_array(zend_array *array, zend_array *root_meta, zend_array *propagated_tags);
 
 void ddtrace_get_propagated_tags(zend_array *tags);
-zend_string *ddtrace_format_propagated_tags(void);
+zend_string *ddtrace_format_root_propagated_tags(void);
+zend_string *ddtrace_format_propagated_tags(zend_array *propagated, zend_array *tags);
 
 #endif  // DDTRACE_TRACER_TAG_PROPAGATION_H

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -48,7 +48,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         $this->assertSame("/*dddbs='testdb',ddps='phpunit',traceparent='00-0000000000000000c08c967f0e5e7b0a-22e2c43f8a1ad34e-01'*/ SELECT 1", $commentedQuery);
         // phpcs:enable Generic.Files.LineLength.TooLong
         $this->assertFlameGraph($traces, [
-            SpanAssertion::exists("phpunit")->withChildren([
+            SpanAssertion::exists("")->withChildren([
                 SpanAssertion::exists('instrumented')->withExactTags([
                     "_dd.dbm_trace_injected" => "true"
                 ])
@@ -80,7 +80,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         $this->assertSame("/*dddbs='dbinstance',ddps='phpunit',traceparent='00-0000000000000000c08c967f0e5e7b0a-22e2c43f8a1ad34e-01'*/ SELECT 1", $commentedQuery);
         // phpcs:enable Generic.Files.LineLength.TooLong
         $this->assertFlameGraph($traces, [
-            SpanAssertion::exists("phpunit")->withChildren([
+            SpanAssertion::exists("")->withChildren([
                 SpanAssertion::exists('instrumented')->withExactTags([
                     "_dd.dbm_trace_injected" => "true"
                 ])

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -186,7 +186,6 @@ class QueueTest extends WebFrameworkTestCase
             $processTrace1,
             [
                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                    ->withExistingTagsNames([Tag::HTTP_URL, Tag::HTTP_METHOD, Tag::HTTP_STATUS_CODE])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         $this->spanQueueResolve('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
@@ -374,18 +373,15 @@ class QueueTest extends WebFrameworkTestCase
     protected function spanProcessOneJob(
         $connection = 'database',
         $queue = 'emails',
-        $resourceDetails = 'App\Jobs\SendVerificationEmail'
+        $resourceDetails = 'App\Jobs\SendVerificationEmail',
+        $isRootSpan = false
     ) {
         return SpanAssertion::build(
             'laravel.queue.process',
             'laravel_queue_test',
             'queue',
             $resourceDetails
-        )->withExactTags([
-            Tag::HTTP_URL => 'http://localhost:9999/queue/workOn',
-            Tag::HTTP_METHOD => 'GET',
-            Tag::HTTP_STATUS_CODE => 200
-        ])->withExactTags(
+        )->withExactTags(
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
             Tag::MQ_MESSAGE_ID,

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -209,7 +209,6 @@ class QueueTest extends WebFrameworkTestCase
             $processTrace1,
             [
                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
-                    ->withExistingTagsNames([Tag::HTTP_URL, Tag::HTTP_METHOD, Tag::HTTP_STATUS_CODE])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         $this->spanQueueResolve('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
@@ -495,11 +494,7 @@ class QueueTest extends WebFrameworkTestCase
             'laravel_queue_test',
             'queue',
             $resourceDetails
-        )->withExactTags([
-            Tag::HTTP_URL => 'http://localhost:9999/queue/workOn',
-            Tag::HTTP_METHOD => 'GET',
-            Tag::HTTP_STATUS_CODE => 200
-        ])->withExactTags(
+        )->withExactTags(
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
             Tag::MQ_MESSAGE_ID,

--- a/tests/Sapi/CliServer/CliServer.php
+++ b/tests/Sapi/CliServer/CliServer.php
@@ -102,7 +102,7 @@ final class CliServer implements Sapi
     public function checkErrors()
     {
         $newLogs = $this->process->getIncrementalErrorOutput();
-        if (preg_match("(=== Total [0-9]+ memory leaks detected ===)", $newLogs)) {
+        if (preg_match("(=== Total [0-9]+ memory leaks detected ===|AddressSanitizer:)", $newLogs)) {
             return $newLogs;
         }
 

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DDTrace\active_span basic functionality
+--SKIPIF--
+<?php if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support %r"); ?>
 --FILE--
 <?php
 
@@ -26,7 +28,7 @@ var_dump(DDTrace\active_span() == DDTrace\active_span());
 Hello, Datadog.
 greet tracer.
 bool(true)
-object(DDTrace\RootSpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (16) {
   ["name"]=>
   string(15) "active_span.php"
   ["resource"]=>
@@ -68,6 +70,16 @@ object(DDTrace\RootSpanData)#%d (12) {
     }
     ["active"]=>
     *RECURSION*
+  }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
+  ["propagatedTags"]=>
+  array(0) {
   }
+  ["samplingPriority"]=>
+  int(1073741824)%r(\s*\["propagatedSamplingPriority"\]=>\s+uninitialized\(int\)\s*\["tracestate"\]=>\s+uninitialized\(string\))?%r
+  ["tracestateTags"]=>
+  array(0) {
+  }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
+  ["traceId"]=>
+  string(32) "0000000000000000%s"
 }
 bool(true)

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -39,10 +39,10 @@ array(1) {
     array(3) {
       ["runtime-id"]=>
       string(36) "%s"
-      ["_dd.origin"]=>
-      string(7) "datadog"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.origin"]=>
+      string(7) "datadog"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
@@ -65,7 +65,7 @@ array(7) {
   }
 }
 bool(true)
-parent: 321, trace: 123, meta: {"_dd.origin":"foo","a":"b"}
+parent: 321, trace: 123, meta: {"a":"b","_dd.origin":"foo"}
 parent: %d, trace: 123, meta: {"_dd.origin":"foo"}
 bool(true)
 array(5) {

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Setting custom distributed header information
+--ENV--
+HTTP_X_DATADOG_TRACE_ID=42
+HTTP_X_DATADOG_PARENT_ID=10
+HTTP_X_DATADOG_ORIGIN=datadog
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag=inherited,_dd.p.second_tag=bar
+--FILE--
+<?php
+
+print_r(DDTrace\SpanLink::fromHeaders(DDTrace\generate_distributed_tracing_headers()));
+
+?>
+--EXPECTF--
+DDTrace\SpanLink Object
+(
+    [traceId] => 0000000000000000000000000000002a
+    [spanId] => %s
+    [traceState] => dd=o:datadog;t.custom_tag:inherited;t.second_tag:bar;t.dm:-1
+    [attributes] => Array
+        (
+            [_dd.p.custom_tag] => inherited
+            [_dd.p.second_tag] => bar
+            [_dd.p.dm] => -1
+        )
+
+)

--- a/tests/ext/inherit_meta_from_parent.phpt
+++ b/tests/ext/inherit_meta_from_parent.phpt
@@ -4,15 +4,12 @@ Inherit some global metadata from parent span
 datadog.trace.generate_root_span=0
 datadog.env = badenv
 datadog.version = badversion
---ENV--
-HTTP_X_DATADOG_ORIGIN=badorigin
 --FILE--
 <?php
 
 $span = \DDTrace\start_span();
 $span->meta["version"] = "goodversion";
 $span->meta["env"] = "goodenv";
-$span->meta["_dd.origin"] = "goodorigin";
 
 \DDTrace\start_span();
 \DDTrace\close_span();
@@ -20,18 +17,15 @@ $span->meta["_dd.origin"] = "goodorigin";
 \DDTrace\close_span();
 
 var_dump(array_intersect_key(dd_trace_serialize_closed_spans()[1]["meta"], [
-    "_dd.origin" => 1,
     "env" => 1,
     "version" => 1,
 ]));
 
 ?>
 --EXPECT--
-array(3) {
+array(2) {
   ["version"]=>
   string(11) "goodversion"
   ["env"]=>
   string(7) "goodenv"
-  ["_dd.origin"]=>
-  string(10) "goodorigin"
 }

--- a/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_sampling_priority.phpt
@@ -22,7 +22,7 @@ function query_headers() {
 }
 
 $rootSpan = DDTrace\active_span();
-$rootSpan->metrics["_sampling_priority_v1"] = 2;
+$rootSpan->samplingPriority = 2;
 
 dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-sampling-priority']);
 

--- a/tests/ext/priority_sampling/001-default-sampling.phpt
+++ b/tests/ext/priority_sampling/001-default-sampling.phpt
@@ -9,7 +9,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
 
     $root = \DDTrace\root_span();
 
-    if ($root->metrics["_sampling_priority_v1"] == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
+    if ($root->samplingPriority == \DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP) {
         echo "metrics[_sampling_priority_v1] OK\n";
 
         if ($root->metrics["_dd.rule_psr"] === 1.0) {

--- a/tests/ext/priority_sampling/002-user-reject.phpt
+++ b/tests/ext/priority_sampling/002-user-reject.phpt
@@ -10,7 +10,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_REJECT)
 
     $root = \DDTrace\root_span();
 
-    if ($root->metrics["_sampling_priority_v1"] == \DD_TRACE_PRIORITY_SAMPLING_USER_REJECT) {
+    if ($root->samplingPriority == \DD_TRACE_PRIORITY_SAMPLING_USER_REJECT) {
         echo "metrics[_sampling_priority_v1] OK\n";
 
         if ($root->metrics["_dd.rule_psr"] == 0) {

--- a/tests/ext/priority_sampling/003-user-keep.phpt
+++ b/tests/ext/priority_sampling/003-user-keep.phpt
@@ -10,7 +10,7 @@ if (\DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
 
     $root = \DDTrace\root_span();
 
-    if ($root->metrics["_sampling_priority_v1"] == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
+    if ($root->samplingPriority == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
         echo "metrics[_sampling_priority_v1] OK\n";
 
         if ($root->metrics["_dd.rule_psr"] == 1) {

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Clone DDTrace\SpanData
+--SKIPIF--
+<?php if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support %r"); ?>
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
@@ -22,7 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-object(DDTrace\RootSpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (16) {
   ["name"]=>
   string(3) "foo"
   ["resource"]=>
@@ -64,9 +66,19 @@ object(DDTrace\RootSpanData)#%d (12) {
     }
     ["active"]=>
     *RECURSION*
+  }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
+  ["propagatedTags"]=>
+  array(0) {
   }
+  ["samplingPriority"]=>
+  int(1073741824)%r(\s*\["propagatedSamplingPriority"\]=>\s+uninitialized\(int\)\s*\["tracestate"\]=>\s+uninitialized\(string\))?%r
+  ["tracestateTags"]=>
+  array(0) {
+  }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
+  ["traceId"]=>
+  string(32) "0000000000000000%s"
 }
-object(DDTrace\RootSpanData)#%d (12) {
+object(DDTrace\RootSpanData)#%d (16) {
   ["name"]=>
   string(5) "dummy"
   ["resource"]=>
@@ -107,7 +119,7 @@ object(DDTrace\RootSpanData)#%d (12) {
       NULL
     }
     ["active"]=>
-    object(DDTrace\RootSpanData)#%d (12) {
+    object(DDTrace\RootSpanData)#%d (16) {
       ["name"]=>
       string(3) "foo"
       ["resource"]=>
@@ -124,12 +136,12 @@ object(DDTrace\RootSpanData)#%d (12) {
       ["metrics"]=>
       array(1) {
         ["process_id"]=>
-        float(%f)
+        float(%d)
       }
       ["exception"]=>
       NULL
       ["id"]=>
-      string(%d) "%d"
+      string(%d) "%s"
       ["links"]=>
       array(0) {
       }
@@ -139,9 +151,29 @@ object(DDTrace\RootSpanData)#%d (12) {
       ["parent"]=>
       NULL
       ["stack"]=>
-      *RECURSION*
+      *RECURSION*%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
+      ["propagatedTags"]=>
+      array(0) {
+      }
+      ["samplingPriority"]=>
+      int(1073741824)%r(\s*\["propagatedSamplingPriority"\]=>\s+uninitialized\(int\)\s*\["tracestate"\]=>\s+uninitialized\(string\))?%r
+      ["tracestateTags"]=>
+      array(0) {
+      }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
+      ["traceId"]=>
+      string(32) "0000000000000000%s"
     }
+  }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
+  ["propagatedTags"]=>
+  array(0) {
   }
+  ["samplingPriority"]=>
+  int(1073741824)%r(\s*\["propagatedSamplingPriority"\]=>\s+uninitialized\(int\)\s*\["tracestate"\]=>\s+uninitialized\(string\))?%r
+  ["tracestateTags"]=>
+  array(0) {
+  }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
+  ["traceId"]=>
+  string(32) "0000000000000000%s"
 }
 array(1) {
   [0]=>

--- a/tests/ext/span_stack/span_stack_swap.phpt
+++ b/tests/ext/span_stack/span_stack_swap.phpt
@@ -45,6 +45,7 @@ DDTrace\switch_stack();
 echo 'Switching to the parent of the active stack: '; var_dump($between_stack == DDTrace\active_stack());
 
 $new_root = DDTrace\start_trace_span();
+$new_root->name = "other root";
 
 # Closes the primary trace itself
 DDTrace\switch_stack();
@@ -82,6 +83,6 @@ spans(\DDTrace\SpanData) (2) {
      (span_stack_swap.php, cli)
        (span_stack_swap.php, cli)
      (span_stack_swap.php, cli)
-  span_stack_swap.php (span_stack_swap.php, span_stack_swap.php, cli)
+  other root (span_stack_swap.php, other root, cli)
     _dd.p.dm => -1
 }

--- a/tests/ext/span_stack/span_trace_swap.phpt
+++ b/tests/ext/span_stack/span_trace_swap.phpt
@@ -10,6 +10,7 @@ include __DIR__ . '/../sandbox/dd_dumper.inc';
 $primary_trace = DDTrace\start_span();
 
 $new_root = DDTrace\start_trace_span();
+$new_root->name = "other root";
 
 DDTrace\switch_stack($primary_trace);
 echo 'We are back on our primary stack: '; var_dump($primary_trace == DDTrace\active_span());
@@ -40,6 +41,6 @@ This automatically switches back to the parent stack: bool(true)
 spans(\DDTrace\SpanData) (2) {
   span_trace_swap.php (span_trace_swap.php, span_trace_swap.php, cli)
     _dd.p.dm => -1
-  span_trace_swap.php (span_trace_swap.php, span_trace_swap.php, cli)
+  other root (span_trace_swap.php, other root, cli)
     _dd.p.dm => -1
 }

--- a/tests/ext/span_stack/start_span_new_trace.phpt
+++ b/tests/ext/span_stack/start_span_new_trace.phpt
@@ -12,6 +12,8 @@ $primary_trace = DDTrace\start_span();
 $primary_active = DDTrace\start_span();
 
 $new_root = DDTrace\start_trace_span();
+$new_root->name = "other root";
+
 echo 'New trace span is reflected in DDTrace\root_span(): '; var_dump($new_root == DDTrace\root_span());
 echo 'New trace span is reflected in DDTrace\active_stack(): '; var_dump($new_root->stack == DDTrace\active_stack());
 echo 'New trace span stack has a parent (a target to switch to on close): '; var_dump($new_root->stack->parent == $primary_active->stack);
@@ -60,7 +62,7 @@ spans(\DDTrace\SpanData) (2) {
     _dd.p.dm => -1
      (start_span_new_trace.php, cli)
        (start_span_new_trace.php, cli)
-  start_span_new_trace.php (start_span_new_trace.php, start_span_new_trace.php, cli)
+  other root (start_span_new_trace.php, other root, cli)
     _dd.p.dm => -1
      (start_span_new_trace.php, cli)
 }


### PR DESCRIPTION
### Description

Moving:
- distributed state directly to the root span
- the extraction logic into its own file, reusable for different purposes (extracting to span, to globals, to span link)
- the trace_id to only the root span
- the parent id to only the root span; the parent id of any other span is simply the id of the parent span

The distributed tracing state is now fully separated between the root span-less (i.e. containing incoming distributed data) and the distributed data tied to a span, allowing it to properly use their own distributed tracing without information leaking across traces.

It also adds a small hexId() helper function on SpanData. SpanLink gains a static fromHeaders() function, which works exactly like DDTrace\consume_distributed_tracing_headers().

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
