### PR TITLE
Update appsec tests (128-bit)

### DIFF
--- a/appsec/tests/extension/client_init_record_span_tags.phpt
+++ b/appsec/tests/extension/client_init_record_span_tags.phpt
@@ -86,6 +86,7 @@ Array
 (
     [_dd.appsec.json] => {"triggers":[{"found":"attack"},{"another":"attack"},{"yet another":"attack"}]}
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
     [_dd.runtime_family] => php
     [appsec.event] => true
     [http.method] => GET

--- a/appsec/tests/extension/ddtrace_basic.phpt
+++ b/appsec/tests/extension/ddtrace_basic.phpt
@@ -44,7 +44,7 @@ echo 'number of commands: ', count($c), "\n";
 
 DDTrace\start_span();
 
-// Compatibility with pre 0.81.0 
+// Compatibility with pre 0.81.0
 $root_span = \DDTrace\root_span();
 var_dump($root_span->name);
 var_dump($root_span->service);
@@ -53,7 +53,7 @@ var_dump($root_span->id);
 var_dump($root_span->meta);
 var_dump($root_span->metrics);
 
-$trace_id = \DDTrace\trace_id();
+$trace_id = \DDTrace\root_span()->id;
 echo 'trace id: ', $trace_id, "\n";
 
 echo "ddtrace_rshutdown\n";
@@ -104,4 +104,5 @@ Array
     [runtime-id] => %s
     [ddappsec] => true
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
 )

--- a/appsec/tests/extension/rinit_record_span_tags.phpt
+++ b/appsec/tests/extension/rinit_record_span_tags.phpt
@@ -81,6 +81,7 @@ Array
 (
     [_dd.appsec.json] => {"triggers":[{"found":"attack"},{"another":"attack"},{"yet another":"attack"}]}
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
     [_dd.runtime_family] => php
     [appsec.event] => true
     [http.method] => GET

--- a/appsec/tests/extension/rinit_record_span_tags_fail.phpt
+++ b/appsec/tests/extension/rinit_record_span_tags_fail.phpt
@@ -54,4 +54,5 @@ Array
 (
     [runtime-id] => %s
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
 )

--- a/appsec/tests/extension/rinit_root_span_add_tag.phpt
+++ b/appsec/tests/extension/rinit_root_span_add_tag.phpt
@@ -60,6 +60,7 @@ tags:
 Array
 (
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
     [ddappsec] => true
     [env] => staging
     [http.method] => GET

--- a/appsec/tests/extension/root_span_add_tag.phpt
+++ b/appsec/tests/extension/root_span_add_tag.phpt
@@ -45,13 +45,15 @@ array(1) {
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
-    array(3) {
+    array(4) {
       ["runtime-id"]=>
       string(%d) %s
       ["after"]=>
       string(9) "root_span"
       ["_dd.p.dm"]=>
       string(2) "-1"
+      ["_dd.p.tid"]=>
+      string(16) "%s"
     }
     ["metrics"]=>
     array(4) {

--- a/appsec/tests/extension/root_span_add_tag_with_intermediate_spans.phpt
+++ b/appsec/tests/extension/root_span_add_tag_with_intermediate_spans.phpt
@@ -70,6 +70,7 @@ tags:
 Array
 (
     [_dd.p.dm] => -1
+    [_dd.p.tid] => %s
     [_dd.runtime_family] => php
     [after] => root_span
     [before] => root_span


### PR DESCRIPTION
### Description

These tests started failing since 128-bit is now enabled by default. Adds the missing `_dd.p.tid`.

### Readiness checklist
- [] (only for Members) Changelog has been added to the release document.
- [X] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
