### PR TITLE
feat(profiling): allow to enable all experimental features

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -58,9 +58,7 @@ jobs:
       - name: Run no profile test
         run: |
           export DD_PROFILING_ENABLED=Off
-          export DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1
-          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=1
-          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+          export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
               mkdir -p profiling/tests/correctness/"$test_case"/
@@ -75,8 +73,7 @@ jobs:
       - name: Run tests
         run: |
           export DD_PROFILING_LOG_LEVEL=trace
-          export DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1
-          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=1
+          export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -239,8 +239,7 @@ pub(crate) unsafe fn profiling_experimental_timeline_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_exception_enabled() -> bool {
-    profiling_experimental_features_enabled()
-        || profiling_enabled() && get_bool(ProfilingExceptionEnabled, true)
+    profiling_enabled() && get_bool(ProfilingExceptionEnabled, true)
 }
 
 /// # Safety

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -216,8 +216,9 @@ pub(crate) unsafe fn profiling_endpoint_collection_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_cpu_time_enabled() -> bool {
-    profiling_experimental_features_enabled()
-        || profiling_enabled() && get_bool(ProfilingExperimentalCpuTimeEnabled, true)
+    profiling_enabled()
+        && (profiling_experimental_features_enabled()
+            || get_bool(ProfilingExperimentalCpuTimeEnabled, true))
 }
 
 /// # Safety
@@ -231,8 +232,9 @@ pub(crate) unsafe fn profiling_allocation_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_timeline_enabled() -> bool {
-    profiling_experimental_features_enabled()
-        || profiling_enabled() && get_bool(ProfilingExperimentalTimelineEnabled, false)
+    profiling_enabled()
+        && (profiling_experimental_features_enabled()
+            || get_bool(ProfilingExperimentalTimelineEnabled, false))
 }
 
 /// # Safety

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -202,42 +202,45 @@ pub(crate) unsafe fn profiling_enabled() -> bool {
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_features_enabled() -> bool {
-    get_bool(ProfilingExperimentalFeaturesEnabled, false)
+    profiling_enabled() && get_bool(ProfilingExperimentalFeaturesEnabled, false)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_endpoint_collection_enabled() -> bool {
-    get_bool(ProfilingEndpointCollectionEnabled, true)
+    profiling_enabled() && get_bool(ProfilingEndpointCollectionEnabled, true)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_cpu_time_enabled() -> bool {
-    get_bool(ProfilingExperimentalCpuTimeEnabled, true)
+    profiling_experimental_features_enabled()
+        || profiling_enabled() && get_bool(ProfilingExperimentalCpuTimeEnabled, true)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_allocation_enabled() -> bool {
-    get_bool(ProfilingAllocationEnabled, true)
+    profiling_enabled() && get_bool(ProfilingAllocationEnabled, true)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_experimental_timeline_enabled() -> bool {
-    get_bool(ProfilingExperimentalTimelineEnabled, false)
+    profiling_experimental_features_enabled()
+        || profiling_enabled() && get_bool(ProfilingExperimentalTimelineEnabled, false)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
 pub(crate) unsafe fn profiling_exception_enabled() -> bool {
-    get_bool(ProfilingExceptionEnabled, true)
+    profiling_experimental_features_enabled()
+        || profiling_enabled() && get_bool(ProfilingExceptionEnabled, true)
 }
 
 /// # Safety

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -478,18 +478,14 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         log_level,
         output_pprof,
     ) = unsafe {
-        let profiling_enabled = config::profiling_enabled();
-        let profiling_experimental_features_enabled =
-            profiling_enabled && config::profiling_experimental_features_enabled();
         (
-            profiling_enabled,
-            profiling_experimental_features_enabled,
-            profiling_enabled && config::profiling_endpoint_collection_enabled(),
-            profiling_experimental_features_enabled
-                || profiling_enabled && config::profiling_experimental_cpu_time_enabled(),
-            profiling_enabled && config::profiling_allocation_enabled(),
-            profiling_enabled && config::profiling_experimental_timeline_enabled(),
-            profiling_enabled && config::profiling_exception_enabled(),
+            config::profiling_enabled(),
+            config::profiling_experimental_features_enabled(),
+            config::profiling_endpoint_collection_enabled(),
+            config::profiling_experimental_cpu_time_enabled(),
+            config::profiling_allocation_enabled(),
+            config::profiling_experimental_timeline_enabled(),
+            config::profiling_exception_enabled(),
             config::profiling_exception_sampling_distance(),
             config::profiling_log_level(),
             config::profiling_output_pprof(),

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -863,13 +863,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             if #[cfg(feature = "exception_profiling")] {
                 zend::php_info_print_table_row(
                     2,
-                    b"Experimental Exception Profiling Enabled\0".as_ptr(),
+                    b"Exception Profiling Enabled\0".as_ptr(),
                     if locals.profiling_exception_enabled {
-                        if locals.profiling_experimental_features_enabled {
-                            yes_exp
-                        } else {
-                            yes
-                        }
+                        yes
                     } else if locals.profiling_enabled {
                         no
                     } else {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -371,6 +371,7 @@ pub struct RequestLocals {
     pub env: Option<Cow<'static, str>>,
     pub interrupt_count: AtomicU32,
     pub profiling_enabled: bool,
+    pub profiling_experimental_features_enabled: bool,
     pub profiling_endpoint_collection_enabled: bool,
     pub profiling_experimental_cpu_time_enabled: bool,
     pub profiling_allocation_enabled: bool,
@@ -387,6 +388,7 @@ pub struct RequestLocals {
 impl RequestLocals {
     pub fn disable(&mut self) {
         self.profiling_enabled = false;
+        self.profiling_experimental_features_enabled = false;
         self.profiling_endpoint_collection_enabled = false;
         self.profiling_experimental_cpu_time_enabled = false;
         self.profiling_allocation_enabled = false;
@@ -401,6 +403,7 @@ impl Default for RequestLocals {
             env: None,
             interrupt_count: AtomicU32::new(0),
             profiling_enabled: false,
+            profiling_experimental_features_enabled: false,
             profiling_endpoint_collection_enabled: true,
             profiling_experimental_cpu_time_enabled: true,
             profiling_allocation_enabled: true,
@@ -465,6 +468,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     // Safety: We are after first rinit and before mshutdown.
     let (
         profiling_enabled,
+        profiling_experimental_features_enabled,
         profiling_endpoint_collection_enabled,
         profiling_experimental_cpu_time_enabled,
         profiling_allocation_enabled,
@@ -475,10 +479,14 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         output_pprof,
     ) = unsafe {
         let profiling_enabled = config::profiling_enabled();
+        let profiling_experimental_features_enabled =
+            profiling_enabled && config::profiling_experimental_features_enabled();
         (
             profiling_enabled,
+            profiling_experimental_features_enabled,
             profiling_enabled && config::profiling_endpoint_collection_enabled(),
-            profiling_enabled && config::profiling_experimental_cpu_time_enabled(),
+            profiling_experimental_features_enabled
+                || profiling_enabled && config::profiling_experimental_cpu_time_enabled(),
             profiling_enabled && config::profiling_allocation_enabled(),
             profiling_enabled && config::profiling_experimental_timeline_enabled(),
             profiling_enabled && config::profiling_exception_enabled(),
@@ -496,6 +504,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         locals.interrupt_count.store(0, Ordering::SeqCst);
 
         locals.profiling_enabled = profiling_enabled;
+        locals.profiling_experimental_features_enabled = profiling_experimental_features_enabled;
         locals.profiling_endpoint_collection_enabled = profiling_endpoint_collection_enabled;
         locals.profiling_experimental_cpu_time_enabled = profiling_experimental_cpu_time_enabled;
         locals.profiling_allocation_enabled = profiling_allocation_enabled;
@@ -765,6 +774,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
     REQUEST_LOCALS.with(|cell| {
         let locals = cell.borrow();
         let yes: &[u8] = b"true\0";
+        let yes_exp: &[u8] = b"true (all experimental features enabled)\0";
         let no: &[u8] = b"false\0";
         let no_all: &[u8] = b"false (profiling disabled)\0";
         zend::php_info_print_table_start();
@@ -777,9 +787,25 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
 
         zend::php_info_print_table_row(
             2,
+            b"Profiling Experimental Features Enabled\0".as_ptr(),
+            if locals.profiling_experimental_features_enabled {
+                yes
+            } else if locals.profiling_enabled {
+                no
+            } else {
+                no_all
+            },
+        );
+
+        zend::php_info_print_table_row(
+            2,
             b"Experimental CPU Time Profiling Enabled\0".as_ptr(),
             if locals.profiling_experimental_cpu_time_enabled {
-                yes
+                if locals.profiling_experimental_features_enabled {
+                    yes_exp
+                } else {
+                    yes
+                }
             } else if locals.profiling_enabled {
                 no
             } else {
@@ -817,7 +843,11 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                     2,
                     b"Experimental Timeline Enabled\0".as_ptr(),
                     if locals.profiling_experimental_timeline_enabled {
-                        yes
+                        if locals.profiling_experimental_features_enabled {
+                            yes_exp
+                        } else {
+                            yes
+                        }
                     } else if locals.profiling_enabled {
                         no
                     } else {
@@ -837,9 +867,13 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             if #[cfg(feature = "exception_profiling")] {
                 zend::php_info_print_table_row(
                     2,
-                    b"Exception Profiling Enabled\0".as_ptr(),
+                    b"Experimental Exception Profiling Enabled\0".as_ptr(),
                     if locals.profiling_exception_enabled {
-                        yes
+                        if locals.profiling_experimental_features_enabled {
+                            yes_exp
+                        } else {
+                            yes
+                        }
                     } else if locals.profiling_enabled {
                         no
                     } else {

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1110,6 +1110,7 @@ mod tests {
             env: None,
             interrupt_count: AtomicU32::new(0),
             profiling_enabled: true,
+            profiling_experimental_features_enabled: false,
             profiling_endpoint_collection_enabled: true,
             profiling_experimental_cpu_time_enabled: false,
             profiling_allocation_enabled: false,

--- a/profiling/tests/phpt/phpinfo_06.phpt
+++ b/profiling/tests/phpt/phpinfo_06.phpt
@@ -1,0 +1,64 @@
+--TEST--
+[profiling] test profiler's extension info with experimental feature override
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=off
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_ALLOCATION_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+--INI--
+assert.exception=1
+opcache.jit=off
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Profiling Enabled", "false"],
+    ["Profiling Experimental Features Enabled", "false (profiling disabled)"],
+    ["Experimental CPU Time Profiling Enabled", "false (profiling disabled)"],
+    ["Allocation Profiling Enabled", "false (profiling disabled)"],
+    ["Experimental Exception Profiling Enabled", "false (profiling disabled)"],
+    ["Experimental Timeline Enabled", "false (profiling disabled)"],
+];
+
+foreach ($sections as [$key, $expected]) {
+    assert(
+        $values[$key] === $expected,
+        "Expected '{$expected}', found '{$values[$key]}', for key '{$key}'"
+    );
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.

--- a/profiling/tests/phpt/phpinfo_06.phpt
+++ b/profiling/tests/phpt/phpinfo_06.phpt
@@ -14,7 +14,7 @@ DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=yes
 DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
 DD_PROFILING_ALLOCATION_ENABLED=no
-DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=no
+DD_PROFILING_EXCEPTION_ENABLED=no
 DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
 --INI--
 assert.exception=1
@@ -46,7 +46,7 @@ $sections = [
     ["Profiling Experimental Features Enabled", "false (profiling disabled)"],
     ["Experimental CPU Time Profiling Enabled", "false (profiling disabled)"],
     ["Allocation Profiling Enabled", "false (profiling disabled)"],
-    ["Experimental Exception Profiling Enabled", "false (profiling disabled)"],
+    ["Exception Profiling Enabled", "false (profiling disabled)"],
     ["Experimental Timeline Enabled", "false (profiling disabled)"],
 ];
 

--- a/profiling/tests/phpt/phpinfo_07.phpt
+++ b/profiling/tests/phpt/phpinfo_07.phpt
@@ -14,7 +14,7 @@ DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=yes
 DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
 DD_PROFILING_ALLOCATION_ENABLED=no
-DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=no
+DD_PROFILING_EXCEPTION_ENABLED=no
 DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
 --INI--
 assert.exception=1
@@ -46,7 +46,7 @@ $sections = [
     ["Profiling Experimental Features Enabled", "true"],
     ["Experimental CPU Time Profiling Enabled", "true (all experimental features enabled)"],
     ["Allocation Profiling Enabled", "false"],
-    ["Experimental Exception Profiling Enabled", "true (all experimental features enabled)"],
+    ["Exception Profiling Enabled", "false"],
     ["Experimental Timeline Enabled", "true (all experimental features enabled)"],
 ];
 

--- a/profiling/tests/phpt/phpinfo_07.phpt
+++ b/profiling/tests/phpt/phpinfo_07.phpt
@@ -1,0 +1,64 @@
+--TEST--
+[profiling] test profiler's extension info with experimental feature override
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=off
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_ALLOCATION_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+--INI--
+assert.exception=1
+opcache.jit=off
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Profiling Enabled", "true"],
+    ["Profiling Experimental Features Enabled", "true"],
+    ["Experimental CPU Time Profiling Enabled", "true (all experimental features enabled)"],
+    ["Allocation Profiling Enabled", "false"],
+    ["Experimental Exception Profiling Enabled", "true (all experimental features enabled)"],
+    ["Experimental Timeline Enabled", "true (all experimental features enabled)"],
+];
+
+foreach ($sections as [$key, $expected]) {
+    assert(
+        $values[$key] === $expected,
+        "Expected '{$expected}', found '{$values[$key]}', for key '{$key}'"
+    );
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
### Description

This will add the `datadog.profiling.experimental_features_enabled` INI setting (and corresponding ENV var `DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED`) which allows to enable all experimental features in the profiler with this one setting.
This will overrule all INI/ENV settings that configure experimental features.

[PROF-8393](https://datadoghq.atlassian.net/browse/PROF-8393)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.


[PROF-8393]: https://datadoghq.atlassian.net/browse/PROF-8393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ