### PR TITLE
fix: Uninitialized access in ExecIntegration

### DIFF
--- a/src/Integrations/Integrations/Exec/ExecIntegration.php
+++ b/src/Integrations/Integrations/Exec/ExecIntegration.php
@@ -196,7 +196,7 @@ class ExecIntegration extends Integration
             },
             static function (HookData $hook) {
                 /** @var SpanData $span */
-                $span = $hook->data;
+                $span = $hook->data ?? null;
                 if (!$span) {
                     return;
                 }


### PR DESCRIPTION
### Description

Stumbled onto this error while running the microbenchmarks with the debug logs.
```
Error thrown in ddtrace's closure defined at /app/candidate/src/Integrations/Integrations/Exec/ExecIntegration.php:197 for proc_close(): Typed property DDTrace\HookData::$data must not be accessed before initialization
```

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
