### PR TITLE
Increase iterations of flaky benchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -57,6 +57,7 @@ benchmarks-tracer:
           - src/**/*
           - zend_abstract_interface/**/*
           - tests/Benchmarks/**/*
+          - benchmark/*
         compare_to: "master"
       when: on_success
     - when: manual

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -56,6 +56,7 @@ benchmarks-tracer:
           - ext/**/*
           - src/**/*
           - zend_abstract_interface/**/*
+          - tests/Benchmarks/**/*
         compare_to: "master"
       when: on_success
     - when: manual

--- a/tests/Benchmarks/API/ContextPropagationBench.php
+++ b/tests/Benchmarks/API/ContextPropagationBench.php
@@ -56,7 +56,7 @@ class ContextPropagationBench
 
     /**
      * @Revs(1)
-     * @Iterations(10)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("resetContext")

--- a/tests/Benchmarks/Integrations/PDOBench.php
+++ b/tests/Benchmarks/Integrations/PDOBench.php
@@ -22,7 +22,7 @@ class PDOBench
     /**
      * @BeforeMethods({"disablePDOIntegration"})
      * @Revs(100)
-     * @Iterations(5)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      */
@@ -34,7 +34,7 @@ class PDOBench
     /**
      * @BeforeMethods({"enablePDOIntegration"})
      * @Revs(100)
-     * @Iterations(5)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      */
@@ -46,7 +46,7 @@ class PDOBench
     /**
      * @BeforeMethods({"enablePDOIntegrationWithDBM"})
      * @Revs(100)
-     * @Iterations(5)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      */

--- a/tests/Benchmarks/Integrations/PHPRedisBench.php
+++ b/tests/Benchmarks/Integrations/PHPRedisBench.php
@@ -15,7 +15,7 @@ class PHPRedisBench
      * @BeforeMethods({"disablePHPRedisIntegration"})
      * @AfterMethods({"closeConnection"})
      * @Revs(100)
-     * @Iterations(5)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      */
@@ -28,7 +28,7 @@ class PHPRedisBench
      * @BeforeMethods({"enablePHPRedisIntegration"})
      * @AfterMethods({"closeConnection"})
      * @Revs(100)
-     * @Iterations(5)
+     * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      */


### PR DESCRIPTION
### Description

Three benchmarks appear to be flaky:
```
PHPRedisBench/benchRedisBaseline
ContextPropagationBench/benchExtractHeaders128Bit
PHPRedisBench/benchRedisOverhead
```

Following @ddyurchenko's recommendations, increase the iteration count of these subjects to 15.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
