### PR TITLE
Test appsec on dependency change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ workflows:
             components/.*  components-c  true
             zend_abstract_interface/.*  zend_abstract_interface true
             zend_abstract_interface/.*  profiling true
+            zend_abstract_interface/.*  appsec true
             profiling/.*  profiling true
             ext/handlers_api.[ch] profiling true
             appsec/.* appsec true
+            ext/.* appsec true


### PR DESCRIPTION
### Description

Enable appsec unit tests when dependencies change, for now only `zend_abstract_interface` and the tracer extension.
### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
