### PR TITLE
Expand arrays in metrics into nested-tag format

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -915,7 +915,6 @@ static void dd_serialize_array_recursively(zend_array *target, zend_string *str,
 #endif
     } else if (convert_to_double) {
         zval val_as_double;
-        zval_dtor(value);
         ZVAL_DOUBLE(&val_as_double, zval_get_double(value));
         zend_hash_update(target, str, &val_as_double);
     } else {

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -867,7 +867,7 @@ static void _dd_serialize_json(zend_array *arr, smart_str *buf, int options) {
     smart_str_0(buf);
 }
 
-static void dd_serialize_array_meta_recursively(zend_array *target, zend_string *str, zval *value) {
+static void dd_serialize_array_recursively(zend_array *target, zend_string *str, zval *value, bool convert_to_double) {
     ZVAL_DEREF(value);
     if (Z_TYPE_P(value) == IS_ARRAY || Z_TYPE_P(value) == IS_OBJECT) {
         zend_array *arr;
@@ -897,7 +897,7 @@ static void dd_serialize_array_meta_recursively(zend_array *target, zend_string 
                 } else {
                     key = zend_strpprintf(0, "%.*s." ZEND_LONG_FMT, (int)ZSTR_LEN(str), ZSTR_VAL(str), num_key);
                 }
-                dd_serialize_array_meta_recursively(target, key, val);
+                dd_serialize_array_recursively(target, key, val, convert_to_double);
                 zend_string_release(key);
             } ZEND_HASH_FOREACH_END();
 
@@ -913,11 +913,24 @@ static void dd_serialize_array_meta_recursively(zend_array *target, zend_string 
             zend_release_properties(arr);
         }
 #endif
+    } else if (convert_to_double) {
+        zval val_as_double;
+        zval_dtor(value);
+        ZVAL_DOUBLE(&val_as_double, zval_get_double(value));
+        zend_hash_update(target, str, &val_as_double);
     } else {
         zval val_as_string;
         ddtrace_convert_to_string(&val_as_string, value);
         zend_hash_update(target, str, &val_as_string);
     }
+}
+
+static void dd_serialize_array_meta_recursively(zend_array *target, zend_string *str, zval *value) {
+    dd_serialize_array_recursively(target, str, value, false);
+}
+
+static void dd_serialize_array_metrics_recursively(zend_array *target, zend_string *str, zval *value) {
+    dd_serialize_array_recursively(target, str, value, true);
 }
 
 static void _serialize_meta(zval *el, ddtrace_span_data *span) {
@@ -1405,7 +1418,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     zval *val;
     ZEND_HASH_FOREACH_STR_KEY_VAL_IND(metrics, str_key, val) {
         if (str_key) {
-            add_assoc_double(&metrics_zv, ZSTR_VAL(str_key), zval_get_double(val));
+            dd_serialize_array_metrics_recursively(Z_ARRVAL(metrics_zv), str_key, val);
         }
     } ZEND_HASH_FOREACH_END();
 

--- a/tests/ext/sandbox/safe_to_string_metrics.phpt
+++ b/tests/ext/sandbox/safe_to_string_metrics.phpt
@@ -1,0 +1,108 @@
+--TEST--
+Span metrics is safely converted to numerics without errors or exceptions
+--FILE--
+<?php
+use DDTrace\SpanData;
+
+const MY_DOUBLE = 4.2;
+const MY_LONG = 42;
+
+function metrics_to_string() {}
+
+DDTrace\trace_function('metrics_to_string', function (SpanData $span, array $args) {
+    $span->name = 'MetricsToString';
+    $span->meta = [];
+    foreach ($args as $key => $arg) {
+        $span->metrics['arg.' . $key] = $arg;
+    }
+});
+
+$allTheTypes = [
+    [42],
+    42,
+    4.2,
+    MY_DOUBLE,
+    MY_LONG,
+    [4.2],
+    [1.1, 2.2, 3.3],
+    [[MY_DOUBLE, MY_LONG], 2.2, [3.3]]
+];
+$allTheTypes[0][1] = &$allTheTypes[0];
+
+call_user_func_array('metrics_to_string', $allTheTypes);
+
+list($span) = dd_trace_serialize_closed_spans();
+$last = -1;
+foreach ($span['metrics'] as $key => $value) {
+    $index = (int)substr($key, 4);
+    if ($last != $index) {
+        echo PHP_EOL;
+        if ($index == 0) {
+            unset($allTheTypes[$index][1]); // *RECURSION* is inconsistent across PHP versions
+        }
+        var_dump($allTheTypes[$index]);
+        $last = $index;
+    }
+    echo "$key: ";
+    var_dump($value);
+}
+?>
+--EXPECTF--
+
+array(1) {
+  [0]=>
+  int(42)
+}
+arg.0.0: float(42)
+arg.0.1: string(0) ""
+
+int(42)
+arg.1: float(42)
+
+float(4.2)
+arg.2: float(4.2)
+
+float(4.2)
+arg.3: float(4.2)
+
+int(42)
+arg.4: float(42)
+
+array(1) {
+  [0]=>
+  float(4.2)
+}
+arg.5.0: float(4.2)
+
+array(3) {
+  [0]=>
+  float(1.1)
+  [1]=>
+  float(2.2)
+  [2]=>
+  float(3.3)
+}
+arg.6.0: float(1.1)
+arg.6.1: float(2.2)
+arg.6.2: float(3.3)
+
+array(3) {
+  [0]=>
+  array(2) {
+    [0]=>
+    float(4.2)
+    [1]=>
+    int(42)
+  }
+  [1]=>
+  float(2.2)
+  [2]=>
+  array(1) {
+    [0]=>
+    float(3.3)
+  }
+}
+arg.7.0.0: float(4.2)
+arg.7.0.1: float(42)
+arg.7.1: float(2.2)
+arg.7.2.0: float(3.3)


### PR DESCRIPTION
### Description

Complements #2302 by applying the nested-tag format on the `metrics` array as well (longs, doubles, or array of longs or doubles).

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
