### PR TITLE
Reset distributed context on request init

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1786,10 +1786,6 @@ PHP_FUNCTION(dd_trace_internal_fn) {
             }
             ddtrace_coms_synchronous_flush(timeout);
             RETVAL_TRUE;
-        } else if (FUNCTION_NAME_MATCHES("initialize_request")) {
-            dd_clean_globals();
-            dd_initialize_request();
-            RETVAL_TRUE;
         }
     }
 }

--- a/tests/ext/distributed_tracing/distributed_trace_reset_context_on_init.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_reset_context_on_init.phpt
@@ -4,7 +4,6 @@ Reset distributed tracing context on request init
 DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
-
 // Initial state
 var_dump(DDTrace\current_context());
 
@@ -13,7 +12,8 @@ DDTrace\set_distributed_tracing_context("123", "321");
 var_dump(DDTrace\current_context());
 
 // Reinitialize request to clear the distributed context state
-dd_trace_internal_fn('initialize_request');
+ini_set("datadog.trace.enabled", 0);
+ini_set("datadog.trace.enabled", 1);
 
 // Reinitialized state
 var_dump(DDTrace\current_context());


### PR DESCRIPTION
### Description

Reset the distributed context trace ID and parent trace ID in the request initialisation phase to avoid polluting new traces with incorrect `trace_id` and `parent_id` values .

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
