### PR TITLE
Fix installer verification on plesk

### DIFF
--- a/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
+++ b/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
@@ -8,7 +8,7 @@ set -e
 new_version="0.82.0"
 generate_installers "${new_version}"
 
-prefix="/opt/plesk/php/8.0"
+prefix="/opt/plesk/php/8.1"
 "$prefix/bin/php" ./build/packages/datadog-setup.php --php-bin=all
 
 assert_ddtrace_version "${new_version}" "$prefix/bin/php"


### PR DESCRIPTION
### Description

Change PHP version used on installer verification tests on plesk, as PHP 8.0 seems to have been removed from the image:

```
Status: Downloaded newer image for plesk/plesk:18.0
dockerfiles/verify_packages/installer/test_install_on_plesk.sh: 12: /opt/plesk/php/8.0/bin/php: not found
```

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
