### PR TITLE
Enable appsec tests on PHP 8.0 with debug-zts-asan 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,4 @@ workflows:
             ext/handlers_api.[ch] profiling true
             appsec/.* appsec true
             ext/.* appsec true
+            .circleci/continue_config.yml appsec true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4414,7 +4414,7 @@ workflows:
           parameters:
             php_major_minor:
               - "7.4"
-             #- "8.0" - Static TLS issues
+              - "8.0"
               - "8.1"
               - "8.2"
               - "8.3"


### PR DESCRIPTION
### Description

Enable appsec extension unit tests on PHP 8.0 with debug-zts-asan, this test was failing but was recently fixed in https://github.com/DataDog/dd-trace-php/pull/2383 and https://github.com/DataDog/dd-trace-php/pull/2353

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
