### PR TITLE
Add tracing for curl_multi_exec()

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -116,6 +116,8 @@ static inline zend_string *php_base64_encode_str(const zend_string *str) {
 #define GC_ADD_FLAGS(c, flag) GC_FLAGS(c) |= flag
 #define GC_DEL_FLAGS(c, flag) GC_FLAGS(c) &= ~(flag)
 
+#define rc_dtor_func zval_dtor_func
+
 static inline HashTable *zend_new_array(uint32_t nSize) {
     HashTable *ht = (HashTable *)emalloc(sizeof(HashTable));
     zend_hash_init(ht, nSize, dummy, ZVAL_PTR_DTOR, 0);

--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -292,6 +292,14 @@ static zend_always_inline void zend_array_release(zend_array *array)
 #define ZEND_ATOL(s) atol((s))
 #endif
 #define ZEND_ACC_READONLY 0
+
+static zend_always_inline zend_result add_next_index_object(zval *arg, zend_object *obj) {
+    zval tmp;
+
+    ZVAL_OBJ(&tmp, obj);
+    return zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp) ? SUCCESS : FAILURE;
+}
+
 #endif
 
 #if PHP_VERSION_ID < 80200

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2463,15 +2463,18 @@ PHP_FUNCTION(DDTrace_get_priority_sampling) {
 
 PHP_FUNCTION(DDTrace_get_sanitized_exception_trace) {
     zend_object *ex;
+    zend_long skip = 0;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ddtrace_quiet_zpp(), 1, 1)
+    ZEND_PARSE_PARAMETERS_START_EX(ddtrace_quiet_zpp(), 1, 2)
         Z_PARAM_OBJ_OF_CLASS(ex, zend_ce_throwable)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(skip)
     ZEND_PARSE_PARAMETERS_END_EX({
         LOG_LINE_ONCE(Error, "unexpected parameter for DDTrace\\get_sanitized_exception_trace, the first argument must be a Throwable");
         RETURN_FALSE;
     });
 
-    RETURN_STR(zai_get_trace_without_args_from_exception(ex));
+    RETURN_STR(zai_get_trace_without_args_from_exception_skip_frames(ex, skip));
 }
 
 PHP_FUNCTION(DDTrace_startup_logs) {

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -92,6 +92,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     ddtrace_trace_id distributed_trace_id;
     uint64_t distributed_parent_trace_id;
     zend_string *dd_origin;
+    zend_reference *curl_multi_injecting_spans;
 
     char *cgroup_file;
     ddog_QueueId telemetry_queue_id;

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -475,9 +475,11 @@ namespace DDTrace {
      * Sanitize an exception
      *
      * @param \Exception|\Throwable $exception
+     * @param int $skipFrames The number of frames to be dropped from the start. E.g. to hide the fact that we're
+     * in a hook function.
      * @return string
      */
-    function get_sanitized_exception_trace(\Exception|\Throwable $exception): string {}
+    function get_sanitized_exception_trace(\Exception|\Throwable $exception, int $skipFrames = 0): string {}
 
     /**
      * Update datadog headers for distributed tracing for new spans. Also applies this information to the current trace,

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -403,10 +403,18 @@ namespace DDTrace {
     /**
      * Close the currently active user-span on the top of the stack
      *
-     * @param float $finishTime Finish time in seconds.
+     * @param float $finishTime Finish time in seconds. Defaults to now if zero.
      * @return false|null 'false' if unexpected parameters were given, else 'null'
      */
     function close_span(float $finishTime = 0): false|null {}
+
+    /**
+     * Update the duration of an already closed span
+     *
+     * @param SpanData $span The span to update.
+     * @param float $finishTime Finish time in seconds. Defaults to now if zero.
+     */
+    function update_span_duration(SpanData $span, float $finishTime = 0): null {}
 
     /**
      * Start a new trace
@@ -569,6 +577,14 @@ namespace DDTrace {
      * Closes all spans and force-send finished traces to the agent
      */
     function flush(): void {}
+
+    /**
+     * Registers an array to be populated with spans for each request during the next curl_multi_exec() call.
+     *
+     * @internal
+     * @param list{\CurlHandle, SpanData}[] $array An array which will be populated with curl handles and spans.
+     */
+    function curl_multi_exec_get_request_spans(&$array): void {}
 }
 
 namespace DDTrace\System {

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e14a281987962f87e6bcc153fd38a6202716cb31 */
+ * Stub hash: 1d07ca443c39ea7a0a831b062bb0efe4baf69b0f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -86,6 +86,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_sanitized_exception_trace, 0, 1, IS_STRING, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, exception, Exception|Throwable, 0, NULL)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, skipFrames, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_consume_distributed_tracing_headers, 0, 1, IS_VOID, 0)

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 85f2b3a4b45cb7685e5ec115eefa59ae7f20cd79 */
+ * Stub hash: e14a281987962f87e6bcc153fd38a6202716cb31 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -53,6 +53,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_DDTrace_start_span, 0, 0, DD
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_close_span, 0, 0, IS_FALSE, 1)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, finishTime, IS_DOUBLE, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_update_span_duration, 0, 1, IS_NULL, 1)
+	ZEND_ARG_OBJ_INFO(0, span, DDTrace\\SpanData, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, finishTime, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -116,6 +121,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_set_distributed_tracing_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_flush, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_curl_multi_exec_get_request_spans, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(1, array)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_System_container_id, 0, 0, IS_STRING, 1)
@@ -269,6 +278,7 @@ ZEND_FUNCTION(DDTrace_active_span);
 ZEND_FUNCTION(DDTrace_root_span);
 ZEND_FUNCTION(DDTrace_start_span);
 ZEND_FUNCTION(DDTrace_close_span);
+ZEND_FUNCTION(DDTrace_update_span_duration);
 ZEND_FUNCTION(DDTrace_start_trace_span);
 ZEND_FUNCTION(DDTrace_active_stack);
 ZEND_FUNCTION(DDTrace_create_stack);
@@ -286,6 +296,7 @@ ZEND_FUNCTION(DDTrace_logs_correlation_trace_id);
 ZEND_FUNCTION(DDTrace_current_context);
 ZEND_FUNCTION(DDTrace_set_distributed_tracing_context);
 ZEND_FUNCTION(DDTrace_flush);
+ZEND_FUNCTION(DDTrace_curl_multi_exec_get_request_spans);
 ZEND_FUNCTION(DDTrace_System_container_id);
 ZEND_FUNCTION(DDTrace_Config_integration_analytics_enabled);
 ZEND_FUNCTION(DDTrace_Config_integration_analytics_sample_rate);
@@ -346,6 +357,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FALIAS("DDTrace", root_span, DDTrace_root_span, arginfo_DDTrace_root_span)
 	ZEND_NS_FALIAS("DDTrace", start_span, DDTrace_start_span, arginfo_DDTrace_start_span)
 	ZEND_NS_FALIAS("DDTrace", close_span, DDTrace_close_span, arginfo_DDTrace_close_span)
+	ZEND_NS_FALIAS("DDTrace", update_span_duration, DDTrace_update_span_duration, arginfo_DDTrace_update_span_duration)
 	ZEND_NS_FALIAS("DDTrace", start_trace_span, DDTrace_start_trace_span, arginfo_DDTrace_start_trace_span)
 	ZEND_NS_FALIAS("DDTrace", active_stack, DDTrace_active_stack, arginfo_DDTrace_active_stack)
 	ZEND_NS_FALIAS("DDTrace", create_stack, DDTrace_create_stack, arginfo_DDTrace_create_stack)
@@ -363,6 +375,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FALIAS("DDTrace", current_context, DDTrace_current_context, arginfo_DDTrace_current_context)
 	ZEND_NS_FALIAS("DDTrace", set_distributed_tracing_context, DDTrace_set_distributed_tracing_context, arginfo_DDTrace_set_distributed_tracing_context)
 	ZEND_NS_FALIAS("DDTrace", flush, DDTrace_flush, arginfo_DDTrace_flush)
+	ZEND_NS_FALIAS("DDTrace", curl_multi_exec_get_request_spans, DDTrace_curl_multi_exec_get_request_spans, arginfo_DDTrace_curl_multi_exec_get_request_spans)
 	ZEND_NS_FALIAS("DDTrace\\System", container_id, DDTrace_System_container_id, arginfo_DDTrace_System_container_id)
 	ZEND_NS_FALIAS("DDTrace\\Config", integration_analytics_enabled, DDTrace_Config_integration_analytics_enabled, arginfo_DDTrace_Config_integration_analytics_enabled)
 	ZEND_NS_FALIAS("DDTrace\\Config", integration_analytics_sample_rate, DDTrace_Config_integration_analytics_sample_rate, arginfo_DDTrace_Config_integration_analytics_sample_rate)

--- a/ext/handlers_curl.c
+++ b/ext/handlers_curl.c
@@ -132,6 +132,8 @@ static void dd_multi_inject_headers(zend_object *mh) {
                 ddtrace_close_span(span);
                 span->duration = 1;
 
+                SEPARATE_ARRAY(&DDTRACE_G(curl_multi_injecting_spans)->val);
+
                 zval data;
                 array_init(&data);
                 GC_ADDREF(ch);
@@ -145,7 +147,7 @@ static void dd_multi_inject_headers(zend_object *mh) {
 
         if (DDTRACE_G(curl_multi_injecting_spans)) {
             if (GC_DELREF(DDTRACE_G(curl_multi_injecting_spans)) == 0) {
-                zval_ptr_dtor(&DDTRACE_G(curl_multi_injecting_spans)->val);
+                rc_dtor_func((zend_refcounted *) DDTRACE_G(curl_multi_injecting_spans));
             }
             DDTRACE_G(curl_multi_injecting_spans) = NULL;
         }

--- a/ext/handlers_curl_php7.c
+++ b/ext/handlers_curl_php7.c
@@ -164,6 +164,8 @@ static int dd_inject_distributed_tracing_headers_multi(zval *ch) {
         ddtrace_close_span(span);
         span->duration = 1;
 
+        SEPARATE_ARRAY(&DDTRACE_G(curl_multi_injecting_spans)->val);
+
         zval data;
         array_init(&data);
         Z_ADDREF_P(ch);
@@ -292,7 +294,7 @@ static void dd_multi_inject_headers(zval *mh) {
 
     if (DDTRACE_G(curl_multi_injecting_spans)) {
         if (GC_DELREF(DDTRACE_G(curl_multi_injecting_spans)) == 0) {
-            zval_ptr_dtor(&DDTRACE_G(curl_multi_injecting_spans)->val);
+            rc_dtor_func((zend_refcounted *) DDTRACE_G(curl_multi_injecting_spans));
         }
         DDTRACE_G(curl_multi_injecting_spans) = NULL;
     }

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -161,6 +161,9 @@ void ddtrace_integrations_minit(void) {
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_exec",
                                            "DDTrace\\Integrations\\Curl\\CurlIntegration");
 
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_multi_exec",
+                                           "DDTrace\\Integrations\\Curl\\CurlIntegration");
+
     DD_SET_UP_DEFERRED_LOADING_BY_METHOD(DDTRACE_INTEGRATION_DRUPAL, "Drupal\\Core\\DrupalKernel", "__construct",
                                          "DDTrace\\Integrations\\Drupal\\DrupalIntegration");
 

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -160,7 +160,6 @@ void ddtrace_integrations_minit(void) {
 
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_exec",
                                            "DDTrace\\Integrations\\Curl\\CurlIntegration");
-
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_multi_exec",
                                            "DDTrace\\Integrations\\Curl\\CurlIntegration");
 

--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -2,12 +2,14 @@
 
 namespace DDTrace\Integrations\Curl;
 
+use DDTrace\HookData;
 use DDTrace\Http\Urls;
 use DDTrace\Integrations\HttpClientIntegrationHelper;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
+use DDTrace\Util\ObjectKVStore;
 
 /**
  * @param \DDTrace\SpanData $span
@@ -48,13 +50,7 @@ final class CurlIntegration extends Integration
             // the ddtrace extension will handle distributed headers
             'instrument_when_limited' => 0,
             'posthook' => function (SpanData $span, $args, $retval) use ($integration) {
-                $span->name = $span->resource = 'curl_exec';
-                $span->type = Type::HTTP_CLIENT;
-                $span->service = 'curl';
-                Integration::handleInternalSpanServiceName($span, CurlIntegration::NAME);
-                $integration->addTraceAnalyticsIfEnabled($span);
-                $span->meta[Tag::COMPONENT] = CurlIntegration::NAME;
-                $span->meta[Tag::SPAN_KIND] = Tag::SPAN_KIND_VALUE_CLIENT;
+                $integration->setup_curl_span($span);
 
                 if (!isset($args[0])) {
                     return;
@@ -69,55 +65,153 @@ final class CurlIntegration extends Integration
                     }
                 }
 
-                $info = \curl_getinfo($ch);
-                $sanitizedUrl = \DDTrace\Util\Normalizer::urlSanitize($info['url']);
-                $normalizedPath = \DDTrace\Util\Normalizer::uriNormalizeOutgoingPath($info['url']);
-                $host = Urls::hostname($sanitizedUrl);
-                $span->meta[Tag::NETWORK_DESTINATION_NAME] = $host;
-                unset($info['url']);
-
-                if (\DDTrace\Util\Runtime::getBoolIni("datadog.trace.http_client_split_by_domain")) {
-                    $span->service = Urls::hostnameForTag($sanitizedUrl);
-                }
-
-                $span->resource = $normalizedPath;
-
-                /* Special case the Datadog Standard Attributes
-                 * See https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
-                 */
-                if (!array_key_exists(Tag::HTTP_URL, $span->meta)) {
-                    $span->meta[Tag::HTTP_URL] = $sanitizedUrl;
-                }
-
-                if (\PHP_MAJOR_VERSION > 5) {
-                    $span->peerServiceSources = HttpClientIntegrationHelper::PEER_SERVICE_SOURCES;
-                }
-
-                addSpanDataTagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
-
-                addSpanDataTagFromCurlInfo($span, $info, 'network.client.ip', 'local_ip');
-                addSpanDataTagFromCurlInfo($span, $info, 'network.client.port', 'local_port');
-
-                addSpanDataTagFromCurlInfo($span, $info, 'network.destination.ip', 'primary_ip');
-                addSpanDataTagFromCurlInfo($span, $info, 'network.destination.port', 'primary_port');
-
-                addSpanDataTagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
-                addSpanDataTagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
-
-                // Add the rest to a 'curl.' object
-                foreach ($info as $key => $val) {
-                    // Datadog doesn't support arrays in tags
-                    if (\is_scalar($val) && $val !== '') {
-                        // Datadog sets durations in nanoseconds - convert from seconds
-                        if (\substr_compare($key, '_time', -5) === 0) {
-                            $val *= 1000000000;
-                        }
-                        $span->meta["curl.{$key}"] = $val;
-                    }
-                }
+                CurlIntegration::set_curl_attributes($span, \curl_getinfo($ch));
             },
         ]);
 
+        if (\PHP_MAJOR_VERSION > 5) {
+            $lastMh = [0, null];
+            \DDTrace\install_hook('curl_multi_exec', function (HookData $hook) use ($integration, &$lastMh) {
+                if (\count($hook->args) >= 2) {
+                    $data = null;
+                    if (\PHP_MAJOR_VERSION > 7) {
+                        $data = ObjectKVStore::get($hook->args[0], "span");
+                    } elseif ($lastMh[0] == (int)$hook->args[0]) {
+                        $data = $lastMh[1];
+                        $lastMh = [0, null];
+                    }
+                    if ($data) {
+                        $hook->data = $data;
+                        return;
+                    }
+                }
+
+                $span = $hook->span();
+                if (\count($hook->args) >= 2) {
+                    \DDTrace\curl_multi_exec_get_request_spans($spans);
+                    $hook->data = [$span, &$spans, true];
+                    ObjectKVStore::put($hook->args[0], "span", [$span, &$spans]);
+                }
+
+                $span->name = 'curl_multi_exec';
+                $span->resource = 'curl_multi_exec';
+                $span->service = "curl";
+                $span->type = Type::HTTP_CLIENT;
+                Integration::handleInternalSpanServiceName($span, CurlIntegration::NAME);
+                $span->meta[Tag::COMPONENT] = CurlIntegration::NAME;
+                $span->peerServiceSources = HttpClientIntegrationHelper::PEER_SERVICE_SOURCES;
+            }, function (HookData $hook) use ($integration, &$lastMh) {
+                if (empty($hook->data)) {
+                    return;
+                }
+
+                $span = $hook->data[0];
+                $spans = &$hook->data[1];
+                if ($spans && $spans[0][1]->name != "curl_exec") {
+                    foreach ($spans as $requestSpan) {
+                        list(, $requestSpan) = $requestSpan;
+                        $integration->setup_curl_span($requestSpan);
+                    }
+                }
+
+                if ($hook->args[1]) {
+                    // not finished
+                    if (\PHP_MAJOR_VERSION == 7) {
+                        $lastMh = [(int)$hook->args[0], [$span, &$spans]];
+                    }
+                } else {
+                    // finished
+                    if (\PHP_MAJOR_VERSION == 8) {
+                        ObjectKVStore::put($hook->args[0], "span", null);
+                    }
+
+                    foreach ($spans as $requestSpan) {
+                        list($ch, $requestSpan) = $requestSpan;
+                        $info = curl_getinfo($ch);
+                        if ($info["connect_time"] <= 0) {
+                            if (!isset($error_trace)) {
+                                $error_trace = \DDTrace\get_sanitized_exception_trace(new \Exception());
+                            }
+                            // TODO: possible future improvement:
+                            // fetching the error message from future curl_multi_info_read() calls
+                            $requestSpan->meta[Tag::ERROR_MSG] = "CURL request failure";
+                            $requestSpan->meta[Tag::ERROR_TYPE] = 'curl error';
+                            $requestSpan->meta[Tag::ERROR_STACK] = $error_trace;
+                        }
+                        CurlIntegration::set_curl_attributes($requestSpan, $info);
+                        if (isset($info["total_time"])) {
+                            $endTime = $info["total_time"] + $requestSpan->getStartTime() / 1e9;
+                            \DDTrace\update_span_duration($requestSpan, $endTime);
+                        }
+                    }
+                }
+
+                if (!isset($hook->data[2])) {
+                    \DDTrace\update_span_duration($span);
+                }
+            });
+        }
+
         return Integration::LOADED;
+    }
+
+    public function setup_curl_span($span) {
+        $span->name = $span->resource = 'curl_exec';
+        $span->type = Type::HTTP_CLIENT;
+        $span->service = 'curl';
+        Integration::handleInternalSpanServiceName($span, CurlIntegration::NAME);
+        $this->addTraceAnalyticsIfEnabled($span);
+        $span->meta[Tag::COMPONENT] = CurlIntegration::NAME;
+        $span->meta[Tag::SPAN_KIND] = Tag::SPAN_KIND_VALUE_CLIENT;
+    }
+
+    public static function set_curl_attributes($span, $info) {
+        $sanitizedUrl = \DDTrace\Util\Normalizer::urlSanitize($info['url']);
+        $normalizedPath = \DDTrace\Util\Normalizer::uriNormalizeOutgoingPath($info['url']);
+        $host = Urls::hostname($sanitizedUrl);
+        $span->meta[Tag::NETWORK_DESTINATION_NAME] = $host;
+        unset($info['url']);
+
+        if (\DDTrace\Util\Runtime::getBoolIni("datadog.trace.http_client_split_by_domain")) {
+            $span->service = Urls::hostnameForTag($sanitizedUrl);
+        }
+
+        $span->resource = $normalizedPath;
+
+        /* Special case the Datadog Standard Attributes
+         * See https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
+         */
+        if (!array_key_exists(Tag::HTTP_URL, $span->meta)) {
+            $span->meta[Tag::HTTP_URL] = $sanitizedUrl;
+        }
+
+        if (\PHP_MAJOR_VERSION > 5) {
+            $span->peerServiceSources = HttpClientIntegrationHelper::PEER_SERVICE_SOURCES;
+        }
+
+        addSpanDataTagFromCurlInfo($span, $info, Tag::HTTP_STATUS_CODE, 'http_code');
+
+        addSpanDataTagFromCurlInfo($span, $info, 'network.client.ip', 'local_ip');
+        addSpanDataTagFromCurlInfo($span, $info, 'network.client.port', 'local_port');
+
+        addSpanDataTagFromCurlInfo($span, $info, 'network.destination.ip', 'primary_ip');
+        addSpanDataTagFromCurlInfo($span, $info, 'network.destination.port', 'primary_port');
+
+        addSpanDataTagFromCurlInfo($span, $info, 'network.bytes_read', 'size_download');
+        addSpanDataTagFromCurlInfo($span, $info, 'network.bytes_written', 'size_upload');
+
+        // Add the rest to a 'curl.' object
+        foreach ($info as $key => $val) {
+            // Datadog doesn't support arrays in tags
+            if (\is_scalar($val) && $val !== '') {
+                // Datadog sets durations in nanoseconds - convert from seconds
+                if (\substr_compare($key, '_time', -5) === 0) {
+                    $val *= 1000000000;
+                }
+                $span->meta["curl.{$key}"] = $val;
+            }
+        }
+
+        return $info;
     }
 }

--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -109,6 +109,15 @@ final class CurlIntegration extends Integration
 
                 $span = $hook->data[0];
                 $spans = &$hook->data[1];
+
+                if (!$spans) {
+                    // Drop the span if nothing was handled here
+                    if (\PHP_MAJOR_VERSION == 8) {
+                        ObjectKVStore::put($hook->args[0], "span", null);
+                    }
+                    return false;
+                }
+
                 if ($spans && $spans[0][1]->name != "curl_exec") {
                     foreach ($spans as $requestSpan) {
                         list(, $requestSpan) = $requestSpan;

--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -137,7 +137,9 @@ final class CurlIntegration extends Integration
                             if (!isset($error_trace)) {
                                 $error_trace = \DDTrace\get_sanitized_exception_trace(new \Exception(), 1);
                             }
-                            $requestSpan->meta[Tag::ERROR_MSG] = "CURL request failure";
+                            if (!isset($requestSpan->meta[Tag::ERROR_MSG])) {
+                                $requestSpan->meta[Tag::ERROR_MSG] = "CURL request failure";
+                            }
                             $requestSpan->meta[Tag::ERROR_TYPE] = 'curl error';
                             $requestSpan->meta[Tag::ERROR_STACK] = $error_trace;
                         }

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -561,6 +561,64 @@ final class CurlIntegrationTest extends IntegrationTestCase
         });
     }
 
+    public function testMulti()
+    {
+        $traces = $this->isolateTracer(function () {
+            $ch1 = curl_init(self::URL . '/status/200');
+            curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+            $ch2 = curl_init(self::URL_NOT_EXISTS);
+            curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+
+            $mh = curl_multi_init();
+            curl_multi_add_handle($mh, $ch1);
+            curl_multi_add_handle($mh, $ch2);
+
+            do {
+                $status = curl_multi_exec($mh, $active);
+                if ($active) {
+                    curl_multi_select($mh);
+                }
+            } while ($active && $status == CURLM_OK);
+
+            $response = curl_multi_getcontent($ch1);
+            $this->assertSame('', $response);
+            $response = curl_multi_getcontent($ch2);
+            $this->assertSame('', $response);
+            curl_multi_close($mh);
+        });
+
+        $this->assertFlameGraph($traces, [
+            SpanAssertion::build('curl_multi_exec', 'curl', 'http', 'curl_multi_exec')
+                ->withExactTags([
+                    Tag::COMPONENT => 'curl',
+                ])->withChildren([
+                    SpanAssertion::build('curl_exec', 'curl', 'http', 'http://httpbin_integration/status/?')
+                        ->setTraceAnalyticsCandidate()
+                        ->withExactTags([
+                            'http.url' => self::URL . '/status/200',
+                            'http.status_code' => '200',
+                            'span.kind' => 'client',
+                            'network.destination.name' => 'httpbin_integration',
+                            Tag::COMPONENT => 'curl',
+                        ])
+                        ->withExistingTagsNames(self::commonCurlInfoTags())
+                        ->skipTagsLike('/^curl\..*/'),
+                    SpanAssertion::build('curl_exec', 'curl', 'http', 'http://__i_am_not_real__.invalid/')
+                        ->setTraceAnalyticsCandidate()
+                        ->withExactTags([
+                            'http.url' => 'http://__i_am_not_real__.invalid/',
+                            'http.status_code' => '0',
+                            'span.kind' => 'client',
+                            'network.destination.name' => '__i_am_not_real__.invalid',
+                            Tag::COMPONENT => 'curl',
+                        ])
+                        ->withExistingTagsNames(self::commonCurlInfoTags())
+                        ->skipTagsLike('/^curl\..*/')
+                        ->setError('curl error', 'CURL request failure', true),
+                ]),
+        ]);
+    }
+
     /**
      * @dataProvider dataProviderTestTraceAnalytics
      */

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -578,6 +578,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 if ($active) {
                     curl_multi_select($mh);
                 }
+                while (false !== curl_multi_info_read($mh));
             } while ($active && $status == CURLM_OK);
 
             $response = curl_multi_getcontent($ch1);
@@ -614,7 +615,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                         ])
                         ->withExistingTagsNames(self::commonCurlInfoTags())
                         ->skipTagsLike('/^curl\..*/')
-                        ->setError('curl error', 'CURL request failure', true),
+                        ->setError('curl error', "Couldn't resolve host name", true),
                 ]),
         ]);
     }

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -256,8 +256,8 @@ class GuzzleIntegrationTest extends IntegrationTestCase
          * without an event loop.
          * @see https://github.com/guzzle/guzzle/issues/1439
          */
-        self::assertDistributedTracingSpan($traces[0][2], $headers1['headers']);
-        self::assertDistributedTracingSpan($traces[0][1], $headers2['headers']);
+        self::assertDistributedTracingSpan($traces[0][6], $headers1['headers']);
+        self::assertDistributedTracingSpan($traces[0][3], $headers2['headers']);
     }
 
     private static function assertDistributedTracingSpan($span, $headers)

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -242,7 +242,6 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             ])
         );
 
-        $index = 3;
         foreach ($found as $data) {
             /*
              * Ideally the distributed traces for curl multi would be children
@@ -253,11 +252,19 @@ class GuzzleIntegrationTest extends IntegrationTestCase
              * $curl->tick() is called.
              */
             $rootSpan = $traces[0][0];
-            $parentSpan = $traces[0][$index--];
-            self::assertSame(
-                $parentSpan['span_id'],
-                $data['headers']['X-Datadog-Parent-Id']
-            );
+            try {
+                $parentSpan = $traces[0][3];
+                self::assertSame(
+                    $parentSpan['span_id'],
+                    $data['headers']['X-Datadog-Parent-Id']
+                );
+            } catch (\Throwable $t) {
+                $parentSpan = $traces[0][2];
+                self::assertSame(
+                    $parentSpan['span_id'],
+                    $data['headers']['X-Datadog-Parent-Id']
+                );
+            }
             self::assertSame(
                 $rootSpan['trace_id'],
                 $data['headers']['X-Datadog-Trace-Id']

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -242,6 +242,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
             ])
         );
 
+        $index = 3;
         foreach ($found as $data) {
             /*
              * Ideally the distributed traces for curl multi would be children
@@ -252,8 +253,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
              * $curl->tick() is called.
              */
             $rootSpan = $traces[0][0];
+            $parentSpan = $traces[0][$index--];
             self::assertSame(
-                $rootSpan['span_id'],
+                $parentSpan['span_id'],
                 $data['headers']['X-Datadog-Parent-Id']
             );
             self::assertSame(

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -147,7 +147,8 @@ function runOneIteration()
     $functions = array_filter($ext->getFunctions(), function ($f) {
         return $f->name != "dd_trace_internal_fn"
             && !strpos($f->name, "Testing")
-            && $f->name != "dd_trace_disable_in_request";
+            && $f->name != "dd_trace_disable_in_request"
+            && (PHP_VERSION_ID >= 70100 || $f->name != 'DDTrace\curl_multi_exec_get_request_spans');
     });
 
     $props = array_filter(

--- a/zend_abstract_interface/exceptions/exceptions.h
+++ b/zend_abstract_interface/exceptions/exceptions.h
@@ -53,5 +53,7 @@ static inline zval *zai_exception_read_property(zend_object *object, zend_string
 zend_string *zai_exception_message(zend_object *ex);  // fallback string if message invalid
 zend_string *zai_get_trace_without_args(zend_array *trace);
 zend_string *zai_get_trace_without_args_from_exception(zend_object *ex);
+zend_string *zai_get_trace_without_args_skip_frames(zend_array *trace, int skip);
+zend_string *zai_get_trace_without_args_from_exception_skip_frames(zend_object *ex, int skip);
 
 #endif  // ZAI_EXCEPTIONS_H


### PR DESCRIPTION
### Description

Fixes the long-standing issue #1156.

This works by creating a parent curl_multi_exec() span, and then creating a span for every single attached request.
When the second arg of curl_multi_request() (i.e. `$still_running`) returns 0, we assume everything is finished and we add data to the request spans.

Doing this needs some support from internal code (`DDTrace\curl_multi_exec_get_request_spans()`) to grab all the CurlHandle instances as well as an associated span started at the right time.

I think it's not fool-proof (it shouldn't throw or crash ever though, just possibly show too short spans / missing some info), but it should work with common patterns of curl_multi usage.

It should provide the insight of tracking individual requests, however it's not possible (currently) to get a proper error message, as this would require a call to `curl_multi_info_read()` which is externally observable.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
