### PR TITLE
fix(profiling) absolute numbers for allocation correctness 

### DIFF
--- a/profiling/tests/correctness/allocations.json
+++ b/profiling/tests/correctness/allocations.json
@@ -8,13 +8,13 @@
           {
             "regular_expression":"<?php;main;a;standard\\|str_repeat$",
             "percent": 66,
-            "value": 1188800320,
+            "value": 1248240336,
             "error_margin": 5
           },
           {
             "regular_expression":"<?php;main;b;standard\\|str_repeat$",
             "percent": 33,
-            "value": 584400587,
+            "value": 613620616,
             "error_margin": 5
           }
         ]


### PR DESCRIPTION
### Description

This fixes the absolute numbers in bytes allocated in the prof-correctness runs.

Part of [PROF-8596](https://datadoghq.atlassian.net/browse/PROF-8596).

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [ ] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.


[PROF-8596]: https://datadoghq.atlassian.net/browse/PROF-8596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ