### PR TITLE
Enable 128-bit trace ID generation by default

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -136,7 +136,7 @@ enum ddtrace_dbm_propagation_mode {
     CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                    \
     CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
     CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \
-    CONFIG(BOOL, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED, "false")                                         \
+    CONFIG(BOOL, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED, "true")                                         \
     CONFIG(BOOL, DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED, "false")                                                                                                           \
     CONFIG(INT, DD_TRACE_AGENT_MAX_CONSECUTIVE_FAILURES,                                                       \
            DD_CFG_EXPSTR(DD_TRACE_CIRCUIT_BREAKER_DEFAULT_MAX_CONSECUTIVE_FAILURES))                           \

--- a/tests/Common/SnapshotTestTrait.php
+++ b/tests/Common/SnapshotTestTrait.php
@@ -115,7 +115,7 @@ trait SnapshotTestTrait
      */
     private function stopAndCompareSnapshotSession(
         string $token,
-        array $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack'],
+        array $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid'],
         int $numExpectedTraces = 1
     ) {
         $this->waitForTraces($token, $numExpectedTraces);
@@ -136,7 +136,7 @@ trait SnapshotTestTrait
 
     public function tracesFromWebRequestSnapshot(
         $fn,
-        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack'],
+        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid'],
         $numExpectedTraces = 1,
         $tracer = null
     ) {

--- a/tests/Composer/ComposerInteroperabilityTest.php
+++ b/tests/Composer/ComposerInteroperabilityTest.php
@@ -96,6 +96,9 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -130,6 +133,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/manual-tracing',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
                 ->withChildren([
                     SpanAssertion::build('my_operation', 'web.request', 'memcached', 'my_resource')
@@ -170,6 +175,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/manual-tracing',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
                 ->withChildren([
                     SpanAssertion::build('my_operation', 'web.request', 'memcached', 'my_resource')
@@ -210,6 +217,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -244,6 +253,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/manual-tracing',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
                 ->withChildren([
                     SpanAssertion::build('my_operation', 'web.request', 'memcached', 'my_resource')
@@ -278,6 +289,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-manual-tracing',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -306,6 +319,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-composer',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -339,6 +354,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-composer',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -374,6 +391,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/no-composer-autoload-fails',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -409,6 +428,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://127.0.0.1:6666/composer-autoload-fails',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }

--- a/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
+++ b/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
@@ -16,7 +16,7 @@ final class CurrentContextAccessTest extends IntegrationTestCase
             __DIR__ . '/web.php',
             [
                 'DD_SERVICE' => 'top_level_app',
-                'DD_TRACE_NO_AUTOLOADER' => true,
+                'DD_TRACE_NO_AUTOLOADER' => true
             ]
         );
 
@@ -25,6 +25,8 @@ final class CurrentContextAccessTest extends IntegrationTestCase
 
         $traceId = $trace[0]['trace_id'];
         $this->assertNotEquals(0, $traceId);
+
+        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
 
         foreach ($trace as $span) {
             $spanId = $span['span_id'];
@@ -40,6 +42,7 @@ final class CurrentContextAccessTest extends IntegrationTestCase
         list($traces) = $this->inCli(__DIR__ . '/short-running.php', ['DD_TRACE_GENERATE_ROOT_SPAN' => 'true']);
 
         $trace = $traces[0];
+        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
         $this->assertCount(2, $trace);
 
         $traceId = $trace[0]['trace_id'];
@@ -75,6 +78,8 @@ final class CurrentContextAccessTest extends IntegrationTestCase
         $this->assertNotEquals(0, $traceId);
         $this->assertSame('root_span', $trace[0]['name']);
         $this->assertSame('internal_span', $trace[1]['name']);
+
+        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
 
         foreach ($trace as $span) {
             $spanId = $span['span_id'];

--- a/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
+++ b/tests/Integration/CurrentContextAccess/CurrentContextAccessTest.php
@@ -7,6 +7,36 @@ use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
 
 final class CurrentContextAccessTest extends IntegrationTestCase
 {
+    // Source: https://magp.ie/2015/09/30/convert-large-integer-to-hexadecimal-without-php-math-extension/
+    public function largeBaseConvert($numString, $fromBase, $toBase)
+    {
+        $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        $toString = substr($chars, 0, $toBase);
+
+        $length = strlen($numString);
+        $result = '';
+        for ($i = 0; $i < $length; $i++) {
+            $number[$i] = strpos($chars, $numString[$i]);
+        }
+        do {
+            $divide = 0;
+            $newLen = 0;
+            for ($i = 0; $i < $length; $i++) {
+                $divide = $divide * $fromBase + $number[$i];
+                if ($divide >= $toBase) {
+                    $number[$newLen++] = (int)($divide / $toBase);
+                    $divide = $divide % $toBase;
+                } elseif ($newLen > 0) {
+                    $number[$newLen++] = 0;
+                }
+            }
+            $length = $newLen;
+            $result = $toString[$divide] . $result;
+        } while ($newLen != 0);
+
+        return $result;
+    }
+
     public function testInWebRequest()
     {
         $traces = $this->inWebServer(
@@ -24,16 +54,17 @@ final class CurrentContextAccessTest extends IntegrationTestCase
         $this->assertCount(2, $trace);
 
         $traceId = $trace[0]['trace_id'];
+        $tid = $trace[0]['meta']['_dd.p.tid'];
         $this->assertNotEquals(0, $traceId);
 
-        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
+        $traceIdHex = self::largeBaseConvert($traceId, 10, 16);
 
         foreach ($trace as $span) {
             $spanId = $span['span_id'];
             $this->assertNotEquals(0, $spanId);
             $this->assertSame($traceId, $span['trace_id']);
             $this->assertSame($spanId, $span['meta']['extracted_span_id']);
-            $this->assertSame($traceId, $span['meta']['extracted_trace_id']);
+            $this->assertSame($tid . $traceIdHex, $span['meta']['extracted_trace_id']);
         }
     }
 
@@ -42,7 +73,6 @@ final class CurrentContextAccessTest extends IntegrationTestCase
         list($traces) = $this->inCli(__DIR__ . '/short-running.php', ['DD_TRACE_GENERATE_ROOT_SPAN' => 'true']);
 
         $trace = $traces[0];
-        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
         $this->assertCount(2, $trace);
 
         $traceId = $trace[0]['trace_id'];
@@ -78,8 +108,6 @@ final class CurrentContextAccessTest extends IntegrationTestCase
         $this->assertNotEquals(0, $traceId);
         $this->assertSame('root_span', $trace[0]['name']);
         $this->assertSame('internal_span', $trace[1]['name']);
-
-        fwrite(STDERR, json_encode($trace, JSON_PRETTY_PRINT) . PHP_EOL);
 
         foreach ($trace as $span) {
             $spanId = $span['span_id'];

--- a/tests/Integration/CurrentContextAccess/long-running.php
+++ b/tests/Integration/CurrentContextAccess/long-running.php
@@ -8,7 +8,7 @@ use DDTrace\Type;
     $span->service = 'some_service';
     $span->type = Type::CLI;
 
-    $span->meta['extracted_trace_id'] = \DDTrace\trace_id();
+    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->id;
     $span->meta['extracted_span_id'] = \DDTrace\active_span()->id;
 });
 
@@ -16,7 +16,7 @@ use DDTrace\Type;
     $span->service = 'some_service';
     $span->type = Type::CLI;
 
-    $span->meta['extracted_trace_id'] = \DDTrace\trace_id();
+    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->id;
     $span->meta['extracted_span_id'] = \DDTrace\active_span()->id;
 });
 

--- a/tests/Integration/CurrentContextAccess/short-running.php
+++ b/tests/Integration/CurrentContextAccess/short-running.php
@@ -8,7 +8,7 @@ use DDTrace\Type;
     $span->service = 'some_service';
     $span->type = Type::CLI;
 
-    $span->meta['extracted_trace_id'] = \DDTrace\trace_id();
+    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->id;
     $span->meta['extracted_span_id'] = \DDTrace\active_span()->id;
 });
 
@@ -20,7 +20,7 @@ function internal_span()
 // Root span
 $tracer = GlobalTracer::get();
 $root = $tracer->getActiveSpan();
-$root->setTag('extracted_trace_id', \DDTrace\trace_id());
+$root->setTag('extracted_trace_id', \DDTrace\root_span()->id);
 $root->setTag('extracted_span_id', \DDTrace\active_span()->id);
 
 internal_span();

--- a/tests/Integration/CurrentContextAccess/web.php
+++ b/tests/Integration/CurrentContextAccess/web.php
@@ -8,7 +8,7 @@ use DDTrace\Type;
     $span->service = 'some_service';
     $span->type = Type::CLI;
 
-    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->id;
+    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->traceId;
     $span->meta['extracted_span_id'] = \DDTrace\active_span()->id;
 });
 
@@ -20,7 +20,7 @@ function internal_span()
 // Root span
 $tracer = GlobalTracer::get();
 $root = $tracer->getActiveSpan();
-$root->setTag('extracted_trace_id', \DDTrace\root_span()->id);
+$root->setTag('extracted_trace_id', \DDTrace\root_span()->traceId);
 $root->setTag('extracted_span_id', \DDTrace\active_span()->id);
 
 internal_span();

--- a/tests/Integration/CurrentContextAccess/web.php
+++ b/tests/Integration/CurrentContextAccess/web.php
@@ -8,7 +8,7 @@ use DDTrace\Type;
     $span->service = 'some_service';
     $span->type = Type::CLI;
 
-    $span->meta['extracted_trace_id'] = \DDTrace\trace_id();
+    $span->meta['extracted_trace_id'] = \DDTrace\root_span()->id;
     $span->meta['extracted_span_id'] = \DDTrace\active_span()->id;
 });
 
@@ -20,7 +20,7 @@ function internal_span()
 // Root span
 $tracer = GlobalTracer::get();
 $root = $tracer->getActiveSpan();
-$root->setTag('extracted_trace_id', \DDTrace\trace_id());
+$root->setTag('extracted_trace_id', \DDTrace\root_span()->id);
 $root->setTag('extracted_span_id', \DDTrace\active_span()->id);
 
 internal_span();

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -45,7 +45,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         }
 
         // phpcs:disable Generic.Files.LineLength.TooLong
-        $this->assertSame("/*dddbs='testdb',ddps='phpunit',traceparent='00-0000000000000000c151df7d6ee5e2d6-a3978fb9b92502a8-01'*/ SELECT 1", $commentedQuery);
+        $this->assertRegularExpression('/^\/\*dddbs=\'testdb\',ddps=\'phpunit\',traceparent=\'00-[0-9a-f]{16}c151df7d6ee5e2d6-a3978fb9b92502a8-01\'\*\/ SELECT 1$/', $commentedQuery);
         // phpcs:enable Generic.Files.LineLength.TooLong
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists("phpunit")->withChildren([
@@ -79,7 +79,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         }
 
         // phpcs:disable Generic.Files.LineLength.TooLong
-        $this->assertSame("/*dddbs='dbinstance',ddps='mapped-service',traceparent='00-0000000000000000c151df7d6ee5e2d6-a3978fb9b92502a8-01'*/ SELECT 1", $commentedQuery);
+        $this->assertRegularExpression('/^\/\*dddbs=\'dbinstance\',ddps=\'mapped-service\',traceparent=\'00-[0-9a-f]{16}c151df7d6ee5e2d6-a3978fb9b92502a8-01\'\*\/ SELECT 1$/', $commentedQuery);
         // phpcs:enable Generic.Files.LineLength.TooLong
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists("phpunit")->withChildren([

--- a/tests/Integration/ResponseStatusCodeTest.php
+++ b/tests/Integration/ResponseStatusCodeTest.php
@@ -39,7 +39,9 @@ class ResponseStatusCodeTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/success',
                     'http.status_code' => '200',
-                ]),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
             ]
         );
     }

--- a/tests/Integration/ResponseStatusCodeTest.php
+++ b/tests/Integration/ResponseStatusCodeTest.php
@@ -65,7 +65,9 @@ class ResponseStatusCodeTest extends WebFrameworkTestCase
                         'http.url'         => 'http://localhost:' . self::PORT . '/error',
                         'http.status_code' => '500',
                     ]
-                )->setError(),
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->setError(),
             ]
         );
     }

--- a/tests/Integrations/AMQP/AMQPTest.php
+++ b/tests/Integrations/AMQP/AMQPTest.php
@@ -47,6 +47,8 @@ final class AMQPTest extends IntegrationTestCase
                     Tag::MQ_DESTINATION_KIND        => 'queue',
                     Tag::MQ_PROTOCOL                => 'AMQP',
                     Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
             ]);
     }
@@ -94,6 +96,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -108,6 +112,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.consume',
@@ -124,7 +130,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_OPERATION               => 'receive',
                 Tag::MQ_DESTINATION             => 'hello',
             ])->withExistingTagsNames([
-                Tag::MQ_CONSUMER_ID
+                Tag::MQ_CONSUMER_ID,
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.basic.consume_ok',
@@ -153,6 +160,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -167,6 +176,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.publish',
@@ -184,6 +195,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_MESSAGE_PAYLOAD_SIZE    => 12,
                 Tag::MQ_OPERATION               => 'send',
                 Tag::RABBITMQ_EXCHANGE          => '<default>',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.basic.deliver',
@@ -203,7 +216,8 @@ final class AMQPTest extends IntegrationTestCase
                     Tag::RABBITMQ_EXCHANGE          => '<default>',
                 ])->withExistingTagsNames([
                     Tag::MQ_CONSUMER_ID,
-                    '_dd.span_links'
+                    '_dd.span_links',
+                    '_dd.p.tid'
                 ])
             ]),
             SpanAssertion::build(
@@ -224,7 +238,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::RABBITMQ_EXCHANGE          => '<default>',
             ])->withExistingTagsNames([
                 Tag::MQ_CONSUMER_ID,
-                '_dd.span_links'
+                '_dd.span_links',
+                '_dd.p.tid'
             ])
         ]);
 
@@ -288,6 +303,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.exchange.declare',
@@ -302,6 +319,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -316,6 +335,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => '<generated>',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.bind',
@@ -332,6 +353,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => '<generated>',
                 Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
                 Tag::RABBITMQ_ROUTING_KEY       => 'info',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.bind',
@@ -348,6 +371,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => '<generated>',
                 Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
                 Tag::RABBITMQ_ROUTING_KEY       => 'warning',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.bind',
@@ -364,6 +389,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => '<generated>',
                 Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
                 Tag::RABBITMQ_ROUTING_KEY       => 'error',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.consume',
@@ -380,7 +407,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => '<generated>',
                 Tag::MQ_OPERATION               => 'receive',
             ])->withExistingTagsNames([
-                Tag::MQ_CONSUMER_ID
+                Tag::MQ_CONSUMER_ID,
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.basic.consume_ok',
@@ -409,6 +437,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.exchange.declare',
@@ -423,13 +453,17 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::RABBITMQ_EXCHANGE          => 'direct_logs',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.publish',
                 'amqp',
                 'queue',
                 'basic.publish direct_logs -> error'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND                  => 'producer',
                 Tag::COMPONENT                  => 'amqp',
                 Tag::MQ_SYSTEM                  => 'rabbitmq',
@@ -459,7 +493,8 @@ final class AMQPTest extends IntegrationTestCase
                     Tag::MQ_OPERATION               => 'receive',
                 ])->withExistingTagsNames([
                     Tag::MQ_CONSUMER_ID,
-                    '_dd.span_links'
+                    '_dd.span_links',
+                    '_dd.p.tid'
                 ])
             ]),
             SpanAssertion::build(
@@ -480,7 +515,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_OPERATION               => 'receive',
             ])->withExistingTagsNames([
                 Tag::MQ_CONSUMER_ID,
-                '_dd.span_links'
+                '_dd.span_links',
+                '_dd.p.tid'
             ])
         ]);
 
@@ -519,6 +555,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -533,6 +571,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.consume',
@@ -549,7 +589,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => 'hello',
                 Tag::MQ_OPERATION               => 'receive',
             ])->withExistingTagsNames([
-                Tag::MQ_CONSUMER_ID
+                Tag::MQ_CONSUMER_ID,
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.basic.consume_ok',
@@ -574,6 +615,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.basic.cancel_ok',
@@ -624,6 +667,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -638,6 +683,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.publish',
@@ -659,7 +706,8 @@ final class AMQPTest extends IntegrationTestCase
                 'PhpAmqpLib\Exception\AMQPChannelClosedException',
                 'Channel connection is closed'
             )->withExistingTagsNames([
-                Tag::ERROR_STACK
+                Tag::ERROR_STACK,
+                '_dd.p.tid'
             ])
         ]);
     }
@@ -690,6 +738,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -704,6 +754,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'hello',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.reconnect',
@@ -717,6 +769,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion()
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'amqp.connect',
@@ -770,6 +824,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion()
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.declare',
@@ -784,6 +840,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::MQ_DESTINATION             => 'basic_get_queue'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.exchange.declare',
@@ -798,6 +856,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion(),
                 Tag::RABBITMQ_EXCHANGE          => 'basic_get_test'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.queue.bind',
@@ -814,6 +874,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION             => 'basic_get_queue',
                 Tag::RABBITMQ_EXCHANGE          => 'basic_get_test',
                 Tag::RABBITMQ_ROUTING_KEY       => '<all>'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.publish',
@@ -832,6 +894,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::RABBITMQ_ROUTING_KEY       => '<all>',
                 Tag::RABBITMQ_EXCHANGE          => 'basic_get_test',
                 Tag::RABBITMQ_DELIVERY_MODE     => '2'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.get',
@@ -852,7 +916,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::RABBITMQ_EXCHANGE          => 'basic_get_test',
                 Tag::RABBITMQ_DELIVERY_MODE     => '2'
             ])->withExistingTagsNames([
-                '_dd.span_links'
+                '_dd.span_links',
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 'amqp.basic.ack',
@@ -866,6 +931,8 @@ final class AMQPTest extends IntegrationTestCase
                 Tag::MQ_DESTINATION_KIND        => 'queue',
                 Tag::MQ_PROTOCOL                => 'AMQP',
                 Tag::MQ_PROTOCOL_VERSION        => AMQPChannel::getProtocolVersion()
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -33,6 +33,8 @@ class CommonScenariosTest extends CLITestCase
                 'cake_console'
             )->withExactTags([
                 Tag::COMPONENT => 'cakephp',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])
         ]);
     }
@@ -49,6 +51,8 @@ class CommonScenariosTest extends CLITestCase
                 'cake_console command_list'
             )->withExactTags([
                 Tag::COMPONENT => 'cakephp',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])
         ]);
     }

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -30,7 +30,9 @@ final class CommonScenariosTest extends CLITestCase
                 'console_test_app',
                 'cli',
                 'run'
-            )
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])
         ]);
     }
 }

--- a/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/NoRootSpanTest.php
@@ -41,6 +41,8 @@ final class NoRootSpanTest extends CLITestCase
                 'foo_resource'
             )->withExactTags([
                 'foo' => 'bar',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'mysqli_connect',

--- a/tests/Integrations/CLI/Laravel/V10_X/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V10_X/CommonScenariosTest.php
@@ -29,7 +29,8 @@ class CommonScenariosTest extends \DDTrace\Tests\Integrations\CLI\Laravel\V8_X\C
                 Tag::COMPONENT => 'laravel',
             ])->withExistingTagsNames([
                 Tag::ERROR_MSG,
-                'error.stack'
+                'error.stack',
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -33,6 +33,8 @@ class CommonScenariosTest extends CLITestCase
                 'artisan'
             )->withExactTags([
                 Tag::COMPONENT => 'laravel',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -71,6 +73,8 @@ class CommonScenariosTest extends CLITestCase
                 'artisan route:list'
             )->withExactTags([
                 Tag::COMPONENT => 'laravel',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -111,7 +115,8 @@ class CommonScenariosTest extends CLITestCase
                 Tag::COMPONENT => 'laravel',
             ])->withExistingTagsNames([
                 Tag::ERROR_MSG,
-                'error.stack'
+                'error.stack',
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',

--- a/tests/Integrations/CLI/Laravel/V8_X/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V8_X/CommonScenariosTest.php
@@ -40,6 +40,8 @@ class CommonScenariosTest extends CLITestCase
                 'artisan'
             )->withExactTags([
                 Tag::COMPONENT => 'laravel',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -78,6 +80,8 @@ class CommonScenariosTest extends CLITestCase
                 'artisan route:list'
             )->withExactTags([
                 Tag::COMPONENT => 'laravel',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -118,7 +122,8 @@ class CommonScenariosTest extends CLITestCase
                 Tag::COMPONENT => 'laravel',
             ])->withExistingTagsNames([
                 Tag::ERROR_MSG,
-                'error.stack'
+                'error.stack',
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',

--- a/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
@@ -29,7 +29,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
@@ -103,7 +103,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
@@ -29,7 +29,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
@@ -103,7 +103,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
@@ -29,7 +29,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
@@ -103,7 +103,9 @@ class CommonScenariosTest extends IntegrationTestCase
                     'console',
                     'cli',
                     'console'
-                )->withChildren([
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'symfony.console.terminate',
                         'symfony',

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -54,6 +54,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Controller.invokeAction',
@@ -79,6 +81,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Controller.invokeAction',
@@ -114,7 +118,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
                     ])->withExistingTagsNames([
-                        'error.stack'
+                        'error.stack',
+                        '_dd.p.tid'
                     ])->setError(
                         null,
                         'Foo error'

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -55,6 +55,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.endpoint' => 'Simple::index',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple.index',
@@ -79,6 +81,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.endpoint' => 'Simple_View::index',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple_View.index',
@@ -115,7 +119,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::COMPONENT => 'codeigniter',
                     ])
                     ->setError("Exception", "Uncaught Exception: datadog in %s:%d")
-                    ->withExistingTagsNames(['error.stack'])
+                    ->withExistingTagsNames(['error.stack', '_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::build(
                             'Error_.index',

--- a/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
@@ -43,6 +43,8 @@ class ExitTest extends WebFrameworkTestCase
                     'app.endpoint' => 'Exits::index',
                     Tag::SPAN_KIND => 'server',
                     Tag::COMPONENT => 'codeigniter',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::build(
                         'Exits.index',

--- a/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
@@ -42,6 +42,8 @@ class NoCIControllertTest extends WebFrameworkTestCase
                     Tag::HTTP_STATUS_CODE => '200',
                     Tag::SPAN_KIND => 'server',
                     Tag::COMPONENT => 'codeigniter',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::build(
                         'Health_check.ping',

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -54,6 +54,8 @@ final class CircuitBreakerTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/circuit_breaker',
                     'http.status_code' => '200',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             ]
         );

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -49,6 +49,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -61,6 +63,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -73,6 +77,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError(),
                 ],
             ]

--- a/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
+++ b/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
@@ -44,7 +44,7 @@ final class FatalErrorTest extends WebFrameworkTestCase
                     'http.status_code' => '200',
                 ])
                 ->setError("E_ERROR", "Intentional E_ERROR")
-                ->withExistingTagsNames(['error.stack']),
+                ->withExistingTagsNames(['error.stack', '_dd.p.tid']),
             ]
         );
     }

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -46,6 +46,8 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             ]
         );

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -56,7 +56,9 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
                     'my-service',
                     'web',
                     'GET /'
-                )->withExactTags($tags),
+                )->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withExactTags($tags),
             ]
         );
     }

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
@@ -46,6 +46,8 @@ final class HttpHeadersNotConfiguredTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             ]
         );

--- a/tests/Integrations/Custom/NotAutoloaded/IncomingUserInfoTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/IncomingUserInfoTest.php
@@ -37,6 +37,8 @@ final class IncomingUserInfoTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             ]
         );

--- a/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -530,15 +530,15 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Elasticsearch.Client.search', 'search index:my_index')
-                ->withChildren([
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::build(
                         'Elasticsearch.Endpoint.performRequest',
                         'elasticsearch',
                         'elasticsearch',
                         'performRequest'
-                    )->withExistingTagsNames([
-                        '_dd.p.tid'
-                    ])->withExactTags([
+                    )->withExactTags([
                         'elasticsearch.url' => '/my_index/_search',
                         'elasticsearch.method' => \PHP_VERSION_ID >= 70300 ? 'POST' : 'GET',
                         'elasticsearch.params' => '[]',

--- a/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V1/ElasticSearchIntegrationTest.php
@@ -67,7 +67,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 '__construct'
-            )->withExactTags([Tag::COMPONENT => 'elasticsearch'])
+            )->withExactTags([Tag::COMPONENT => 'elasticsearch'])->withExistingTagsNames([
+                '_dd.p.tid'
+            ])
         ]);
     }
 
@@ -84,7 +86,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'count'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -123,7 +127,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'delete index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -162,7 +168,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'exists index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -209,7 +217,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'explain index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -252,7 +262,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'get index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->setTraceAnalyticsCandidate()
@@ -287,7 +299,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'index index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -422,7 +436,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'scroll'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ]),
@@ -433,7 +449,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'scroll'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ]),
@@ -467,7 +485,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'search index:' . 'my_index'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->setTraceAnalyticsCandidate()
@@ -516,7 +536,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                         'elasticsearch',
                         'elasticsearch',
                         'performRequest'
-                    )->withExactTags([
+                    )->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])->withExactTags([
                         'elasticsearch.url' => '/my_index/_search',
                         'elasticsearch.method' => \PHP_VERSION_ID >= 70300 ? 'POST' : 'GET',
                         'elasticsearch.params' => '[]',
@@ -562,7 +584,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'update index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren(

--- a/tests/Integrations/Elasticsearch/V8/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V8/ElasticSearchIntegrationTest.php
@@ -68,6 +68,8 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 '__construct'
             )->withExactTags([
                 Tag::COMPONENT => 'elasticsearch'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -88,6 +90,8 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
             )->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('Elasticsearch.Endpoint.performRequest', 'performRequest')->withChildren([
                     SpanAssertion::exists('Psr\Http\Client\ClientInterface.sendRequest', 'sendRequest'),
@@ -124,6 +128,8 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
             )->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('Elasticsearch.Endpoint.performRequest', 'performRequest')->withChildren([
                     SpanAssertion::exists('Psr\Http\Client\ClientInterface.sendRequest', 'sendRequest'),
@@ -160,6 +166,8 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
             )->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('Elasticsearch.Endpoint.performRequest', 'performRequest')->withChildren([
                     SpanAssertion::exists('Psr\Http\Client\ClientInterface.sendRequest', 'sendRequest'),
@@ -200,7 +208,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'explain index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -237,7 +247,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'get index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->setTraceAnalyticsCandidate()
@@ -269,7 +281,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'index index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([
@@ -399,7 +413,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'scroll'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ]),
@@ -411,7 +427,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'scroll'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ]),
@@ -446,7 +464,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'search index:' . 'my_index'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->setTraceAnalyticsCandidate()
@@ -527,7 +547,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
                 'elasticsearch',
                 'elasticsearch',
                 'update index:my_index type:my_type'
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'elasticsearch'
             ])->withChildren([

--- a/tests/Integrations/Elasticsearch/V8/ElasticSearchIntegrationTest.php
+++ b/tests/Integrations/Elasticsearch/V8/ElasticSearchIntegrationTest.php
@@ -502,6 +502,9 @@ class ElasticSearchIntegrationTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Elasticsearch.Client.search', 'search index:my_index')
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
                 ->withChildren([
                     SpanAssertion::exists('Elastic.Transport.Serializer.JsonSerializer.serialize', 'Elastic.Transport.Serializer.JsonSerializer.serialize'),
                     SpanAssertion::build(

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -74,6 +74,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -107,6 +110,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -126,6 +132,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -146,6 +155,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -334,6 +346,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -355,6 +370,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -375,7 +393,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'top_level_app', 'web', 'GET /guzzle_in_web_request.php')
-                ->withExistingTagsNames(['http.method', 'http.url', 'http.status_code'])
+                ->withExistingTagsNames(['http.method', 'http.url', 'http.status_code', '_dd.p.tid'])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.send', 'guzzle', 'http', 'send')
                         ->setTraceAnalyticsCandidate()
@@ -415,6 +433,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                 Tag::COMPONENT => 'guzzle',
                 'peer.service' => 'example.com',
                 '_dd.peer.service.source' => 'network.destination.name',
+            ])
+            ->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -99,6 +99,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.transfer', 'guzzle', 'http', 'transfer')
                         ->setTraceAnalyticsCandidate()
@@ -129,6 +132,8 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -149,6 +154,8 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -299,6 +306,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -351,6 +361,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -372,6 +385,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -392,7 +408,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('web.request', 'top_level_app', 'web', 'GET /guzzle_in_web_request.php')
-                ->withExistingTagsNames(['http.method', 'http.url', 'http.status_code'])
+                ->withExistingTagsNames(['http.method', 'http.url', 'http.status_code', '_dd.p.tid'])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.send', 'guzzle', 'http', 'send')
                         ->setTraceAnalyticsCandidate()
@@ -434,6 +450,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle',
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.transfer', 'guzzle', 'http', 'transfer')
                         ->setTraceAnalyticsCandidate()
@@ -473,6 +492,9 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -66,6 +66,8 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'network.destination.name' => 'example.com',
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'guzzle'
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }

--- a/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
@@ -24,6 +24,9 @@ class GuzzleIntegrationTest extends \DDTrace\Tests\Integrations\Guzzle\V6\Guzzle
                     TAG::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'psr18'
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.transfer', 'guzzle', 'http', 'transfer')
                         ->setTraceAnalyticsCandidate()

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -55,6 +55,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             TAG::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'laravel',
                         ])
+                        ->withExistingTagsNames([
+                            '_dd.p.tid'
+                        ])
                         ->withChildren([
                             SpanAssertion::exists('laravel.application.handle')
                                 ->withChildren([
@@ -132,6 +135,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build('laravel.request', 'laravel', 'web', 'HomeController@error error')
+                        ->withExistingTagsNames([
+                            '_dd.p.tid'
+                        ])
                         ->withExactTags([
                             'laravel.route.name' => 'error',
                             'laravel.route.action' => 'HomeController@error',
@@ -180,6 +186,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 ],
                 'A GET request to a dynamic route returning a string' => [
                     SpanAssertion::build('laravel.request', 'laravel', 'web', 'HomeController@dynamicRoute unnamed_route')
+                        ->withExistingTagsNames([
+                            '_dd.p.tid'
+                        ])
                         ->withExactTags([
                             'laravel.route.name' => 'unnamed_route',
                             'laravel.route.action' => 'HomeController@dynamicRoute',

--- a/tests/Integrations/Laravel/V4/EloquentTest.php
+++ b/tests/Integrations/Laravel/V4/EloquentTest.php
@@ -39,6 +39,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -58,6 +60,8 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -76,6 +80,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -95,6 +101,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -114,6 +122,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V4/EloquentTest.php
+++ b/tests/Integrations/Laravel/V4/EloquentTest.php
@@ -39,8 +39,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -60,8 +58,6 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -80,8 +76,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -101,8 +95,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -122,8 +114,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
@@ -50,6 +50,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::exists('laravel.application.handle')
                             ->withChildren([

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple',
                         TAG::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'laravel',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple')
                         ->withExactTags([
@@ -97,6 +99,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple_view',
                         TAG::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'laravel',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                         ->withExactTags([
@@ -159,6 +163,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'error',
                         TAG::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'laravel',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists(
@@ -199,6 +205,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'dynamic_route/{param01}/static/{param02?}',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',

--- a/tests/Integrations/Laravel/V5_7/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_7/EloquentTest.php
@@ -39,6 +39,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -58,6 +60,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -77,6 +81,8 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -95,6 +101,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -114,6 +122,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -133,6 +143,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V5_7/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_7/EloquentTest.php
@@ -39,8 +39,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -60,8 +58,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -81,8 +77,6 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -101,8 +95,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -122,8 +114,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -143,8 +133,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             Tag::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
@@ -55,6 +55,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
                     ])
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists(

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',
@@ -101,6 +103,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple_view',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',
@@ -167,6 +171,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'error',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists('laravel.view.render')
@@ -216,6 +222,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'dynamic_route/{param01}/static/{param02?}',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',

--- a/tests/Integrations/Laravel/V5_8/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_8/EloquentTest.php
@@ -37,9 +37,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -58,9 +56,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -78,9 +74,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'select * from `users`'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             'sql.query' => 'select * from `users`',
             TAG::COMPONENT => 'eloquent',
@@ -99,9 +93,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -120,9 +112,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -141,9 +131,7 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExistingTagsNames([
-            '_dd.p.tid'
-        ])->withExactTags([
+        )->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',

--- a/tests/Integrations/Laravel/V5_8/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_8/EloquentTest.php
@@ -37,7 +37,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -56,7 +58,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -74,7 +78,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'select * from `users`'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             'sql.query' => 'select * from `users`',
             TAG::COMPONENT => 'eloquent',
@@ -93,7 +99,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -112,7 +120,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
@@ -131,7 +141,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([
+        )->withExistingTagsNames([
+            '_dd.p.tid'
+        ])->withExactTags([
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -83,6 +83,7 @@ class QueueTest extends WebFrameworkTestCase
             $createTraces,
             [
                 SpanAssertion::exists('laravel.request')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')
                             ->withExactTags([
@@ -106,6 +107,7 @@ class QueueTest extends WebFrameworkTestCase
 
         $this->assertFlameGraph($artisanTrace, [
             SpanAssertion::exists('laravel.artisan')
+                ->withExistingTagsNames(['_dd.p.tid'])
                 ->withChildren([
                     SpanAssertion::exists('laravel.action')
                         ->withChildren([
@@ -166,6 +168,7 @@ class QueueTest extends WebFrameworkTestCase
             $createTraces,
             [
                 SpanAssertion::exists('laravel.request')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')
                             ->withExactTags([
@@ -186,6 +189,7 @@ class QueueTest extends WebFrameworkTestCase
             $processTrace1,
             [
                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         $this->spanQueueResolve('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
@@ -205,6 +209,7 @@ class QueueTest extends WebFrameworkTestCase
             $artisanTrace,
             [
                 SpanAssertion::exists('laravel.artisan')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -134,10 +134,11 @@ class QueueTest extends WebFrameworkTestCase
         $processSpanId = $processSpanFromProcessTrace['span_id'];
         $processParentId = $processSpanFromProcessTrace['parent_id'];
 
+        $tid = $processSpanFromProcessTrace["meta"]['_dd.p.tid'];
         $hexProcessTraceId = self::largeBaseConvert($processTraceId, 10, 16);
         $hexProcessSpanId = self::largeBaseConvert($processSpanId, 10, 16);
 
-        $this->assertTrue($spanLinksTraceId == $hexProcessTraceId);
+        $this->assertTrue($spanLinksTraceId == $tid . $hexProcessTraceId);
         $this->assertTrue($spanLinksSpanId == $hexProcessSpanId);
 
         $pushSpanFromCreateTrace = array_filter($createTraces[0], function ($span) {

--- a/tests/Integrations/Laravel/V5_8/QueueTest.php
+++ b/tests/Integrations/Laravel/V5_8/QueueTest.php
@@ -391,7 +391,8 @@ class QueueTest extends WebFrameworkTestCase
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
             Tag::MQ_MESSAGE_ID,
-            '_dd.span_links'
+            '_dd.span_links',
+            '_dd.p.tid'
         ])->withChildren([
             $this->spanEventJobProcessing(),
             $this->spanQueueFire($connection, $queue, $resourceDetails)

--- a/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
@@ -55,6 +55,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
                     ])
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists(

--- a/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
@@ -56,6 +56,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',
@@ -102,6 +104,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'simple_view',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                         ->withExactTags([
@@ -164,6 +168,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'error',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists('laravel.view.render')
@@ -209,6 +215,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_METHOD => 'GET',
                         Tag::COMPONENT => 'laravel',
                         Tag::HTTP_STATUS_CODE => '404',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('laravel.event.handle', null, null, 'laravel_test_app'),
                         SpanAssertion::exists('laravel.event.handle', null, null, 'laravel_test_app'),

--- a/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
@@ -271,6 +271,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.route' => 'dynamic_route/{param01}/static/{param02?}',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'laravel.action',

--- a/tests/Integrations/Laravel/V8_x/EloquentTest.php
+++ b/tests/Integrations/Laravel/V8_x/EloquentTest.php
@@ -79,8 +79,6 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -99,8 +97,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -120,8 +116,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 
@@ -141,8 +135,6 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
-        ])->withExistingTagsNames([
-            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V8_x/EloquentTest.php
+++ b/tests/Integrations/Laravel/V8_x/EloquentTest.php
@@ -79,6 +79,8 @@ class EloquentTest extends WebFrameworkTestCase
             'sql.query' => 'select * from `users`',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -97,6 +99,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -116,6 +120,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 
@@ -135,6 +141,8 @@ class EloquentTest extends WebFrameworkTestCase
             TAG::SPAN_KIND => 'client',
             TAG::COMPONENT => 'eloquent',
             Tag::DB_SYSTEM => 'other_sql',
+        ])->withExistingTagsNames([
+            '_dd.p.tid'
         ]));
     }
 

--- a/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
+++ b/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
@@ -52,6 +52,9 @@ class InternalExceptionsTest extends WebFrameworkTestCase
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
@@ -111,6 +114,9 @@ class InternalExceptionsTest extends WebFrameworkTestCase
                         'http.route' => 'unauthorized',
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
+                    ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->withExactMetrics([
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -154,10 +154,11 @@ class QueueTest extends WebFrameworkTestCase
         $processSpanId = $processSpanFromProcessTrace['span_id'];
         $processParentId = $processSpanFromProcessTrace['parent_id'];
 
+        $tid = $processSpanFromProcessTrace["meta"]['_dd.p.tid'];
         $hexProcessTraceId = self::largeBaseConvert($processTraceId, 10, 16);
         $hexProcessSpanId = self::largeBaseConvert($processSpanId, 10, 16);
 
-        $this->assertTrue($spanLinksTraceId == $hexProcessTraceId);
+        $this->assertTrue($spanLinksTraceId == $tid . $hexProcessTraceId);
         $this->assertTrue($spanLinksSpanId == $hexProcessSpanId);
 
         $pushSpanFromCreateTrace = array_filter($createTraces[0], function ($span) {

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -100,6 +100,7 @@ class QueueTest extends WebFrameworkTestCase
             $createTraces,
             [
                 SpanAssertion::exists('laravel.request')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')
                             ->withExactTags([
@@ -126,6 +127,7 @@ class QueueTest extends WebFrameworkTestCase
 
         $this->assertFlameGraph($artisanTrace, [
             SpanAssertion::exists('laravel.artisan')
+                ->withExistingTagsNames(['_dd.p.tid'])
                 ->withChildren([
                     SpanAssertion::exists('laravel.action')
                         ->withChildren([
@@ -186,6 +188,7 @@ class QueueTest extends WebFrameworkTestCase
             $createTraces,
             [
                 SpanAssertion::exists('laravel.request')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')
                             ->withExactTags([
@@ -209,6 +212,7 @@ class QueueTest extends WebFrameworkTestCase
             $processTrace1,
             [
                 $this->spanQueueProcess('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         $this->spanQueueResolve('database', 'emails', 'App\Jobs\SendVerificationEmail -> emails'),
@@ -228,6 +232,7 @@ class QueueTest extends WebFrameworkTestCase
             $artisanTrace,
             [
                 SpanAssertion::exists('laravel.artisan')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')
@@ -295,6 +300,7 @@ class QueueTest extends WebFrameworkTestCase
 
         $this->assertFlameGraph($dispatchTraces, [
             SpanAssertion::exists('laravel.request')
+                ->withExistingTagsNames(['_dd.p.tid'])
                 ->withChildren([
                     SpanAssertion::exists('laravel.action')
                         ->withChildren([

--- a/tests/Integrations/Laravel/V8_x/QueueTest.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTest.php
@@ -504,7 +504,8 @@ class QueueTest extends WebFrameworkTestCase
             $this->getCommonTags('receive', $queue, $connection)
         )->withExistingTagsNames([
             Tag::MQ_MESSAGE_ID,
-            '_dd.span_links'
+            '_dd.span_links',
+            '_dd.p.tid'
         ])->withChildren([
             $this->spanEventJobProcessing(),
             $this->spanQueueFire($connection, $queue, $resourceDetails)

--- a/tests/Integrations/Laravel/V8_x/QueueTestNotDistributed.php
+++ b/tests/Integrations/Laravel/V8_x/QueueTestNotDistributed.php
@@ -70,6 +70,7 @@ class QueueTestNotDistributed extends WebFrameworkTestCase
             $artisanTrace,
             [
                 SpanAssertion::exists('laravel.artisan')
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->setError('Exception', 'Triggered Exception', true)
                     ->withChildren([
                         SpanAssertion::exists('laravel.action')

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -46,6 +46,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
                     ])
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists('laravel.provider.load'),
@@ -94,6 +95,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
                     ])
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists('laravel.provider.load'),

--- a/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
@@ -50,6 +50,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         TAG::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'laravel'
                     ])
+                    ->withExistingTagsNames(['_dd.p.tid'])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Lumen/V10_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V10_0/TraceSearchConfigTest.php
@@ -49,6 +49,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -54,6 +54,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'lumen'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -114,7 +116,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'lumen'
-                    ])->withExistingTagsNames(\PHP_MAJOR_VERSION === 5 ? [] : ['error.stack'])
+                    ])->withExistingTagsNames(\PHP_MAJOR_VERSION === 5 ? ['_dd.p.tid'] : ['error.stack', '_dd.p.tid'])
                     ->setError(
                         'Exception',
                         'Controller error',
@@ -162,6 +164,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'http.status_code' => '200',
                 Tag::SPAN_KIND => 'server',
                 TAG::COMPONENT => 'lumen'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'Laravel\Lumen\Application.handleFoundRoute',

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -54,6 +54,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -54,6 +54,8 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'lumen',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -79,6 +81,8 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'lumen',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -125,7 +129,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         Tag::SPAN_KIND => 'server',
                         TAG::COMPONENT => 'lumen'
                     ])->withExistingTagsNames([
-                        'error.stack',
+                        'error.stack', '_dd.p.tid'
                     ])->setError('Exception', 'Controller error')
                     ->withChildren([
                         SpanAssertion::build(

--- a/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
+++ b/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
@@ -48,6 +48,9 @@ class DeprecatedResourceNameTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -49,6 +49,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -49,6 +49,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Lumen/V8_1/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V8_1/TraceSearchConfigTest.php
@@ -49,6 +49,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Lumen/V9_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V9_0/TraceSearchConfigTest.php
@@ -49,6 +49,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'lumen',
                     ])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Memcache/MemcacheTest.php
+++ b/tests/Integrations/Memcache/MemcacheTest.php
@@ -52,7 +52,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'add',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -67,7 +69,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'append',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -91,7 +95,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'delete ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'delete',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcache.get'),
         ]);
     }
@@ -114,7 +120,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'decrement',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcache.get'),
         ]);
     }
@@ -136,7 +144,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'increment',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcache.get'),
         ]);
     }
@@ -161,6 +171,8 @@ final class MemcacheTest extends IntegrationTestCase
                     Tag::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'memcache',
                     Tag::DB_SYSTEM => 'memcached',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             SpanAssertion::exists('Memcache.get'),
         ]);
@@ -185,6 +197,8 @@ final class MemcacheTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -208,6 +222,8 @@ final class MemcacheTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -227,7 +243,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'replace ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'replace',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcache.get'),
         ]);
     }
@@ -244,7 +262,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'set ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'set',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -264,7 +284,7 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.command' => 'cas',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames(['memcache.cas_token']),
+                ->withExistingTagsNames(['memcache.cas_token', '_dd.p.tid']),
         ]);
     }
 
@@ -282,7 +302,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'add',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -304,7 +326,7 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.command' => 'cas',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames(['memcache.cas_token']),
+                ->withExistingTagsNames(['memcache.cas_token', '_dd.p.tid'])
         ]);
     }
 
@@ -343,7 +365,9 @@ final class MemcacheTest extends IntegrationTestCase
                     'memcache.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcache.command' => 'add',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 }

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -51,7 +51,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'add',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -68,7 +70,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'addByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -90,7 +94,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'append',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.type', 'error.stack']),
+                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.type', 'error.stack', '_dd.p.tid']),
         ]);
     }
 
@@ -106,7 +110,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'append',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -129,7 +135,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.type', 'error.stack']),
+                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.type', 'error.stack', '_dd.p.tid']),
         ]);
     }
 
@@ -147,7 +153,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -171,7 +179,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'delete ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'delete',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -197,7 +207,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'deleteByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
     }
@@ -248,7 +260,9 @@ final class MemcachedTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                     'memcached.query' => 'deleteMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'deleteMulti',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::exists('Memcached.get'),
         ]);
@@ -279,7 +293,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'deleteMultiByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getByKey'),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
@@ -307,14 +323,18 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.decrement', 'memcached', 'memcached', 'decrement')
                 ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -338,7 +358,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'decrement ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'decrement',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -362,7 +384,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'decrementByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
     }
@@ -387,14 +411,18 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
             SpanAssertion::build('Memcached.increment', 'memcached', 'memcached', 'increment')
                 ->withExactTags(array_merge(self::baseTags(), [
                     'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -417,7 +445,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'increment ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'increment',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -440,7 +470,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'incrementByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
     }
@@ -462,7 +494,9 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.flush', 'memcached', 'memcached', 'flush')
                 ->withExactTags(array_merge($this->baseTags(), [
                     'memcached.command' => 'flush',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -486,6 +520,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -509,6 +545,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -532,6 +570,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 2,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -555,6 +595,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -573,6 +615,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -596,6 +640,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -624,6 +670,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 2,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -643,7 +691,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'replace ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'replace',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -664,7 +714,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'replaceByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
     }
@@ -681,7 +733,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'set ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'set',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -698,7 +752,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'setByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -714,7 +770,9 @@ final class MemcachedTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                     'memcached.query' => 'setMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
                     'memcached.command' => 'setMulti',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getMulti'),
         ]);
     }
@@ -736,7 +794,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'setMultiByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.getMultiByKey'),
         ]);
     }
@@ -752,7 +812,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'touch ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'touch',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -768,7 +830,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'touchByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -793,7 +857,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'cas',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames(['memcached.cas_token']),
+                ->withExistingTagsNames(['memcached.cas_token', '_dd.p.tid']),
         ]);
     }
 
@@ -819,7 +883,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames(['memcached.cas_token']),
+                ->withExistingTagsNames(['memcached.cas_token', '_dd.p.tid']),
         ]);
     }
 
@@ -852,7 +916,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'add',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -871,7 +937,9 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'addByKey',
                     'memcached.server_key' => 'my_server',
                     Tag::SPAN_KIND => 'client',
-                ]))
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -896,6 +964,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 2,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -926,6 +996,8 @@ final class MemcachedTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 2,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -950,7 +1022,9 @@ final class MemcachedTest extends IntegrationTestCase
                 ->withExactTags(array_merge(self::baseTags(true), [
                     'memcached.command' => 'flush',
                     Tag::SPAN_KIND => 'client',
-                ])),
+                ]))->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('Memcached.get'),
         ]);
     }
@@ -979,7 +1053,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'cas',
                     Tag::SPAN_KIND => 'client',
                 ]))
-                ->withExistingTagsNames(['memcached.cas_token']),
+                ->withExistingTagsNames(['memcached.cas_token', '_dd.p.tid']),
         ]);
     }
 

--- a/tests/Integrations/Mongo/MongoTest.php
+++ b/tests/Integrations/Mongo/MongoTest.php
@@ -46,6 +46,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.db' => self::DATABASE,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -75,6 +77,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.db' => self::DATABASE,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -104,6 +108,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.db' => self::DATABASE,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -121,6 +127,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.db' => self::DATABASE,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -137,6 +145,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.db' => self::DATABASE,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -153,6 +163,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.read_preference' => MongoClient::RP_NEAREST,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -168,6 +180,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -186,6 +200,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -219,6 +235,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.timeout' => '500',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -236,6 +254,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.bson.id' => '47cc67093475061e3d9536d2',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -252,6 +272,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -267,6 +289,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -286,6 +310,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -302,6 +328,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -318,6 +346,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.profiling_level' => '2',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -334,6 +364,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.read_preference' => MongoClient::RP_NEAREST,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -349,6 +381,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -367,6 +401,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -401,6 +437,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -416,6 +454,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -427,7 +467,10 @@ class MongoTest extends IntegrationTestCase
         });
 
         $this->assertFlameGraph($traces, [
-            SpanAssertion::build('MongoCollection.aggregateCursor', 'mongo', 'mongodb', 'aggregateCursor'),
+            SpanAssertion::build('MongoCollection.aggregateCursor', 'mongo', 'mongodb', 'aggregateCursor')
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -445,6 +488,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -461,6 +506,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"title":"Foo"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -478,6 +525,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -493,6 +542,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -508,6 +559,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -525,6 +578,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -542,6 +597,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -564,6 +621,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -581,6 +640,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -601,6 +662,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.collection' => 'foo_collection',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -620,6 +683,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -635,6 +700,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -651,10 +718,11 @@ class MongoTest extends IntegrationTestCase
                 'mongo',
                 'mongodb',
                 'parallelCollectionScan'
-            )
-            ->withExactTags([
+            )->withExactTags([
                 Tag::COMPONENT => 'mongo',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -671,6 +739,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -686,6 +756,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -702,6 +774,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.read_preference' => MongoClient::RP_NEAREST,
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -717,6 +791,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -737,6 +813,8 @@ class MongoTest extends IntegrationTestCase
                     'mongodb.query' => '{"foo":"bar"}',
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -755,6 +833,8 @@ class MongoTest extends IntegrationTestCase
                 ->withExactTags([
                     Tag::COMPONENT => 'mongo',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }

--- a/tests/Integrations/MongoDB/MongoDBTest.php
+++ b/tests/Integrations/MongoDB/MongoDBTest.php
@@ -79,6 +79,8 @@ class MongoDBTest extends IntegrationTestCase
                     Tag::DB_SYSTEM => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ];
 
@@ -121,6 +123,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('mongodb.driver.cmd')
             ]),
@@ -179,6 +183,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('mongodb.driver.cmd')
             ]),
@@ -206,7 +212,7 @@ class MongoDBTest extends IntegrationTestCase
                     Tag::COMPONENT => 'mongodb',
                     Tag::DB_SYSTEM => 'mongodb',
                 ])->setError('MongoDB\Exception\InvalidArgumentException')
-                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack']),
+                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack', '_dd.p.tid']),
         ]);
     }
 
@@ -226,6 +232,8 @@ class MongoDBTest extends IntegrationTestCase
                     'out.port' => self::PORT,
                     Tag::COMPONENT => 'mongodb',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -307,6 +315,8 @@ class MongoDBTest extends IntegrationTestCase
                     'out.port' => self::PORT,
                     Tag::COMPONENT => 'mongodb',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -401,6 +411,8 @@ class MongoDBTest extends IntegrationTestCase
                     Tag::DB_SYSTEM => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ];
 
@@ -505,6 +517,8 @@ class MongoDBTest extends IntegrationTestCase
                     'out.port' => self::PORT,
                     Tag::COMPONENT => 'mongodb',
                     Tag::DB_SYSTEM => 'mongodb',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ];
 
@@ -548,6 +562,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ];
 
@@ -592,6 +608,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ];
 
@@ -648,6 +666,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ];
 
@@ -704,6 +724,8 @@ class MongoDBTest extends IntegrationTestCase
                 'out.port' => self::PORT,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])
         ];
 
@@ -775,6 +797,8 @@ class MongoDBTest extends IntegrationTestCase
                 'mongodb.insertsCount' => 2,
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -807,7 +831,7 @@ class MongoDBTest extends IntegrationTestCase
                 Tag::COMPONENT => 'mongodb',
                 Tag::DB_SYSTEM => 'mongodb',
             ])->setError()
-                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack']),
+                ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack', '_dd.p.tid']),
         ]);
     }
 
@@ -829,6 +853,8 @@ class MongoDBTest extends IntegrationTestCase
                     Tag::DB_SYSTEM => 'mongodb',
                     'peer.service' => self::DATABASE,
                     '_dd.peer.service.source' => 'mongodb.db',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ];
 
@@ -875,6 +901,8 @@ class MongoDBTest extends IntegrationTestCase
                 Tag::DB_SYSTEM => 'mongodb',
                 'peer.service' => self::DATABASE,
                 '_dd.peer.service.source' => 'mongodb.db',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -900,6 +928,8 @@ class MongoDBTest extends IntegrationTestCase
                 Tag::DB_SYSTEM => 'mongodb',
                 'peer.service' => self::DATABASE,
                 '_dd.peer.service.source' => 'mongodb.db',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ];
 
@@ -929,6 +959,8 @@ class MongoDBTest extends IntegrationTestCase
                     Tag::DB_SYSTEM => 'mongodb',
                     'peer.service' => self::DATABASE,
                     '_dd.peer.service.source' => 'mongodb.db',
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),

--- a/tests/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integrations/Mysqli/MysqliTest.php
@@ -46,7 +46,10 @@ class MysqliTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('mysqli_connect', 'mysqli', 'sql', 'mysqli_connect')
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -68,6 +71,7 @@ class MysqliTest extends IntegrationTestCase
                     Tag::ERROR_MSG,
                     'error.type',
                     'error.stack',
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -90,6 +94,7 @@ class MysqliTest extends IntegrationTestCase
                     Tag::ERROR_MSG,
                     'error.type',
                     'error.stack',
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -103,7 +108,10 @@ class MysqliTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('mysqli.__construct', 'mysqli', 'sql', 'mysqli.__construct')
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -124,6 +132,8 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -146,7 +156,10 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+            ->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
     }
 
@@ -166,7 +179,10 @@ class MysqliTest extends IntegrationTestCase
             SpanAssertion::exists('mysqli_connect', 'mysqli_connect'),
             SpanAssertion::build('mysqli_execute_query', 'mysqli', 'sql', 'SELECT * from tests WHERE 1 = ?')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -188,7 +204,10 @@ class MysqliTest extends IntegrationTestCase
             SpanAssertion::exists('mysqli_connect', 'mysqli_connect'),
             SpanAssertion::build('mysqli_execute_query', 'mysqli', 'sql', 'SELECT * from tests WHERE 1 = ?')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags(true, true)),
+                ->withExactTags(self::baseTags(true, true))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -204,7 +223,10 @@ class MysqliTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('mysqli_real_connect', 'mysqli', 'sql', 'mysqli_real_connect')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli_query', 'mysqli', 'sql', 'SELECT * from tests')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags())
@@ -212,6 +234,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -230,7 +255,10 @@ class MysqliTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('mysqli_real_connect', 'mysqli', 'sql', 'mysqli_real_connect')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli_query', 'mysqli', 'sql', 'SELECT * from tests')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags(true, true))
@@ -238,6 +266,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -259,6 +290,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -282,6 +316,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -299,7 +336,10 @@ class MysqliTest extends IntegrationTestCase
             SpanAssertion::exists('mysqli.__construct', 'mysqli.__construct'),
             SpanAssertion::build('mysqli.real_connect', 'mysqli', 'sql', 'mysqli.real_connect')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli.query', 'mysqli', 'sql', 'SELECT * from tests')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags())
@@ -307,6 +347,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -326,7 +369,10 @@ class MysqliTest extends IntegrationTestCase
             SpanAssertion::exists('mysqli.__construct', 'mysqli.__construct'),
             SpanAssertion::build('mysqli.real_connect', 'mysqli', 'sql', 'mysqli.real_connect')
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli.query', 'mysqli', 'sql', 'SELECT * from tests')
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags(true, true))
@@ -334,6 +380,9 @@ class MysqliTest extends IntegrationTestCase
                     Tag::DB_ROW_COUNT => 1,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -353,7 +402,10 @@ class MysqliTest extends IntegrationTestCase
             SpanAssertion::exists('mysqli_connect', 'mysqli_connect'),
             SpanAssertion::exists('mysqli_query', $query),
             SpanAssertion::build('mysqli_commit', 'mysqli', 'sql', $query)
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -373,10 +425,16 @@ class MysqliTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('mysqli.__construct', 'mysqli.__construct'),
             SpanAssertion::build('mysqli.prepare', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli_stmt.execute', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
                 ->withExactTags(self::baseTags())
-                ->setTraceAnalyticsCandidate(),
+                ->setTraceAnalyticsCandidate()
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -398,10 +456,16 @@ class MysqliTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('mysqli.__construct', 'mysqli.__construct'),
             SpanAssertion::build('mysqli.prepare', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli_stmt.execute', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
                 ->withExactTags(self::baseTags(true, true))
-                ->setTraceAnalyticsCandidate(),
+                ->setTraceAnalyticsCandidate()
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -551,9 +615,15 @@ class MysqliTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('mysqli_connect', 'mysqli_connect'),
             SpanAssertion::build('mysqli_prepare', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
-                ->withExactTags(self::baseTags()),
+                ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('mysqli_stmt_execute', 'mysqli', 'sql', 'INSERT INTO tests (id, name) VALUES (?, ?)')
-                ->withExactTags(self::baseTags(true, true)),
+                ->withExactTags(self::baseTags(true, true))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -577,6 +647,7 @@ class MysqliTest extends IntegrationTestCase
                     Tag::SPAN_KIND,
                     Tag::COMPONENT,
                     Tag::DB_SYSTEM,
+                    '_dd.p.tid'
                 ]),
         ]);
     }

--- a/tests/Integrations/Nette/V2_4/NetteTest.php
+++ b/tests/Integrations/Nette/V2_4/NetteTest.php
@@ -35,7 +35,6 @@ final class NetteTest extends WebFrameworkTestCase
         });
 
         $this->assertFlameGraph($traces, $spanExpectations);
-        //$this->assertExpectedSpans($traces, $spanExpectations);
     }
 
     public function provideSpecs()
@@ -56,6 +55,8 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'nette'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -98,6 +99,8 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'nette'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -144,7 +147,9 @@ final class NetteTest extends WebFrameworkTestCase
                         'nette_test_app',
                         'web',
                         'GET /error'
-                    )->withExactTags([
+                    )->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])->withExactTags([
                         'nette.route.presenter' => 'Homepage',
                         'nette.route.action' => 'errorView',
                         'http.method' => 'GET',

--- a/tests/Integrations/Nette/V3_0/NetteTest.php
+++ b/tests/Integrations/Nette/V3_0/NetteTest.php
@@ -56,6 +56,8 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'nette'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -98,6 +100,8 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'nette'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -152,6 +156,8 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'nette'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError(
                         'Exception',

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -72,7 +72,7 @@ final class PDOTest extends IntegrationTestCase
                 'pdo',
                 'sql',
                 $query
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build(
                 'PDOStatement.execute',
                 'pdo',
@@ -86,7 +86,7 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -117,7 +117,8 @@ final class PDOTest extends IntegrationTestCase
             )
                 ->setError()
                 ->setTraceAnalyticsCandidate()
-                ->withExactTags(SpanAssertion::NOT_TESTED),
+                ->withExactTags(SpanAssertion::NOT_TESTED)
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -149,7 +150,8 @@ final class PDOTest extends IntegrationTestCase
         });
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.__construct', 'pdo', 'sql', 'PDO.__construct')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -162,7 +164,8 @@ final class PDOTest extends IntegrationTestCase
 
         $this->assertSpans($traces, [
             SpanAssertion::build('PDO.__construct', 'pdo-mysql_integration', 'sql', 'PDO.__construct')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -179,7 +182,8 @@ final class PDOTest extends IntegrationTestCase
                 ->withExactTags(array_merge($this->baseTags(), [
                     'db.user' => 'wrong_user',
                 ]))
-                ->setError('PDOException', static::ERROR_CONSTRUCT, true),
+                ->setError('PDOException', static::ERROR_CONSTRUCT, true)
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -203,7 +207,7 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::exists('PDO.commit'),
         ]);
     }
@@ -226,7 +230,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error data: You have an error in your SQL syntax')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::exists('PDO.commit'),
         ]);
     }
@@ -251,7 +256,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.exec', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_EXEC, true)
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -273,7 +279,8 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -297,7 +304,8 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -317,7 +325,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDO error', 'SQL error: 42000. Driver error: 1064. Driver-specific error data: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'WRONG QUERY\'')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -338,7 +347,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_QUERY, true)
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -362,7 +372,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::build('PDO.query', 'pdo', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_QUERY, true)
-                ->withExactTags($this->baseTags(true)),
+                ->withExactTags($this->baseTags(true))
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -380,7 +391,8 @@ final class PDOTest extends IntegrationTestCase
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::exists('PDO.exec'),
             SpanAssertion::build('PDO.commit', 'pdo', 'sql', 'PDO.commit')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -404,7 +416,7 @@ final class PDOTest extends IntegrationTestCase
                 'pdo',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build(
                 'PDOStatement.execute',
                 'pdo',
@@ -418,7 +430,8 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -444,7 +457,7 @@ final class PDOTest extends IntegrationTestCase
                 'pdo',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build(
                 'PDOStatement.execute',
                 'pdo',
@@ -458,7 +471,8 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -483,7 +497,7 @@ final class PDOTest extends IntegrationTestCase
                 'pdo-mysql_integration',
                 'sql',
                 "SELECT * FROM tests WHERE id = ?"
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build(
                 'PDOStatement.execute',
                 'pdo-mysql_integration',
@@ -497,7 +511,8 @@ final class PDOTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
-                ]),
+                ])
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -557,11 +572,13 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.prepare', 'pdo', 'sql', "WRONG QUERY")
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build('PDOStatement.execute', 'pdo', 'sql', "WRONG QUERY")
                 ->settraceanalyticscandidate()
                 ->seterror('PDOStatement error', 'SQL error: 42000. Driver error: 1064')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -584,11 +601,13 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.prepare', 'pdo', 'sql', "WRONG QUERY")
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build('PDOStatement.execute', 'pdo', 'sql', "WRONG QUERY")
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_STATEMENT, true)
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 
@@ -613,11 +632,13 @@ final class PDOTest extends IntegrationTestCase
         $this->assertSpans($traces, [
             SpanAssertion::exists('PDO.__construct'),
             SpanAssertion::build('PDO.prepare', 'pdo', 'sql', "WRONG QUERY")
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames(['_dd.p.tid']),
             SpanAssertion::build('PDOStatement.execute', 'pdo', 'sql', "WRONG QUERY")
                 ->setTraceAnalyticsCandidate()
                 ->setError('PDOException', static::ERROR_STATEMENT, true)
-                ->withExactTags($this->baseTags(true)),
+                ->withExactTags($this->baseTags(true))
+                ->withExistingTagsNames(['_dd.p.tid']),
         ]);
     }
 

--- a/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
@@ -77,7 +77,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.close"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -100,7 +102,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand)))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand)))
         ]);
     }
 
@@ -144,7 +148,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -189,7 +195,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expected, $redis->get($args[0]));
@@ -325,7 +333,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSet"
-            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -346,7 +356,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -382,7 +394,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertSame($expected, $result);
     }
@@ -490,7 +504,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -640,7 +656,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -880,7 +898,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1048,7 +1068,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1216,7 +1238,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.publish"
-            )->withExactTags($this->baseTags('publish ch1 hi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('publish ch1 hi')),
         ]);
     }
 
@@ -1235,25 +1259,33 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.multi"
-            )->withExactTags($this->baseTags('multi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('multi')),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'phpredis',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set k1 v1')),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
-            )->withExactTags($this->baseTags('get k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('get k1')),
             SpanAssertion::build(
                 "RedisCluster.exec",
                 'phpredis',
                 'redis',
                 "RedisCluster.exec"
-            )->withExactTags($this->baseTags('exec')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('exec')),
         ]);
     }
 
@@ -1285,7 +1317,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1360,7 +1394,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.restore"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1397,7 +1433,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_FLOAT) {
@@ -1469,14 +1507,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1495,14 +1533,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1580,14 +1618,18 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags([Tag::SPAN_KIND => 'client',
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'phpredis', Tag::DB_SYSTEM => 'redis', 'out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
         ]);
 
         $redis->close();
@@ -1612,7 +1654,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags([
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags([
                 'out.host' => $this->connection1[0], 'out.port' => $this->connection1[1], Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'phpredis', Tag::DB_SYSTEM => 'redis',
             ]),
@@ -1621,7 +1665,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
         ]);
 
         $redis->close();
@@ -1647,13 +1693,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 $serviceName,
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags($this->baseTags(null, false, false), ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags(null, false, false), ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]),
             SpanAssertion::build(
                 "RedisCluster.set",
                 $serviceName,
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value'))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value'))
         ]);
 
         $redis->close();

--- a/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
@@ -1388,7 +1388,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.dump"
-            )->withExactTags($this->baseTags('dump k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('dump k1')),
             SpanAssertion::build(
                 "RedisCluster.restore",
                 'phpredis',

--- a/tests/Integrations/PHPRedis/V3/PHPRedisTest.php
+++ b/tests/Integrations/PHPRedis/V3/PHPRedisTest.php
@@ -494,7 +494,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1933,7 +1935,7 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis',
                 "Redis.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid$']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 

--- a/tests/Integrations/PHPRedis/V3/PHPRedisTest.php
+++ b/tests/Integrations/PHPRedis/V3/PHPRedisTest.php
@@ -77,6 +77,8 @@ class PHPRedisTest extends IntegrationTestCase
                 Tag::DB_SYSTEM => 'redis',
                 'out.host' => $this->host,
                 'out.port' => $this->port,
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -123,7 +125,7 @@ class PHPRedisTest extends IntegrationTestCase
                 'out.host' => $host,
                 'out.port' => $port ?: $this->port,
             ])
-            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack']),
+            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack', '_dd.p.tid']),
         ]);
     }
 
@@ -162,7 +164,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.close"
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
     }
 
@@ -196,7 +200,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExactTags($this->baseTags($rawCommand))->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
     }
 
@@ -245,7 +251,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags()),
+            )->withExactTags($this->baseTags())->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
     }
 
@@ -276,7 +284,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.select"
-            )->withExactTags($this->baseTags(), ['db.index' => '1']),
+            )->withExactTags($this->baseTags(), ['db.index' => '1'])->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
     }
 
@@ -309,7 +319,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExactTags($this->baseTags($rawCommand))->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
 
         $this->assertSame($expected, $redis->get($args[0]));
@@ -459,7 +471,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.mSet"
-            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
+            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2'))->withExistingTagsNames([
+                '_dd.p.tid'
+            ]),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -501,7 +515,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.rawCommand"
-            )->withExactTags($this->baseTags('rawCommand set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('rawCommand set k1 v1')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -536,7 +552,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertSame($expected, $result);
     }
@@ -658,7 +676,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -807,7 +827,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -1077,7 +1099,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1273,7 +1297,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1469,7 +1495,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.publish"
-            )->withExactTags($this->baseTags('publish ch1 hi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('publish ch1 hi')),
         ]);
     }
 
@@ -1488,25 +1516,33 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.multi"
-            )->withExactTags($this->baseTags('multi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('multi')),
             SpanAssertion::build(
                 "Redis.set",
                 'phpredis',
                 'redis',
                 "Redis.set"
-            )->withExactTags($this->baseTags('set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set k1 v1')),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
-            )->withExactTags($this->baseTags('get k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('get k1')),
             SpanAssertion::build(
                 "Redis.exec",
                 'phpredis',
                 'redis',
                 "Redis.exec"
-            )->withExactTags($this->baseTags('exec')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('exec')),
         ]);
     }
 
@@ -1539,7 +1575,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1617,7 +1655,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1680,13 +1720,17 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.dump"
-            )->withExactTags($this->baseTags('dump k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('dump k1')),
             SpanAssertion::build(
                 "Redis.restore",
                 'phpredis',
                 'redis',
                 "Redis.restore"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1712,7 +1756,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.migrate"
-            )->withExactTags($this->baseTags("migrate redis_integration 6380 k1 0 3600")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("migrate redis_integration 6380 k1 0 3600")),
         ]);
 
         $traces = $this->isolateTracer(function () {
@@ -1724,7 +1770,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.migrate"
-            )->withExactTags($this->baseTags("migrate redis_integration 6380 k2 k3 0 3600")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("migrate redis_integration 6380 k2 k3 0 3600")),
         ]);
 
         $this->assertSame('v1', $this->redisSecondInstance->get('k1'));
@@ -1750,7 +1798,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.move"
-            )->withExactTags($this->baseTags("move k1 1")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("move k1 1")),
         ]);
 
         $this->assertSame('v1', $this->redis->get('k1'));
@@ -1769,7 +1819,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.renameKey"
-            )->withExactTags($this->baseTags("renameKey k1 k2")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("renameKey k1 k2")),
         ]);
 
         $this->assertFalse($this->redis->get('k1'));
@@ -1790,14 +1842,14 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis',
                 "Redis.set"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1821,7 +1873,7 @@ class PHPRedisTest extends IntegrationTestCase
                 "Redis.connect"
             )
             ->setError()
-            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack'])
+            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack', '_dd.p.tid'])
             ->withExactTags($this->baseTags(), ['out.host' => 'non-existing-host', 'out.port' => '6379']),
         ]);
     }
@@ -1843,14 +1895,20 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis',
                 "Redis.connect"
             )
-                ->withExactTags($this->baseTags(), [Tag::TARGET_PORT => '6379']),
+                ->withExactTags($this->baseTags(), [Tag::TARGET_PORT => '6379'])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build(
                 "Redis.set",
                 'redis-redis_integration',
                 'redis',
                 "Redis.set"
             )
-                ->withExactTags($this->baseTags('set key value')),
+                ->withExactTags($this->baseTags('set key value'))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -1868,14 +1926,14 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis',
                 "Redis.set"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid$']),
         ]);
     }
 

--- a/tests/Integrations/PHPRedis/V4/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V4/PHPRedisClusterTest.php
@@ -77,7 +77,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.close"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -100,7 +102,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand)))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand)))
         ]);
     }
 
@@ -144,7 +148,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -189,7 +195,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expected, $redis->get($args[0]));
@@ -325,7 +333,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSet"
-            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -346,7 +356,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -382,7 +394,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertSame($expected, $result);
     }
@@ -490,7 +504,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -640,7 +656,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -880,7 +898,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1048,7 +1068,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1230,7 +1252,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.publish"
-            )->withExactTags($this->baseTags('publish ch1 hi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('publish ch1 hi')),
         ]);
     }
 
@@ -1249,25 +1273,33 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.multi"
-            )->withExactTags($this->baseTags('multi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('multi')),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'phpredis',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set k1 v1')),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
-            )->withExactTags($this->baseTags('get k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('get k1')),
             SpanAssertion::build(
                 "RedisCluster.exec",
                 'phpredis',
                 'redis',
                 "RedisCluster.exec"
-            )->withExactTags($this->baseTags('exec')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('exec')),
         ]);
     }
 
@@ -1299,7 +1331,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1368,13 +1402,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.dump"
-            )->withExactTags($this->baseTags('dump k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('dump k1')),
             SpanAssertion::build(
                 "RedisCluster.restore",
                 'phpredis',
                 'redis',
                 "RedisCluster.restore"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1411,7 +1449,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_FLOAT) {
@@ -1486,7 +1526,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xAdd"
-            )->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
         ]);
 
         // xGroup
@@ -1500,7 +1542,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xGroup"
-            )->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
         ]);
 
         // xInfo
@@ -1514,7 +1558,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xInfo"
-            )->withExactTags($this->baseTags('xInfo GROUPS s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xInfo GROUPS s1')),
         ]);
 
         // xLen
@@ -1528,7 +1574,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xLen"
-            )->withExactTags($this->baseTags('xLen s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xLen s1')),
         ]);
 
         // xPending
@@ -1542,7 +1590,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xPending"
-            )->withExactTags($this->baseTags('xPending s1 group1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xPending s1 group1')),
         ]);
 
         // xRange
@@ -1556,7 +1606,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRange"
-            )->withExactTags($this->baseTags('xRange s1 - +')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRange s1 - +')),
         ]);
 
         // xRevRange
@@ -1570,7 +1622,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRevRange"
-            )->withExactTags($this->baseTags('xRevRange s1 + -')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRevRange s1 + -')),
         ]);
 
         // xRead
@@ -1584,7 +1638,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRead"
-            )->withExactTags($this->baseTags('xRead s1 $')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRead s1 $')),
         ]);
 
         // xReadGroup
@@ -1598,7 +1654,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xReadGroup"
-            )->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
         ]);
 
         // xAck
@@ -1612,7 +1670,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xAck"
-            )->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
         ]);
 
         // xClaim
@@ -1626,7 +1686,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xClaim"
-            )->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
         ]);
 
         // xDel
@@ -1640,7 +1702,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xDel"
-            )->withExactTags($this->baseTags('xDel s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xDel s1 123-456')),
         ]);
 
         // xTrim
@@ -1654,7 +1718,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xTrim"
-            )->withExactTags($this->baseTags('xTrim s1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xTrim s1 0')),
         ]);
     }
 
@@ -1672,14 +1738,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1698,14 +1764,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-            ->withExistingTagsNames(['redis.raw_command']),
+            ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1786,13 +1852,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
             )->withExactTags([
                 'out.host' => $this->connection1[0], 'out.port' => $this->connection1[1], Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'phpredis', Tag::DB_SYSTEM => 'redis',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
         ]);
 
         $redis->close();
@@ -1820,13 +1890,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
             )->withExactTags([
                 'out.host' => $this->connection1[0], 'out.port' => $this->connection1[1], Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'phpredis', Tag::DB_SYSTEM => 'redis',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value', false, false), ['_dd.cluster.name' => 'cluster_name'])
         ]);
 
         $redis->close();
@@ -1852,13 +1926,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 $serviceName,
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags($this->baseTags(null, false, false), ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags(null, false, false), ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]),
             SpanAssertion::build(
                 "RedisCluster.set",
                 $serviceName,
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value'))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value'))
         ]);
 
         $redis->close();

--- a/tests/Integrations/PHPRedis/V4/PHPRedisTest.php
+++ b/tests/Integrations/PHPRedis/V4/PHPRedisTest.php
@@ -76,6 +76,8 @@ class PHPRedisTest extends IntegrationTestCase
                 Tag::SPAN_KIND => 'client',
                 Tag::COMPONENT => 'phpredis',
                 Tag::DB_SYSTEM => 'redis',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ]),
         ]);
     }
@@ -122,7 +124,7 @@ class PHPRedisTest extends IntegrationTestCase
                 Tag::COMPONENT => 'phpredis',
                 Tag::DB_SYSTEM => 'redis',
             ])
-            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack']),
+            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack'], '_dd.p.tid'),
         ]);
     }
 
@@ -161,7 +163,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.close"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -195,7 +199,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
     }
 
@@ -245,7 +251,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -276,7 +284,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.select"
-            )->withExactTags($this->baseTags(), ['db.index' => '1']),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags(), ['db.index' => '1']),
         ]);
     }
 
@@ -309,7 +319,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expected, $redis->get($args[0]));
@@ -459,7 +471,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.mSet"
-            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -480,7 +494,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -501,7 +517,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.rawCommand"
-            )->withExactTags($this->baseTags('rawCommand set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('rawCommand set k1 v1')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -536,7 +554,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertSame($expected, $result);
     }
@@ -658,7 +678,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -807,7 +829,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -1077,7 +1101,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1273,7 +1299,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1469,7 +1497,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.publish"
-            )->withExactTags($this->baseTags('publish ch1 hi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('publish ch1 hi')),
         ]);
     }
 
@@ -1488,25 +1518,33 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.multi"
-            )->withExactTags($this->baseTags('multi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('multi')),
             SpanAssertion::build(
                 "Redis.set",
                 'phpredis',
                 'redis',
                 "Redis.set"
-            )->withExactTags($this->baseTags('set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set k1 v1')),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
-            )->withExactTags($this->baseTags('get k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('get k1')),
             SpanAssertion::build(
                 "Redis.exec",
                 'phpredis',
                 'redis',
                 "Redis.exec"
-            )->withExactTags($this->baseTags('exec')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('exec')),
         ]);
     }
 
@@ -1539,7 +1577,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1617,7 +1657,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1680,13 +1722,17 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.dump"
-            )->withExactTags($this->baseTags('dump k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('dump k1')),
             SpanAssertion::build(
                 "Redis.restore",
                 'phpredis',
                 'redis',
                 "Redis.restore"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1712,7 +1758,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.migrate"
-            )->withExactTags($this->baseTags("migrate redis_integration 6380 k1 0 3600")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("migrate redis_integration 6380 k1 0 3600")),
         ]);
 
         $traces = $this->isolateTracer(function () {
@@ -1724,7 +1772,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.migrate"
-            )->withExactTags($this->baseTags("migrate redis_integration 6380 k2 k3 0 3600")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("migrate redis_integration 6380 k2 k3 0 3600")),
         ]);
 
         $this->assertSame('v1', $this->redisSecondInstance->get('k1'));
@@ -1750,7 +1800,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.move"
-            )->withExactTags($this->baseTags("move k1 1")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("move k1 1")),
         ]);
 
         $this->assertSame('v1', $this->redis->get('k1'));
@@ -1769,7 +1821,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.renameKey"
-            )->withExactTags($this->baseTags("renameKey k1 k2")),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags("renameKey k1 k2")),
         ]);
 
         $this->assertFalse($this->redis->get('k1'));
@@ -1806,7 +1860,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_FLOAT) {
@@ -1881,7 +1937,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xAdd"
-            )->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
         ]);
 
         // xGroup
@@ -1895,7 +1953,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xGroup"
-            )->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
         ]);
 
         // xInfo
@@ -1909,7 +1969,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xInfo"
-            )->withExactTags($this->baseTags('xInfo GROUPS s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xInfo GROUPS s1')),
         ]);
 
         // xLen
@@ -1923,7 +1985,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xLen"
-            )->withExactTags($this->baseTags('xLen s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xLen s1')),
         ]);
 
         // xPending
@@ -1937,7 +2001,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xPending"
-            )->withExactTags($this->baseTags('xPending s1 group1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xPending s1 group1')),
         ]);
 
         // xRange
@@ -1951,7 +2017,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xRange"
-            )->withExactTags($this->baseTags('xRange s1 - +')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRange s1 - +')),
         ]);
 
         // xRevRange
@@ -1965,7 +2033,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xRevRange"
-            )->withExactTags($this->baseTags('xRevRange s1 + -')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRevRange s1 + -')),
         ]);
 
         // xRead
@@ -1979,7 +2049,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xRead"
-            )->withExactTags($this->baseTags('xRead s1 $')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRead s1 $')),
         ]);
 
         // xReadGroup
@@ -1993,7 +2065,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xReadGroup"
-            )->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
         ]);
 
         // xAck
@@ -2007,7 +2081,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xAck"
-            )->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
         ]);
 
         // xClaim
@@ -2021,7 +2097,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xClaim"
-            )->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
         ]);
 
         // xDel
@@ -2035,7 +2113,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xDel"
-            )->withExactTags($this->baseTags('xDel s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xDel s1 123-456')),
         ]);
 
         // xTrim
@@ -2049,7 +2129,9 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.xTrim"
-            )->withExactTags($this->baseTags('xTrim s1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xTrim s1 0')),
         ]);
     }
 
@@ -2066,14 +2148,18 @@ class PHPRedisTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "Redis.set"
-            )->withExactTags($this->baseTags())
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags())
                 ->withExistingTagsNames(['redis.raw_command']),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
-            )->withExactTags($this->baseTags())
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags())
                 ->withExistingTagsNames(['redis.raw_command']),
         ]);
     }
@@ -2098,7 +2184,7 @@ class PHPRedisTest extends IntegrationTestCase
                 "Redis.connect"
             )
             ->setError()
-            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack'])
+            ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack', '_dd.p.tid'])
             ->withExactTags($this->baseTags(), ['out.host' => 'non-existing-host', 'out.port' => '6379']),
         ]);
     }
@@ -2119,15 +2205,17 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis-redis_integration',
                 'redis',
                 "Redis.connect"
-            )
-                ->withExactTags($this->baseTags(), [Tag::TARGET_PORT => '6379']),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags(), [Tag::TARGET_PORT => '6379']),
             SpanAssertion::build(
                 "Redis.set",
                 'redis-redis_integration',
                 'redis',
                 "Redis.set"
-            )
-                ->withExactTags($this->baseTags('set key value')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value')),
         ]);
     }
 
@@ -2145,14 +2233,14 @@ class PHPRedisTest extends IntegrationTestCase
                 'redis',
                 "Redis.set"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "Redis.get",
                 'phpredis',
                 'redis',
                 "Redis.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 

--- a/tests/Integrations/PHPRedis/V5/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V5/PHPRedisClusterTest.php
@@ -79,7 +79,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.close"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -102,7 +104,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
         ]);
     }
 
@@ -146,7 +150,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
     }
 
@@ -191,7 +197,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expected, $redis->get($args[0]));
@@ -327,7 +335,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSet"
-            )->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSet k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -348,7 +358,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -384,7 +396,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand))
         ]);
         $this->assertSame($expected, $result);
     }
@@ -492,7 +506,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -642,7 +658,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         $this->assertSame($expectedResult, $result);
@@ -882,7 +900,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1050,7 +1070,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_STRING) {
@@ -1232,7 +1254,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.publish"
-            )->withExactTags($this->baseTags('publish ch1 hi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('publish ch1 hi')),
         ]);
     }
 
@@ -1251,25 +1275,33 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.multi"
-            )->withExactTags($this->baseTags('multi')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('multi')),
             SpanAssertion::build(
                 "RedisCluster.set",
                 'phpredis',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set k1 v1')),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
-            )->withExactTags($this->baseTags('get k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('get k1')),
             SpanAssertion::build(
                 "RedisCluster.exec",
                 'phpredis',
                 'redis',
                 "RedisCluster.exec"
-            )->withExactTags($this->baseTags('exec')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('exec')),
         ]);
     }
 
@@ -1301,7 +1333,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($this->normalizeRawCommand($method, $rawCommand))),
         ]);
         $this->assertEquals($expectedResult, $result);
     }
@@ -1370,13 +1404,17 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.dump"
-            )->withExactTags($this->baseTags('dump k1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('dump k1')),
             SpanAssertion::build(
                 "RedisCluster.restore",
                 'phpredis',
                 'redis',
                 "RedisCluster.restore"
-            )->withExactTags($this->baseTags()),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags()),
         ]);
 
         $this->assertSame('v1', $redis->get('k1'));
@@ -1413,7 +1451,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.$method"
-            )->withExactTags($this->baseTags($rawCommand)),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags($rawCommand)),
         ]);
 
         if ($expectedResult === self::A_FLOAT) {
@@ -1488,7 +1528,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xAdd"
-            )->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAdd s1 123-456 k1 v1')),
         ]);
 
         // xGroup
@@ -1502,7 +1544,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xGroup"
-            )->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xGroup CREATE s1 group1 0')),
         ]);
 
         // xInfo
@@ -1516,7 +1560,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xInfo"
-            )->withExactTags($this->baseTags('xInfo GROUPS s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xInfo GROUPS s1')),
         ]);
 
         // xLen
@@ -1530,7 +1576,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xLen"
-            )->withExactTags($this->baseTags('xLen s1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xLen s1')),
         ]);
 
         // xPending
@@ -1544,7 +1592,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xPending"
-            )->withExactTags($this->baseTags('xPending s1 group1')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xPending s1 group1')),
         ]);
 
         // xRange
@@ -1558,7 +1608,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRange"
-            )->withExactTags($this->baseTags('xRange s1 - +')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRange s1 - +')),
         ]);
 
         // xRevRange
@@ -1572,7 +1624,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRevRange"
-            )->withExactTags($this->baseTags('xRevRange s1 + -')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRevRange s1 + -')),
         ]);
 
         // xRead
@@ -1586,7 +1640,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xRead"
-            )->withExactTags($this->baseTags('xRead s1 $')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xRead s1 $')),
         ]);
 
         // xReadGroup
@@ -1600,7 +1656,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xReadGroup"
-            )->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xReadGroup group1 consumer1 s1 >')),
         ]);
 
         // xAck
@@ -1614,7 +1672,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xAck"
-            )->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xAck s1 group1 s1 123-456')),
         ]);
 
         // xClaim
@@ -1628,7 +1688,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xClaim"
-            )->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xClaim s1 group1 consumer1 0 s1 123-456')),
         ]);
 
         // xDel
@@ -1642,7 +1704,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xDel"
-            )->withExactTags($this->baseTags('xDel s1 123-456')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xDel s1 123-456')),
         ]);
 
         // xTrim
@@ -1656,7 +1720,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.xTrim"
-            )->withExactTags($this->baseTags('xTrim s1 0')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('xTrim s1 0')),
         ]);
     }
 
@@ -1674,14 +1740,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1700,14 +1766,14 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis',
                 "RedisCluster.set"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
             SpanAssertion::build(
                 "RedisCluster.get",
                 'phpredis',
                 'redis',
                 "RedisCluster.get"
             )->withExactTags($this->baseTags())
-                ->withExistingTagsNames(['redis.raw_command']),
+                ->withExistingTagsNames(['redis.raw_command', '_dd.p.tid']),
         ]);
     }
 
@@ -1785,7 +1851,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags(null, false, false),
                 ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]
             )),
@@ -1794,7 +1862,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags('set key value', false, false),
                 [
                     '_dd.cluster.name' => 'cluster_name',
@@ -1825,7 +1895,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags(null, false, false),
                 ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]
             )),
@@ -1834,7 +1906,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags('set key value', true, false),
                 [
                     '_dd.cluster.name' => 'cluster_name',
@@ -1865,7 +1939,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags(null, false, false),
                 ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]
             )),
@@ -1874,7 +1950,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'phpredis',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags('set key value', true, true)
             ))
         ]);
@@ -1901,7 +1979,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags(null, false, false),
                 ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]
             )),
@@ -1910,7 +1990,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'redis-cluster_name',
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags('set key value', false, false),
                 [
                     '_dd.cluster.name' => 'cluster_name',
@@ -1941,7 +2023,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 $serviceName,
                 'redis',
                 "RedisCluster.__construct"
-            )->withExactTags(array_merge(
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags(array_merge(
                 $this->baseTags(null, false, false),
                 ['out.host' => $this->connection1[0], 'out.port' => $this->connection1[1]]
             )),
@@ -1950,7 +2034,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 $serviceName,
                 'redis',
                 "RedisCluster.set"
-            )->withExactTags($this->baseTags('set key value'))
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('set key value'))
         ]);
 
         $redis->close();
@@ -1975,7 +2061,9 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 'configured_service',
                 'redis',
                 "RedisCluster.mSetNx"
-            )->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
+            )->withExistingTagsNames([
+                '_dd.p.tid'
+            ])->withExactTags($this->baseTags('mSetNx k1 v1 k2 v2')),
         ]);
     }
 

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -128,7 +128,10 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('Predis.Client.__construct', 'redis', 'redis', 'Predis.Client.__construct')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -144,7 +147,10 @@ final class PredisTest extends IntegrationTestCase
 
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('Predis.Client.__construct', 'redis', 'redis', 'Predis.Client.__construct')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -158,7 +164,10 @@ final class PredisTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
             SpanAssertion::build('Predis.Client.connect', 'redis', 'redis', 'Predis.Client.connect')
-                ->withExactTags($this->baseTags()),
+                ->withExactTags($this->baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -178,6 +187,9 @@ final class PredisTest extends IntegrationTestCase
                     Tag::SPAN_KIND => 'client',
                     Tag::COMPONENT => 'predis',
                     Tag::DB_SYSTEM => 'redis',
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
         ]);
     }
@@ -196,7 +208,10 @@ final class PredisTest extends IntegrationTestCase
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'SET foo value',
                     'redis.args_length' => '3',
-                ])),
+                ]))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -216,7 +231,10 @@ final class PredisTest extends IntegrationTestCase
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'GET key',
                     'redis.args_length' => '2',
-                ])),
+                ]))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -234,7 +252,10 @@ final class PredisTest extends IntegrationTestCase
                 ->withExactTags(array_merge([], $this->baseTags(), [
                     'redis.raw_command' => 'SET key value',
                     'redis.args_length' => '3',
-                ])),
+                ]))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 
@@ -268,7 +289,10 @@ final class PredisTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('Predis.Client.__construct'),
             SpanAssertion::build('Predis.Pipeline.executePipeline', 'redis', 'redis', 'Predis.Pipeline.executePipeline')
-                ->withExactTags($exactTags),
+                ->withExactTags($exactTags)
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
         ]);
     }
 

--- a/tests/Integrations/Roadrunner/V2/CommonScenariosTest.php
+++ b/tests/Integrations/Roadrunner/V2/CommonScenariosTest.php
@@ -50,6 +50,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'roadrunner'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -64,6 +66,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'roadrunner'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -72,7 +76,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'roadrunner',
                         'web',
                         'GET /error'
-                    )->withExactTags([
+                    )->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])->withExactTags([
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',

--- a/tests/Integrations/Roadrunner/V2/DistributedTracingTest.php
+++ b/tests/Integrations/Roadrunner/V2/DistributedTracingTest.php
@@ -26,10 +26,10 @@ class DistributedTracingTest extends WebFrameworkTestCase
 
     public function testDistributedTracing()
     {
-        $traces = $this->tracesFromWebRequest(function () use (&$current_context) {
+        $traces = $this->tracesFromWebRequest(function () use (&$traceId) {
             \DDTrace\add_distributed_tag("user_id", 42);
             \DDTrace\start_span();
-            $current_context = \DDTrace\current_context();
+            $traceId = \DDTrace\root_span()->id;
             $spec = GetSpec::create('request', '/', [
                 "User-Agent: Test",
                 "x-header: somevalue",
@@ -39,7 +39,7 @@ class DistributedTracingTest extends WebFrameworkTestCase
         });
 
         $trace = $traces[0][0];
-        $this->assertSame($current_context["trace_id"], $trace["trace_id"]);
+        $this->assertSame($traceId, $trace["trace_id"]);
         $this->assertSame("42", $trace["meta"]["_dd.p.user_id"]);
         $this->assertSame("Test", $trace["meta"]["http.useragent"]);
         $this->assertSame("somevalue", $trace["meta"]["http.request.headers.x-header"]);
@@ -48,10 +48,10 @@ class DistributedTracingTest extends WebFrameworkTestCase
 
     public function testDistributedTracingPostWithAllowedParams()
     {
-        $traces = $this->tracesFromWebRequest(function () use (&$current_context) {
+        $traces = $this->tracesFromWebRequest(function () use (&$traceId) {
             \DDTrace\add_distributed_tag("user_id", 42);
             \DDTrace\start_span();
-            $current_context = \DDTrace\current_context();
+            $traceId = \DDTrace\root_span()->id;
             $spec = PostSpec::create('request', '/', [
                 'User-Agent: Test',
                 'x-header: somevalue',
@@ -66,7 +66,7 @@ class DistributedTracingTest extends WebFrameworkTestCase
         });
 
         $trace = $traces[0][0];
-        $this->assertSame($current_context["trace_id"], $trace["trace_id"]);
+        $this->assertSame($traceId, $trace["trace_id"]);
         $this->assertSame("42", $trace["meta"]["_dd.p.user_id"]);
         $this->assertSame("Test", $trace["meta"]["http.useragent"]);
         $this->assertSame("somevalue", $trace["meta"]["http.request.headers.x-header"]);

--- a/tests/Integrations/Roadrunner/V2/IPExtractionTest.php
+++ b/tests/Integrations/Roadrunner/V2/IPExtractionTest.php
@@ -27,10 +27,10 @@ class IPExtractionTest extends WebFrameworkTestCase
 
     public function testIpExtraction()
     {
-        $traces = $this->tracesFromWebRequest(function () use (&$current_context) {
+        $traces = $this->tracesFromWebRequest(function () use (&$traceId) {
             \DDTrace\add_distributed_tag("user_id", 42);
             \DDTrace\start_span();
-            $current_context = \DDTrace\current_context();
+            $traceId = \DDTrace\root_span()->id;
             $spec = GetSpec::create('request', '/', [
                 "User-Agent: Test",
                 "x-header: somevalue",
@@ -40,7 +40,7 @@ class IPExtractionTest extends WebFrameworkTestCase
         });
 
         $trace = $traces[0][0];
-        $this->assertSame($current_context["trace_id"], $trace["trace_id"]);
+        $this->assertSame($traceId, $trace["trace_id"]);
         $this->assertSame("42", $trace["meta"]["_dd.p.user_id"]);
         $this->assertSame("Test", $trace["meta"]["http.useragent"]);
         $this->assertSame("somevalue", $trace["meta"]["http.request.headers.x-header"]);

--- a/tests/Integrations/SQLSRV/SQLSRVTest.php
+++ b/tests/Integrations/SQLSRV/SQLSRVTest.php
@@ -73,6 +73,9 @@ class SQLSRVTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('sqlsrv_connect', 'sqlsrv', 'sql', 'sqlsrv_connect')
                 ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -109,6 +112,9 @@ class SQLSRVTest extends IntegrationTestCase
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -133,6 +139,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -159,6 +168,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -188,6 +200,9 @@ class SQLSRVTest extends IntegrationTestCase
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -213,9 +228,15 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ]),
             SpanAssertion::build('sqlsrv_commit', 'sqlsrv', 'sql', 'sqlsrv_commit')
                 ->withExactTags(self::baseTags())
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -232,7 +253,10 @@ class SQLSRVTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('sqlsrv_connect'),
             SpanAssertion::build('sqlsrv_prepare', 'sqlsrv', 'sql', $query)
-                ->withExactTags(self::baseTags($query)),
+                ->withExactTags(self::baseTags($query))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('sqlsrv_execute', 'sqlsrv', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags($query))
@@ -241,6 +265,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -260,7 +287,10 @@ class SQLSRVTest extends IntegrationTestCase
         $this->assertFlameGraph($traces, [
             SpanAssertion::exists('sqlsrv_connect'),
             SpanAssertion::build('sqlsrv_prepare', 'sqlsrv', 'sql', $query)
-                ->withExactTags(self::baseTags($query)),
+                ->withExactTags(self::baseTags($query))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('sqlsrv_execute', 'sqlsrv', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(self::baseTags($query, true))
@@ -269,6 +299,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -296,6 +329,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -326,6 +362,9 @@ class SQLSRVTest extends IntegrationTestCase
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
                 ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])
         ]);
     }
 
@@ -349,7 +388,10 @@ class SQLSRVTest extends IntegrationTestCase
                 ->setError(
                     'SQLSRV error',
                     self::getArchitecture() === 'x86_64' ? SQLSRVTest::ERROR_QUERY_17 : SQLSRVTest::ERROR_QUERY_18
-                )->withExactTags(self::baseTags($query)),
+                )->withExactTags(self::baseTags($query))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::exists('sqlsrv_commit')
         ]);
     }
@@ -412,7 +454,10 @@ class SQLSRVTest extends IntegrationTestCase
                 ->withExactTags(
                     array_merge(self::baseTags($query), [
                         '_dd.base_service' => 'phpunit',
-                    ])),
+                    ]))
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
+                ]),
             SpanAssertion::build('sqlsrv_execute', 'sqlsrv', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge(self::baseTags($query), [
@@ -421,6 +466,9 @@ class SQLSRVTest extends IntegrationTestCase
                 ->withExactMetrics([
                     Tag::DB_ROW_COUNT => 1.0,
                     Tag::ANALYTICS_KEY => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }
@@ -449,6 +497,9 @@ class SQLSRVTest extends IntegrationTestCase
                     Tag::ANALYTICS_KEY => 1.0,
                     '_dd.rule_psr' => 1.0,
                     '_sampling_priority_v1' => 1.0,
+                ])
+                ->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])
         ]);
     }

--- a/tests/Integrations/SQLSRV/SQLSRVTest.php
+++ b/tests/Integrations/SQLSRV/SQLSRVTest.php
@@ -455,9 +455,7 @@ class SQLSRVTest extends IntegrationTestCase
                     array_merge(self::baseTags($query), [
                         '_dd.base_service' => 'phpunit',
                     ]))
-                ->withExistingTagsNames([
-                    '_dd.p.tid'
-                ]),
+                ,
             SpanAssertion::build('sqlsrv_execute', 'sqlsrv', 'sql', $query)
                 ->setTraceAnalyticsCandidate()
                 ->withExactTags(array_merge(self::baseTags($query), [
@@ -466,9 +464,6 @@ class SQLSRVTest extends IntegrationTestCase
                 ->withExactMetrics([
                     Tag::DB_ROW_COUNT => 1.0,
                     Tag::ANALYTICS_KEY => 1.0,
-                ])
-                ->withExistingTagsNames([
-                    '_dd.p.tid'
                 ])
         ]);
     }

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -55,6 +55,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ]),
                     ],
                     'A simple GET request with a view' => [
@@ -69,6 +71,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.view',
@@ -93,6 +97,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])->setError(null, null /* On PHP 5.6 slim error messages are not traced on sandboxed */),
                     ],
                 ]
@@ -113,6 +119,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.route.controller',
@@ -137,6 +145,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.route.controller',
@@ -171,6 +181,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'slim'
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])->setError(null, null)
                             ->withChildren([
                                 SpanAssertion::build(

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -46,6 +46,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'Slim\\Middleware\\ErrorMiddleware'
             )->withExactTags([
                 Tag::COMPONENT => 'slim'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'slim.middleware',
@@ -76,6 +78,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'Slim\\Middleware\\ErrorMiddleware'
             )->withExactTags([
                 Tag::COMPONENT => 'slim'
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'slim.middleware',
@@ -116,6 +120,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'slim'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         $this->wrapMiddleware([
                             SpanAssertion::build(
@@ -143,6 +149,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'slim'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         $this->wrapMiddleware([
                             SpanAssertion::build(
@@ -179,6 +187,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'slim'
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError(null, null)
                     ->withChildren([

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -46,8 +46,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'Slim\\Middleware\\ErrorMiddleware'
             )->withExactTags([
                 Tag::COMPONENT => 'slim'
-            ])->withExistingTagsNames([
-                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'slim.middleware',
@@ -78,8 +76,6 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 'Slim\\Middleware\\ErrorMiddleware'
             )->withExactTags([
                 Tag::COMPONENT => 'slim'
-            ])->withExistingTagsNames([
-                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::build(
                     'slim.middleware',

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -41,6 +41,8 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.status_code' => '200',
                 Tag::SPAN_KIND => 'server',
                 Tag::COMPONENT => 'symfony',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -37,6 +37,8 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.status_code' => '200',
                 Tag::SPAN_KIND => 'server',
                 Tag::COMPONENT => 'symfony',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -47,6 +47,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -84,6 +86,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -130,6 +134,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -196,6 +202,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -47,6 +47,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -85,6 +87,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -132,6 +136,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -200,6 +206,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -41,6 +41,8 @@ class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
                 'http.status_code' => '200',
                 Tag::SPAN_KIND => 'server',
                 Tag::COMPONENT => 'symfony',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -54,6 +54,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -92,6 +94,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -141,6 +145,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'symfony',
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])
                         ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack'])
@@ -196,6 +202,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '404',
                             Tag::SPAN_KIND => 'server',
                             Tag::COMPONENT => 'symfony',
+                        ])->withExistingTagsNames([
+                            '_dd.p.tid'
                         ])
                         ->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -34,6 +34,8 @@ class TemplateEnginesTest extends WebFrameworkTestCase
                 'http.status_code' => '200',
                 Tag::SPAN_KIND => 'server',
                 Tag::COMPONENT => 'symfony',
+            ])->withExistingTagsNames([
+                '_dd.p.tid'
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -93,6 +95,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -140,6 +144,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -208,6 +214,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -93,6 +95,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -140,6 +144,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
                     ->withChildren([
@@ -206,6 +212,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -51,7 +51,9 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
-                ]) ->withChildren([
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
+                ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -95,6 +97,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -142,6 +146,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -198,6 +204,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_0/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -95,6 +97,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -142,6 +146,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -198,6 +204,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_1/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_1/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -95,6 +97,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -142,6 +146,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -198,6 +204,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -93,6 +95,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -141,6 +145,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
@@ -190,6 +197,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '404',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
+++ b/tests/Integrations/Symfony/V5_2/ConsoleCommandTest.php
@@ -23,6 +23,9 @@ class ConsoleCommandTest extends IntegrationTestCase
             $traces,
             [
                 SpanAssertion::build('console', 'console', 'cli', 'console')
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::build('symfony.console.command.run', 'symfony', 'cli', 'about')
                             ->withExactTags([

--- a/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V6_2/CommonScenariosTest.php
@@ -55,6 +55,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'symfony',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([

--- a/tests/Integrations/Symfony/V6_2/ConsoleCommandTest.php
+++ b/tests/Integrations/Symfony/V6_2/ConsoleCommandTest.php
@@ -23,6 +23,9 @@ class ConsoleCommandTest extends IntegrationTestCase
             $traces,
             [
                 SpanAssertion::build('console', 'console', 'cli', 'console')
+                    ->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])
                     ->withChildren([
                         SpanAssertion::build('symfony.console.command.run', 'symfony', 'cli', 'about')
                             ->withExactTags([

--- a/tests/Integrations/Symfony/V6_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V6_2/TraceSearchConfigTest.php
@@ -51,6 +51,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,
                     'process_id' => getmypid(),
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::exists('symfony.kernel.terminate'),
                     SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Yii/V2_0/CommonScenariosTest.php
+++ b/tests/Integrations/Yii/V2_0/CommonScenariosTest.php
@@ -55,6 +55,8 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.route.path' => '/simple',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "yii",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->withChildren([
                         SpanAssertion::build(
                             'yii\web\Application.run',
@@ -90,7 +92,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'yii2_test_app',
                         'web',
                         'GET /simple_view'
-                    )->withExactTags([
+                    )->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])->withExactTags([
                         Tag::HTTP_METHOD => 'GET',
                         Tag::HTTP_URL => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         Tag::HTTP_STATUS_CODE => '200',
@@ -136,7 +140,9 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'yii2_test_app',
                         'web',
                         'GET /error'
-                    )->withExactTags([
+                    )->withExistingTagsNames([
+                        '_dd.p.tid'
+                    ])->withExactTags([
                         Tag::HTTP_METHOD => 'GET',
                         Tag::HTTP_URL => 'http://localhost:9999/error?key=value&<redacted>',
                         Tag::HTTP_STATUS_CODE => '500',

--- a/tests/Integrations/Yii/V2_0/ModuleTest.php
+++ b/tests/Integrations/Yii/V2_0/ModuleTest.php
@@ -45,6 +45,8 @@ class ModuleTest extends WebFrameworkTestCase
                     'app.endpoint' => 'app\modules\forum\controllers\ModuleController::actionView',
                     Tag::SPAN_KIND => "server",
                     Tag::COMPONENT => "yii",
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::build(
                         'yii\web\Application.run',

--- a/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
@@ -45,6 +45,8 @@ class ParameterizedRouteTest extends WebFrameworkTestCase
                     'app.endpoint' => 'app\controllers\HomesController::actionView',
                     Tag::SPAN_KIND => "server",
                     Tag::COMPONENT => "yii",
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::build(
                         'yii\web\Application.run',

--- a/tests/Integrations/Yii/V2_0/YiiDetailsTest.php
+++ b/tests/Integrations/Yii/V2_0/YiiDetailsTest.php
@@ -46,6 +46,8 @@ class LazyLoadingIntegrationsFromYiiTest extends WebFrameworkTestCase
                     'app.endpoint' => 'app\controllers\SiteController::actionIndex',
                     Tag::SPAN_KIND => "server",
                     Tag::COMPONENT => "yii",
+                ])->withExistingTagsNames([
+                    '_dd.p.tid'
                 ])->withChildren([
                     SpanAssertion::build(
                         'yii\web\Application.run',

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -43,6 +43,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
             ],
             'A simple GET request with a view' => [

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -56,6 +56,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
             ],
             'A GET request with an exception' => [
@@ -69,6 +71,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])->setError('Exception', 'Controller error', true),
             ],
         ];

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -44,6 +44,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'zendframework',
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/ZendFramework/V1_21/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1_21/CommonScenariosTest.php
@@ -43,6 +43,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
             ],
             'A simple GET request with a view' => [
@@ -56,6 +58,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
             ],
             'A GET request with an exception' => [
@@ -69,6 +73,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => "server",
                         Tag::COMPONENT => "zendframework",
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ])
                     ->setError('Exception', 'Controller error', true)
             ],

--- a/tests/Integrations/ZendFramework/V1_21/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1_21/TraceSearchConfigTest.php
@@ -49,6 +49,8 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         '_dd1.sr.eausr' => 0.3,
                         '_sampling_priority_v1' => 1,
                         'process_id' => getmypid(),
+                    ])->withExistingTagsNames([
+                        '_dd.p.tid'
                     ]),
             ]
         );

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -80,6 +80,6 @@ object(DDTrace\RootSpanData)#%d (16) {
   array(0) {
   }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
   ["traceId"]=>
-  string(32) "0000000000000000%s"
+  string(32) "%s"
 }
 bool(true)

--- a/tests/ext/dd_trace_span_data_get_link.phpt
+++ b/tests/ext/dd_trace_span_data_get_link.phpt
@@ -9,9 +9,10 @@ DDTrace\trace_function('greet',
     function (\DDTrace\SpanData $span) {
         echo "greet tracer.\n";
         $span->name = "foo";
-        var_dump(json_encode($span->getLink()));
-        var_dump(dd_trace_peek_span_id());
-        var_dump(\DDTrace\trace_id());
+        $link = $span->getLink();
+        var_dump(json_encode($link));
+        var_dump(\DDTrace\active_span()->hexId() === $link->spanId);
+        var_dump(\DDTrace\root_span()->traceId === $link->traceId);
     }
 );
 
@@ -26,6 +27,6 @@ greet('Datadog');
 --EXPECTF--
 Hello, Datadog.
 greet tracer.
-string(76) "{"trace_id":"0000000000000000c151df7d6ee5e2d6","span_id":"a3978fb9b92502a8"}"
-string(20) "11788048577503494824"
-string(20) "13930160852258120406"
+string(%d) "{"trace_id":"%s","span_id":"%s"}"
+bool(true)
+bool(true)

--- a/tests/ext/dd_trace_span_data_serialization_with_links.phpt
+++ b/tests/ext/dd_trace_span_data_serialization_with_links.phpt
@@ -46,17 +46,17 @@ var_dump(dd_trace_serialize_closed_spans()[0]);
 
 ?>
 --EXPECTF--
-string(76) "{"trace_id":"0000000000000000c151df7d6ee5e2d6","span_id":"a3978fb9b92502a8"}"
+string(76) "{"trace_id":"%sc151df7d6ee5e2d6","span_id":"a3978fb9b92502a8"}"
 array(5) {
   ["trace_id"]=>
-  string(32) "0000000000000000c151df7d6ee5e2d6"
+  string(32) "%sc151df7d6ee5e2d6"
   ["span_id"]=>
   string(16) "a3978fb9b92502a8"
 }
-string(76) "{"trace_id":"0000000000000000c151df7d6ee5e2d6","span_id":"c08c967f0e5e7b0a"}"
+string(76) "{"trace_id":"%sc151df7d6ee5e2d6","span_id":"c08c967f0e5e7b0a"}"
 array(5) {
   ["trace_id"]=>
-  string(32) "0000000000000000c151df7d6ee5e2d6"
+  string(32) "%sc151df7d6ee5e2d6"
   ["span_id"]=>
   string(16) "c08c967f0e5e7b0a"
 }
@@ -82,6 +82,6 @@ array(10) {
   ["meta"]=>
   array(1) {
     ["_dd.span_links"]=>
-    string(155) "[{"trace_id":"0000000000000000c151df7d6ee5e2d6","span_id":"a3978fb9b92502a8"},{"trace_id":"0000000000000000c151df7d6ee5e2d6","span_id":"c08c967f0e5e7b0a"}]"
+    string(155) "[{"trace_id":"%sc151df7d6ee5e2d6","span_id":"a3978fb9b92502a8"},{"trace_id":"%sc151df7d6ee5e2d6","span_id":"c08c967f0e5e7b0a"}]"
   }
 }

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -36,13 +36,15 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
       ["_dd.origin"]=>
       string(7) "datadog"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_overwrite_active_span.phpt
@@ -7,6 +7,36 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 
+// Source: https://magp.ie/2015/09/30/convert-large-integer-to-hexadecimal-without-php-math-extension/
+function largeBaseConvert($numString, $fromBase, $toBase)
+{
+    $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+    $toString = substr($chars, 0, $toBase);
+
+    $length = strlen($numString);
+    $result = '';
+    for ($i = 0; $i < $length; $i++) {
+        $number[$i] = strpos($chars, $numString[$i]);
+    }
+    do {
+        $divide = 0;
+        $newLen = 0;
+        for ($i = 0; $i < $length; $i++) {
+            $divide = $divide * $fromBase + $number[$i];
+            if ($divide >= $toBase) {
+                $number[$newLen++] = (int)($divide / $toBase);
+                $divide = $divide % $toBase;
+            } elseif ($newLen > 0) {
+                $number[$newLen++] = 0;
+            }
+        }
+        $length = $newLen;
+        $result = $toString[$divide] . $result;
+    } while ($newLen != 0);
+
+    return $result;
+}
+
 function dump_spans() {
     foreach (dd_trace_serialize_closed_spans() as $span) {
         unset($span["meta"]["process_id"], $span["meta"]["runtime-id"], $span["meta"]["_dd.p.dm"]);
@@ -34,13 +64,13 @@ var_dump(DDTrace\set_distributed_tracing_context("0", "0", "", []));
 var_dump(DDTrace\current_context());
 $trace_id = DDTrace\trace_id();
 var_dump($trace_id != 123);
-var_dump($trace_id == DDTrace\root_span()->id);
-
+var_dump(largeBaseConvert($trace_id, 10, 16) == DDTrace\root_span()->traceId);
+$id = DDTrace\root_span()->id;
 DDTrace\close_span();
 DDTrace\close_span();
 
 $span = dump_spans();
-echo "all spans trace_id updated: "; var_dump($span["trace_id"] == $trace_id);
+echo "all spans trace_id updated: "; var_dump($span["trace_id"] == $id);
 
 ?>
 --EXPECTF--
@@ -83,6 +113,6 @@ array(5) {
 }
 bool(true)
 bool(true)
-parent: 0, trace: %d, meta: []
+parent: 0, trace: %d, meta: {"_dd.p.tid":"%s"}
 parent: %d, trace: %d, meta: []
 all spans trace_id updated: bool(true)

--- a/tests/ext/extract_server_values.phpt
+++ b/tests/ext/extract_server_values.phpt
@@ -22,11 +22,13 @@ var_dump(dd_trace_serialize_closed_spans()[0]["meta"]);
 
 ?>
 --EXPECTF--
-array(3) {
+array(4) {
   ["runtime-id"]=>
   string(36) "%s"
   ["http.request.headers.0"]=>
   string(16) "http_zero_header"
   ["_dd.p.dm"]=>
   string(2) "-1"
+  ["_dd.p.tid"]=>
+  string(16) "%s"
 }

--- a/tests/ext/fibers/fiber_observer_bailout.phpt
+++ b/tests/ext/fibers/fiber_observer_bailout.phpt
@@ -51,6 +51,7 @@ spans(\DDTrace\SpanData) (1) {
 #3 %s(%d): outer()
 #4 {main}
     _dd.p.dm => -1
+    _dd.p.tid => %s
     inFiber (fiber_observer_bailout.php, inFiber, cli) (error: Allowed memory size of %d bytes exhausted %s)
       error.type => E_ERROR
       error.message => Allowed memory size of %d bytes exhausted %s

--- a/tests/ext/fibers/fiber_stack_switch.phpt
+++ b/tests/ext/fibers/fiber_stack_switch.phpt
@@ -78,6 +78,7 @@ Caught ex
 spans(\DDTrace\SpanData) (1) {
   fiber_stack_switch.php (fiber_stack_switch.php, fiber_stack_switch.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     Fiber.start (fiber_stack_switch.php, Fiber.start, cli)
       inFiber (fiber_stack_switch.php, inFiber, cli)
         otherFiber (fiber_stack_switch.php, otherFiber, cli) (error: Thrown Exception: ex in %s:%d)

--- a/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
@@ -42,11 +42,11 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-b3: 248869c998246a2e-248869c998246a2e-1
-traceparent: 00-0000000000000000248869c998246a2e-248869c998246a2e-01
-tracestate: dd=o:_______~_: ;t.escaped:_~_: ;t.dm:-1
+b3: %s248869c998246a2e-248869c998246a2e-1
+traceparent: 00-%s248869c998246a2e-248869c998246a2e-01
+tracestate: dd=o:_______~_: ;t.tid:%s;t.escaped:_~_: ;t.dm:-1
 x-datadog-origin: ∂~,=;:
-x-datadog-tags: _dd.p.escaped=_=;: ,_dd.p.dm=-1
+x-datadog-tags: _dd.p.tid=%s,_dd.p.escaped=_=;: ,_dd.p.dm=-1
 bool(false)
 Done.
 No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_propagate_custom_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_propagate_custom_tags.phpt
@@ -28,6 +28,6 @@ var_dump($meta["_dd.p.usr.id"]);
 dt_dump_headers_from_httpbin(query_headers(), ['x-datadog-tags']);
 
 ?>
---EXPECT--
+--EXPECTF--
 string(4) "1234"
-x-datadog-tags: _dd.p.usr.id=1234,_dd.p.dm=-1
+x-datadog-tags: _dd.p.tid=%s,_dd.p.usr.id=1234,_dd.p.dm=-1

--- a/tests/ext/retrieve_128_bit_trace_id.phpt
+++ b/tests/ext/retrieve_128_bit_trace_id.phpt
@@ -55,12 +55,12 @@ ini_set("datadog.trace.128_bit_traceid_logging_enabled", "1"); // 2^64 -> 1 0000
 var_dump(\DDTrace\logs_correlation_trace_id());
 
 ?>
---EXPECT--
+--EXPECTF--
 string(20) "13930160852258120406"
-string(20) "13930160852258120406"
-string(20) "11788048577503494824"
+string(32) "%sc151df7d6ee5e2d6"
+string(32) "%sa3978fb9b92502a8"
 string(32) "192f3581c8461c79abf2684ee31ce27d"
-string(19) "2513787319205155662"
+string(32) "%s22e2c43f8a1ad34e"
 string(20) "12390080212876714621"
 string(1) "1"
 string(32) "00000000000000010000000000000001"

--- a/tests/ext/root_span_url_as_resource_names.phpt
+++ b/tests/ext/root_span_url_as_resource_names.phpt
@@ -22,7 +22,7 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(5) {
+array(6) {
   ["runtime-id"]=>
   string(36) "%s"
   ["http.url"]=>
@@ -33,4 +33,6 @@ array(5) {
   string(2) "-1"
   ["http.status_code"]=>
   string(3) "200"
+  ["_dd.p.tid"]=>
+  string(16) "%s"
 }

--- a/tests/ext/root_span_url_as_resource_names_no_host.phpt
+++ b/tests/ext/root_span_url_as_resource_names_no_host.phpt
@@ -18,7 +18,7 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(5) {
+array(6) {
   ["runtime-id"]=>
   string(36) "%s"
   ["http.url"]=>
@@ -29,4 +29,6 @@ array(5) {
   string(2) "-1"
   ["http.status_code"]=>
   string(3) "200"
+  ["_dd.p.tid"]=>
+  string(16) "%s"
 }

--- a/tests/ext/root_span_url_with_post_no_param.phpt
+++ b/tests/ext/root_span_url_with_post_no_param.phpt
@@ -16,9 +16,11 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(2) {
+array(3) {
   ["runtime-id"]=>
   string(36) "%s"
   ["_dd.p.dm"]=>
   string(2) "-1"
+  ["_dd.p.tid"]=>
+  string(16) "%s"
 }

--- a/tests/ext/root_span_url_with_post_no_param_set.phpt
+++ b/tests/ext/root_span_url_with_post_no_param_set.phpt
@@ -15,9 +15,11 @@ $spans = dd_trace_serialize_closed_spans();
 var_dump($spans[0]['meta']);
 ?>
 --EXPECTF--
-array(2) {
+array(3) {
   ["runtime-id"]=>
   string(36) "%s"
   ["_dd.p.dm"]=>
   string(2) "-1"
+  ["_dd.p.tid"]=>
+  string(16) "%s"
 }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -110,13 +110,15 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["runtime-id"]=>
       string(36) "%s"
       ["args.0"]=>
       string(18) "tracing is awesome"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(6) {
@@ -179,11 +181,13 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/sandbox-regression/nested_dropped_spans.phpt
+++ b/tests/ext/sandbox-regression/nested_dropped_spans.phpt
@@ -29,5 +29,6 @@ dd_dump_spans();
 spans(\DDTrace\SpanData) (1) {
   root span (nested_dropped_spans.php, root span, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     inner span (nested_dropped_spans.php, inner span, cli)
 }

--- a/tests/ext/sandbox/dd_trace_function_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_function_alias.phpt
@@ -26,4 +26,5 @@ bar(hello)
 spans(\DDTrace\SpanData) (1) {
   bar (alias, bar, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -111,7 +111,7 @@ array(5) {
     ["type"]=>
     string(7) "BarType"
     ["meta"]=>
-    array(6) {
+    array(7) {
       ["runtime-id"]=>
       string(36) "%s"
       ["args.0"]=>
@@ -124,6 +124,8 @@ array(5) {
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(6) {
@@ -212,11 +214,13 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {
@@ -249,11 +253,13 @@ array(5) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -42,11 +42,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -119,7 +119,7 @@ array(3) {
     ["type"]=>
     string(7) "FooType"
     ["meta"]=>
-    array(6) {
+    array(7) {
       ["runtime-id"]=>
       string(36) "%s"
       ["args.0"]=>
@@ -132,6 +132,8 @@ array(3) {
       string(%d) "%d"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(6) {
@@ -198,11 +200,13 @@ array(3) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/sandbox/dd_trace_method_alias.phpt
+++ b/tests/ext/sandbox/dd_trace_method_alias.phpt
@@ -30,4 +30,5 @@ Foo::bar(hello)
 spans(\DDTrace\SpanData) (1) {
   Foo.bar (alias, Foo.bar, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/default_span_properties.phpt
+++ b/tests/ext/sandbox/default_span_properties.phpt
@@ -29,13 +29,14 @@ main(6);
 include 'dd_dumper.inc';
 dd_dump_spans();
 ?>
---EXPECT--
+--EXPECTF--
 21
 28
 spans(\DDTrace\SpanData) (1) {
   main (default_span_properties.php, main, cli)
     max => 6
     _dd.p.dm => -1
+    _dd.p.tid => %s
     MyRange (default_span_properties.php, MyRange, cli)
     array_sum (default_span_properties.php, array_sum, cli)
       retval => 21

--- a/tests/ext/sandbox/default_span_properties_method.phpt
+++ b/tests/ext/sandbox/default_span_properties_method.phpt
@@ -37,12 +37,13 @@ $foo->main(2020);
 include 'dd_dumper.inc';
 dd_dump_spans();
 ?>
---EXPECT--
+--EXPECTF--
 06
 spans(\DDTrace\SpanData) (1) {
   Foo.main (default_span_properties_method.php, Foo.main, cli)
     year => 2020
     _dd.p.dm => -1
+    _dd.p.tid => %s
     DateTime.__construct (default_span_properties_method.php, DateTime.__construct, cli)
       date => 2020-06-15
     MyDateTimeFormat (default_span_properties_method.php, MyDateTimeFormat, cli)

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -44,13 +44,15 @@ array(1) {
     ["error"]=>
     int(1)
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["runtime-id"]=>
       string(36) "%s"
       ["error.message"]=>
       string(9) "Foo error"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/sandbox/install_hook/hook_scoped_file.phpt
+++ b/tests/ext/sandbox/install_hook/hook_scoped_file.phpt
@@ -30,5 +30,6 @@ test
 spans(\DDTrace\SpanData) (1) {
   A.include (hook_scoped_file.php, A.include, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     %s/testinclude.inc (hook_scoped_file.php, %s/testinclude.inc, cli)
 }

--- a/tests/ext/sandbox/install_hook/trace_callable.phpt
+++ b/tests/ext/sandbox/install_hook/trace_callable.phpt
@@ -61,9 +61,12 @@ include __DIR__ . '/../dd_dumper.inc';
 spans(\DDTrace\SpanData) (3) {
   test\foo (trace_callable.php, 0, cli)
     result => 1
+    _dd.p.tid => %s
   test\bar.foo (trace_callable.php, 1, cli)
     result => 2
+    _dd.p.tid => %s
   test\closure.{closure} (trace_callable.php, 2, cli)
     closure.declaration => %s:%d
     result => 3
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_closure.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure.phpt
@@ -64,24 +64,32 @@ include __DIR__ . '/../dd_dumper.inc';
 spans(\DDTrace\SpanData) (8) {
   intval (trace_closure.php, 0, cli)
     result => 0
+    _dd.p.tid => %s
   test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
-    closure.declaration => %s:7
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:7
     result => 1
+    _dd.p.tid => %s
   test\foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => %s:12
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:12
     result => 2
+    _dd.p.tid => %s
   test\bar.foo.{closure} (trace_closure.php, 3, cli)
-    closure.declaration => %s:19
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:19
     result => 3
+    _dd.p.tid => %s
   intval (trace_closure.php, 0, cli)
     result => 1
+    _dd.p.tid => %s
   test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
-    closure.declaration => %s:7
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:7
     result => 2
+    _dd.p.tid => %s
   test\foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => %s:12
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:12
     result => 3
+    _dd.p.tid => %s
   test\bar.foo.{closure} (trace_closure.php, 3, cli)
-    closure.declaration => %s:19
+    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:19
     result => 4
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_closure.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure.phpt
@@ -66,30 +66,30 @@ spans(\DDTrace\SpanData) (8) {
     result => 0
     _dd.p.tid => %s
   test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:7
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:7
     result => 1
     _dd.p.tid => %s
   test\foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:12
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:12
     result => 2
     _dd.p.tid => %s
   test\bar.foo.{closure} (trace_closure.php, 3, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:19
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:19
     result => 3
     _dd.p.tid => %s
   intval (trace_closure.php, 0, cli)
     result => 1
     _dd.p.tid => %s
   test\trace_closure.php:7\{closure} (trace_closure.php, 1, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:7
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:7
     result => 2
     _dd.p.tid => %s
   test\foo.{closure} (trace_closure.php, 2, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:12
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:12
     result => 3
     _dd.p.tid => %s
   test\bar.foo.{closure} (trace_closure.php, 3, cli)
-    closure.declaration => /home/circleci/app/tmp/build_extension/tests/ext/sandbox/install_hook/trace_closure.php:19
+    closure.declaration => %s/tests/ext/sandbox/install_hook/trace_closure.php:19
     result => 4
     _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
+++ b/tests/ext/sandbox/install_hook/trace_closure_from_callable.phpt
@@ -31,15 +31,19 @@ include __DIR__ . '/../dd_dumper.inc';
 \dd_dump_spans(true);
 
 ?>
---EXPECT--
+--EXPECTF--
 spans(\DDTrace\SpanData) (4) {
   foo (trace_closure_from_callable.php, foo, cli)
     global => 1
+    _dd.p.tid => %s
   foo (trace_closure_from_callable.php, foo, cli)
     global => 1
     fake => 1
+    _dd.p.tid => %s
   foo (trace_closure_from_callable.php, foo, cli)
     global => 1
+    _dd.p.tid => %s
   foo (trace_closure_from_callable.php, foo, cli)
     global => 1
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_file.phpt
+++ b/tests/ext/sandbox/install_hook/trace_file.phpt
@@ -23,6 +23,8 @@ test
 spans(\DDTrace\SpanData) (2) {
   %s/testinclude.inc (trace_file.php, %s/install_hook/testinclude.inc, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   %s/testinclude.inc (trace_file.php, %s/install_hook/testinclude.inc, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_function.phpt
+++ b/tests/ext/sandbox/install_hook/trace_function.phpt
@@ -47,6 +47,8 @@ include __DIR__ . '/../dd_dumper.inc';
 spans(\DDTrace\SpanData) (2) {
   test\foo (trace_function.php, 0, cli)
     result => 1
+    _dd.p.tid => %s
   test\bar.foo (trace_function.php, 1, cli)
     result => 2
+    _dd.p.tid => %s
 }

--- a/tests/ext/sandbox/install_hook/trace_generator.phpt
+++ b/tests/ext/sandbox/install_hook/trace_generator.phpt
@@ -33,5 +33,6 @@ spans(\DDTrace\SpanData) (1) {
   test\trace_generator.php:%d\{closure} (trace_generator.php, test\trace_generator.php:%d\{closure}, cli)
     closure.declaration => %s:%d
     result => 3
+    _dd.p.tid => %s
      (trace_generator.php, cli)
 }

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -76,7 +76,7 @@ object(DDTrace\RootSpanData)#%d (16) {
   array(0) {
   }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
   ["traceId"]=>
-  string(32) "0000000000000000%s"
+  string(32) "%s"
 }
 object(DDTrace\RootSpanData)#%d (16) {
   ["name"]=>
@@ -161,7 +161,7 @@ object(DDTrace\RootSpanData)#%d (16) {
       array(0) {
       }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
       ["traceId"]=>
-      string(32) "0000000000000000%s"
+      string(32) "%s"
     }
   }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
   ["propagatedTags"]=>
@@ -173,7 +173,7 @@ object(DDTrace\RootSpanData)#%d (16) {
   array(0) {
   }%r(\s*\["parentId"\]=>\s+uninitialized\(string\))?%r
   ["traceId"]=>
-  string(32) "0000000000000000%s"
+  string(32) "%s"
 }
 array(1) {
   [0]=>
@@ -195,11 +195,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/span_stack/span_stack_clone.phpt
+++ b/tests/ext/span_stack/span_stack_clone.phpt
@@ -52,12 +52,17 @@ Switching to an initial stacks parent has no effect: bool(true)
 spans(\DDTrace\SpanData) (5) {
   primary (span_stack_clone.php, primary, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   root (span_stack_clone.php, root, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   root clone (span_stack_clone.php, root clone, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   primary clone (span_stack_clone.php, primary clone, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   initial clone (span_stack_clone.php, initial clone, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/span_stack/span_stack_swap.phpt
+++ b/tests/ext/span_stack/span_stack_swap.phpt
@@ -80,9 +80,11 @@ We closed the active stack after all other stacks were closed. No other span is 
 spans(\DDTrace\SpanData) (2) {
   span_stack_swap.php (span_stack_swap.php, span_stack_swap.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
      (span_stack_swap.php, cli)
        (span_stack_swap.php, cli)
      (span_stack_swap.php, cli)
   other root (span_stack_swap.php, other root, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/span_stack/span_stack_swap_traced_function.phpt
+++ b/tests/ext/span_stack/span_stack_swap_traced_function.phpt
@@ -58,6 +58,7 @@ We closed the active stack after all other stacks were closed. No other span is 
 spans(\DDTrace\SpanData) (1) {
   span_stack_swap_traced_function.php (span_stack_swap_traced_function.php, span_stack_swap_traced_function.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     outer (span_stack_swap_traced_function.php, outer, cli)
       creates_span_stack (span_stack_swap_traced_function.php, creates_span_stack, cli)
         inner (span_stack_swap_traced_function.php, inner, cli)

--- a/tests/ext/span_stack/span_trace_stack_autoclose.phpt
+++ b/tests/ext/span_stack/span_trace_stack_autoclose.phpt
@@ -35,5 +35,6 @@ Having lost all references to the that span stacks objects, it is autoclosed: bo
 spans(\DDTrace\SpanData) (1) {
   span_trace_stack_autoclose.php (span_trace_stack_autoclose.php, span_trace_stack_autoclose.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
      (span_trace_stack_autoclose.php, cli)
 }

--- a/tests/ext/span_stack/span_trace_swap.phpt
+++ b/tests/ext/span_stack/span_trace_swap.phpt
@@ -41,6 +41,8 @@ This automatically switches back to the parent stack: bool(true)
 spans(\DDTrace\SpanData) (2) {
   span_trace_swap.php (span_trace_swap.php, span_trace_swap.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
   other root (span_trace_swap.php, other root, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/span_stack/start_span_new_trace.phpt
+++ b/tests/ext/span_stack/start_span_new_trace.phpt
@@ -18,7 +18,7 @@ echo 'New trace span is reflected in DDTrace\root_span(): '; var_dump($new_root 
 echo 'New trace span is reflected in DDTrace\active_stack(): '; var_dump($new_root->stack == DDTrace\active_stack());
 echo 'New trace span stack has a parent (a target to switch to on close): '; var_dump($new_root->stack->parent == $primary_active->stack);
 echo 'New trace span has no parent: '; var_dump($new_root->parent == null);
-echo 'New trace span has a trace id equal to itself: '; var_dump($new_root->id == DDTrace\trace_id());
+echo 'New trace span has a trace id equal to itself: '; var_dump($new_root->id == DDTrace\root_span()->id);
 
 # on new root
 $active_new_root_span = DDTrace\start_span();
@@ -60,9 +60,11 @@ With the trace root also accordingly updated: bool(true)
 spans(\DDTrace\SpanData) (2) {
   start_span_new_trace.php (start_span_new_trace.php, start_span_new_trace.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
      (start_span_new_trace.php, cli)
        (start_span_new_trace.php, cli)
   other root (start_span_new_trace.php, other root, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
      (start_span_new_trace.php, cli)
 }

--- a/tests/ext/span_stack/start_span_stack.phpt
+++ b/tests/ext/span_stack/start_span_stack.phpt
@@ -54,6 +54,7 @@ The stack still retains its direct parent as active: bool(true)
 spans(\DDTrace\SpanData) (1) {
   start_span_stack.php (start_span_stack.php, start_span_stack.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
      (start_span_stack.php, cli)
        (start_span_stack.php, cli)
 }

--- a/tests/ext/span_stack/start_top_level_span_stack.phpt
+++ b/tests/ext/span_stack/start_top_level_span_stack.phpt
@@ -13,7 +13,7 @@ print 'That new span stack has the same parent: '; var_dump($new_stack == DDTrac
 
 $stack_span = DDTrace\start_span();
 print 'That top-level span is, in fact a trace root span without parent: '; var_dump($stack_span->parent == null);
-print 'And it has matching a trace id: '; var_dump($stack_span->id == DDTrace\trace_id());
+print 'And it has matching a trace id: '; var_dump($stack_span->id == DDTrace\root_span()->id);
 
 DDTrace\close_span();
 echo 'Verify the stack_span stays if the top-level span is closed - this span stack is not tied to a trace directly: '; var_dump($new_stack == DDTrace\active_stack());
@@ -45,4 +45,5 @@ Impliying we also have no active span: bool(true)
 spans(\DDTrace\SpanData) (1) {
   start_top_level_span_stack.php (start_top_level_span_stack.php, start_top_level_span_stack.php, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -73,6 +73,8 @@ array(1) {
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {
@@ -112,6 +114,8 @@ array(1) {
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {
@@ -151,6 +155,8 @@ array(1) {
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -68,7 +68,7 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
@@ -109,7 +109,7 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
@@ -150,7 +150,7 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -73,11 +73,13 @@ array(2) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {
@@ -110,13 +112,15 @@ array(2) {
     ["type"]=>
     string(6) "runner"
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["runtime-id"]=>
       string(36) "%s"
       ["aa"]=>
       string(2) "bb"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(5) {

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -45,11 +45,13 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(2) {
+    array(3) {
       ["runtime-id"]=>
       string(36) "%s"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/tests/ext/traced_attribute.phpt
+++ b/tests/ext/traced_attribute.phpt
@@ -55,17 +55,20 @@ noRecursion();
 dd_dump_spans();
 
 ?>
---EXPECT--
+--EXPECTF--
 spans(\DDTrace\SpanData) (3) {
   bar (traced_attribute.php, bar, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     simplename (test, rsrc, typeee)
       a => b
       _dd.base_service => traced_attribute.php
   recursion (traced_attribute.php, recursion, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
     recursion (traced_attribute.php, recursion, cli)
       recursion (traced_attribute.php, recursion, cli)
   noRecursion (traced_attribute.php, noRecursion, cli)
     _dd.p.dm => -1
+    _dd.p.tid => %s
 }


### PR DESCRIPTION
### Description

Enable 128-bit trace ID generation by default.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
