### PR TITLE
ci(profiling): run prof-correctness nightly

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -1,7 +1,9 @@
 name: Profiling correctness
 
 on:
-  - pull_request
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   prof-correctness:


### PR DESCRIPTION
### Description

This PR adds a nightly run for the prof-correctness job. The goal is to run the nightly jobs for `master` in the `dd-trace-php` repo and not in the `prof-correctness` repo to not need to keep the tests and expectations in sync.

PROF-8786

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
