### PR TITLE
Move the dummy function of call_attribute_constructor onto the VM stack

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -218,6 +218,7 @@ static void dd_patch_zend_call_known_function(void) {
         page_size <<= 1; // if overlapping pages, use two
     }
     if (mprotect(page, page_size, PROT_READ | PROT_WRITE) != 0) { // Some architectures enforce W^X (either write _or_ execute, but not both).
+        LOG(Error, "Could not alter the memory protection for zend_call_known_function. Tracer execution continues, but may crash when encountering attributes.");
         return; // Make absolutely sure we can write
     }
 


### PR DESCRIPTION
### Description

Fixes possible crashes on old versions by ensuring that attribute constructor dummy functions are always on the VM stack.
(essentially works around https://bugs.php.net/bug.php?id=81430, which happens to crash more often for users now, given that Symfony started using PHP attributes.)

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
