### PR TITLE
[ASM] Upgrade libddwaf to v1.15.1

### DIFF
--- a/appsec/cmake/helper.cmake
+++ b/appsec/cmake/helper.cmake
@@ -1,6 +1,10 @@
 hunter_add_package(Boost COMPONENTS system)
 find_package(Boost CONFIG REQUIRED COMPONENTS system)
 
+hunter_add_package(RapidJSON)
+find_package(RapidJSON CONFIG REQUIRED)
+set_target_properties(RapidJSON::rapidjson PROPERTIES INTERFACE_COMPILE_DEFINITIONS "RAPIDJSON_HAS_STDSTRING=1")
+
 configure_file(src/helper/version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/src/helper/version.hpp)
 
 set(HELPER_SOURCE_DIR src/helper)
@@ -14,7 +18,7 @@ set_target_properties(helper_objects PROPERTIES
     POSITION_INDEPENDENT_CODE 1)
 target_include_directories(helper_objects PUBLIC ${HELPER_INCLUDE_DIR})
 target_compile_definitions(helper_objects PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
-target_link_libraries(helper_objects PUBLIC libddwaf_objects pthread spdlog cpp-base64 msgpack_c lib_rapidjson Boost::system)
+target_link_libraries(helper_objects PUBLIC libddwaf_objects pthread spdlog cpp-base64 msgpack_c RapidJSON::rapidjson Boost::system)
 
 add_executable(ddappsec-helper src/helper/main.cpp
 	$<TARGET_OBJECTS:helper_objects>

--- a/appsec/src/helper/client.cpp
+++ b/appsec/src/helper/client.cpp
@@ -5,7 +5,6 @@
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #include <chrono>
 #include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/appsec/src/helper/client.cpp
+++ b/appsec/src/helper/client.cpp
@@ -3,16 +3,18 @@
 //
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+#include <chrono>
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
 #include "client.hpp"
 #include "exception.hpp"
 #include "network/broker.hpp"
 #include "network/proto.hpp"
 #include "std_logging.hpp"
-#include <chrono>
-#include <spdlog/spdlog.h>
-#include <stdexcept>
-#include <string>
-#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -28,7 +30,7 @@ bool maybe_exec_cmd_M(client &client, network::request &msg)
         if constexpr (sizeof...(Mrest) == 0) {
             SPDLOG_WARN(
                 "a message of type {} ({}) was not expected at this point",
-                msg.id, msg.method);
+                static_cast<unsigned>(msg.id), msg.method);
             throw unexpected_command(msg.method);
         } else {
             return maybe_exec_cmd_M<Mrest...>(client, msg);

--- a/appsec/src/helper/engine.cpp
+++ b/appsec/src/helper/engine.cpp
@@ -203,14 +203,14 @@ engine::action_map engine::parse_actions(
     const auto &actions_array = it->value;
     if (actions_array.GetType() != rapidjson::kArrayType) {
         SPDLOG_ERROR("unexpected 'actions' type {}, expected array",
-            actions_array.GetType());
+            static_cast<unsigned>(actions_array.GetType()));
         return actions;
     }
 
     for (auto &action_object : actions_array.GetArray()) {
         if (action_object.GetType() != rapidjson::kObjectType) {
             SPDLOG_ERROR("unexpected action item type {}, expected object",
-                action_object.GetType());
+                static_cast<unsigned>(action_object.GetType()));
             continue;
         }
 

--- a/appsec/src/helper/std_logging.hpp
+++ b/appsec/src/helper/std_logging.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
 
 // NOLINTNEXTLINE
 #define DD_STDLOG(...)                                                         \

--- a/appsec/src/helper/std_logging.hpp
+++ b/appsec/src/helper/std_logging.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
 
 // NOLINTNEXTLINE
 #define DD_STDLOG(...)                                                         \

--- a/appsec/src/helper/subscriber/waf.cpp
+++ b/appsec/src/helper/subscriber/waf.cpp
@@ -177,7 +177,7 @@ std::optional<subscriber::event> instance::listener::call(
     ddwaf_result res;
     DDWAF_RET_CODE code;
     auto run_waf = [&]() {
-        code = ddwaf_run(handle_, data, &res, waf_timeout_.count());
+        code = ddwaf_run(handle_, data, nullptr, &res, waf_timeout_.count());
     };
 
     if (spdlog::should_log(spdlog::level::debug)) {
@@ -254,7 +254,7 @@ instance::instance(parameter &rule,
     }
 
     uint32_t size;
-    const auto *addrs = ddwaf_required_addresses(handle_, &size);
+    const auto *addrs = ddwaf_known_addresses(handle_, &size);
 
     addresses_.clear();
     for (uint32_t i = 0; i < size; i++) { addresses_.emplace(addrs[i]); }
@@ -302,7 +302,7 @@ instance::instance(
       ruleset_version_(std::move(version))
 {
     uint32_t size;
-    const auto *addrs = ddwaf_required_addresses(handle_, &size);
+    const auto *addrs = ddwaf_known_addresses(handle_, &size);
 
     addresses_.clear();
     for (uint32_t i = 0; i < size; i++) { addresses_.emplace(addrs[i]); }

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -139,7 +139,7 @@ TEST(ClientTest, ClientInit)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.14.0");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.15.1");
     EXPECT_STREQ(msg_res->meta[tag::event_rules_errors].c_str(), "{}");
 
     EXPECT_EQ(msg_res->metrics.size(), 2);
@@ -259,7 +259,7 @@ TEST(ClientTest, ClientInitInvalidRules)
 
     EXPECT_STREQ(msg_res->status.c_str(), "ok");
     EXPECT_EQ(msg_res->meta.size(), 2);
-    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.14.0");
+    EXPECT_STREQ(msg_res->meta[tag::waf_version].c_str(), "1.15.1");
 
     rapidjson::Document doc;
     doc.Parse(msg_res->meta[tag::event_rules_errors]);

--- a/appsec/third_party/CMakeLists.txt
+++ b/appsec/third_party/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.12.0)
+    GIT_TAG eb3220622e73a4889eee355ffa37972b3cac3df5)
 FetchContent_MakeAvailable(spdlog)
 
 include(ExternalProject)

--- a/appsec/third_party/CMakeLists.txt
+++ b/appsec/third_party/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG eb3220622e73a4889eee355ffa37972b3cac3df5)
+    GIT_TAG v1.12.0)
 FetchContent_MakeAvailable(spdlog)
 
 include(ExternalProject)


### PR DESCRIPTION
### Description

- `TEST(WafTest, Logging)` had to be removed due to build-time conflicts between `spdlog/fmt` and `libddwaf/fmt`.

Related Jira: [APPSEC-12103]

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.


[APPSEC-12103]: https://datadoghq.atlassian.net/browse/APPSEC-12103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ