### PR TITLE
Appsec helper build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2479,7 +2479,6 @@ jobs:
       - setup_docker:
           docker_image: "datadog/libddwaf:toolchain"
       - run: mkdir -p appsec_$(uname -m)
-      - run: git config --global --add safe.directory appsec/third_party/libddwaf
       - run:
           name: Create clang symlinks
           command: |
@@ -2489,6 +2488,7 @@ jobs:
       - run:
           name: Build
           command: |
+            git config --global --add safe.directory $(pwd)/appsec/third_party/libddwaf
             mkdir -p appsec/build ; cd appsec/build
             cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_EXTENSION=OFF -DCMAKE_TOOLCHAIN_FILE=$(pwd)/../cmake/Toolchain.$(uname -m).cmake
             make -j $(nproc)

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2466,6 +2466,42 @@ jobs:
           root: '.'
           paths: [ './appsec_*' ]
 
+  compile_appsec_helper:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: medium
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: "datadog/libddwaf:toolchain"
+      - run: mkdir -p appsec_$(uname -m)
+      - run:
+          name: Create clang symlinks
+          command: |
+            ln -s /usr/bin/clang++-16 /usr/bin/clang++
+            ln -s /usr/bin/clang-16 /usr/bin/clang
+            ln -s /usr/bin/clang-cpp-16 /usr/bin/clang-cpp
+      - run:
+          name: Build
+          command: |
+            mkdir -p appsec/build ; cd appsec/build
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_EXTENSION=OFF -DCMAKE_TOOLCHAIN_FILE=~/datadog/appsec/cmake/Toolchain.$(uname -m).cmake
+            make -j $(nproc)
+            cp -v ddappsec-helper ../../appsec_$(uname -m)/ddappsec-helper
+      - run:
+          name: Test
+          command: |
+            cd appsec/build
+            make -j $(nproc) ddappsec_helper_test
+            ./tests/helper/ddappsec_helper_test
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './appsec_*' ]
+
   "Prepare Code":
     working_directory: ~/datadog
     docker: [ image: 'cimg/php:7.3' ]
@@ -2982,6 +3018,14 @@ workflows:
                 - '8.1'
                 - '8.2'
                 - '8.3'
+              resource_class:
+                - "medium"
+                - "arm.medium"
+
+      - compile_appsec_helper:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
               resource_class:
                 - "medium"
                 - "arm.medium"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2489,7 +2489,7 @@ jobs:
           name: Build
           command: |
             mkdir -p appsec/build ; cd appsec/build
-            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_EXTENSION=OFF -DCMAKE_TOOLCHAIN_FILE=~/datadog/appsec/cmake/Toolchain.$(uname -m).cmake
+            cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDD_APPSEC_BUILD_EXTENSION=OFF -DCMAKE_TOOLCHAIN_FILE=$(pwd)/../cmake/Toolchain.$(uname -m).cmake
             make -j $(nproc)
             cp -v ddappsec-helper ../../appsec_$(uname -m)/ddappsec-helper
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2479,6 +2479,7 @@ jobs:
       - setup_docker:
           docker_image: "datadog/libddwaf:toolchain"
       - run: mkdir -p appsec_$(uname -m)
+      - run: git config --global --add safe.directory appsec/third_party/libddwaf
       - run:
           name: Create clang symlinks
           command: |

--- a/appsec/CMakeLists.txt
+++ b/appsec/CMakeLists.txt
@@ -22,6 +22,7 @@ cmake_policy(SET CMP0083 NEW) # make PIE executables when PIC property is set
 option(DD_APPSEC_BUILD_HELPER "Whether to builder the helper" ON)
 option(DD_APPSEC_BUILD_EXTENSION "Whether to builder the extension" ON)
 option(DD_APPSEC_ENABLE_COVERAGE "Whether to enable coverage calculation" OFF)
+option(DD_APPSEC_TESTING "Whether to enable testing" ON)
 
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 

--- a/appsec/cmake/Toolchain.aarch64.cmake
+++ b/appsec/cmake/Toolchain.aarch64.cmake
@@ -1,0 +1,25 @@
+set(sysroot /sysroot/aarch64-none-linux-musl)
+set(arch aarch64)
+set(interpreter ld-musl-aarch64.so.1)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${arch})
+set(CMAKE_SYSROOT ${sysroot})
+set(CMAKE_AR /usr/bin/llvm-ar-16)
+set(triple ${arch}-none-linux-musl)
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILER /usr/bin/clang-16)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -isystem/sysroot/aarch64-none-linux-musl/usr/include/c++/v1/")
+set(CMAKE_C_FLAGS ${c_cxx_flags})
+set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
+
+set(linker_flags "-v -fuse-ld=lld-16 -static -nodefaultlibs -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
+
+set(CMAKE_NM /usr/bin/llvm-nm-16)
+set(CMAKE_RANLIB /usr/bin/llvm-ranlib-16)
+set(CMAKE_STRIP /usr/bin/aarch64-linux-gnu-strip) # llvm-strip-11 doesn't seem to work correctly

--- a/appsec/cmake/Toolchain.x86_64.cmake
+++ b/appsec/cmake/Toolchain.x86_64.cmake
@@ -1,0 +1,25 @@
+set(sysroot /sysroot/x86_64-none-linux-musl)
+set(arch x86_64)
+set(interpreter ld-musl-x86_64.so.1)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${arch})
+set(CMAKE_SYSROOT ${sysroot})
+set(CMAKE_AR /usr/bin/llvm-ar-16)
+set(triple ${arch}-none-linux-musl)
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILER /usr/bin/clang-16)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -isystem/sysroot/x86_64-none-linux-musl/usr/include/c++/v1/")
+set(CMAKE_C_FLAGS ${c_cxx_flags})
+set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
+
+set(linker_flags "-v -fuse-ld=lld-16 -static -nodefaultlibs -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
+
+set(CMAKE_NM /usr/bin/llvm-nm-16)
+set(CMAKE_RANLIB /usr/bin/llvm-ranlib-16)
+set(CMAKE_STRIP /usr/bin/x86_64-linux-gnu-strip) # llvm-strip-11 doesn't seem to work correctly


### PR DESCRIPTION
### Description

This PR introduces a new job to build the appsec helper using the libddwaf cross-compilation toolchain (although no cross-compilation is being done here)

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
