### PR TITLE
fix(profiler) zai tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ workflows:
             zend_abstract_interface/.*  profiling true
             zend_abstract_interface/.*  appsec true
             profiling/.*  profiling true
+            profiling/src/capi.rs  zend_abstract_interface true
             ext/handlers_api.[ch] profiling true
             appsec/.* appsec true
             ext/.* appsec true

--- a/tests/tea/profiling/profiling.cc
+++ b/tests/tea/profiling/profiling.cc
@@ -9,7 +9,7 @@ ZEND_TLS datadog_php_stack_sample last_stack_sample;
 
 ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void) { return last_stack_sample; }
 
-ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_data) {
+ZEND_API void ddog_php_prof_interrupt_function(zend_execute_data *execute_data) {
     datadog_php_stack_sample_ctor(&last_stack_sample);
 
     /* Don't try to re-implement everything. Remember, the tracer is being

--- a/tests/tea/profiling/profiling.h
+++ b/tests/tea/profiling/profiling.h
@@ -9,7 +9,7 @@ BEGIN_EXTERN_C()
 #include <components/stack-sample/stack-sample.h>
 
 ZEND_API datadog_php_stack_sample tea_get_last_stack_sample(void);
-ZEND_API void datadog_profiling_interrupt_function(zend_execute_data *execute_data);
+ZEND_API void ddog_php_prof_interrupt_function(zend_execute_data *execute_data);
 END_EXTERN_C()
 
 #endif


### PR DESCRIPTION
### Description

Fixes the failing zai test in `master` that came after merging #2467. Also enabled running the zai tests on profiler changes so that we do not fall for this again.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
