### PR TITLE
Avoid %.*s in places where longer strings are used

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -235,9 +235,9 @@ static zend_result dd_exception_to_error_msg(zend_object *exception, void *conte
         default: exception_type = "Thrown"; break;
     }
 
-    int error_len = asprintf(&error_text, "%s %s%s%s%.*s in %s:" ZEND_LONG_FMT, exception_type,
+    int error_len = asprintf(&error_text, "%s %s%s%s%s in %s:" ZEND_LONG_FMT, exception_type,
                              ZSTR_VAL(exception->ce->name), status_line ? status_line : "", ZSTR_LEN(msg) > 0 ? ": " : "",
-                             (int)ZSTR_LEN(msg), ZSTR_VAL(msg), ZSTR_VAL(file), line);
+                             ZSTR_VAL(msg), ZSTR_VAL(file), line);
 
     free(status_line);
 
@@ -603,8 +603,8 @@ static zend_string *dd_build_req_url() {
     }
 
     zend_string *url =
-        zend_strpprintf(0, "http%s://%s%.*s%s%.*s", is_https ? "s" : "", Z_STRVAL_P(host_zv), uri_len, uri,
-                        ZSTR_LEN(query_string) ? "?" : "", (int)ZSTR_LEN(query_string), ZSTR_VAL(query_string));
+        zend_strpprintf(0, "http%s://%s%.*s%s%s", is_https ? "s" : "", Z_STRVAL_P(host_zv), uri_len, uri,
+                        ZSTR_LEN(query_string) ? "?" : "", ZSTR_VAL(query_string));
 
     zend_string_release(query_string);
 
@@ -699,9 +699,7 @@ void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
                                                         get_DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP());
                     }
 
-                    ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%.*s", method, ZSTR_VAL(normalized),
-                                                            ZSTR_LEN(query_string) ? "?" : "", (int) ZSTR_LEN(query_string),
-                                                            ZSTR_VAL(query_string)));
+                    ZVAL_STR(prop_resource, zend_strpprintf(0, "%s %s%s%s", method, ZSTR_VAL(normalized), ZSTR_LEN(query_string) ? "?" : "", ZSTR_VAL(query_string)));
                     zend_string_release(query_string);
                     zend_string_release(normalized);
                     zend_string_release(path);

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.c
@@ -53,8 +53,7 @@ void ddtrace_add_tracer_tags_from_header(zend_string *headerstr, zend_array *roo
             tagstart = ++header;
         } else if (*header == ',') {
             // we skip invalid tags without = within
-            LOG(Warn, "Found x-datadog-tags header without key-separating equals character; raw input: %.*s",
-                               ZSTR_LEN(headerstr), ZSTR_VAL(headerstr));
+            LOG(Warn, "Found x-datadog-tags header without key-separating equals character; raw input: %s", ZSTR_VAL(headerstr));
             tagstart = ++header;
 
             zval error_zv;
@@ -143,8 +142,8 @@ zend_string *ddtrace_format_propagated_tags(zend_array *propagated, zend_array *
 
             for (char *cur = ZSTR_VAL(str), *end = cur + ZSTR_LEN(str); cur < end; ++cur) {
                 if (*cur < 0x20 || *cur > 0x7E || *cur == ',') {
-                    LOG(Error, "The to be propagated tag '%s=%.*s' value is invalid and is thus dropped.",
-                                     ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str));
+                    LOG(Error, "The to be propagated tag '%s=%s' value is invalid and is thus dropped.",
+                                     ZSTR_VAL(tagname), ZSTR_VAL(str));
                     ZVAL_STRING(&error_zv, "encoding_error");
                     goto error;
                 }
@@ -160,9 +159,9 @@ zend_string *ddtrace_format_propagated_tags(zend_array *propagated, zend_array *
                 smart_str_append(&taglist, str);
             } else if (get_DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH()) {
                 LOG(Error,
-                    "The to be propagated tag '%s=%.*s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
+                    "The to be propagated tag '%s=%s' is too long and exceeds the maximum limit of " ZEND_LONG_FMT
                     " characters and is thus dropped.",
-                    ZSTR_VAL(tagname), ZSTR_LEN(str), ZSTR_VAL(str), get_DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH());
+                    ZSTR_VAL(tagname), ZSTR_VAL(str), get_DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH());
                 ZVAL_STRING(&error_zv, "inject_max_size");
             } else {
                 ZVAL_STRING(&error_zv, "disabled");


### PR DESCRIPTION
### Description

Before https://github.com/php/php-src/commit/e14fbc84acef9a14283986d47433ed7de45b4033 (i.e. PHP 8.1) strings provided with a max length were always truncated at 500 chars.

Note: libdatadog submodule updated for commit https://github.com/DataDog/libdatadog/commit/c9a8afc839e23a49a8e9358949587027b64f676c.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
