### PR TITLE
feat(profiling): enable timeline by default

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1803,6 +1803,12 @@ function get_ini_settings($requestInitHookPath, $appsecHelperPath, $appsecRulesP
                 . ' Acceptable values are off, error, warn, info, debug, and trace.'
                 . ' The profiler’s logs are written to the standard error stream of the process.',
         ],
+        [
+            'name' => 'datadog.profiling.timeline_enabled',
+            'default' => '1',
+            'commented' => true,
+            'description' => 'Enable the timeline profile type.',
+        ],
 
         [
             'name' => 'datadog.trace.request_init_hook',

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -141,7 +141,7 @@ pub(crate) enum ConfigId {
     ProfilingEndpointCollectionEnabled,
     ProfilingExperimentalCpuTimeEnabled,
     ProfilingAllocationEnabled,
-    ProfilingExperimentalTimelineEnabled,
+    ProfilingTimelineEnabled,
     ProfilingExceptionEnabled,
     ProfilingExceptionSamplingDistance,
     ProfilingLogLevel,
@@ -167,7 +167,7 @@ impl ConfigId {
             ProfilingEndpointCollectionEnabled => b"DD_PROFILING_ENDPOINT_COLLECTION_ENABLED\0",
             ProfilingExperimentalCpuTimeEnabled => b"DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED\0",
             ProfilingAllocationEnabled => b"DD_PROFILING_ALLOCATION_ENABLED\0",
-            ProfilingExperimentalTimelineEnabled => b"DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED\0",
+            ProfilingTimelineEnabled => b"DD_PROFILING_TIMELINE_ENABLED\0",
             ProfilingExceptionEnabled => b"DD_PROFILING_EXCEPTION_ENABLED\0",
             ProfilingExceptionSamplingDistance => b"DD_PROFILING_EXCEPTION_SAMPLING_DISTANCE\0",
             ProfilingLogLevel => b"DD_PROFILING_LOG_LEVEL\0",
@@ -231,10 +231,8 @@ pub(crate) unsafe fn profiling_allocation_enabled() -> bool {
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
-pub(crate) unsafe fn profiling_experimental_timeline_enabled() -> bool {
-    profiling_enabled()
-        && (profiling_experimental_features_enabled()
-            || get_bool(ProfilingExperimentalTimelineEnabled, false))
+pub(crate) unsafe fn profiling_timeline_enabled() -> bool {
+    profiling_enabled() && get_bool(ProfilingTimelineEnabled, true)
 }
 
 /// # Safety
@@ -456,6 +454,12 @@ pub(crate) fn minit(module_number: libc::c_int) {
             )]
         };
 
+        const TIMELINE_ALIASES: &[ZaiStr] = unsafe {
+            &[ZaiStr::literal(
+                b"DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED\0",
+            )]
+        };
+
         // Note that function pointers cannot appear in const functions, so we
         // can't extract each entry into a helper function.
         static mut ENTRIES: &mut [zai_config_entry] = unsafe {
@@ -511,12 +515,12 @@ pub(crate) fn minit(module_number: libc::c_int) {
                     parser: None,
                 },
                 zai_config_entry {
-                    id: transmute(ProfilingExperimentalTimelineEnabled),
-                    name: ProfilingExperimentalTimelineEnabled.env_var_name(),
+                    id: transmute(ProfilingTimelineEnabled),
+                    name: ProfilingTimelineEnabled.env_var_name(),
                     type_: ZAI_CONFIG_TYPE_BOOL,
-                    default_encoded_value: ZaiStr::literal(b"0\0"),
-                    aliases: std::ptr::null_mut(),
-                    aliases_count: 0,
+                    default_encoded_value: ZaiStr::literal(b"1\0"),
+                    aliases: TIMELINE_ALIASES.as_ptr(),
+                    aliases_count: TIMELINE_ALIASES.len() as u8,
                     ini_change: None,
                     parser: None,
                 },
@@ -683,6 +687,11 @@ mod tests {
             (
                 b"DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED\0",
                 "datadog.profiling.experimental_timeline_enabled",
+            ),
+            #[cfg(feature = "timeline")]
+            (
+                b"DD_PROFILING_TIMELINE_ENABLED\0",
+                "datadog.profiling.timeline_enabled",
             ),
             (b"DD_PROFILING_LOG_LEVEL\0", "datadog.profiling.log_level"),
             (

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -16,6 +16,7 @@ mod exception;
 
 #[cfg(feature = "timeline")]
 mod timeline;
+
 mod wall_time;
 
 use bindings as zend;
@@ -315,7 +316,7 @@ pub struct RequestLocals {
     pub profiling_endpoint_collection_enabled: bool,
     pub profiling_experimental_cpu_time_enabled: bool,
     pub profiling_allocation_enabled: bool,
-    pub profiling_experimental_timeline_enabled: bool,
+    pub profiling_timeline_enabled: bool,
     pub profiling_exception_enabled: bool,
     pub profiling_exception_sampling_distance: u32,
     pub profiling_log_level: LevelFilter, // Only used for minfo
@@ -332,7 +333,7 @@ impl RequestLocals {
         self.profiling_endpoint_collection_enabled = false;
         self.profiling_experimental_cpu_time_enabled = false;
         self.profiling_allocation_enabled = false;
-        self.profiling_experimental_timeline_enabled = false;
+        self.profiling_timeline_enabled = false;
         self.profiling_exception_enabled = false;
     }
 }
@@ -347,7 +348,7 @@ impl Default for RequestLocals {
             profiling_endpoint_collection_enabled: true,
             profiling_experimental_cpu_time_enabled: true,
             profiling_allocation_enabled: true,
-            profiling_experimental_timeline_enabled: true,
+            profiling_timeline_enabled: true,
             profiling_exception_enabled: true,
             profiling_exception_sampling_distance: 100,
             profiling_log_level: LevelFilter::Off,
@@ -412,7 +413,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         profiling_endpoint_collection_enabled,
         profiling_experimental_cpu_time_enabled,
         profiling_allocation_enabled,
-        profiling_experimental_timeline_enabled,
+        profiling_timeline_enabled,
         profiling_exception_enabled,
         profiling_exception_sampling_distance,
         log_level,
@@ -424,7 +425,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
             config::profiling_endpoint_collection_enabled(),
             config::profiling_experimental_cpu_time_enabled(),
             config::profiling_allocation_enabled(),
-            config::profiling_experimental_timeline_enabled(),
+            config::profiling_timeline_enabled(),
             config::profiling_exception_enabled(),
             config::profiling_exception_sampling_distance(),
             config::profiling_log_level(),
@@ -444,7 +445,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         locals.profiling_endpoint_collection_enabled = profiling_endpoint_collection_enabled;
         locals.profiling_experimental_cpu_time_enabled = profiling_experimental_cpu_time_enabled;
         locals.profiling_allocation_enabled = profiling_allocation_enabled;
-        locals.profiling_experimental_timeline_enabled = profiling_experimental_timeline_enabled;
+        locals.profiling_timeline_enabled = profiling_timeline_enabled;
         locals.profiling_exception_enabled = profiling_exception_enabled;
         locals.profiling_exception_sampling_distance = profiling_exception_sampling_distance;
         locals.profiling_log_level = log_level;
@@ -777,13 +778,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             if #[cfg(feature = "timeline")] {
                 zend::php_info_print_table_row(
                     2,
-                    b"Experimental Timeline Enabled\0".as_ptr(),
-                    if locals.profiling_experimental_timeline_enabled {
-                        if locals.profiling_experimental_features_enabled {
-                            yes_exp
-                        } else {
-                            yes
-                        }
+                    b"Timeline Enabled\0".as_ptr(),
+                    if locals.profiling_timeline_enabled {
+                        yes
                     } else if locals.profiling_enabled {
                         no
                     } else {
@@ -793,7 +790,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             } else {
                 zend::php_info_print_table_row(
                     2,
-                    b"Experimental Timeline Enabled\0".as_ptr(),
+                    b"Timeline Enabled\0".as_ptr(),
                     b"Not available. The profiler was build without timeline support.\0"
                 );
             }

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -663,7 +663,7 @@ impl Profiler {
                 let labels = Profiler::message_labels();
                 let mut timestamp = 0;
                 #[cfg(feature = "timeline")]
-                if locals.profiling_experimental_timeline_enabled {
+                if locals.profiling_timeline_enabled {
                     if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
                         timestamp = now.as_nanos() as i64;
                     }
@@ -1054,7 +1054,7 @@ impl Profiler {
             }
 
             #[cfg(feature = "timeline")]
-            if locals.profiling_experimental_timeline_enabled {
+            if locals.profiling_timeline_enabled {
                 sample_types.push(SAMPLE_TYPES[5]);
                 sample_values.push(values[5]);
             }
@@ -1121,7 +1121,7 @@ mod tests {
             profiling_endpoint_collection_enabled: true,
             profiling_experimental_cpu_time_enabled: false,
             profiling_allocation_enabled: false,
-            profiling_experimental_timeline_enabled: false,
+            profiling_timeline_enabled: false,
             profiling_exception_enabled: false,
             profiling_exception_sampling_distance: 1,
             profiling_log_level: LevelFilter::Off,
@@ -1271,7 +1271,7 @@ mod tests {
         let mut locals = get_request_locals();
         locals.profiling_enabled = true;
         locals.profiling_experimental_cpu_time_enabled = true;
-        locals.profiling_experimental_timeline_enabled = true;
+        locals.profiling_timeline_enabled = true;
 
         let message: SampleMessage =
             Profiler::prepare_sample_message(frames, samples, labels, &locals, 900);

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -39,7 +39,7 @@ fn try_sleeping_fn(
 ) -> anyhow::Result<()> {
     let timeline_enabled = REQUEST_LOCALS.with(|cell| {
         cell.try_borrow()
-            .map(|locals| locals.profiling_experimental_timeline_enabled)
+            .map(|locals| locals.profiling_timeline_enabled)
             .unwrap_or(false)
     });
 
@@ -197,7 +197,7 @@ pub fn timeline_rinit() {
             return;
         };
 
-        if !locals.profiling_experimental_timeline_enabled {
+        if !locals.profiling_timeline_enabled {
             return;
         }
 
@@ -228,7 +228,7 @@ pub fn timeline_rinit() {
 pub fn timeline_prshutdown() {
     let timeline_enabled = REQUEST_LOCALS.with(|cell| {
         cell.try_borrow()
-            .map(|locals| locals.profiling_experimental_timeline_enabled)
+            .map(|locals| locals.profiling_timeline_enabled)
             .unwrap_or(false)
     });
 
@@ -255,7 +255,7 @@ pub(crate) fn timeline_mshutdown() {
             return;
         };
 
-        if !locals.profiling_experimental_timeline_enabled {
+        if !locals.profiling_timeline_enabled {
             return;
         }
 
@@ -295,7 +295,7 @@ unsafe extern "C" fn ddog_php_prof_compile_string(
     if let Some(prev) = PREV_ZEND_COMPILE_STRING {
         let timeline_enabled = REQUEST_LOCALS.with(|cell| {
             cell.try_borrow()
-                .map(|locals| locals.profiling_experimental_timeline_enabled)
+                .map(|locals| locals.profiling_timeline_enabled)
                 .unwrap_or(false)
         });
 
@@ -363,7 +363,7 @@ unsafe extern "C" fn ddog_php_prof_compile_file(
     if let Some(prev) = PREV_ZEND_COMPILE_FILE {
         let timeline_enabled = REQUEST_LOCALS.with(|cell| {
             cell.try_borrow()
-                .map(|locals| locals.profiling_experimental_timeline_enabled)
+                .map(|locals| locals.profiling_timeline_enabled)
                 .unwrap_or(false)
         });
 
@@ -448,7 +448,7 @@ unsafe extern "C" fn ddog_php_prof_gc_collect_cycles() -> i32 {
     if let Some(prev) = PREV_GC_COLLECT_CYCLES {
         let timeline_enabled = REQUEST_LOCALS.with(|cell| {
             cell.try_borrow()
-                .map(|locals| locals.profiling_experimental_timeline_enabled)
+                .map(|locals| locals.profiling_timeline_enabled)
                 .unwrap_or(false)
         });
 

--- a/profiling/tests/phpt/phpinfo_06.phpt
+++ b/profiling/tests/phpt/phpinfo_06.phpt
@@ -15,7 +15,7 @@ DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
 DD_PROFILING_ALLOCATION_ENABLED=no
 DD_PROFILING_EXCEPTION_ENABLED=no
-DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_TIMELINE_ENABLED=no
 --INI--
 assert.exception=1
 opcache.jit=off
@@ -47,7 +47,7 @@ $sections = [
     ["Experimental CPU Time Profiling Enabled", "false (profiling disabled)"],
     ["Allocation Profiling Enabled", "false (profiling disabled)"],
     ["Exception Profiling Enabled", "false (profiling disabled)"],
-    ["Experimental Timeline Enabled", "false (profiling disabled)"],
+    ["Timeline Enabled", "false (profiling disabled)"],
 ];
 
 foreach ($sections as [$key, $expected]) {

--- a/profiling/tests/phpt/phpinfo_07.phpt
+++ b/profiling/tests/phpt/phpinfo_07.phpt
@@ -15,7 +15,7 @@ DD_PROFILING_LOG_LEVEL=off
 DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
 DD_PROFILING_ALLOCATION_ENABLED=no
 DD_PROFILING_EXCEPTION_ENABLED=no
-DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_TIMELINE_ENABLED=no
 --INI--
 assert.exception=1
 opcache.jit=off
@@ -47,7 +47,7 @@ $sections = [
     ["Experimental CPU Time Profiling Enabled", "true (all experimental features enabled)"],
     ["Allocation Profiling Enabled", "false"],
     ["Exception Profiling Enabled", "false"],
-    ["Experimental Timeline Enabled", "true (all experimental features enabled)"],
+    ["Timeline Enabled", "false"],
 ];
 
 foreach ($sections as [$key, $expected]) {


### PR DESCRIPTION
### Description

This PR will default enable timeline for the PHP profiler

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
