### PR TITLE
CakePHP http.route implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,6 @@ TEST_INTEGRATIONS_71 := \
 
 TEST_WEB_71 := \
 	test_metrics \
-	test_web_cakephp_28 \
 	test_web_codeigniter_22 \
 	test_web_laravel_42 \
 	test_web_laravel_57 \

--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,7 @@ TEST_INTEGRATIONS_71 := \
 
 TEST_WEB_71 := \
 	test_metrics \
+	test_web_cakephp_28 \
 	test_web_codeigniter_22 \
 	test_web_laravel_42 \
 	test_web_laravel_57 \

--- a/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
@@ -132,6 +132,19 @@ class CakePHPIntegration extends Integration
             $span->meta[Tag::COMPONENT] = CakePHPIntegration::NAME;
         });
 
+        \DDTrace\hook_method(
+            'CakeRoute',
+            'parse',
+            null,
+            function ($app, $appClass, $args, $retval) use ($integration) {
+                if (!$retval) {
+                    return;
+                }
+
+                $integration->rootSpan->meta[Tag::HTTP_ROUTE] = $app->template;
+            }
+        );
+
         return Integration::LOADED;
     }
 }

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Config/routes.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Config/routes.php
@@ -31,7 +31,10 @@
  */
 	Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 
-	Router::connect('/parameterized/:param', array('controller' => 'Parameterized', 'action' => 'customAction'));
+	Router::connect('/parameterized/:param',
+		array('controller' => 'Parameterized', 'action' => 'customAction'),
+		array('pass' => array('param'))
+	);
 /**
  * Load all plugin routes. See the CakePlugin documentation on
  * how to customize the loading of plugin routes.

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Config/routes.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Config/routes.php
@@ -31,6 +31,7 @@
  */
 	Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 
+	Router::connect('/parameterized/:param', array('controller' => 'Parameterized', 'action' => 'customAction'));
 /**
  * Load all plugin routes. See the CakePlugin documentation on
  * how to customize the loading of plugin routes.

--- a/tests/Frameworks/CakePHP/Version_2_8/app/Controller/ParameterizedController.php
+++ b/tests/Frameworks/CakePHP/Version_2_8/app/Controller/ParameterizedController.php
@@ -1,0 +1,12 @@
+<?php
+
+App::uses('AppController', 'Controller');
+
+class ParameterizedController extends AppController
+{
+	public function customAction($param)
+	{
+		$this->autoRender = false;
+		echo 'Hello ' + $param;
+	}
+}

--- a/tests/Frameworks/TestScenarios.php
+++ b/tests/Frameworks/TestScenarios.php
@@ -17,6 +17,7 @@ class TestScenarios
             )->expectStatusCode(500),
             GetSpec::create('A GET request to a missing route', '/does_not_exist?key=value&pwd=should_redact'),
             GetSpec::create('A GET request to a dynamic route returning a string', '/dynamic_route/dynamic01/static/dynamic02'),
+            GetSpec::create('A GET request to a route with a parameter', '/parameterized/paramValue'),
         ];
     }
 }

--- a/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
+++ b/tests/Frameworks/Util/CommonScenariosDataProviderTrait.php
@@ -46,6 +46,11 @@ trait CommonScenariosDataProviderTrait
         if ($i !== false) {
             unset($unexpectedRequest[$i]);
         }
+        //Only available in frameworks implementing http.route
+        $i = array_search('A GET request to a route with a parameter', $unexpectedRequest, true);
+        if ($i !== false) {
+            unset($unexpectedRequest[$i]);
+        }
         if ($unexpectedRequest) {
             throw new \Exception(
                 'Found the following scenarios not having any expectation defined: '

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'http.route' => '/:controller',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
                     ])->withChildren([
@@ -77,6 +78,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'http.route' => '/:controller',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
                     ])->withChildren([
@@ -111,6 +113,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'http.route' => '/:controller',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'cakephp',
                     ])->withExistingTagsNames([
@@ -140,6 +143,32 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ]),
                     ]),
                 ],
+                'A GET request to a route with a parameter' => [
+                    SpanAssertion::build(
+                        'cakephp.request',
+                        'cakephp_test_app',
+                        'web',
+                        'GET ParameterizedController@customAction'
+                    )->withExactTags([
+                        'cakephp.route.controller' => 'Parameterized',
+                        'cakephp.route.action' => 'index',
+                        'http.method' => 'GET',
+                        'http.url' => 'http://localhost:9999/parameterized/paramValue',
+                        'http.status_code' => '200',
+                        'http.route' => '/parameterized/:param',
+                        Tag::SPAN_KIND => 'server',
+                        Tag::COMPONENT => 'cakephp',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'Controller.invokeAction',
+                            'cakephp_test_app',
+                            'web',
+                            'Controller.invokeAction'
+                        )->withExactTags([
+                            Tag::COMPONENT => 'cakephp',
+                        ])
+                    ]),
+                ]
             ]
         );
     }

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -151,7 +151,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'GET ParameterizedController@customAction'
                     )->withExactTags([
                         'cakephp.route.controller' => 'Parameterized',
-                        'cakephp.route.action' => 'index',
+                        'cakephp.route.action' => 'customAction',
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/parameterized/paramValue',
                         'http.status_code' => '200',


### PR DESCRIPTION
### Description

Add `http.route` tag to CakePHP root spans

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
