### PR TITLE
fix(benchmarks): Ensure OPCache is used in cgi-fcgi web servers

### DIFF
--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -94,7 +94,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected static function getInis()
     {
-        $enableOpcache = \getenv('DD_TRACE_OPCACHE_BENCHMARKS_MODE');
+        $enableOpcache = \extension_loaded("Zend OpCache");
 
         return [
             'ddtrace.request_init_hook' => realpath(__DIR__ . '/../../bridge/dd_wrap_autoloader.php'),

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -94,6 +94,8 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected static function getInis()
     {
+        $enableOpcache = \getenv('DD_TRACE_OPCACHE_BENCHMARKS_MODE');
+
         return [
             'ddtrace.request_init_hook' => realpath(__DIR__ . '/../../bridge/dd_wrap_autoloader.php'),
             // The following values should be made configurable from the outside. I could not get env XDEBUG_CONFIG
@@ -102,7 +104,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             'xdebug.remote_enable' => 1,
             'xdebug.remote_host' => 'host.docker.internal',
             'xdebug.remote_autostart' => 1,
-        ];
+        ] + ($enableOpcache ? ["opcache.enabled" => "1"] : []);
     }
 
     /**

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -104,7 +104,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             'xdebug.remote_enable' => 1,
             'xdebug.remote_host' => 'host.docker.internal',
             'xdebug.remote_autostart' => 1,
-        ] + ($enableOpcache ? ["opcache.enabled" => "1"] : []);
+        ] + ($enableOpcache ? ["zend_extension" => "opcache.so"] : []);
     }
 
     /**

--- a/tests/phpbench-opcache.json
+++ b/tests/phpbench-opcache.json
@@ -6,7 +6,8 @@
     "runner.php_env": {
         "DD_TRACE_OTEL_ENABLED": "true",
         "DD_TRACE_TEST_SAPI": "cgi-fcgi",
-        "DD_TRACE_SIDECAR_TRACE_SENDER": "true"
+        "DD_TRACE_SIDECAR_TRACE_SENDER": "true",
+        "DD_TRACE_OPCACHE_BENCHMARKS_MODE": "true"
     },
     "runner.php_config": {
         "zend_extension": "opcache.so",

--- a/tests/phpbench-opcache.json
+++ b/tests/phpbench-opcache.json
@@ -6,8 +6,7 @@
     "runner.php_env": {
         "DD_TRACE_OTEL_ENABLED": "true",
         "DD_TRACE_TEST_SAPI": "cgi-fcgi",
-        "DD_TRACE_SIDECAR_TRACE_SENDER": "true",
-        "DD_TRACE_OPCACHE_BENCHMARKS_MODE": "true"
+        "DD_TRACE_SIDECAR_TRACE_SENDER": "true"
     },
     "runner.php_config": {
         "zend_extension": "opcache.so",


### PR DESCRIPTION
### Description

I somehow messed up something while rebasing/force-pushing in #2531... This PR adds the "and ensure opcache is used" part.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
