### PR TITLE
fix: Allow hooks to be removed after class binding

### DIFF
--- a/tests/ext/sandbox/install_hook/exclude_inherited_hook_after_binding.phpt
+++ b/tests/ext/sandbox/install_hook/exclude_inherited_hook_after_binding.phpt
@@ -1,0 +1,28 @@
+--TEST--
+remove_hook() with class argument
+--FILE--
+<?php
+
+interface Elder {
+    function foo();
+}
+
+$id = DDTrace\install_hook("Elder::foo", function () { print "HOOKED: " . static::class . "\n"; });
+
+if (time()) {
+    abstract class Child implements Elder {}
+
+    class GrandChild extends Child {
+        function foo() {
+            print static::class . "\n";
+        }
+    }
+}
+
+DDTrace\remove_hook($id, "GrandChild");
+
+(new GrandChild)->foo(); // no hook
+
+?>
+--EXPECT--
+GrandChild

--- a/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
+++ b/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
@@ -2,7 +2,6 @@
 Remove hook
 --ENV--
 DD_TRACE_LOGS_ENABLED=false
-DD_TRACE_DEBUG=1
 --FILE--
 <?php
 

--- a/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
+++ b/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Remove hook
+--ENV--
+DD_TRACE_LOGS_ENABLED=false
+DD_TRACE_DEBUG=1
+--FILE--
+<?php
+
+namespace Psr\Log {
+    interface LoggerInterface {
+        public function log($level, $message, array $context = array());
+    }
+
+    abstract class AbstractLogger implements LoggerInterface {
+        public function log($level, $message, array $context = array()) {
+            echo static::class . "\n";
+        }
+    }
+
+    class NullLogger extends AbstractLogger {
+        public function log($level, $message, array $context = array()) {
+            echo static::class . "\n";
+        }
+    }
+}
+
+
+namespace {
+    $hook = \DDTrace\install_hook("Psr\Log\LoggerInterface::log", function () {
+        echo "HOOKED: " . static::class . "\n";
+    });
+    \DDTrace\remove_hook($hook, \Psr\Log\NullLogger::class);
+
+    $logger = new \Psr\Log\NullLogger();
+    for ($i = 0; $i < 3; $i++) {
+        $logger->log("info", "Hello World!");
+    }
+}
+
+?>
+--EXPECTF--
+Psr\Log\NullLogger
+Psr\Log\NullLogger
+Psr\Log\NullLogger

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -936,6 +936,17 @@ zai_hook_continued zai_hook_continue(zend_execute_data *ex, zai_hook_memory_t *m
         }
 
         if (check_scope) {
+            if (zai_hook_is_excluded(hook, ex->func->common.scope)) {
+                // hook is no longer valid, remove it
+                zai_hook_remove_from_entry(hooks, hook->id);
+
+                zend_hash_iterator_del(ht_iter);
+                memory->hook_count = (zend_ulong)hook_num;
+                zai_hook_finish(ex, NULL, memory);
+
+                return ZAI_HOOK_BAILOUT;
+            }
+
             if (!(hook->resolved_scope->ce_flags & ZEND_ACC_TRAIT) && !instanceof_function(zend_get_called_scope(ex), hook->resolved_scope)) {
                 continue;
             }


### PR DESCRIPTION
### Description

During the micro benchmarking process, I came across an unexpected behavior related to #2367. The goal of the latter was most notably to introduce minimal overhead when injecting logs while instrumenting `Psr\Log\NullLogger`. However, the results showed otherwise (refer to the Before/After comparison below).

The problem arises when the call to `\DDTrace\remove_hook` is made after a class bind (`zen_compile.c:do_bind_class`). As a result, the observers-related code (`zend_observer.c: _zend_observer_class_linked_notify`) does not get executed. This implies that `hook.c:zai_hook_resolve_class` and `hook.c:zai_hook_is_excluded` are not called either. Thus, when the supposedly removed class is called again, there is no check to see if the hook was removed or not and we directly go to `zend_observer.c:_zend_observe_fcall_begin` & `hook.c:zai_hook_continue`. _This pull request addresses this issue by adding the necessary check._

From a general perspective, it was only effective to remove a hook before a class binding occurs. Attempting to remove a hook at any other point was ineffective. 

While microbenchmarks are still being developed, the before/after comparison below shows the effect of logs injection (Injection) versus no logs injection (Baseline):
**Before:**
![image](https://github.com/DataDog/dd-trace-php/assets/42672104/3d0e85dc-7f64-4cdb-98b1-0235b5fde04f)

**After:**
![image](https://github.com/DataDog/dd-trace-php/assets/42672104/7f989eb9-5f00-4c58-8013-cace41d991e4)


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
