### PR TITLE
feat(ci): bump to latest PHP versions

### DIFF
--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -96,8 +96,8 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.1.22
-        php_sha: f5140e94b139b4adec4b29c337537b7b6f1ef023197eb32be909e724e3da157a
+        php_version: 8.1.26
+        php_sha: d954cecfc3d294c2fccbe2b1a6bef784ce0d6c5d44a9e28f8a527e092825f2cb
         php_api: 20210902
     command: build-dd-trace-php
     volumes:
@@ -109,8 +109,8 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.2.8
-        php_sha: 6419b74e9b675c8d5a1afd2788c4d7996a19bbe2be409716ccb2067897af9df1
+        php_version: 8.2.13
+        php_sha: 6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b
         php_api: 20220829
     command: build-dd-trace-php
     volumes:
@@ -123,8 +123,8 @@ services:
       x-bake: *bake
       args:
         php_version: 8.3.0
-        php_url: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
-        php_sha: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
+        php_url: https://www.php.net/distributions/php-8.3.0.tar.gz
+        php_sha: "557ae14650f1d1984d3213e3fcd8d93a5f11418b3f8026d3a2d5022251163951"
         php_api: 20230831
     command: build-dd-trace-php
     volumes:

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -17,7 +17,7 @@ elif [[ $PHP_VERSION_ID -le 81 ]]; then
 elif [[ $PHP_VERSION_ID -le 82 ]]; then
   XDEBUG_VERSIONS=(-3.2.2)
 else
-  XDEBUG_VERSIONS=(-3.3.0alpha2)
+  XDEBUG_VERSIONS=(-3.3.0)
 fi
 
 MONGODB_VERSION=

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.3"
-        phpTarGzUrl: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
-        phpSha256Hash: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.3.0.tar.gz
+        phpSha256Hash: "557ae14650f1d1984d3213e3fcd8d93a5f11418b3f8026d3a2d5022251163951"
 
   php-8.2:
     image: datadog/dd-trace-ci:php-8.2_buster
@@ -30,8 +30,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.2.8.tar.gz
-        phpSha256Hash: "6419b74e9b675c8d5a1afd2788c4d7996a19bbe2be409716ccb2067897af9df1"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.13.tar.gz
+        phpSha256Hash: "6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b"
 
   php-8.1:
     image: datadog/dd-trace-ci:php-8.1_buster
@@ -41,8 +41,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.1"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.1.22.tar.gz
-        phpSha256Hash: "f5140e94b139b4adec4b29c337537b7b6f1ef023197eb32be909e724e3da157a"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.1.26.tar.gz
+        phpSha256Hash: "d954cecfc3d294c2fccbe2b1a6bef784ce0d6c5d44a9e28f8a527e092825f2cb"
 
   php-8.0:
     image: datadog/dd-trace-ci:php-8.0_buster

--- a/dockerfiles/ci/centos/7/docker-compose.yml
+++ b/dockerfiles/ci/centos/7/docker-compose.yml
@@ -84,8 +84,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.1"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.1.22.tar.gz
-        phpSha256Hash: f5140e94b139b4adec4b29c337537b7b6f1ef023197eb32be909e724e3da157a
+        phpTarGzUrl: https://www.php.net/distributions/php-8.1.26.tar.gz
+        phpSha256Hash: d954cecfc3d294c2fccbe2b1a6bef784ce0d6c5d44a9e28f8a527e092825f2cb
     image: 'datadog/dd-trace-ci:php-8.1_centos-7'
 
   php-8.2:
@@ -95,8 +95,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.2.8.tar.gz
-        phpSha256Hash: 6419b74e9b675c8d5a1afd2788c4d7996a19bbe2be409716ccb2067897af9df1
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.13.tar.gz
+        phpSha256Hash: 6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b
     image: 'datadog/dd-trace-ci:php-8.2_centos-7'
 
   php-8.3:
@@ -106,6 +106,6 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.3"
-        phpTarGzUrl: https://downloads.php.net/~eric/php-8.3.0RC6.tar.gz
-        phpSha256Hash: "83e838f91a0b6370caff3dacf0d80275234ace7f9892212732807a4c5e33c6ed"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.3.0.tar.gz
+        phpSha256Hash: 557ae14650f1d1984d3213e3fcd8d93a5f11418b3f8026d3a2d5022251163951
     image: 'datadog/dd-trace-ci:php-8.3_centos-7'


### PR DESCRIPTION
### Description

This PR will upgrade the containers used to run tests and build the libraries
- from PHP 8.1.22 -> 8.1.26
- from PHP 8.2.8 -> 8.2.13
- from PHP 8.3 RC6 -> 8.3.0

Additionally it will upgrade XDebug from 3.3.0alpha2 to 3.3.0

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
