### PR TITLE
Handle extra arguments for internal overrideArgs

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -280,6 +280,8 @@ static zend_always_inline void zend_array_release(zend_array *array)
         }
     }
 }
+
+#define ZEND_ARG_SEND_MODE(arg_info) (arg_info)->pass_by_reference
 #endif
 
 #if PHP_VERSION_ID < 80100

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -273,7 +273,7 @@ class PDOIntegration extends Integration
         return $tags;
     }
 
-    private static function injectDBIntegration($pdo, $hook)
+    public static function injectDBIntegration($pdo, $hook)
     {
         $driver = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
         if ($driver === "odbc") {

--- a/tests/ext/sandbox/install_hook/replace_hook_args_internal.phpt
+++ b/tests/ext/sandbox/install_hook/replace_hook_args_internal.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Adding additional function arguments on internal functions via install_hook()
+--FILE--
+<?php
+
+$hook = DDTrace\install_hook("preg_replace_callback_array", function($hook) {
+    $args = $hook->args;
+    $args[] = 2;
+    $args[] = null;
+    $hook->overrideArguments($args);
+});
+
+var_dump(preg_replace_callback_array(["((a))" => function () { var_dump(func_get_args()); }], "ababab"));
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(1) "a"
+    [1]=>
+    string(1) "a"
+  }
+}
+array(1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(1) "a"
+    [1]=>
+    string(1) "a"
+  }
+}
+string(4) "bbab"

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -862,6 +862,11 @@ zai_hook_continued zai_hook_continue(zend_execute_data *ex, zai_hook_memory_t *m
         return ZAI_HOOK_SKIP;
     }
 
+    // Ensure there's a bit of space in case arguments are going to be overridden.
+    if (!ZEND_USER_CODE(ex->func->type) && ZEND_CALL_NUM_ARGS(ex) < ex->func->common.num_args) {
+        EG(vm_stack_top) = MIN(EG(vm_stack_end), EG(vm_stack_top) + ex->func->common.num_args - ZEND_CALL_NUM_ARGS(ex));
+    }
+
     size_t hook_info_size = allocated_hook_count * sizeof(zai_hook_info);
     size_t dynamic_size = hooks->dynamic + hook_info_size;
     // a vector of first N hook_info entries, then N entries of variable size (as much memory as the individual hooks require)

--- a/zend_abstract_interface/symbols/call.c
+++ b/zend_abstract_interface/symbols/call.c
@@ -75,6 +75,16 @@ static zend_execute_data *zai_set_observed_frame(zend_execute_data *execute_data
 }
 #endif
 
+static inline int zai_symbol_try_call(zend_fcall_info *fci, zend_fcall_info_cache *fcc) {
+    volatile int ret;
+    zend_try {
+        ret = zend_call_function(fci, fcc);
+    } zend_catch {
+        ret = 2;
+    } zend_end_try();
+    return ret;
+}
+
 /* {{{ private call code */
 bool zai_symbol_call_impl(
     // clang-format off
@@ -172,11 +182,11 @@ bool zai_symbol_call_impl(
     }
 
     // clang-format off
-    volatile int  zai_symbol_call_result    = FAILURE;
-    volatile bool zai_symbol_call_bailed    = false;
-    volatile bool rebound_closure = false;
-    volatile zval new_closure;
-    zend_op_array *volatile op_array;
+    int  zai_symbol_call_result    = FAILURE;
+    bool zai_symbol_call_bailed    = false;
+    bool rebound_closure = false;
+    zval new_closure;
+    zend_op_array *op_array;
 
     if (function_type == ZAI_SYMBOL_FUNCTION_CLOSURE && fcc.called_scope) {
         zend_class_entry *closure_called_scope;
@@ -216,7 +226,7 @@ bool zai_symbol_call_impl(
 #if PHP_VERSION_ID >= 70400
                 op_array->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
 #if PHP_VERSION_ID >= 80200
-                void *ptr = emalloc(op_array->cache_size);
+                void *ptr = emalloc((size_t)op_array->cache_size);
                 ZEND_MAP_PTR_INIT(op_array->run_time_cache, ptr);
 #else
                 void *ptr = emalloc(op_array->cache_size + sizeof(void *));
@@ -255,18 +265,12 @@ bool zai_symbol_call_impl(
     zend_execute_data *prev_observed = zai_set_observed_frame(NULL);
 #endif
 
-    zend_try {
-        zai_symbol_call_result =
-            zend_call_function(&fci, &fcc);
-    } zend_catch {
-        zai_symbol_call_bailed = true;
-    } zend_end_try();
+    zai_symbol_call_result = zai_symbol_try_call(&fci, &fcc);
+    zai_symbol_call_bailed = zai_symbol_call_result == 2;
     // clang-format on
 
-    if (argc) {
-        for (uint32_t arg = 0; arg < argc; arg++) {
-            zval_ptr_dtor(&fci.params[arg]);
-        }
+    for (uint32_t arg = 0; arg < argc; arg++) {
+        zval_ptr_dtor(&fci.params[arg]);
     }
 
     if (zai_symbol_call_bailed) {


### PR DESCRIPTION
### Description

This fixes:
- overrideArguments usage when changing a by-ref parameter
- overrideArguments usage when optional arguments to internal functions are being set
- properly handles freeing of garbage in overrideArguments for internal functions on PHP 8 when more arguments are provided than initially set.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
