### PR TITLE
Use k8s runners for `tracer-base-image`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,12 +68,11 @@ tracer-base-image:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: always
   stage: deploy
+  tags: [ "arch:arm64" ]
   script:
     - echo $GH_TOKEN|docker login ghcr.io/datadog -u uploader --password-stdin
     - ./tooling/ci/download-binary-php.sh dev
-    - docker build -t ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot -f ./tooling/ci/Dockerfile .
-    - docker push ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot
+    - docker buildx build --platform linux/amd64 -t ghcr.io/datadog/dd-trace-php/dd-trace-php:latest_snapshot --push -f ./tooling/ci/Dockerfile .
     - rm -rf ./tooling/ci/binaries
     - ./tooling/ci/download-binary-php.sh prod
-    - docker build -t ghcr.io/datadog/dd-trace-php/dd-trace-php:latest -f ./tooling/ci/Dockerfile .
-    - docker push ghcr.io/datadog/dd-trace-php/dd-trace-php:latest
+    - docker buildx build --platform linux/amd64 -t ghcr.io/datadog/dd-trace-php/dd-trace-php:latest --push -f ./tooling/ci/Dockerfile .


### PR DESCRIPTION
### Description

Context: There is an effort to [deprecate/migrate non-k8s Docker runners](https://datadoghq.atlassian.net/wiki/spaces/CCRJF/pages/3317203267/Runner+docker+and+docker-arm+migration). From this [GSheet](https://docs.google.com/spreadsheets/d/1Kx_P5UFLZ8WmerCgQhjd3dyDm4OUn5oMqnvsdrhaor4/edit#gid=711154826), it seems that `tracer-base-image` ought to be changed **if possible**

From this [doc](https://datadoghq.atlassian.net/wiki/spaces/CCRJF/pages/3317203267/Runner+docker+and+docker-arm+migration) (& this example [PR](https://github.com/DataDog/async-profiler-build/commit/f2420db4d10961a881e4b660865f9b7dad06594b)), I assume that we can indeed migrate, but this has yet to be thoroughly verified. 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
