### PR TITLE
feat(profiling) report PHP build (`NTS` vs `ZTS`)

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -516,6 +516,15 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 // standardized tag name.
                 add_tag(&mut tags, "runtime_version", PHP_VERSION.as_str());
                 add_tag(&mut tags, "php.sapi", SAPI.as_ref());
+                // In case we ever add PHP debug build support, we should add `zend-zts-debug` and
+                // `zend-nts-debug`. For the time being we only support `zend-zts-ndebug` and
+                // `zend-nts-ndebug`
+                let runtime_engine = if cfg!(php_zts) {
+                    "zend-zts-ndebug"
+                } else {
+                    "zend-nts-ndebug"
+                };
+                add_tag(&mut tags, "runtime_engine", runtime_engine);
                 cell.replace(Arc::new(tags));
             });
 


### PR DESCRIPTION
### Description

PROF-9204 / #2070 

This PR will add the PHP build (`ZTS` vs `NTS`) as a tag (`runtime_engine`) to the profiles. In more detail: we will start reporting ZTS as `zend-zts-ndebug` and NTS as `zend-nts-ndebug`(because there is no `debug` build support so far). In case we would support `debug` builds, we'd also add a `zend-nts-debug` and `zend-zts-debug` value.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
