### PR TITLE
propagation: convert default style to datadog,tracecontext

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -131,11 +131,11 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED, "false")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED, "false")                                   \
     CONFIG(BOOL, DD_TRACE_PROPAGATE_SERVICE, "false")                                                          \
-    CALIAS(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE_EXTRACT, "tracecontext,Datadog,B3,B3 single header",      \
+    CALIAS(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE_EXTRACT, "datadog,tracecontext,B3,B3 single header",      \
            CALIASES("DD_PROPAGATION_STYLE_EXTRACT"))                                                           \
-    CALIAS(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE_INJECT, "tracecontext,Datadog",                           \
+    CALIAS(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE_INJECT, "datadog,tracecontext",                           \
            CALIASES("DD_PROPAGATION_STYLE_INJECT"))                                                            \
-    CONFIG(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE, "tracecontext,Datadog")                                  \
+    CONFIG(SET_LOWERCASE, DD_TRACE_PROPAGATION_STYLE, "datadog,tracecontext")                                  \
     CONFIG(SET, DD_TRACE_TRACED_INTERNAL_FUNCTIONS, "")                                                        \
     CONFIG(INT, DD_TRACE_AGENT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_TIMEOUT_VAL),                             \
            .ini_change = zai_config_system_ini_change)                                                         \

--- a/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
+++ b/tests/ext/integrations/curl/distributed_tracing_curl_drop_dm.phpt
@@ -10,7 +10,7 @@ DD_TRACE_LOG_LEVEL=info,startup=off
 DD_TRACE_GENERATE_ROOT_SPAN=0
 HTTP_TRACEPARENT=00-00000012345678907890123456789012-1234567890123456-00
 HTTP_TRACESTATE=foo=1,dd=s:1;t.dm:-0;t.usr.id:baz64~~;t.url:http://localhost
-DD_PROPAGATION_STYLE=tracecontext,Datadog
+DD_PROPAGATION_STYLE=datadog,tracecontext
 --FILE--
 <?php
 include 'curl_helper.inc';


### PR DESCRIPTION
### Description

W3C Phase 2: Convert default propagation headers from tracecontext,datadog to datadog,tracecontext

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
