### PR TITLE
fix(profiler) prevent emitting empty profiles

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1046,38 +1046,38 @@ impl Profiler {
             let len = 2 + locals.profiling_experimental_cpu_time_enabled as usize;
             sample_types.extend_from_slice(&SAMPLE_TYPES[0..len]);
             sample_values.extend_from_slice(&values[0..len]);
-        }
 
-        // alloc-samples, alloc-size
-        if locals.profiling_allocation_enabled {
-            sample_types.extend_from_slice(&SAMPLE_TYPES[3..5]);
-            sample_values.extend_from_slice(&values[3..5]);
-        }
+            // alloc-samples, alloc-size
+            if locals.profiling_allocation_enabled {
+                sample_types.extend_from_slice(&SAMPLE_TYPES[3..5]);
+                sample_values.extend_from_slice(&values[3..5]);
+            }
 
-        #[cfg(feature = "timeline")]
-        if locals.profiling_experimental_timeline_enabled {
-            sample_types.push(SAMPLE_TYPES[5]);
-            sample_values.push(values[5]);
-        }
+            #[cfg(feature = "timeline")]
+            if locals.profiling_experimental_timeline_enabled {
+                sample_types.push(SAMPLE_TYPES[5]);
+                sample_values.push(values[5]);
+            }
 
-        #[cfg(feature = "exception_profiling")]
-        if locals.profiling_exception_enabled {
-            sample_types.push(SAMPLE_TYPES[6]);
-            sample_values.push(values[6]);
-        }
+            #[cfg(feature = "exception_profiling")]
+            if locals.profiling_exception_enabled {
+                sample_types.push(SAMPLE_TYPES[6]);
+                sample_values.push(values[6]);
+            }
 
-        #[cfg(php_has_fibers)]
-        if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
-            // Safety: the fcc is set by Fiber::__construct as part of zpp,
-            // which will always set the function_handler on success, and
-            // there's nothing changing that value in all of fibers
-            // afterwards, from start to destruction of the fiber itself.
-            let func = unsafe { &*fiber.fci_cache.function_handler };
-            if let Some(functionname) = extract_function_name(func) {
-                labels.push(Label {
-                    key: "fiber",
-                    value: LabelValue::Str(functionname.into()),
-                });
+            #[cfg(php_has_fibers)]
+            if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
+                // Safety: the fcc is set by Fiber::__construct as part of zpp,
+                // which will always set the function_handler on success, and
+                // there's nothing changing that value in all of fibers
+                // afterwards, from start to destruction of the fiber itself.
+                let func = unsafe { &*fiber.fci_cache.function_handler };
+                if let Some(functionname) = extract_function_name(func) {
+                    labels.push(Label {
+                        key: "fiber",
+                        value: LabelValue::Str(functionname.into()),
+                    });
+                }
             }
         }
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -346,6 +346,12 @@ impl TimeCollector {
         profiles: &mut HashMap<ProfileIndex, InternalProfile>,
         started_at: &WallTime,
     ) {
+        if message.key.sample_types.len() == 0 {
+            // profiling disabled, this should not happen!
+            warn!("You spot a bug in the profiler, please be so kind and report this do Datadog.");
+            return;
+        }
+
         let profile: &mut InternalProfile = if let Some(value) = profiles.get_mut(&message.key) {
             value
         } else {
@@ -572,12 +578,6 @@ impl Profiler {
     }
 
     pub fn send_sample(&self, message: SampleMessage) -> Result<(), TrySendError<ProfilerMessage>> {
-        if message.key.sample_types.len() == 0 {
-            // profiling disabled, this should not happen!
-            warn!("You spot a bug in the profiler, please be so kind and report this do Datadog.");
-            // this return is technically not correct :-(
-            return Err(TrySendError::Disconnected(ProfilerMessage::Sample(message)));
-        }
         self.message_sender
             .try_send(ProfilerMessage::Sample(message))
     }

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1010,6 +1010,10 @@ impl Profiler {
         locals: &RequestLocals,
         timestamp: i64,
     ) -> SampleMessage {
+        if !locals.profiling_enabled {
+            panic!("Profiling is disabled and this function should not be called!")
+        }
+
         // Lay this out in the same order as SampleValues
         static SAMPLE_TYPES: &[ValueType; 7] = &[
             ValueType::new("sample", "count"),
@@ -1034,43 +1038,42 @@ impl Profiler {
 
         let mut sample_types = Vec::with_capacity(SAMPLE_TYPES.len());
         let mut sample_values = Vec::with_capacity(SAMPLE_TYPES.len());
-        if locals.profiling_enabled {
-            // sample, wall-time, cpu-time
-            let len = 2 + locals.profiling_experimental_cpu_time_enabled as usize;
-            sample_types.extend_from_slice(&SAMPLE_TYPES[0..len]);
-            sample_values.extend_from_slice(&values[0..len]);
 
-            // alloc-samples, alloc-size
-            if locals.profiling_allocation_enabled {
-                sample_types.extend_from_slice(&SAMPLE_TYPES[3..5]);
-                sample_values.extend_from_slice(&values[3..5]);
-            }
+        // sample, wall-time, cpu-time
+        let len = 2 + locals.profiling_experimental_cpu_time_enabled as usize;
+        sample_types.extend_from_slice(&SAMPLE_TYPES[0..len]);
+        sample_values.extend_from_slice(&values[0..len]);
 
-            #[cfg(feature = "timeline")]
-            if locals.profiling_experimental_timeline_enabled {
-                sample_types.push(SAMPLE_TYPES[5]);
-                sample_values.push(values[5]);
-            }
+        // alloc-samples, alloc-size
+        if locals.profiling_allocation_enabled {
+            sample_types.extend_from_slice(&SAMPLE_TYPES[3..5]);
+            sample_values.extend_from_slice(&values[3..5]);
+        }
 
-            #[cfg(feature = "exception_profiling")]
-            if locals.profiling_exception_enabled {
-                sample_types.push(SAMPLE_TYPES[6]);
-                sample_values.push(values[6]);
-            }
+        #[cfg(feature = "timeline")]
+        if locals.profiling_experimental_timeline_enabled {
+            sample_types.push(SAMPLE_TYPES[5]);
+            sample_values.push(values[5]);
+        }
 
-            #[cfg(php_has_fibers)]
-            if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
-                // Safety: the fcc is set by Fiber::__construct as part of zpp,
-                // which will always set the function_handler on success, and
-                // there's nothing changing that value in all of fibers
-                // afterwards, from start to destruction of the fiber itself.
-                let func = unsafe { &*fiber.fci_cache.function_handler };
-                if let Some(functionname) = extract_function_name(func) {
-                    labels.push(Label {
-                        key: "fiber",
-                        value: LabelValue::Str(functionname.into()),
-                    });
-                }
+        #[cfg(feature = "exception_profiling")]
+        if locals.profiling_exception_enabled {
+            sample_types.push(SAMPLE_TYPES[6]);
+            sample_values.push(values[6]);
+        }
+
+        #[cfg(php_has_fibers)]
+        if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
+            // Safety: the fcc is set by Fiber::__construct as part of zpp,
+            // which will always set the function_handler on success, and
+            // there's nothing changing that value in all of fibers
+            // afterwards, from start to destruction of the fiber itself.
+            let func = unsafe { &*fiber.fci_cache.function_handler };
+            if let Some(functionname) = extract_function_name(func) {
+                labels.push(Label {
+                    key: "fiber",
+                    value: LabelValue::Str(functionname.into()),
+                });
             }
         }
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -348,7 +348,7 @@ impl TimeCollector {
     ) {
         if message.key.sample_types.len() == 0 {
             // profiling disabled, this should not happen!
-            warn!("You spot a bug in the profiler, please be so kind and report this do Datadog.");
+            warn!("A sample with no sample types was recorded in the profiler. Please report this to Datadog.");
             return;
         }
 


### PR DESCRIPTION
### Description

This will make sure that empty profiles that we might send to the `ddprof_time` thread will be ignored. This should not happen anyway, but it happened in the past.

PROF-8749

### Readiness checklist
- [x] (only for Members) Changelog has been added to the release document.
- [x] Tests added for this feature/bug.

### Reviewer checklist
- [x] Appropriate labels assigned.
- [x] Milestone is set.
- [x] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
