### PR TITLE
feat(profiling) allocation profiling for PHP ZTS

### DIFF
--- a/profiling/README.md
+++ b/profiling/README.md
@@ -4,8 +4,9 @@
 
 The profiler is implemented in Rust. To see the currently required Rust
 version, refer to the [rust-toolchain](rust-toolchain) file. The profiler
-requires PHP 7.1+, and does not support debug nor ZTS builds. There are bits of
-ZTS support in the build system and profiler, but it's not complete.
+requires PHP 7.1+, and does not support debug builds. There are bits of ZTS
+support in the build system and profiler, but it's not complete, consider the
+current state of ZTS support beta.
 
 ## Time Profiling
 

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -40,9 +40,10 @@ pub struct AllocationProfilingStats {
 }
 
 struct ZendMMState {
-    /// The heap installed in ZendMM at the time we install our custom handlers, this is also the
-    /// heap our custom handlers are installed in. We need this in case there is no custom handlers
-    /// installed prior to us, in order to forward our allocation calls to this heap.
+    /// The heap installed in ZendMM at the time we install our custom
+    /// handlers, this is also the heap our custom handlers are installed in.
+    /// We need this in case there is no custom handlers installed prior to us,
+    /// in order to forward our allocation calls to this heap.
     heap: Option<*mut zend::zend_mm_heap>,
     /// The engine's previous custom allocation function, if there is one.
     prev_custom_mm_alloc: Option<zend::VmMmCustomAllocFn>,
@@ -52,17 +53,20 @@ struct ZendMMState {
     prev_custom_mm_free: Option<zend::VmMmCustomFreeFn>,
     prepare_zend_heap: unsafe fn(heap: *mut zend::_zend_mm_heap) -> c_int,
     restore_zend_heap: unsafe fn(heap: *mut zend::_zend_mm_heap, custom_heap: c_int),
-    /// Safety: this function pointer is only allowed to point to `allocation_profiling_prev_alloc()`
-    /// when at the same time the `ZEND_MM_STATE.prev_custom_mm_alloc` is initialised to a valid
-    /// function pointer, otherwise there will be dragons.
+    /// Safety: this function pointer is only allowed to point to
+    /// `allocation_profiling_prev_alloc()` when at the same time the
+    /// `ZEND_MM_STATE.prev_custom_mm_alloc` is initialised to a valid function
+    /// pointer, otherwise there will be dragons.
     alloc: unsafe fn(size_t) -> *mut c_void,
-    /// Safety: this function pointer is only allowed to point to `allocation_profiling_prev_realloc()`
-    /// when at the same time the `ZEND_MM_STATE.prev_custom_mm_realloc` is initialised to a valid
+    /// Safety: this function pointer is only allowed to point to
+    /// `allocation_profiling_prev_realloc()` when at the same time the
+    /// `ZEND_MM_STATE.prev_custom_mm_realloc` is initialised to a valid
     /// function pointer, otherwise there will be dragons.
     realloc: unsafe fn(*mut c_void, size_t) -> *mut c_void,
-    /// Safety: this function pointer is only allowed to point to `allocation_profiling_prev_free()`
-    /// when at the same time the `ZEND_MM_STATE.prev_custom_mm_free` is initialised to a valid
-    /// function pointer, otherwise there will be dragons.
+    /// Safety: this function pointer is only allowed to point to
+    /// `allocation_profiling_prev_free()` when at the same time the
+    /// `ZEND_MM_STATE.prev_custom_mm_free` is initialised to a valid function
+    /// pointer, otherwise there will be dragons.
     free: unsafe fn(*mut c_void),
 }
 

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -106,23 +106,24 @@ impl AllocationProfilingStats {
 }
 
 thread_local! {
-    static ALLOCATION_PROFILING_STATS: RefCell<AllocationProfilingStats> = RefCell::new(AllocationProfilingStats::new());
-    /// Using an `UnsafeCell` here should be okay. There might not be any synchronisation issues,
-    /// as it is used in as thread local and only mutated in RINIT and RSHUTDOWN.
+    static ALLOCATION_PROFILING_STATS: RefCell<AllocationProfilingStats> =
+        RefCell::new(AllocationProfilingStats::new());
+
+    /// Using an `UnsafeCell` here should be okay. There might not be any
+    /// synchronisation issues, as it is used in as thread local and only
+    /// mutated in RINIT and RSHUTDOWN.
     static ZEND_MM_STATE: UnsafeCell<ZendMMState> = const {
-        UnsafeCell::new(
-            ZendMMState{
-                heap: None,
-                prev_custom_mm_alloc: None,
-                prev_custom_mm_realloc: None,
-                prev_custom_mm_free: None,
-                prepare_zend_heap: prepare_zend_heap,
-                restore_zend_heap: restore_zend_heap,
-                alloc:  allocation_profiling_orig_alloc,
-                realloc: allocation_profiling_orig_realloc,
-                free: allocation_profiling_orig_free,
-            }
-        )
+        UnsafeCell::new(ZendMMState {
+            heap: None,
+            prev_custom_mm_alloc: None,
+            prev_custom_mm_realloc: None,
+            prev_custom_mm_free: None,
+            prepare_zend_heap,
+            restore_zend_heap,
+            alloc: allocation_profiling_orig_alloc,
+            realloc: allocation_profiling_orig_realloc,
+            free: allocation_profiling_orig_free,
+        })
     };
 }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -282,7 +282,7 @@ extern "C" fn minit(_type: c_int, module_number: c_int) -> ZendResult {
     unsafe { zend::zend_register_extension(&extension, handle) };
 
     #[cfg(feature = "allocation_profiling")]
-    allocation::allocation_profiling_minit();
+    allocation::alloc_prof_minit();
 
     #[cfg(feature = "timeline")]
     timeline::timeline_minit();
@@ -369,8 +369,8 @@ thread_local! {
     /// The tags for this thread/request. These get sent to other threads,
     /// which is why they are Arc. However, they are wrapped in a RefCell
     /// because the values _can_ change from request to request depending on
-    /// the on the values sent in the SAPI for env, service, version, etc.
-    /// They get reset at the end of the request.
+    /// the values sent in the SAPI for env, service, version, etc. They get
+    /// reset at the end of the request.
     static TAGS: RefCell<Arc<Vec<Tag>>> = RefCell::new(Arc::new(Vec::new()));
 }
 
@@ -541,7 +541,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     }
 
     #[cfg(feature = "allocation_profiling")]
-    allocation::allocation_profiling_rinit();
+    allocation::alloc_prof_rinit();
 
     // SAFETY: called after config is initialized.
     #[cfg(feature = "timeline")]
@@ -599,7 +599,7 @@ extern "C" fn rshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     });
 
     #[cfg(feature = "allocation_profiling")]
-    allocation::allocation_profiling_rshutdown();
+    allocation::alloc_prof_rshutdown();
 
     ZendResult::Success
 }
@@ -843,7 +843,7 @@ extern "C" fn startup(extension: *mut ZendExtension) -> ZendResult {
     }
 
     #[cfg(feature = "allocation_profiling")]
-    allocation::allocation_profiling_startup();
+    allocation::alloc_prof_startup();
 
     ZendResult::Success
 }

--- a/profiling/src/pcntl.rs
+++ b/profiling/src/pcntl.rs
@@ -1,4 +1,4 @@
-use crate::allocation::allocation_profiling_rshutdown;
+use crate::allocation::alloc_prof_rshutdown;
 use crate::bindings::{
     datadog_php_install_handler, datadog_php_zif_handler, zend_execute_data, zend_long, zval,
     InternalFunctionHandler,
@@ -94,7 +94,7 @@ fn stop_and_forget_profiling(maybe_profiler: &mut Option<Profiler>) {
     swap(&mut *maybe_profiler, &mut old_profiler);
     forget(old_profiler);
 
-    allocation_profiling_rshutdown();
+    alloc_prof_rshutdown();
 
     // Reset some global state to prevent further profiling and to not handle
     // any pending interrupts.

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -15,11 +15,6 @@ if (!extension_loaded('datadog-profiling'))
 $arch = php_uname('m');
 if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
     echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
-
-// TODO: remove once ZTS support for allocation profiling is done
-if (PHP_ZTS) {
-    echo "skip: not support on ZTS builds at the moment";
-}
 ?>
 --INI--
 datadog.profiling.enabled=yes

--- a/profiling/tests/phpt/jit_02.phpt
+++ b/profiling/tests/phpt/jit_02.phpt
@@ -14,12 +14,6 @@ if (!extension_loaded('datadog-profiling'))
 $arch = php_uname('m');
 if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
     echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
-
-// TODO: remove once ZTS support for allocation profiling is done
-if (PHP_ZTS) {
-    echo "skip: not support on ZTS builds at the moment";
-}
-
 ?>
 --INI--
 datadog.profiling.enabled=yes

--- a/profiling/tests/phpt/phpinfo_02.phpt
+++ b/profiling/tests/phpt/phpinfo_02.phpt
@@ -14,11 +14,6 @@ if (!extension_loaded('datadog-profiling'))
 $arch = php_uname('m');
 if (PHP_VERSION_ID < 80100 && in_array($arch, ['aarch64', 'arm64']))
     echo "skip: JIT not available on aarch64 on PHP 8.0", PHP_EOL;
-
-// TODO: remove once ZTS support for allocation profiling is done
-if (PHP_ZTS) {
-    echo "skip: not support on ZTS builds at the moment";
-}
 ?>
 --ENV--
 DD_PROFILING_ENABLED=yes


### PR DESCRIPTION
### Description

PROF-8922 / #2070 

This PR will bring allocation profiling to ZTS versions of PHP. In the "there is another custom handler installed" code path we are using an `UnsafeCell` for a thread local which is the cheapest way (evaluated at compile time and not runtime), as this is in the hot path (every allocation and free would borrow check at runtime).
We could argue that the case of another extension that has custom handlers installed is nearly non existing, so we could also be better safe then sorry, but OTOH I could not get it to crash.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
