### PR TITLE
Fix PHP 5: The Drupal integration is not part of PHP 5

### DIFF
--- a/src/Integrations/Integrations/IntegrationsLoader.php
+++ b/src/Integrations/Integrations/IntegrationsLoader.php
@@ -71,8 +71,6 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\CodeIgniter\V2\CodeIgniterIntegration';
             $this->integrations[CurlIntegration::NAME] =
                 '\DDTrace\Integrations\Curl\CurlIntegration';
-            $this->integrations[DrupalIntegration::NAME] =
-                '\DDTrace\Integrations\Drupal\DrupalIntegration';
             $this->integrations[ElasticSearchIntegration::NAME] =
                 '\DDTrace\Integrations\ElasticSearch\V1\ElasticSearchIntegration';
             $this->integrations[EloquentIntegration::NAME] =


### PR DESCRIPTION
### Description

This seems like an oversight - it's only present on PHP 7+.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
