### PR TITLE
Make PDO split-by coherent with other DB split-by with service name flattening

### DIFF
--- a/src/Integrations/Integrations/Integration.php
+++ b/src/Integrations/Integrations/Integration.php
@@ -156,10 +156,10 @@ abstract class Integration
      * @param SpanData $span
      * @param string $fallbackName
      */
-    public static function handleInternalSpanServiceName(SpanData $span, $fallbackName)
+    public static function handleInternalSpanServiceName(SpanData $span, $fallbackName, $skipFlattening = false)
     {
         $flatServiceNames =
-            \PHP_MAJOR_VERSION > 5
+            !$skipFlattening && \PHP_MAJOR_VERSION > 5
                 && \dd_trace_env_config('DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED');
 
         if ($flatServiceNames) {

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -317,8 +317,9 @@ class PDOIntegration extends Integration
             \DDTrace\Util\Runtime::getBoolIni("datadog.trace.db_client_split_by_instance") &&
                 isset($storedConnectionInfo[Tag::TARGET_HOST])
         ) {
-            $span->service = PDOIntegration::NAME . '-' .
-                    \DDTrace\Util\Normalizer::normalizeHostUdsAsService($storedConnectionInfo[Tag::TARGET_HOST]);
+            Integration::handleInternalSpanServiceName($span, PDOIntegration::NAME, true);
+            $span->service = $span->service
+                . '-' . \DDTrace\Util\Normalizer::normalizeHostUdsAsService($storedConnectionInfo[Tag::TARGET_HOST]);
         } else {
             Integration::handleInternalSpanServiceName($span, PDOIntegration::NAME);
         }

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -311,14 +311,16 @@ class PDOIntegration extends Integration
         }
 
         $span->type = Type::SQL;
-        Integration::handleInternalSpanServiceName($span, PDOIntegration::NAME);
         $span->meta[Tag::SPAN_KIND] = 'client';
         $span->meta[Tag::COMPONENT] = PDOIntegration::NAME;
-        if (\DDTrace\Util\Runtime::getBoolIni("datadog.trace.db_client_split_by_instance")) {
-            if (isset($storedConnectionInfo[Tag::TARGET_HOST])) {
-                $span->service .=
-                    '-' . \DDTrace\Util\Normalizer::normalizeHostUdsAsService($storedConnectionInfo[Tag::TARGET_HOST]);
-            }
+        if (
+            \DDTrace\Util\Runtime::getBoolIni("datadog.trace.db_client_split_by_instance") &&
+                isset($storedConnectionInfo[Tag::TARGET_HOST])
+        ) {
+            $span->service = PDOIntegration::NAME . '-' .
+                    \DDTrace\Util\Normalizer::normalizeHostUdsAsService($storedConnectionInfo[Tag::TARGET_HOST]);
+        } else {
+            Integration::handleInternalSpanServiceName($span, PDOIntegration::NAME);
         }
 
         foreach ($storedConnectionInfo as $tag => $value) {


### PR DESCRIPTION
Split by should take priority in PDO integration over service name flattening

Fixes #2519.
