### PR TITLE
Fix removal of the directly accessed hook after binding in DDTrace\remove_hook

### DIFF
--- a/tests/ext/sandbox/install_hook/exclude_inherited_hook_after_binding.phpt
+++ b/tests/ext/sandbox/install_hook/exclude_inherited_hook_after_binding.phpt
@@ -1,0 +1,28 @@
+--TEST--
+remove_hook() with class argument
+--FILE--
+<?php
+
+interface Elder {
+    function foo();
+}
+
+$id = DDTrace\install_hook("Elder::foo", function () { print "HOOKED: " . static::class . "\n"; });
+
+if (time()) {
+    abstract class Child implements Elder {}
+
+    class GrandChild extends Child {
+        function foo() {
+            print static::class . "\n";
+        }
+    }
+}
+
+DDTrace\remove_hook($id, "GrandChild");
+
+(new GrandChild)->foo(); // no hook
+
+?>
+--EXPECT--
+GrandChild

--- a/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
+++ b/tests/ext/sandbox/install_hook/remove_hook_null_logger.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Remove hook
+--ENV--
+DD_TRACE_LOGS_ENABLED=false
+--FILE--
+<?php
+
+namespace Psr\Log {
+    interface LoggerInterface {
+        public function log($level, $message, array $context = array());
+    }
+
+    abstract class AbstractLogger implements LoggerInterface {
+        public function log($level, $message, array $context = array()) {
+            echo static::class . "\n";
+        }
+    }
+
+    class NullLogger extends AbstractLogger {
+        public function log($level, $message, array $context = array()) {
+            echo static::class . "\n";
+        }
+    }
+}
+
+
+namespace {
+    $hook = \DDTrace\install_hook("Psr\Log\LoggerInterface::log", function () {
+        echo "HOOKED: " . static::class . "\n";
+    });
+    \DDTrace\remove_hook($hook, \Psr\Log\NullLogger::class);
+
+    $logger = new \Psr\Log\NullLogger();
+    for ($i = 0; $i < 3; $i++) {
+        $logger->log("info", "Hello World!");
+    }
+}
+
+?>
+--EXPECTF--
+Psr\Log\NullLogger
+Psr\Log\NullLogger
+Psr\Log\NullLogger


### PR DESCRIPTION
### Description

Taking the tests from #2422, but actually remove the hooks inside DDTrace\remove_hook instead.

And for some reason I was left-shifting ce_addresses, causing more collisions, instead of less. Fixed to right-shift.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
