### PR TITLE
Fix analytics.event override

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1151,14 +1151,14 @@ void ddtrace_shutdown_span_sampling_limiter(void) {
 }
 
 // ParseBool returns the boolean value represented by the string.
-// It accepts 1, t, T, True (case insensitive), 0, f, F, False (case insensitive).
-// Any other value returns 0
+// It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
+// Any other value returns -1.
 static zend_always_inline double strconv_parse_bool(zend_string *str) {
     // See Go's strconv.ParseBool
     // https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/strconv/atob.go;drc=1f137052e4a20dbd302f947b1cf34cdf4b427d65;l=10
     size_t len = ZSTR_LEN(str);
     if (len == 0) {
-        return 0;
+        return -1;
     }
 
     char *s = ZSTR_VAL(str);
@@ -1176,18 +1176,18 @@ static zend_always_inline double strconv_parse_bool(zend_string *str) {
             }
             break;
         case 4:
-            if (strcasecmp(s, "true") == 0) {
+            if (strcmp(s, "TRUE") == 0 || strcmp(s, "True") == 0 || strcmp(s, "true") == 0) {
                 return 1;
             }
             break;
         case 5:
-            if (strcasecmp(s, "false") == 0) {
+            if (strcmp(s, "FALSE") == 0 || strcmp(s, "False") == 0 || strcmp(s, "false") == 0) {
                 return 0;
             }
             break;
     }
 
-    return 0;
+    return -1;
 }
 
 void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
@@ -1313,12 +1313,17 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     if (analytics_event) {
         zval analytics_event_as_double;
         if (Z_TYPE_P(analytics_event) == IS_STRING) {
-            ZVAL_DOUBLE(&analytics_event_as_double, strconv_parse_bool(Z_STR_P(analytics_event)));
+            double parsed_analytics_event = strconv_parse_bool(Z_STR_P(analytics_event));
+            if (parsed_analytics_event >= 0) {
+                ZVAL_DOUBLE(&analytics_event_as_double, parsed_analytics_event);
+                zend_array *metrics = ddtrace_property_array(&span->property_metrics);
+                zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &analytics_event_as_double);
+            }
         } else {
             ZVAL_DOUBLE(&analytics_event_as_double, zval_get_double(analytics_event));
+            zend_array *metrics = ddtrace_property_array(&span->property_metrics);
+            zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &analytics_event_as_double);
         }
-        zend_array *metrics = ddtrace_property_array(&span->property_metrics);
-        zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &analytics_event_as_double);
         zend_hash_str_del(meta, ZEND_STRL("analytics.event"));
     }
 

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1156,12 +1156,13 @@ void ddtrace_shutdown_span_sampling_limiter(void) {
 static zend_always_inline double strconv_parse_bool(zend_string *str) {
     // See Go's strconv.ParseBool
     // https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/strconv/atob.go;drc=1f137052e4a20dbd302f947b1cf34cdf4b427d65;l=10
-    if (ZSTR_LEN(str) == 0) {
+    size_t len = ZSTR_LEN(str);
+    if (len == 0) {
         return 0;
     }
 
     char *s = ZSTR_VAL(str);
-    switch (ZSTR_LEN(str)) {
+    switch (len) {
         case 1:
             switch (s[0]) {
                 case '1':

--- a/tests/OpenTelemetry/Integration/API/TracerTest.php
+++ b/tests/OpenTelemetry/Integration/API/TracerTest.php
@@ -347,7 +347,13 @@ final class TracerTest extends BaseTestCase
             ["FALSE", 0],
             ["something-else", 0],
             [True, 1],
-            [False, 0]
+            [False, 0],
+            ['t', 1],
+            ['T', 1],
+            ['f', 0],
+            ['F', 0],
+            ['1', 1],
+            ['0', 0],
         ];
     }
 

--- a/tests/OpenTelemetry/Integration/API/TracerTest.php
+++ b/tests/OpenTelemetry/Integration/API/TracerTest.php
@@ -345,7 +345,7 @@ final class TracerTest extends BaseTestCase
             ["false", 0],
             ["False", 0],
             ["FALSE", 0],
-            ["something-else", 0],
+            ["something-else", null],
             [True, 1],
             [False, 0],
             ['t', 1],
@@ -354,6 +354,8 @@ final class TracerTest extends BaseTestCase
             ['F', 0],
             ['1', 1],
             ['0', 0],
+            ['fAlse', null],
+            ['trUe', null]
         ];
     }
 
@@ -372,8 +374,12 @@ final class TracerTest extends BaseTestCase
         });
 
         $span = $traces[0][0];
-        $actualMetricValue = $span['metrics']['_dd1.sr.eausr'];
-        $this->assertEquals($expectedMetricValue, $actualMetricValue);
+        if ($expectedMetricValue !== null) {
+            $actualMetricValue = $span['metrics']['_dd1.sr.eausr'];
+            $this->assertEquals($expectedMetricValue, $actualMetricValue);
+        } else {
+            $this->assertArrayNotHasKey('_dd1.sr.eausr', $span['metrics']);
+        }
     }
 
     public function testSpanErrorStatus()


### PR DESCRIPTION
### Description

A system-test testing the behavior of `analytics.event` tag override was added with Datadog/system-tests#1818. The current implementation would fail :)

This PR simply explicitly checks for 'true' (not case sensitive) to return `1.0`, and _anything else_ would yield `0.0`

I set it as  `do-not-merge` as I need the pipeline to finish to test it properly, but the local tests otherwise pass.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [X] Appropriate labels assigned.
