### PR TITLE
Move collecting and flushing telemetry to after final request flush

### DIFF
--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -171,6 +171,8 @@ ddog_MaybeError ddog_sidecar_telemetry_buffer_flush(ddog_SidecarTransport **tran
                                                     const ddog_QueueId *queue_id,
                                                     struct ddog_SidecarActionsBuffer *buffer);
 
+void ddog_sidecar_telemetry_buffer_drop(struct ddog_SidecarActionsBuffer*);
+
 ddog_MaybeError ddog_sidecar_connect_php(ddog_SidecarTransport **connection,
                                          const char *error_path,
                                          ddog_CharSlice log_level,

--- a/components-rs/telemetry.rs
+++ b/components-rs/telemetry.rs
@@ -127,3 +127,7 @@ pub extern "C" fn ddog_sidecar_telemetry_buffer_flush(
 
     MaybeError::None
 }
+
+#[no_mangle]
+pub extern "C" fn ddog_sidecar_telemetry_buffer_drop(_: Box<SidecarActionsBuffer>) {
+}

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -101,6 +101,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
 
     char *cgroup_file;
     ddog_QueueId telemetry_queue_id;
+    ddog_SidecarActionsBuffer *telemetry_buffer;
     ddog_AgentRemoteConfigReader *remote_config_reader;
     HashTable *agent_rate_by_service;
     zend_string *last_flushed_root_service_name;

--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -25,23 +25,16 @@ void ddtrace_telemetry_first_init(void) {
     dd_composer_hook_id = zai_hook_install((zai_str)ZAI_STR_EMPTY, (zai_str)ZAI_STR_EMPTY, dd_check_for_composer_autoloader, NULL, ZAI_HOOK_AUX_UNUSED, 0);
 }
 
-void ddtrace_telemetry_finalize(void) {
+void ddtrace_telemetry_collect_config(void) {
     if (!ddtrace_sidecar || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
         return;
     }
 
-    ddog_SidecarActionsBuffer *buffer = ddog_sidecar_telemetry_buffer_alloc();
+    if (DDTRACE_G(telemetry_buffer)) {
+        ddog_sidecar_telemetry_buffer_drop(DDTRACE_G(telemetry_buffer));
+    }
 
-    zend_module_entry *module;
-    char module_name[261] = { 'e', 'x', 't', '-' };
-    ZEND_HASH_FOREACH_PTR(&module_registry, module) {
-        size_t namelen = strlen(module->name);
-        memcpy(module_name + 4, module->name, MIN(256, strlen(module->name)));
-        const char *version = module->version ? module->version : "";
-        ddog_sidecar_telemetry_addDependency_buffer(buffer,
-                                                    (ddog_CharSlice) {.len = namelen + 4, .ptr = module_name},
-                                                    (ddog_CharSlice) {.len = strlen(version), .ptr = version});
-    } ZEND_HASH_FOREACH_END();
+    ddog_SidecarActionsBuffer *buffer = DDTRACE_G(telemetry_buffer) = ddog_sidecar_telemetry_buffer_alloc();
 
     for (uint8_t i = 0; i < zai_config_memoized_entries_count; i++) {
         zai_config_memoized_entry *cfg = &zai_config_memoized_entries[i];
@@ -69,6 +62,31 @@ void ddtrace_telemetry_finalize(void) {
             ddog_sidecar_telemetry_addIntegration_buffer(buffer, integration_name, (ddog_CharSlice)DDOG_CHARSLICE_C(""), false);
         }
     }
+}
+
+void ddtrace_telemetry_finalize(void) {
+    if (!ddtrace_sidecar || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
+        return;
+    }
+
+    ddog_SidecarActionsBuffer *buffer = DDTRACE_G(telemetry_buffer);
+    if (buffer) {
+        DDTRACE_G(telemetry_buffer) = NULL;
+    } else {
+        buffer = ddog_sidecar_telemetry_buffer_alloc();
+    }
+
+    zend_module_entry *module;
+    char module_name[261] = { 'e', 'x', 't', '-' };
+    ZEND_HASH_FOREACH_PTR(&module_registry, module) {
+        size_t namelen = strlen(module->name);
+        memcpy(module_name + 4, module->name, MIN(256, strlen(module->name)));
+        const char *version = module->version ? module->version : "";
+        ddog_sidecar_telemetry_addDependency_buffer(buffer,
+                                                    (ddog_CharSlice) {.len = namelen + 4, .ptr = module_name},
+                                                    (ddog_CharSlice) {.len = strlen(version), .ptr = version});
+    } ZEND_HASH_FOREACH_END();
+
     ddog_sidecar_telemetry_buffer_flush(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), buffer);
 
     ddog_CharSlice service_name = DDOG_CHARSLICE_C("unnamed-php-service");

--- a/ext/telemetry.h
+++ b/ext/telemetry.h
@@ -6,6 +6,7 @@
 void ddtrace_telemetry_first_init(void);
 ddog_TelemetryWorkerHandle *ddtrace_build_telemetry_handle(void);
 void ddtrace_telemetry_notify_integration(const char *name, size_t name_len);
+void ddtrace_telemetry_collect_config(void);
 void ddtrace_telemetry_finalize(void);
 
 #endif // DDTRACE_TELEMETRY_H


### PR DESCRIPTION
Moving things around, basically between request flush and request memory free.

Reduces the request latency, even though it doesn't change anything about CPU time used.

Note: This does not affect the cli-server sapi.