### PR TITLE
feat(profiling): add idle phases to timeline

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -363,6 +363,9 @@ extern "C" fn prshutdown() -> ZendResult {
 
     TAGS.with(|cell| cell.replace(Arc::default()));
 
+    #[cfg(feature = "timeline")]
+    timeline::timeline_prshutdown();
+
     ZendResult::Success
 }
 
@@ -747,9 +750,6 @@ extern "C" fn rshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
 
     #[cfg(feature = "allocation_profiling")]
     allocation::allocation_profiling_rshutdown();
-
-    #[cfg(feature = "timeline")]
-    timeline::timeline_rshutdown();
 
     ZendResult::Success
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -361,8 +361,6 @@ extern "C" fn prshutdown() -> ZendResult {
      */
     unsafe { bindings::zai_config_rshutdown() };
 
-    TAGS.with(|cell| cell.replace(Arc::default()));
-
     #[cfg(feature = "timeline")]
     timeline::timeline_prshutdown();
 
@@ -637,6 +635,8 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 profiler.add_interrupt(interrupt);
             }
         });
+    } else {
+        TAGS.with(|cell| cell.replace(Arc::default()));
     }
 
     #[cfg(feature = "allocation_profiling")]
@@ -910,6 +910,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
 extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     #[cfg(debug_assertions)]
     trace!("MSHUTDOWN({_type}, {_module_number})");
+
+    #[cfg(feature = "timeline")]
+    timeline::timeline_mshutdown();
 
     #[cfg(feature = "exception_profiling")]
     exception::exception_profiling_mshutdown();

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -888,10 +888,6 @@ impl Profiler {
             key: "event",
             value: LabelValue::Str(reason.into()),
         });
-        labels.push(Label {
-            key: "end_timestamp_ns",
-            value: LabelValue::Num(now, None),
-        });
 
         let n_labels = labels.len();
 
@@ -907,6 +903,7 @@ impl Profiler {
             },
             labels,
             locals,
+            now,
         )) {
             Ok(_) => {
                 trace!("Sent event 'idle' with {n_labels} labels to profiler.")

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -195,9 +195,9 @@ pub fn timeline_rinit() {
     });
 }
 
-/// This function is run during the RSHUTDOWN phase and resets the `IDLE_SINCE` thread local to
+/// This function is run during the P-RSHUTDOWN phase and resets the `IDLE_SINCE` thread local to
 /// "now", indicating the start of a new idle phase
-pub fn timeline_rshutdown() {
+pub fn timeline_prshutdown() {
     IDLE_SINCE.with(|cell| {
         // try to borrow and bail out if not successful
         let Ok(mut idle_since) = cell.try_borrow_mut() else {

--- a/profiling/tests/correctness/timeline.json
+++ b/profiling/tests/correctness/timeline.json
@@ -61,6 +61,19 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "regular_expression": "^\\[idle\\]$",
+                    "percent": 100,
+                    "error_margin": 100,
+                    "labels": [
+                        {
+                            "key": "event",
+                            "values": [
+                                "sleeping"
+                            ]
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
### Description

This PR will add idle phases between requests and idle phases due to the `sleep()`-class functions to the timeline view.
In detail this covers:
- idle phase between RSHUTDOWN and RINIT (PHP process not handling a request)
- and PHP process sleeping due to a sleep-class function call, namely
  - `sleep()`
  - `usleep()`
  - `time_nanosleep()`
  - and `time_sleep_until()`

Also includes one unrelated change: Moves the call to `exception::exception_profiling_mshutdown();` a few lines up, so that it happens before the config and the profiler is shutdown.

This PR superseeds #2315 and will only contain idle phases as in sleeping or waiting to handle a new request in synchronous PHP (as used in PHP-FPM or Apache mod_php). Everything else (like event loop idle phases) shall go to another PR.

<img width="1780" alt="image" src="https://github.com/DataDog/dd-trace-php/assets/14161194/4694ee84-78e6-4a46-a13c-f5ecb217068a">

PROF-8370 

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
