### PR TITLE
Change DD_TRACE_SAMPLING_RULES_FORMAT default from regex to glob

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -128,7 +128,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(INT, DD_TRACE_RATE_LIMIT, "0", .ini_change = zai_config_system_ini_change)                          \
     CALIAS(DOUBLE, DD_TRACE_SAMPLE_RATE, "-1", CALIASES("DD_SAMPLING_RATE"))                                   \
     CONFIG(JSON, DD_TRACE_SAMPLING_RULES, "[]")                                                                \
-    CONFIG(CUSTOM(INT), DD_TRACE_SAMPLING_RULES_FORMAT, "regex", .parser = dd_parse_sampling_rules_format)     \
+    CONFIG(CUSTOM(INT), DD_TRACE_SAMPLING_RULES_FORMAT, "glob", .parser = dd_parse_sampling_rules_format)     \
     CONFIG(JSON, DD_SPAN_SAMPLING_RULES, "[]")                                                                 \
     CONFIG(STRING, DD_SPAN_SAMPLING_RULES_FILE, "", .ini_change = ddtrace_alter_sampling_rules_file_config)    \
     CONFIG(SET_LOWERCASE, DD_TRACE_HEADER_TAGS, "")                                                            \

--- a/tests/ext/priority_sampling/005-rule-name.phpt
+++ b/tests/ext/priority_sampling/005-rule-name.phpt
@@ -3,6 +3,7 @@ priority_sampling rule with name match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.7, "name": "bar"},{"sample_rate": 0.3, "name": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SAMPLING_RULES_FORMAT=regex
 --FILE--
 <?php
 $root = \DDTrace\root_span();

--- a/tests/ext/priority_sampling/007-rule-service.phpt
+++ b/tests/ext/priority_sampling/007-rule-service.phpt
@@ -3,6 +3,7 @@ priority_sampling rule with service match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.7, "service": "bar"},{"sample_rate": 0.3, "service": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SAMPLING_RULES_FORMAT=regex
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0" && !getenv("SKIP_ASAN")) {

--- a/tests/ext/priority_sampling/009-rule-name-service.phpt
+++ b/tests/ext/priority_sampling/009-rule-name-service.phpt
@@ -3,6 +3,7 @@ priority_sampling rule with name and service match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "name": "fo.*ame", "service": "bar"}, {"sample_rate": 0.7}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SAMPLING_RULES_FORMAT=regex
 --FILE--
 <?php
 $root = \DDTrace\root_span();

--- a/tests/ext/priority_sampling/014-rule-resource.phpt
+++ b/tests/ext/priority_sampling/014-rule-resource.phpt
@@ -3,6 +3,7 @@ priority_sampling rule with resource match
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.7, "resource": "bar"},{"sample_rate": 0.3, "resource": "foo"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SAMPLING_RULES_FORMAT=regex
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0" && !getenv("SKIP_ASAN")) {

--- a/tests/ext/priority_sampling/021-rule-name-as-glob-with-question-mark.phpt
+++ b/tests/ext/priority_sampling/021-rule-name-as-glob-with-question-mark.phpt
@@ -2,7 +2,6 @@
 priority_sampling rule with name match, using glob
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_SAMPLING_RULES_FORMAT=glob
 --FILE--
 <?php
 

--- a/tests/ext/priority_sampling/022-rule-name-as-glob-with-multiple-criterias.phpt
+++ b/tests/ext/priority_sampling/022-rule-name-as-glob-with-multiple-criterias.phpt
@@ -2,7 +2,6 @@
 priority_sampling rule with name match, using glob
 --ENV--
 DD_TRACE_GENERATE_ROOT_SPAN=1
-DD_TRACE_SAMPLING_RULES_FORMAT=glob
 --FILE--
 <?php
 

--- a/tests/ext/priority_sampling/invalid-regex-rule.phpt
+++ b/tests/ext/priority_sampling/invalid-regex-rule.phpt
@@ -3,6 +3,7 @@ Invalid regex: default sampling rate applies
 --ENV--
 DD_TRACE_SAMPLING_RULES=[{"sample_rate": 0.3, "service": "*"}]
 DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SAMPLING_RULES_FORMAT=regex
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0" && !getenv("SKIP_ASAN")) {


### PR DESCRIPTION
### Description

Change DD_TRACE_SAMPLING_RULES_FORMAT default from regex to glob.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
