### PR TITLE
fix(profiling) exception sampling distance

### DIFF
--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -41,9 +41,8 @@ impl ExceptionProfilingStats {
     }
 
     fn track_exception(&mut self, name: String) {
-        let next_sample = self.next_sample.checked_sub(1);
-        if next_sample.is_some() {
-            self.next_sample = next_sample.unwrap();
+        if let Some(next_sample) = self.next_sample.checked_sub(1) {
+            self.next_sample = next_sample;
             return;
         }
 

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -41,7 +41,9 @@ impl ExceptionProfilingStats {
     }
 
     fn track_exception(&mut self, name: String) {
-        if self.next_sample.checked_sub(1).is_none() {
+        let next_sample = self.next_sample.checked_sub(1);
+        if next_sample.is_some() {
+            self.next_sample = next_sample.unwrap();
             return;
         }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -457,8 +457,6 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         unsafe { bindings::zai_config_first_time_rinit() };
-        #[cfg(feature = "exception_profiling")]
-        exception::exception_profiling_first_rinit();
     });
 
     unsafe { bindings::zai_config_rinit() };
@@ -575,6 +573,9 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 info!("CPU Time profiling enabled.");
             }
         }
+
+        #[cfg(feature = "exception_profiling")]
+        exception::exception_profiling_first_rinit();
     });
 
     // Preloading happens before zend_post_startup_cb is called for the first

--- a/profiling/tests/phpt/exceptions_01.phpt
+++ b/profiling/tests/phpt/exceptions_01.phpt
@@ -1,0 +1,46 @@
+--TEST--
+[profiling] test exceptions being sampled
+--DESCRIPTION--
+This test will check that exceptions are being sampled and that a custom
+sampling rate will actually be used.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+if (strpos($info, 'Experimental Exception Profiling Enabled') === false)
+    echo "skip: datadog profiler is compiled without exception profiling support\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=true
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=20
+DD_PROFILING_ALLOCATION_ENABLED=no
+DD_PROFILING_LOG_LEVEL=trace
+--FILE--
+<?php
+
+function generateExceptions() {
+    for ($i = 0; $i <= 100; $i++) {
+        try {
+            throw new \RuntimeException();
+        } catch (\RuntimeException $e) {
+            # I don't care :-P
+        }
+    }
+}
+
+generateExceptions();
+
+echo 'Done.';
+
+?>
+--EXPECTREGEX--
+.* Exception profiling sampling distance initialized to 20
+.* Sent stack sample of 2 frames, 1 labels with Exception RuntimeException to profiler.
+.*Done..*
+.*


### PR DESCRIPTION
### Description

There were two problems in exception profiling that this PR fixes:
1. `checked_sub()` does not change the value, but return the new one, which we have only checked for `is_none()` and ignored the return value otherwise. We did not update the `self.next_sample` value, effectively walking the stack for every exception.
2. When moving the initialisation to the first `RINIT`, we moved to a too early position in `lib.rs` where `REQUEST_LOCALS` where not yet initialised, resulting in sampling distance always defaulting to `100`.

I also added a test to ensure this is not failing again in the future 😉 

PROF-6915

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
