### PR TITLE
Fix orphans removal when 128-bit is enabled

### DIFF
--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -57,7 +57,7 @@ class LaravelIntegration extends Integration
             && (
                 \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
                 || \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_USER_KEEP
-            ) && \DDTrace\trace_id() == $span->id
+            ) && \DDTrace\root_span()->id == $span->id
         ) {
             \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
         }

--- a/src/Integrations/Integrations/PHPRedis/PHPRedisIntegration.php
+++ b/src/Integrations/Integrations/PHPRedis/PHPRedisIntegration.php
@@ -47,7 +47,7 @@ class PHPRedisIntegration extends Integration
             && (
                 \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
                 || \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_USER_KEEP
-            ) && \DDTrace\trace_id() == $span->id
+            ) && \DDTrace\root_span()->id == $span->id
         ) {
             \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
         }

--- a/src/Integrations/Integrations/Predis/PredisIntegration.php
+++ b/src/Integrations/Integrations/Predis/PredisIntegration.php
@@ -37,7 +37,7 @@ class PredisIntegration extends Integration
             && (
                 \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_AUTO_KEEP
                 || \DDTrace\get_priority_sampling() == DD_TRACE_PRIORITY_SAMPLING_USER_KEEP
-            ) && \DDTrace\trace_id() == $span->id
+            ) && \DDTrace\root_span()->id == $span->id
         ) {
             \DDTrace\set_priority_sampling(DD_TRACE_PRIORITY_SAMPLING_AUTO_REJECT);
         }

--- a/tests/Integrations/PHPRedis/V5/PHPRedisTest.php
+++ b/tests/Integrations/PHPRedis/V5/PHPRedisTest.php
@@ -2453,4 +2453,19 @@ class PHPRedisTest extends IntegrationTestCase
                 Tag::COMPONENT => 'phpredis', Tag::DB_SYSTEM => 'redis', Tag::TARGET_HOST => $this->host]),
         ]);
     }
+
+    public function testOrphansRemoval()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS=1'
+        ]);
+
+        $redis = $this->redis;
+        $traces = $this->isolateTracer(function () use ($redis) {
+            $redis->save();
+        });
+
+        $span = $traces[0][0];
+        $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
+    }
 }

--- a/tests/Integrations/PHPRedis/V5/PHPRedisTest.php
+++ b/tests/Integrations/PHPRedis/V5/PHPRedisTest.php
@@ -2468,4 +2468,20 @@ class PHPRedisTest extends IntegrationTestCase
         $span = $traces[0][0];
         $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
     }
+
+    public function testOrphansRemoval64bit()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS=1',
+            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=0'
+        ]);
+
+        $redis = $this->redis;
+        $traces = $this->isolateTracer(function () use ($redis) {
+            $redis->save();
+        });
+
+        $span = $traces[0][0];
+        $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
+    }
 }

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -352,6 +352,21 @@ final class PredisTest extends IntegrationTestCase
         $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
     }
 
+    public function testOrphansRemoval64bit()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS=1',
+            'DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=0'
+        ]);
+
+        $traces = $this->isolateTracer(function () {
+            new \Predis\Client(["host" => $this->host]);
+        });
+
+        $span = $traces[0][0];
+        $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
+    }
+
     private function baseTags()
     {
         return [

--- a/tests/Integrations/Predis/PredisTest.php
+++ b/tests/Integrations/Predis/PredisTest.php
@@ -338,6 +338,20 @@ final class PredisTest extends IntegrationTestCase
         $this->assertSame('redis-non_existing', $traces[0][1]['service']);
     }
 
+    public function testOrphansRemoval()
+    {
+        $this->putEnvAndReloadConfig([
+            'DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS=1'
+        ]);
+
+        $traces = $this->isolateTracer(function () {
+            new \Predis\Client(["host" => $this->host]);
+        });
+
+        $span = $traces[0][0];
+        $this->assertEquals(0, $span['metrics']['_sampling_priority_v1']);
+    }
+
     private function baseTags()
     {
         return [


### PR DESCRIPTION
### Description

Complements #2358.

`\DDTrace\trace_id()`, with 128-bit trace IDs, is 32-character long, whereas `$span->id` was 16-character long, failing the comparison and the orphan removal. Instead, this PR uses `\DDTrace\root_span()->id` and adds some regression tests for the Redis & Predis integrations.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors, the reviewer is in charge of this task.
