### PR TITLE
perf(profiling): increase allocation sampling distance

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -33,8 +33,8 @@ pub fn allocation_profiling_minit() {
     unsafe { zend::ddog_php_opcache_init_handle() };
 }
 
-/// take a sample every 2048 KB
-pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 2048.0;
+/// take a sample every 4096 KiB
+pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 4096.0;
 
 pub struct AllocationProfilingStats {
     /// number of bytes until next sample collection

--- a/profiling/tests/correctness/allocations.json
+++ b/profiling/tests/correctness/allocations.json
@@ -8,13 +8,13 @@
           {
             "regular_expression":"<?php;main;a;standard\\|str_repeat$",
             "percent": 66,
-            "value": 121999579,
+            "value": 1188800320,
             "error_margin": 5
           },
           {
             "regular_expression":"<?php;main;b;standard\\|str_repeat$",
             "percent": 33,
-            "value": 64258130,
+            "value": 584400587,
             "error_margin": 5
           }
         ]

--- a/profiling/tests/correctness/allocations.php
+++ b/profiling/tests/correctness/allocations.php
@@ -2,12 +2,12 @@
 
 function a()
 {
-    str_repeat("a", 1024 * 12000);
+    str_repeat("a", 1024 * 120_000);
 }
 
 function b()
 {
-    str_repeat("a", 1024 * 6000);
+    str_repeat("a", 1024 * 60_000);
 }
 
 function main()
@@ -23,7 +23,7 @@ function main()
         // so we end up doing 10 iterations per second
         $sleep = (0.1 - $elapsed);
         if ($sleep > 0.0) {
-            usleep($sleep * 1_000_000);
+            usleep((int) ($sleep * 1_000_000));
         }
     }
 }


### PR DESCRIPTION
### Description

This causes fewer stack walks due to allocation profiling.

A customer recently complained about performance overhead, and in their case, the allocation profile was more than twice as expensive as the wall-time/cpu-time profiles.

I did some testing with the symfony-demo application as well, and also came up with ~2x cost. So... doubling this number brings allocation profiling costs roughly in line with wall-time/cpu-time, at least for a few recent tests (overhead can vary substantially based on the test).

Part of PROF-8596.


### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
