### PR TITLE
ci(profiling) prof correctness supports lz4 now

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -90,7 +90,6 @@ jobs:
               mkdir -p profiling/tests/correctness/"$test_case"/
               export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof
               php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/"$test_case".php
-              lz4 -d --rm "$DD_PROFILING_OUTPUT_PPROF".1.lz4 "$DD_PROFILING_OUTPUT_PPROF"
           done
 
       - name: Check profiler correctness for allocations


### PR DESCRIPTION
### Description

With https://github.com/DataDog/prof-correctness/pull/21 the `prof-correctness` tests in this repo started failing, as the regex looking for `pprof` files does not match anymore. Luckily the referenced PR also brings lz4 support to prof-correctness, so we can just remove the `lz4 -d` step and let `prof-correctness` read directly from that lz4 file 🎉 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [x] Test coverage seems ok.
- [ ] Appropriate labels assigned.
