### PR TITLE
ci: Run Macrobenchmarks nightly

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -87,7 +87,7 @@ download_circle_ci_release:
 .macrobenchmarks:
   stage: benchmarks
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE != "schedule"
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") #&& $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
   tags: ["runner:apm-k8s-same-cpu"]

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -66,7 +66,7 @@ benchmarks-tracer:
 download_circle_ci_release:
   stage: benchmarks
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE != "schedule"
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") #&& $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
   tags: [ "arch:amd64" ]

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -66,7 +66,7 @@ benchmarks-tracer:
 download_circle_ci_release:
   stage: benchmarks
   rules:
-    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") #&& $CI_COMMIT_REF_NAME == "master"
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
   tags: [ "arch:amd64" ]
@@ -87,7 +87,7 @@ download_circle_ci_release:
 .macrobenchmarks:
   stage: benchmarks
   rules:
-    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") #&& $CI_COMMIT_REF_NAME == "master"
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
   tags: ["runner:apm-k8s-same-cpu"]


### PR DESCRIPTION
### Description

Run macrobenchmarks nightly (master). 

More specifically, the PR introduces a `NIGHTLY_BENCHMARKS` to specifically allow the benchmarks to be run with the added corresponding [scheduled pipeline](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipeline_schedules).

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
