### PR TITLE
[Automation] Adds automatically merged PRs to next milestone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,9 @@
 Any description you feel is relevant and gives more background to this PR, if necessary.
 -->
 
-### Readiness checklist
-- [ ] (only for Members) Changelog has been added to the release document.
-- [ ] Tests added for this feature/bug.
+<!-- Fixes #{issue} -->
+<!-- Documented in #{doc pr} -->
 
 ### Reviewer checklist
+- [ ] Test coverage seems ok.
 - [ ] Appropriate labels assigned.
-- [ ] Milestone is set.
-- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -6,10 +6,10 @@ labels:
     allFilesIn: "(appsec\/.*|docker-compose.yml|.*\/.circleci\/.*)"
 
   - name: "profiling"
-    title: "^*(profiler)"
+    title: "^.*\\(profiler\\)"
 
   - name: "profiling"
-    title: "^*(profiling)"
+    title: "^.*\\(profiling\\)"
 
   - name: "profiling"
     allFilesIn: "(profiling\/.*|docker-compose.yml|.*\/.circleci\/.*)"

--- a/.github/workflows/auto_add_pr_to_miletone.yml
+++ b/.github/workflows/auto_add_pr_to_miletone.yml
@@ -1,0 +1,26 @@
+name: Auto add PR to vNext milestone
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    types: [closed]
+
+jobs:
+  add_to_milestone:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.101'
+
+      - name: "Assign to vNext Milestone"
+        run: ./tracer/build.sh AssignPullRequestToMilestone
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tmp/opcache*
 docker-compose.override.yml
 tests/Sapi/Roadrunner/rr-*
 github-actions-helpers/_build.csproj.DotSettings
+.nuke

--- a/github-actions-helpers/Build.cs
+++ b/github-actions-helpers/Build.cs
@@ -24,6 +24,9 @@ partial class Build : NukeBuild
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
+    [Parameter("The current version of the source and build")]
+    readonly string Version = "0.94.0";
+
     Target Clean => _ => _
         .Before(Restore)
         .Executes(() =>


### PR DESCRIPTION
### Description

All PRs merged to master will be in the next minor release. Adding to the milestone can be done automatically.
The action does nothing if there's already a milestone on the PR.
We will use in a next PR, the milestone content to generate the release notes

Additionally, fixes a missing gitignore and some regexes for the labeller

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the release document.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Changelog has been added to the release document. For community contributors the reviewer is in charge of this task.
