### PR TITLE
fix(profiler) do not emit profiles when profiler is disabled

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -55,13 +55,30 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Run no profile test
+        run: |
+          export DD_PROFILING_ENABLED=Off
+          export DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1
+          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=1
+          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+          php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
+          for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
+              mkdir -p profiling/tests/correctness/"$test_case"/
+              export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof
+              php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/"$test_case".php
+              if [ -f "$DD_PROFILING_OUTPUT_PPROF".1.lz4 ]; then
+                echo "File $DD_PROFILING_OUTPUT_PPROF.1.lz4 should not exist!"
+                exit 1;
+              fi
+          done
+
       - name: Run tests
         run: |
           export DD_PROFILING_LOG_LEVEL=trace
           export DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
-          php -d extension=target/release/libdatadog_php_profiling.so -v
+          php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
               mkdir -p profiling/tests/correctness/"$test_case"/
               export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof


### PR DESCRIPTION
### Description

A customer contacted us that with upgrading to `0.94.0` they see profiles being send to Datadog, although the profiler is disabled for them and therefore should not send profiles.
The bug is that the new idle phases added in https://github.com/DataDog/dd-trace-php/pull/2343 where not checking if the timeline is enabled.

This PR will add this missing check, as well as a test to ensure that in all prof-correctness cases the profiler does not emit pprof files when profiling is disabled.

[SCP-378](https://datadoghq.atlassian.net/browse/SCP-378)

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.


[SCP-378]: https://datadoghq.atlassian.net/browse/SCP-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ