### PR TITLE
test(profiling): with address sanitizer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
   '8.0-buster-shared-ext': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.0-shared-ext' }
   '8.1-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.1_buster' }
   '8.2-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.2_buster' }
+  '8.3-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-8.3_buster' }
   'php-master-buster': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-master_buster' }
   # --- CentOS 6 ---
   '7.0-centos7': { <<: *base_php_service, image: 'datadog/dd-trace-ci:php-7.0_centos-7' }

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rustc-link-arg=-fsanitize=address");
     let php_config_includes_output = Command::new("php-config")
         .arg("--includes")
         .output()
@@ -140,9 +141,10 @@ fn build_zend_php_ffis(
                 .map(Path::new)
                 .chain([Path::new("../zend_abstract_interface")]),
         )
-        .flag_if_supported("-fuse-ld=lld")
+        .flag_if_supported("-fuse-ld=lld-16")
         .flag_if_supported("-std=c11")
         .flag_if_supported("-std=c17")
+        .flag("-fsanitize=address")
         .compile("php_ffi");
 }
 

--- a/profiling/tests/phpt/fork_01.phpt
+++ b/profiling/tests/phpt/fork_01.phpt
@@ -10,6 +10,7 @@ opportunities to lock or crash if that lock is held.
 foreach (['datadog-profiling', 'pcntl'] as $extension)
     if (!extension_loaded($extension))
         echo "skip: test requires {$extension}\n";
+if (getenv('SKIP_ASAN')) die('skip: the profiler leaks on purpose in child of a fork');
 ?>
 --INI--
 assert.exception=1


### PR DESCRIPTION
### Description

This PR will run the tests under `profiling/tests/phpt` with the address sanitizer enabled. Note that it seems like our previous work to get clang 16 into the containers will unexpectedly pay off here, as the version of the OS sanitizers were too old to work with Rust nightly.

State of PR: tests are passing locally with ad-hoc builds and configurations. Next I need to get it working with CI.

This work is the continuation and follow-up to these other PRs:

- #2280
- #2291

And is part of JIRA task PROF-8286.

### Readiness checklist
- [ ] Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
