### PR TITLE
Build AppSec extension & helper in CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2926,7 +2926,7 @@ workflows:
           requires: [ 'Prepare Code' ]
           matrix:
             parameters:
-              php_major_minor:
+              php_version:
                 - '7.0'
                 - '7.1'
                 - '7.2'

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2388,6 +2388,51 @@ jobs:
           root: '.'
           paths: [ './extensions_*' ]
 
+  compile_appsec_extension_centos:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: medium
+      docker_image:
+        type: string
+      so_suffix:
+        type: string
+        default: unknown
+      catch_warnings:
+        type: boolean
+        default: true
+      php_version:
+        type: string
+      cmake_version:
+        type: string
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: << parameters.docker_image >>
+      - run: mkdir -p extensions_$(uname -m)
+      - run:
+          name: Install cmake << parameters.cmake_version >>
+          command: |
+            if [ ! -d "/opt/cmake/<< parameters.cmake_version >>" ]
+            then
+              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+              mkdir -p /opt/cmake/<< parameters.cmake_version >>
+              cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
+            fi
+            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
+      - run:
+          name: Build ndebug, nts configuration
+          command: |
+            set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
+            switch-php << parameters.php_version >>
+            cd appsec ; mkdir build ; cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+
   "Prepare Code":
     working_directory: ~/datadog
     docker: [ image: 'cimg/php:7.3' ]
@@ -2871,6 +2916,14 @@ workflows:
           abi_no: "20230831"
           triplet: "aarch64-unknown-linux-gnu"
           resource_class: "arm.medium"
+
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "Compile AppSec x86_64 PHP 70 nts + zts + debug"
+          php_version: "7.0"
+          docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
+          so_suffix: "20151012"
+          cmake_version: "3.24.4"
 
       - compile_alpine:
           requires: [ 'Prepare Code' ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2394,14 +2394,8 @@ jobs:
       resource_class:
         type: string
         default: medium
-      so_suffix:
-        type: string
-        default: unknown
       php_version:
         type: string
-      cmake_version:
-        type: string
-        default: "3.24.4"
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -2415,28 +2409,31 @@ jobs:
       - run:
           name: Install cmake << parameters.cmake_version >>
           command: |
-            if [ ! -d "/opt/cmake/<< parameters.cmake_version >>" ]
+            if [ ! -d "/opt/cmake/3.24.4" ]
             then
-              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-$(uname -m).tar.gz
-              mkdir -p /opt/cmake/<< parameters.cmake_version >>
-              cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-$(uname -m).tar.gz --strip 1
+              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3.24.4-Linux-$(uname -m).tar.gz
+              mkdir -p /opt/cmake/3.24.4
+              cd /opt/cmake/3.24.4 && tar -xf /tmp/cmake-3.24.4-Linux-$(uname -m).tar.gz --strip 1
             fi
+            echo 'export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"' >> "$BASH_ENV"
+            echo 'export PHP_API_SUFFIX=$(php -i | grep "PHP Extension => " | sed "s/PHP Extension => //g")' >> "$BASH_ENV"
+            source "$BASH_ENV"
       - run:
           name: Build ndebug, nts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>
             mkdir -p appsec/build-release ; cd appsec/build-release
-            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>.so
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API_SUFFIX.so
       - run:
           name: Build ndebug, zts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>-zts
             mkdir -p appsec/build-release-zts ; cd appsec/build-release-zts
-            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>-zts.so
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API_SUFFIX-zts.so
       - persist_to_workspace:
           root: '.'
           paths: [ './appsec_*' ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2406,6 +2406,7 @@ jobs:
         type: string
       cmake_version:
         type: string
+        default: "3.24.4"
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -2415,23 +2416,35 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
-      - run: mkdir -p extensions_$(uname -m)
+      - run: mkdir -p appsec_$(uname -m)
       - run:
           name: Install cmake << parameters.cmake_version >>
           command: |
             if [ ! -d "/opt/cmake/<< parameters.cmake_version >>" ]
             then
-              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz
+              cd /tmp && curl -OL https://github.com/Kitware/CMake/releases/download/v<< parameters.cmake_version >>/cmake-<< parameters.cmake_version >>-Linux-$(uname -m).tar.gz
               mkdir -p /opt/cmake/<< parameters.cmake_version >>
-              cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
+              cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-$(uname -m).tar.gz --strip 1
             fi
       - run:
           name: Build ndebug, nts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>
-            cd appsec ; mkdir build ; cd build
-            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            mkdir -p appsec/build-release ; cd appsec/build-release
+            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cp -v ddappsec.so appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>.so
+      - run:
+          name: Build ndebug, zts configuration
+          command: |
+            set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
+            switch-php << parameters.php_version >>-zts
+            mkdir -p appsec/build-release-zts ; cd appsec/build-release-zts
+            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cp -v ddappsec.so appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>-zts.so
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './appsec_*' ]
 
   "Prepare Code":
     working_directory: ~/datadog
@@ -2919,11 +2932,17 @@ workflows:
 
       - compile_appsec_extension_centos:
           requires: [ 'Prepare Code' ]
-          name: "Compile AppSec x86_64 PHP 70 nts + zts + debug"
+          name: "Compile AppSec x86_64 PHP 70 nts + zts"
           php_version: "7.0"
           docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
-          cmake_version: "3.24.4"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "Compile AppSec aarch64 PHP 70 nts + zts"
+          php_version: "7.0"
+          docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
+          so_suffix: "20151012"
+          resource_class: "arm.medium"
 
       - compile_alpine:
           requires: [ 'Prepare Code' ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2407,7 +2407,7 @@ jobs:
           docker_image: "datadog/dd-trace-ci:php-<< parameters.php_version >>_centos-7"
       - run: mkdir -p appsec_$(uname -m)
       - run:
-          name: Install cmake << parameters.cmake_version >>
+          name: Install cmake 3.24.4
           command: |
             if [ ! -d "/opt/cmake/3.24.4" ]
             then
@@ -2415,7 +2415,7 @@ jobs:
               mkdir -p /opt/cmake/3.24.4
               cd /opt/cmake/3.24.4 && tar -xf /tmp/cmake-3.24.4-Linux-$(uname -m).tar.gz --strip 1
             fi
-            echo 'export PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"' >> "$BASH_ENV"
+            echo 'export PATH="/opt/cmake/3.24.4/bin:$PATH"' >> "$BASH_ENV"
             echo 'export PHP_API_SUFFIX=$(php -i | grep "PHP Extension => " | sed "s/PHP Extension => //g")' >> "$BASH_ENV"
             source "$BASH_ENV"
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2466,6 +2466,43 @@ jobs:
           root: '.'
           paths: [ './appsec_*' ]
 
+  compile_appsec_helper:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: medium
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: "datadog/libddwaf:toolchain"
+      - run: mkdir -p appsec_$(uname -m)
+      - run:
+          name: Create clang symlinks
+          command: |
+            ln -s /usr/bin/clang++-16 /usr/bin/clang++
+            ln -s /usr/bin/clang-16 /usr/bin/clang
+            ln -s /usr/bin/clang-cpp-16 /usr/bin/clang-cpp
+      - run:
+          name: Build
+          command: |
+            git config --global --add safe.directory $(pwd)/appsec/third_party/libddwaf
+            mkdir -p appsec/build ; cd appsec/build
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_EXTENSION=OFF -DCMAKE_TOOLCHAIN_FILE=$(pwd)/../cmake/Toolchain.$(uname -m).cmake
+            make -j $(nproc)
+            cp -v ddappsec-helper ../../appsec_$(uname -m)/ddappsec-helper
+      - run:
+          name: Test
+          command: |
+            cd appsec/build
+            make -j $(nproc) ddappsec_helper_test
+            ./tests/helper/ddappsec_helper_test
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './appsec_*' ]
+
   "Prepare Code":
     working_directory: ~/datadog
     docker: [ image: 'cimg/php:7.3' ]
@@ -2982,6 +3019,14 @@ workflows:
                 - '8.1'
                 - '8.2'
                 - '8.3'
+              resource_class:
+                - "medium"
+                - "arm.medium"
+
+      - compile_appsec_helper:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
               resource_class:
                 - "medium"
                 - "arm.medium"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2924,103 +2924,21 @@ workflows:
 
       - compile_appsec_extension_centos:
           requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 7.0 nts + zts"
-          php_version: "7.0"
-          so_suffix: "20151012"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 7.0 nts + zts"
-          php_version: "7.0"
-          so_suffix: "20151012"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 7.1 nts + zts"
-          php_version: "7.1"
-          so_suffix: "20160303"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 7.1 nts + zts"
-          php_version: "7.1"
-          so_suffix: "20160303"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 7.2 nts + zts"
-          php_version: "7.2"
-          so_suffix: "20170718"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 7.2 nts + zts"
-          php_version: "7.2"
-          so_suffix: "20170718"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 7.3 nts + zts"
-          php_version: "7.3"
-          so_suffix: "20180731"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 7.3 nts + zts"
-          php_version: "7.3"
-          so_suffix: "20180731"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 7.4 nts + zts"
-          php_version: "7.4"
-          so_suffix: "20190902"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 7.4 nts + zts"
-          php_version: "7.4"
-          so_suffix: "20190902"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 8.0 nts + zts"
-          php_version: "8.0"
-          so_suffix: "20200930"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 8.0 nts + zts"
-          php_version: "8.0"
-          so_suffix: "20200930"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 8.1 nts + zts"
-          php_version: "8.1"
-          so_suffix: "20190902"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 8.1 nts + zts"
-          php_version: "8.1"
-          so_suffix: "20210902"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 8.2 nts + zts"
-          php_version: "8.2"
-          so_suffix: "20220829"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 8.2 nts + zts"
-          php_version: "8.2"
-          so_suffix: "20220829"
-          resource_class: "arm.medium"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec x86_64 PHP 8.3 nts + zts"
-          php_version: "8.3"
-          so_suffix: "20230831"
-      - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
-          name: "AppSec aarch64 PHP 8.3 nts + zts"
-          php_version: "8.3"
-          so_suffix: "20230831"
-          resource_class: "arm.medium"
+          matrix:
+            parameters:
+              php_major_minor:
+                - '7.0'
+                - '7.1'
+                - '7.2'
+                - '7.3'
+                - '7.4'
+                - '8.0'
+                - '8.1'
+                - '8.2'
+                - '8.3'
+              resource_class:
+                - "medium"
+                - "arm.medium"
 
       - compile_alpine:
           requires: [ 'Prepare Code' ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2433,7 +2433,7 @@ jobs:
             switch-php << parameters.php_version >>
             mkdir -p appsec/build-release ; cd appsec/build-release
             PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>.so
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>.so
       - run:
           name: Build ndebug, zts configuration
           command: |
@@ -2441,7 +2441,7 @@ jobs:
             switch-php << parameters.php_version >>-zts
             mkdir -p appsec/build-release-zts ; cd appsec/build-release-zts
             PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>-zts.so
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-<< parameters.so_suffix >>-zts.so
       - persist_to_workspace:
           root: '.'
           paths: [ './appsec_*' ]

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2394,14 +2394,9 @@ jobs:
       resource_class:
         type: string
         default: medium
-      docker_image:
-        type: string
       so_suffix:
         type: string
         default: unknown
-      catch_warnings:
-        type: boolean
-        default: true
       php_version:
         type: string
       cmake_version:
@@ -2415,7 +2410,7 @@ jobs:
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
-          docker_image: << parameters.docker_image >>
+          docker_image: "datadog/dd-trace-ci:php-<< parameters.php_version >>_centos-7"
       - run: mkdir -p appsec_$(uname -m)
       - run:
           name: Install cmake << parameters.cmake_version >>
@@ -2932,16 +2927,102 @@ workflows:
 
       - compile_appsec_extension_centos:
           requires: [ 'Prepare Code' ]
-          name: "Compile AppSec x86_64 PHP 70 nts + zts"
+          name: "AppSec x86_64 PHP 7.0 nts + zts"
           php_version: "7.0"
-          docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
       - compile_appsec_extension_centos:
           requires: [ 'Prepare Code' ]
-          name: "Compile AppSec aarch64 PHP 70 nts + zts"
+          name: "AppSec aarch64 PHP 7.0 nts + zts"
           php_version: "7.0"
-          docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 7.1 nts + zts"
+          php_version: "7.1"
+          so_suffix: "20160303"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 7.1 nts + zts"
+          php_version: "7.1"
+          so_suffix: "20160303"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 7.2 nts + zts"
+          php_version: "7.2"
+          so_suffix: "20170718"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 7.2 nts + zts"
+          php_version: "7.2"
+          so_suffix: "20170718"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 7.3 nts + zts"
+          php_version: "7.3"
+          so_suffix: "20180731"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 7.3 nts + zts"
+          php_version: "7.3"
+          so_suffix: "20180731"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 7.4 nts + zts"
+          php_version: "7.4"
+          so_suffix: "20190902"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 7.4 nts + zts"
+          php_version: "7.4"
+          so_suffix: "20190902"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 8.0 nts + zts"
+          php_version: "8.0"
+          so_suffix: "20200930"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 8.0 nts + zts"
+          php_version: "8.0"
+          so_suffix: "20200930"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 8.1 nts + zts"
+          php_version: "8.1"
+          so_suffix: "20190902"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 8.1 nts + zts"
+          php_version: "8.1"
+          so_suffix: "20210902"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 8.2 nts + zts"
+          php_version: "8.2"
+          so_suffix: "20220829"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 8.2 nts + zts"
+          php_version: "8.2"
+          so_suffix: "20220829"
+          resource_class: "arm.medium"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec x86_64 PHP 8.3 nts + zts"
+          php_version: "8.3"
+          so_suffix: "20230831"
+      - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          name: "AppSec aarch64 PHP 8.3 nts + zts"
+          php_version: "8.3"
+          so_suffix: "20230831"
           resource_class: "arm.medium"
 
       - compile_alpine:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2398,9 +2398,6 @@ jobs:
         type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - restore_cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
@@ -2416,7 +2413,7 @@ jobs:
               cd /opt/cmake/3.24.4 && tar -xf /tmp/cmake-3.24.4-Linux-$(uname -m).tar.gz --strip 1
             fi
             echo 'export PATH="/opt/cmake/3.24.4/bin:$PATH"' >> "$BASH_ENV"
-            echo 'export PHP_API_SUFFIX=$(php -i | grep "PHP Extension => " | sed "s/PHP Extension => //g")' >> "$BASH_ENV"
+            echo 'export PHP_API=$(php -i | grep "PHP Extension => " | sed "s/PHP Extension => //g")' >> "$BASH_ENV"
             source "$BASH_ENV"
       - run:
           name: Build ndebug, nts configuration
@@ -2425,7 +2422,7 @@ jobs:
             switch-php << parameters.php_version >>
             mkdir -p appsec/build-release ; cd appsec/build-release
             cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API_SUFFIX.so
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API.so
       - run:
           name: Build ndebug, zts configuration
           command: |
@@ -2433,7 +2430,38 @@ jobs:
             switch-php << parameters.php_version >>-zts
             mkdir -p appsec/build-release-zts ; cd appsec/build-release-zts
             cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
-            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API_SUFFIX-zts.so
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API-zts.so
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './appsec_*' ]
+
+  compile_appsec_extension_alpine:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: medium
+      php_version:
+        type: string
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_version >>"
+      - run: mkdir -p appsec_$(uname -m)
+      - run:
+          name: Install dependencies
+          command: |
+            apk add cmake gcc g++ git python3 autoconf coreutils
+            echo 'export PHP_API=$(php -i | grep "PHP Extension => " | sed "s/PHP Extension => //g")' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - run:
+          name: Build
+          command: |
+            mkdir -p appsec/build ; cd appsec/build
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cp -v ddappsec.so ../../appsec_$(uname -m)/ddappsec-$PHP_API-alpine.so
       - persist_to_workspace:
           root: '.'
           paths: [ './appsec_*' ]
@@ -2923,6 +2951,24 @@ workflows:
           resource_class: "arm.medium"
 
       - compile_appsec_extension_centos:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              php_version:
+                - '7.0'
+                - '7.1'
+                - '7.2'
+                - '7.3'
+                - '7.4'
+                - '8.0'
+                - '8.1'
+                - '8.2'
+                - '8.3'
+              resource_class:
+                - "medium"
+                - "arm.medium"
+
+      - compile_appsec_extension_alpine:
           requires: [ 'Prepare Code' ]
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2425,14 +2425,13 @@ jobs:
               mkdir -p /opt/cmake/<< parameters.cmake_version >>
               cd /opt/cmake/<< parameters.cmake_version >> && tar -xf /tmp/cmake-<< parameters.cmake_version >>-Linux-x86_64.tar.gz --strip 1
             fi
-            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH"
       - run:
           name: Build ndebug, nts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>
             cd appsec ; mkdir build ; cd build
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            PATH="/opt/cmake/<< parameters.cmake_version >>/bin:$PATH" cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
 
   "Prepare Code":
     working_directory: ~/datadog

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2431,7 +2431,8 @@ jobs:
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>
-            cd appsec ; mkdir build ; cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
+            cd appsec ; mkdir build ; cd build
+            cmake .. -DCMAKE_BUILD_TYPE=Release -DDD_APPSEC_BUILD_HELPER=OFF  -DDD_APPSEC_TESTING=OFF ; make -j $(nproc)
 
   "Prepare Code":
     working_directory: ~/datadog

--- a/appsec/CMakeLists.txt
+++ b/appsec/CMakeLists.txt
@@ -22,6 +22,7 @@ cmake_policy(SET CMP0083 NEW) # make PIE executables when PIC property is set
 option(DD_APPSEC_BUILD_HELPER "Whether to builder the helper" ON)
 option(DD_APPSEC_BUILD_EXTENSION "Whether to builder the extension" ON)
 option(DD_APPSEC_ENABLE_COVERAGE "Whether to enable coverage calculation" OFF)
+option(DD_APPSEC_TESTING "Whether to enable testing" ON)
 
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 

--- a/appsec/cmake/Toolchain.aarch64.cmake
+++ b/appsec/cmake/Toolchain.aarch64.cmake
@@ -1,0 +1,25 @@
+set(sysroot /sysroot/aarch64-none-linux-musl)
+set(arch aarch64)
+set(interpreter ld-musl-aarch64.so.1)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${arch})
+set(CMAKE_SYSROOT ${sysroot})
+set(CMAKE_AR /usr/bin/llvm-ar-16)
+set(triple ${arch}-none-linux-musl)
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILER /usr/bin/clang-16)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -isystem/sysroot/aarch64-none-linux-musl/usr/include/c++/v1/")
+set(CMAKE_C_FLAGS ${c_cxx_flags})
+set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
+
+set(linker_flags "-v -fuse-ld=lld-16 -static -nodefaultlibs -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
+
+set(CMAKE_NM /usr/bin/llvm-nm-16)
+set(CMAKE_RANLIB /usr/bin/llvm-ranlib-16)
+set(CMAKE_STRIP /usr/bin/aarch64-linux-gnu-strip) # llvm-strip-11 doesn't seem to work correctly

--- a/appsec/cmake/Toolchain.x86_64.cmake
+++ b/appsec/cmake/Toolchain.x86_64.cmake
@@ -1,0 +1,25 @@
+set(sysroot /sysroot/x86_64-none-linux-musl)
+set(arch x86_64)
+set(interpreter ld-musl-x86_64.so.1)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${arch})
+set(CMAKE_SYSROOT ${sysroot})
+set(CMAKE_AR /usr/bin/llvm-ar-16)
+set(triple ${arch}-none-linux-musl)
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILER /usr/bin/clang-16)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -isystem/sysroot/x86_64-none-linux-musl/usr/include/c++/v1/")
+set(CMAKE_C_FLAGS ${c_cxx_flags})
+set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
+
+set(linker_flags "-v -fuse-ld=lld-16 -static -nodefaultlibs -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
+
+set(CMAKE_NM /usr/bin/llvm-nm-16)
+set(CMAKE_RANLIB /usr/bin/llvm-ranlib-16)
+set(CMAKE_STRIP /usr/bin/x86_64-linux-gnu-strip) # llvm-strip-11 doesn't seem to work correctly

--- a/appsec/cmake/extension.cmake
+++ b/appsec/cmake/extension.cmake
@@ -21,9 +21,11 @@ target_link_libraries(extension PRIVATE mpack PhpConfig)
 
 target_include_directories(extension PRIVATE ../zend_abstract_interface)
 
-if(DD_APPSEC_ENABLE_COVERAGE)
-    target_compile_options(extension PRIVATE --coverage)
-    target_link_options(extension PRIVATE --coverage)
-endif()
+if(DD_APPSEC_TESTING)
+    if(DD_APPSEC_ENABLE_COVERAGE)
+        target_compile_options(extension PRIVATE --coverage)
+        target_link_options(extension PRIVATE --coverage)
+    endif()
 
-include(cmake/run_tests.cmake)
+    include(cmake/run_tests.cmake)
+endif()

--- a/appsec/cmake/helper.cmake
+++ b/appsec/cmake/helper.cmake
@@ -45,17 +45,19 @@ if(NOT STDLIBXX_FS_NO_LIB_NEEDED)
     endif()
 endif()
 
-# Testing and examples
-add_subdirectory(tests/helper EXCLUDE_FROM_ALL)
-#add_subdirectory(tests/bench_helper EXCLUDE_FROM_ALL)
-#add_subdirectory(tests/fuzzer EXCLUDE_FROM_ALL)
+if(DD_APPSEC_TESTING)
+       # Testing and examples
+       add_subdirectory(tests/helper EXCLUDE_FROM_ALL)
+       #add_subdirectory(tests/bench_helper EXCLUDE_FROM_ALL)
+       #add_subdirectory(tests/fuzzer EXCLUDE_FROM_ALL)
 
-if(DD_APPSEC_ENABLE_COVERAGE)
-    target_compile_options(helper_objects PRIVATE --coverage)
-    target_compile_options(ddappsec_helper_test PRIVATE --coverage)
+       if(DD_APPSEC_ENABLE_COVERAGE)
+           target_compile_options(helper_objects PRIVATE --coverage)
+           target_compile_options(ddappsec_helper_test PRIVATE --coverage)
 
-    target_link_options(ddappsec_helper_test PRIVATE --coverage)
+           target_link_options(ddappsec_helper_test PRIVATE --coverage)
 
-    # helper objects are shared, so we need to link ddappsec-helper with --coverage too
-    target_link_options(ddappsec-helper PRIVATE --coverage)
+           # helper objects are shared, so we need to link ddappsec-helper with --coverage too
+           target_link_options(ddappsec-helper PRIVATE --coverage)
+       endif()
 endif()


### PR DESCRIPTION
### Description

This is a first step towards building / testing appsec within this repository. This PR  introduces:

- Extension build for all PHP versions, nts and zts for both aarch64 and x86_64, gnu and musl. 
- Helper build on aarch64 and x86_64, statically linked musl & libc++ using the libddwaf toolchain.

Note that helper builds could be massively simplified, however since the helper logic will eventually be migrated to the sidecar, this might not be worth the effort at this stage.

The next steps (in a future PR):
- Build package using the outcome of the new build jobs.
- Extension tests
- Integration tests

Related Jira: [APPSEC-11707] [APPSEC-11708]

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.


[APPSEC-11707]: https://datadoghq.atlassian.net/browse/APPSEC-11707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPSEC-11708]: https://datadoghq.atlassian.net/browse/APPSEC-11708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ