### PR TITLE
Fix crash with functions with no run_time_cache yet

### DIFF
--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -523,9 +523,9 @@ static void zai_interceptor_observer_placeholder_handler(zend_execute_data *exec
 
 void zai_interceptor_replace_observer(zend_function *func, bool remove) {
 #if PHP_VERSION_ID < 80200
-    if (!RUN_TIME_CACHE(&func->op_array) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
+    if (!ZEND_MAP_PTR(func->op_array.run_time_cache) || !RUN_TIME_CACHE(&func->op_array) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
 #else
-    if (!RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
+    if (!ZEND_MAP_PTR(func->common.run_time_cache) || !RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
 #endif
         return;
     }
@@ -590,7 +590,7 @@ void zai_interceptor_replace_observer(zend_function *func, bool remove) {
 }
 #else
 void zai_interceptor_replace_observer(zend_function *func, bool remove) {
-    if (!RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
+    if (!ZEND_MAP_PTR(func->op_array.run_time_cache) || !RUN_TIME_CACHE(&func->common) || !ZEND_OBSERVER_DATA(func) || (func->common.fn_flags & ZEND_ACC_HEAP_RT_CACHE) != 0) {
         return;
     }
 


### PR DESCRIPTION
### Description

Fix possible segfault when dynamically installing hooks before the first call to the function.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
