### PR TITLE
Completely avoid instrumenting the PSR NullLogger

### DIFF
--- a/ext/hook/uhook.stub.php
+++ b/ext/hook/uhook.stub.php
@@ -122,5 +122,7 @@ function install_hook(
  * Removes an installed hook by its id, as returned by install_hook or HookData->id.
  *
  * @param int $id The id to remove.
+ * @param string $location A class name (which inherits this hook through inheritance), which to specifically remove
+ * this hook from.
  */
-function remove_hook(int $id): void {}
+function remove_hook(int $id, string $location = ""): void {}

--- a/ext/hook/uhook_arginfo.h
+++ b/ext/hook/uhook_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 01f2bb558e7a4e81a309bd02af464ca618ea62ff */
+ * Stub hash: e25a961e65f8aa086ed4f7d83b86b141e13e718c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_install_hook, 0, 1, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, target, Closure|Generator, MAY_BE_STRING|MAY_BE_CALLABLE, NULL)
@@ -10,6 +10,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_remove_hook, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, id, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, location, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_HookData_span, 0, 0, DDTrace\\SpanData, 0)

--- a/src/Integrations/Integrations/Logs/LogsIntegration.php
+++ b/src/Integrations/Integrations/Logs/LogsIntegration.php
@@ -4,8 +4,8 @@ namespace DDTrace\Integrations\Logs;
 
 use DDTrace\HookData;
 use DDTrace\Integrations\Integration;
-use DDTrace\SpanData;
 use DDTrace\Util\ObjectKVStore;
+use Psr\Log\NullLogger;
 
 use function DDTrace\logs_correlation_trace_id;
 
@@ -234,16 +234,18 @@ class LogsIntegration extends Integration
         ];
 
         foreach ($levelNames as $levelName) {
-            \DDTrace\install_hook(
+            $hook = \DDTrace\install_hook(
                 "Psr\Log\LoggerInterface::$levelName",
                 self::getHookFn($levelName, 0, 1)
             );
+            \DDTrace\remove_hook($hook, NullLogger::class);
         }
 
-        \DDTrace\install_hook(
+        $hook = \DDTrace\install_hook(
             "Psr\Log\LoggerInterface::log",
             self::getHookFn('log', 1, 2, 0)
         );
+        \DDTrace\remove_hook($hook, NullLogger::class);
 
         return Integration::LOADED;
     }

--- a/tests/ext/sandbox/install_hook/exclude_inherited_hook.phpt
+++ b/tests/ext/sandbox/install_hook/exclude_inherited_hook.phpt
@@ -1,0 +1,50 @@
+--TEST--
+remove_hook() with class argument
+--FILE--
+<?php
+
+interface Elder {
+    function foo();
+}
+
+class Other implements Elder {
+    function foo() {
+        print static::class . "\n";
+    }
+}
+
+class OtherChild extends Other {}
+
+$id = DDTrace\install_hook("Elder::foo", function () { print "HOOKED: " . static::class . "\n"; });
+DDTrace\remove_hook($id, "Child");
+
+(new Other)->foo();
+
+if (time()) {
+    abstract class Child implements Elder {}
+
+    class GrandChild extends Child {
+        function foo() {
+            print static::class . "\n";
+        }
+    }
+
+    class GreatGrandChild extends GrandChild {
+    }
+}
+
+(new GrandChild)->foo(); // no hook
+(new GreatGrandChild)->foo(); // no hook
+
+DDTrace\remove_hook($id, "Other");
+(new Other)->foo(); // also removed now
+(new OtherChild)->foo(); // also removed now
+
+?>
+--EXPECT--
+HOOKED: Other
+Other
+GrandChild
+GreatGrandChild
+Other
+OtherChild

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -17,6 +17,7 @@ typedef struct {
     bool is_abstract;
     zend_long id;
     int refcount; // one ref held by the existence in the array, one ref held by each frame
+    HashTable exclusions;
 } zai_hook_t; /* }}} */
 
 typedef struct _zai_hooks_entry {
@@ -106,6 +107,10 @@ static void zai_hook_data_dtor(zai_hook_t *hook) {
 
     if (hook->function) {
         zend_string_release(hook->function);
+    }
+
+    if (hook->exclusions.arData) {
+        zend_hash_destroy(&hook->exclusions);
     }
 }
 
@@ -224,6 +229,30 @@ static void zai_hook_hash_destroy(zval *zv) {
     zend_hash_destroy(hooks);
 
     efree(hooks);
+}
+
+static inline bool zai_hook_is_excluded(zai_hook_t *hook, zend_class_entry *ce) {
+    if (hook->exclusions.arData && ce) {
+        do {
+            zend_string *lower_class = zend_string_tolower(ce->name);
+            if (zend_hash_exists(&hook->exclusions, lower_class)) {
+                zend_string_release(lower_class);
+                return true;
+            }
+            zend_string_release(lower_class);
+
+            for (uint32_t i = 0; i < ce->num_interfaces; ++i) {
+                zend_string *interface = ce->interfaces[i]->name;
+                zend_string *lower_interface = zend_string_tolower(interface);
+                if (zend_hash_exists(&hook->exclusions, lower_interface)) {
+                    zend_string_release(lower_interface);
+                    return true;
+                }
+                zend_string_release(lower_interface);
+            }
+        } while ((ce = ce->parent));
+    }
+    return false;
 }
 
 /* {{{ */
@@ -417,6 +446,10 @@ static inline zai_hooks_entry *zai_hook_resolved_ensure_hooks_entry(zend_functio
 }
 
 static inline void zai_hook_resolved_install_shared_hook(zai_hook_t *hook, zend_ulong index, zend_function *func, zend_class_entry *ce) {
+    if (zai_hook_is_excluded(hook, ce)) {
+        return;
+    }
+
     zai_hooks_entry *hooks = zai_hook_resolved_ensure_hooks_entry(func, ce);
 
     zval hook_zv;
@@ -549,20 +582,24 @@ static inline void zai_hook_merge_inherited_hooks(zai_hooks_entry **hooks_entry,
     zai_hooks_entry *protoHooks;
     if ((protoHooks = zend_hash_index_find_ptr(&zai_hook_resolved, addr))) {
         zai_hooks_entry *hooks = *hooks_entry;
-        if (!hooks && !(hooks = zend_hash_index_find_ptr(&zai_hook_resolved, zai_hook_install_address(function)))) {
-            *hooks_entry = hooks = zend_hash_index_add_ptr(&zai_hook_resolved, zai_hook_install_address(function), zai_hook_alloc_hooks_entry());
-            zai_hook_resolve_hooks_entry(hooks, function);
-#if PHP_VERSION_ID >= 80200
-            // Internal functions duplicated onto userland classes share their run_time_cache with their parent function
-            zai_hook_handle_internal_duplicate_function(hooks, ce, function);
-#else
-            (void)ce;
-#endif
-        }
-
         zval *hook_zv;
         zend_ulong index;
         ZEND_HASH_FOREACH_NUM_KEY_VAL(&protoHooks->hooks, index, hook_zv) {
+            if (zai_hook_is_excluded(Z_PTR_P(hook_zv), ce)) {
+                continue;
+            }
+
+            if (!hooks && !(hooks = zend_hash_index_find_ptr(&zai_hook_resolved, zai_hook_install_address(function)))) {
+                *hooks_entry = hooks = zend_hash_index_add_ptr(&zai_hook_resolved, zai_hook_install_address(function), zai_hook_alloc_hooks_entry());
+                zai_hook_resolve_hooks_entry(hooks, function);
+#if PHP_VERSION_ID >= 80200
+                // Internal functions duplicated onto userland classes share their run_time_cache with their parent function
+                zai_hook_handle_internal_duplicate_function(hooks, ce, function);
+#else
+                (void)ce;
+#endif
+            }
+
             if ((hook_zv = zend_hash_index_add(&hooks->hooks, index, hook_zv))) {
                 zai_hook_t *hook = Z_PTR_P(hook_zv);
                 hooks->dynamic += hook->dynamic;
@@ -1144,6 +1181,7 @@ zend_long zai_hook_install_resolved_generator(zend_function *function,
         .id = 0,
         .dynamic = dynamic,
         .refcount = 1,
+        .exclusions = {{ 0 }},
     };
 
     return hook->id = zai_hook_resolved_install(hook, function, function->common.scope);
@@ -1185,6 +1223,7 @@ zend_long zai_hook_install_generator(zai_str scope, zai_str function,
         .id = 0,
         .dynamic = dynamic,
         .refcount = 1,
+        .exclusions = {{ 0 }},
     };
 
     if (persistent) {
@@ -1200,6 +1239,67 @@ zend_long zai_hook_install(zai_str scope, zai_str function,
         zai_hook_aux aux, size_t dynamic) {
     return zai_hook_install_generator(scope, function, begin, NULL, NULL, end, aux, dynamic);
 } /* }}} */
+
+static inline void zai_hook_add_exclusion(zai_hooks_entry *hooks, zend_long index, zend_string *lc_classname) {
+    if (hooks) {
+        zai_hook_t *hook = zend_hash_index_find_ptr(&hooks->hooks, index);
+
+        if (!hook || hook->id < 0) {
+            return;
+        }
+
+        if (!hook->exclusions.arData) {
+            zend_hash_init(&hook->exclusions, 8, NULL, NULL, 0);
+        }
+
+        zend_hash_add_empty_element(&hook->exclusions, lc_classname);
+    }
+}
+
+void zai_hook_exclude_class_resolved(zai_install_address function_address, zend_long index, zend_string *lc_classname) {
+    zai_hooks_entry *hooks = zend_hash_index_find_ptr(&zai_hook_resolved, function_address);
+    if (!hooks) {
+        return;
+    }
+    zai_hook_add_exclusion(hooks, index, lc_classname);
+
+    zend_class_entry *ce;
+    zend_function *resolved = zai_hook_lookup_function(zai_str_from_zstr(lc_classname), zai_str_from_zstr(hooks->resolved->common.function_name), &ce);
+    if (!resolved) {
+        return;
+    }
+    zai_hooks_entry *excluded_hooks = zend_hash_index_find_ptr(&zai_hook_resolved, zai_hook_install_address(resolved));
+    if (!excluded_hooks) {
+        return;
+    }
+
+    zval *hook_zv = zend_hash_index_find(&excluded_hooks->hooks, index);
+    if (!hook_zv || Z_TYPE_INFO_P(hook_zv) != ZAI_IS_SHARED_HOOK_PTR) {
+        return;
+    }
+
+    zai_hook_remove_shared_hook(resolved, (zend_ulong) index, hooks);
+}
+
+void zai_hook_exclude_class(zai_str scope, zai_str function, zend_long index, zend_string *lc_classname) {
+    if (!function.len || !scope.len) {
+        return;
+    }
+
+    zend_class_entry *ce;
+    zend_function *resolved = zai_hook_lookup_function(scope, function, &ce);
+    if (resolved) {
+        zai_hook_exclude_class_resolved(zai_hook_install_address(resolved), index, lc_classname);
+        return;
+    }
+
+    HashTable *base_ht = zend_hash_str_find_ptr_lc(&zai_hook_tls->request_classes, scope.ptr, scope.len);
+    if (!base_ht) {
+        return;
+    }
+    zai_hooks_entry *hooks = zend_hash_str_find_ptr_lc(base_ht, function.ptr, function.len);
+    zai_hook_add_exclusion(hooks, index, lc_classname);
+}
 
 bool zai_hook_remove_resolved(zai_install_address function_address, zend_long index) {
     zai_hooks_entry *hooks = zend_hash_index_find_ptr(&zai_hook_resolved, function_address);

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -1263,9 +1263,10 @@ void zai_hook_exclude_class_resolved(zai_install_address function_address, zend_
     }
     zai_hook_add_exclusion(hooks, index, lc_classname);
 
-    zend_class_entry *ce;
-    zend_function *resolved = zai_hook_lookup_function(zai_str_from_zstr(lc_classname), zai_str_from_zstr(hooks->resolved->common.function_name), &ce);
-    if (!resolved) {
+    zend_class_entry *ce = NULL;
+    zend_string *function_name = hooks->resolved->common.function_name;
+    zend_function *resolved = zai_hook_lookup_function(zai_str_from_zstr(lc_classname), zai_str_from_zstr(function_name), &ce);
+    if (!ce || !resolved) {
         return;
     }
     zai_hooks_entry *excluded_hooks = zend_hash_index_find_ptr(&zai_hook_resolved, zai_hook_install_address(resolved));
@@ -1278,7 +1279,7 @@ void zai_hook_exclude_class_resolved(zai_install_address function_address, zend_
         return;
     }
 
-    zai_hook_remove_shared_hook(resolved, (zend_ulong) index, hooks);
+    zai_hook_remove_abstract_recursive(hooks, ce, function_name, (zend_ulong) index);
 }
 
 void zai_hook_exclude_class(zai_str scope, zai_str function, zend_long index, zend_string *lc_classname) {

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -1,6 +1,6 @@
 #ifndef ZAI_HOOK_H
 #define ZAI_HOOK_H
-#include <symbols/symbols.h>
+#include "../symbols/symbols.h"
 
 /* The Hook interface intends to abstract away the storage and resolution of hook targets */
 
@@ -61,6 +61,10 @@ zend_long zai_hook_install_resolved_generator(zend_function *function,
 /* {{{ zai_hook_remove removes a hook from the request local hook tables. It does not touch static hook tables. */
 bool zai_hook_remove(zai_str scope, zai_str function, zend_long index);
 bool zai_hook_remove_resolved(zai_install_address function_address, zend_long index); /* }}} */
+
+/* {{{ zai_hook_exclude_class prevents a hook from being installed on a specific class through inheritance. */
+void zai_hook_exclude_class(zai_str scope, zai_str function, zend_long index, zend_string *lc_classname);
+void zai_hook_exclude_class_resolved(zai_install_address function_address, zend_long index, zend_string *lc_classname); /* }}} */
 
 /* {{{ zai_hook_memory_t structure is passed between
         continue and finish and managed by the hook interface */


### PR DESCRIPTION
### Description

This is implemented by adding the ability to remove a hook from selected classes directly.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
