### PR TITLE
feat(profiler) add exception message to exception sample

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -39,6 +39,7 @@ fn main() {
         run_time_cache,
         fibers,
         trigger_time_sample,
+        vernum,
     );
 
     cfg_php_major_version(vernum);
@@ -89,11 +90,18 @@ fn build_zend_php_ffis(
     run_time_cache: bool,
     fibers: bool,
     trigger_time_sample: bool,
+    vernum: u64,
 ) {
     println!("cargo:rerun-if-changed=src/php_ffi.h");
     println!("cargo:rerun-if-changed=src/php_ffi.c");
     println!("cargo:rerun-if-changed=../ext/handlers_api.c");
     println!("cargo:rerun-if-changed=../ext/handlers_api.h");
+
+    let sandbox = if vernum < 80000 {
+        "../zend_abstract_interface/sandbox/php7/sandbox.c"
+    } else {
+        "../zend_abstract_interface/sandbox/php8/sandbox.c"
+    };
 
     // Profiling only needs config and its dependencies.
     let zai_c_files = [
@@ -104,6 +112,7 @@ fn build_zend_php_ffis(
         "../zend_abstract_interface/env/env.c",
         "../zend_abstract_interface/exceptions/exceptions.c",
         "../zend_abstract_interface/symbols/lookup.c",
+        sandbox,
         "../zend_abstract_interface/json/json.c",
         "../zend_abstract_interface/zai_string/string.c",
     ];

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -78,6 +78,7 @@ const ZAI_H_FILES: &[&str] = &[
     "../zend_abstract_interface/config/config_decode.h",
     "../zend_abstract_interface/config/config_ini.h",
     "../zend_abstract_interface/env/env.h",
+    "../zend_abstract_interface/exceptions/exceptions.h",
     "../zend_abstract_interface/json/json.h",
 ];
 
@@ -101,6 +102,8 @@ fn build_zend_php_ffis(
         "../zend_abstract_interface/config/config.c",
         "../zend_abstract_interface/config/config_runtime.c",
         "../zend_abstract_interface/env/env.c",
+        "../zend_abstract_interface/exceptions/exceptions.c",
+        "../zend_abstract_interface/symbols/lookup.c",
         "../zend_abstract_interface/json/json.c",
         "../zend_abstract_interface/zai_string/string.c",
     ];

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -103,7 +103,7 @@ fn build_zend_php_ffis(
         "../zend_abstract_interface/sandbox/php8/sandbox.c"
     };
 
-    // Profiling only needs config and its dependencies.
+    // Profiling only needs config, exceptions and its dependencies.
     let zai_c_files = [
         "../zend_abstract_interface/config/config_decode.c",
         "../zend_abstract_interface/config/config_ini.c",

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -60,14 +60,13 @@ impl ExceptionProfilingStats {
         #[cfg(php8)]
         let exception_name = unsafe { (*exception).class_name() };
 
-        #[cfg(php7)]
         let message = unsafe {
-            zend::zai_str_from_zstr(zend::zai_exception_message((*exception).value.obj).as_mut())
+            #[cfg(php7)]
+            let exception_obj = (*exception).value.obj;
+            #[cfg(php8)]
+            let exception_obj = exception;
+            zend::zai_str_from_zstr(zend::zai_exception_message(exception_obj).as_mut())
                 .into_string()
-        };
-        #[cfg(php8)]
-        let message = unsafe {
-            zend::zai_str_from_zstr(zend::zai_exception_message(exception).as_mut()).into_string()
         };
 
         self.next_sampling_interval();

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -56,8 +56,8 @@ impl ExceptionProfilingStats {
         }
 
         #[cfg(php7)]
-        let exception_name = unsafe { (*(*exception).value.obj).class_name() };
-        #[cfg(php8)]
+        let exception = unsafe { (*exception).value.obj };
+
         let exception_name = unsafe { (*exception).class_name() };
 
         let collect_message = REQUEST_LOCALS.with(|cell| {
@@ -67,12 +67,8 @@ impl ExceptionProfilingStats {
         });
 
         let message = if collect_message {
-            #[cfg(php7)]
-            let exception_obj = unsafe { (*exception).value.obj };
-            #[cfg(php8)]
-            let exception_obj = exception;
             Some(unsafe {
-                zend::zai_str_from_zstr(zend::zai_exception_message(exception_obj).as_mut())
+                zend::zai_str_from_zstr(zend::zai_exception_message(exception).as_mut())
                     .into_string()
             })
         } else {

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -45,18 +45,35 @@ impl ExceptionProfilingStats {
         self.next_sample = self.poisson.sample(&mut self.rng) as u32;
     }
 
-    fn track_exception(&mut self, name: String) {
+    fn track_exception(
+        &mut self,
+        #[cfg(php7)] exception: *mut zend::zval,
+        #[cfg(php8)] exception: *mut zend::zend_object,
+    ) {
         if let Some(next_sample) = self.next_sample.checked_sub(1) {
             self.next_sample = next_sample;
             return;
         }
+
+        #[cfg(php7)]
+        let exception_name = unsafe { (*(*exception).value.obj).class_name() };
+        #[cfg(php8)]
+        let exception_name = unsafe { (*exception).class_name() };
+
+        let message = unsafe {
+            zend::zai_str_from_zstr(zend::zai_exception_message(exception).as_mut()).into_string()
+        };
 
         self.next_sampling_interval();
 
         if let Some(profiler) = PROFILER.lock().unwrap().as_ref() {
             // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
             unsafe {
-                profiler.collect_exception(zend::ddog_php_prof_get_current_execute_data(), name)
+                profiler.collect_exception(
+                    zend::ddog_php_prof_get_current_execute_data(),
+                    exception_name,
+                    message,
+                )
             };
         }
     }
@@ -116,14 +133,9 @@ unsafe extern "C" fn exception_profiling_throw_exception_hook(
     // traversed. Fortunately, this behavior can be easily identified by checking for a NULL
     // pointer.
     if exception_profiling && !exception.is_null() {
-        #[cfg(php7)]
-        let exception_name = (*(*exception).value.obj).class_name();
-        #[cfg(php8)]
-        let exception_name = (*exception).class_name();
-
         EXCEPTION_PROFILING_STATS.with(|cell| {
             let mut exceptions = cell.borrow_mut();
-            exceptions.track_exception(exception_name)
+            exceptions.track_exception(exception)
         });
     }
 

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -60,6 +60,12 @@ impl ExceptionProfilingStats {
         #[cfg(php8)]
         let exception_name = unsafe { (*exception).class_name() };
 
+        #[cfg(php7)]
+        let message = unsafe {
+            zend::zai_str_from_zstr(zend::zai_exception_message((*exception).value.obj).as_mut())
+                .into_string()
+        };
+        #[cfg(php8)]
         let message = unsafe {
             zend::zai_str_from_zstr(zend::zai_exception_message(exception).as_mut()).into_string()
         };

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -7,11 +7,6 @@
 #include <string.h>
 #include "SAPI.h"
 
-/* needed by zend_abstract_interface/sandbox/sandbox.h which is included in
- * zend_abstract_interface/symbols/lookup.c which we need due to
- * zend_abstract_interface/exceptions/exeptions.c */
-long zai_sandbox_active = 0;
-
 #if CFG_STACK_WALKING_TESTS
 #include <dlfcn.h> // for dlsym
 #endif

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -7,6 +7,11 @@
 #include <string.h>
 #include "SAPI.h"
 
+/* needed by zend_abstract_interface/sandbox/sandbox.h which is included in
+ * zend_abstract_interface/symbols/lookup.c which we need due to
+ * zend_abstract_interface/exceptions/exeptions.c */
+long zai_sandbox_active = 0;
+
 #if CFG_STACK_WALKING_TESTS
 #include <dlfcn.h> // for dlsym
 #endif

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -20,6 +20,8 @@
 // And json to cleanup json state for graceful restart
 #include <json/json.h>
 
+// Exception profiling needs to get the message of the exception (and ZAI
+// provides `zai_exception_message()`)
 #include <exceptions/exceptions.h>
 
 // Used to communicate strings from C -> Rust.

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -20,6 +20,8 @@
 // And json to cleanup json state for graceful restart
 #include <json/json.h>
 
+#include <exceptions/exceptions.h>
+
 // Used to communicate strings from C -> Rust.
 #include <zai_string/string.h>
 

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -754,7 +754,12 @@ impl Profiler {
 
     #[cfg(feature = "exception_profiling")]
     /// Collect a stack sample with exception
-    pub fn collect_exception(&self, execute_data: *mut zend_execute_data, exception: String) {
+    pub fn collect_exception(
+        &self,
+        execute_data: *mut zend_execute_data,
+        exception: String,
+        message: String,
+    ) {
         let result = collect_stack_sample(execute_data);
         match result {
             Ok(frames) => {
@@ -765,6 +770,12 @@ impl Profiler {
                     key: "exception type",
                     value: LabelValue::Str(exception.clone().into()),
                 });
+
+                labels.push(Label {
+                    key: "exception message",
+                    value: LabelValue::Str(message.clone().into()),
+                });
+
                 let n_labels = labels.len();
 
                 match self.send_sample(self.prepare_sample_message(

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -758,7 +758,7 @@ impl Profiler {
         &self,
         execute_data: *mut zend_execute_data,
         exception: String,
-        message: String,
+        message: Option<String>,
     ) {
         let result = collect_stack_sample(execute_data);
         match result {
@@ -771,10 +771,12 @@ impl Profiler {
                     value: LabelValue::Str(exception.clone().into()),
                 });
 
-                labels.push(Label {
-                    key: "exception message",
-                    value: LabelValue::Str(message.into()),
-                });
+                if message.is_some() {
+                    labels.push(Label {
+                        key: "exception message",
+                        value: LabelValue::Str(message.unwrap().into()),
+                    });
+                }
 
                 let n_labels = labels.len();
 
@@ -1083,6 +1085,7 @@ mod tests {
             profiling_allocation_enabled: false,
             profiling_timeline_enabled: false,
             profiling_exception_enabled: false,
+            profiling_exception_message_enabled: false,
             output_pprof: None,
             profiling_exception_sampling_distance: 100,
             profiling_log_level: LevelFilter::Off,

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -773,7 +773,7 @@ impl Profiler {
 
                 labels.push(Label {
                     key: "exception message",
-                    value: LabelValue::Str(message.clone().into()),
+                    value: LabelValue::Str(message.into()),
                 });
 
                 let n_labels = labels.len();

--- a/zend_abstract_interface/symbols/lookup.c
+++ b/zend_abstract_interface/symbols/lookup.c
@@ -206,10 +206,12 @@ static inline zval* zai_symbol_lookup_constant_class(zai_symbol_scope_t scope_ty
             ce = Z_OBJCE_P((zval*) scope);
         break;
 
-        default: { /* unreachable */ }
+        default: /* unreachable */
+            ce = NULL;
+        break;
     }
 
-    if (!zai_symbol_update(ce	)) {
+    if (!zai_symbol_update(ce)) {
         return NULL;
     }
 


### PR DESCRIPTION
### Description

This will add the exception message to the sample that is taken. You'd need to opt-in to the collection of exception messages by setting the environment variable `DD_PROFILING_EXCEPTION_MESSAGE_ENABLED` or the INI setting `datadog.profiling.exception_message_enabled` to `true`/`1`/`on`.

Additionally I moved reading the exception class name (and the message) to after the sampling decision which lowers the overhead of exception profiling.

PROF-8838

### Reviewer checklist

- [x] Backend and UI support is implemented
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
