### PR TITLE
Zero pad the tid and exclude it from OTel tracestate

### DIFF
--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -40,6 +40,11 @@ static inline zend_string *ddtrace_format_tracestate(zend_string *tracestate, ze
             if (last_separator) {
                 next_equals = ':';
                 cur += strlen("_dd.p");
+                // drop the tid from otel tracestate
+                if (cur + strlen(".tid=") + 16 /* 16 byte tid */ <= end && memcmp(cur, ".tid=", strlen(".tid=")) == 0) {
+                    cur += strlen(".tid=") + 16;
+                    continue;
+                }
                 smart_str_appendc(&str, 't');
             }
             signed char chr = *cur;

--- a/ext/tracer_tag_propagation/tracer_tag_propagation.c
+++ b/ext/tracer_tag_propagation/tracer_tag_propagation.c
@@ -122,7 +122,7 @@ zend_string *ddtrace_format_propagated_tags(zend_array *propagated, zend_array *
 
     ddtrace_trace_id trace_id = ddtrace_peek_trace_id();
     if (trace_id.high) {
-        smart_str_append_printf(&taglist, "_dd.p.tid=%" PRIx64, trace_id.high);
+        smart_str_append_printf(&taglist, "_dd.p.tid=%016" PRIx64, trace_id.high);
     }
 
     zend_string *tagname;

--- a/tests/OpenTelemetry/Integration/API/TracerTest.php
+++ b/tests/OpenTelemetry/Integration/API/TracerTest.php
@@ -497,9 +497,9 @@ final class TracerTest extends BaseTestCase
                 '_dd.p.congo' => 't61rcWkgMzE',
                 '_dd.p.some_val' => 'tehehe'
             ]);
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.congo:t61rcWkgMzE;t.some_val:tehehe$/', (string)$span->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0;t.congo:t61rcWkgMzE;t.some_val:tehehe$/', (string)$span->getContext()->getTraceState());
             $span->end();
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.congo:t61rcWkgMzE;t.some_val:tehehe$/', (string)$span->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0;t.congo:t61rcWkgMzE;t.some_val:tehehe$/', (string)$span->getContext()->getTraceState());
         });
 
         $span = $traces[0][0];
@@ -543,7 +543,7 @@ final class TracerTest extends BaseTestCase
             $this->assertSame($remoteContext->getSpanId(), $child->getParentContext()->getSpanId());
             $this->assertFalse($childContext->isRemote()); // "When creating children from remote spans, their IsRemote flag MUST be set to false."
             $this->assertEquals(1, $childContext->getTraceFlags()); // RECORD_AND_SAMPLED ==> 01 (AlwaysOn sampler)
-            $this->assertSame("dd=t.tid:4bf92f3577b34da6;t.dm:-0" . ($traceState ? ",$traceState" : ""), (string)$childContext->getTraceState());
+            $this->assertSame("dd=t.dm:-0" . ($traceState ? ",$traceState" : ""), (string)$childContext->getTraceState());
         });
 
         $span = $traces[0][0];
@@ -618,11 +618,11 @@ final class TracerTest extends BaseTestCase
             )))->getTracer('OpenTelemetry.TracerTest');
             $parent = $tracer->spanBuilder("parent")->startSpan(); // root sampler will be used
             $scope = $parent->activate();
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
             $parent->setAttributes([
                 '_dd.p.some_val' => 'tehehe'
             ]);
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.some_val:tehehe,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0;t.some_val:tehehe,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
             try {
                 $child = $tracer->spanBuilder("child")->startSpan(); // local parent sampler will be used
 
@@ -631,8 +631,8 @@ final class TracerTest extends BaseTestCase
                 $this->assertSame($parent->getContext()->getSpanId(), $child->getParentContext()->getSpanId());
                 $this->assertFalse($childContext->isRemote()); // "When creating children from remote spans, their IsRemote flag MUST be set to false."
                 $this->assertEquals(1, $childContext->getTraceFlags()); // RECORD_AND_SAMPLED ==> 01 (AlwaysOn sampler)
-                $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$childContext->getTraceState());
-                $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
+                $this->assertRegularExpression('/^dd=t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$childContext->getTraceState());
+                $this->assertRegularExpression('/^dd=t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
 
                 $grandChild = $tracer->spanBuilder("grandChild")
                     ->setParent(Context::getCurrent()->withContextValue($child))
@@ -644,14 +644,14 @@ final class TracerTest extends BaseTestCase
                 $this->assertSame($child->getContext()->getSpanId(), $grandChild->getParentContext()->getSpanId());
                 $this->assertFalse($grandChildContext->isRemote()); // "When creating children from remote spans, their IsRemote flag MUST be set to false."
                 $this->assertEquals(1, $grandChildContext->getTraceFlags()); // RECORD_AND_SAMPLED ==> 01 (AlwaysOn sampler)
-                $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$grandChildContext->getTraceState());
+                $this->assertRegularExpression('/^dd=t.dm:-0,localparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$grandChildContext->getTraceState());
 
                 $grandChildScope->detach();
                 $grandChild->end();
 
                 $child->end();
             } finally {
-                $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.some_val:tehehe,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
+                $this->assertRegularExpression('/^dd=t.dm:-0;t.some_val:tehehe,root=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE$/', (string)$parent->getContext()->getTraceState());
                 $scope->detach();
                 $parent->end();
             }
@@ -760,13 +760,13 @@ final class TracerTest extends BaseTestCase
             $this->assertSame($remoteContext->getSpanId(), $child->getParentContext()->getSpanId());
             $this->assertFalse($childContext->isRemote()); // "When creating children from remote spans, their IsRemote flag MUST be set to false."
             $this->assertEquals(1, $childContext->getTraceFlags()); // RECORD_AND_SAMPLED ==> 01 (AlwaysOn sampler)
-            //$this->assertSame("dd=t.tid:4bf92f3577b34da6;t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$childContext->getTraceState());
+            //$this->assertSame("dd=t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$childContext->getTraceState());
 
             $tracer = self::getTracer();
             $grandChild = $tracer->spanBuilder("grandChild")
                 ->setParent(Context::getCurrent()->withContextValue($child))
                 ->startSpan();
-            $this->assertSame("dd=t.tid:4bf92f3577b34da6;t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$child->getContext()->getTraceState());
+            $this->assertSame("dd=t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$child->getContext()->getTraceState());
             $grandChildScope = $grandChild->activate();
 
             $grandChildContext = $grandChild->getContext();
@@ -774,8 +774,8 @@ final class TracerTest extends BaseTestCase
             $this->assertSame($child->getContext()->getSpanId(), $grandChild->getParentContext()->getSpanId());
             $this->assertFalse($grandChildContext->isRemote()); // "When creating children from remote spans, their IsRemote flag MUST be set to false."
             $this->assertEquals(1, $grandChildContext->getTraceFlags()); // RECORD_AND_SAMPLED ==> 01 (AlwaysOn sampler)
-            $this->assertSame("dd=t.tid:4bf92f3577b34da6;t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$child->getContext()->getTraceState());
-            $this->assertSame("dd=t.tid:4bf92f3577b34da6;t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$grandChildContext->getTraceState());
+            $this->assertSame("dd=t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$child->getContext()->getTraceState());
+            $this->assertSame("dd=t.dm:-0,remoteparent=yes,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", (string)$grandChildContext->getTraceState());
 
             $grandChildScope->detach();
             $grandChild->end();
@@ -807,7 +807,7 @@ final class TracerTest extends BaseTestCase
                 '_dd.p.congo' => 't61rcWkgMzE',
             ]);
 
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.congo:t61rcWkgMzE$/', (string)$span->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0;t.congo:t61rcWkgMzE$/', (string)$span->getContext()->getTraceState());
 
             $traceState = $span->getContext()->getTraceState()->with('rojo', '00f067aa0ba902b7');
             $context = SpanContext::create(
@@ -821,7 +821,7 @@ final class TracerTest extends BaseTestCase
                 ->setParent(Context::getCurrent()->withContextValue(Span::wrap($context)))
                 ->startSpan();
 
-            $this->assertRegularExpression('/^dd=t.tid:[0-9a-f]{16};t.dm:-0;t.congo:t61rcWkgMzE,rojo=00f067aa0ba902b7$/', (string)$child->getContext()->getTraceState());
+            $this->assertRegularExpression('/^dd=t.dm:-0;t.congo:t61rcWkgMzE,rojo=00f067aa0ba902b7$/', (string)$child->getContext()->getTraceState());
 
             $child->end();
             $span->end();

--- a/tests/OpenTelemetry/Integration/InteroperabilityTest.php
+++ b/tests/OpenTelemetry/Integration/InteroperabilityTest.php
@@ -643,7 +643,7 @@ final class InteroperabilityTest extends BaseTestCase
             $OTelRootSpan->end();
 
             $this->assertSame("00-ff0000000000051791e0000000000041-$DDChildSpanId-01", $carrier[TraceContextPropagator::TRACEPARENT]);
-            $this->assertSame('dd=t.tid:ff00000000000517;t.dm:-0', $carrier[TraceContextPropagator::TRACESTATE]); // ff00000000000517 is the high 64-bit part of the 128-bit trace id
+            $this->assertSame('dd=t.dm:-0', $carrier[TraceContextPropagator::TRACESTATE]); // ff00000000000517 is the high 64-bit part of the 128-bit trace id
         });
 
         $this->assertSame('10511401530282737729', $traces[0][0]['trace_id']);

--- a/tests/OpenTelemetry/Integration/SDK/TracerTest.php
+++ b/tests/OpenTelemetry/Integration/SDK/TracerTest.php
@@ -79,7 +79,7 @@ class TracerTest extends BaseTestCase
             $span = $tracer->spanBuilder('test.span')->setParent($parentContext)->startSpan();
 
             $this->assertNotEquals($parentTraceState, $span->getContext()->getTraceState());
-            $this->assertEquals('dd=t.tid:4bf92f3577b34da6;t.dm:-0,new-key=new_value', (string)$span->getContext()->getTraceState());
+            $this->assertEquals('dd=t.dm:-0,new-key=new_value', (string)$span->getContext()->getTraceState());
         });
     }
 

--- a/tests/ext/distributed_tracestate_consumption.phpt
+++ b/tests/ext/distributed_tracestate_consumption.phpt
@@ -28,5 +28,5 @@ array(2) {
   ["traceparent"]=>
   string(55) "00-%sc151df7d6ee5e2d6-a3978fb9b92502a8-01"
   ["tracestate"]=>
-  string(75) "dd=t.tid:%s;t.dm:-1;t.congo:t61rcWkgMzE,rojo=00f067aa0ba902b7"
+  string(52) "dd=t.dm:-1;t.congo:t61rcWkgMzE,rojo=00f067aa0ba902b7"
 }

--- a/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
@@ -8,7 +8,7 @@ ddtrace.request_init_hook={PWD}/distributed_tracing_curl_inject.inc
 --ENV--
 DD_TRACE_DEBUG=1
 DD_TRACE_GENERATE_ROOT_SPAN=0
-HTTP_TRACEPARENT=00-12345678901234567890123456789012-1234567890123456-00
+HTTP_TRACEPARENT=00-00000012345678907890123456789012-1234567890123456-00
 HTTP_TRACESTATE=foo=1,dd=s:1;t.dm:-0;t.usr.id:baz64~~;t.url:http://localhost
 DD_PROPAGATION_STYLE=tracecontext,Datadog
 --FILE--
@@ -43,10 +43,10 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-traceparent: 00-12345678901234567890123456789012-1234567890123456-00
-tracestate: dd=t.tid:1234567890123456;t.usr.id:baz64~~;t.url:http://localhost,foo=1
+traceparent: 00-00000012345678907890123456789012-1234567890123456-00
+tracestate: dd=t.usr.id:baz64~~;t.url:http://localhost,foo=1
 x-datadog-parent-id: 1311768467284833366
-x-datadog-tags: _dd.p.tid=1234567890123456,_dd.p.usr.id=baz64==,_dd.p.url=http://localhost
+x-datadog-tags: _dd.p.tid=0000001234567890,_dd.p.usr.id=baz64==,_dd.p.url=http://localhost
 x-datadog-trace-id: 8687463697196027922
 bool(false)
 Done.

--- a/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
@@ -44,7 +44,7 @@ echo 'Done.' . PHP_EOL;
 --EXPECTF--
 b3: %s248869c998246a2e-248869c998246a2e-1
 traceparent: 00-%s248869c998246a2e-248869c998246a2e-01
-tracestate: dd=o:_______~_: ;t.tid:%s;t.escaped:_~_: ;t.dm:-0
+tracestate: dd=o:_______~_: ;t.escaped:_~_: ;t.dm:-0
 x-datadog-origin: ∂~,=;:
 x-datadog-tags: _dd.p.tid=%s,_dd.p.escaped=_=;: ,_dd.p.dm=-0
 bool(false)

--- a/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
@@ -45,7 +45,7 @@ echo 'Done.' . PHP_EOL;
 --EXPECTF--
 b3: 12345678901234567890123456789012-6543210987654321-d
 traceparent: 00-12345678901234567890123456789012-6543210987654321-01
-tracestate: dd=o:phpt-test;s:2;t.tid:1234567890123456;t.test:qvalue;t.dm:-0;unknown1:val;unknown2:1,foo=bar:;=,baz=qux
+tracestate: dd=o:phpt-test;s:2;t.test:qvalue;t.dm:-0;unknown1:val;unknown2:1,foo=bar:;=,baz=qux
 x-datadog-origin: phpt-test
 x-datadog-tags: _dd.p.tid=1234567890123456,_dd.p.test=qvalue,_dd.p.dm=-0
 bool(false)


### PR DESCRIPTION
### Description

As per our specification, otherwise other tracers may complain about a malformed tid.

### Readiness checklist
- [X] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [X] Milestone is set.
- [X] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
