### PR TITLE
Respect `DD_LOGS_INJECTION` default value

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -52,13 +52,15 @@ enum ddtrace_dbm_propagation_mode {
 
 #define DD_CFG_STR(str) #str
 #define DD_CFG_EXPSTR(str) DD_CFG_STR(str)
-#define INTEGRATION_ALIAS(id, _, alias) \
-    CALIAS(BOOL, DD_TRACE_##id##_ENABLED, "true", CALIASES(DD_CFG_STR(alias)))
+#define INTEGRATION_ALIAS(id, _, initial, alias) \
+    CALIAS(BOOL, DD_TRACE_##id##_ENABLED, initial, CALIASES(DD_CFG_STR(alias)))
+#define INTEGRATION_WITH_DEFAULT(id, _, initial) \
+    CONFIG(BOOL, DD_TRACE_##id##_ENABLED, initial)
 #define INTEGRATION_NORMAL(id, _) \
     CONFIG(BOOL, DD_TRACE_##id##_ENABLED, "true")
-#define GET_INTEGRATION_CONFIG_MACRO(_1, _2, NAME, ...) NAME
+#define GET_INTEGRATION_CONFIG_MACRO(_1, _2, DEFAULT, NAME, ...) NAME
 #define INTEGRATION(id, ...)                                                                                           \
-    GET_INTEGRATION_CONFIG_MACRO(__VA_ARGS__, INTEGRATION_ALIAS, INTEGRATION_NORMAL)(id, __VA_ARGS__)                  \
+    GET_INTEGRATION_CONFIG_MACRO(__VA_ARGS__, INTEGRATION_ALIAS, INTEGRATION_WITH_DEFAULT, INTEGRATION_NORMAL)(id, __VA_ARGS__)                  \
     CALIAS(BOOL, DD_TRACE_##id##_ANALYTICS_ENABLED, DD_CFG_EXPSTR(DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT),           \
            CALIASES(DD_CFG_STR(DD_##id##_ANALYTICS_ENABLED), DD_CFG_STR(DD_TRACE_##id##_ANALYTICS_ENABLED)))           \
     CALIAS(DOUBLE, DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE, DD_CFG_EXPSTR(DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT), \

--- a/ext/integrations/integrations.h
+++ b/ext/integrations/integrations.h
@@ -19,7 +19,7 @@
     INTEGRATION(LAMINAS, "laminas")             \
     INTEGRATION(LARAVEL, "laravel")             \
     INTEGRATION(LARAVELQUEUE, "laravelqueue")   \
-    INTEGRATION(LOGS, "logs", DD_LOGS_INJECTION) \
+    INTEGRATION(LOGS, "logs", "false", DD_LOGS_INJECTION) \
     INTEGRATION(LUMEN, "lumen")                 \
     INTEGRATION(MAGENTO, "magento")            \
     INTEGRATION(MEMCACHE, "memcache")           \

--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -78,9 +78,16 @@ final class InstrumentationTest extends WebFrameworkTestCase
         $this->assertEquals("app-started", $payloads[0]["request_type"]);
         $this->assertEquals("app-dependencies-loaded", $payloads[1]["request_type"]);
         $this->assertEquals("app-integrations-change", $payloads[2]["request_type"]);
-        $this->assertEquals([[
-            "name" => "pdo",
-            "enabled" => true,
-        ]], $payloads[2]["payload"]["integrations"]);
+        $this->assertEquals([
+            [
+                "name" => "pdo",
+                "enabled" => true,
+            ],
+            [
+                "name" => "logs",
+                "enabled" => false,
+                "version" => ""
+            ]
+        ], $payloads[2]["payload"]["integrations"]);
     }
 }

--- a/tests/Integrations/Logs/BaseLogsTest.php
+++ b/tests/Integrations/Logs/BaseLogsTest.php
@@ -37,7 +37,8 @@ class BaseLogsTest extends \DDTrace\Tests\Common\IntegrationTestCase
             'DD_ENV=my-env',
             'DD_SERVICE=my-service',
             'DD_VERSION=4.2',
-            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0')
+            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0'),
+            'DD_LOGS_INJECTION=1'
         ]);
 
         $this->isolateTracer(function () use ($levelNameFn, $logger, $is128bit, $logLevelName) {
@@ -72,7 +73,8 @@ class BaseLogsTest extends \DDTrace\Tests\Common\IntegrationTestCase
             'DD_ENV=my-env',
             'DD_SERVICE=my-service',
             'DD_VERSION=4.2',
-            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0')
+            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0'),
+            'DD_LOGS_INJECTION=1'
         ]);
 
         $this->isolateTracer(function () use ($levelNameFn, $logger, $is128bit, $logLevelName) {
@@ -107,7 +109,8 @@ class BaseLogsTest extends \DDTrace\Tests\Common\IntegrationTestCase
             'DD_ENV=my-env',
             'DD_SERVICE=my-service',
             'DD_VERSION=4.2',
-            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0')
+            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=' . ($is128bit ? '1' : '0'),
+            'DD_LOGS_INJECTION=1'
         ]);
 
         $this->isolateTracer(function () use ($levelNameFn, $logger, $is128bit, $logLevelName) {

--- a/tests/Integrations/Logs/LaminasLogV2/LaminasLogV2Test.php
+++ b/tests/Integrations/Logs/LaminasLogV2/LaminasLogV2Test.php
@@ -13,6 +13,9 @@ class LaminasLogV2Test extends BaseLogsTest
     protected function ddSetUp()
     {
         parent::ddSetUp();
+        $this->putEnvAndReloadConfig([
+            'DD_LOGS_INJECTION=1'
+        ]);
         $integration = new LaminasIntegration();
         $integration->init();
     }

--- a/tests/ext/logging_default_value.phpt
+++ b/tests/ext/logging_default_value.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Assess that the log integration is disabled by default
+--FILE--
+<?php
+
+var_dump(\dd_trace_env_config("DD_LOGS_INJECTION"));
+var_dump(\dd_trace_env_config("DD_TRACE_LOGS_ENABLED"));
+
+ini_set("datadog.logs_injection", "true");
+
+var_dump(\dd_trace_env_config("DD_LOGS_INJECTION"));
+var_dump(\dd_trace_env_config("DD_TRACE_LOGS_ENABLED"));
+
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(true)
+bool(true)

--- a/tests/ext/telemetry/integration.phpt
+++ b/tests/ext/telemetry/integration.phpt
@@ -54,7 +54,7 @@ namespace
                     $batch = $json["request_type"] == "message-batch" ? $json["payload"] : [$json];
                     foreach ($batch as $json) {
                         if ($json["request_type"] == "app-integrations-change") {
-                            print_r($json["payload"]);
+                            var_dump($json["payload"]);
                             break 3;
                         }
                     }
@@ -68,19 +68,27 @@ namespace
 --EXPECT--
 PUBLIC STATIC METHOD
 test_access hook
-Array
-(
-    [integrations] => Array
-        (
-            [0] => Array
-                (
-                    [name] => ddtrace\test\testsandboxedintegration
-                    [enabled] => 1
-                )
-
-        )
-
-)
+array(1) {
+  ["integrations"]=>
+  array(2) {
+    [0]=>
+    array(2) {
+      ["name"]=>
+      string(37) "ddtrace\test\testsandboxedintegration"
+      ["enabled"]=>
+      bool(true)
+    }
+    [1]=>
+    array(3) {
+      ["name"]=>
+      string(4) "logs"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+    }
+  }
+}
 --CLEAN--
 <?php
 


### PR DESCRIPTION
### Description

Disables the LogsIntegration by default (`DD_TRACE_LOGS_ENABLED` & `DD_LOGS_INJECTION`)

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
