### PR TITLE
Update CI images to use PHP 8.3.0rc6, pin mongodb for PHP 7.2-7.3

### DIFF
--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -123,8 +123,8 @@ services:
       x-bake: *bake
       args:
         php_version: 8.3.0
-        php_url: https://downloads.php.net/~jakub/php-8.3.0RC3.tar.gz
-        php_sha: "5885965b3e315d62fdc151735fe579b1e2301a4ccf56b3fa18f96c34a3b898c8"
+        php_url: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
+        php_sha: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
         php_api: 20230831
     command: build-dd-trace-php
     volumes:

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -25,6 +25,8 @@ if [[ $PHP_VERSION_ID -le 70 ]]; then
   MONGODB_VERSION=-1.9.2
 elif [[ $PHP_VERSION_ID -le 71 ]]; then
   MONGODB_VERSION=-1.11.1
+elif [[ $PHP_VERSION_ID -le 73 ]]; then
+  MONGODB_VERSION=-1.16.2
 fi
 
 AST_VERSION=

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.3"
-        phpTarGzUrl: https://downloads.php.net/~jakub/php-8.3.0RC3.tar.gz
-        phpSha256Hash: "5885965b3e315d62fdc151735fe579b1e2301a4ccf56b3fa18f96c34a3b898c8"
+        phpTarGzUrl: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
+        phpSha256Hash: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
 
   php-8.2:
     image: datadog/dd-trace-ci:php-8.2_buster

--- a/dockerfiles/ci/centos/7/docker-compose.yml
+++ b/dockerfiles/ci/centos/7/docker-compose.yml
@@ -106,6 +106,6 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.3"
-        phpTarGzUrl: https://downloads.php.net/~jakub/php-8.3.0RC3.tar.gz
-        phpSha256Hash: "5885965b3e315d62fdc151735fe579b1e2301a4ccf56b3fa18f96c34a3b898c8"
+        phpTarGzUrl: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
+        phpSha256Hash: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
     image: 'datadog/dd-trace-ci:php-8.3_centos-7'

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -157,6 +157,7 @@ ext/standard/tests/streams/stream_context_tcp_nodelay_fopen.phpt
 ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/zend_test/tests/
+sapi/cli/tests/bug80092.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -57,6 +57,10 @@ The following tests assert the output of `var_dump($obj)` and fail because we ad
 
 # Specific tests
 
+## `sapi/cli/tests/bug80092.phpt`
+
+Temporarily disabled due to a too strict of a check for the precise php -v output.
+
 ## `Zend/tests/object_gc_in_shutdown.phpt`, `Zend/tests/bug81104.phpt`, `Zend/tests/gh11189(_1).phpt`, `Zend/tests/gh12073.phpt`
 
 Tests memory limits, which we exceed due to tracer being loaded.

--- a/tests/Integrations/MongoDB/MongoDBTest.php
+++ b/tests/Integrations/MongoDB/MongoDBTest.php
@@ -193,19 +193,25 @@ class MongoDBTest extends IntegrationTestCase
             } catch (Exception $e) {
             }
         });
-
+        $tags = [
+            'mongodb.db' => self::DATABASE,
+            'mongodb.collection' => 'cars',
+            'mongodb.query' => '"?"',
+            'span.kind' => 'client',
+            Tag::COMPONENT => 'mongodb',
+            Tag::DB_SYSTEM => 'mongodb',
+        ];
+        // On newer versions of the mongodb library, the datadog subscriber is only called after the arguments check
+        if (PHP_VERSION_ID < 70400) {
+            $tags += [
+                'out.host' => self::HOST,
+                'out.port' => self::PORT,
+            ];
+        }
         $this->assertFlameGraph($traces, [
             SpanAssertion::build('mongodb.cmd', 'mongodb', 'mongodb', 'find test_db cars "?"')
-                ->withExactTags([
-                    'mongodb.db' => self::DATABASE,
-                    'mongodb.collection' => 'cars',
-                    'mongodb.query' => '"?"',
-                    'span.kind' => 'client',
-                    'out.host' => self::HOST,
-                    'out.port' => self::PORT,
-                    Tag::COMPONENT => 'mongodb',
-                    Tag::DB_SYSTEM => 'mongodb',
-                ])->setError('MongoDB\Exception\InvalidArgumentException')
+                ->withExactTags($tags)
+                ->setError('MongoDB\Exception\InvalidArgumentException')
                 ->withExistingTagsNames([Tag::ERROR_MSG, 'error.stack']),
         ]);
     }

--- a/tests/ext/force_flush_traces.phpt
+++ b/tests/ext/force_flush_traces.phpt
@@ -44,4 +44,4 @@ tracing process
 process
 Flushing trace of size 3 to send-queue for %s
 kill
-Killed%r\n*(Termsig=9)?%r
+%r\n*(Killed\n*)?(Termsig=9)?%r


### PR DESCRIPTION
### Description

This PR updates CI images:

- PHP 8.3.0rc3 upgraded to PHP 8.3.0rc6.
- mongodb is pinned to 1.16.2 for PHP 7.2-7.3 as 1.17.0 was released last week and dropped support for these versions.

This is a prerequisite for PROF-8286.

### Readiness checklist
- [x] Changelog has been added to the release document.
- [x] ~Tests added for this feature/bug.~

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
