### PR TITLE
feat: add DD_PROFILING_WALLTIME_ENABLED

### DIFF
--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -42,7 +42,7 @@ extern "C" fn ddog_php_prof_trigger_time_sample() {
     super::REQUEST_LOCALS.with(|cell| {
         if let Ok(locals) = cell.try_borrow() {
             if locals.profiling_enabled {
-                // Safety: only vm interrupts are stored there, or possibly null (edges only).
+                // Safety: only vm interrupts are stored there, or possibly null in edge cases.
                 if let Some(vm_interrupt) = unsafe { locals.vm_interrupt_addr.as_ref() } {
                     locals.interrupt_count.fetch_add(1, Ordering::SeqCst);
                     vm_interrupt.store(true, Ordering::SeqCst);


### PR DESCRIPTION
### Description

This doesn't currently disable wall-time profiles completely, it only cancels the timer. You can still trigger them manually.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
