### PR TITLE
feat(profiling) reuse poisson sampler and thread rng

### DIFF
--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -2,6 +2,7 @@ use crate::bindings as zend;
 use crate::PROFILER;
 use crate::REQUEST_LOCALS;
 use log::{error, info};
+use rand::rngs::ThreadRng;
 use std::cell::RefCell;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -17,20 +18,26 @@ pub static EXCEPTION_PROFILING_INTERVAL: AtomicU32 = AtomicU32::new(100);
 pub struct ExceptionProfilingStats {
     /// number of exceptions until next sample collection
     next_sample: u32,
+    poisson: Poisson<f64>,
+    rng: ThreadRng,
 }
 
 impl ExceptionProfilingStats {
     fn new() -> ExceptionProfilingStats {
-        ExceptionProfilingStats {
-            next_sample: ExceptionProfilingStats::next_sampling_interval(),
-        }
+        // Safety: this will only error if lambda <= 0
+        let poisson =
+            Poisson::new(EXCEPTION_PROFILING_INTERVAL.load(Ordering::SeqCst) as f64).unwrap();
+        let mut stats = ExceptionProfilingStats {
+            next_sample: 0,
+            poisson,
+            rng: rand::thread_rng(),
+        };
+        stats.next_sampling_interval();
+        stats
     }
 
-    fn next_sampling_interval() -> u32 {
-        // Panic: `unwrap()` only panics if lambda <= 0 and in the parser we ensure it is not
-        Poisson::new(EXCEPTION_PROFILING_INTERVAL.load(Ordering::SeqCst) as f32)
-            .unwrap()
-            .sample(&mut rand::thread_rng()) as u32
+    fn next_sampling_interval(&mut self) {
+        self.next_sample = self.poisson.sample(&mut self.rng) as u32;
     }
 
     fn track_exception(&mut self, name: String) {
@@ -38,7 +45,7 @@ impl ExceptionProfilingStats {
             return;
         }
 
-        self.next_sample = ExceptionProfilingStats::next_sampling_interval();
+        self.next_sampling_interval();
 
         REQUEST_LOCALS.with(|cell| {
             // try to borrow and bail out if not successful


### PR DESCRIPTION
### Description

While doing work on the overhead task, I found that we are spending quite some amount of work in actual sampling, and suddenly I saw that we are recreating the poisson distribution thread RNG every time we calc the next sample. Turns out, we do not have to and can just reuse the one already created. This does not bring a huge amount of performance, but every step counts 😉 

PROF-7418

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
