### PR TITLE
feat(profiler) make the profiler compile in ZTS PHP

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   prof-correctness:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.1', '8.2', '8.3']
+        phpts: ['nts', 'zts']
 
     steps:
       - name: Checkout
@@ -19,7 +23,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php-versions }}
+        env:
+          phpts: ${{ matrix.phpts }}
 
       - name: Restore build cache
         uses: actions/cache/restore@v3
@@ -30,7 +36,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.php-versions }}-${{ matrix.phpts }}
 
       - name: Build profiler
         run: |
@@ -55,12 +61,13 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.php-versions }}-${{ matrix.phpts }}
 
       - name: Run no profile test
         run: |
           export DD_PROFILING_ENABLED=Off
           export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
+          php -v
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
               mkdir -p profiling/tests/correctness/"$test_case"/
@@ -77,6 +84,7 @@ jobs:
           export DD_PROFILING_LOG_LEVEL=trace
           export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+          php -v
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
               mkdir -p profiling/tests/correctness/"$test_case"/

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -18,7 +18,7 @@ mod exception;
 mod timeline;
 
 use bindings as zend;
-use bindings::{ddog_php_prof_php_version_id, sapi_globals, ZendExtension, ZendResult};
+use bindings::{ddog_php_prof_php_version_id, ZendExtension, ZendResult};
 use clocks::*;
 use config::AgentEndpoint;
 use datadog_profiling::exporter::{Tag, Uri};
@@ -41,6 +41,8 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, Once};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
+
+use crate::zend::datadog_sapi_globals_request_info;
 
 /// The global profiler. Profiler gets made during the first rinit after an
 /// minit, and is destroyed on mshutdown.
@@ -479,7 +481,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 match *SAPI {
                     Sapi::Cli => {
                         // Safety: sapi globals are safe to access during rinit
-                        SAPI.request_script_name(&sapi_globals)
+                        SAPI.request_script_name(datadog_sapi_globals_request_info())
                             .or(Some(Cow::Borrowed("cli.command")))
                     }
                     _ => Some(Cow::Borrowed("web.request")),

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "SAPI.h"
 
 #if CFG_STACK_WALKING_TESTS
 #include <dlfcn.h> // for dlsym
@@ -69,6 +70,10 @@ static unsigned int php_version_id(void) {
     exit_php_version_id(constant_str);
 }
 #endif
+
+sapi_request_info datadog_sapi_globals_request_info() {
+    return SG(request_info);
+}
 
 /**
  * Returns the PHP_VERSION_ID of the engine at run-time, not the version the

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -39,6 +39,11 @@ const char *datadog_extension_build_id(void);
 const char *datadog_module_build_id(void);
 
 /**
+ * Returns the `sapi_request_info` from the SAPI_GLOBALS
+ */
+sapi_request_info datadog_sapi_globals_request_info();
+
+/**
  * Lookup module by name in the module registry. Returns NULL if not found.
  * This is meant to be called from Rust, so it uses uintptr_t, not size_t, for
  * the length for convenience.

--- a/profiling/src/sapi.rs
+++ b/profiling/src/sapi.rs
@@ -1,4 +1,4 @@
-use crate::bindings::sapi_globals_struct;
+use crate::zend::sapi_request_info;
 use log::warn;
 use once_cell::sync::OnceCell;
 use std::borrow::Cow;
@@ -49,17 +49,16 @@ impl Sapi {
 
     pub fn request_script_name<'a>(
         &self,
-        sapi_globals: &'a sapi_globals_struct,
+        sapi_request_info: sapi_request_info,
     ) -> Option<Cow<'a, str>> {
         match self {
             /* Right now all we need is CLI support, but theoretically it can
              * be obtained for web requests too if we care.
              */
             Sapi::Cli => {
-                let request_info = &sapi_globals.request_info;
-                if request_info.argc > 0 && !request_info.argv.is_null() {
+                if sapi_request_info.argc > 0 && !sapi_request_info.argv.is_null() {
                     // Safety: It's not null; the VM should do the rest.
-                    let cstr = unsafe { CStr::from_ptr(*request_info.argv) };
+                    let cstr = unsafe { CStr::from_ptr(*sapi_request_info.argv) };
                     let bytes = cstr.to_bytes();
                     return if !bytes.is_empty() {
                         let osstr = OsStr::from_bytes(bytes);


### PR DESCRIPTION
### Description

**Note:** This does not make the profiler ZTS compatible, it only ensures that it is compiling against a ZTS version of PHP

This PR will additionally add ZTS PHP version to the `prof_correctness` tests. Even though this seems awesome, please note that this test currently only runs one thread, so it is expected to not fail 😉 

PROF-8904

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
