### PR TITLE
Add http.route to CodeIgniter

### DIFF
--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
@@ -42,6 +42,7 @@ $route['default_controller'] = "welcome";
 $route['404_override'] = '';
 $route['error'] = 'error_';
 
+$route['parameterized/(:any)'] = "parameterized/$1";
 
 /* End of file routes.php */
 /* Location: ./application/config/routes.php */

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/config/routes.php
@@ -42,7 +42,7 @@ $route['default_controller'] = "welcome";
 $route['404_override'] = '';
 $route['error'] = 'error_';
 
-$route['parameterized/(:any)'] = "parameterized/$1";
+$route['parameterized/(:any)'] = "parameterized/customAction/$1";
 
 /* End of file routes.php */
 /* Location: ./application/config/routes.php */

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/parameterized.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/parameterized.php
@@ -1,0 +1,7 @@
+<?php
+
+class Parameterized extends CI_Controller {
+    function customAction($param) {
+        echo 'custom ' + $param;
+    }
+}

--- a/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/parameterized.php
+++ b/tests/Frameworks/CodeIgniter/Version_2_2/application/controllers/parameterized.php
@@ -2,6 +2,6 @@
 
 class Parameterized extends CI_Controller {
     function customAction($param) {
-        echo 'custom ' + $param;
+        echo 'custom ' . $param;
     }
 }

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -140,9 +140,19 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_METHOD => 'GET',
                         Tag::HTTP_URL => 'http://localhost:9999/parameterized/paramValue',
                         Tag::HTTP_STATUS_CODE => '200',
+                        'app.endpoint' => 'Parameterized::customAction',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
                         Tag::HTTP_ROUTE =>  'parameterized/(:any)',
+                    ])->withChildren([
+                        SpanAssertion::build(
+                            'Parameterized.customAction',
+                            'codeigniter_test_app',
+                            Type::WEB_SERVLET,
+                            'Parameterized.customAction'
+                        )->withExactTags([
+                            Tag::COMPONENT => 'codeigniter',
+                        ])
                     ]),
                 ],
             ]

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -55,6 +55,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.endpoint' => 'Simple::index',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
+                        Tag::HTTP_ROUTE => 'simple',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple.index',
@@ -79,6 +80,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.endpoint' => 'Simple_View::index',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
+                        Tag::HTTP_ROUTE => 'simple_view',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple_View.index',
@@ -113,6 +115,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'app.endpoint' => 'Error_::index',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'codeigniter',
+                        Tag::HTTP_ROUTE => 'error'
                     ])
                     ->setError("Exception", "Uncaught Exception: datadog in %s:%d")
                     ->withExistingTagsNames(['error.stack'])
@@ -125,6 +128,21 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         )->withExactTags([
                             Tag::COMPONENT => 'codeigniter',
                         ])->setError('Exception', 'datadog', true),
+                    ]),
+                ],
+                'A GET request to a route with a parameter' => [
+                    SpanAssertion::build(
+                        'codeigniter.request',
+                        'codeigniter_test_app',
+                        'web',
+                        'GET /parameterized/paramValue'
+                    )->withExactTags([
+                        Tag::HTTP_METHOD => 'GET',
+                        Tag::HTTP_URL => 'http://localhost:9999/parameterized/paramValue',
+                        Tag::HTTP_STATUS_CODE => '200',
+                        Tag::SPAN_KIND => 'server',
+                        Tag::COMPONENT => 'codeigniter',
+                        Tag::HTTP_ROUTE =>  'parameterized/(:any)',
                     ]),
                 ],
             ]

--- a/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
@@ -43,6 +43,7 @@ class ExitTest extends WebFrameworkTestCase
                     'app.endpoint' => 'Exits::index',
                     Tag::SPAN_KIND => 'server',
                     Tag::COMPONENT => 'codeigniter',
+                    Tag::HTTP_ROUTE => 'exits'
                 ])->withChildren([
                     SpanAssertion::build(
                         'Exits.index',

--- a/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/NoCI_ControllertTest.php
@@ -42,6 +42,7 @@ class NoCIControllertTest extends WebFrameworkTestCase
                     Tag::HTTP_STATUS_CODE => '200',
                     Tag::SPAN_KIND => 'server',
                     Tag::COMPONENT => 'codeigniter',
+                    Tag::HTTP_ROUTE => 'health_check/ping',
                 ])->withChildren([
                     SpanAssertion::build(
                         'Health_check.ping',


### PR DESCRIPTION
### Description

Add `http.route` tag to CodeIgniter spans

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [X] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
