### PR TITLE
fix(ci) fix xdebug

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4276,7 +4276,7 @@ workflows:
           requires: [ 'Prepare Code' ]
           name: "PHP 83 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
-          xdebug_version_one: "3.3.0alpha2"
+          xdebug_version_one: "3.3.0"
 
       - placeholder:
           requires: [ 'Prepare Code' ]

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -161,6 +161,7 @@ ext/standard/tests/strings/sprintf_variation54.phpt
 ext/tokenizer/tests/PhpToken_getAll.phpt
 ext/zend_test/tests/
 ext/zip/tests/bug38943.phpt
+sapi/cli/tests/bug80092.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -183,3 +183,4 @@ sapi/phpdbg/tests/stepping_001.phpt
 tests/classes/__call_007.phpt
 tests/lang/bug45392.phpt
 tests/output/ob_start_basic_002.phpt
+Zend/tests/gh12073.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -176,3 +176,4 @@ sapi/phpdbg/tests/exceptions_003.phpt
 sapi/phpdbg/tests/stepping_001.phpt
 tests/lang/bug45392.phpt
 tests/output/ob_start_basic_002.phpt
+Zend/tests/gh12073.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -155,6 +155,7 @@ ext/standard/tests/streams/stream_context_tcp_nodelay_fopen.phpt
 ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/zend_test/tests/
+sapi/cli/tests/bug80092.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt


### PR DESCRIPTION
### Description

This will fix the failing xdebug tests with the new containers and also add

- `sapi/cli/tests/bug80092.phpt` and
- `Zend/tests/gh12073.phpt`

to the xfail list.  `bug80092.phpt` is already blacklisted for PHP 8.3 and might be unlisted with 8.3.1. `gh12073` sets the memory limit to 2MB which is not possible anymore when the `dd_wrap_autoloader.php' is included.

`gh12073` fails with:
```
========DIFF========
001+ Warning: Failed to set memory limit to 2097152 bytes (Current memory usage is 8388608 bytes) in /usr/local/src/php/Zend/tests/gh12073.php on line 10
001- Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
```

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
