### PR TITLE
refactor(profiling): use SystemSettings in locals

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1904,6 +1904,7 @@ jobs:
           DD_TRACE_AGENT_PORT: 80
           DD_TRACE_AGENT_FLUSH_INTERVAL: 1000
           INSTALL_TYPE: << parameters.install_type >>
+          RUST_BACKTRACE: 1
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
     steps:
       - restore_cache:
@@ -1975,6 +1976,7 @@ jobs:
           VERIFY_APACHE: << parameters.verify_apache >>
           INSTALL_MODE: << parameters.install_mode >>
           INSTALL_TYPE: << parameters.install_type >>
+          RUST_BACKTRACE: 1
       - <<: *IMAGE_DOCKER_REQUEST_REPLAYER
     steps:
       - restore_cache:
@@ -2057,6 +2059,8 @@ jobs:
       - run:
           name: Run tests
           command: make -C dockerfiles/verify_packages test_installer
+          environment:
+              RUST_BACKTRACE: 1
 
   randomized_tests:
     working_directory: ~/datadog

--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -60,5 +60,5 @@ jobs:
           switch-php nts-asan
           cd profiling/tests
           cp -v $(php-config --prefix)/lib/php/build/run-tests.php .
-          php run-tests.php --asan -d extension=datadog-profiling.so phpt
+          php run-tests.php --show-diff --asan -d extension=datadog-profiling.so phpt
 

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -41,7 +41,7 @@ extern "C" fn ddog_php_prof_trigger_time_sample() {
     use std::sync::atomic::Ordering;
     super::REQUEST_LOCALS.with(|cell| {
         if let Ok(locals) = cell.try_borrow() {
-            if locals.profiling_enabled {
+            if locals.system_settings().profiling_enabled {
                 // Safety: only vm interrupts are stored there, or possibly null (edges only).
                 if let Some(vm_interrupt) = unsafe { locals.vm_interrupt_addr.as_ref() } {
                     locals.interrupt_count.fetch_add(1, Ordering::SeqCst);

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -79,7 +79,7 @@ pub fn exception_profiling_minit() {
 pub fn exception_profiling_first_rinit() {
     let sampling_distance = REQUEST_LOCALS.with(|cell| {
         match cell.try_borrow() {
-            Ok(locals) => locals.profiling_exception_sampling_distance,
+            Ok(locals) => locals.system_settings().profiling_exception_sampling_distance,
             Err(_err) => {
                 error!("Exception profiling was not initialized correctly due to a borrow error. Please report this to Datadog.");
                 100
@@ -107,7 +107,7 @@ unsafe extern "C" fn exception_profiling_throw_exception_hook(
 
     let exception_profiling = REQUEST_LOCALS.with(|cell| {
         cell.try_borrow()
-            .map(|locals| locals.profiling_exception_enabled)
+            .map(|locals| locals.system_settings().profiling_exception_enabled)
             .unwrap_or(false)
     });
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -23,8 +23,8 @@ use crate::config::SystemSettings;
 use bindings as zend;
 use bindings::{ddog_php_prof_php_version_id, ZendExtension, ZendResult};
 use clocks::*;
-use config::AgentEndpoint;
-use datadog_profiling::exporter::{Tag, Uri};
+use core::ptr;
+use datadog_profiling::exporter::Tag;
 use ddcommon::cstr;
 use lazy_static::lazy_static;
 use libc::c_char;
@@ -36,8 +36,6 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::ffi::CStr;
 use std::os::raw::c_int;
-use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, Once};
 use std::time::{Duration, Instant};
@@ -252,7 +250,7 @@ extern "C" fn minit(_type: c_int, module_number: c_int) -> ZendResult {
         unsafe {
             let module = &mut *ptr;
             let handle = module.handle;
-            module.handle = std::ptr::null_mut();
+            module.handle = ptr::null_mut();
             handle
         }
     };
@@ -312,30 +310,22 @@ extern "C" fn prshutdown() -> ZendResult {
 pub struct RequestLocals {
     pub env: Option<Cow<'static, str>>,
     pub interrupt_count: AtomicU32,
-    pub profiling_enabled: bool,
-    pub profiling_experimental_features_enabled: bool,
-    pub profiling_endpoint_collection_enabled: bool,
-    pub profiling_experimental_cpu_time_enabled: bool,
-    pub profiling_allocation_enabled: bool,
-    pub profiling_timeline_enabled: bool,
-    pub profiling_exception_enabled: bool,
-    pub profiling_exception_sampling_distance: u32,
-    pub profiling_log_level: LevelFilter, // Only used for minfo
     pub service: Option<Cow<'static, str>>,
-    pub uri: Box<AgentEndpoint>,
+
+    /// SystemSettings are global. This ptr must be non-null after rinit
+    /// through rshutdown.
+    pub system_settings: *const SystemSettings,
+
     pub version: Option<Cow<'static, str>>,
     pub vm_interrupt_addr: *const AtomicBool,
 }
 
 impl RequestLocals {
-    pub fn disable(&mut self) {
-        self.profiling_enabled = false;
-        self.profiling_experimental_features_enabled = false;
-        self.profiling_endpoint_collection_enabled = false;
-        self.profiling_experimental_cpu_time_enabled = false;
-        self.profiling_allocation_enabled = false;
-        self.profiling_timeline_enabled = false;
-        self.profiling_exception_enabled = false;
+    pub fn system_settings(&self) -> &SystemSettings {
+        // SAFETY: system_settings should be non-null except during edge cases
+        // like after module creation but before first rinit. Request locals
+        // should not generally be used at such times anyway.
+        unsafe { self.system_settings.as_ref().unwrap() }
     }
 }
 
@@ -344,19 +334,10 @@ impl Default for RequestLocals {
         RequestLocals {
             env: None,
             interrupt_count: AtomicU32::new(0),
-            profiling_enabled: false,
-            profiling_experimental_features_enabled: false,
-            profiling_endpoint_collection_enabled: true,
-            profiling_experimental_cpu_time_enabled: true,
-            profiling_allocation_enabled: true,
-            profiling_timeline_enabled: true,
-            profiling_exception_enabled: true,
-            profiling_exception_sampling_distance: 100,
-            profiling_log_level: LevelFilter::Off,
             service: None,
-            uri: Box::<AgentEndpoint>::default(),
+            system_settings: ptr::null(),
             version: None,
-            vm_interrupt_addr: std::ptr::null_mut(),
+            vm_interrupt_addr: ptr::null_mut(),
         }
     }
 }
@@ -397,42 +378,21 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     #[cfg(debug_assertions)]
     trace!("RINIT({_type}, {_module_number})");
 
-    /* At the moment, logging is truly global, so init it exactly once whether
-     * profiling is enabled or not.
-     */
     static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-        unsafe { bindings::zai_config_first_time_rinit() };
+    ONCE.call_once(|| unsafe {
+        bindings::zai_config_first_time_rinit();
     });
 
     unsafe { bindings::zai_config_rinit() };
 
+    // todo: why can't I move this before `zai_config_rinit`?
+    static CONFIG_ONCE: Once = Once::new();
+    CONFIG_ONCE.call_once(|| unsafe {
+        config::first_rinit();
+    });
+
     // Safety: We are after first rinit and before mshutdown.
-    let (
-        profiling_enabled,
-        profiling_experimental_features_enabled,
-        profiling_endpoint_collection_enabled,
-        profiling_experimental_cpu_time_enabled,
-        profiling_allocation_enabled,
-        profiling_timeline_enabled,
-        profiling_exception_enabled,
-        profiling_exception_sampling_distance,
-        log_level,
-        output_pprof,
-    ) = unsafe {
-        (
-            config::profiling_enabled(),
-            config::profiling_experimental_features_enabled(),
-            config::profiling_endpoint_collection_enabled(),
-            config::profiling_experimental_cpu_time_enabled(),
-            config::profiling_allocation_enabled(),
-            config::profiling_timeline_enabled(),
-            config::profiling_exception_enabled(),
-            config::profiling_exception_sampling_distance(),
-            config::profiling_log_level(),
-            config::profiling_output_pprof(),
-        )
-    };
+    let system_settings = unsafe { &*SystemSettings::get() };
 
     // initialize the thread local storage and cache some items
     REQUEST_LOCALS.with(|cell| {
@@ -440,16 +400,6 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
         // Safety: we are in rinit on a PHP thread.
         locals.vm_interrupt_addr = unsafe { zend::datadog_php_profiling_vm_interrupt_addr() };
         locals.interrupt_count.store(0, Ordering::SeqCst);
-
-        locals.profiling_enabled = profiling_enabled;
-        locals.profiling_experimental_features_enabled = profiling_experimental_features_enabled;
-        locals.profiling_endpoint_collection_enabled = profiling_endpoint_collection_enabled;
-        locals.profiling_experimental_cpu_time_enabled = profiling_experimental_cpu_time_enabled;
-        locals.profiling_allocation_enabled = profiling_allocation_enabled;
-        locals.profiling_timeline_enabled = profiling_timeline_enabled;
-        locals.profiling_exception_enabled = profiling_exception_enabled;
-        locals.profiling_exception_sampling_distance = profiling_exception_sampling_distance;
-        locals.profiling_log_level = log_level;
 
         // Safety: We are after first rinit and before mshutdown.
         unsafe {
@@ -465,33 +415,21 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 }
             });
             locals.version = config::version();
-
-            // Select agent URI/UDS
-            let agent_host = config::agent_host();
-            let trace_agent_port = config::trace_agent_port();
-            let trace_agent_url = config::trace_agent_url();
-            let endpoint = detect_uri_from_config(trace_agent_url, agent_host, trace_agent_port);
-            locals.uri = Box::new(endpoint);
-
-            // todo: tags
         }
+        locals.system_settings = system_settings;
     });
 
     static ONCE2: Once = Once::new();
     ONCE2.call_once(|| {
         // Don't log when profiling is disabled as that can mess up tests.
-        let profiling_log_level = if profiling_enabled {
-            log_level
-        } else {
-            LevelFilter::Off
-        };
+        let profiling_log_level = system_settings.profiling_log_level;
 
         #[cfg(not(debug_assertions))]
         logging::log_init(profiling_log_level);
         #[cfg(debug_assertions)]
         log::set_max_level(profiling_log_level);
 
-        if profiling_enabled {
+        if system_settings.profiling_enabled {
             /* Safety: sapi_module is initialized by rinit and shouldn't be
              * modified at this point (safe to read values).
              */
@@ -511,12 +449,12 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 }
             }
             if let Err(err) = cpu_time::ThreadTime::try_now() {
-                if profiling_experimental_cpu_time_enabled {
+                if system_settings.profiling_experimental_cpu_time_enabled {
                     warn!("CPU Time collection was enabled but collection failed: {err}");
                 } else {
                     debug!("CPU Time collection was not enabled and isn't available: {err}");
                 }
-            } else if profiling_experimental_cpu_time_enabled {
+            } else if system_settings.profiling_experimental_cpu_time_enabled {
                 info!("CPU Time profiling enabled.");
             }
         }
@@ -551,35 +489,14 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
          */
         let mut profiler = PROFILER.lock().unwrap();
         if profiler.is_none() {
-            // Select agent URI/UDS
-            // SAFETY: config is called in rinit after its been initialized.
-            let uri = unsafe {
-                let agent_host = config::agent_host();
-                let trace_agent_port = config::trace_agent_port();
-                let trace_agent_url = config::trace_agent_url();
-                detect_uri_from_config(trace_agent_url, agent_host, trace_agent_port)
-            };
-
-            *profiler = Some(Profiler::new(SystemSettings {
-                profiling_enabled,
-                profiling_experimental_features_enabled,
-                profiling_endpoint_collection_enabled,
-                profiling_experimental_cpu_time_enabled,
-                profiling_allocation_enabled,
-                profiling_timeline_enabled,
-                profiling_exception_enabled,
-                output_pprof,
-                profiling_exception_sampling_distance,
-                profiling_log_level: log_level,
-                uri,
-            }))
+            *profiler = Some(Profiler::new(system_settings))
         }
     };
 
-    if profiling_enabled {
+    if system_settings.profiling_enabled {
         REQUEST_LOCALS.with(|cell| {
             let locals = cell.borrow();
-            let cpu_time_enabled = locals.profiling_experimental_cpu_time_enabled;
+            let cpu_time_enabled = system_settings.profiling_experimental_cpu_time_enabled;
             CLOCKS.with(|cell| cell.borrow_mut().initialize(cpu_time_enabled));
 
             TAGS.with(|cell| {
@@ -609,8 +526,11 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     #[cfg(feature = "allocation_profiling")]
     allocation::allocation_profiling_rinit();
 
+    // SAFETY: called after config is initialized.
     #[cfg(feature = "timeline")]
-    timeline::timeline_rinit();
+    unsafe {
+        timeline::timeline_rinit()
+    };
 
     ZendResult::Success
 }
@@ -633,61 +553,6 @@ fn add_tag(tags: &mut Vec<Tag>, key: &str, value: &str) {
     }
 }
 
-fn detect_uri_from_config(
-    url: Option<Cow<'static, str>>,
-    host: Option<Cow<'static, str>>,
-    port: Option<u16>,
-) -> AgentEndpoint {
-    /* Priority:
-     *  1. DD_TRACE_AGENT_URL
-     *     - RFC allows unix:///path/to/some/socket so parse these out.
-     *     - Maybe emit diagnostic if an invalid URL is detected or the path is non-existent, but
-     *       continue down the priority list.
-     *  2. DD_AGENT_HOST and/or DD_TRACE_AGENT_PORT. If only one is set, default the other.
-     *  3. Unix Domain Socket at /var/run/datadog/apm.socket
-     *  4. http://localhost:8126
-     */
-    if let Some(trace_agent_url) = url {
-        // check for UDS first
-        if let Some(path) = trace_agent_url.strip_prefix("unix://") {
-            let path = PathBuf::from(path);
-            if path.exists() {
-                return AgentEndpoint::Socket(path);
-            } else {
-                warn!(
-                    "Unix socket specified in DD_TRACE_AGENT_URL does not exist: {} ",
-                    path.to_string_lossy()
-                );
-            }
-        } else {
-            match Uri::from_str(trace_agent_url.as_ref()) {
-                Ok(uri) => return AgentEndpoint::Uri(uri),
-                Err(err) => warn!("DD_TRACE_AGENT_URL was not a valid URL: {err}"),
-            }
-        }
-        // continue down priority list
-    }
-    if port.is_some() || host.is_some() {
-        let host = host.unwrap_or(Cow::Borrowed("localhost"));
-        let port = port.unwrap_or(8126u16);
-        let url = if host.contains(':') {
-            format!("http://[{host}]:{port}")
-        } else {
-            format!("http://{host}:{port}")
-        };
-
-        match Uri::from_str(url.as_str()) {
-            Ok(uri) => return AgentEndpoint::Uri(uri),
-            Err(err) => {
-                warn!("The combination of DD_AGENT_HOST({host}) and DD_TRACE_AGENT_PORT({port}) was not a valid URL: {err}")
-            }
-        }
-        // continue down priority list
-    }
-
-    AgentEndpoint::default()
-}
-
 extern "C" fn rshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     #[cfg(debug_assertions)]
     trace!("RSHUTDOWN({_type}, {_module_number})");
@@ -703,8 +568,9 @@ extern "C" fn rshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
 
     REQUEST_LOCALS.with(|cell| {
         let locals = cell.borrow();
+        let system_settings = locals.system_settings();
 
-        if locals.profiling_enabled {
+        if system_settings.profiling_enabled {
             if let Some(profiler) = PROFILER.lock().unwrap().as_ref() {
                 let interrupt = VmInterrupt {
                     interrupt_count_ptr: &locals.interrupt_count,
@@ -732,6 +598,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
 
     REQUEST_LOCALS.with(|cell| {
         let locals = cell.borrow();
+        let system_settings = locals.system_settings();
         let yes: &[u8] = b"true\0";
         let yes_exp: &[u8] = b"true (all experimental features enabled)\0";
         let no: &[u8] = b"false\0";
@@ -741,15 +608,15 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
         zend::php_info_print_table_row(
             2,
             b"Profiling Enabled\0".as_ptr(),
-            if locals.profiling_enabled { yes } else { no },
+            if system_settings.profiling_enabled { yes } else { no },
         );
 
         zend::php_info_print_table_row(
             2,
             b"Profiling Experimental Features Enabled\0".as_ptr(),
-            if locals.profiling_experimental_features_enabled {
+            if system_settings.profiling_experimental_features_enabled {
                 yes
-            } else if locals.profiling_enabled {
+            } else if system_settings.profiling_enabled {
                 no
             } else {
                 no_all
@@ -759,13 +626,13 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
         zend::php_info_print_table_row(
             2,
             b"Experimental CPU Time Profiling Enabled\0".as_ptr(),
-            if locals.profiling_experimental_cpu_time_enabled {
-                if locals.profiling_experimental_features_enabled {
+            if system_settings.profiling_experimental_cpu_time_enabled {
+                if system_settings.profiling_experimental_features_enabled {
                     yes_exp
                 } else {
                     yes
                 }
-            } else if locals.profiling_enabled {
+            } else if system_settings.profiling_enabled {
                 no
             } else {
                 no_all
@@ -777,11 +644,11 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Allocation Profiling Enabled\0".as_ptr(),
-                    if locals.profiling_allocation_enabled {
+                    if system_settings.profiling_allocation_enabled {
                         yes
                     } else if zend::ddog_php_jit_enabled() {
                         b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.\0"
-                    } else if locals.profiling_enabled {
+                    } else if system_settings.profiling_enabled {
                         no
                     } else {
                         no_all
@@ -801,9 +668,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Timeline Enabled\0".as_ptr(),
-                    if locals.profiling_timeline_enabled {
+                    if system_settings.profiling_timeline_enabled {
                         yes
-                    } else if locals.profiling_enabled {
+                    } else if system_settings.profiling_enabled {
                         no
                     } else {
                         no_all
@@ -823,9 +690,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                 zend::php_info_print_table_row(
                     2,
                     b"Exception Profiling Enabled\0".as_ptr(),
-                    if locals.profiling_exception_enabled {
+                    if system_settings.profiling_exception_enabled {
                         yes
-                    } else if locals.profiling_enabled {
+                    } else if system_settings.profiling_enabled {
                         no
                     } else {
                         no_all
@@ -843,9 +710,9 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
         zend::php_info_print_table_row(
             2,
             b"Endpoint Collection Enabled\0".as_ptr(),
-            if locals.profiling_endpoint_collection_enabled {
+            if system_settings.profiling_endpoint_collection_enabled {
                 yes
-            } else if locals.profiling_enabled {
+            } else if system_settings.profiling_enabled {
                 no
             } else {
                 no_all
@@ -862,12 +729,12 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
             },
         );
 
-        let mut log_level = format!("{}\0", locals.profiling_log_level);
+        let mut log_level = format!("{}\0", system_settings.profiling_log_level);
         log_level.make_ascii_lowercase();
         zend::php_info_print_table_row(2, b"Profiling Log Level\0".as_ptr(), log_level.as_ptr());
 
         let key = b"Profiling Agent Endpoint\0".as_ptr();
-        let agent_endpoint = format!("{}\0", locals.uri);
+        let agent_endpoint = format!("{}\0", system_settings.uri);
         zend::php_info_print_table_row(2, key, agent_endpoint.as_ptr());
 
         let vars = [
@@ -895,8 +762,11 @@ extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     #[cfg(debug_assertions)]
     trace!("MSHUTDOWN({_type}, {_module_number})");
 
+    // SAFETY: being called before config::mshutdown.
     #[cfg(feature = "timeline")]
-    timeline::timeline_mshutdown();
+    unsafe {
+        timeline::timeline_mshutdown()
+    };
 
     #[cfg(feature = "exception_profiling")]
     exception::exception_profiling_mshutdown();
@@ -907,6 +777,8 @@ extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     if let Some(profiler) = profiler.as_mut() {
         profiler.stop(Duration::from_secs(1));
     }
+
+    unsafe { config::mshutdown() };
 
     ZendResult::Success
 }
@@ -968,7 +840,8 @@ extern "C" fn shutdown(_extension: *mut ZendExtension) {
 fn notify_trace_finished(local_root_span_id: u64, span_type: Cow<str>, resource: Cow<str>) {
     REQUEST_LOCALS.with(|cell| {
         let locals = cell.borrow();
-        if locals.profiling_enabled && locals.profiling_endpoint_collection_enabled {
+        let system_settings = locals.system_settings();
+        if system_settings.profiling_enabled && system_settings.profiling_endpoint_collection_enabled {
             // Only gather Endpoint Profiling data for web spans, partly for PII reasons.
             if span_type != "web" {
                 debug!(
@@ -992,47 +865,4 @@ fn notify_trace_finished(local_root_span_id: u64, span_type: Cow<str>, resource:
             }
         }
     });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn detect_uri_from_config_works() {
-        // expected
-        let endpoint = detect_uri_from_config(None, None, None);
-        let expected = AgentEndpoint::default();
-        assert_eq!(endpoint, expected);
-
-        // ipv4 host
-        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("127.0.0.1".to_owned())), None);
-        let expected = AgentEndpoint::Uri(Uri::from_static("http://127.0.0.1:8126"));
-        assert_eq!(endpoint, expected);
-
-        // ipv6 host
-        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("::1".to_owned())), None);
-        let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:8126"));
-        assert_eq!(endpoint, expected);
-
-        // ipv6 host, custom port
-        let endpoint = detect_uri_from_config(None, Some(Cow::Owned("::1".to_owned())), Some(9000));
-        let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:9000"));
-        assert_eq!(endpoint, expected);
-
-        // agent_url
-        let endpoint =
-            detect_uri_from_config(Some(Cow::Owned("http://[::1]:8126".to_owned())), None, None);
-        let expected = AgentEndpoint::Uri(Uri::from_static("http://[::1]:8126"));
-        assert_eq!(endpoint, expected);
-
-        // fallback on non existing UDS
-        let endpoint = detect_uri_from_config(
-            Some(Cow::Owned("unix://foo/bar/baz/I/do/not/exist".to_owned())),
-            None,
-            None,
-        );
-        let expected = AgentEndpoint::default();
-        assert_eq!(endpoint, expected);
-    }
 }

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -559,3 +559,7 @@ static const zend_function_entry functions[] = {
     ZEND_FE_END
 };
 const zend_function_entry* ddog_php_prof_functions = functions;
+
+zval *ddog_php_prof_get_memoized_config(uint16_t config_id) {
+    return &zai_config_memoized_entries[config_id].decoded_value;
+}

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -16,7 +16,8 @@ use crate::bindings::ddog_php_prof_get_active_fiber_test as ddog_php_prof_get_ac
 
 use crate::bindings::{datadog_php_profiling_get_profiling_context, zend_execute_data};
 use crate::config::SystemSettings;
-use crate::{AgentEndpoint, CLOCKS, TAGS};
+use crate::{CLOCKS, TAGS};
+use core::{ptr, str};
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use datadog_profiling::api::{
     Function, Label as ApiLabel, Location, Period, Sample, ValueType as ApiValueType,
@@ -29,7 +30,6 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::intrinsics::transmute;
 use std::num::NonZeroI64;
-use std::str;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread::JoinHandle;
@@ -148,7 +148,6 @@ impl ValueType {
 pub struct ProfileIndex {
     pub sample_types: Vec<ValueType>,
     pub tags: Arc<Vec<Tag>>,
-    pub endpoint: AgentEndpoint,
 }
 
 #[derive(Debug)]
@@ -208,9 +207,17 @@ pub struct Profiler {
     time_collector_handle: JoinHandle<()>,
     uploader_handle: JoinHandle<()>,
     should_join: AtomicBool,
-    system_settings: SystemSettings,
     sample_types_filter: SampleTypeFilter,
+    system_settings: ptr::NonNull<SystemSettings>,
 }
+
+/// The [Profiler] is sync *except* for some edge cases system_settings, which
+/// may be mutated under fringe conditions like in the child of a fork.
+unsafe impl Sync for Profiler {}
+
+/// The [Profiler] is send *except* for some edge cases system_settings, which
+/// may be mutated under fringe conditions like in the child of a fork.
+unsafe impl Send for Profiler {}
 
 struct TimeCollector {
     fork_barrier: Arc<Barrier>,
@@ -502,7 +509,7 @@ pub enum UploadMessage {
 }
 
 impl Profiler {
-    pub fn new(system_settings: SystemSettings) -> Self {
+    pub fn new(system_settings: &SystemSettings) -> Self {
         let fork_barrier = Arc::new(Barrier::new(3));
         let interrupt_manager = Arc::new(InterruptManager::new());
         let (message_sender, message_receiver) = crossbeam_channel::bounded(100);
@@ -519,11 +526,12 @@ impl Profiler {
             fork_barrier.clone(),
             upload_receiver,
             system_settings.output_pprof.clone(),
+            system_settings.uri.clone(),
         );
 
         let ddprof_time = "ddprof_time";
         let ddprof_upload = "ddprof_upload";
-        let sample_types_filter = SampleTypeFilter::new(&system_settings);
+        let sample_types_filter = SampleTypeFilter::new(system_settings);
         Profiler {
             fork_barrier,
             interrupt_manager,
@@ -538,13 +546,9 @@ impl Profiler {
                 trace!("thread {ddprof_upload} complete, shutting down");
             }),
             should_join: AtomicBool::new(true),
-            system_settings,
             sample_types_filter,
+            system_settings: ptr::NonNull::from(system_settings),
         }
-    }
-
-    pub fn is_timeline_enabled(&self) -> bool {
-        self.system_settings.profiling_timeline_enabled
     }
 
     pub fn add_interrupt(&self, interrupt: VmInterrupt) {
@@ -673,8 +677,10 @@ impl Profiler {
 
                 let labels = Profiler::message_labels();
                 let mut timestamp = 0;
+                // SAFETY: collecting time is done during PHP requests only,
+                //         so the ptr is valid at this time.
                 #[cfg(feature = "timeline")]
-                if self.is_timeline_enabled() {
+                if unsafe { self.system_settings.as_ref() }.profiling_timeline_enabled {
                     if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
                         timestamp = now.as_nanos() as i64;
                     }
@@ -999,37 +1005,33 @@ impl Profiler {
         #[cfg(not(php_has_fibers))] labels: Vec<Label>,
         timestamp: i64,
     ) -> SampleMessage {
-        let mut sample_types = Vec::new();
-        let mut sample_values = Vec::new();
+        // If profiling is disabled, these will naturally return empty Vec.
+        // There's no short-cutting here because:
+        //  1. Nobody should be calling this when it's disabled anyway.
+        //  2. It would require tracking more state and/or spending CPU on
+        //     something that shouldn't be done anyway (see #1).
+        let sample_types = self.sample_types_filter.sample_types();
+        let sample_values = self.sample_types_filter.filter(samples);
 
-        if self.system_settings.profiling_enabled {
-            sample_types = self.sample_types_filter.sample_types();
-            sample_values = self.sample_types_filter.filter(samples);
-
-            #[cfg(php_has_fibers)]
-            if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
-                // Safety: the fcc is set by Fiber::__construct as part of zpp,
-                // which will always set the function_handler on success, and
-                // there's nothing changing that value in all of fibers
-                // afterwards, from start to destruction of the fiber itself.
-                let func = unsafe { &*fiber.fci_cache.function_handler };
-                if let Some(functionname) = extract_function_name(func) {
-                    labels.push(Label {
-                        key: "fiber",
-                        value: LabelValue::Str(functionname.into()),
-                    });
-                }
+        #[cfg(php_has_fibers)]
+        if let Some(fiber) = unsafe { ddog_php_prof_get_active_fiber().as_mut() } {
+            // Safety: the fcc is set by Fiber::__construct as part of zpp,
+            // which will always set the function_handler on success, and
+            // there's nothing changing that value in all of fibers
+            // afterwards, from start to destruction of the fiber itself.
+            let func = unsafe { &*fiber.fci_cache.function_handler };
+            if let Some(functionname) = extract_function_name(func) {
+                labels.push(Label {
+                    key: "fiber",
+                    value: LabelValue::Str(functionname.into()),
+                });
             }
         }
 
         let tags = TAGS.with(|cell| Arc::clone(&cell.borrow()));
 
         SampleMessage {
-            key: ProfileIndex {
-                sample_types,
-                tags,
-                endpoint: self.system_settings.uri.clone(),
-            },
+            key: ProfileIndex { sample_types, tags },
             value: SampleData {
                 frames,
                 labels,
@@ -1043,6 +1045,7 @@ impl Profiler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::AgentEndpoint;
     use datadog_profiling::exporter::Uri;
     use log::LevelFilter;
 
@@ -1093,7 +1096,7 @@ mod tests {
         settings.profiling_experimental_cpu_time_enabled = true;
         settings.profiling_timeline_enabled = true;
 
-        let profiler = Profiler::new(settings);
+        let profiler = Profiler::new(&settings);
 
         let message: SampleMessage = profiler.prepare_sample_message(frames, samples, labels, 900);
 

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -115,10 +115,12 @@ impl Uploader {
                     Ok(UploadMessage::Upload(request)) => {
                         match pprof_filename {
                             Some(filename) => {
-                                let filename_str = filename.as_ref();
+                                let filename_prefix = filename.as_ref();
                                 let r = request.profile.serialize_into_compressed_pprof(None, None).unwrap();
                                 i += 1;
-                                std::fs::write(format!("{filename_str}.{i}.lz4"), r.buffer).expect("write to succeed")
+                                let name = format!("{filename_prefix}.{i}.lz4");
+                                std::fs::write(&name, r.buffer).expect("write to succeed");
+                                info!("Successfully wrote profile to {name}");
                             },
                             None => match self.upload(request) {
                                 Ok(status) => {

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -115,9 +115,10 @@ impl Uploader {
                     Ok(UploadMessage::Upload(request)) => {
                         match pprof_filename {
                             Some(filename) => {
+                                let filename_str = filename.as_ref();
                                 let r = request.profile.serialize_into_compressed_pprof(None, None).unwrap();
                                 i += 1;
-                                std::fs::write(format!("{filename}.{i}.lz4"), r.buffer).expect("write to succeed")
+                                std::fs::write(format!("{filename_str}.{i}.lz4"), r.buffer).expect("write to succeed")
                             },
                             None => match self.upload(request) {
                                 Ok(status) => {

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -243,7 +243,7 @@ pub fn timeline_prshutdown() {
 /// period for this PHP thread. This will report the last `IDLE_SINCE` duration created in the last
 /// `P-RSHUTDOWN` (just above) when the PHP process is shutting down.
 /// # Saftey
-/// Must be called in mshutdown before [crate::config::mshutdown].
+/// Must be called in mshutdown before [crate::config::shutdown].
 pub(crate) unsafe fn timeline_mshutdown() {
     IDLE_SINCE.with(|cell| {
         // try to borrow and bail out if not successful

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -243,7 +243,7 @@ pub fn timeline_prshutdown() {
 /// period for this PHP thread. This will report the last `IDLE_SINCE` duration created in the last
 /// `P-RSHUTDOWN` (just above) when the PHP process is shutting down.
 /// # Saftey
-/// Must be called in mshutdown before [crate::config::shutdown].
+/// Must be called in shutdown before [crate::config::shutdown].
 pub(crate) unsafe fn timeline_mshutdown() {
     IDLE_SINCE.with(|cell| {
         // try to borrow and bail out if not successful
@@ -256,6 +256,7 @@ pub(crate) unsafe fn timeline_mshutdown() {
                 .try_borrow()
                 .map(|locals| locals.system_settings().profiling_timeline_enabled)
                 .unwrap_or(false);
+
             if !is_timeline_enabled {
                 return;
             }

--- a/profiling/src/wall_time.rs
+++ b/profiling/src/wall_time.rs
@@ -39,7 +39,7 @@ pub extern "C" fn ddog_php_prof_interrupt_function(execute_data: *mut zend_execu
             return;
         };
 
-        if !locals.profiling_enabled {
+        if !locals.system_settings().profiling_enabled {
             return;
         }
 

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -29,7 +29,6 @@ opcache.jit_buffer_size=4M
 <?php
 echo "Done.", PHP_EOL;
 ?>
---EXPECTREGEX--
-.*Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https:\/\/github.com\/DataDog\/dd-trace-php\/pull\/2088
-.*Done.
-.*
+--EXPECTF--
+%aMemory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https://github.com/DataDog/dd-trace-php/pull/2088
+%ADone.%a

--- a/profiling/tests/phpt/phpinfo_01.phpt
+++ b/profiling/tests/phpt/phpinfo_01.phpt
@@ -51,7 +51,7 @@ $sections = [
     ["Allocation Profiling Enabled", "false (profiling disabled)"],
     ["Exception Profiling Enabled", "false (profiling disabled)"],
     ["Endpoint Collection Enabled", "false (profiling disabled)"],
-    ["Profiling Log Level", "info"],
+    ["Profiling Log Level", "off (profiling disabled)"],
     ["Profiling Agent Endpoint", "http://datadog:8126/"],
     ["Application's Environment (DD_ENV)", "dev"],
     ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],

--- a/profiling/tests/phpt/phpinfo_ini_01.phpt
+++ b/profiling/tests/phpt/phpinfo_ini_01.phpt
@@ -50,7 +50,7 @@ $sections = [
     ["Allocation Profiling Enabled", "false (profiling disabled)"],
     ["Exception Profiling Enabled", "false (profiling disabled)"],
     ["Endpoint Collection Enabled", "false (profiling disabled)"],
-    ["Profiling Log Level", "info"],
+    ["Profiling Log Level", "off (profiling disabled)"],
     ["Profiling Agent Endpoint", "http://datadog:8126/"],
     ["Application's Environment (DD_ENV)", "dev"],
     ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],


### PR DESCRIPTION
### Description

PROF-8912

The recently introduced `SystemSettings` had its data duplicated in `RequestLocals` because there were multiple ways to handle that issue. This PR is one way to resolve this.

There's now one `SystemSettings` in memory, and it's defined in `src/config.rs`. The `RequestLocals` and `Profiler` objects hold a non-null pointer to it. The system settings are fetched from the zai config's memoized entries, rather than the thread-locals, and this is done on first rinit. These changes caused a fair bit of churn in the codebase.

There are a few side effects as well:

- The agent endpoint is no longer part of the profile index key, since that's part of system configuration. Less things to hash and compare, so this is a tiny perf reduction on each sample collected.
- The allocation profiler does some runtime checks and disables the allocation profiler under certain circumstances. One of these was moved to rinit, but the other is now a runtime panic, because the new invariants cannot be upheld per-request.
- The minfo for logging will now say "off (profiling disabled)" when profiling is disabled. Previously, it reported whatever the value would be if profiling was enabled but it was actually off.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
