### PR TITLE
Always include the whole of src/ in the Windows and PECL build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -136,7 +136,7 @@ This release introduces support for the Roadrunner application server and extend
 ]]></notes>
     <contents>
         <dir name="/">
-            <!-- code and test files -->${codefiles}
+            <!-- code, PHP and test files -->${codefiles}
             <file name="config.m4" role="src" />
             <file name="config.w32" role="src" />
             <file name="ddtrace.sym" role="src" />
@@ -150,18 +150,6 @@ This release introduces support for the Roadrunner application server and extend
             <file name="NOTICE" role="doc" />
             <file name="README.md" role="doc" />
             <file name="UPGRADE-0.10.md" role="doc" />
-
-            <!-- PHP files -->
-            <!-- Include any files from ./bridge that are not referenced in ./bridge/_files.php -->
-            <!-- Make sure to update <filelist> below too -->
-            <file name="bridge/_generated_api.php" role="php" />
-            <file name="bridge/_generated_integrations.php" role="php" />
-            <file name="bridge/_generated_tracer.php" role="php" />
-            <file name="bridge/_generated_tracer_api.php" role="php" />
-            <file name="bridge/autoload.php" role="php" />
-            <file name="bridge/dd_init.php" role="php" />
-            <file name="bridge/dd_register_optional_deps_autoloader.php" role="php" />
-            <file name="bridge/dd_wrap_autoloader.php" role="php" />
         </dir>
     </contents>
     <dependencies>
@@ -181,14 +169,7 @@ This release introduces support for the Roadrunner application server and extend
     <providesextension>ddtrace</providesextension>
     <extsrcrelease>
         <filelist>
-            <install as="datadog_trace/bridge/_generated_api.php" name="bridge/_generated_api.php" />
-            <install as="datadog_trace/bridge/_generated_integrations.php" name="bridge/_generated_integrations.php" />
-            <install as="datadog_trace/bridge/_generated_tracer.php" name="bridge/_generated_tracer.php" />
-            <install as="datadog_trace/bridge/_generated_tracer_api.php" name="bridge/_generated_tracer_api.php" />
-            <install as="datadog_trace/bridge/autoload.php" name="bridge/autoload.php" />
-            <install as="datadog_trace/bridge/dd_init.php" name="bridge/dd_init.php" />
-            <install as="datadog_trace/bridge/dd_register_optional_deps_autoloader.php" name="bridge/dd_register_optional_deps_autoloader.php" />
-            <install as="datadog_trace/bridge/dd_wrap_autoloader.php" name="bridge/dd_wrap_autoloader.php" />
+            <!-- Move PHP files to target destination -->${filelist}
         </filelist>
     </extsrcrelease>
 </package>

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -62,6 +62,7 @@ for architecture in "${architectures[@]}"; do
     cp -r ./src ${tmp_folder_final_musl_trace};
     cp -r ./bridge ${tmp_folder_final_musl_trace};
     if [[ -z ${DDTRACE_MAKE_PACKAGES_ASAN:-} && $architecture == "x86_64" ]]; then
+      cp -r ./src ${tmp_folder_final_windows_trace};
       cp -r ./bridge ${tmp_folder_final_windows_trace};
     fi
 

--- a/tooling/bin/pecl-build
+++ b/tooling/bin/pecl-build
@@ -2,7 +2,7 @@
 
 set -e
 
-rm -f ./bridge/_generated*.php
+rm -f bridge/_generated*.php
 composer -dtooling/generation update
 composer -dtooling/generation generate
 composer -dtooling/generation verify
@@ -22,11 +22,18 @@ for file in "$@"; do
   codefiles="${codefiles}"$'\n            <file name="'"${file}"'" role="'"$([[ $file == tests/* ]] && echo test || echo src)"'" '"$([[ $file == */configuration.h ]] && echo ">$configuration_placeholder" || echo "/>")"
 done
 
+filelist=""
+for file in $(ls bridge/*.php | grep -v _files_; find src -name "*.php"); do
+  codefiles="${codefiles}"$'\n            <file name="'"${file}"'" role="php" />'
+  filelist="${filelist}"$'\n            <install as="datadog_trace/'"${file}"'" name="'"${file}"'" />'
+done
+
 pkg_xml=$(cat package.xml)
 
 pkg_xml=${pkg_xml//'${version}'/${dd_version}}
 pkg_xml=${pkg_xml//'${date}'/$(date +%Y-%m-%d)}
 pkg_xml=${pkg_xml//'${codefiles}'/${codefiles}}
+pkg_xml=${pkg_xml//'${filelist}'/${filelist}}
 
 echo "$pkg_xml" > package.xml
 


### PR DESCRIPTION
### Description

This is in particular necessary for Opentelemetry support.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
