### PR TITLE
feat: Add `no-sidecar` benchmark configuration

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -139,3 +139,6 @@ macrobenchmarks:
 
       - DD_BENCHMARKS_CONFIGURATION: only-tracing
         PHP_VERSION: "7.4"
+
+      - DD_BENCHMARKS_CONFIGURATION: no-sidecar
+        PHP_VERSION: "8.1"


### PR DESCRIPTION
### Description

Run the macrobenchmarks without the sidecar on PHP 8.

[Sample Results](https://ddstaging.datadoghq.com/dashboard/ipf-dbi-7ub?refresh_mode=paused&tpl_var_bp_branch%5B0%5D=alex%2Fbench%2Fno-sidecar&tpl_var_bp_commit_sha%5B0%5D=1d5c31af&tpl_var_ci_pipeline_id%5B0%5D=26212920&view=spans&from_ts=1704890404619&to_ts=1704891211000&live=false)

Works hand-in-hand with this [commit](https://github.com/DataDog/benchmarking-platform/commit/3626ef5f2fe67ea8c33d8caeac352be643f89a53) made to the benchmarking platform.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
