### PR TITLE
Track DD_TRACE_DEBUG=1 errors in integration and web tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -942,6 +942,10 @@ define run_tests
 	$(ENV_OVERRIDE) php $(TEST_EXTRA_INI) $(REQUEST_INIT_HOOK) $(PHPUNIT) $(1) --filter=$(FILTER)
 endef
 
+define run_tests_debug
+	(set -o pipefail; { DD_TRACE_DEBUG=1 $(call run_tests,$(1)) 2>&1 >&3 | tee >(grep -vE '\[ddtrace\] \[debug\]|\[ddtrace\] \[info\]' >&2) | { ! (grep -E '\[error\]|\[warning\]|\[deprecated\]' >/dev/null && echo $$'\033[41m'"ERROR: Found debug log errors in the output."$$'\033[0m'); }; } 3>&1)
+endef
+
 define run_benchmarks
 	$(ENV_OVERRIDE) php $(TEST_EXTRA_INI) $(REQUEST_INIT_HOOK) $(PHPBENCH) --config=$(1) --filter=$(FILTER) --report=all --output=file --output=console
 endef
@@ -1043,235 +1047,235 @@ test_web: $(TEST_WEB_$(PHP_MAJOR_MINOR))
 
 test_integrations_amqp2: global_test_run_dependencies
 	$(MAKE) test_scenario_amqp2
-	$(call run_tests,tests/Integrations/AMQP)
+	$(call run_tests_debug,tests/Integrations/AMQP)
 test_integrations_amqp35: global_test_run_dependencies
 	$(MAKE) test_scenario_amqp35
-	$(call run_tests,tests/Integrations/AMQP)
+	$(call run_tests_debug,tests/Integrations/AMQP)
 test_integrations_deferred_loading: global_test_run_dependencies
 	$(MAKE) test_scenario_predis1
-	$(call run_tests,tests/Integrations/DeferredLoading)
+	$(call run_tests_debug,tests/Integrations/DeferredLoading)
 test_integrations_curl: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/Curl)
+	$(call run_tests_debug,tests/Integrations/Curl)
 test_integrations_elasticsearch1: global_test_run_dependencies
 	$(MAKE) test_scenario_elasticsearch1
-	$(call run_tests,tests/Integrations/Elasticsearch/V1)
+	$(call run_tests_debug,tests/Integrations/Elasticsearch/V1)
 test_integrations_elasticsearch7: global_test_run_dependencies
 	$(MAKE) test_scenario_elasticsearch7
-	$(call run_tests,tests/Integrations/Elasticsearch/V1)
+	$(call run_tests_debug,tests/Integrations/Elasticsearch/V1)
 test_integrations_elasticsearch8: global_test_run_dependencies
 	$(MAKE) test_scenario_elasticsearch8
-	$(call run_tests,tests/Integrations/Elasticsearch/V8)
+	$(call run_tests_debug,tests/Integrations/Elasticsearch/V8)
 test_integrations_guzzle5: global_test_run_dependencies
 	$(MAKE) test_scenario_guzzle5
-	$(call run_tests,tests/Integrations/Guzzle/V5)
+	$(call run_tests_debug,tests/Integrations/Guzzle/V5)
 test_integrations_guzzle6: global_test_run_dependencies
 	$(MAKE) test_scenario_guzzle6
-	$(call run_tests,tests/Integrations/Guzzle/V6)
+	$(call run_tests_debug,tests/Integrations/Guzzle/V6)
 test_integrations_guzzle7: global_test_run_dependencies
 	$(MAKE) test_scenario_guzzle7
-	$(call run_tests,tests/Integrations/Guzzle/V7)
+	$(call run_tests_debug,tests/Integrations/Guzzle/V7)
 test_integrations_laminaslog2: global_test_run_dependencies
 	$(MAKE) test_scenario_laminaslog2
-	$(call run_tests,tests/Integrations/Logs/LaminasLogV2)
+	$(call run_tests_debug,tests/Integrations/Logs/LaminasLogV2)
 test_integrations_memcached: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/Memcached)
+	$(call run_tests_debug,tests/Integrations/Memcached)
 test_integrations_memcache: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/Memcache)
+	$(call run_tests_debug,tests/Integrations/Memcache)
 test_integrations_monolog1: global_test_run_dependencies
 	$(MAKE) test_scenario_monolog1
-	$(call run_tests,tests/Integrations/Logs/MonologV1)
+	$(call run_tests_debug,tests/Integrations/Logs/MonologV1)
 test_integrations_monolog2: global_test_run_dependencies
 	$(MAKE) test_scenario_monolog2
-	$(call run_tests,tests/Integrations/Logs/MonologV2)
+	$(call run_tests_debug,tests/Integrations/Logs/MonologV2)
 test_integrations_monolog3: global_test_run_dependencies
 	$(MAKE) test_scenario_monolog3
-	$(call run_tests,tests/Integrations/Logs/MonologV3)
+	$(call run_tests_debug,tests/Integrations/Logs/MonologV3)
 test_integrations_mysqli: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/Mysqli)
+	$(call run_tests_debug,tests/Integrations/Mysqli)
 test_integrations_mongo: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/Mongo)
+	$(call run_tests_debug,tests/Integrations/Mongo)
 test_integrations_mongodb1:
 	$(MAKE) test_scenario_mongodb1
-	$(call run_tests,tests/Integrations/MongoDB)
+	$(call run_tests_debug,tests/Integrations/MongoDB)
 test_integrations_pcntl: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/PCNTL)
+	$(call run_tests_debug,tests/Integrations/PCNTL)
 test_integrations_pdo: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/PDO)
+	$(call run_tests_debug,tests/Integrations/PDO)
 test_integrations_phpredis3: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis3
-	$(call run_tests,tests/Integrations/PHPRedis/V3)
+	$(call run_tests_debug,tests/Integrations/PHPRedis/V3)
 test_integrations_phpredis4: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis4
-	$(call run_tests,tests/Integrations/PHPRedis/V4)
+	$(call run_tests_debug,tests/Integrations/PHPRedis/V4)
 test_integrations_phpredis5: global_test_run_dependencies
 	$(MAKE) test_scenario_phpredis5
-	$(call run_tests,tests/Integrations/PHPRedis/V5)
+	$(call run_tests_debug,tests/Integrations/PHPRedis/V5)
 test_integrations_predis1: global_test_run_dependencies
 	$(MAKE) test_scenario_predis1
-	$(call run_tests,tests/Integrations/Predis)
+	$(call run_tests_debug,tests/Integrations/Predis)
 test_integrations_roadrunner: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Roadrunner/Version_2 update
-	$(call run_tests,tests/Integrations/Roadrunner/V2)
+	$(call run_tests_debug,tests/Integrations/Roadrunner/V2)
 test_integrations_sqlsrv: global_test_run_dependencies
 	$(MAKE) test_scenario_default
-	$(call run_tests,tests/Integrations/SQLSRV)
+	$(call run_tests_debug,tests/Integrations/SQLSRV)
 test_web_cakephp_28: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/CakePHP/Version_2_8 update
-	$(call run_tests,--testsuite=cakephp-28-test)
+	$(call run_tests_debug,--testsuite=cakephp-28-test)
 test_web_codeigniter_22: global_test_run_dependencies
-	$(call run_tests,--testsuite=codeigniter-22-test)
+	$(call run_tests_debug,--testsuite=codeigniter-22-test)
 test_web_drupal_89: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_8_9/core update --ignore-platform-reqs
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_8_9 update --ignore-platform-reqs
-	$(call run_tests,tests/Integrations/Drupal/V8_9)
+	$(call run_tests_debug,tests/Integrations/Drupal/V8_9)
 test_web_drupal_95: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_9_5/core update --ignore-platform-reqs
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_9_5 update --ignore-platform-reqs
-	$(call run_tests,tests/Integrations/Drupal/V9_5)
+	$(call run_tests_debug,tests/Integrations/Drupal/V9_5)
 test_web_drupal_101: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_10_1/core update --ignore-platform-reqs
 	$(COMPOSER) --working-dir=tests/Frameworks/Drupal/Version_10_1 update --ignore-platform-reqs
-	$(call run_tests,tests/Integrations/Drupal/V10_1)
+	$(call run_tests_debug,tests/Integrations/Drupal/V10_1)
 test_web_laminas_rest_19: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laminas/ApiTools/Version_1_9 update
-	$(call run_tests,tests/Integrations/Laminas/ApiTools/V1_9)
+	$(call run_tests_debug,tests/Integrations/Laminas/ApiTools/V1_9)
 test_web_laminas_14: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laminas/Version_1_4 update
-	$(call run_tests,tests/Integrations/Laminas/V1_4)
+	$(call run_tests_debug,tests/Integrations/Laminas/V1_4)
 test_web_laminas_20: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laminas/Version_2_0 update
-	$(call run_tests,tests/Integrations/Laminas/V2_0)
+	$(call run_tests_debug,tests/Integrations/Laminas/V2_0)
 test_web_laravel_42: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_4_2 update
 	php tests/Frameworks/Laravel/Version_4_2/artisan optimize
-	$(call run_tests,tests/Integrations/Laravel/V4)
+	$(call run_tests_debug,tests/Integrations/Laravel/V4)
 test_web_laravel_57: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_5_7 update
-	$(call run_tests,tests/Integrations/Laravel/V5_7)
+	$(call run_tests_debug,tests/Integrations/Laravel/V5_7)
 test_web_laravel_58: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_5_8 update
-	$(call run_tests,--testsuite=laravel-58-test)
+	$(call run_tests_debug,--testsuite=laravel-58-test)
 test_web_laravel_8x: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_8_x update
-	$(call run_tests,--testsuite=laravel-8x-test)
+	$(call run_tests_debug,--testsuite=laravel-8x-test)
 test_web_laravel_9x: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_9_x update
-	$(call run_tests,--testsuite=laravel-9x-test)
+	$(call run_tests_debug,--testsuite=laravel-9x-test)
 test_web_laravel_10x: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Laravel/Version_10_x update
-	$(call run_tests,--testsuite=laravel-10x-test)
+	$(call run_tests_debug,--testsuite=laravel-10x-test)
 test_web_lumen_52: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_2 update
-	$(call run_tests,tests/Integrations/Lumen/V5_2)
+	$(call run_tests_debug,tests/Integrations/Lumen/V5_2)
 test_web_lumen_56: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_6 update
-	$(call run_tests,tests/Integrations/Lumen/V5_6)
+	$(call run_tests_debug,tests/Integrations/Lumen/V5_6)
 test_web_lumen_58: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_5_8 update
-	$(call run_tests,tests/Integrations/Lumen/V5_8)
+	$(call run_tests_debug,tests/Integrations/Lumen/V5_8)
 test_web_lumen_81: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_8_1 update
-	$(call run_tests,tests/Integrations/Lumen/V8_1)
+	$(call run_tests_debug,tests/Integrations/Lumen/V8_1)
 test_web_lumen_90: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_9_0 update
-	$(call run_tests,tests/Integrations/Lumen/V9_0)
+	$(call run_tests_debug,tests/Integrations/Lumen/V9_0)
 test_web_lumen_100: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Lumen/Version_10_0 update
-	$(call run_tests,tests/Integrations/Lumen/V10_0)
+	$(call run_tests_debug,tests/Integrations/Lumen/V10_0)
 test_web_slim_312: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_3_12 update
-	$(call run_tests,--testsuite=slim-312-test)
+	$(call run_tests_debug,--testsuite=slim-312-test)
 test_web_slim_4: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Slim/Version_4 update
-	$(call run_tests,--testsuite=slim-4-test)
+	$(call run_tests_debug,--testsuite=slim-4-test)
 test_web_symfony_23: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_2_3 update
-	$(call run_tests,tests/Integrations/Symfony/V2_3)
+	$(call run_tests_debug,tests/Integrations/Symfony/V2_3)
 test_web_symfony_28: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_2_8 update
-	$(call run_tests,tests/Integrations/Symfony/V2_8)
+	$(call run_tests_debug,tests/Integrations/Symfony/V2_8)
 test_web_symfony_30: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_0 update
 	php tests/Frameworks/Symfony/Version_3_0/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V3_0)
+	$(call run_tests_debug,tests/Integrations/Symfony/V3_0)
 test_web_symfony_33: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_3 update
 	php tests/Frameworks/Symfony/Version_3_3/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V3_3)
+	$(call run_tests_debug,tests/Integrations/Symfony/V3_3)
 test_web_symfony_34: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_3_4 update
 	php tests/Frameworks/Symfony/Version_3_4/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V3_4)
+	$(call run_tests_debug,tests/Integrations/Symfony/V3_4)
 test_web_symfony_40: global_test_run_dependencies
 	# We hit broken updates in this unmaintained version, so we committed a
 	# working composer.lock and we composer install instead of composer update
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_0 install
 	php tests/Frameworks/Symfony/Version_4_0/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V4_0)
+	$(call run_tests_debug,tests/Integrations/Symfony/V4_0)
 test_web_symfony_42: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_2 update
 	php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V4_2)
+	$(call run_tests_debug,tests/Integrations/Symfony/V4_2)
 test_web_symfony_44: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_4_4 update
 	php tests/Frameworks/Symfony/Version_4_4/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,--testsuite=symfony-44-test)
+	$(call run_tests_debug,--testsuite=symfony-44-test)
 test_web_symfony_50: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_0 install # EOL; install from lock
 	php tests/Frameworks/Symfony/Version_5_0/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V5_0)
+	$(call run_tests_debug,tests/Integrations/Symfony/V5_0)
 test_web_symfony_51: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_1 update
 	php tests/Frameworks/Symfony/Version_5_1/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,tests/Integrations/Symfony/V5_1)
+	$(call run_tests_debug,tests/Integrations/Symfony/V5_1)
 test_web_symfony_52: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_2 update
 	php tests/Frameworks/Symfony/Version_5_2/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,--testsuite=symfony-52-test)
+	$(call run_tests_debug,--testsuite=symfony-52-test)
 test_web_symfony_62: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_6_2 update
 	php tests/Frameworks/Symfony/Version_6_2/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,--testsuite=symfony-62-test)
+	$(call run_tests_debug,--testsuite=symfony-62-test)
 test_web_symfony_70: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_7_0 update
 	php tests/Frameworks/Symfony/Version_7_0/bin/console cache:clear --no-warmup --env=prod
-	$(call run_tests,--testsuite=symfony-70-test)
+	$(call run_tests_debug,--testsuite=symfony-70-test)
 
 test_web_wordpress_48: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/WordPress/V4_8)
+	$(call run_tests_debug,tests/Integrations/WordPress/V4_8)
 test_web_wordpress_55: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/WordPress/V5_5)
+	$(call run_tests_debug,tests/Integrations/WordPress/V5_5)
 test_web_wordpress_59: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/WordPress/V5_9)
+	$(call run_tests_debug,tests/Integrations/WordPress/V5_9)
 test_web_wordpress_61: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/WordPress/V6_1)
+	$(call run_tests_debug,tests/Integrations/WordPress/V6_1)
 test_web_yii_2: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Yii/Version_2_0 update
-	$(call run_tests,tests/Integrations/Yii/V2_0)
+	$(call run_tests_debug,tests/Integrations/Yii/V2_0)
 test_web_magento_23: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Magento/Version_2_3 update
-	$(call run_tests,tests/Integrations/Magento/V2_3)
+	$(call run_tests_debug,tests/Integrations/Magento/V2_3)
 test_web_magento_24: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Magento/Version_2_4 update
-	$(call run_tests,tests/Integrations/Magento/V2_4)
+	$(call run_tests_debug,tests/Integrations/Magento/V2_4)
 test_web_nette_24: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Nette/Version_2_4 update
-	$(call run_tests,tests/Integrations/Nette/V2_4)
+	$(call run_tests_debug,tests/Integrations/Nette/V2_4)
 test_web_nette_30: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Nette/Version_3_0 update
-	$(call run_tests,tests/Integrations/Nette/V3_0)
+	$(call run_tests_debug,tests/Integrations/Nette/V3_0)
 test_web_zend_1: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/ZendFramework/V1)
+	$(call run_tests_debug,tests/Integrations/ZendFramework/V1)
 test_web_zend_1_21: global_test_run_dependencies
-	$(call run_tests,tests/Integrations/ZendFramework/V1_21)
+	$(call run_tests_debug,tests/Integrations/ZendFramework/V1_21)
 test_web_custom: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Custom/Version_Autoloaded update
-	$(call run_tests,--testsuite=custom-framework-autoloading-test)
+	$(call run_tests_debug,--testsuite=custom-framework-autoloading-test)
 
 test_scenario_%:
 	$(Q) $(COMPOSER_TESTS) scenario $*

--- a/ext/logging.c
+++ b/ext/logging.c
@@ -74,16 +74,24 @@ int ddtrace_bgs_logf(const char *fmt, ...) {
 }
 
 static void ddtrace_log_callback(ddog_Log log, ddog_CharSlice msg) {
-    (void)log; // maybe use?
-
-    char *message = (char*)msg.ptr;
-    if (msg.ptr[msg.len]) {
-        message = strndup(msg.ptr, msg.len);
-        php_log_err(message);
-        free(message);
+    const char *name = "debug";
+    uint32_t bits = log.bits & ~ddog_Log_Once.bits;
+    if (bits == (ddog_Log_Deprecated.bits & ~ddog_Log_Once.bits)) {
+        name = "deprecated";
+    } else if (bits == ddog_Log_Warn.bits) {
+        name = "warning";
+    } else if (bits == ddog_Log_Info.bits) {
+        name = "info";
+    } else if (bits == ddog_Log_Startup.bits) {
+        name = "startup";
     } else {
-        php_log_err(message);
+        name = "error";
     }
+
+    char *message;
+    asprintf(&message, "[ddtrace] [%s] %.*s", name, (int)msg.len, msg.ptr);
+    php_log_err(message);
+    free(message);
 }
 
 

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1568,6 +1568,11 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
     // On fatal error we explicitly bail out.
     bool is_fatal_error = orig_type & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR);
     if (zai_sandbox_active) {
+        // Do not track silenced errors like via @ operator
+        if (!is_fatal_error && (orig_type & EG(error_reporting)) == 0) {
+            return;
+        }
+
         clear_last_error();
         PG(last_error_type) = orig_type & E_ALL;
 #if PHP_VERSION_ID < 80000

--- a/src/Integrations/Integrations/Mysqli/MysqliCommon.php
+++ b/src/Integrations/Integrations/Mysqli/MysqliCommon.php
@@ -15,7 +15,8 @@ class MysqliCommon
      */
     public static function extractHostInfo($mysqli)
     {
-        if (!isset($mysqli->host_info) || !is_string($mysqli->host_info)) {
+        // silence "Property access is not allowed yet" for PHP <= 7.3
+        if (@(!isset($mysqli->host_info) || !is_string($mysqli->host_info))) {
             return [];
         }
         $hostInfo = $mysqli->host_info;

--- a/src/Integrations/Integrations/Psr18/Psr18Integration.php
+++ b/src/Integrations/Integrations/Psr18/Psr18Integration.php
@@ -51,6 +51,8 @@ class Psr18Integration extends Integration
                 }
             }
         );
+
+        return Integration::LOADED;
     }
 
     public function addRequestInfo(SpanData $span, $request)

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -21,6 +21,11 @@ class FakeSpan extends Span
 {
     public $startTime;
     public $duration;
+
+    public function __destruct()
+    {
+        // Silence destructor warning about unclosed spans for fake spans
+    }
 }
 
 trait TracerTestTrait

--- a/tests/Integrations/AMQP/AMQPTest.php
+++ b/tests/Integrations/AMQP/AMQPTest.php
@@ -901,7 +901,7 @@ final class AMQPTest extends IntegrationTestCase
         );
 
         // Assess that user headers weren't lost
-        $this->assertSame("", $output);
+        $this->assertSame("", trim(preg_replace("(.*\[ddtrace].*)", "", $output)));
 
         $sendTraces = $sendTraces[0][0]; // There is a root span
         // Spans: send.php -> basic_publish -> queue_declare -> connect
@@ -942,7 +942,7 @@ final class AMQPTest extends IntegrationTestCase
         );
 
         // Assess that user headers weren't lost
-        $this->assertSame("", $output);
+        $this->assertSame("", trim(preg_replace("(.*\[ddtrace].*)", "", $output)));
 
         $sendTraces = $sendTraces[0][0]; // There is a root span
         // Spans: send.php -> basic_publish -> queue_declare -> connect

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -136,12 +136,12 @@ class RouteCachingTest extends WebFrameworkTestCase
     private function routeCache()
     {
         $appRoot = \dirname(\dirname(self::getAppIndexScript()));
-        `cd $appRoot && php artisan route:cache`;
+        `cd $appRoot && DD_TRACE_CLI_ENABLED=0 php artisan route:cache`;
     }
 
     private function routeClear()
     {
         $appRoot = \dirname(\dirname(self::getAppIndexScript()));
-        `cd $appRoot && php artisan route:clear`;
+        `cd $appRoot && DD_TRACE_CLI_ENABLED=0 php artisan route:clear`;
     }
 }

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -104,6 +104,7 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
+                'DD_TRACE_DEBUG' => 'false',
             ],
             [],
             "",

--- a/tests/ext/background-sender/agent_headers.phpt
+++ b/tests/ext/background-sender/agent_headers.phpt
@@ -40,7 +40,7 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 
 content-type: application/msgpack
 datadog-meta-lang: php
@@ -50,4 +50,4 @@ datadog-meta-tracer-version: %s
 x-datadog-trace-count: 1
 
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id.phpt
@@ -38,10 +38,10 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 
 datadog-container-id: 9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f
 datadog-meta-lang: php
 
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id_empty.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_empty.phpt
@@ -38,9 +38,9 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 
 datadog-meta-lang: php
 
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
@@ -37,10 +37,10 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 
 datadog-container-id: 34dc0b5e626f2c5c4c5170e34b10e765-1234567890
 datadog-meta-lang: php
 
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_headers_ignore_userland.phpt
+++ b/tests/ext/background-sender/agent_headers_ignore_userland.phpt
@@ -45,4 +45,4 @@ bool(true)
 datadog-meta-lang: php
 
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/background-sender/agent_sampling.phpt
+++ b/tests/ext/background-sender/agent_sampling.phpt
@@ -48,10 +48,10 @@ echo "Specific sampling: {$get_sampling()}\n";
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 Initial sampling: 1
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 Generic sampling: 0
-Flushing trace of size 1 to send-queue for http://request-replayer:80
+[ddtrace] [info] Flushing trace of size 1 to send-queue for http://request-replayer:80
 Specific sampling: 1
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/close_spans_until.phpt
+++ b/tests/ext/close_spans_until.phpt
@@ -30,4 +30,4 @@ int(2)
 int(2)
 int(1)
 int(0)
-Flushing trace of size 7 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 7 to send-queue for %s

--- a/tests/ext/dd_trace_serialize_msgpack_error.phpt
+++ b/tests/ext/dd_trace_serialize_msgpack_error.phpt
@@ -13,7 +13,7 @@ array_map(function ($data) {
 ]);
 ?>
 --EXPECTF--
-Serialize values must be of type array, string, int, float, bool or null
+[ddtrace] [warning] Serialize values must be of type array, string, int, float, bool or null
 array(1) {
   [0]=>
   object(stdClass)#%d (0) {
@@ -21,7 +21,7 @@ array(1) {
 }
 bool(false)
 
-Serialize values must be of type array, string, int, float, bool or null
+[ddtrace] [warning] Serialize values must be of type array, string, int, float, bool or null
 array(2) {
   [0]=>
   string(3) "bar"
@@ -30,4 +30,4 @@ array(2) {
 }
 bool(false)
 
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/dropped_spans_have_negative_duration.phpt
+++ b/tests/ext/dropped_spans_have_negative_duration.phpt
@@ -18,4 +18,4 @@ var_dump($outerSpan->getDuration());
 --EXPECTF--
 int(1)
 int(-1)
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/extract_ip_addr.phpt
+++ b/tests/ext/extract_ip_addr.phpt
@@ -108,16 +108,16 @@ x_forwarded_for: [2001::1]:1111
 string(7) "2001::1"
 
 x_forwarded_for: bad_value, 1.1.1.1
-Not recognized as IP address: "bad_value"
-Not recognized as IP address: "bad_value"
+[ddtrace] [error] Not recognized as IP address: "bad_value"
+[ddtrace] [error] Not recognized as IP address: "bad_value"
 string(7) "1.1.1.1"
 
 x_real_ip: 2.2.2.2
 string(7) "2.2.2.2"
 
 x_real_ip: 2.2.2.2, 3.3.3.3
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
 NULL
 
 x_real_ip: 127.0.0.1
@@ -157,16 +157,16 @@ x_forwarded: for="2001:abcf::1"
 string(12) "2001:abcf::1"
 
 x_forwarded: for=some_host
-Not recognized as IP address: "some_host"
-Not recognized as IP address: "some_host"
+[ddtrace] [error] Not recognized as IP address: "some_host"
+[ddtrace] [error] Not recognized as IP address: "some_host"
 NULL
 
 x_forwarded: for=127.0.0.1, FOR=1.1.1.1
 string(7) "1.1.1.1"
 
 x_forwarded: for="\"foobar";proto=http,FOR="1.1.1.1"
-Not recognized as IP address: "\"foobar"
-Not recognized as IP address: "\"foobar"
+[ddtrace] [error] Not recognized as IP address: "\"foobar"
+[ddtrace] [error] Not recognized as IP address: "\"foobar"
 string(7) "1.1.1.1"
 
 x_forwarded: for="8.8.8.8:2222",
@@ -191,8 +191,8 @@ fastly_client_ip: 2.2.2.2
 string(7) "2.2.2.2"
 
 fastly_client_ip: 2.2.2.2, 3.3.3.3
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
 NULL
 
 fastly_client_ip: 127.0.0.1
@@ -226,8 +226,8 @@ cf_connecting_ip: 2.2.2.2
 string(7) "2.2.2.2"
 
 cf_connecting_ip: 2.2.2.2, 3.3.3.3
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
-Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
+[ddtrace] [error] Not recognized as IP address: "2.2.2.2, 3.3.3.3"
 NULL
 
 cf_connecting_ip: 127.0.0.1

--- a/tests/ext/flush-autofinish.phpt
+++ b/tests/ext/flush-autofinish.phpt
@@ -16,7 +16,7 @@ var_dump(DDTrace\active_span() != null);
 
 ?>
 --EXPECTF--
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
 bool(true)
 bool(true)
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/force_flush_traces.phpt
+++ b/tests/ext/force_flush_traces.phpt
@@ -42,6 +42,6 @@ var_dump(dd_trace_serialize_closed_spans()); // Spans should be flushed, so this
 --EXPECTF--
 tracing process
 process
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 kill
 %r\n*(Killed\n*)?(Termsig=9)?%r

--- a/tests/ext/includes/fake_tracer.inc
+++ b/tests/ext/includes/fake_tracer.inc
@@ -36,7 +36,7 @@ class Tracer
         }, dd_trace_serialize_closed_spans());
 
         // Reporting
-        $output = 'Flushing tracer...' . PHP_EOL;
+        $output = '[ddtrace] [info] Flushing tracer...' . PHP_EOL;
         foreach ($valuesStrings as $value) {
             $output .= $value;
         }

--- a/tests/ext/includes/fake_tracer_exception.inc
+++ b/tests/ext/includes/fake_tracer_exception.inc
@@ -6,7 +6,7 @@ class Tracer
 {
     public function flush()
     {
-        echo 'Flushing tracer with exception...' . PHP_EOL;
+        echo '[ddtrace] [info] Flushing tracer with exception...' . PHP_EOL;
         throw new \Exception('You should not see this');
     }
 

--- a/tests/ext/integrations/curl/distributed_tracing_curl.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl.phpt
@@ -54,7 +54,7 @@ echo 'Done.' . PHP_EOL;
 
 ?>
 --EXPECTF--
-The to be propagated tag '_dd.p.very=looooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
+[ddtrace] [error] The to be propagated tag '_dd.p.very=looooooooooooooooong' is too long and exceeds the maximum limit of 25 characters and is thus dropped.
 b3: %s-%s-1
 traceparent: 00-%s-%s
 tracestate: dd=o:phpt-test
@@ -69,4 +69,4 @@ bool(true)
 bool(true)
 string(15) "inject_max_size"
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_copy_handle.phpt
@@ -96,4 +96,4 @@ x-datadog-trace-id: %d
 x-foo: after-the-copy
 
 Done.
-Flushing trace of size 5 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 5 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
@@ -50,4 +50,4 @@ x-datadog-tags: _dd.p.tid=0000001234567890,_dd.p.usr.id=baz64==,_dd.p.url=http:/
 x-datadog-trace-id: 8687463697196027922
 bool(false)
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_001.phpt
@@ -66,4 +66,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_002.phpt
@@ -66,4 +66,4 @@ x-mas: tree
 x-my-custom-header: foo
 
 Done.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_existing_headers_003.phpt
@@ -83,4 +83,4 @@ x-datadog-parent-id: %d
 x-orig-header: foo
 
 Done.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_invalid_tags.phpt
@@ -49,4 +49,4 @@ x-datadog-origin: ∂~,=;:
 x-datadog-tags: _dd.p.tid=%s,_dd.p.escaped=_=;: ,_dd.p.dm=-0
 bool(false)
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_001.phpt
@@ -73,4 +73,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_002.phpt
@@ -74,4 +74,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_003.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_003.phpt
@@ -75,4 +75,4 @@ x-datadog-parent-id: %d
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_copy_handle.phpt
@@ -92,4 +92,4 @@ x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 x-foo: not copied
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_001.phpt
@@ -89,4 +89,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_multi_exec_existing_headers_002.phpt
@@ -93,4 +93,4 @@ x-ch-2-foo: foo
 x-datadog-origin: phpt-test
 x-datadog-parent-id: %d
 Done.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_tracestate.phpt
@@ -50,4 +50,4 @@ x-datadog-origin: phpt-test
 x-datadog-tags: _dd.p.tid=1234567890123456,_dd.p.test=qvalue,_dd.p.dm=-0
 bool(false)
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_autoflush.phpt
@@ -51,13 +51,13 @@ function long_running_entry_point()
 ?>
 --EXPECTF--
 child is enabled
-Flushing trace of size 1 to send-queue for %s
-No finished traces to be sent to the agent
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent
 parent is enabled
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 child is enabled
-Flushing trace of size 1 to send-queue for %s
-No finished traces to be sent to the agent
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent
 parent is enabled
-Flushing trace of size 3 to send-queue for %s
-No finished traces to be sent to the agent
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
+++ b/tests/ext/pcntl/pcntl_fork_long_running_manual.phpt
@@ -50,7 +50,7 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     $output = ob_get_contents();
     ob_end_clean();
     $lines = explode(PHP_EOL, $output);
-    if (in_array("Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) {
+    if (in_array("[ddtrace] [info] Flushing tracer...", $lines) && in_array("Tracer reset", $lines)) {
         echo "OK" . PHP_EOL;
     }
 }

--- a/tests/ext/request-init-hook/dd_init_open_basedir.phpt
+++ b/tests/ext/request-init-hook/dd_init_open_basedir.phpt
@@ -11,7 +11,7 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECTF--
 Calling dd_init.php from parent directory "%s/includes"
-Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
-Error opening request init hook: %s/dd_init.php
+[ddtrace] [warning] Error raised while opening request-init-hook stream: ddtrace_init(): open_basedir restriction in effect. File(%s/includes/dd_init.php) is not within the allowed path(s): (%s) in %s on line %d
+[ddtrace] [warning] Error opening request init hook: %s/dd_init.php
 Done.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
+++ b/tests/ext/request-init-hook/error_get_last_is_unaffected.phpt
@@ -12,4 +12,4 @@ var_dump(error_get_last());
 --EXPECTF--
 %s in request init hook: Undefined variable%sthis_does_not_%s
 NULL
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_confined_to_open_basedir.phpt
@@ -11,6 +11,6 @@ echo "Request start" . PHP_EOL;
 
 ?>
 --EXPECTF--
-open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
+[ddtrace] [warning] open_basedir restriction in effect; cannot open request init hook: '%s/sanity_check.php'
 Request start
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_file_not_found.phpt
@@ -10,6 +10,6 @@ echo "Request start" . PHP_EOL;
 
 ?>
 --EXPECTF--
-Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
+[ddtrace] [warning] Cannot open request init hook; file does not exist: '%s/this_file_doesnt_exist.php'
 Request start
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_exceptions.phpt
@@ -11,6 +11,6 @@ echo "Request start" . PHP_EOL;
 ?>
 --EXPECTF--
 Throwing an exception...
-Exception thrown in request init hook: Oops!
+[ddtrace] [warning] Exception thrown in request init hook: Oops!
 Request start
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
+++ b/tests/ext/request-init-hook/request_init_hook_ignores_fatal_errors.phpt
@@ -11,6 +11,6 @@ echo "Request start" . PHP_EOL;
 ?>
 --EXPECTF--
 Calling a function that does not exist...
-Error %s in request init hook: Call to undefined function this_function_does_not_%s
+[ddtrace] [warning] Error %s in request init hook: Call to undefined function this_function_does_not_%s
 Request start
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox-prehook/exception_error_log.phpt
+++ b/tests/ext/sandbox-prehook/exception_error_log.phpt
@@ -12,6 +12,6 @@ $sum = array_sum([1, 3, 5]);
 var_dump($sum);
 ?>
 --EXPECTF--
-RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
+[ddtrace] [warning] RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
 int(9)
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox-prehook/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -45,12 +45,12 @@ array_map(function($span) {
 var_dump(error_get_last());
 ?>
 --EXPECTF--
-%s in ddtrace's closure defined at %s:%d for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
-Exception thrown in ddtrace's closure defined at %s:%d for mt_srand(): This should be ignored
-Error raised in ddtrace's closure defined at %s:%d for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:%d for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:%d for mt_srand(): This should be ignored
+[ddtrace] [warning] Error raised in ddtrace's closure defined at %s:%d for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
 Test::testFoo() fav num: %d
 TestFoo
 MTRand
 MTSeed
 NULL
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox-regression/class_resolver_bailout_hook.phpt
+++ b/tests/ext/sandbox-regression/class_resolver_bailout_hook.phpt
@@ -26,6 +26,6 @@ class A extends B {}
 
 ?>
 --EXPECTF--
-Error raised in ddtrace's closure defined at %s:%d for x(): No D in %s
+[ddtrace] [warning] Error raised in ddtrace's closure defined at %s:%d for x(): No D in %s
 Leaving Autoloader
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox-regression/limiter_reset_flush_with_open_spans.phpt
+++ b/tests/ext/sandbox-regression/limiter_reset_flush_with_open_spans.phpt
@@ -69,7 +69,7 @@ baz() called
 bar() called
 string(28) "current :2513787319205155662"
 string(28) "closing :2513787319205155662"
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
 string(34) "newly active :13874630024467741450"
 string(28) "initial :1735254072534978428"
 string(29) "started :10598951352238613536"
@@ -79,7 +79,7 @@ baz() called
 bar() called
 string(29) "current :10598951352238613536"
 string(29) "closing :10598951352238613536"
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
 string(33) "newly active :1735254072534978428"
 string(28) "initial :5052085463162682550"
 string(28) "started :7199227068870524257"
@@ -89,8 +89,8 @@ baz() called
 bar() called
 string(28) "current :7199227068870524257"
 string(28) "closing :7199227068870524257"
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
 string(33) "newly active :5052085463162682550"
 foo() called
-Flushing trace of size 5 to send-queue for %s
-No finished traces to be sent to the agent
+[ddtrace] [info] Flushing trace of size 5 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush.phpt
+++ b/tests/ext/sandbox/auto_flush.phpt
@@ -33,14 +33,14 @@ echo PHP_EOL;
 --EXPECTF--
 3
 6
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 10
 15
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 21
 28
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_attach_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_attach_exception.phpt
@@ -35,5 +35,5 @@ try {
 ?>
 --EXPECTF--
 Caught exception: Oops!
-Flushing trace of size 2 to send-queue for %s
-No finished traces to be sent to the agent
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_disables_tracing.phpt
+++ b/tests/ext/sandbox/auto_flush_disables_tracing.phpt
@@ -38,14 +38,14 @@ echo PHP_EOL;
 --EXPECTF--
 3
 6
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 10
 15
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 21
 28
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
+++ b/tests/ext/sandbox/auto_flush_sandbox_exception.phpt
@@ -33,6 +33,6 @@ try {
 }
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s
 Caught exception: Oops!
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/auto_flush_userland_root_span.phpt
+++ b/tests/ext/sandbox/auto_flush_userland_root_span.phpt
@@ -33,16 +33,16 @@ echo PHP_EOL;
 3
 6
 Has not flushed yet.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 10
 15
 Has not flushed yet.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
 21
 28
 Has not flushed yet.
-Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
 
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
+++ b/tests/ext/sandbox/deferred_load_attempt_loading_once.phpt
@@ -40,4 +40,4 @@ namespace
 autoload_attempted
 PUBLIC STATIC METHOD
 PUBLIC STATIC METHOD
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/die_in_sandbox.phpt
+++ b/tests/ext/sandbox/die_in_sandbox.phpt
@@ -15,5 +15,5 @@ x();
 
 ?>
 --EXPECTF--
-UnwindExit thrown in ddtrace's closure defined at %s:%d for x(): <exit>
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [warning] UnwindExit thrown in ddtrace's closure defined at %s:%d for x(): <exit>
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/exception_error_log.phpt
+++ b/tests/ext/sandbox/exception_error_log.phpt
@@ -12,6 +12,6 @@ $sum = array_sum([1, 3, 5]);
 var_dump($sum);
 ?>
 --EXPECTF--
-RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
+[ddtrace] [warning] RuntimeException thrown in ddtrace's closure defined at %s:%d for array_sum(): This exception is expected
 int(9)
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/exceptions_and_errors_are_ignored_in_tracing_closure.phpt
@@ -45,12 +45,12 @@ array_map(function($span) {
 var_dump(error_get_last());
 ?>
 --EXPECTF--
-Exception thrown in ddtrace's closure defined at %s:21 for mt_srand(): This should be ignored
-Error raised in ddtrace's closure defined at %s:26 for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:21 for mt_srand(): This should be ignored
+[ddtrace] [warning] Error raised in ddtrace's closure defined at %s:26 for mt_rand(): htmlentities(): Only basic entities substitution is supported for multi-byte encodings other than UTF-8; functionality is equivalent to htmlspecialchars in %s on line %d
 Test::testFoo() fav num: %d
-%s in ddtrace's closure defined at %s:16 for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:16 for Test::testFoo(): Undefined variable%sthis_normally_raises_an_%s
 TestFoo
 MTRand
 MTSeed
 NULL
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_shutdown.phpt
@@ -68,5 +68,5 @@ array_sum
 array_sum
 array_sum
 array_sum
-Error raised in ddtrace's closure defined at %s:%d for flushTracer(): Allowed memory size of 2097152 bytes exhausted %s in %s on line %d
-No finished traces to be sent to the agent
+[ddtrace] [warning] Error raised in ddtrace's closure defined at %s:%d for flushTracer(): Allowed memory size of 2097152 bytes exhausted %s in %s on line %d
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure.phpt
+++ b/tests/ext/sandbox/fatal_errors_ignored_in_tracing_closure.phpt
@@ -18,8 +18,8 @@ array_map(function($span) {
 var_dump(error_get_last());
 ?>
 --EXPECTF--
-Error thrown in ddtrace's closure defined at %s:%d for array_sum(): Call to undefined function this_function_does_not_exist()
+[ddtrace] [warning] Error thrown in ddtrace's closure defined at %s:%d for array_sum(): Call to undefined function this_function_does_not_exist()
 int(100)
 array_sum
 NULL
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/hook_function/03.phpt
+++ b/tests/ext/sandbox/hook_function/03.phpt
@@ -16,7 +16,7 @@ greet('Datadog');
 
 ?>
 --EXPECTF--
-DDTrace\hook_function was given neither prehook nor posthook in %s on line %d
+[ddtrace] [warning] DDTrace\hook_function was given neither prehook nor posthook in %s on line %d
 bool(false)
 Hello, Datadog.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt
+++ b/tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt
@@ -27,5 +27,5 @@ foo();
 ?>
 --EXPECTF--
 int(200)
-Error raised in ddtrace's closure defined at %s:%d for foo(): Fatal in %s on line %d
-Flushing trace of size %s
+[ddtrace] [warning] Error raised in ddtrace's closure defined at %s:%d for foo(): Fatal in %s on line %d
+[ddtrace] [info] Flushing trace of size %s

--- a/tests/ext/sandbox/hook_function/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_error_02.phpt
@@ -26,5 +26,5 @@ greet('Datadog');
 --EXPECTF--
 Hello, Datadog.
 greet hooked.
-%s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/posthook_exceptions_04.phpt
@@ -29,6 +29,6 @@ try {
 ?>
 --EXPECTF--
 array_sum hooked.
-Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
 Sum = 4.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_error_02.phpt
@@ -24,6 +24,6 @@ greet('Datadog');
 ?>
 --EXPECTF--
 greet hooked.
-%s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:%d for greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_02.phpt
@@ -31,7 +31,7 @@ try {
 ?>
 --EXPECTF--
 greet hooked.
-Exception thrown in ddtrace's closure defined at %s:%d for greet(): !
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:%d for greet(): !
 Hello, Datadog.
 Done.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
+++ b/tests/ext/sandbox/hook_function/prehook_exceptions_04.phpt
@@ -27,6 +27,6 @@ try {
 ?>
 --EXPECTF--
 array_sum hooked.
-Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:%d for array_sum(): !
 Sum = 4.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_limit.phpt
+++ b/tests/ext/sandbox/hook_limit.phpt
@@ -22,8 +22,8 @@ print "foo hooks were $invocations times invoked\n";
 
 ?>
 --EXPECTF--
-Could not add hook to foo with more than datadog.trace.hook_limit = 2 installed hooks in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Could not add hook to foo with more than datadog.trace.hook_limit = 2 installed hooks in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 bool(false)
-Could not add hook to foo with more than datadog.trace.hook_limit = 2 installed hooks in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Could not add hook to foo with more than datadog.trace.hook_limit = 2 installed hooks in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 int(0)
 foo hooks were 2 times invoked

--- a/tests/ext/sandbox/hook_method/03.phpt
+++ b/tests/ext/sandbox/hook_method/03.phpt
@@ -19,7 +19,7 @@ Greeter::greet('Datadog');
 
 ?>
 --EXPECTF--
-DDTrace\hook_method was given neither prehook nor posthook in %s on line %d
+[ddtrace] [warning] DDTrace\hook_method was given neither prehook nor posthook in %s on line %d
 bool(false)
 Hello, Datadog.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/posthook_07.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_07.phpt
@@ -56,4 +56,4 @@ $app->run();
 App::__construct hooked.
 App::run
 App::run traced.
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/posthook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/posthook_error_02.phpt
@@ -29,5 +29,5 @@ Greeter::greet('Datadog');
 --EXPECTF--
 Hello, Datadog.
 Greeter::greet hooked.
-%s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/prehook_error_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_error_02.phpt
@@ -28,6 +28,6 @@ Greeter::greet('Datadog');
 ?>
 --EXPECTF--
 Greeter::greet hooked.
-%s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
+[ddtrace] [warning] %s in ddtrace's closure defined at %s:%d for Greeter::greet(): Undefined variable%sthis_normally_raises_an_%s
 Hello, Datadog.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
+++ b/tests/ext/sandbox/hook_method/prehook_exceptions_02.phpt
@@ -32,7 +32,7 @@ try {
 ?>
 --EXPECTF--
 Greeter::greet hooked.
-Exception thrown in ddtrace's closure defined at %s:%d for Greeter::greet(): !
+[ddtrace] [warning] Exception thrown in ddtrace's closure defined at %s:%d for Greeter::greet(): !
 Hello, Datadog.
 Done.
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/install_hook/hook_file.phpt
+++ b/tests/ext/sandbox/install_hook/hook_file.phpt
@@ -22,7 +22,7 @@ echo include "testinclude.inc", "\n";
 
 ?>
 --EXPECTF--
-Could not add hook to file path ../testinclude.inc, could not resolve path in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Could not add hook to file path ../testinclude.inc, could not resolve path in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 %s/install_hook/testinclude.inc: %s/install_hook/testinclude.inc, ret: test
 ./testinclude.inc: %s/install_hook/testinclude.inc, ret: test
 testinclude.inc: %s/install_hook/testinclude.inc, ret: test

--- a/tests/ext/sandbox/install_hook/install_hook_return_by_ref.phpt
+++ b/tests/ext/sandbox/install_hook/install_hook_return_by_ref.phpt
@@ -41,9 +41,9 @@ var_dump(A::$var);
 --EXPECTF--
 int(2)
 int(2)
-TypeError thrown in ddtrace's closure defined at %s:%d for ref(): Cannot assign string to reference held by property A::$var of type ?int
+[ddtrace] [warning] TypeError thrown in ddtrace's closure defined at %s:%d for ref(): Cannot assign string to reference held by property A::$var of type ?int
 int(3)
 int(3)
 NULL
 NULL
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/install_hook/replace_hook_args.phpt
+++ b/tests/ext/sandbox/install_hook/replace_hook_args.phpt
@@ -59,19 +59,19 @@ Array
     [2] => 7
     [3] => 8
 )
-Cannot set more args than provided: got too many arguments for hook in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Cannot set more args than provided: got too many arguments for hook in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 Array
 (
     [0] => 1
     [1] => 2
 )
-Not enough args provided for hook in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Not enough args provided for hook in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 Array
 (
     [0] => 1
     [1] => 2
 )
-Can't pass less args to an untyped function than originally passed (minus extra args) in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+[ddtrace] [error] Can't pass less args to an untyped function than originally passed (minus extra args) in %s on line %d; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
 Array
 (
     [0] => 1

--- a/tests/ext/sandbox/manual_flush.phpt
+++ b/tests/ext/sandbox/manual_flush.phpt
@@ -21,5 +21,5 @@ main();
 
 ?>
 --EXPECTF--
-Flushing trace of size 1 to send-queue for %s
-Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 1 to send-queue for %s

--- a/tests/ext/sandbox/retval_is_null_with_exception.phpt
+++ b/tests/ext/sandbox/retval_is_null_with_exception.phpt
@@ -30,4 +30,4 @@ try {
 bool(true)
 NULL
 Oops!
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/spans_out_of_sync_01.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_01.phpt
@@ -17,8 +17,8 @@ var_dump(dd_trace_serialize_closed_spans());
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
-Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+[ddtrace] [error] Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
 array(0) {
 }
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_02.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_02.phpt
@@ -16,8 +16,8 @@ var_dump(dd_trace_serialize_closed_spans());
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
-Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
+[ddtrace] [error] Cannot run tracing closure for dd_trace_serialize_closed_spans(); spans out of sync
 array(0) {
 }
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_03.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_03.phpt
@@ -22,6 +22,6 @@ echo 'Done.' . PHP_EOL;
 --EXPECT--
 array(0) {
 }
-Cannot run tracing closure for shutdown_and_flush(); spans out of sync
+[ddtrace] [error] Cannot run tracing closure for shutdown_and_flush(); spans out of sync
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_04.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_04.phpt
@@ -21,6 +21,6 @@ echo 'Done.' . PHP_EOL;
 --EXPECT--
 array(0) {
 }
-Cannot run tracing closure for shutdown_and_flush(); spans out of sync
+[ddtrace] [error] Cannot run tracing closure for shutdown_and_flush(); spans out of sync
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_05.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_05.phpt
@@ -21,4 +21,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/spans_out_of_sync_06.phpt
+++ b/tests/ext/sandbox/spans_out_of_sync_06.phpt
@@ -19,4 +19,4 @@ echo 'Done.' . PHP_EOL;
 ?>
 --EXPECT--
 Done.
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
+++ b/tests/ext/sandbox/static_tracing_closures_will_not_bind_this.phpt
@@ -24,4 +24,4 @@ $foo->test();
 --EXPECTF--
 Foo::test()
 TRACED Foo::test()
-Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/segfault_backtrace_enabled.phpt
+++ b/tests/ext/segfault_backtrace_enabled.phpt
@@ -17,10 +17,10 @@ posix_kill(posix_getpid(), 11); // boom
 
 ?>
 --EXPECTREGEX--
-Segmentation fault
-Datadog PHP Trace extension \(DEBUG MODE\)
-Received Signal 11
-Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime
-Backtrace:
+\[ddtrace] \[error] Segmentation fault
+\[ddtrace] \[error] Datadog PHP Trace extension \(DEBUG MODE\)
+\[ddtrace] \[error] Received Signal 11
+\[ddtrace] \[error] Note: Backtrace below might be incomplete and have wrong entries due to optimized runtime
+\[ddtrace] \[error] Backtrace:
 .*ddtrace\.so.*
 .*

--- a/tests/ext/span_stack/start_top_level_span_stack.phpt
+++ b/tests/ext/span_stack/start_top_level_span_stack.phpt
@@ -37,7 +37,7 @@ That top-level span is, in fact a trace root span without parent: bool(true)
 And it has matching a trace id: bool(true)
 Verify the stack_span stays if the top-level span is closed - this span stack is not tied to a trace directly: bool(true)
 There is no active span now: bool(true)
-There is no user-span on the top of the stack. Cannot close.
+[ddtrace] [error] There is no user-span on the top of the stack. Cannot close.
 Given no active span, the active span stays null: bool(true)
 This also must not affect the active span stack: bool(true)
 Now, we are back on the global span stack: bool(true)

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -24,7 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-Found unfinished span while automatically closing spans with name 'my precious span'
+[ddtrace] [warning] Found unfinished span while automatically closing spans with name 'my precious span'
 array(1) {
   [0]=>
   array(10) {
@@ -66,7 +66,7 @@ array(1) {
     }
   }
 }
-There is no user-span on the top of the stack. Cannot close.
+[ddtrace] [error] There is no user-span on the top of the stack. Cannot close.
 array(0) {
 }
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/ext/start_span_without_closing_autofinish.phpt
+++ b/tests/ext/start_span_without_closing_autofinish.phpt
@@ -24,7 +24,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-Found unfinished span while automatically closing spans with name 'my precious span'
+[ddtrace] [warning] Found unfinished span while automatically closing spans with name 'my precious span'
 array(2) {
   [0]=>
   array(9) {
@@ -69,7 +69,7 @@ array(2) {
     string(3) "cli"
   }
 }
-There is no user-span on the top of the stack. Cannot close.
+[ddtrace] [error] There is no user-span on the top of the stack. Cannot close.
 array(0) {
 }
-No finished traces to be sent to the agent
+[ddtrace] [info] No finished traces to be sent to the agent

--- a/tests/xdebug/2.7.2/request_init_hook_disable_php_7.0.phpt
+++ b/tests/xdebug/2.7.2/request_init_hook_disable_php_7.0.phpt
@@ -12,5 +12,5 @@ if (!extension_loaded('Xdebug')) die('skip: Xdebug required');
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECTF--
-Found incompatible Xdebug version %s; disabling conflicting functionality
+[ddtrace] [error] Found incompatible Xdebug version %s; disabling conflicting functionality
 Done.

--- a/tests/xdebug/2.9.2/request_init_hook_disable.phpt
+++ b/tests/xdebug/2.9.2/request_init_hook_disable.phpt
@@ -12,5 +12,5 @@ if (!extension_loaded('Xdebug') || version_compare(phpversion('Xdebug'), '2.9.5'
 echo 'Done.' . PHP_EOL;
 ?>
 --EXPECTF--
-Found incompatible Xdebug version %s; ddtrace requires Xdebug 2.9.5 or greater; disabling conflicting functionality
+[ddtrace] [error] Found incompatible Xdebug version %s; ddtrace requires Xdebug 2.9.5 or greater; disabling conflicting functionality
 Done.

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -147,7 +147,6 @@ inline void zai_sandbox_error_state_backup(zai_error_state *es) {
     PG(last_error_file) = NULL;
 
     es->error_reporting = EG(error_reporting);
-    EG(error_reporting) = 0;
     zend_replace_error_handling(EH_THROW, NULL, &es->error_handling);
 }
 
@@ -275,7 +274,6 @@ inline void zai_sandbox_error_state_backup(zai_error_state *es) {
     PG(last_error_file) = NULL;
 
     es->error_reporting = EG(error_reporting);
-    EG(error_reporting) = 0;
     zend_replace_error_handling(EH_THROW, NULL, &es->error_handling);
 }
 

--- a/zend_abstract_interface/uri_normalization/uri_normalization.c
+++ b/zend_abstract_interface/uri_normalization/uri_normalization.c
@@ -215,6 +215,7 @@ bool zai_match_regex(zend_string *pattern, zend_string *subject) {
     zai_error_state error_state;
     zai_sandbox_error_state_backup(&error_state);
     zend_replace_error_handling(EH_NORMAL, NULL, NULL);
+    EG(error_reporting) = 0;
 
     pcre_cache_entry *pce = pcre_get_compiled_regex_cache(regex);
 


### PR DESCRIPTION
### Description

Fix reporting @-suppressed errors within the sandbox.

Also prefix all ddtrace errors with `[ddtrace] [loglevel]` to make them easily greppable.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
