### PR TITLE
[WIP - Experimental] feat: Add Span End Callback

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -22,3 +22,6 @@ labels:
 
   - name: "tracing"
     allFilesIn: "(.*\/ext\/.*|.*\/src\/.*|.*\/tests\/.*|.*\/zend_abstract_interface\/.*|docker-compose.yml|.*\/.circleci\/.*)"
+
+  - name: "cat:opentelemetry"
+    allFilesIn: "(.*\/OpenTelemetry\/.*)"

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -121,6 +121,11 @@ namespace DDTrace {
         public array $peerServiceSources = [];
 
         /**
+         * @var \Closure|null $endCallback A callback to be called when the span is finished, if any.
+         */
+        public \Closure|null $endCallback = null;
+
+        /**
          * @var SpanData|null The parent span, or 'null' if there is none
          */
         public readonly SpanData|null $parent;
@@ -424,7 +429,7 @@ namespace DDTrace {
      * @param float $startTime Start time of the span in seconds.
      * @return SpanData The newly created root span
      */
-    function start_trace_span(float $startTime = 0): SpanData {}
+    function start_trace_span(float $startTime = 0): RootSpanData {}
 
     /**
      * Get the active stack

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -121,9 +121,9 @@ namespace DDTrace {
         public array $peerServiceSources = [];
 
         /**
-         * @var \Closure|null $endCallback A callback to be called when the span is finished, if any.
+         * @var \Closure|string|null $endCallback A callback to be called when the span is finished, if any.
          */
-        public \Closure|null $endCallback = null;
+        public \Closure|string|null $endCallback = null;
 
         /**
          * @var SpanData|null The parent span, or 'null' if there is none

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1d07ca443c39ea7a0a831b062bb0efe4baf69b0f */
+ * Stub hash: d95d154ba605844f46f82c7ed9df0298bf5a0872 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -78,6 +78,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_set_priority_sampling, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, priority, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, global, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_set_end_callback, 0, 2, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO(0, span, DDTrace\\SpanData, 0)
+	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_priority_sampling, 0, 0, IS_LONG, 1)
@@ -285,6 +290,7 @@ ZEND_FUNCTION(DDTrace_active_stack);
 ZEND_FUNCTION(DDTrace_create_stack);
 ZEND_FUNCTION(DDTrace_switch_stack);
 ZEND_FUNCTION(DDTrace_set_priority_sampling);
+ZEND_FUNCTION(DDTrace_set_end_callback);
 ZEND_FUNCTION(DDTrace_get_priority_sampling);
 ZEND_FUNCTION(DDTrace_get_sanitized_exception_trace);
 ZEND_FUNCTION(DDTrace_consume_distributed_tracing_headers);
@@ -364,6 +370,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FALIAS("DDTrace", create_stack, DDTrace_create_stack, arginfo_DDTrace_create_stack)
 	ZEND_NS_FALIAS("DDTrace", switch_stack, DDTrace_switch_stack, arginfo_DDTrace_switch_stack)
 	ZEND_NS_FALIAS("DDTrace", set_priority_sampling, DDTrace_set_priority_sampling, arginfo_DDTrace_set_priority_sampling)
+	ZEND_NS_FALIAS("DDTrace", set_end_callback, DDTrace_set_end_callback, arginfo_DDTrace_set_end_callback)
 	ZEND_NS_FALIAS("DDTrace", get_priority_sampling, DDTrace_get_priority_sampling, arginfo_DDTrace_get_priority_sampling)
 	ZEND_NS_FALIAS("DDTrace", get_sanitized_exception_trace, DDTrace_get_sanitized_exception_trace, arginfo_DDTrace_get_sanitized_exception_trace)
 	ZEND_NS_FALIAS("DDTrace", consume_distributed_tracing_headers, DDTrace_consume_distributed_tracing_headers, arginfo_DDTrace_consume_distributed_tracing_headers)
@@ -568,6 +575,13 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	zend_string *property_peerServiceSources_name = zend_string_init("peerServiceSources", sizeof("peerServiceSources") - 1, 1);
 	zend_declare_typed_property(class_entry, property_peerServiceSources_name, &property_peerServiceSources_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_peerServiceSources_name);
+
+	zval property_endCallback_default_value;
+	ZVAL_NULL(&property_endCallback_default_value);
+	zend_string *property_endCallback_name = zend_string_init("endCallback", sizeof("endCallback") - 1, 1);
+	zend_string *property_endCallback_class_Closure = zend_string_init("Closure", sizeof("Closure")-1, 1);
+	zend_declare_typed_property(class_entry, property_endCallback_name, &property_endCallback_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_endCallback_class_Closure, 0, MAY_BE_NULL));
+	zend_string_release(property_endCallback_name);
 
 	zval property_parent_default_value;
 	ZVAL_UNDEF(&property_parent_default_value);

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 55972d231789add1cf24ac96d74b532cd7f112f5 */
+ * Stub hash: e001e68def98ce39cf3f6a11337dc109cca4868f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -573,7 +573,7 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	ZVAL_NULL(&property_endCallback_default_value);
 	zend_string *property_endCallback_name = zend_string_init("endCallback", sizeof("endCallback") - 1, 1);
 	zend_string *property_endCallback_class_Closure = zend_string_init("Closure", sizeof("Closure")-1, 1);
-	zend_declare_typed_property(class_entry, property_endCallback_name, &property_endCallback_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_endCallback_class_Closure, 0, MAY_BE_NULL));
+	zend_declare_typed_property(class_entry, property_endCallback_name, &property_endCallback_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_endCallback_class_Closure, 0, MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_endCallback_name);
 
 	zval property_parent_default_value;

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d95d154ba605844f46f82c7ed9df0298bf5a0872 */
+ * Stub hash: 55972d231789add1cf24ac96d74b532cd7f112f5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -61,7 +61,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_update_span_duration, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, finishTime, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_DDTrace_start_trace_span, 0, 0, DDTrace\\SpanData, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_DDTrace_start_trace_span, 0, 0, DDTrace\\RootSpanData, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, startTime, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -78,11 +78,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_set_priority_sampling, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, priority, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, global, _IS_BOOL, 0, "false")
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_set_end_callback, 0, 2, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, span, DDTrace\\SpanData, 0)
-	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_priority_sampling, 0, 0, IS_LONG, 1)
@@ -290,7 +285,6 @@ ZEND_FUNCTION(DDTrace_active_stack);
 ZEND_FUNCTION(DDTrace_create_stack);
 ZEND_FUNCTION(DDTrace_switch_stack);
 ZEND_FUNCTION(DDTrace_set_priority_sampling);
-ZEND_FUNCTION(DDTrace_set_end_callback);
 ZEND_FUNCTION(DDTrace_get_priority_sampling);
 ZEND_FUNCTION(DDTrace_get_sanitized_exception_trace);
 ZEND_FUNCTION(DDTrace_consume_distributed_tracing_headers);
@@ -370,7 +364,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FALIAS("DDTrace", create_stack, DDTrace_create_stack, arginfo_DDTrace_create_stack)
 	ZEND_NS_FALIAS("DDTrace", switch_stack, DDTrace_switch_stack, arginfo_DDTrace_switch_stack)
 	ZEND_NS_FALIAS("DDTrace", set_priority_sampling, DDTrace_set_priority_sampling, arginfo_DDTrace_set_priority_sampling)
-	ZEND_NS_FALIAS("DDTrace", set_end_callback, DDTrace_set_end_callback, arginfo_DDTrace_set_end_callback)
 	ZEND_NS_FALIAS("DDTrace", get_priority_sampling, DDTrace_get_priority_sampling, arginfo_DDTrace_get_priority_sampling)
 	ZEND_NS_FALIAS("DDTrace", get_sanitized_exception_trace, DDTrace_get_sanitized_exception_trace, arginfo_DDTrace_get_sanitized_exception_trace)
 	ZEND_NS_FALIAS("DDTrace", consume_distributed_tracing_headers, DDTrace_consume_distributed_tracing_headers, arginfo_DDTrace_consume_distributed_tracing_headers)

--- a/ext/span.h
+++ b/ext/span.h
@@ -50,6 +50,7 @@ typedef union ddtrace_span_properties {
         };
         zval property_links;
         zval property_peer_service_sources;
+        zval property_end_closure;
         union {
             union ddtrace_span_properties *parent;
             zval property_parent;

--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Context;
 
+use DDTrace\OpenTelemetry\API\Trace as DDTraceAPI;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Util\ObjectKVStore;
@@ -191,7 +192,7 @@ final class Context implements ContextInterface
 
         $OTelCurrentSpan = SDK\Span::startSpan(
             $currentSpan,
-            API\SpanContext::create($currentTraceId, $currentSpanId, $traceFlags, $traceState), // $context
+            DDTraceAPI\SpanContext::createFromLocalSpan($currentSpan, $traceFlags === API\TraceFlags::SAMPLED, $currentSpanId),
             self::getDDInstrumentationScope(), // $instrumentationScope
             isset($currentSpan->meta[Tag::SPAN_KIND]) ? self::convertDDSpanKindToOtel($currentSpan->meta[Tag::SPAN_KIND]) : API\SpanKind::KIND_INTERNAL, // $kind
             API\Span::fromContext($parentContext), // $parentSpan (TODO: Handle null parent span) ?

--- a/src/DDTrace/OpenTelemetry/Span.php
+++ b/src/DDTrace/OpenTelemetry/Span.php
@@ -111,6 +111,8 @@ final class Span extends API\Span implements ReadWriteSpanInterface
                 $span->links[] = $spanLink;
             }
         }
+
+        $span->endCallback = fn () => $this->endOTelSpan();
     }
 
     /**
@@ -401,6 +403,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
             return;
         }
 
+        $this->span->endCallback = null; // No need for the callback
         $this->endOTelSpan($endEpochNanos);
 
         switch_stack($this->span);

--- a/tests/ext/span_callback_basic.phpt
+++ b/tests/ext/span_callback_basic.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Basic end callback behavior
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+$myGlobalClosedSpansCounter = 0;
+
+$callback = function (\DDTrace\SpanData $span) use (&$myGlobalClosedSpansCounter) {
+    $myGlobalClosedSpansCounter++;
+    $activeSpan = \DDTrace\active_span();
+    echo "$activeSpan->name\n";
+    echo "Passed span: $span->name\n";
+    $span->meta['counter.value'] = $myGlobalClosedSpansCounter;
+};
+
+$span = \DDTrace\start_span();
+$span->name = "mySpan";
+//\DDTrace\set_end_callback($span, $callback);
+$span->endCallback = $callback;
+
+var_dump(\DDTrace\current_context());
+var_dump(\DDTrace\logs_correlation_trace_id());
+
+\DDTrace\close_span();
+
+var_dump($myGlobalClosedSpansCounter);
+var_dump(dd_trace_serialize_closed_spans());
+
+class mySpanWrapper {
+    private $mySpan;
+
+    private function __construct(\DDTrace\SpanData $span) {
+        $this->mySpan = $span;
+        /*
+        // Doesn't crash
+        $span->endCallback = function (\DDTrace\SpanData $span) {
+            $this->end();
+        };*/
+    }
+
+    public static function create(\DDTrace\SpanData $span) {
+        $spanWrapper = new mySpanWrapper($span);
+        // Crash
+        $span->endCallback = function (\DDTrace\SpanData $span) use ($spanWrapper) {
+            $spanWrapper->end();
+        };
+    }
+
+    public function end() {
+        echo "This is the end of {$this->mySpan->name}\n";
+    }
+}
+
+$span = \DDTrace\start_span();
+$span->name = "mySpan";
+mySpanWrapper::create($span);
+\DDTrace\close_span();
+
+?>
+--EXPECT--

--- a/tests/ext/span_callback_basic.phpt
+++ b/tests/ext/span_callback_basic.phpt
@@ -12,7 +12,7 @@ $callback = function (\DDTrace\SpanData $span) use (&$myGlobalClosedSpansCounter
     $activeSpan = \DDTrace\active_span();
     echo "$activeSpan->name\n";
     echo "Passed span: $span->name\n";
-    $span->meta['counter.value'] = $myGlobalClosedSpansCounter;
+    //$span->meta['counter.value'] = $myGlobalClosedSpansCounter;
 };
 
 $span = \DDTrace\start_span();
@@ -20,13 +20,10 @@ $span->name = "mySpan";
 //\DDTrace\set_end_callback($span, $callback);
 $span->endCallback = $callback;
 
-var_dump(\DDTrace\current_context());
-var_dump(\DDTrace\logs_correlation_trace_id());
-
 \DDTrace\close_span();
 
 var_dump($myGlobalClosedSpansCounter);
-var_dump(dd_trace_serialize_closed_spans());
+//var_dump(dd_trace_serialize_closed_spans());
 
 class mySpanWrapper {
     private $mySpan;

--- a/tests/ext/span_callback_static.phpt
+++ b/tests/ext/span_callback_static.phpt
@@ -1,0 +1,28 @@
+--TEST--
+End callback using a static method
+--ENV--
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+$counter = 0;
+
+class MyCounter
+{
+    public static function increment()
+    {
+        global $counter;
+        $counter++;
+    }
+}
+
+$closure = Closure::fromCallable('MyCounter::increment');
+
+$span = \DDTrace\start_span();
+$span->endCallback = $closure;
+\DDTrace\close_span();
+
+var_dump($counter);
+
+?>
+--EXPECT--


### PR DESCRIPTION
### Description

**Experimental**

Leverage span end callback to end the OTel Span (if any) when a span is closed using the DD Api. This affects both OTel-created & remapped OTel spans. The goal is to fix edge cases + properly handle trace ids (See Tests Cases).

_Sample Edge Case_:
> 1. Start a span using DD API
> 2. Retrieve the current span using the OTel API
> 3. Add a distributed tag, which subsequently changes the tracestate 
> 4. Close the span using the DD API
> 5. Add a distributed tag, which subsequently changes the tracestate
> 6. Create a read-only copy of the span and read its tracestate

At present, there are issues with the third and fifth steps where the trace states are not being updated correctly in accordance with the OTel-API. Once these changes are made, the trace states can be dynamically retrieved and distributed context changes will accurately be reflected in the OTel API.

TODO:
- [X] Fix crashing callback scenario
- [ ] Add intertwined, start trace interoperability tests

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
