### PR TITLE
CI: Handle latest Alpine 3.19 image

### DIFF
--- a/dockerfiles/verify_packages/alpine/install.sh
+++ b/dockerfiles/verify_packages/alpine/install.sh
@@ -64,6 +64,10 @@ if [ ! -f "${WWW_CONF}" ]; then
     WWW_CONF=/usr/local/etc/php-fpm.d/www.conf
 fi
 if [ ! -f "${WWW_CONF}" ]; then
+    # Alpine 3.19
+    WWW_CONF=/etc/php82/php-fpm.d/www.conf
+fi
+if [ ! -f "${WWW_CONF}" ]; then
     # Alpine 3.17
     WWW_CONF=/etc/php81/php-fpm.d/www.conf
 fi

--- a/dockerfiles/verify_packages/alpine/install.sh
+++ b/dockerfiles/verify_packages/alpine/install.sh
@@ -22,6 +22,9 @@ if [ -z "$PHP_BIN" ]; then
     PHP_BIN=$(command -v php81 || true)
 fi
 if [ -z "$PHP_BIN" ]; then
+    PHP_BIN=$(command -v php82 || true)
+fi
+if [ -z "$PHP_BIN" ]; then
     PHP_BIN=$(command -v php7 || true)
 fi
 
@@ -45,6 +48,9 @@ cp $(pwd)/dockerfiles/verify_packages/nginx.conf /etc/nginx/nginx.conf
 # Preparing PHP-FPM
 if [ -z "$PHP_FPM_BIN" ]; then
     PHP_FPM_BIN=$(command -v php-fpm || true)
+fi
+if [ -z "$PHP_FPM_BIN" ]; then
+    PHP_FPM_BIN=$(command -v php-fpm82 || true)
 fi
 if [ -z "$PHP_FPM_BIN" ]; then
     PHP_FPM_BIN=$(command -v php-fpm81 || true)


### PR DESCRIPTION
### Description

A [new Alpine image](https://hub.docker.com/_/alpine/tags) was released four days ago, which uses PHP 8.2 instead of 8.1, which would make the verify alpine:latest tests fail on the CI.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
