### PR TITLE
Change schema extraction zip compression to PHP_ZLIB_ENCODING_GZIP

### DIFF
--- a/appsec/src/helper/compression.cpp
+++ b/appsec/src/helper/compression.cpp
@@ -12,7 +12,7 @@
 namespace dds {
 
 namespace {
-constexpr int64_t encoding = -0xf;
+constexpr int64_t encoding = 0x1f;
 constexpr int max_round_decompression = 100;
 // Taken from PHP approach
 // https://heap.space/xref/PHP-7.3/ext/zlib/php_zlib.h?r=8d3f8ca1#36


### PR DESCRIPTION
### Description

This change fixed the encoding used on schema extraction and therefore will fix the sytem tests checks

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

APPSEC-18493

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
