### PR TITLE
feat(profiling) add allocation and exception count to `event.json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "perfcnt",
  "rand 0.8.5",
  "rand_distr",
+ "serde_json",
  "uuid",
 ]
 

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -28,6 +28,7 @@ libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"]}
 once_cell = { version = "1.12" }
 ouroboros = { version = "0.17.0" }
+serde_json = {version = "1.0"}
 rand = { version = "0.8.5" }
 rand_distr = { version = "0.4.3" }
 uuid = { version = "1.0", features = ["v4"] }

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -8,6 +8,8 @@ use log::{debug, error, trace, warn};
 use rand::rngs::ThreadRng;
 use std::cell::RefCell;
 use std::ffi::CStr;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::SeqCst;
 
 use rand_distr::{Distribution, Poisson};
 
@@ -35,6 +37,15 @@ pub fn allocation_profiling_minit() {
 
 /// take a sample every 4096 KiB
 pub const ALLOCATION_PROFILING_INTERVAL: f64 = 1024.0 * 4096.0;
+
+/// this will store the count of allocations (including reallocations) during a profiling period.
+/// This will overflow when doing more then u64::MAX allocations, which seems big enough to ignore.
+pub static ALLOCATION_PROFILING_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// this will store the accumulated size of all allocations in bytes during the profiling period.
+/// This will overflow when allocating more then 18 exabyte of memory (u64::MAX) which might not
+/// happen, so we can ignore this
+pub static ALLOCATION_PROFILING_SIZE: AtomicU64 = AtomicU64::new(0);
 
 pub struct AllocationProfilingStats {
     /// number of bytes until next sample collection
@@ -326,6 +337,9 @@ unsafe extern "C" fn alloc_profiling_gc_mem_caches(
 }
 
 unsafe extern "C" fn alloc_profiling_malloc(len: size_t) -> *mut c_void {
+    ALLOCATION_PROFILING_COUNT.fetch_add(1, SeqCst);
+    ALLOCATION_PROFILING_SIZE.fetch_add(len as u64, SeqCst);
+
     let ptr: *mut c_void = ALLOCATION_PROFILING_ALLOC(len);
 
     // during startup, minit, rinit, ... current_execute_data is null
@@ -379,6 +393,9 @@ unsafe fn allocation_profiling_orig_free(ptr: *mut c_void) {
 }
 
 unsafe extern "C" fn alloc_profiling_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    ALLOCATION_PROFILING_COUNT.fetch_add(1, SeqCst);
+    ALLOCATION_PROFILING_SIZE.fetch_add(len as u64, SeqCst);
+
     let ptr: *mut c_void = ALLOCATION_PROFILING_REALLOC(prev_ptr, len);
 
     // during startup, minit, rinit, ... current_execute_data is null


### PR DESCRIPTION
### Description

Alongside the pprof file we can upload an `event.json` which this PR will add and deliver the absolute numbers for:
- allocations count
- allocations len
- exceptions count

To see them you'd need to enable the `profiling_custom_data_display` feature flag, so this would most likely help us in debugging.

<img width="728" alt="image" src="https://github.com/DataDog/dd-trace-php/assets/14161194/6bf45a05-e787-4eb5-b1cb-82450cd2d562">

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
