### PR TITLE
fix: Ignore symfony/flex v1.21.0 version

### DIFF
--- a/tests/Frameworks/Symfony/Version_4_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_2/composer.json
@@ -11,7 +11,7 @@
         "symfony/console": "4.2.*",
         "symfony/dotenv": "4.2.*",
         "symfony/expression-language": "4.2.*",
-        "symfony/flex": "^1.1",
+        "symfony/flex": "^1.1, != 1.21.0",
         "symfony/form": "4.2.*",
         "symfony/framework-bundle": "4.2.*",
         "symfony/monolog-bundle": "^3.1",

--- a/tests/Frameworks/Symfony/Version_4_4/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_4/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "4.4.*",
         "symfony/dotenv": "4.4.*",
         "symfony/expression-language": "4.4.*",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^1.3.1 && != 1.21.0",
         "symfony/form": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-client": "4.4.*",

--- a/tests/Frameworks/Symfony/Version_4_4/composer.json
+++ b/tests/Frameworks/Symfony/Version_4_4/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "4.4.*",
         "symfony/dotenv": "4.4.*",
         "symfony/expression-language": "4.4.*",
-        "symfony/flex": "^1.3.1 && != 1.21.0",
+        "symfony/flex": "^1.3.1, != 1.21.0",
         "symfony/form": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-client": "4.4.*",

--- a/tests/Frameworks/Symfony/Version_5_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_0/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "5.0.*",
         "symfony/dotenv": "5.0.*",
         "symfony/expression-language": "5.0.*",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^1.3.1 && != 1.21.0",
         "symfony/form": "5.0.*",
         "symfony/framework-bundle": "5.0.*",
         "symfony/http-client": "5.0.*",

--- a/tests/Frameworks/Symfony/Version_5_0/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_0/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "5.0.*",
         "symfony/dotenv": "5.0.*",
         "symfony/expression-language": "5.0.*",
-        "symfony/flex": "^1.3.1 && != 1.21.0",
+        "symfony/flex": "^1.3.1, != 1.21.0",
         "symfony/form": "5.0.*",
         "symfony/framework-bundle": "5.0.*",
         "symfony/http-client": "5.0.*",

--- a/tests/Frameworks/Symfony/Version_5_1/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_1/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "5.1.*",
         "symfony/dotenv": "5.1.*",
         "symfony/expression-language": "5.1.*",
-        "symfony/flex": "^1.18.7 && != 1.21.0",
+        "symfony/flex": "^1.18.7, != 1.21.0",
         "symfony/form": "5.1.*",
         "symfony/framework-bundle": "5.1.*",
         "symfony/http-client": "5.1.*",

--- a/tests/Frameworks/Symfony/Version_5_1/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_1/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "5.1.*",
         "symfony/dotenv": "5.1.*",
         "symfony/expression-language": "5.1.*",
-        "symfony/flex": "^1.18.7",
+        "symfony/flex": "^1.18.7 && != 1.21.0",
         "symfony/form": "5.1.*",
         "symfony/framework-bundle": "5.1.*",
         "symfony/http-client": "5.1.*",

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -14,7 +14,7 @@
         "doctrine/orm": "^2.15",
         "symfony/console": "5.2.*",
         "symfony/dotenv": "5.2.*",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^1.3.1 && != 1.21.0",
         "symfony/form": "5.2.*",
         "symfony/framework-bundle": "5.2.*",
         "symfony/security-bundle": "5.2.*",

--- a/tests/Frameworks/Symfony/Version_5_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_5_2/composer.json
@@ -14,7 +14,7 @@
         "doctrine/orm": "^2.15",
         "symfony/console": "5.2.*",
         "symfony/dotenv": "5.2.*",
-        "symfony/flex": "^1.3.1 && != 1.21.0",
+        "symfony/flex": "^1.3.1, != 1.21.0",
         "symfony/form": "5.2.*",
         "symfony/framework-bundle": "5.2.*",
         "symfony/security-bundle": "5.2.*",

--- a/tests/Frameworks/Symfony/Version_6_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_6_2/composer.json
@@ -13,7 +13,7 @@
         "doctrine/orm": "^2.15",
         "symfony/console": "6.2.*",
         "symfony/dotenv": "6.2.*",
-        "symfony/flex": "^1.17.1 && != 1.21.0",
+        "symfony/flex": "^1.17.1",
         "symfony/form": "6.2.*",
         "symfony/framework-bundle": "6.2.*",
         "symfony/monolog-bundle": "^3.8",

--- a/tests/Frameworks/Symfony/Version_6_2/composer.json
+++ b/tests/Frameworks/Symfony/Version_6_2/composer.json
@@ -13,7 +13,7 @@
         "doctrine/orm": "^2.15",
         "symfony/console": "6.2.*",
         "symfony/dotenv": "6.2.*",
-        "symfony/flex": "^1.17.1",
+        "symfony/flex": "^1.17.1 && != 1.21.0",
         "symfony/form": "6.2.*",
         "symfony/framework-bundle": "6.2.*",
         "symfony/monolog-bundle": "^3.8",


### PR DESCRIPTION
### Description

The CI started failing with the following error:
```
Fatal error: Uncaught Error: Call to undefined function Symfony\Flex\Configurator\str_starts_with() in /home/circleci/datadog/tests/Frameworks/Symfony/Version_4_4/vendor/symfony/flex/src/Configurator/DockerComposeConfigurator.php:154
Stack trace:
#0 /home/circleci/datadog/tests/Frameworks/Symfony/Version_4_4/vendor/symfony/flex/src/Configurator/DockerComposeConfigurator.php(235): Symfony\Flex\Configurator\DockerComposeConfigurator->normalizeConfig(Array)
#1 /home/circleci/datadog/tests/Frameworks/Symfony/Version_4_4/vendor/symfony/flex/src/Configurator/DockerComposeConfigurator.php(49): Symfony\Flex\Configurator\DockerComposeConfigurator->configureDockerCompose(Object(Symfony\Flex\Recipe), Array, false)
#2 /home/circleci/datadog/tests/Frameworks/Symfony/Version_4_4/vendor/symfony/flex/src/Configurator.php(59): Symfony\Flex\Configurator\DockerComposeConfigurator->configure(Object(Symfony\Flex\Recipe), Array, Object(Symfony\Flex\Lock), Array)
#3 phar:///usr/local/bin/composer/src/Composer/Plugin/PluginManager.php(286) : eva in /home/circleci/datadog/tests/Frameworks/Symfony/Version_4_4/vendor/symfony/flex/src/Configurator/DockerComposeConfigurator.php on line 154
```

This error started happening when the [1.21.0](https://github.com/symfony/flex/releases/tag/v1.21.0) tag of `symfony/flex` was made. 

This PR ignores this tag on impacted test suites. I've made a PR (symfony/flex#1000) to their repo, so this may be fixed in v1.21.1 if the latter gets approved 🤞 

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
