### PR TITLE
Increase revolutions of context propagation benchmarks

### DIFF
--- a/tests/Benchmarks/API/ContextPropagationBench.php
+++ b/tests/Benchmarks/API/ContextPropagationBench.php
@@ -31,7 +31,7 @@ class ContextPropagationBench
     ];
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -43,7 +43,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -55,7 +55,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -67,7 +67,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -79,7 +79,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -91,7 +91,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(1)
+     * @Revs(20)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)

--- a/tests/Benchmarks/API/ContextPropagationBench.php
+++ b/tests/Benchmarks/API/ContextPropagationBench.php
@@ -31,7 +31,7 @@ class ContextPropagationBench
     ];
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -43,7 +43,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -55,7 +55,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -67,7 +67,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -79,7 +79,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
@@ -91,7 +91,7 @@ class ContextPropagationBench
     }
 
     /**
-     * @Revs(20)
+     * @Revs(100)
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)


### PR DESCRIPTION
### Description

These benchmarks are flaky, particularly because of their short execution time, which is too short for `microtime`'s precision. Increasing revolutions may address this issue.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
