### PR TITLE
Update datadog-setup.php

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -2164,7 +2164,7 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
  */
 function get_supported_php_versions()
 {
-    return ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2'];
+    return ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'];
 }
 
 main();


### PR DESCRIPTION
### Description

8.3 was not in the list of supported versions. Which made it so that the installer script could only find the main binary /usr/bin/php because it didn't had a version number included in the path.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
