### PR TITLE
Fix removing an end observer with other observers active

### DIFF
--- a/tests/ext/sandbox/install_hook/remove_executing_hook.phpt
+++ b/tests/ext/sandbox/install_hook/remove_executing_hook.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Ensure proper interoperability with multiple observers installed on observer removal
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die('skip: observers only exist on PHP 8+'); ?>
+<?php if (extension_loaded("zend-test") || extension_loaded("zend_test")) die('skip: zend_test may not be loaded twice'); ?>
+<?php if (!file_exists(ini_get("extension_dir") . "/zend_test.so")) die('skip: zend_test is not available'); ?>
+--INI--
+extension=zend_test
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+function foo() {
+    echo "Called\n";
+}
+
+DDTrace\install_hook("foo", function($hook) {
+    echo "Removing hook\n";
+    DDTrace\remove_hook($hook->id);
+});
+foo();
+
+?>
+--EXPECTREGEX--
+<!-- init '.+' -->
+<file '.+'>(\n  <!-- init DDTrace\\install_hook\(\) -->\n  <DDTrace\\install_hook>\n  <\/DDTrace\\install_hook>)?
+  <!-- init foo\(\) -->
+  <foo>
+    <!-- init \{closure}\(\) -->
+    <\{closure}>
+Removing hook(\n      <!-- init DDTrace\\remove_hook\(\) -->\n      <DDTrace\\remove_hook>\n      <\/DDTrace\\remove_hook>)?
+    <\/\{closure}>
+Called
+  <\/foo>
+<\/file '.+'>

--- a/zend_abstract_interface/hook/hook.h
+++ b/zend_abstract_interface/hook/hook.h
@@ -1,6 +1,9 @@
 #ifndef ZAI_HOOK_H
 #define ZAI_HOOK_H
 #include "../symbols/symbols.h"
+#if PHP_VERSION_ID >= 80000
+#include <zend_observer.h>
+#endif
 
 /* The Hook interface intends to abstract away the storage and resolution of hook targets */
 
@@ -103,7 +106,7 @@ extern TSRM_TLS HashTable zai_hook_resolved;
 /* }}} */
 
 #if PHP_VERSION_ID >= 80000
-extern void (*zai_hook_on_update)(zend_function *func, bool remove);
+extern void (*zai_hook_on_update)(zend_function *func, bool remove, zend_observer_fcall_end_handler *next_end_handler);
 extern void (*zai_hook_on_function_resolve)(zend_function *func);
 #endif
 


### PR DESCRIPTION
### Description

Fixes https://bugs.xdebug.org/view.php?id=2232.

We need to keep track of the observer which we just replaced if we removed it in an end observer, and call it manually.

The underlying reason is that call_end_observers() in php-src merely iterates through the pointers. When removing an observer, all trailing observers will be memmove()d by one slot back, so that handler is the next observer and handler+1 in call_end_observers is now the observer after, leading to the next observer being skipped.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
