### PR TITLE
benchmarks: Use 1 Warmup Interation and ensure opcache is used

### DIFF
--- a/tests/Benchmarks/API/ContextPropagationBench.php
+++ b/tests/Benchmarks/API/ContextPropagationBench.php
@@ -36,6 +36,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("resetContext")
+     * @Warmup(1)
      */
     public function benchExtractTraceContext128Bit()
     {
@@ -48,6 +49,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("resetContext")
+     * @Warmup(1)
      */
     public function benchExtractTraceContext64Bit()
     {
@@ -60,6 +62,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("resetContext")
+     * @Warmup(1)
      */
     public function benchExtractHeaders128Bit()
     {
@@ -72,6 +75,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("resetContext")
+     * @Warmup(1)
      */
     public function benchExtractHeaders64Bit()
     {
@@ -84,6 +88,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUp128BitContext")
+     * @Warmup(1)
      */
     public function benchInject128Bit()
     {
@@ -96,6 +101,7 @@ class ContextPropagationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUp64BitContext")
+     * @Warmup(1)
      */
     public function benchInject64Bit()
     {

--- a/tests/Benchmarks/API/HookBench.php
+++ b/tests/Benchmarks/API/HookBench.php
@@ -11,6 +11,7 @@ class HookBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchWithoutHook()
     {
@@ -25,6 +26,7 @@ class HookBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchHookOverheadTraceMethod()
     {
@@ -39,6 +41,7 @@ class HookBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchHookOverheadTraceFunction()
     {
@@ -53,6 +56,7 @@ class HookBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchHookOverheadInstallHookOnMethod()
     {
@@ -67,6 +71,7 @@ class HookBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchHookOverheadInstallHookOnFunction()
     {

--- a/tests/Benchmarks/API/MessagePackSerializationBench.php
+++ b/tests/Benchmarks/API/MessagePackSerializationBench.php
@@ -12,6 +12,7 @@ class MessagePackSerializationBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @ParamProviders({"provideTraceArrays"})
+     * @Warmup(1)
      */
     public function benchMessagePackSerialization($traceArray)
     {

--- a/tests/Benchmarks/API/SamplingRuleMatchingBench.php
+++ b/tests/Benchmarks/API/SamplingRuleMatchingBench.php
@@ -11,6 +11,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchGlobMatching1(): void
     {
@@ -22,6 +23,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchGlobMatching2(): void
     {
@@ -33,6 +35,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchGlobMatching3(): void
     {
@@ -44,6 +47,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchGlobMatching4(): void
     {
@@ -55,6 +59,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchRegexMatching1(): void
     {
@@ -66,6 +71,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchRegexMatching2(): void
     {
@@ -77,6 +83,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchRegexMatching3(): void
     {
@@ -88,6 +95,7 @@ class SamplingRuleMatchingBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchRegexMatching4(): void
     {

--- a/tests/Benchmarks/API/SpanBench.php
+++ b/tests/Benchmarks/API/SpanBench.php
@@ -16,6 +16,7 @@ class SpanBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchDatadogAPI()
     {
@@ -44,6 +45,7 @@ class SpanBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUpOpenTelemetry")
+     * @Warmup(1)
      */
     public function benchOpenTelemetryAPI()
     {
@@ -72,6 +74,7 @@ class SpanBench
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUpOpenTelemetry")
+     * @Warmup(1)
      */
     public function benchOpenTelemetryInteroperability()
     {

--- a/tests/Benchmarks/API/TraceAnnotationsBench.php
+++ b/tests/Benchmarks/API/TraceAnnotationsBench.php
@@ -11,6 +11,7 @@ class TraceAnnotationsBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchTraceAnnotationOverhead()
     {

--- a/tests/Benchmarks/API/TraceSerializationBench.php
+++ b/tests/Benchmarks/API/TraceSerializationBench.php
@@ -8,7 +8,7 @@ class TraceSerializationBench
 {
     /**
      * @Revs(1)
-     * @Iterations(10)
+     * @Iterations(20)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUp")

--- a/tests/Benchmarks/Integrations/EmptyFileBench.php
+++ b/tests/Benchmarks/Integrations/EmptyFileBench.php
@@ -16,6 +16,7 @@ class EmptyFileBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchEmptyFileBaseline()
     {
@@ -32,6 +33,7 @@ class EmptyFileBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchEmptyFileOverhead()
     {

--- a/tests/Benchmarks/Integrations/LaravelBench.php
+++ b/tests/Benchmarks/Integrations/LaravelBench.php
@@ -16,6 +16,7 @@ class LaravelBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLaravelBaseline()
     {
@@ -32,6 +33,7 @@ class LaravelBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLaravelOverhead()
     {

--- a/tests/Benchmarks/Integrations/LogsInjectionBench.php
+++ b/tests/Benchmarks/Integrations/LogsInjectionBench.php
@@ -20,6 +20,7 @@ class LogsInjectionBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLogsInfoBaseline()
     {
@@ -32,6 +33,7 @@ class LogsInjectionBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLogsInfoInjection()
     {
@@ -44,6 +46,7 @@ class LogsInjectionBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLogsNullBaseline()
     {
@@ -58,6 +61,7 @@ class LogsInjectionBench
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchLogsNullInjection()
     {

--- a/tests/Benchmarks/Integrations/PDOBench.php
+++ b/tests/Benchmarks/Integrations/PDOBench.php
@@ -25,6 +25,7 @@ class PDOBench
      * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchPDOBaseline()
     {
@@ -37,6 +38,7 @@ class PDOBench
      * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchPDOOverhead()
     {
@@ -49,6 +51,7 @@ class PDOBench
      * @Iterations(15)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchPDOOverheadWithDBM()
     {

--- a/tests/Benchmarks/Integrations/SymfonyBench.php
+++ b/tests/Benchmarks/Integrations/SymfonyBench.php
@@ -16,6 +16,7 @@ class SymfonyBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchSymfonyBaseline()
     {
@@ -32,6 +33,7 @@ class SymfonyBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchSymfonyOverhead()
     {

--- a/tests/Benchmarks/Integrations/WordPressBench.php
+++ b/tests/Benchmarks/Integrations/WordPressBench.php
@@ -16,6 +16,7 @@ class WordPressBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchWordPressOverhead()
     {
@@ -32,6 +33,7 @@ class WordPressBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchEnhancedWordPressOverhead()
     {
@@ -82,6 +84,7 @@ class WordPressBench extends WebFrameworkTestCase
      * @Iterations(10)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
+     * @Warmup(1)
      */
     public function benchWordPressBaseline()
     {


### PR DESCRIPTION
### Description


Native profiles when:
- [Running benchSymfonyOverhead (i.e., with tracer) and opcache](https://app.datadoghq.eu/profiling/search?query=service%3Abenchsymfonyoverhead-opcache-1708611588%20&fromUser=true&op_filter=function%3A%22opcache_compile_file%20%28ZendAccelerator.c%29%22&viz=flame_graph&start=1708608216377&end=1708611816377&paused=true). We can indeed see some opcache_compile_file calls
- [Running benchSymfonyOverhead (i.e., with tracer) without opcache](https://app.datadoghq.eu/profiling/search?query=service%3Abenchsymfonyoverhead-base-1708611812%20&fromUser=false&op_filter=opcache&viz=flame_graph&start=1708608473149&end=1708612073149&paused=false). We cannot see any opcache_compile_file calls

These profiles assess that opcache is indeed used in web requests. What's more, the warmups seemingly responsible for improvements in **both** kinds of benchmarks, because the first run will be longer since DD_AUTOLOAD_NO_COMPILE is used.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
