### PR TITLE
Reduce macrobenchmark flakiness

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -99,7 +99,7 @@ download_circle_ci_release:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:php_laravel-realworld
   script:
     - git clone --branch php/laravel-realworld https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
-    - bp-runner bp-runner.yml --debug
+    - ./steps/run-benchmarks.sh
   artifacts:
     name: "artifacts"
     when: always
@@ -109,15 +109,21 @@ download_circle_ci_release:
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
+    K6_OPTIONS_WARMUP_RATE: 70
+    K6_OPTIONS_WARMUP_DURATION: 1m
+    K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
+    K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_WARMUP_MAX_VUS: 4
+
     K6_OPTIONS_NORMAL_OPERATION_RATE: 50
-    K6_OPTIONS_NORMAL_OPERATION_DURATION: 20m
-    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 1m
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 5m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
     K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
 
     K6_OPTIONS_HIGH_LOAD_RATE: 200
-    K6_OPTIONS_HIGH_LOAD_DURATION: 5m
-    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 1m
+    K6_OPTIONS_HIGH_LOAD_DURATION: 2m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
     K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
 
@@ -130,17 +136,5 @@ macrobenchmarks:
   extends: .macrobenchmarks
   parallel:
     matrix:
-      - DD_BENCHMARKS_CONFIGURATION: baseline
-        PHP_VERSION: "8.1"
-
-      - DD_BENCHMARKS_CONFIGURATION: baseline
-        PHP_VERSION: "7.4"
-
-      - DD_BENCHMARKS_CONFIGURATION: only-tracing
-        PHP_VERSION: "8.1"
-
-      - DD_BENCHMARKS_CONFIGURATION: only-tracing
-        PHP_VERSION: "7.4"
-
-      - DD_BENCHMARKS_CONFIGURATION: no-sidecar
-        PHP_VERSION: "8.1"
+      - PHP_VERSION: "7.4"
+      - PHP_VERSION: "8.1"


### PR DESCRIPTION
### Description

Reduce flakiness of macrobenchmark.

Improves spread of p50 latency from 9.7ms to 0.02ms (by ~40x).

Downside is that all variants are run now sequentially on the same machine (which currently takes still under 30 minutes).

If we need to scale horizontally to reduce execution time, there should be done more investigation into flakiness on reruns (in particular, I would use same seed for [random data generation](https://github.com/PROFeNoM/laravel-realworld-example-app/blob/main/database/seeders/DummyDataSeeder.php#L29-L81) that happens on benchmark reruns, but totally possible that something more might be done there).

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
