### PR TITLE
fix(profiling) flaky exception correctness test

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -60,7 +60,7 @@ jobs:
           export DD_PROFILING_LOG_LEVEL=trace
           export DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=1
-          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMLPING_DISTANCE=1
+          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
           php -d extension=target/release/libdatadog_php_profiling.so -v
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
               mkdir -p profiling/tests/correctness/"$test_case"/


### PR DESCRIPTION
### Description

There was a typo in the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE`:

```diff
- SAMLPING
+ SAMPLING
```

Which was why the test was flaky

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
