### PR TITLE
Mark config as immutable and interned to avoid refcounting race conditions

### DIFF
--- a/appsec/src/extension/configuration.c
+++ b/appsec/src/extension/configuration.c
@@ -226,7 +226,7 @@ bool dd_config_minit(int module_number)
     // places wishing to use values pre-RINIT do have to explicitly opt in by
     // using the arduous way of accessing the decoded_value directly from
     // zai_config_memoized_entries.
-    zai_config_first_time_rinit();
+    zai_config_first_time_rinit(false);
 #ifdef TESTING
     _register_testing_objects();
 #endif
@@ -236,7 +236,7 @@ bool dd_config_minit(int module_number)
 
 void dd_config_first_rinit()
 {
-    zai_config_first_time_rinit();
+    zai_config_first_time_rinit(true);
     zai_config_rinit();
 
     runtime_config_first_init = true;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -140,7 +140,7 @@ bool ddtrace_config_minit(int module_number) {
     // Note that we are not calling zai_config_rinit(), i.e. the get_...() functions will not work.
     // This is intentional, so that places wishing to use values pre-RINIT do have to explicitly opt in by using the
     // arduous way of accessing the decoded_value directly from zai_config_memoized_entries.
-    zai_config_first_time_rinit();
+    zai_config_first_time_rinit(false);
 
     ddtrace_log_ginit();
     return true;
@@ -152,7 +152,7 @@ void ddtrace_config_first_rinit() {
     zend_string *internal_functions_old = zend_string_copy(
         internal_functions_ini->modified ? internal_functions_ini->orig_value : internal_functions_ini->value);
 
-    zai_config_first_time_rinit();
+    zai_config_first_time_rinit(true);
     zai_config_rinit();
 
     zend_string *internal_functions_new =

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -399,7 +399,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
 
     // SAFETY: not being mutated during rinit.
     unsafe { &ZAI_CONFIG_ONCE }.call_once(|| unsafe {
-        bindings::zai_config_first_time_rinit();
+        bindings::zai_config_first_time_rinit(true);
         config::first_rinit();
     });
 

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -154,8 +154,15 @@ static void zai_config_intern_zval(zval *pzval) {
 #endif
     }
     if (Z_TYPE_P(pzval) == IS_ARRAY) {
+        Z_ADDREF_P(pzval);
         GC_ADD_FLAGS(Z_ARR_P(pzval), IS_ARRAY_IMMUTABLE);
-        Z_TYPE_FLAGS_P(pzval) = IS_ARRAY_IMMUTABLE;
+#if PHP_VERSION_ID < 70200
+        Z_TYPE_FLAGS_P(pzval) = IS_TYPE_IMMUTABLE;
+#elif PHP_VERSION_ID < 70300
+        Z_TYPE_FLAGS_P(pzval) = IS_TYPE_COPYABLE;
+#else
+        Z_TYPE_FLAGS_P(pzval) = 0;
+#endif
 
 #if PHP_VERSION_ID >= 80200
         if (HT_IS_PACKED(Z_ARR_P(pzval))) {

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -142,11 +142,12 @@ void zai_config_runtime_config_dtor(void);
 
 #if PHP_VERSION_ID < 70300
 #define GC_ADD_FLAGS(c, flag) GC_FLAGS(c) |= flag
+#define GC_ADDREF(p) ++GC_REFCOUNT(p)
 #endif
 
 static void zai_config_intern_zval(zval *pzval) {
     if (Z_TYPE_P(pzval) == IS_STRING) {
-#if PHP_VERSION_ID >= 70200
+#if PHP_VERSION_ID >= 70400
         ZVAL_INTERNED_STR(pzval, zend_new_interned_string(Z_STR_P(pzval)));
 #else
         GC_ADD_FLAGS(Z_STR_P(pzval), IS_STR_INTERNED);
@@ -154,7 +155,7 @@ static void zai_config_intern_zval(zval *pzval) {
 #endif
     }
     if (Z_TYPE_P(pzval) == IS_ARRAY) {
-        Z_ADDREF_P(pzval);
+        GC_ADDREF(Z_ARR_P(pzval));
         GC_ADD_FLAGS(Z_ARR_P(pzval), IS_ARRAY_IMMUTABLE);
 #if PHP_VERSION_ID < 70200
         Z_TYPE_FLAGS_P(pzval) = IS_TYPE_IMMUTABLE;
@@ -176,7 +177,7 @@ static void zai_config_intern_zval(zval *pzval) {
         Bucket *bucket;
             ZEND_HASH_FOREACH_BUCKET(Z_ARR_P(pzval), bucket) {
                 if (bucket->key) {
-#if PHP_VERSION_ID >= 70200
+#if PHP_VERSION_ID >= 70400
                     bucket->key = zend_new_interned_string(bucket->key);
 #else
                     GC_ADD_FLAGS(bucket->key, IS_STR_INTERNED);
@@ -189,7 +190,7 @@ static void zai_config_intern_zval(zval *pzval) {
 }
 
 void zai_config_first_time_rinit(bool in_request) {
-#if PHP_VERSION_ID >= 70200
+#if PHP_VERSION_ID >= 70400
     if (in_request) {
         zend_interned_strings_switch_storage(0);
     }
@@ -203,7 +204,7 @@ void zai_config_first_time_rinit(bool in_request) {
         }
     }
 
-#if PHP_VERSION_ID >= 70200
+#if PHP_VERSION_ID >= 70400
     if (in_request) {
         zend_interned_strings_switch_storage(1);
     }

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -140,11 +140,67 @@ void zai_config_mshutdown(void) {
 void zai_config_runtime_config_ctor(void);
 void zai_config_runtime_config_dtor(void);
 
-void zai_config_first_time_rinit(void) {
+#if PHP_VERSION_ID < 70300
+#define GC_ADD_FLAGS(c, flag) GC_FLAGS(c) |= flag
+#endif
+
+static void zai_config_intern_zval(zval *pzval) {
+    if (Z_TYPE_P(pzval) == IS_STRING) {
+#if PHP_VERSION_ID >= 70200
+        ZVAL_INTERNED_STR(pzval, zend_new_interned_string(Z_STR_P(pzval)));
+#else
+        GC_ADD_FLAGS(Z_STR_P(pzval), IS_STR_INTERNED);
+        Z_TYPE_INFO_P(pzval) = IS_INTERNED_STRING_EX;
+#endif
+    }
+    if (Z_TYPE_P(pzval) == IS_ARRAY) {
+        GC_ADD_FLAGS(Z_ARR_P(pzval), IS_ARRAY_IMMUTABLE);
+        Z_TYPE_FLAGS_P(pzval) = IS_ARRAY_IMMUTABLE;
+
+#if PHP_VERSION_ID >= 80200
+        if (HT_IS_PACKED(Z_ARR_P(pzval))) {
+            zval *zv;
+            ZEND_HASH_FOREACH_VAL(Z_ARR_P(pzval), zv) {
+                zai_config_intern_zval(zv);
+            } ZEND_HASH_FOREACH_END();
+        } else
+#endif
+        {
+        Bucket *bucket;
+            ZEND_HASH_FOREACH_BUCKET(Z_ARR_P(pzval), bucket) {
+                if (bucket->key) {
+#if PHP_VERSION_ID >= 70200
+                    bucket->key = zend_new_interned_string(bucket->key);
+#else
+                    GC_ADD_FLAGS(bucket->key, IS_STR_INTERNED);
+#endif
+                }
+                zai_config_intern_zval(&bucket->val);
+            } ZEND_HASH_FOREACH_END();
+        }
+    }
+}
+
+void zai_config_first_time_rinit(bool in_request) {
+#if PHP_VERSION_ID >= 70200
+    if (in_request) {
+        zend_interned_strings_switch_storage(0);
+    }
+#endif
+
     for (uint8_t i = 0; i < zai_config_memoized_entries_count; i++) {
         zai_config_memoized_entry *memoized = &zai_config_memoized_entries[i];
         zai_config_find_and_set_value(memoized, i);
+        if (in_request) {
+            zai_config_intern_zval(&memoized->decoded_value);
+        }
     }
+
+#if PHP_VERSION_ID >= 70200
+    if (in_request) {
+        zend_interned_strings_switch_storage(1);
+    }
+#endif
 }
 
 void zai_config_rinit(void) {

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -80,7 +80,7 @@ void zai_config_mshutdown(void);
 // Not thread-safe; must block (Use pthread_once)
 // Must be called before zai_config_rinit()
 // Update decoded_value with env/ini value if exists
-void zai_config_first_time_rinit(void);
+void zai_config_first_time_rinit(bool in_request);
 
 // Runtime config ctor (++rc)
 void zai_config_rinit(void);

--- a/zend_abstract_interface/config/tests/ext_zai_config.cc
+++ b/zend_abstract_interface/config/tests/ext_zai_config.cc
@@ -46,7 +46,7 @@ static PHP_RINIT_FUNCTION(zai_config) {
 
         int expected_first_rinit = 1;
         if (atomic_compare_exchange_strong(&ext_first_rinit, &expected_first_rinit, 0)) {
-            zai_config_first_time_rinit();
+            zai_config_first_time_rinit(true);
         }
 
         zai_config_rinit();

--- a/zend_abstract_interface/config/tests/ini.cc
+++ b/zend_abstract_interface/config/tests/ini.cc
@@ -528,7 +528,7 @@ TEST_INI("setting perdir INI setting for multiple ZAI config users", {
     zai_config_memoized_entry *entry = &zai_config_memoized_entries[EXT_CFG_INI_FOO_STRING];
     entry->original_on_modify = dummy;
 
-    zai_config_first_time_rinit();
+    zai_config_first_time_rinit(true);
     REQUEST_BEGIN();
 
     zval *value = zai_config_get_value(EXT_CFG_INI_FOO_STRING);

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -164,6 +164,10 @@ void zai_json_release_persistent_array(HashTable *ht) {
 void zai_json_dtor_pzval(zval *pval) {
     if (Z_TYPE_P(pval) == IS_ARRAY) {
         zai_json_release_persistent_array(Z_ARR_P(pval));
+#if PHP_VERSION_ID >= 70200
+    } else if (Z_TYPE_P(pval) == IS_STRING && ZSTR_IS_INTERNED(Z_STR_P(pval))) {
+        // nothing
+#endif
     } else {
         zval_internal_ptr_dtor(pval);
     }

--- a/zend_abstract_interface/json/json.c
+++ b/zend_abstract_interface/json/json.c
@@ -150,10 +150,11 @@ void zai_json_shutdown_bindings(void) {
 }
 
 void zai_json_release_persistent_array(HashTable *ht) {
+    uint32_t immutable = (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) != 0;
 #if PHP_VERSION_ID < 70300
-    if (--GC_REFCOUNT(ht) == 0)
+    if (--GC_REFCOUNT(ht) == immutable)
 #else
-    if (GC_DELREF(ht) == 0)
+    if (GC_DELREF(ht) == immutable)
 #endif
     {
         zend_hash_destroy(ht);


### PR DESCRIPTION
### Description

Multiple threads manipulating the refcount at once is a possible source of race conditions (especially with many small requests increasing the likeness).

Properly mark the strings as interned / arrays as immutable to avoid this.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
