### PR TITLE
Fix handling of invalid persistent JSON

### DIFF
--- a/tests/ext/priority_sampling/invalid-json-rule.phpt
+++ b/tests/ext/priority_sampling/invalid-json-rule.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Invalid rule json: default sampling rate applies
+--ENV--
+DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "tags": {"test": "foo", "value": "bar"}]
+DD_TRACE_GENERATE_ROOT_SPAN=1
+--SKIPIF--
+<?php
+if (getenv("USE_ZEND_ALLOC") === "0" && !getenv("SKIP_ASAN")) {
+    die("skip: test will show memory errors under valgrind where PCRE is built without valgrind support");
+}
+?>
+--FILE--
+<?php
+
+\DDTrace\get_priority_sampling();
+
+$root = \DDTrace\root_span();
+if (($root->metrics["_dd.rule_psr"] ?? 0) != 0.3 && $root->metrics["_dd.agent_psr"] == 1) {
+    echo "Rule OK\n";
+} else {
+    var_dump($root->metrics);
+}
+
+?>
+--EXPECT--
+Rule OK


### PR DESCRIPTION
### Description

The json parse is going to helpfully call zval_ptr_dtor_nogc, which eventually calls zend_array_destroy upon encountering a json parse error.

zend_array_destroy really dislikes persistent arrays. Cheat it by creating a RC=2 array and allow insertion into these (CoW violation bypass).

Effectively fixes invalid. sampling rules.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
