### PR TITLE
Remove Symfony Command Hook After Execution

### DIFF
--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -274,7 +274,7 @@ class SymfonyIntegration extends Integration
                     $span->resource = $this->getName() ?: $span->name;
                     $span->service = \ddtrace_config_app_name($integration->frameworkPrefix);
                     $span->type = Type::CLI;
-                    $span->meta['symfony.console.command.class'] = get_class($this);
+                    $span->meta['symfony.console.command.class'] = \get_class($this);
                     $span->meta[Tag::COMPONENT] = SymfonyIntegration::NAME;
                 }
             ]


### PR DESCRIPTION
### Description

Fixes #2427

This PR should have been included with #2436

TL;DR of the issue:
```
Could not add hook to MyCommand::run with more than datadog.trace.hook_limit = 100 installed hooks in /opt/datadog-php/dd-trace-sources/bridge/_generated_integrations.php on line 4014; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
```

The current implementation of the command hooks adds a hook to a `<scope>::run` if it wasn't already added. This could, theoretically, lead to multiple hooks added when considering numerous inheritors.

About the fix: Considering that in the previous version the hook was made on `Symfony\Component\Console\Command\Command::__construct`, it means that `$scope` fundamentally represents a `Symfony\Component\Console\Command\Command` instance. From this, the new implementation directly hooks `Symfony\Component\Console\Command\Command::run` instead of adding a seemingly unnecessary intermediary step.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
