### PR TITLE
feat(profiling) add phases of inactivity to timeline

### DIFF
--- a/ext/handlers_api.c
+++ b/ext/handlers_api.c
@@ -10,3 +10,15 @@ void datadog_php_install_handler(datadog_php_zif_handler handler) {
         old_handler->internal_function.handler = handler.new_handler;
     }
 }
+
+void datadog_php_install_method_handler(datadog_php_zim_handler handler) {
+    zend_function *old_handler;
+    zend_class_entry *ce = zend_hash_str_find_ptr(CG(class_table), handler.class_name, handler.class_name_len);
+    if (ce != NULL) {
+        old_handler = zend_hash_str_find_ptr(&ce->function_table, handler.name, handler.name_len);
+        if (old_handler != NULL) {
+            *handler.old_handler = old_handler->internal_function.handler;
+            old_handler->internal_function.handler = handler.new_handler;
+        }
+    }
+}

--- a/ext/handlers_api.h
+++ b/ext/handlers_api.h
@@ -4,6 +4,7 @@
 // This api is used by both the tracer and profiler.
 
 #include <php.h>
+#include <stddef.h>
 
 typedef struct datadog_php_zif_handler_s {
     const char *name;
@@ -12,11 +13,27 @@ typedef struct datadog_php_zif_handler_s {
     void (*new_handler)(INTERNAL_FUNCTION_PARAMETERS);
 } datadog_php_zif_handler;
 
+typedef struct datadog_php_zim_handler_s {
+    const char *class_name;
+    size_t class_name_len;
+    const char *name;
+    size_t name_len;
+    void (**old_handler)(INTERNAL_FUNCTION_PARAMETERS);
+    void (*new_handler)(INTERNAL_FUNCTION_PARAMETERS);
+} datadog_php_zim_handler;
+
 /**
  * Installs the `handler` if the function represented by `name` + `name_len`
  * is found; otherwise does nothing.
  */
 void datadog_php_install_handler(datadog_php_zif_handler handler);
+
+/**
+ * Installs the `handler` if the method represented by `name` + `name_len` is
+ * found in the class represented by `class_name` and `class_len`; otherwise
+ * does nothing.
+ */
+void datadog_php_install_method_handler(datadog_php_zim_handler handler);
 
 #endif  // DDTRACE_HANDLERS_API_H
 

--- a/ext/handlers_api.h
+++ b/ext/handlers_api.h
@@ -4,7 +4,6 @@
 // This api is used by both the tracer and profiler.
 
 #include <php.h>
-#include <stddef.h>
 
 typedef struct datadog_php_zif_handler_s {
     const char *name;

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -381,6 +381,26 @@ impl datadog_php_zif_handler {
     }
 }
 
+impl datadog_php_zim_handler {
+    pub fn new(
+        class: &'static CStr,
+        name: &'static CStr,
+        old_handler: &'static mut InternalFunctionHandler,
+        new_handler: InternalFunctionHandler,
+    ) -> Self {
+        let name = name.to_bytes();
+        let class = class.to_bytes();
+        Self {
+            class_name: class.as_ptr() as *const c_char,
+            class_name_len: class.len(),
+            name: name.as_ptr() as *const c_char,
+            name_len: name.len(),
+            old_handler,
+            new_handler,
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a mut zval> for &'a mut zend_long {
     type Error = u8;
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -363,6 +363,9 @@ extern "C" fn prshutdown() -> ZendResult {
 
     TAGS.with(|cell| cell.replace(Arc::default()));
 
+    #[cfg(feature = "timeline")]
+    timeline::timeline_prshutdown();
+
     ZendResult::Success
 }
 
@@ -747,9 +750,6 @@ extern "C" fn rshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
 
     #[cfg(feature = "allocation_profiling")]
     allocation::allocation_profiling_rshutdown();
-
-    #[cfg(feature = "timeline")]
-    timeline::timeline_rshutdown();
 
     ZendResult::Success
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -139,10 +139,11 @@ extern "C" {
 /// consecutive return value.
 #[no_mangle]
 pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
-    static DEPS: [zend::ModuleDep; 4] = [
+    static DEPS: [zend::ModuleDep; 5] = [
         zend::ModuleDep::required(cstr!("standard")),
         zend::ModuleDep::required(cstr!("json")),
         zend::ModuleDep::optional(cstr!("ddtrace")),
+        zend::ModuleDep::required(cstr!("event")),
         zend::ModuleDep::end(),
     ];
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -139,11 +139,14 @@ extern "C" {
 /// consecutive return value.
 #[no_mangle]
 pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
-    static DEPS: [zend::ModuleDep; 5] = [
+    static DEPS: [zend::ModuleDep; 8] = [
         zend::ModuleDep::required(cstr!("standard")),
         zend::ModuleDep::required(cstr!("json")),
         zend::ModuleDep::optional(cstr!("ddtrace")),
-        zend::ModuleDep::required(cstr!("event")),
+        zend::ModuleDep::optional(cstr!("ev")),
+        zend::ModuleDep::optional(cstr!("event")),
+        zend::ModuleDep::optional(cstr!("libevent")),
+        zend::ModuleDep::optional(cstr!("uv")),
         zend::ModuleDep::end(),
     ];
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -888,10 +888,6 @@ impl Profiler {
             key: "event",
             value: LabelValue::Str(reason.into()),
         });
-        labels.push(Label {
-            key: "end_timestamp_ns",
-            value: LabelValue::Num(now, None),
-        });
 
         let n_labels = labels.len();
 
@@ -907,6 +903,7 @@ impl Profiler {
             },
             labels,
             locals,
+            now,
         )) {
             Ok(_) => {
                 trace!("Sent event 'idle' with {n_labels} labels to profiler.")

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -195,9 +195,9 @@ pub fn timeline_rinit() {
     });
 }
 
-/// This function is run during the RSHUTDOWN phase and resets the `IDLE_SINCE` thread local to
+/// This function is run during the P-RSHUTDOWN phase and resets the `IDLE_SINCE` thread local to
 /// "now", indicating the start of a new idle phase
-pub fn timeline_rshutdown() {
+pub fn timeline_prshutdown() {
     IDLE_SINCE.with(|cell| {
         // try to borrow and bail out if not successful
         let Ok(mut idle_since) = cell.try_borrow_mut() else {

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -45,6 +45,7 @@ static mut TIME_SLEEP_UNTIL_HANDLER: InternalFunctionHandler = None;
 
 // handlers for stream blocking functions
 static mut STREAM_SELECT_HANDLER: InternalFunctionHandler = None;
+static mut SOCKET_SELECT_HANDLER: InternalFunctionHandler = None;
 static mut UV_RUN_HANDLER: InternalFunctionHandler = None;
 static mut EVENT_BASE_LOOP_HANDLER: InternalFunctionHandler = None;
 static mut EV_LOOP_RUN_HANDLER: InternalFunctionHandler = None;
@@ -133,6 +134,14 @@ unsafe extern "C" fn php_stream_select(
     report_wait_time(STREAM_SELECT_HANDLER, execute_data, return_value, "select");
 }
 
+/// Wrapping the PHP `socket_select()` function to take the time it is blocking the current thread
+unsafe extern "C" fn php_socket_select(
+    execute_data: *mut zend::zend_execute_data,
+    return_value: *mut zend::zval,
+) {
+    report_wait_time(SOCKET_SELECT_HANDLER, execute_data, return_value, "select");
+}
+
 /// Wrapping the PHP `uv_run()` function to take the time it is blocking the current thread
 unsafe extern "C" fn php_uv_run(
     execute_data: *mut zend::zend_execute_data,
@@ -200,6 +209,11 @@ pub unsafe fn timeline_startup() {
             CStr::from_bytes_with_nul_unchecked(b"stream_select\0"),
             &mut STREAM_SELECT_HANDLER,
             Some(php_stream_select),
+        ),
+        zend::datadog_php_zif_handler::new(
+            CStr::from_bytes_with_nul_unchecked(b"socket_select\0"),
+            &mut SOCKET_SELECT_HANDLER,
+            Some(php_socket_select),
         ),
         // provided by `ext-uv` from https://pecl.php.net/package/uv
         zend::datadog_php_zif_handler::new(

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -49,7 +49,7 @@ static mut SOCKET_SELECT_HANDLER: InternalFunctionHandler = None;
 static mut UV_RUN_HANDLER: InternalFunctionHandler = None;
 static mut EVENT_BASE_LOOP_HANDLER: InternalFunctionHandler = None;
 static mut EV_LOOP_RUN_HANDLER: InternalFunctionHandler = None;
-static mut EVENT_LOOP_HANDLER: InternalFunctionHandler = None;
+static mut EVENTBASE_LOOP_HANDLER: InternalFunctionHandler = None;
 
 fn report_wait_time(
     handler: InternalFunctionHandler,
@@ -163,15 +163,15 @@ unsafe extern "C" fn php_event_base_loop(
     );
 }
 
-/// Wrapping the PHP `\EventBase\loop()` function to take the time it is blocking the current thread
-unsafe extern "C" fn php_event_loop(
+/// Wrapping the PHP `\EventBase\loop()` method to take the time it is blocking the current thread
+unsafe extern "C" fn php_eventbase_loop(
     execute_data: *mut zend::zend_execute_data,
     return_value: *mut zend::zval,
 ) {
-    report_wait_time(EVENT_LOOP_HANDLER, execute_data, return_value, "select");
+    report_wait_time(EVENTBASE_LOOP_HANDLER, execute_data, return_value, "select");
 }
 
-/// Wrapping the PHP `\EvLoop\run()` function to take the time it is blocking the current thread
+/// Wrapping the PHP `\EvLoop\run()` method to take the time it is blocking the current thread
 unsafe extern "C" fn php_ev_loop_run(
     execute_data: *mut zend::zend_execute_data,
     return_value: *mut zend::zval,
@@ -246,8 +246,8 @@ pub unsafe fn timeline_startup() {
         zend::datadog_php_zim_handler::new(
             CStr::from_bytes_with_nul_unchecked(b"eventbase\0"),
             CStr::from_bytes_with_nul_unchecked(b"loop\0"),
-            &mut EVENT_LOOP_HANDLER,
-            Some(php_event_loop),
+            &mut EVENTBASE_LOOP_HANDLER,
+            Some(php_eventbase_loop),
         ),
     ];
 

--- a/profiling/tests/correctness/timeline.json
+++ b/profiling/tests/correctness/timeline.json
@@ -61,6 +61,19 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "regular_expression": "^\\[idle\\]$",
+                    "percent": 100,
+                    "error_margin": 100,
+                    "labels": [
+                        {
+                            "key": "event",
+                            "values": [
+                                "sleeping"
+                            ]
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
### Description

This PR will add reporting of inactivity phases in PHP to the timeline:
- calling `sleep()`/`usleep()` in userland
- blocking on `stream_select()`, `uv_run()`, `event_base_loop()`, `\EventBase\loop()` and `\EvLoop\run()` like you'd do in the [ReactPHP](https://github.com/reactphp/event-loop/) or [Revolt](https://github.com/revoltphp/event-loop) event loop implementations (AMPHP uses Revolt as its event loop)
- idle phases between PHP requests like in `php-fpm`, Apache `mod_php` or the PHP build-in webserver (`php -S`)

A thing that is currently open in this PR is this problem:
<img width="1785" alt="image" src="https://github.com/DataDog/dd-trace-php/assets/14161194/b784ee3e-5d48-4f46-9c0e-df076d563a88">
As you can see at the end of the "Main" thread lane, there should also be a grey box indicating and idle phase between requests. Now this box shows up in the next pprof with the idle time being correct. When looking into real world data, this is less of a problem and we might just ignore this for now, especially as the UI handles this pretty well.

- [x] Needs this backend PR: https://github.com/DataDog/profiling-backend/pull/4548

PROF-8370

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
