### PR TITLE
Include generated curl_exec spans of curl_multi_exec() in metrics

### DIFF
--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -131,6 +131,7 @@ final class CurlIntegration extends Integration
                     // finished
                     foreach ($spans as $requestSpan) {
                         list($ch, $requestSpan) = $requestSpan;
+                        $requestSpan->metrics["_dd.measured"] = 1;
                         $info = curl_getinfo($ch);
                         if (isset($requestSpan->meta['network.destination.name']) && $requestSpan->meta['network.destination.name'] !== 'unparsable-host') {
                             continue;

--- a/tests/snapshots/tests.integrations.guzzle.v6.guzzle_integration_test.test_multi_exec.json
+++ b/tests/snapshots/tests.integrations.guzzle.v6.guzzle_integration_test.test_multi_exec.json
@@ -258,6 +258,9 @@
             "network.destination.name": "google.wrong",
             "network.destination.port": "0",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -309,6 +312,9 @@
             "network.destination.name": "google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -360,6 +366,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -410,6 +419,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -460,6 +472,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -510,6 +525,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -562,6 +580,9 @@
             "network.destination.name": "google.still.wrong",
             "network.destination.port": "0",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -612,6 +633,9 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -662,6 +686,9 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -712,5 +739,8 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         }]]

--- a/tests/snapshots/tests.integrations.guzzle.v7.guzzle_integration_test.test_multi_exec.json
+++ b/tests/snapshots/tests.integrations.guzzle.v7.guzzle_integration_test.test_multi_exec.json
@@ -258,6 +258,9 @@
             "network.destination.name": "google.wrong",
             "network.destination.port": "0",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -309,6 +312,9 @@
             "network.destination.name": "google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -360,6 +366,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -410,6 +419,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -460,6 +472,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -510,6 +525,9 @@
             "network.destination.name": "httpbin_integration",
             "network.destination.port": "80",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -562,6 +580,9 @@
             "network.destination.name": "google.still.wrong",
             "network.destination.port": "0",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -612,6 +633,9 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -662,6 +686,9 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         },
         {
@@ -712,5 +739,8 @@
             "network.destination.name": "www.google.com",
             "network.destination.port": "443",
             "span.kind": "client"
+          },
+          "metrics": {
+            "_dd.measured": 1
           }
         }]]


### PR DESCRIPTION
### Description

Gives the same experience for any curl_exec operation independently of whether it's behind curl_multi_exec or not.

Fixes #2504.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
